### PR TITLE
ui: Standardize the tests in the device directory

### DIFF
--- a/ui/tests/unit/components/device/Device.spec.js
+++ b/ui/tests/unit/components/device/Device.spec.js
@@ -48,11 +48,14 @@ describe('Device', () => {
   it('Renders the component', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
-  it('Has a search field and verify variable', () => {
-    expect(wrapper.find('[data-test="search-text"]').exists()).toBe(true);
+  it('Compare data with the default and defined value', () => {
+    expect(wrapper.vm.search).toEqual('');
 
     wrapper.setData({ search: 'ShellHub' });
     expect(wrapper.vm.search).toEqual('ShellHub');
+  });
+  it('Renders the template with data', () => {
+    expect(wrapper.find('[data-test="search-text"]').exists()).toBe(true);
 
     const textInputSearch = wrapper.find('[data-test="search-text"]');
     textInputSearch.element.value = 'ShellHub';

--- a/ui/tests/unit/components/device/DeviceAdd.spec.js
+++ b/ui/tests/unit/components/device/DeviceAdd.spec.js
@@ -38,7 +38,7 @@ describe('DeviceAdd', () => {
   it('Renders the component', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
-  it('Has a command field', () => {
+  it('Renders the template with data', () => {
     expect(wrapper.find('[data-test="command-field"]').exists()).toBe(true);
   });
 });

--- a/ui/tests/unit/components/device/DeviceDelete.spec.js
+++ b/ui/tests/unit/components/device/DeviceDelete.spec.js
@@ -33,7 +33,7 @@ describe('DeviceDelete', () => {
   it('Renders the component', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
-  it('Receive uid in props', () => {
+  it('Receive data in props', () => {
     expect(wrapper.vm.uid).toEqual(uid);
   });
 });

--- a/ui/tests/unit/components/device/DeviceDetails.spec.js
+++ b/ui/tests/unit/components/device/DeviceDetails.spec.js
@@ -3,31 +3,33 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import DeviceDetails from '@/components/device/DeviceDetails';
 
 describe('DeviceDetails', () => {
-  let wrapper;
-
   const localVue = createLocalVue();
   localVue.use(Vuex);
+
+  let wrapper;
+
+  const device = {
+    uid: 'a582b47a42d',
+    name: '39-5e-2a',
+    identity: {
+      mac: '00:00:00:00:00:00',
+    },
+    info: {
+      id: 'arch',
+      pretty_name: 'Linux Mint 19.3',
+      version: '',
+    },
+    public_key: '----- PUBLIC KEY -----',
+    tenant_id: '00000000',
+    last_seen: '2020-05-20T18:58:53.276Z',
+    online: false,
+    namespace: 'user',
+  };
 
   const store = new Vuex.Store({
     namespaced: true,
     state: {
-      device: {
-        uid: 'a582b47a42d',
-        name: '39-5e-2a',
-        identity: {
-          mac: '00:00:00:00:00:00',
-        },
-        info: {
-          id: 'arch',
-          pretty_name: 'Linux Mint 19.3',
-          version: '',
-        },
-        public_key: '----- PUBLIC KEY -----',
-        tenant_id: '00000000',
-        last_seen: '2020-05-20T18:58:53.276Z',
-        online: false,
-        namespace: 'user',
-      },
+      device,
     },
     getters: {
       'devices/get': (state) => state.device,
@@ -59,13 +61,12 @@ describe('DeviceDetails', () => {
   it('Renders the component', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
-  it('Compare data and method with store', () => {
-    expect(wrapper.vm.device.uid).toEqual('a582b47a42d');
-    expect(wrapper.vm.device.identity.mac).toEqual('00:00:00:00:00:00');
-    expect(wrapper.vm.device.info.pretty_name).toEqual('Linux Mint 19.3');
-    expect(wrapper.vm.convertDate).toEqual('Wednesday, May 20th 2020, 6:58:53 pm');
+  Object.keys(device).forEach((field) => {
+    it(`Receives the field ${field} of device state from store`, () => {
+      expect(wrapper.vm.device[field]).toEqual(device[field]);
+    });
   });
-  it('Has a elements field and compare with store', () => {
+  it('Renders the template with data', () => {
     expect(wrapper.find('[data-test="deviceUid-field"]').text()).toEqual('a582b47a42d');
     expect(wrapper.find('[data-test="deviceMac-field"]').text()).toEqual('00:00:00:00:00:00');
     expect(wrapper.find('[data-test="devicePrettyName-field"]').text()).toEqual('Linux Mint 19.3');

--- a/ui/tests/unit/components/device/DeviceRename.spec.js
+++ b/ui/tests/unit/components/device/DeviceRename.spec.js
@@ -33,7 +33,7 @@ describe('DeviceRename', () => {
   it('Renders the component', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
-  it('Receive params in props', () => {
+  it('Receive data in props', () => {
     expect(wrapper.vm.name).toEqual(name);
     expect(wrapper.vm.uid).toEqual(uid);
   });


### PR DESCRIPTION
Standardizes tests in the device directory, separating them into
sets. And use forEach to verify the object in device details.

This closes #414, and closes #418.