### PR TITLE
Minor fixes for cicd workflow

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,5 +1,5 @@
 name: 'Commit Message Check'
-on: [pull_request, push]
+on: [push]
 
 jobs:
   check-commit-message:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Check Commit Type
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[a-z]+: .+(?:\n(?:\n.+)+)?(?:\n\n.+)?$'
+          pattern: '^[a-z0-9,\s]+: .+(?:\n(?:\n.+)+)?(?:\n\n.+)?$'
           error: 'Your message must have the correct format "<scope>: <subject>" with an optional body and footer separated by blank lines.'
 
       - name: Check Title Capitalize


### PR DESCRIPTION
We reworked cicd workflow, especially the commit message one, to allow the use of numbers, spaces, and comma for commit scope as this happens often.

Another change was as a consequence of most PR being marked as failing, while this was not really the case. To fix, we restrict the workflow to the 'push' event only.
