### PR TITLE
agent: Improve logging when generating the private key

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -33,11 +33,14 @@ func NewAgent() (*Agent, error) {
 
 func (a *Agent) generatePrivateKey() error {
 	if _, err := os.Stat(a.opts.PrivateKey); os.IsNotExist(err) {
-		logrus.Info("Private key not found. Generating...")
+		logrus.Info("Generating private key prior start communication...")
+
 		err := keygen.GeneratePrivateKey(a.opts.PrivateKey)
 		if err != nil {
 			return err
 		}
+
+		logrus.Info("Private key generated successfully.")
 	}
 
 	return nil


### PR DESCRIPTION
The private key process now prints a log information when starting its
generation and when it is complete.

Refs: #184.
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>