### PR TITLE
agent: Use NegotiateAPIVersion for docker client

### DIFF
--- a/agent/selfupdater/updater_docker.go
+++ b/agent/selfupdater/updater_docker.go
@@ -178,6 +178,8 @@ func NewUpdater(_ string) (Updater, error) {
 		return nil, err
 	}
 
+	api.NegotiateAPIVersion(context.Background())
+
 	return &dockerUpdater{api: api}, nil
 }
 


### PR DESCRIPTION
WithAPIVersionNegotiation makes the Docker client negotiate down to a lower
version if Docker's current API version is newer than the server version.