### PR TITLE
ui: Add port number to device registration command

### DIFF
--- a/ui/src/components/device/DeviceAdd.vue
+++ b/ui/src/components/device/DeviceAdd.vue
@@ -73,6 +73,7 @@ export default {
   data() {
     return {
       hostname: window.location.hostname,
+      port: window.location.port,
       copySnack: false,
     };
   },
@@ -95,7 +96,10 @@ export default {
 
   methods: {
     command() {
-      return `curl "${window.location.protocol}//${this.hostname}/install.sh?tenant_id=${this.tenant}" | sh`;
+      let port = '';
+      if (window.location.port !== '') port = `:${this.port}`;
+
+      return `curl "${window.location.protocol}//${this.hostname}${port}/install.sh?tenant_id=${this.tenant}" | sh`;
     },
 
     copyCommand() {


### PR DESCRIPTION
Check the port on which the server is running Shellhub and set the port on the
command when the server is running on a different port 80(HTTP) and 443(HTTPS).

This closes #222.