### PR TITLE
api: delete device from connected_device on removeDevice

### DIFF
--- a/api/store/mongo/store.go
+++ b/api/store/mongo/store.go
@@ -193,7 +193,8 @@ func (s *Store) DeleteDevice(ctx context.Context, uid models.UID) error {
 		return err
 	}
 
-	return nil
+	_, err := s.db.Collection("connected_devices").DeleteMany(ctx, bson.M{"uid": uid})
+	return err
 }
 
 func (s *Store) AddDevice(ctx context.Context, d models.Device, hostname string) error {


### PR DESCRIPTION
this fix avoid GetStats from count the removed device as an online device