### PR TITLE
ui: Fix the problem with token expiration

### DIFF
--- a/ui/src/store/helpers/http.js
+++ b/ui/src/store/helpers/http.js
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+import router from '@/router/index';
 import store from '..';
 
 export default () => {
@@ -11,9 +12,10 @@ export default () => {
 
   axios.interceptors.response.use(
     (response) => response,
-    (error) => {
+    async (error) => {
       if (error.response.status === 401) {
-        store.dispatch('auth/logout');
+        await store.dispatch('auth/logout');
+        await router.push({ name: 'login' });
       }
       throw error;
     },


### PR DESCRIPTION
This resolve problem when token expired and not redirect to login in
first moment. Use the await in router, because without watch the
redundancy redirect with login.