### PR TITLE
api, ssh: Fix 'revive' warnings on new code of 0.4.0

### DIFF
--- a/api/deviceadm/service_test.go
+++ b/api/deviceadm/service_test.go
@@ -29,10 +29,10 @@ func TestListDevices(t *testing.T) {
 			Params: &models.PropertyParams{Name: "hostname", Operator: "eq"}},
 	}
 
-	filterJson, err := json.Marshal(filters)
+	filterJSON, err := json.Marshal(filters)
 	assert.NoError(t, err)
 
-	encodedFilter := base64.StdEncoding.EncodeToString(filterJson)
+	encodedFilter := base64.StdEncoding.EncodeToString(filterJSON)
 
 	query := paginator.Query{Page: 1, PerPage: 10}
 

--- a/api/sessionmngr/service.go
+++ b/api/sessionmngr/service.go
@@ -45,13 +45,11 @@ func (s *service) DeactivateSession(ctx context.Context, uid models.UID) error {
 func (s *service) SetSessionAuthenticated(ctx context.Context, uid models.UID, authenticated bool) error {
 	return s.store.SetSessionAuthenticated(ctx, uid, authenticated)
 }
+
 func (s *service) RecordSession(ctx context.Context, uid models.UID, recordString string, width, height int) error {
-	if err := s.store.RecordSession(ctx, uid, recordString, width, height); err != nil {
-		return err
-	}
-	return nil
+	 return s.store.RecordSession(ctx, uid, recordString, width, height)
 }
+
 func (s *service) GetRecord(ctx context.Context, uid models.UID) ([]models.RecordedSession, int, error) {
 	return s.store.GetRecord(ctx, uid)
-
 }

--- a/api/sessionmngr/service_test.go
+++ b/api/sessionmngr/service_test.go
@@ -129,5 +129,4 @@ func TestGetRecord(t *testing.T) {
 	assert.Equal(t, len(recordedSession), count)
 
 	mock.AssertExpectations(t)
-
 }


### PR DESCRIPTION
This has no semantic changes. All trivial lints fixes.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>