### PR TITLE
ui: Add possibility to register messages specific in snackbar

### DIFF
--- a/ui/src/components/snackbar/Snackbar.vue
+++ b/ui/src/components/snackbar/Snackbar.vue
@@ -1,7 +1,11 @@
 <template>
   <fragment>
-    <snackbarSuccess />
-    <snackbarError />
+    <snackbarSuccess
+      :type-message="typeMessage"
+    />
+    <snackbarError
+      :type-message="typeMessage"
+    />
   </fragment>
 </template>
 
@@ -17,6 +21,15 @@ export default {
     snackbarSuccess,
     snackbarError,
   },
+
+  props: {
+    typeMessage: {
+      type: String,
+      default: 'default',
+      validator: (value) => ['default'].includes(value),
+    },
+  },
+
 };
 
 </script>

--- a/ui/src/components/snackbar/SnackbarError.vue
+++ b/ui/src/components/snackbar/SnackbarError.vue
@@ -8,7 +8,7 @@
       outlined
       text
     >
-      The request has failed, please try again.
+      {{ message[typeMessage] }}
     </v-snackbar>
   </fragment>
 </template>
@@ -17,6 +17,21 @@
 
 export default {
   name: 'SnackbarError',
+
+  props: {
+    typeMessage: {
+      type: String,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      message: {
+        default: 'The request has failed, please try again.',
+      },
+    };
+  },
 
   computed: {
     snackbar: {

--- a/ui/src/components/snackbar/SnackbarSuccess.vue
+++ b/ui/src/components/snackbar/SnackbarSuccess.vue
@@ -8,7 +8,7 @@
       outlined
       text
     >
-      The request has succeeded.
+      {{ message[typeMessage] }}
     </v-snackbar>
   </fragment>
 </template>
@@ -17,6 +17,21 @@
 
 export default {
   name: 'SnackbarSuccess',
+
+  props: {
+    typeMessage: {
+      type: String,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      message: {
+        default: 'The request has succeeded.',
+      },
+    };
+  },
 
   computed: {
     snackbar: {


### PR DESCRIPTION
If not send type message in props, the component has default type.
However, you can send the type message and register new message
in components.