### PR TITLE
api: firewall rules

### DIFF
--- a/api/pkg/services/firewall/service.go
+++ b/api/pkg/services/firewall/service.go
@@ -1,0 +1,108 @@
+package firewall
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/shellhub-io/shellhub/api/pkg/store"
+	"github.com/shellhub-io/shellhub/pkg/models"
+)
+
+type Service interface {
+	Evaluate(ctx context.Context, req Request) (bool, error)
+	CreateRule(ctx context.Context, rule *models.FirewallRule) error
+	ListRules(ctx context.Context, perPage, page int) ([]models.FirewallRule, int, error)
+	GetRule(ctx context.Context, id string) (*models.FirewallRule, error)
+	UpdateRule(ctx context.Context, id string, rule models.FirewallRuleUpdate) (*models.FirewallRule, error)
+	DeleteRule(ctx context.Context, id string) error
+}
+
+type Request struct {
+	Hostname  string
+	Namespace string
+	Username  string
+	IPAddress string
+}
+
+type service struct {
+	store store.Store
+}
+
+func NewService(store store.Store) Service {
+	return &service{store}
+}
+
+func (s *service) Evaluate(ctx context.Context, req Request) (bool, error) {
+	user, err := s.store.GetUserByUsername(ctx, req.Namespace)
+	if err != nil {
+		return false, err
+	}
+
+	ctx = context.WithValue(ctx, "tenant", user.TenantID)
+
+	rules, count, err := s.store.ListFirewallRules(ctx, -1, -1)
+	if err != nil {
+		return false, err
+	}
+
+	if count == 0 {
+		return true, nil
+	}
+
+	allow := true
+
+	for _, rule := range rules {
+		if !rule.Active {
+			continue
+		}
+
+		ok, err := regexp.MatchString(rule.SourceIP, req.IPAddress)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			continue
+		}
+
+		ok, _ = regexp.MatchString(rule.Username, req.Username)
+		if err != nil {
+			return false, err
+
+		}
+		if !ok {
+			continue
+		}
+
+		ok, err = regexp.MatchString(rule.Hostname, req.Hostname)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			continue
+		}
+
+		allow = rule.Action == "allow"
+	}
+
+	return allow, nil
+}
+
+func (s *service) CreateRule(ctx context.Context, rule *models.FirewallRule) error {
+	return s.store.CreateFirewallRule(ctx, rule)
+}
+
+func (s *service) ListRules(ctx context.Context, perPage, page int) ([]models.FirewallRule, int, error) {
+	return s.store.ListFirewallRules(ctx, perPage, page)
+}
+
+func (s *service) GetRule(ctx context.Context, id string) (*models.FirewallRule, error) {
+	return s.store.GetFirewallRule(ctx, id)
+}
+
+func (s *service) UpdateRule(ctx context.Context, id string, rule models.FirewallRuleUpdate) (*models.FirewallRule, error) {
+	return s.store.UpdateFirewallRule(ctx, id, rule)
+}
+
+func (s *service) DeleteRule(ctx context.Context, id string) error {
+	return s.store.DeleteFirewallRule(ctx, id)
+}

--- a/api/pkg/store/mongo/store.go
+++ b/api/pkg/store/mongo/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shellhub-io/shellhub/api/pkg/store"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -560,6 +561,97 @@ func (s *Store) GetDeviceByUID(ctx context.Context, uid models.UID, tenant strin
 	return device, nil
 }
 
