### PR TITLE
docker-compose: rename nginx service to autossl

### DIFF
--- a/docker-compose.autossl.yml
+++ b/docker-compose.autossl.yml
@@ -1,9 +1,13 @@
 version: '3.7'
 
 services:
-  nginx:
+  autossl:
     image: valian/docker-nginx-auto-ssl:1.2.0
     restart: on-failure
+    depends_on:
+      - gateway
+    links:
+      - gateway
     ports:
       - 80:80
       - 443:443

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -80,6 +80,10 @@ services:
   mongo:
     networks:
       - shellhub
+  autossl:
+    image: tianon/true
+    networks:
+      - shellhub
 
 networks:
   shellhub:


### PR DESCRIPTION
Also set a nop image for autossl service in development environment when autossl is disabled