### PR TITLE
Refactor Dockerfiles

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -8,15 +8,14 @@ RUN ln -sf /bin/bash /bin/sh
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/agent
 
-ADD ./glide.yaml .
-ADD ./glide.lock .
+COPY glide.yaml glide.lock ./
 
 RUN glide install
 
 # builder stage
 FROM base AS builder
 
-ADD . .
+COPY . .
 
 RUN glide -q install --skip-test && go build
 
@@ -29,7 +28,7 @@ RUN go get github.com/markbates/refresh
 RUN glide -q install --skip-test
 RUN cp -a vendor /vendor
 
-ADD entrypoint-dev.sh /entrypoint.sh
+COPY entrypoint-dev.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/agent/Dockerfile.amd64
+++ b/agent/Dockerfile.amd64
@@ -5,12 +5,11 @@ RUN apk add --update git ca-certificates util-linux build-base bash && \
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/agent
 
-ADD ./glide.yaml .
-ADD ./glide.lock .
+COPY glide.yaml glide.lock ./
 
 RUN glide install
 
-ADD . .
+COPY . .
 
 RUN glide -q install --skip-test && GOOS=linux GOARCH=amd64 go build -tags docker
 

--- a/agent/Dockerfile.arm32v6
+++ b/agent/Dockerfile.arm32v6
@@ -7,12 +7,11 @@ RUN apk add --update git ca-certificates util-linux build-base bash && \
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/agent
 
-ADD ./glide.yaml .
-ADD ./glide.lock .
+COPY glide.yaml glide.lock ./
 
 RUN glide install
 
-ADD . .
+COPY . .
 
 RUN glide -q install --skip-test && GOOS=linux GOARCH=arm go build -tags docker
 

--- a/agent/Dockerfile.arm64v8
+++ b/agent/Dockerfile.arm64v8
@@ -7,12 +7,11 @@ RUN apk add --update git ca-certificates util-linux build-base bash && \
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/agent
 
-ADD ./glide.yaml .
-ADD ./glide.lock .
+COPY glide.yaml glide.lock ./
 
 RUN glide install
 
-ADD . .
+COPY . .
 
 RUN glide -q install --skip-test && GOOS=linux GOARCH=arm64 go build -tags docker
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,15 +6,14 @@ RUN apk add --update git ca-certificates && \
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/api
 
-ADD ./glide.yaml .
-ADD ./glide.lock .
+COPY glide.yaml  glide.lock ./
 
 RUN glide install
 
 # builder stage
 FROM base AS builder
 
-ADD . .
+COPY . .
 
 RUN glide -q install --skip-test && go build
 
@@ -27,7 +26,7 @@ RUN go get github.com/markbates/refresh
 RUN glide -q install --skip-test
 RUN cp -a vendor /vendor
 
-ADD entrypoint-dev.sh /entrypoint.sh
+COPY entrypoint-dev.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -6,15 +6,14 @@ RUN apk add --update git ca-certificates openssh-client && \
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/ssh
 
-ADD ./glide.yaml .
-ADD ./glide.lock .
+COPY glide.yaml glide.lock ./
 
 RUN glide install
 
 # builder stage
 FROM base AS builder
 
-ADD . .
+COPY . .
 
 RUN glide -q install --skip-test && go build
 
@@ -27,7 +26,7 @@ RUN go get github.com/markbates/refresh
 RUN glide -q install --skip-test
 RUN cp -a vendor /vendor
 
-ADD entrypoint-dev.sh /entrypoint.sh
+COPY entrypoint-dev.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.9.0-alpine as base
+FROM node:12.16.0-alpine as base
 
 RUN apk add --update build-base python
 
@@ -14,7 +14,7 @@ WORKDIR /src
 
 COPY --from=base /app/node_modules /node_modules
 
-ADD entrypoint-dev.sh /entrypoint.sh
+COPY entrypoint-dev.sh /entrypoint.sh
 
 CMD ["/entrypoint.sh"]
 

--- a/ws/Dockerfile
+++ b/ws/Dockerfile
@@ -6,15 +6,14 @@ RUN apk add --update git ca-certificates && \
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/ws
 
-ADD ./glide.yaml .
-ADD ./glide.lock .
+COPY glide.yaml glide.lock ./
 
 RUN glide install
 
 # builder stage
 FROM base AS builder
 
-ADD . .
+COPY . .
 
 RUN glide -q install --skip-test && go build
 
@@ -27,7 +26,7 @@ RUN go get github.com/markbates/refresh
 RUN glide -q install --skip-test
 RUN cp -a vendor /vendor
 
-ADD entrypoint-dev.sh /entrypoint.sh
+COPY entrypoint-dev.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
- Use `COPY` rather than `ADD` for cache strategy(ADD never generates cache)
- Use Node.js 12(and newer than 12.15 for important CVE fix) as it is the current LTS version