### PR TITLE
ui: Update lists in pagination

### DIFF
--- a/ui/src/components/device/DeviceDelete.vue
+++ b/ui/src/components/device/DeviceDelete.vue
@@ -73,9 +73,11 @@ export default {
   methods: {
     async remove() {
       await this.$store.dispatch('devices/remove', this.uid);
+      this.dialog = !this.dialog;
       if (this.redirect) {
         this.$router.push('/devices');
       }
+      this.$emit('update');
     },
   },
 };

--- a/ui/src/components/device/DeviceList.vue
+++ b/ui/src/components/device/DeviceList.vue
@@ -108,6 +108,7 @@
 
             <DeviceDelete
               :uid="item.uid"
+              @update="refresh"
             />
           </template>
         </v-data-table>
@@ -228,6 +229,10 @@ export default {
 
     showCopySnack() {
       this.copySnack = true;
+    },
+
+    refresh() {
+      this.getDevices();
     },
 
     save(item) {

--- a/ui/src/components/session/SessionClose.vue
+++ b/ui/src/components/session/SessionClose.vue
@@ -70,6 +70,7 @@ export default {
     async close() {
       await this.$store.dispatch('sessions/close', this.session);
       this.dialog = false;
+      this.$emit('update');
     },
   },
 };

--- a/ui/src/components/session/SessionList.vue
+++ b/ui/src/components/session/SessionList.vue
@@ -128,6 +128,7 @@
             <SessionClose
               v-if="item.active"
               :session="item"
+              @update="refresh"
             />
           </template>
         </v-data-table>
@@ -207,11 +208,8 @@ export default {
 
   watch: {
     pagination: {
-      async handler() {
-        const data = { perPage: this.pagination.itemsPerPage, page: this.pagination.page };
-        await this.$store.dispatch('sessions/fetch', data);
-        this.listSessions = this.$store.getters['sessions/list'];
-        this.numberSessions = this.$store.getters['sessions/getNumberSessions'];
+      handler() {
+        this.getSessions();
       },
       deep: true,
     },
@@ -220,6 +218,17 @@ export default {
   methods: {
     detailsSession(session) {
       this.$router.push(`/session/${session.uid}`);
+    },
+
+    refresh() {
+      this.getSessions();
+    },
+
+    async getSessions() {
+      const data = { perPage: this.pagination.itemsPerPage, page: this.pagination.page };
+      await this.$store.dispatch('sessions/fetch', data);
+      this.listSessions = this.$store.getters['sessions/list'];
+      this.numberSessions = this.$store.getters['sessions/getNumberSessions'];
     },
   },
 };

--- a/ui/src/modules/devices.js
+++ b/ui/src/modules/devices.js
@@ -46,7 +46,6 @@ export default {
 
     remove: async (context, uid) => {
       await apiDevice.removeDevice(uid);
-      context.commit('removeDevice', uid);
     },
 
     rename: async (context, data) => {


### PR DESCRIPTION
The lists of sessions and devices are now automatically
updated through an event handler, without the need to refresh page
to see them.
This closes #189 and closes #190.