### PR TITLE
ssh: fix ssh2ws to get client's IP behind a layer7 lb

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -18,12 +18,10 @@ import (
 	"github.com/shellhub-io/shellhub/api/pkg/services/authsvc"
 	"github.com/shellhub-io/shellhub/api/pkg/services/deviceadm"
 	"github.com/shellhub-io/shellhub/api/pkg/services/sessionmngr"
-	"github.com/shellhub-io/shellhub/api/pkg/services/ssh2ws"
 	"github.com/shellhub-io/shellhub/api/pkg/store/mongo"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	mgo "go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"golang.org/x/net/websocket"
 )
 
 type config struct {
@@ -368,11 +366,6 @@ func main() {
 		}
 
 		return c.JSON(http.StatusOK, session)
-	})
-
-	publicAPI.GET("/ws/ssh", func(c echo.Context) error {
-		websocket.Handler(ssh2ws.Handler).ServeHTTP(c.Response(), c.Request())
-		return nil
 	})
 
 	internalAPI.GET("/lookup", func(c echo.Context) error {

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -21,5 +21,10 @@ http {
 
     keepalive_timeout  65;
 
+    map $http_x_real_ip $x_real_ip {
+        default $http_x_real_ip;
+        "" $remote_addr;
+    }
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -38,7 +38,7 @@ server {
         {{ if bool (env.Getenv "SHELLHUB_PROXY") -}}
         proxy_set_header X-Real-IP $proxy_protocol_addr;
         {{ else -}}
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $x_real_ip;
         {{ end -}}
         proxy_set_header X-Device-UID $device_uid;
         proxy_http_version 1.1;
@@ -55,7 +55,7 @@ server {
         {{ if bool (env.Getenv "SHELLHUB_PROXY") -}}
         proxy_set_header X-Real-IP $proxy_protocol_addr;
         {{ else -}}
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $x_real_ip;
         {{ end -}}
         proxy_http_version 1.1;
         proxy_cache_bypass $http_upgrade;
@@ -95,15 +95,15 @@ server {
 
     location /ws {
         resolver 127.0.0.11 ipv6=off valid=10s;
-        rewrite ^/ws/(.*)$ /api/ws/$1 break;
-        proxy_pass http://api:8080;
+        proxy_pass http://ssh:8080;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
+
         {{ if bool (env.Getenv "SHELLHUB_PROXY") -}}
         proxy_set_header X-Real-IP $proxy_protocol_addr;
         {{ else -}}
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $x_real_ip;
         {{ end -}}
         proxy_http_version 1.1;
         proxy_cache_bypass $http_upgrade;

--- a/ssh/go.mod
+++ b/ssh/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/shellhub-io/shellhub v0.0.0-00010101000000-000000000000
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6
+	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
 	moul.io/http2curl v1.0.0 // indirect
 )
 

--- a/ssh/main.go
+++ b/ssh/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"golang.org/x/net/websocket"
 
 	"github.com/parnurzeal/gorequest"
 	"github.com/shellhub-io/shellhub/pkg/httptunnel"
@@ -52,6 +53,8 @@ func main() {
 			return
 		}
 	})
+	router.Handle("/ws/ssh", websocket.Handler(HandlerWebsocket))
+
 	go http.ListenAndServe(":8080", router)
 
 	server := NewServer(opts, tunnel)

--- a/ssh/session.go
+++ b/ssh/session.go
@@ -228,17 +228,12 @@ func (s *Session) connect(passwd string, session sshserver.Session, conn net.Con
 func (s *Session) register(session sshserver.Session) error {
 	env := loadEnv(session.Environ())
 
-	ipaddr, err := net.LookupIP("api")
-	if err != nil {
-		return err
-	}
-
 	host, _, err := net.SplitHostPort(session.RemoteAddr().String())
 	if err != nil {
 		return err
 	}
 
-	if ipaddr[0].String() == host {
+	if host == "127.0.0.1" || host == "::1" {
 		if value, ok := env["IP_ADDRESS"]; ok {
 			s.IPAddress = value
 		}

--- a/ssh/ssh2ws.go
+++ b/ssh/ssh2ws.go
@@ -1,4 +1,4 @@
-package ssh2ws
+package main
 
 import (
 	"fmt"
@@ -15,7 +15,7 @@ func copyWorker(dst io.Writer, src io.Reader, doneCh chan<- bool) {
 	doneCh <- true
 }
 
-func Handler(ws *websocket.Conn) {
+func HandlerWebsocket(ws *websocket.Conn) {
 	user := ws.Request().URL.Query().Get("user")
 	passwd := ws.Request().URL.Query().Get("passwd")
 	cols, _ := strconv.Atoi(ws.Request().URL.Query().Get("cols"))
@@ -29,7 +29,7 @@ func Handler(ws *websocket.Conn) {
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
-	client, err := ssh.Dial("tcp", "ssh:2222", config)
+	client, err := ssh.Dial("tcp", "localhost:2222", config)
 	if err != nil {
 		fmt.Println(err)
 		ws.Close()
@@ -116,5 +116,3 @@ func (self *wsconn) keepAlive(ws *websocket.Conn) {
 		}
 	}
 }
-
-//	http.Handle("/ssh", websocket.Handler(relayHandler))


### PR DESCRIPTION
Fix ssh2ws to get client's IP behind a layer7 load balancer by moving the ssh2ws bridge to ssh service, where connections are established to localhost. It's allow us to trust in the `IP_ADDRESS` session environment variables set by our internal ssh client. This variable contains the real IP address from the client's browser which original connection came from.