### PR TITLE
api: add CreateUser to store

### DIFF
--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -67,6 +67,20 @@ func (_m *Store) CreateSession(ctx context.Context, session models.Session) (*mo
 	return r0, r1
 }
 
+// CreateUser provides a mock function with given fields: ctx, user
+func (_m *Store) CreateUser(ctx context.Context, user *models.User) error {
+	ret := _m.Called(ctx, user)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *models.User) error); ok {
+		r0 = rf(ctx, user)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeactivateSession provides a mock function with given fields: ctx, uid
 func (_m *Store) DeactivateSession(ctx context.Context, uid models.UID) error {
 	ret := _m.Called(ctx, uid)

--- a/api/store/mongo/store.go
+++ b/api/store/mongo/store.go
@@ -1075,6 +1075,17 @@ func (s *Store) ListUsers(ctx context.Context, pagination paginator.Query, filte
 	return users, count, err
 }
 
+func (s *Store) CreateUser(ctx context.Context, user *models.User) error {
+	_, err := s.db.Collection("users").InsertOne(ctx, user)
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate key error") {
+			return store.ErrDuplicateEmail
+		}
+	}
+
+	return err
+}
+
 func (s *Store) LoadLicense(ctx context.Context) (*models.License, error) {
 	findOpts := options.FindOne()
 	findOpts.SetSort(bson.M{"created_at": -1})

--- a/api/store/mongo/store_test.go
+++ b/api/store/mongo/store_test.go
@@ -1035,6 +1035,22 @@ func TestGetStats(t *testing.T) {
 	assert.Equal(t, 1, stats.ActiveSessions)
 }
 
+func TestCreateUser(t *testing.T) {
+	db := dbtest.DBServer{}
+	defer db.Stop()
+
+	ctx := context.TODO()
+	mongostore := NewStore(db.Client().Database("test"))
+
+	err := mongostore.CreateUser(ctx, &models.User{
+		Name:     "user",
+		Email:    "user@shellhub.io",
+		Password: "password",
+		TenantID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+	})
+	assert.NoError(t, err)
+}
+
 func TestLoadLicense(t *testing.T) {
 	db := dbtest.DBServer{}
 	defer db.Stop()

--- a/api/store/store.go
+++ b/api/store/store.go
@@ -2,9 +2,14 @@ package store
 
 import (
 	"context"
+	"errors"
 
 	"github.com/shellhub-io/shellhub/pkg/api/paginator"
 	"github.com/shellhub-io/shellhub/pkg/models"
+)
+
+var (
+	ErrDuplicateEmail = errors.New("email address is already in use")
 )
 
 type Store interface {
@@ -41,6 +46,7 @@ type Store interface {
 	UpdateDataUserSecurity(ctx context.Context, sessionRecord bool, tenant string) error
 	GetDataUserSecurity(ctx context.Context, tenant string) (bool, error)
 	ListUsers(ctx context.Context, pagination paginator.Query, filters []models.Filter, countSessionsDevices bool) ([]models.User, int, error)
+	CreateUser(ctx context.Context, user *models.User) error
 	LoadLicense(ctx context.Context) (*models.License, error)
 	SaveLicense(ctx context.Context, license *models.License) error
 }


### PR DESCRIPTION
This method will be used by our user Cloud SaaS backend to handle user registration requests. If you intend to implement your own backend service this method could be useful.