### PR TITLE
ui: Move snackbarCopy to global and refactor where it is call in code

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -95,7 +95,9 @@
                   </span>
                   <v-icon
                     v-clipboard="tenant"
-                    v-clipboard:success="() => { copySnack = true; }"
+                    v-clipboard:success="() => {
+                      this.$store.dispatch('modals/showSnackbarCopy', this.$copy.tenantId);
+                    }"
                     right
                   >
                     mdi-content-copy
@@ -127,12 +129,6 @@
       >
         <router-view :key="$route.fullPath" />
       </v-container>
-      <v-snackbar
-        v-model="copySnack"
-        :timeout="3000"
-      >
-        Tenant ID copied to clipboard
-      </v-snackbar>
 
       <snackbar />
     </v-main>
@@ -154,7 +150,6 @@ export default {
     return {
       drawer: true,
       clipped: false,
-      copySnack: false,
       items: [
         {
           icon: 'dashboard',

--- a/ui/src/components/device/Device.vue
+++ b/ui/src/components/device/Device.vue
@@ -56,13 +56,6 @@
       <v-divider />
 
       <router-view />
-
-      <v-snackbar
-        v-model="copySnack"
-        :timeout="3000"
-      >
-        Device SSHID copied to clipboard
-      </v-snackbar>
     </v-card>
   </fragment>
 </template>
@@ -80,7 +73,6 @@ export default {
 
   data() {
     return {
-      copySnack: false,
       search: '',
     };
   },
@@ -148,10 +140,6 @@ export default {
         status: formatedStatus,
         statusString: ascOrDesc,
       };
-    },
-
-    showCopySnack() {
-      this.copySnack = true;
     },
   },
 };

--- a/ui/src/components/device/DeviceAdd.vue
+++ b/ui/src/components/device/DeviceAdd.vue
@@ -55,13 +55,6 @@
           Close
         </v-btn>
       </v-card-actions>
-
-      <v-snackbar
-        v-model="copySnack"
-        :timeout="3000"
-      >
-        Command copied to clipboard
-      </v-snackbar>
     </v-card>
   </v-dialog>
 </template>
@@ -75,7 +68,6 @@ export default {
     return {
       hostname: window.location.hostname,
       port: window.location.port,
-      copySnack: false,
     };
   },
 
@@ -105,7 +97,7 @@ export default {
 
     copyCommand() {
       this.$clipboard(this.command());
-      this.copySnack = true;
+      this.$store.dispatch('modals/showSnackbarCopy', this.$copy.command);
     },
   },
 };

--- a/ui/src/components/device/DeviceList.vue
+++ b/ui/src/components/device/DeviceList.vue
@@ -43,7 +43,8 @@
 
         <template v-slot:item.namespace="{ item }">
           <v-chip class="list-itens">
-            {{ address(item) }}<v-icon
+            {{ address(item) }}
+            <v-icon
               v-clipboard="() => address(item)"
               v-clipboard:success="showCopySnack"
               small
@@ -81,12 +82,6 @@
         </template>
       </v-data-table>
     </v-card-text>
-    <v-snackbar
-      v-model="copySnack"
-      :timeout="3000"
-    >
-      Device SSHID copied to clipboard
-    </v-snackbar>
   </fragment>
 </template>
 <script>
@@ -111,7 +106,6 @@ export default {
     return {
       hostname: window.location.hostname,
       pagination: {},
-      copySnack: false,
       headers: [
         {
           text: 'Online',
@@ -199,7 +193,7 @@ export default {
     },
 
     showCopySnack() {
-      this.copySnack = true;
+      this.$store.dispatch('modals/showSnackbarCopy', this.$copy.deviceSSHID);
     },
 
     refresh() {

--- a/ui/src/components/device/DevicePendingList.vue
+++ b/ui/src/components/device/DevicePendingList.vue
@@ -66,7 +66,6 @@ export default {
   data() {
     return {
       pagination: {},
-      copySnack: false,
       headers: [
         {
           text: 'Hostname',

--- a/ui/src/components/device/DeviceRejectedList.vue
+++ b/ui/src/components/device/DeviceRejectedList.vue
@@ -66,8 +66,6 @@ export default {
   data() {
     return {
       pagination: {},
-      copySnack: false,
-      editName: '',
       headers: [
         {
           text: 'Hostname',

--- a/ui/src/components/session/SessionDetails.vue
+++ b/ui/src/components/session/SessionDetails.vue
@@ -143,13 +143,6 @@
           </div>
         </div>
       </v-card-text>
-
-      <v-snackbar
-        v-model="closeSessionSnack"
-        :timeout="3000"
-      >
-        Closed session conection to the device
-      </v-snackbar>
     </v-card>
 
     <div class="text-center">
@@ -202,7 +195,6 @@ export default {
     return {
       uid: '',
       session: null,
-      closeSessionSnack: false,
       dialog: false,
       hide: true,
     };
@@ -234,7 +226,6 @@ export default {
 
     async refresh() {
       try {
-        this.closeSessionSnack = true;
         await this.$store.dispatch('sessions/get', this.uid);
         this.session = this.$store.getters['sessions/get'];
       } catch {

--- a/ui/src/components/session/SessionList.vue
+++ b/ui/src/components/session/SessionList.vue
@@ -138,12 +138,6 @@
           </template>
         </v-data-table>
       </v-card-text>
-      <v-snackbar
-        v-model="sessionSnack"
-        :timeout="3000"
-      >
-        Session closed
-      </v-snackbar>
     </v-card>
   </fragment>
 </template>
@@ -163,7 +157,6 @@ export default {
 
   data() {
     return {
-      sessionSnack: false,
       numberSessions: 0,
       listSessions: [],
       pagination: {},

--- a/ui/src/components/setting/SettingProfile.vue
+++ b/ui/src/components/setting/SettingProfile.vue
@@ -36,7 +36,9 @@
                     </span>
                     <v-icon
                       v-clipboard="tenant"
-                      v-clipboard:success="() => { copySnack = true; }"
+                      v-clipboard:success="() => {
+                        this.$store.dispatch('modals/showSnackbarCopy', this.$copy.tenantId);
+                      }"
                       right
                     >
                       mdi-content-copy
@@ -209,12 +211,6 @@
           </ValidationObserver>
         </v-col>
       </v-row>
-      <v-snackbar
-        v-model="copySnack"
-        :timeout="3000"
-      >
-        Tenant ID copied do clipboard
-      </v-snackbar>
     </v-container>
   </v-form>
 </template>
@@ -244,7 +240,6 @@ export default {
       editDataStatus: false,
       editPasswordStatus: false,
       show: false,
-      copySnack: false,
     };
   },
 

--- a/ui/src/components/snackbar/Snackbar.vue
+++ b/ui/src/components/snackbar/Snackbar.vue
@@ -8,6 +8,9 @@
       :type-message="message.typeMessage"
       :main-content="message.typeContent"
     />
+    <snackbarCopy
+      :main-content="message.typeContent"
+    />
   </fragment>
 </template>
 
@@ -15,6 +18,7 @@
 
 import snackbarSuccess from '@/components/snackbar/SnackbarSuccess';
 import snackbarError from '@/components/snackbar/SnackbarError';
+import snackbarCopy from '@/components/snackbar/SnackbarCopy';
 
 export default {
   name: 'Snackbar',
@@ -22,6 +26,7 @@ export default {
   components: {
     snackbarSuccess,
     snackbarError,
+    snackbarCopy,
   },
 
   computed: {

--- a/ui/src/components/snackbar/SnackbarCopy.vue
+++ b/ui/src/components/snackbar/SnackbarCopy.vue
@@ -1,0 +1,42 @@
+<template>
+  <fragment>
+    <v-snackbar
+      v-model="snackbar"
+      :timeout="4000"
+    >
+      {{ message }}
+    </v-snackbar>
+  </fragment>
+</template>
+
+<script>
+
+export default {
+  name: 'SnackbarCopy',
+
+  props: {
+    mainContent: {
+      type: String,
+      default: '',
+      required: true,
+    },
+  },
+
+  computed: {
+    snackbar: {
+      get() {
+        return this.$store.getters['modals/snackbarCopy'];
+      },
+
+      set() {
+        this.$store.dispatch('modals/unsetShowStatusSnackbarCopy');
+      },
+    },
+
+    message() {
+      return `${this.mainContent} copied to clipboard.`;
+    },
+  },
+};
+
+</script>

--- a/ui/src/components/terminal/TerminalDialog.vue
+++ b/ui/src/components/terminal/TerminalDialog.vue
@@ -204,10 +204,6 @@ export default {
         this.attachAddon.dispose();
       };
     },
-
-    showCopySnack() {
-      this.copySnack = true;
-    },
   },
 };
 

--- a/ui/src/components/welcome/Welcome.vue
+++ b/ui/src/components/welcome/Welcome.vue
@@ -74,7 +74,6 @@
             >
               <WelcomeSecondScreen
                 :command="command()"
-                @expClip="receiveClip"
               />
             </v-card>
             <v-card-actions>
@@ -104,12 +103,6 @@
                 Next
               </v-btn>
             </v-card-actions>
-            <v-snackbar
-              v-model="copy"
-              :timeout="3000"
-            >
-              Command copied to clipboard
-            </v-snackbar>
           </v-stepper-content>
 
           <v-stepper-content step="3">
@@ -142,12 +135,6 @@
                 Accept
               </v-btn>
             </v-card-actions>
-            <v-snackbar
-              v-model="copy"
-              :timeout="3000"
-            >
-              Command copied to clipboard
-            </v-snackbar>
           </v-stepper-content>
 
           <v-stepper-content step="4">
@@ -206,7 +193,6 @@ export default {
   data() {
     return {
       e1: 1,
-      copy: false,
       enable: false,
       polling: null,
       trigger: null,
@@ -230,10 +216,6 @@ export default {
   },
 
   methods: {
-    receiveClip(params) {
-      this.copy = params;
-    },
-
     beforeDestroy() {
       clearInterval(this.polling);
     },

--- a/ui/src/components/welcome/WelcomeSecondScreen.vue
+++ b/ui/src/components/welcome/WelcomeSecondScreen.vue
@@ -30,12 +30,6 @@
         for more information and alternative install methods.
       </p>
     </div>
-    <v-snackbar
-      v-model="copySnack"
-      :timeout="3000"
-    >
-      Command copied to clipboard
-    </v-snackbar>
   </fragment>
 </template>
 
@@ -54,7 +48,6 @@ export default {
   data() {
     return {
       hostname: window.location.hostname,
-      copySnack: false,
       allowsUserContinue: false,
     };
   },
@@ -62,8 +55,7 @@ export default {
   methods: {
     copyCommand() {
       this.$clipboard(this.command);
-      this.copySnack = true;
-      this.$emit('expClip', this.copySnack);
+      this.$store.dispatch('modals/showSnackbarCopy', this.$copy.command);
     },
   },
 

--- a/ui/src/copy.js
+++ b/ui/src/copy.js
@@ -1,0 +1,14 @@
+export default {
+  /* eslint-disable no-param-reassign */
+  install(Vue) {
+    const copy = {
+      command: 'Command',
+      deviceSSHID: 'Device SSHID',
+      tenantId: 'Tenant ID',
+    };
+
+    Vue.copy = copy;
+    Vue.prototype.$copy = copy;
+  },
+  /* eslint-enable no-param-reassign */
+};

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -8,6 +8,7 @@ import store from './store';
 import env from './env';
 import success from './success';
 import errors from './errors';
+import copy from './copy';
 import './vee-validate';
 import vuetify from './plugins/vuetify';
 
@@ -20,6 +21,7 @@ Vue.use(require('vue-moment'));
 Vue.use(env);
 Vue.use(success);
 Vue.use(errors);
+Vue.use(copy);
 
 new Vue({
   vuetify,

--- a/ui/src/store/modules/modals.js
+++ b/ui/src/store/modules/modals.js
@@ -9,6 +9,7 @@ export default {
     snackbarError: false,
     snackbarSuccess: false,
     SnackbarMessageAndContentType: { typeMessage: '', typeContent: '' },
+    snackbarCopy: false,
   },
 
   getters: {
@@ -17,6 +18,7 @@ export default {
     snackbarSuccess: (state) => state.snackbarSuccess,
     snackbarError: (state) => state.snackbarError,
     SnackbarMessageAndContentType: (state) => state.SnackbarMessageAndContentType,
+    snackbarCopy: (state) => state.snackbarCopy,
   },
 
   mutations: {
@@ -54,6 +56,15 @@ export default {
 
     unsetSnackbarError: (state) => {
       Vue.set(state, 'snackbarError', false);
+    },
+
+    setSnackbarCopy: (state, value) => {
+      Vue.set(state, 'SnackbarMessageAndContentType', { typeMessage: '', typeContent: value });
+      Vue.set(state, 'snackbarCopy', true);
+    },
+
+    unsetSnackbarCopy: (state) => {
+      Vue.set(state, 'snackbarCopy', false);
     },
   },
 
@@ -95,6 +106,14 @@ export default {
 
     unsetShowStatusSnackbarError: (context) => {
       context.commit('unsetSnackbarError');
+    },
+
+    showSnackbarCopy: (context, value) => {
+      context.commit('setSnackbarCopy', value);
+    },
+
+    unsetShowStatusSnackbarCopy: (context) => {
+      context.commit('unsetSnackbarCopy');
     },
   },
 };

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -28,15 +28,6 @@
       >
         <router-view />
       </v-container>
-
-      <v-main>
-        <v-snackbar
-          v-model="copySnack"
-          :timeout="3000"
-        >
-          Tenant ID copied to clipboard
-        </v-snackbar>
-      </v-main>
     </v-card>
   </v-container>
 </template>
@@ -50,7 +41,6 @@ export default {
     return {
       drawer: true,
       clipped: false,
-      copySnack: false,
       items: [
         {
           title: 'Profile',


### PR DESCRIPTION
This modification improves the use of the snackbarCopy, as it is
declared globally and use of it is done by vuex. And remove unused
variable in DeviceRejectedList component.