### PR TITLE
agent: Don't set ctty fd

### DIFF
--- a/agent/sshd/pty.go
+++ b/agent/sshd/pty.go
@@ -34,7 +34,6 @@ func openPty(c *exec.Cmd) (*os.File, *os.File, error) {
 
 	c.SysProcAttr.Setsid = true
 	c.SysProcAttr.Setctty = true
-	c.SysProcAttr.Ctty = int(tty.Fd())
 
 	if err := c.Start(); err != nil {
 		_ = ptmx.Close()


### PR DESCRIPTION
`Ctty` in `SysProcAttr` should be set to a fd in a child process, but we were setting it to a fd in the parent process.
This was working by accident, but now a panic is raised by `os/exec`.

See: https://github.com/golang/go/issues/29458