### PR TITLE
api: avoid devices with same name

### DIFF
--- a/api/pkg/services/deviceadm/service.go
+++ b/api/pkg/services/deviceadm/service.go
@@ -68,7 +68,10 @@ func (s *service) RenameDevice(ctx context.Context, uid models.UID, name string,
 		if device.Name != name {
 			device.Name = name
 			if err := validate.Struct(device); err == nil {
-				return s.store.RenameDevice(ctx, uid, name)
+				otherDevice, _ := s.store.GetDeviceByName(ctx, name, tenant)
+				if otherDevice == nil {
+					return s.store.RenameDevice(ctx, uid, name)
+				}
 			}
 		}
 	}


### PR DESCRIPTION

Restoring getDeviceByName  function to avoid renaming a device
to an already taken name.

Fixes: d44e0c884dfb39e7209252623bbd99fb0e94c447