### PR TITLE
ui: Move v-if hidden in the call component to internal component

### DIFF
--- a/ui/src/components/session/SessionList.vue
+++ b/ui/src/components/session/SessionList.vue
@@ -132,7 +132,6 @@
               @update="refresh"
             />
             <SessionPlay
-              v-if="hidden()"
               :recorded="item.authenticated && item.recorded"
               :uid="item.uid"
             />
@@ -242,10 +241,6 @@ export default {
       } catch {
         this.$store.dispatch('modals/showSnackbarError', true);
       }
-    },
-
-    hidden() {
-      return this.$env.isHosted;
     },
   },
 };

--- a/ui/src/components/session/SessionPlay.vue
+++ b/ui/src/components/session/SessionPlay.vue
@@ -1,5 +1,7 @@
 <template>
-  <fragment>
+  <fragment
+    v-if="hidden()"
+  >
     <v-tooltip bottom>
       <template v-slot:activator="{ on }">
         <v-icon
@@ -358,6 +360,10 @@ export default {
         this.iterativePrinting = setTimeout(this.print.bind(null, i + 1, logsArray),
           interval * (1 / this.defaultSpeed));
       }
+    },
+
+    hidden() {
+      return this.$env.isHosted;
     },
   },
 };

--- a/ui/tests/unit/components/session/SessionPlay.spec.js
+++ b/ui/tests/unit/components/session/SessionPlay.spec.js
@@ -30,6 +30,9 @@ describe('SessionPlay', () => {
       localVue,
       stubs: ['fragment'],
       propsData: { uid, recorded },
+      mocks: {
+        $env: (isHosted) => isHosted,
+      },
     });
   });
 


### PR DESCRIPTION
This modification is better in another way, because when using the
sessionPlay component it's not necessary to put the if in the
instance.