### PR TITLE
agent: Add utmp and wtmp recording of pty sessions (Revised)

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/shellhub-io/shellhub v0.4.2
 	github.com/sirupsen/logrus v1.7.0
 	github.com/smartystreets/goconvey v1.6.4 // indirect
-	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 // indirect
+	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
-	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
 	google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 // indirect
 	google.golang.org/grpc v1.33.2 // indirect

--- a/agent/selfupdater/updater_docker.go
+++ b/agent/selfupdater/updater_docker.go
@@ -23,15 +23,15 @@ type dockerContainer struct {
 	info *types.ContainerJSON
 }
 
-func (c *dockerContainer) splitImageVersion() (string, string) {
+func (c *dockerContainer) splitImageVersion() (image, version string) {
 	parts := strings.SplitN(c.info.Config.Image, ":", 2)
-	image, version := parts[0], ""
+	image, version = parts[0], ""
 
 	if len(parts) == 2 {
 		version = parts[1]
 	}
 
-	return image, version
+	return
 }
 
 type dockerUpdater struct {
@@ -96,8 +96,6 @@ func (d *dockerUpdater) CompleteUpdate() error {
 		if err != nil {
 			return err
 		}
-
-		os.Exit(0)
 	}
 
 	return nil
@@ -141,11 +139,8 @@ func (d *dockerUpdater) stopContainer(container *dockerContainer) error {
 	}
 
 	opts := types.ContainerRemoveOptions{Force: true, RemoveVolumes: true}
-	if err := d.api.ContainerRemove(ctx, container.info.ID, opts); err != nil {
-		return err
-	}
-
-	return nil
+	err := d.api.ContainerRemove(ctx, container.info.ID, opts)
+	return err
 }
 
 func (d *dockerUpdater) updateContainer(container *dockerContainer, image, name string, parent bool) (*dockerContainer, error) {
@@ -185,7 +180,6 @@ func (d *dockerUpdater) updateContainer(container *dockerContainer, image, name 
 	}
 
 	return d.getContainer(clone.ID)
-
 }
 
 func NewUpdater(_ string) (Updater, error) {

--- a/agent/selfupdater/updater_docker.go
+++ b/agent/selfupdater/updater_docker.go
@@ -92,6 +92,25 @@ func (d *dockerUpdater) CompleteUpdate() error {
 			}
 		}
 
+                // Append /var/run and /var/log to mount if old container
+                // version is less than v0.4.2 since utmp and wtmp are
+                // required inside container to record login sessions
+                v0_4_2, _ := semver.NewVersion("v0.4.2")
+                if v.LessThan(v0_4_2) {
+                        parent.info.HostConfig.Mounts = []mount.Mount{
+                                mount.Mount{
+                                        Type:   mount.TypeBind,
+                                        Source: "/var/run",
+                                        Target: "/var/run",
+                                },
+                                mount.Mount{
+                                        Type:   mount.TypeBind,
+                                        Source: "/var/log",
+                                        Target: "/var/log",
+                                },
+                        }
+                }
+
 		_, err = d.updateContainer(parent, container.info.Config.Image, parent.info.Name, false)
 		if err != nil {
 			return err

--- a/agent/sshd/server.go
+++ b/agent/sshd/server.go
@@ -122,19 +122,19 @@ func (s *Server) sessionHandler(session sshserver.Session) {
 
 		os.Chown(pts.Name(), uid, -1)
 
-		remoteAddr := session.RemoteAddr().String()
+		remoteAddr := session.RemoteAddr()
 
 		logrus.WithFields(logrus.Fields{
 			"user":       session.User(),
 			"pty":        pts.Name(),
 			"remoteaddr": remoteAddr,
-			"localaddr":  session.LocalAddr().String(),
+			"localaddr":  session.LocalAddr(),
 		}).Info("Session started")
 
 		ut := utmpStartSession(
 			pts.Name(),
 			session.User(),
-			remoteAddr,
+			remoteAddr.String(),
 		)
 
 		s.mu.Lock()
@@ -148,8 +148,8 @@ func (s *Server) sessionHandler(session sshserver.Session) {
 		logrus.WithFields(logrus.Fields{
 			"user":       session.User(),
 			"pty":        pts.Name(),
-			"remoteaddr": session.RemoteAddr().String(),
-			"localaddr":  session.LocalAddr().String(),
+			"remoteaddr": remoteAddr,
+			"localaddr":  session.LocalAddr(),
 		}).Info("Session ended")
 
 		utmpEndSession(ut)
@@ -162,8 +162,8 @@ func (s *Server) sessionHandler(session sshserver.Session) {
 
 		logrus.WithFields(logrus.Fields{
 			"user":        session.User(),
-			"remoteaddr":  session.RemoteAddr().String(),
-			"localaddr":   session.LocalAddr().String(),
+			"remoteaddr":  session.RemoteAddr(),
+			"localaddr":   session.LocalAddr(),
 			"Raw command": session.RawCommand(),
 		}).Info("Command started")
 
@@ -185,8 +185,8 @@ func (s *Server) sessionHandler(session sshserver.Session) {
 
 		logrus.WithFields(logrus.Fields{
 			"user":        session.User(),
-			"remoteaddr":  session.RemoteAddr().String(),
-			"localaddr":   session.LocalAddr().String(),
+			"remoteaddr":  session.RemoteAddr(),
+			"localaddr":   session.LocalAddr(),
 			"Raw command": session.RawCommand(),
 		}).Info("Command ended")
 	}

--- a/agent/sshd/utmp.go
+++ b/agent/sshd/utmp.go
@@ -1,0 +1,267 @@
+package sshd
+
+/*	The Utmpx struct is derived from the Linux definition (man 5 utmpx).
+
+	At session start, a utmp record is constructed containing the PID,
+	tty name, ID, username, remote host, source IP and time.
+	Type is set to UserProcess and the record is written to UtmpxFile.
+	If a record with the same ID exists, that record is overwritten;
+	otherwise the record is appended to the file.  The same record is
+	appended to WtmpxFile.
+
+	At session end, Type is set to DeadProcess, the User and Host fields
+	are cleared, time is updated and the record is wrtten to UtmpxFile,
+	overwriting the session start record. The same record with ID and
+	source IP address cleared is appended to WtmpxFile.
+*/
+
+import (
+	"os"
+	"unsafe"
+	"bytes"
+	"net"
+	"strings"
+	"encoding/binary"
+	"golang.org/x/sys/unix"
+	"github.com/sirupsen/logrus"
+)
+
+type ExitStatus struct {
+	ETermination	int16		// Process temination status - not used
+	EExit		int16		// Process exit status - not used
+}
+
+type Utmpx struct {
+	Type		int16		// UserProcess or DeadProcess
+	Padding		[2]byte		// Padding to align rest of struct
+	Pid		int32		// PID of the ShellHub agent
+	Line		[32]byte	// tty associated with the process
+	ID		[4]byte		// Index, last 4 characters of Line
+	User		[32]byte	// Username
+	Host		[256]byte	// Source IP address
+	Exit		ExitStatus	// Exit status - not used
+	Session		int32		// Session ID - not used
+	Tv		unix.Timeval	// Time entry was made
+	AddrV6		[4]uint32	// Source IP address. IPv4 in AddrV6[0]
+	Reserved	[20]byte	// Not used
+}
+
+const (
+	UtmpxFile   = "/var/run/utmp"
+	WtmpxFile   = "/var/log/wtmp"
+	UserProcess = 0x7		// Normal process
+	DeadProcess = 0x8		// Terminated process
+)
+
+// This function updates the utmp and wtmp files at the start of a user session
+func utmpStartSession(line, user, remoteAddr string) Utmpx {
+	var u Utmpx
+
+	u.Type = UserProcess
+	a := unix.Timeval{}
+	unix.Gettimeofday(&a)
+	u.Tv.Sec, u.Tv.Usec = a.Sec, a.Usec
+	u.Pid = int32(os.Getpid())
+
+	// remoteAddr has the form <IPv4 address>:<port>
+	// or [<IPv6 address>]:<port>
+	// Remove the port suffix and also the square brackets
+	// if IPv6, leaving the bare IPv4 or IPv6 address
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"ip": remoteAddr,
+		}).Warn("wrong remoteAddr format")
+	} else {
+		// Parse IP address to a standard 16-byte representation
+		ip := net.ParseIP(host)
+		// Check whether IPv4 or IPv6
+		if ip4 := ip.To4(); ip4 != nil {
+			// This is a 32-bit IPv4 address to be
+			// stored in the first element of u.AddrV6 
+			u.AddrV6[0] = binary.LittleEndian.Uint32(ip4)
+		} else {
+			// This is a 128-bit IPv6 address. Each 4 bytes
+			// of the address is stored as a 32-bit int in
+			// successive elements of u.AddrV6
+			u.AddrV6[0] = binary.LittleEndian.Uint32(ip[0:4])
+			u.AddrV6[1] = binary.LittleEndian.Uint32(ip[4:8])
+			u.AddrV6[2] = binary.LittleEndian.Uint32(ip[8:12])
+			u.AddrV6[3] = binary.LittleEndian.Uint32(ip[12:16])
+		}
+	}
+
+	line = strings.TrimPrefix(line,"/dev/")
+	// The index to the utmp record is the last 4 chars of line
+	id := line[len(line)-4:]
+
+	_ = copy(u.ID[:], id)
+	_ = copy(u.Line[:], line)
+	_ = copy(u.User[:], user)
+	_ = copy(u.Host[:], host)
+
+	updUtmp(u, id)
+	updWtmp(u)
+	return u
+}
+
+// This function updates the utmp and wtmp files at the end of a user session
+func utmpEndSession(u Utmpx) {
+	u.Type = DeadProcess
+	u.User = [32]byte{}
+	u.Host = [256]byte{}
+	a := unix.Timeval{}
+	unix.Gettimeofday(&a)
+	u.Tv.Sec, u.Tv.Usec = a.Sec, a.Usec
+
+	updUtmp(u, string(u.ID[:]))
+
+	u.ID = [4]byte{}
+	u.AddrV6 = [4]uint32{}
+
+	updWtmp(u)
+}
+
+// This function updates the utmp file by overwriting the record with index
+// id if present; otherwise by appending the new record to the file
+func updUtmp(u Utmpx, id string) {
+	file, err := os.OpenFile(
+			UtmpxFile,
+			os.O_RDWR|os.O_CREATE,
+			0644)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"file": UtmpxFile,
+			"err": err,
+		}).Warn("Open failed")
+		return
+	}
+
+	defer file.Close()
+
+	// Lock the file
+	lk := unix.Flock_t{
+		Type: int16(unix.F_WRLCK),
+		Pid:  int32(os.Getpid()),
+		}
+
+	err = unix.FcntlFlock(file.Fd(), unix.F_SETLKW, &lk)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"file": UtmpxFile,
+			"err": err,
+		}).Warn("Lock failed")
+		return
+	}
+
+	var ut Utmpx
+
+	// Read through the utmp file looking for a record with index id
+	for {
+		offset, err := file.Seek(0, os.SEEK_CUR)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"file": UtmpxFile,
+				"err": err,
+			}).Warn("Null seek failed")
+			return
+		}
+
+		err = binary.Read(file, binary.LittleEndian, &ut)
+		if err != nil {
+			break  // EOF found: no record with index id
+		}
+
+		utID := string(bytes.Trim(ut.ID[:], "\x00"))
+
+		if utID == id {
+			// Required record found, rewind to overwrite it
+			_, err = file.Seek(offset, os.SEEK_SET)
+			if err != nil {
+				logrus.WithFields(logrus.Fields{
+					"file": UtmpxFile,
+					"err": err,
+				}).Warn("Back seek failed")
+				return
+			}
+			break
+		}
+	}
+
+	err = binary.Write(file, binary.LittleEndian, &u)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"file": UtmpxFile,
+			"err": err,
+		}).Warn("Write failed")
+	}
+
+	return
+}
+
+// This function updates the wtmp file by appending the record to the file
+func updWtmp(u Utmpx) {
+	file, err := os.OpenFile(
+			WtmpxFile,
+			os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+			0644)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"file": WtmpxFile,
+			"err": err,
+		}).Warn("Open failed")
+		return
+	}
+
+	defer file.Close()
+
+	lk := unix.Flock_t{
+		Type: int16(unix.F_WRLCK),
+		Pid:  int32(os.Getpid()),
+	}
+
+	err = unix.FcntlFlock(file.Fd(), unix.F_SETLKW, &lk)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"file": WtmpxFile,
+			"err": err,
+		}).Warn("Lock failed")
+	}
+
+	fileSize, err := file.Seek(0, os.SEEK_END)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"file": WtmpxFile,
+			"err": err,
+		}).Warn("Seek to end failed")
+		return
+	}
+
+	// Check that the file is a multiple of the record size
+	rem := fileSize%int64(unsafe.Sizeof(Utmpx{}))
+	if rem != 0 {
+		fileSize -= rem
+		logrus.WithFields(logrus.Fields{
+			"file": WtmpxFile,
+			"filesize": fileSize,
+		}).Warn("Database size invalid, truncating")
+		err := file.Truncate(fileSize)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"file": WtmpxFile,
+				"err": err,
+			}).Warn("Database truncate failed")
+			return
+		}
+	}
+
+	err = binary.Write(file, binary.LittleEndian, &u)
+
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"file": WtmpxFile,
+			"err": err,
+		}).Warn("Write failed")
+		file.Truncate(fileSize)
+	}
+}

--- a/gateway/kickstart.sh
+++ b/gateway/kickstart.sh
@@ -46,6 +46,8 @@ $SUDO docker run -d \
        -v /var/run/docker.sock:/var/run/docker.sock \
        -v /etc/passwd:/etc/passwd \
        -v /etc/group:/etc/group \
+       -v /var/run:/var/run \
+       -v /var/log:/var/log \
        -e SHELLHUB_SERVER_ADDRESS={{scheme}}://{{host}} \
        -e SHELLHUB_PRIVATE_KEY=/host/etc/shellhub.key \
        -e SHELLHUB_TENANT_ID={{tenant_id}} \


### PR DESCRIPTION
This change implements recording of login activity to the utmp
and wtmp databases so that sessions are reported by standard
utilities such as "who", "last", "w" and "users".

This revised PR removes the dependency on glibc, so that the
code works when the Agent is run in an Alpine docker
environment as well as when it's run natively.

Comments and feedback on the code is very welcome as I'm
new to Go programming.

Fixes https://github.com/shellhub-io/shellhub/issues/317