### PR TITLE
agent: Extend logging during connection handling

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -117,6 +117,17 @@ func main() {
 
 	server := sshd.NewSSHServer(opts.PrivateKey, opts.KeepAliveInterval)
 
+	servername := strings.Split(info.Endpoints.SSH, ":")[0]
+
+	logrus.WithFields(logrus.Fields{
+		"server": servername,
+		"namespace": auth.Namespace,
+		"device": auth.Name,
+		"http_port": strings.Split(info.Endpoints.SSH, ":")[1],
+		"ssh_port": strings.Split(info.Endpoints.SSH, ":")[2],
+		"sshid": auth.Namespace + "." + auth.Name + "@" + servername,
+		}).Info("Server connection established")
+
 	router := mux.NewRouter()
 	router.HandleFunc("/ssh/{id}", func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)

--- a/agent/sshd/sshserver.go
+++ b/agent/sshd/sshserver.go
@@ -119,6 +119,13 @@ func (s *SSHServer) sessionHandler(session sshserver.Session) {
 
 		os.Chown(pts.Name(), uid, -1)
 
+		logrus.WithFields(logrus.Fields{
+			"user": session.User(),
+			"pty": pts.Name(),
+			"remoteaddr": session.RemoteAddr().String(),
+			"localaddr": session.LocalAddr().String(),
+			}).Info("Session started")
+
 		s.mu.Lock()
 		s.cmds[session.Context().Value(sshserver.ContextKeySessionID).(string)] = scmd
 		s.mu.Unlock()
@@ -126,12 +133,26 @@ func (s *SSHServer) sessionHandler(session sshserver.Session) {
 		if err := scmd.Wait(); err != nil {
 			logrus.Warn(err)
 		}
+
+		logrus.WithFields(logrus.Fields{
+			"user": session.User(),
+			"pty": pts.Name(),
+			"remoteaddr": session.RemoteAddr().String(),
+			"localaddr": session.LocalAddr().String(),
+			}).Info("Session ended")
 	} else {
 		u := osauth.LookupUser(session.User())
 		cmd := newCmd(u, "", "", s.deviceName, session.Command()...)
 
 		stdout, _ := cmd.StdoutPipe()
 		stdin, _ := cmd.StdinPipe()
+
+		logrus.WithFields(logrus.Fields{
+			"user": session.User(),
+			"remoteaddr": session.RemoteAddr().String(),
+			"localaddr": session.LocalAddr().String(),
+			"Raw command": session.RawCommand(),
+			}).Info("Command started")
 
 		cmd.Start()
 
@@ -148,6 +169,13 @@ func (s *SSHServer) sessionHandler(session sshserver.Session) {
 		}()
 
 		cmd.Wait()
+         
+		logrus.WithFields(logrus.Fields{
+			"user": session.User(),
+			"remoteaddr": session.RemoteAddr().String(),
+			"localaddr": session.LocalAddr().String(),
+			"Raw command": session.RawCommand(),
+			}).Info("Command ended")
 	}
 }
 

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/parnurzeal/gorequest"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -27,7 +28,7 @@ func NewClient(opts ...Opt) Client {
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient = &http.Client{}
 	retryClient.RetryMax = math.MaxInt32
-	retryClient.Logger = nil
+	retryClient.Logger = logrus.New()
 	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		if _, ok := err.(net.Error); ok {
 			return true, nil


### PR DESCRIPTION
These changes introduce additional loggging into the Shellhub
agent, to improve diagnostics and to provide an audit trail of
inbound connections:

1.  A "connection established" mesage is written to the log when the agent
    has successfully established a connection with the server. An example
    of this message is:

    time="2020-08-21T15:18:51Z" level=info msg="Server connection
    established" device=atom http_port=443 namespace=sixhills
    sshid=sixhills.atom@cloud.shellhub.io ssh_port=22
    server=cloud.shellhub.io

2.  Logging is switched on within the http client, so that failures to connect
    to the server are logged. This includes failures resultng from name
    resolution failures, server refusing the connection and general network
    errors. If the agent fails to connect to the server, retries are logged
    during the exponential backoff process. Examples of these messages are
    (line breaks inserted for readability):

    time="2020-08-21T15:29:28Z" level=info
    msg="[ERR] GET http://xyxyxy.shellhub.io:80/info request failed:
         Get http://xyxyxy.shellhub.io:80/info: dial tcp:
         lookup xyxyxy.shellhub.io on 192.168.11.111:53: no such host"

    time="2020-08-21T15:29:28Z" level=info
     msg="[DEBUG] GET http://xyxyxy.shellhub.io:80/info:
          retrying in 8s (2147483644 left)"

3.  The start and end of inbound ssh shell sessions is logged.  Examples are:

    time="2020-08-21T15:35:52Z" level=info msg="Session started"
    localaddr="192.168.11.141:59416" pty=/dev/pts/0
    remoteaddr="157.230.203.130:443" user=pi

    time="2020-08-21T15:36:04Z" level=info msg="Session ended"
    localaddr="192.168.11.141:59416" pty=/dev/pts/0
    remoteaddr="157.230.203.130:443" user=pi

4.  The start and end of ssh ccommand sessions is logged.  Examples are:

    time="2020-08-21T15:39:02Z" level=info msg="Command started"
    Raw command="sleep 10" localaddr="192.168.11.141:59564"
    remoteaddr="157.230.203.130:443" user=pi

    time="2020-08-21T15:39:12Z" level=info msg="Command ended"
    Raw command="sleep 10" localaddr="192.168.11.141:59564"
    remoteaddr="157.230.203.130:443" user=pi

Fixes: #298.