### PR TITLE
global: Adapt code style to gofumports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         go-version: 1.14
       id: go
 
+    - name: Install gofumpt
+      run: go get mvdan.cc/gofumpt/gofumports
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
@@ -39,13 +42,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Run gofmt -s
+    - name: Run gofumports
       working-directory: ${{ matrix.project }}
       run: |
-        gofmt -s -d .
+        gofumports -d .
 
         # If there are any diff, exit as error
-        [ "$(gofmt -s -l .)" == "" ] || exit 1
+        [ "$(gofumports -l .)" == "" ] || exit 1
 
     - name: Build
       working-directory: ${{ matrix.project }}

--- a/agent/identity.go
+++ b/agent/identity.go
@@ -99,7 +99,7 @@ func primaryIface() (*net.Interface, error) {
 	return ifdev, nil
 }
 
-func readSysFs(iface string, file string) (string, error) {
+func readSysFs(iface, file string) (string, error) {
 	data, err := ioutil.ReadFile(filepath.Join("/sys/class/net", iface, file))
 	return strings.TrimSpace(string(data)), err
 }

--- a/agent/internal/osauth/auth_docker.go
+++ b/agent/internal/osauth/auth_docker.go
@@ -13,13 +13,14 @@ package osauth
 #include <crypt.h>
 */
 import "C"
+
 import (
 	"unsafe"
 )
 
 const passwdFilename = "/host/etc/passwd"
 
-func AuthUser(user string, passwd string) bool {
+func AuthUser(user, passwd string) bool {
 	cuser := C.CString(user)
 	defer C.free(unsafe.Pointer(cuser))
 

--- a/agent/internal/osauth/auth_native.go
+++ b/agent/internal/osauth/auth_native.go
@@ -20,7 +20,7 @@ import "unsafe"
 
 const passwdFilename = "/etc/passwd"
 
-func AuthUser(user string, passwd string) bool {
+func AuthUser(user, passwd string) bool {
 	cuser := C.CString(user)
 	defer C.free(unsafe.Pointer(cuser))
 

--- a/agent/internal/osauth/user.go
+++ b/agent/internal/osauth/user.go
@@ -9,6 +9,7 @@ package osauth
 #include <pwd.h>
 */
 import "C"
+
 import (
 	"strconv"
 	"unsafe"

--- a/agent/keypair.go
+++ b/agent/keypair.go
@@ -24,7 +24,7 @@ func generatePrivateKey(filename string) error {
 
 	defer f.Close()
 
-	var privateKey = &pem.Block{
+	privateKey := &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}

--- a/agent/main.go
+++ b/agent/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"net"
@@ -12,8 +13,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"encoding/json"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -77,6 +76,7 @@ func getInfo(input string) string {
 	}
 	return string(prettyJSON)
 }
+
 func main() {
 	opts := ConfigOptions{}
 
@@ -179,7 +179,7 @@ func main() {
 	}
 }
 
-func NewListener(host string, protocol string, token string) (*revdial.Listener, error) {
+func NewListener(host, protocol, token string) (*revdial.Listener, error) {
 	req, _ := http.NewRequest("GET", "", nil)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 

--- a/agent/sshserver.go
+++ b/agent/sshserver.go
@@ -180,7 +180,7 @@ func (s *SSHServer) closeSession(id string) {
 	}
 }
 
-func newShellCmd(s *SSHServer, username string, term string) *exec.Cmd {
+func newShellCmd(s *SSHServer, username, term string) *exec.Cmd {
 	shell := os.Getenv("SHELL")
 
 	u := osauth.LookupUser(username)

--- a/api/main.go
+++ b/api/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -397,7 +396,7 @@ func main() {
 	e.Logger.Fatal(e.Start(":8080"))
 }
 
-func DecodeMap(input interface{}, output interface{}) error {
+func DecodeMap(input, output interface{}) error {
 	config := &mapstructure.DecoderConfig{
 		TagName:  "json",
 		Metadata: nil,

--- a/api/pkg/services/deviceadm/service.go
+++ b/api/pkg/services/deviceadm/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+
 	"github.com/shellhub-io/shellhub/api/pkg/store"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"gopkg.in/go-playground/validator.v9"
@@ -14,10 +15,10 @@ var UnauthorizedErr = errors.New("unauthorized")
 
 type Service interface {
 	CountDevices(ctx context.Context) (int64, error)
-	ListDevices(ctx context.Context, perPage int, page int, filter string) ([]models.Device, int, error)
+	ListDevices(ctx context.Context, perPage, page int, filter string) ([]models.Device, int, error)
 	GetDevice(ctx context.Context, uid models.UID) (*models.Device, error)
 	DeleteDevice(ctx context.Context, uid models.UID, tenant string) error
-	RenameDevice(ctx context.Context, uid models.UID, name string, tenant string) error
+	RenameDevice(ctx context.Context, uid models.UID, name, tenant string) error
 	LookupDevice(ctx context.Context, namespace, name string) (*models.Device, error)
 	UpdateDeviceStatus(ctx context.Context, uid models.UID, online bool) error
 }
@@ -29,12 +30,12 @@ type service struct {
 func NewService(store store.Store) Service {
 	return &service{store}
 }
+
 func (s *service) CountDevices(ctx context.Context) (int64, error) {
 	return s.store.CountDevices(ctx)
 }
 
-func (s *service) ListDevices(ctx context.Context, perPage int, page int, filterB64 string) ([]models.Device, int, error) {
-
+func (s *service) ListDevices(ctx context.Context, perPage, page int, filterB64 string) ([]models.Device, int, error) {
 	raw, err := base64.StdEncoding.DecodeString(filterB64)
 	if err != nil {
 		return nil, 0, err
@@ -61,7 +62,7 @@ func (s *service) DeleteDevice(ctx context.Context, uid models.UID, tenant strin
 	return UnauthorizedErr
 }
 
-func (s *service) RenameDevice(ctx context.Context, uid models.UID, name string, tenant string) error {
+func (s *service) RenameDevice(ctx context.Context, uid models.UID, name, tenant string) error {
 	device, _ := s.store.GetDeviceByUid(ctx, uid, tenant)
 	validate := validator.New()
 	if device != nil {

--- a/api/pkg/services/sessionmngr/service.go
+++ b/api/pkg/services/sessionmngr/service.go
@@ -9,7 +9,7 @@ import (
 
 type Service interface {
 	CountSessions(ctx context.Context) (int64, error)
-	ListSessions(ctx context.Context, perPage int, page int) ([]models.Session, int, error)
+	ListSessions(ctx context.Context, perPage, page int) ([]models.Session, int, error)
 	GetSession(ctx context.Context, uid models.UID) (*models.Session, error)
 	CreateSession(ctx context.Context, session models.Session) (*models.Session, error)
 	DeactivateSession(ctx context.Context, uid models.UID) error
@@ -28,7 +28,7 @@ func (s *service) CountSessions(ctx context.Context) (int64, error) {
 	return s.store.CountSessions(ctx)
 }
 
-func (s *service) ListSessions(ctx context.Context, perPage int, page int) ([]models.Session, int, error) {
+func (s *service) ListSessions(ctx context.Context, perPage, page int) ([]models.Session, int, error) {
 	return s.store.ListSessions(ctx, perPage, page)
 }
 

--- a/api/pkg/store/mongo/migrations.go
+++ b/api/pkg/store/mongo/migrations.go
@@ -66,13 +66,11 @@ var migrations = []migrate.Migration{
 			_, err := db.Collection("users").Indexes().CreateOne(context.TODO(), mod)
 
 			return err
-
 		},
 		Down: func(db *mongo.Database) error {
 			_, err := db.Collection("users").Indexes().DropOne(context.TODO(), "email")
 
 			return err
-
 		},
 	},
 }

--- a/api/pkg/store/mongo/store.go
+++ b/api/pkg/store/mongo/store.go
@@ -23,12 +23,11 @@ func NewStore(db *mongo.Database) *Store {
 	return &Store{db: db}
 }
 
-func (s *Store) ListDevices(ctx context.Context, perPage int, page int, filters []models.Filter) ([]models.Device, int, error) {
+func (s *Store) ListDevices(ctx context.Context, perPage, page int, filters []models.Filter) ([]models.Device, int, error) {
 	skip := perPage * (page - 1)
 	var query_filter []bson.M
 	for _, filter := range filters {
 		if filter.Type == "property" && filter.Params.Operator == "like" {
-
 			query_filter = append(query_filter, bson.M{
 
 				filter.Params.Name: bson.M{
@@ -37,18 +36,15 @@ func (s *Store) ListDevices(ctx context.Context, perPage int, page int, filters 
 				},
 			})
 		} else if filter.Type == "property" && filter.Params.Operator == "eq" {
-
 			query_filter = append(query_filter, bson.M{
 
 				filter.Params.Name: bson.M{
 					"$eq": filter.Params.Value,
 				},
 			})
-
 		} else if filter.Type == "property" && filter.Params.Operator == "bool" {
 			operator, err := strconv.ParseBool(filter.Params.Value)
 			if err != nil {
-
 				return nil, 0, err
 			}
 			query_filter = append(query_filter, bson.M{
@@ -125,9 +121,7 @@ func (s *Store) ListDevices(ctx context.Context, perPage int, page int, filters 
 	devices := make([]models.Device, 0)
 
 	cursor, err := s.db.Collection("devices").Aggregate(ctx, query)
-
 	if err != nil {
-
 		return devices, count, err
 	}
 	defer cursor.Close(ctx)
@@ -285,7 +279,6 @@ func (s *Store) CountDevices(ctx context.Context) (int64, error) {
 
 	count, err := s.db.Collection("devices").CountDocuments(ctx, query)
 	return count, err
-
 }
 
 func (s *Store) CountSessions(ctx context.Context) (int64, error) {
@@ -298,10 +291,9 @@ func (s *Store) CountSessions(ctx context.Context) (int64, error) {
 
 	count, err := s.db.Collection("sessions").CountDocuments(ctx, query)
 	return count, err
-
 }
 
-func (s *Store) ListSessions(ctx context.Context, perPage int, page int) ([]models.Session, int, error) {
+func (s *Store) ListSessions(ctx context.Context, perPage, page int) ([]models.Session, int, error) {
 	skip := perPage * (page - 1)
 	query := []bson.M{
 		{
@@ -602,7 +594,7 @@ func (s *Store) GetUserByTenant(ctx context.Context, tenant string) (*models.Use
 	return user, nil
 }
 
-func (s *Store) GetDeviceByMac(ctx context.Context, mac string, tenant string) (*models.Device, error) {
+func (s *Store) GetDeviceByMac(ctx context.Context, mac, tenant string) (*models.Device, error) {
 	device := new(models.Device)
 	if err := s.db.Collection("devices").FindOne(ctx, bson.M{"tenant_id": tenant, "identity": bson.M{"mac": mac}}).Decode(&device); err != nil {
 		return nil, err
@@ -611,7 +603,7 @@ func (s *Store) GetDeviceByMac(ctx context.Context, mac string, tenant string) (
 	return device, nil
 }
 
-func (s *Store) GetDeviceByName(ctx context.Context, name string, tenant string) (*models.Device, error) {
+func (s *Store) GetDeviceByName(ctx context.Context, name, tenant string) (*models.Device, error) {
 	device := new(models.Device)
 	if err := s.db.Collection("devices").FindOne(ctx, bson.M{"tenant_id": tenant, "name": name}).Decode(&device); err != nil {
 		return nil, err

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -7,14 +7,14 @@ import (
 )
 
 type Store interface {
-	ListDevices(ctx context.Context, perPage int, page int, filters []models.Filter) ([]models.Device, int, error)
+	ListDevices(ctx context.Context, perPage, page int, filters []models.Filter) ([]models.Device, int, error)
 	GetDevice(ctx context.Context, uid models.UID) (*models.Device, error)
 	DeleteDevice(ctx context.Context, uid models.UID) error
 	AddDevice(ctx context.Context, d models.Device) error
 	RenameDevice(ctx context.Context, uid models.UID, name string) error
 	LookupDevice(ctx context.Context, namespace, name string) (*models.Device, error)
 	UpdateDeviceStatus(ctx context.Context, uid models.UID, online bool) error
-	ListSessions(ctx context.Context, perPage int, page int) ([]models.Session, int, error)
+	ListSessions(ctx context.Context, perPage, page int) ([]models.Session, int, error)
 	GetSession(ctx context.Context, uid models.UID) (*models.Session, error)
 	CreateSession(ctx context.Context, session models.Session) (*models.Session, error)
 	SetSessionAuthenticated(ctx context.Context, uid models.UID, authenticated bool) error
@@ -22,8 +22,8 @@ type Store interface {
 	DeactivateSession(ctx context.Context, uid models.UID) error
 	GetUserByUsername(ctx context.Context, username string) (*models.User, error)
 	GetUserByTenant(ctx context.Context, tenant string) (*models.User, error)
-	GetDeviceByMac(ctx context.Context, mac string, tenant string) (*models.Device, error)
-	GetDeviceByName(ctx context.Context, name string, tenant string) (*models.Device, error)
+	GetDeviceByMac(ctx context.Context, mac, tenant string) (*models.Device, error)
+	GetDeviceByName(ctx context.Context, name, tenant string) (*models.Device, error)
 	CountDevices(ctx context.Context) (int64, error)
 	CountSessions(ctx context.Context) (int64, error)
 	GetDeviceByUid(ctx context.Context, uid models.UID, tenant string) (*models.Device, error)

--- a/pkg/httptunnel/httptunnel.go
+++ b/pkg/httptunnel/httptunnel.go
@@ -14,16 +14,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/wsconnadapter"
 )
 
-var (
-	upgrader = websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-		Subprotocols:    []string{"binary"},
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
-	}
-)
+var upgrader = websocket.Upgrader{ReadBufferSize: 1024, WriteBufferSize: 1024, Subprotocols: []string{"binary"}, CheckOrigin: func(r *http.Request) bool { return true }}
 
 const (
 	DefaultConnectionURL = "/connection"

--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	jwt "github.com/dgrijalva/jwt-go"
 	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 type Device struct {

--- a/pkg/wsconnadapter/wsconnadapter.go
+++ b/pkg/wsconnadapter/wsconnadapter.go
@@ -2,11 +2,12 @@ package wsconnadapter
 
 import (
 	"errors"
-	"github.com/gorilla/websocket"
 	"io"
 	"net"
 	"sync"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 // an adapter for representing WebSocket connection as a net.Conn

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -123,7 +123,6 @@ func (s *Server) sessionHandler(session sshserver.Session) {
 	}
 
 	sess.finish()
-
 }
 
 func (s *Server) publicKeyHandler(ctx sshserver.Context, key sshserver.PublicKey) bool {

--- a/ssh/session.go
+++ b/ssh/session.go
@@ -287,11 +287,10 @@ func NewClientConnWithDeadline(conn net.Conn, addr string, config *ssh.ClientCon
 	return ssh.NewClient(c, chans, reqs), nil
 }
 
-func DialWithDeadline(network string, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
+func DialWithDeadline(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
 	conn, err := net.DialTimeout(network, addr, config.Timeout)
 	if err != nil {
 		return nil, err
-
 	}
 
 	return NewClientConnWithDeadline(conn, addr, config)


### PR DESCRIPTION
We are adopting gofumpt tool so we avoid missing whitespace and use a
strict format. This reduces the risk of bad indented code.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>