### PR TITLE
ui: fix problem when user edit fields in firewallrules

### DIFF
--- a/ui/src/components/firewall_rules/FirewallRulesFormDialog.vue
+++ b/ui/src/components/firewall_rules/FirewallRulesFormDialog.vue
@@ -215,21 +215,29 @@ export default {
   },
 
   async created() {
-    if (this.createRule) {
-      this.ruleFirewallLocal = {
-        active: false,
-        priority: '',
-        action: '',
-        source_ip: '',
-        username: '',
-        hostname: '',
-      };
-    } else {
-      this.ruleFirewallLocal = await { ...this.firewallRule };
-    }
+    await this.setLocalVariable();
+  },
+
+  async updated() {
+    await this.setLocalVariable();
   },
 
   methods: {
+    setLocalVariable() {
+      if (this.createRule) {
+        this.ruleFirewallLocal = {
+          active: false,
+          priority: '',
+          action: '',
+          source_ip: '',
+          username: '',
+          hostname: '',
+        };
+      } else {
+        this.ruleFirewallLocal = { ...this.firewallRule };
+      }
+    },
+
     async create() {
       await this.$store.dispatch('firewallrules/post', this.ruleFirewallLocal);
       this.update();
@@ -246,9 +254,6 @@ export default {
     },
 
     close() {
-      requestAnimationFrame(() => {
-        this.$refs.obs.reset();
-      });
       this.dialog = !this.dialog;
     },
   },


### PR DESCRIPTION
The user edits the rule, but does not save changes and closes the dialog.
When you open the dialog box again, the values ​​are the same as the change and
are not this data is saved in the list. Resolves this issue.