### PR TITLE
Custom keepalive interval

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -28,9 +28,10 @@ import (
 var AgentVersion string
 
 type ConfigOptions struct {
-	ServerAddress string `envconfig:"server_address"`
-	PrivateKey    string `envconfig:"private_key"`
-	TenantID      string `envconfig:"tenant_id"`
+	ServerAddress     string `envconfig:"server_address"`
+	PrivateKey        string `envconfig:"private_key"`
+	TenantID          string `envconfig:"tenant_id"`
+	KeepAliveInterval int    `envconfig:"keepalive_interval" default:"30"`
 }
 
 type Information struct {
@@ -112,7 +113,7 @@ func main() {
 		return
 	}
 
-	server := sshd.NewSSHServer(opts.PrivateKey)
+	server := sshd.NewSSHServer(opts.PrivateKey, opts.KeepAliveInterval)
 
 	router := mux.NewRouter()
 	router.HandleFunc("/ssh/{id}", func(w http.ResponseWriter, r *http.Request) {
@@ -171,7 +172,7 @@ func main() {
 		}()
 	}
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(time.Duration(opts.KeepAliveInterval) * time.Second)
 
 	for range ticker.C {
 		sessions := make([]string, 0, len(server.Sessions))

--- a/gateway/install.sh
+++ b/gateway/install.sh
@@ -32,4 +32,7 @@ $SUDO docker run -d \
        -e SERVER_ADDRESS={{scheme}}://{{host}} \
        -e PRIVATE_KEY=/host/etc/shellhub.key \
        -e TENANT_ID={{tenant_id}} \
+       {% if keepalive_interval ~= '' and keepalive_interval ~= nil then %}
+       -e KEEPALIVE_INTERVAL={{keepalive_interval}} \
+       {% end %}
        shellhubio/agent:{{version}}

--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -154,6 +154,7 @@ server {
             local host=ngx.var.http_host
             local scheme = ngx.var.http_x_forwarded_proto ~= '' and ngx.var.http_x_forwarded_proto or ngx.var.scheme
             local tenant_id=ngx.var.arg_tenant_id
+            local keepalive_interval=ngx.var.arg_keepalive_interval
             local version=os.getenv("SHELLHUB_VERSION")
 
             local template = require "resty.template"
@@ -161,6 +162,7 @@ server {
 	        scheme = scheme,
 		host = host,
 		tenant_id = tenant_id,
+		keepalive_interval = keepalive_interval,
 		version = version
 	    })
         }


### PR DESCRIPTION
To set a custom keepalive interval just append `keepalive_interval` param (value in seconds) to the install script, e.g.

`http://localhost/install.sh?tenant_id=xxx-xxxx....&keepalive_interval=60`

This closes #215