### PR TITLE
ui: Add mounted in device to clear devices from list

### DIFF
--- a/ui/src/components/device/DeviceList.vue
+++ b/ui/src/components/device/DeviceList.vue
@@ -158,6 +158,10 @@ export default {
     },
   },
 
+  mounted() {
+    this.$store.dispatch('devices/resetListDevices');
+  },
+
   methods: {
     async getDevices() {
       let sortStatusMap = {};

--- a/ui/src/components/device/DevicePendingList.vue
+++ b/ui/src/components/device/DevicePendingList.vue
@@ -113,6 +113,10 @@ export default {
     },
   },
 
+  mounted() {
+    this.$store.dispatch('devices/resetListDevices');
+  },
+
   methods: {
     async getPendingDevices() {
       let sortStatusMap = {};

--- a/ui/src/components/device/DeviceRejectedList.vue
+++ b/ui/src/components/device/DeviceRejectedList.vue
@@ -113,6 +113,10 @@ export default {
     },
   },
 
+  mounted() {
+    this.$store.dispatch('devices/resetListDevices');
+  },
+
   methods: {
     async getRejectedDevices() {
       let sortStatusMap = {};

--- a/ui/src/store/modules/devices.js
+++ b/ui/src/store/modules/devices.js
@@ -144,5 +144,9 @@ export default {
         throw error;
       }
     },
+
+    resetListDevices: async (context) => {
+      context.commit('clearListDevices');
+    },
   },
 };


### PR DESCRIPTION
Fix problem show the store's content list device not related to your
tab in the data loading interval of the other tab. Happens when the
user switches between list, pending and rejected devices.