### PR TITLE
agent: init supplementary groups

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,7 +1,7 @@
 # base stage
 FROM golang:1.13-alpine3.11 AS base
 
-RUN apk add --update git ca-certificates build-base bash util-linux
+RUN apk add --update git ca-certificates build-base bash util-linux setpriv
 
 RUN ln -sf /bin/bash /bin/sh
 

--- a/agent/cmd_docker.go
+++ b/agent/cmd_docker.go
@@ -22,6 +22,8 @@ func newCmd(u *osauth.User, shell, term, host string, command ...string) *exec.C
 		"TERM=" + term,
 		"HOME=" + u.HomeDir,
 		"SHELL=" + shell,
+		"USER=" + u.Username,
+		"LOGNAME=" + u.Username,
 		"SHELLHUB_HOST=" + host,
 	}
 
@@ -33,11 +35,17 @@ func nsenterCommandWrapper(uid, gid int, home string, command ...string) ([]stri
 
 	if _, err := os.Stat("/usr/bin/nsenter"); err == nil {
 		wrappedCommand = append([]string{
+			"/usr/bin/setpriv",
+			"--init-groups",
+			"--ruid",
+			strconv.Itoa(uid),
+			"--regid",
+			strconv.Itoa(gid),
 			"/usr/bin/nsenter",
 			"-t", "1",
 			"-a",
-			"-S", strconv.Itoa(uid),
-			"-G", strconv.Itoa(gid),
+			"-S",
+			strconv.Itoa(uid),
 			fmt.Sprintf("--wd=%s", home),
 		}, wrappedCommand...)
 	} else if err != nil && !os.IsNotExist(err) {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,8 @@ services:
       - ./agent:/go/src/github.com/shellhub-io/shellhub/agent
       - ./pkg:/go/src/github.com/shellhub-io/shellhub/pkg
       - /:/host
+      - /etc/passwd:/etc/passwd
+      - /etc/group:/etc/group
     depends_on:
       - api
       - ssh

--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -131,7 +131,7 @@ server {
             local scheme = ngx.var.http_x_forwarded_proto ~= '' and ngx.var.http_x_forwarded_proto or ngx.var.scheme
             local tenant_id=ngx.var.arg_tenant_id
             local version=os.getenv("SHELLHUB_VERSION")
-            ngx.say("docker run -d --name=shellhub --restart=unless-stopped --privileged --net=host --pid=host -v /:/host -e SERVER_ADDRESS=",scheme,"://",host," -e PRIVATE_KEY=/host/etc/shellhub.key -e TENANT_ID=",tenant_id," shellhubio/agent:",version)
+            ngx.say("docker run -d --name=shellhub --restart=unless-stopped --privileged --net=host --pid=host -v /:/host -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group -e SERVER_ADDRESS=",scheme,"://",host," -e PRIVATE_KEY=/host/etc/shellhub.key -e TENANT_ID=",tenant_id," shellhubio/agent:",version)
         }
     }
 }


### PR DESCRIPTION
Init supplementary groups by wrapping around 'nsenter' using 'setpriv' utility for changing user's shell process privileges. Fixes #96 