### PR TITLE
ui: Set default state to firewall rule active

### DIFF
--- a/ui/src/components/firewall_rules/FirewallRulesFormDialog.vue
+++ b/ui/src/components/firewall_rules/FirewallRulesFormDialog.vue
@@ -226,7 +226,7 @@ export default {
     setLocalVariable() {
       if (this.createRule) {
         this.ruleFirewallLocal = {
-          active: false,
+          active: true,
           priority: '',
           action: '',
           source_ip: '',


### PR DESCRIPTION
Fixes the creation of a new firewall rule
to active state.
This closes #235.