### PR TITLE
ui: reset validation firewall dialog

### DIFF
--- a/ui/src/components/firewall_rules/FirewallRulesFormDialog.vue
+++ b/ui/src/components/firewall_rules/FirewallRulesFormDialog.vue
@@ -260,11 +260,12 @@ export default {
 
     update() {
       this.$emit('update');
-      this.dialog = !this.dialog;
+      this.close();
     },
 
     close() {
       this.dialog = !this.dialog;
+      this.$refs.obs.reset();
     },
   },
 };


### PR DESCRIPTION
Form errors in firewall rules are now reseted when closing the dialog.