### PR TITLE
ui: Redirection to dashboard with alert when non-existing route gets acessed

### DIFF
--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -44,6 +44,15 @@ const router = new Router({
       name: 'login',
       component: () =>
         import('./../views/Login.vue')
+    },
+    {
+      path: '*',
+      name: 'NotFound',
+      component: Dashboard,
+      redirect: () => {
+        localStorage.setItem('flag', true);
+        return '/';
+      }
     }
   ]
 });

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1,5 +1,12 @@
 <template>
   <fragment>
+    <v-alert
+      v-if="flag"
+      type="warning"
+      outlined
+    >
+      Sorry, we couldn't find the page you were looking for
+    </v-alert>
     <v-row>
       <v-col
         cols="12"
@@ -129,6 +136,12 @@ export default {
     DeviceAdd
   },
 
+  data(){
+    return {
+      flag: false
+    };
+  },
+
   computed: {
     stats() {
       return this.$store.getters['stats/stats'];
@@ -137,6 +150,12 @@ export default {
 
   created() {
     this.$store.dispatch('stats/get');
+  },
+
+  mounted() {
+    this.flag = localStorage.getItem('flag');
+    localStorage.removeItem('flag');
   }
 };
 </script>
+


### PR DESCRIPTION
A treatment for not found URLs was defined
by redirecting to homepage and displaying
a warning vuetify alert.