### PR TITLE
cicd: build-agent: Fix Docker manifest variant for ARMv6

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -86,7 +86,7 @@ jobs:
 
             archname=(arm32v6 arm32v7 arm64v8)
             arch=(arm arm arm64)
-            variant=(6 7 8)
+            variant=(v6l v7l v8)
 
             for ((i = 0; i < 3; i++))  ; do
               echo "Running ${archname[i]} manifest annotation"
@@ -109,7 +109,7 @@ jobs:
 
             archname=(arm32v6 arm32v7 arm64v8)
             arch=(arm arm arm64)
-            variant=(6 7 8)
+            variant=(v6l v7l v8)
 
             for ((i = 0; i < 3; i++))  ; do
               echo "Running ${archname[i]} manifest annotation"

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -7,11 +7,13 @@ on:
       - v*
     paths:
     - 'agent/**'
+    - '.github/workflows/build-agent.yml'
 
   pull_request:
     branches: [ master ]
     paths:
     - 'agent/**'
+    - '.github/workflows/build-agent.yml'
 
 jobs:
   build:


### PR DESCRIPTION
We need to use adjust the variant for Docker manifest proper use. This
can be seen at:

https://github.com/moby/moby/issues/34875#issuecomment-602140402

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>