### PR TITLE
pkg: fix websocket url

### DIFF
--- a/pkg/api/client/client_public.go
+++ b/pkg/api/client/client_public.go
@@ -68,7 +68,7 @@ func (c *client) NewReverseListener(token string) (*revdial.Listener, error) {
 	req, _ := http.NewRequest("GET", "", nil)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	url := regexp.MustCompile(`^https?`).ReplaceAllString(buildURL(c, "/ssh/connection"), "ws")
+	url := regexp.MustCompile(`^http`).ReplaceAllString(buildURL(c, "/ssh/connection"), "ws")
 	conn, _, err := websocket.DefaultDialer.Dial(url, req.Header)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fix cover all cases (secure and insecure) servers.
http becomes ws and https becomes wss