### PR TITLE
agent: Add utmp and wtmp recording of pty sessions

### DIFF
--- a/agent/sshd/server.go
+++ b/agent/sshd/server.go
@@ -1,7 +1,11 @@
 package sshd
 
+//#include <utmp.h>
+//#include <paths.h>
+//#include <stdlib.h>
+import "C"
+
 import (
-	"C"
 	"fmt"
 	"io"
 	"net"
@@ -10,10 +14,19 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"strings"
+	"unsafe"
 
 	sshserver "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/agent/pkg/osauth"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	UserProcess = C.USER_PROCESS   // 0x7
+	DeadProcess = C.DEAD_PROCESS   // 0x8
+	PathUtmp = C._PATH_UTMP        // /var/run/utmp
+	PathWtmp = C._PATH_WTMP        // /var/log/wtmp
 )
 
 type sshConn struct {
@@ -107,12 +120,43 @@ func (s *Server) sessionHandler(session sshserver.Session) {
 
 		os.Chown(pts.Name(), uid, -1)
 
+		hostport := session.RemoteAddr().String()
+
 		logrus.WithFields(logrus.Fields{
 			"user": session.User(),
 			"pty": pts.Name(),
-			"remoteaddr": session.RemoteAddr().String(),
+			"remoteaddr": hostport,
 			"localaddr": session.LocalAddr().String(),
 			}).Info("Session started")
+
+		var host string
+		if !strings.Contains(hostport, "[") {
+			host = strings.Split(hostport, ":")[0]
+		} else {
+			host = strings.Split(strings.Split(hostport, "[")[1], "]")[0]
+		}
+
+		bits := strings.Split(host, ".")
+
+		b0, _ := strconv.Atoi(bits[0])
+		b1, _ := strconv.Atoi(bits[1])
+		b2, _ := strconv.Atoi(bits[2])
+		b3, _ := strconv.Atoi(bits[3])
+
+		var ip uint32
+
+		ip += uint32(b3) << 24
+		ip += uint32(b2) << 16
+		ip += uint32(b1) << 8
+		ip += uint32(b0)
+
+		ut := utmpStartSession(
+			strings.TrimPrefix(pts.Name(),"/dev/"),
+			session.User(),
+			host,
+			os.Getpid(),
+			ip,
+		)
 
 		s.mu.Lock()
 		s.cmds[session.Context().Value(sshserver.ContextKeySessionID).(string)] = scmd
@@ -128,6 +172,9 @@ func (s *Server) sessionHandler(session sshserver.Session) {
 			"remoteaddr": session.RemoteAddr().String(),
 			"localaddr": session.LocalAddr().String(),
 			}).Info("Session ended")
+
+		utmpEndSession(ut)
+
 	} else {
 		u := osauth.LookupUser(session.User())
 		cmd := newCmd(u, "", "", s.deviceName, session.Command()...)
@@ -210,4 +257,78 @@ func newShellCmd(s *Server, username, term string) *exec.Cmd {
 	cmd := newCmd(u, shell, term, s.deviceName, shell, "--login")
 
 	return cmd
+}
+
+func utmpStartSession(line, user, host string, pid int, ip uint32) (C.struct_utmp) {
+
+	var u C.struct_utmp
+
+	t := time.Now().Unix()
+	id := line[len(line)-4:]  // last 4 chars of line
+
+	idC := [4]C.char{}
+	for i := 0; i < len(id) && i < 4; i++ {
+		idC[i] = C.char(id[i])
+	}
+
+	lineC := [32]C.char{}
+	for i := 0; i < len(line) && i < 31; i++ {
+		lineC[i] = C.char(line[i])
+	}
+
+	userC := [32]C.char{}
+	for i := 0; i < len(user) && i < 31; i++ {
+		userC[i] = C.char(user[i])
+	}
+
+	hostC := [256]C.char{}
+	for i := 0; i < len(host) && i < 255; i++ {
+		hostC[i] = C.char(host[i])
+	}
+
+	u.ut_type = UserProcess
+	u.ut_tv.tv_sec = C.time_t(t)
+	u.ut_pid = C.int(pid)
+	u.ut_id = idC
+	u.ut_line = lineC
+	u.ut_user = userC
+	u.ut_host = hostC
+
+// The following line with "C.int(ip)" is compatible with
+// standard glibc but needs to be changed to "C.uint(ip)"
+// to be compatible with the Alpine musl libc used by the
+// Shellhub Docker build process.
+
+	u.ut_addr_v6[0] = C.int(ip)
+
+	C.setutent()
+	C.pututline(&u)
+	C.endutent()
+
+	cfilename := C.CString(PathWtmp)
+	defer C.free(unsafe.Pointer(cfilename))
+	C.updwtmp(cfilename, &u)
+
+	return u
+}
+
+func utmpEndSession(u C.struct_utmp) {
+
+	t := time.Now().Unix()
+
+	u.ut_type = DeadProcess
+	u.ut_tv.tv_sec = C.time_t(t)
+	u.ut_user = [32]C.char{}
+	u.ut_host = [256]C.char{}
+
+	C.setutent()
+	C.pututline(&u)
+	C.endutent()
+
+	u.ut_id = [4]C.char{}
+	u.ut_addr_v6[0] = 0
+
+	cfilename := C.CString(PathWtmp)
+	defer C.free(unsafe.Pointer(cfilename))
+	C.updwtmp(cfilename, &u)
 }


### PR DESCRIPTION
This change implements recording of login activity to the utmp
and wtmp databases so that sessions are reported by standard
utilities such as "who", "last", "w" and "users".

The code uses the glibc functions pututline(3) and updwtmp(3)
to access the utmp and wtmp files but these functions are not
implemented within the musl libc included within the alpine
base used by the Docker agent build process. musl libc defines
PATH_UTMP as /dev/null/utmp and PATH_WTMP as /dev/null/wtmp
and pututline(3) and updwtmp(3) as null functions. The code runs
without error within an Alpine Docker container but has no
effect. It updates utmp and wtmp only when run natively or
inside a Docker container built with glibc support.

For this reason, this change is not suitable for merging but
may be useful as a basis for a more complete implementation,
either using https://skarnet.org/software/utmps/ as suggested
by @otavio or by porting pututline(3) and updwtmp(3) to Go and
including them within the agent code.

Comments and feedback on the code is very welcome as I'm not
a Go programmer and I'm sure the code can be improved.

Partially fixes https://github.com/shellhub-io/shellhub/issues/317