+func (s *Store) CreateFirewallRule(ctx context.Context, rule *models.FirewallRule) error {
+	if err := rule.Validate(); err != nil {
+		return err
+	}
+
+	rule.ID = primitive.NewObjectID().Hex()
+
+	if _, err := s.db.Collection("firewall_rules").InsertOne(ctx, &rule); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) ListFirewallRules(ctx context.Context, perPage, page int) ([]models.FirewallRule, int, error) {
+	skip := perPage * (page - 1)
+	query := []bson.M{
+		{
+			"$sort": bson.M{
+				"priority": 1,
+			},
+		},
+	}
+
+	// Only match for the respective tenant if requested
+	if tenant := store.TenantFromContext(ctx); tenant != nil {
+		query = append(query, bson.M{
+			"$match": bson.M{
+				"tenant_id": tenant.ID,
+			},
+		})
+	}
+
+	queryCount := append(query, bson.M{"$count": "count"})
+	count, err := aggregateCount(ctx, s.db.Collection("firewall_rules"), queryCount)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	query = append(query, buildPaginationQuery(skip, perPage)...)
+
+	rules := make([]models.FirewallRule, 0)
+	cursor, err := s.db.Collection("firewall_rules").Aggregate(ctx, query)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer cursor.Close(ctx)
+
+	for cursor.Next(ctx) {
+		rule := new(models.FirewallRule)
+		err = cursor.Decode(&rule)
+		if err != nil {
+			return rules, count, err
+		}
+
+		rules = append(rules, *rule)
+	}
+
+	return rules, count, err
+}
+
+func (s *Store) GetFirewallRule(ctx context.Context, id string) (*models.FirewallRule, error) {
+	rule := new(models.FirewallRule)
+	if err := s.db.Collection("firewall_rules").FindOne(ctx, bson.M{"_id": id}).Decode(&rule); err != nil {
+		return nil, err
+	}
+
+	return rule, nil
+}
+
+func (s *Store) UpdateFirewallRule(ctx context.Context, id string, rule models.FirewallRuleUpdate) (*models.FirewallRule, error) {
+	if err := rule.Validate(); err != nil {
+		return nil, err
+	}
+
+	if _, err := s.db.Collection("firewall_rules").UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": rule}); err != nil {
+		return nil, err
+	}
+
+	r, err := s.GetFirewallRule(ctx, id)
+	return r, err
+}
+
+func (s *Store) DeleteFirewallRule(ctx context.Context, id string) error {
+	if _, err := s.db.Collection("firewall_rules").DeleteOne(ctx, bson.M{"_id": id}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func buildFilterQuery(filters []models.Filter) ([]bson.M, error) {
 	var queryMatch []bson.M
 	var queryFilter []bson.M
@@ -618,6 +710,10 @@ func buildFilterQuery(filters []models.Filter) ([]bson.M, error) {
 }
 
 func buildPaginationQuery(skip, perPage int) []bson.M {
+	if perPage == -1 {
+		return nil
+	}
+
 	return []bson.M{
 		bson.M{"$skip": skip},
 		bson.M{"$limit": perPage},

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -25,4 +25,9 @@ type Store interface {
 	GetDeviceByMac(ctx context.Context, mac, tenant string) (*models.Device, error)
 	GetDeviceByName(ctx context.Context, name, tenant string) (*models.Device, error)
 	GetDeviceByUID(ctx context.Context, uid models.UID, tenant string) (*models.Device, error)
+	CreateFirewallRule(ctx context.Context, rule *models.FirewallRule) error
+	ListFirewallRules(ctx context.Context, perPage, page int) ([]models.FirewallRule, int, error)
+	GetFirewallRule(ctx context.Context, id string) (*models.FirewallRule, error)
+	UpdateFirewallRule(ctx context.Context, id string, rule models.FirewallRuleUpdate) (*models.FirewallRule, error)
+	DeleteFirewallRule(ctx context.Context, id string) error
 }

--- a/pkg/models/firewall.go
+++ b/pkg/models/firewall.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"regexp"
+
+	"gopkg.in/go-playground/validator.v9"
+)
+
+type FirewallRuleFields struct {
+	Priority int    `json:"priority"`
+	Action   string `json:"action" validate:"required,oneof=allow deny"`
+	Active   bool   `json:"active"`
+	SourceIP string `json:"source_ip" bson:"source_ip" validate:"required,regexp"`
+	Username string `json:"username" validate:"required,regexp"`
+	Hostname string `json:"hostname" validate:"required,regexp"`
+}
+
+func (f *FirewallRuleFields) Validate() error {
+	v := validator.New()
+
+	_ = v.RegisterValidation("regexp", func(fl validator.FieldLevel) bool {
+		_, err := regexp.Compile(fl.Field().String())
+		return err == nil
+	})
+
+	return v.Struct(f)
+}
+
+type FirewallRule struct {
+	ID                 string `json:"id" bson:"_id"`
+	TenantID           string `json:"tenant_id" bson:"tenant_id"`
+	FirewallRuleFields `bson:",inline"`
+}
+
+type FirewallRuleUpdate struct {
+	FirewallRuleFields `bson:",inline"`
+}

--- a/ssh/go.mod
+++ b/ssh/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/elazarl/goproxy v0.0.0-20200426045556-49ad98f6dac1 // indirect
 	github.com/gliderlabs/ssh v0.3.0
+	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/pires/go-proxyproto v0.1.3
 	github.com/pkg/errors v0.9.1 // indirect
@@ -19,6 +21,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 	golang.org/x/sys v0.0.0-20200610111108-226ff32320da // indirect
+	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 )
 

--- a/ssh/go.sum
+++ b/ssh/go.sum
@@ -1,5 +1,6 @@
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
@@ -10,6 +11,10 @@ github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy0
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/gliderlabs/ssh v0.3.0 h1:7GcKy4erEljCE/QeQ2jTVpu+3f3zkpZOxOJjFYkMqYU=
 github.com/gliderlabs/ssh v0.3.0/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
+github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
+github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
@@ -26,6 +31,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
+github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/parnurzeal/gorequest v0.2.16 h1:T/5x+/4BT+nj+3eSknXmCTnEVGSzFzPGdpqmUVVZXHQ=
 github.com/parnurzeal/gorequest v0.2.16/go.mod h1:3Kh2QUMJoqw3icWAecsyzkpY7UzRfDhbRdTjtNwNiUE=
 github.com/pires/go-proxyproto v0.1.3 h1:2XEuhsQluSNA5QIQkiUv8PfgZ51sNYIQkq/yFquiSQM=
@@ -41,8 +48,10 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -60,6 +69,12 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200610111108-226ff32320da h1:bGb80FudwxpeucJUjPYJXuJ8Hk91vNtfvrymzwiei38=
 golang.org/x/sys v0.0.0-20200610111108-226ff32320da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
+gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 moul.io/http2curl v1.0.0 h1:6XwpyZOYsgZJrU8exnG87ncVkU1FVCcTRpwzOkTDUi8=
 moul.io/http2curl v1.0.0/go.mod h1:f6cULg+e4Md/oW1cYmwW4IWQOVl2lGbmCNGOHvzX2kE=


### PR DESCRIPTION
This commits implements a flexible firewall for filtering SSH connections.
It gives a fine-grained control over which SSH connections reach the devices.
    
The firewall rules can deny/allow SSH connections from specific IP address
to a specific or a group of devices using a given username.
    
Each firewall rule has a priority number which is evaluated in ascending order
(starting with the lowest). It's makes a lot easier to manage a large number
of firewall rules.