### PR TITLE
api: fix issues with counting and delete devices

### DIFF
--- a/api/pkg/services/deviceadm/service.go
+++ b/api/pkg/services/deviceadm/service.go
@@ -14,7 +14,6 @@ import (
 var ErrUnauthorized = errors.New("unauthorized")
 
 type Service interface {
-	CountDevices(ctx context.Context) (int64, error)
 	ListDevices(ctx context.Context, perPage, page int, filter string) ([]models.Device, int, error)
 	GetDevice(ctx context.Context, uid models.UID) (*models.Device, error)
 	DeleteDevice(ctx context.Context, uid models.UID, tenant string) error
@@ -29,10 +28,6 @@ type service struct {
 
 func NewService(store store.Store) Service {
 	return &service{store}
-}
-
-func (s *service) CountDevices(ctx context.Context) (int64, error) {
-	return s.store.CountDevices(ctx)
 }
 
 func (s *service) ListDevices(ctx context.Context, perPage, page int, filterB64 string) ([]models.Device, int, error) {

--- a/api/pkg/services/deviceadm/service.go
+++ b/api/pkg/services/deviceadm/service.go
@@ -55,7 +55,7 @@ func (s *service) GetDevice(ctx context.Context, uid models.UID) (*models.Device
 }
 
 func (s *service) DeleteDevice(ctx context.Context, uid models.UID, tenant string) error {
-	device, _ := s.store.GetDeviceByUid(ctx, uid, tenant)
+	device, _ := s.store.GetDeviceByUID(ctx, uid, tenant)
 	if device != nil {
 		return s.store.DeleteDevice(ctx, uid)
 	}
@@ -63,7 +63,7 @@ func (s *service) DeleteDevice(ctx context.Context, uid models.UID, tenant strin
 }
 
 func (s *service) RenameDevice(ctx context.Context, uid models.UID, name, tenant string) error {
-	device, _ := s.store.GetDeviceByUid(ctx, uid, tenant)
+	device, _ := s.store.GetDeviceByUID(ctx, uid, tenant)
 	validate := validator.New()
 	if device != nil {
 		if device.Name != name {

--- a/api/pkg/services/sessionmngr/service.go
+++ b/api/pkg/services/sessionmngr/service.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Service interface {
-	CountSessions(ctx context.Context) (int64, error)
 	ListSessions(ctx context.Context, perPage, page int) ([]models.Session, int, error)
 	GetSession(ctx context.Context, uid models.UID) (*models.Session, error)
 	CreateSession(ctx context.Context, session models.Session) (*models.Session, error)
@@ -22,10 +21,6 @@ type service struct {
 
 func NewService(store store.Store) Service {
 	return &service{store}
-}
-
-func (s *service) CountSessions(ctx context.Context) (int64, error) {
-	return s.store.CountSessions(ctx)
 }
 
 func (s *service) ListSessions(ctx context.Context, perPage, page int) ([]models.Session, int, error) {

--- a/api/pkg/store/mongo/store.go
+++ b/api/pkg/store/mongo/store.go
@@ -264,30 +264,6 @@ func (s *Store) UpdateDeviceStatus(ctx context.Context, uid models.UID, online b
 	return nil
 }
 
-func (s *Store) CountDevices(ctx context.Context) (int64, error) {
-	query := bson.M{}
-	if tenant := store.TenantFromContext(ctx); tenant != nil {
-		query = bson.M{
-			"tenant_id": tenant.ID,
-		}
-	}
-
-	count, err := s.db.Collection("devices").CountDocuments(ctx, query)
-	return count, err
-}
-
-func (s *Store) CountSessions(ctx context.Context) (int64, error) {
-	query := bson.M{}
-	if tenant := store.TenantFromContext(ctx); tenant != nil {
-		query = bson.M{
-			"tenant_id": tenant.ID,
-		}
-	}
-
-	count, err := s.db.Collection("sessions").CountDocuments(ctx, query)
-	return count, err
-}
-
 func (s *Store) ListSessions(ctx context.Context, perPage, page int) ([]models.Session, int, error) {
 	skip := perPage * (page - 1)
 	query := []bson.M{

--- a/api/pkg/store/mongo/store.go
+++ b/api/pkg/store/mongo/store.go
@@ -98,7 +98,7 @@ func (s *Store) ListDevices(ctx context.Context, perPage, page int, filters []mo
 		})
 	}
 
-	queryCount := append(query, bson.M{"$group": bson.M{"_id": bson.M{"uid": "$uid"}, "count": bson.M{"$sum": 1}}})
+	queryCount := append(query, bson.M{"$count": "count"})
 	count, err := aggregateCount(ctx, s.db.Collection("devices"), queryCount)
 	if err != nil {
 		return nil, 0, err
@@ -321,7 +321,7 @@ func (s *Store) ListSessions(ctx context.Context, perPage, page int) ([]models.S
 		})
 	}
 
-	queryCount := append(query, bson.M{"$group": bson.M{"_id": bson.M{"uid": "$uid"}, "count": bson.M{"$sum": 1}}})
+	queryCount := append(query, bson.M{"$count": "count"})
 	count, err := aggregateCount(ctx, s.db.Collection("sessions"), queryCount)
 	if err != nil {
 		return nil, 0, err

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -24,7 +24,5 @@ type Store interface {
 	GetUserByTenant(ctx context.Context, tenant string) (*models.User, error)
 	GetDeviceByMac(ctx context.Context, mac, tenant string) (*models.Device, error)
 	GetDeviceByName(ctx context.Context, name, tenant string) (*models.Device, error)
-	CountDevices(ctx context.Context) (int64, error)
-	CountSessions(ctx context.Context) (int64, error)
 	GetDeviceByUID(ctx context.Context, uid models.UID, tenant string) (*models.Device, error)
 }

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -26,5 +26,5 @@ type Store interface {
 	GetDeviceByName(ctx context.Context, name, tenant string) (*models.Device, error)
 	CountDevices(ctx context.Context) (int64, error)
 	CountSessions(ctx context.Context) (int64, error)
-	GetDeviceByUid(ctx context.Context, uid models.UID, tenant string) (*models.Device, error)
+	GetDeviceByUID(ctx context.Context, uid models.UID, tenant string) (*models.Device, error)
 }


### PR DESCRIPTION
2 fixes

the aggregateCount only needs "count" field to return the number of elements.
commit  71cd3441fc526f9dca4bf543536d2adc845d8b1e fixes the query

the linter changes the GetDeviceByUid to GetDeviceByUID 
in some parts of the code. 
commit b7bb36c5178132953f70d92577f63c45a2ae2339 fixes all the calls