### PR TITLE
Remove CGO dependency in agent

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
 	github.com/Masterminds/semver v1.5.0
 	github.com/Microsoft/go-winio v0.4.15 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
@@ -24,6 +25,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/shellhub-io/shellhub v0.4.2
 	github.com/sirupsen/logrus v1.7.0
+	github.com/smartystreets/goconvey v1.6.4 // indirect
 	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 h1:KeNholpO2xKjgaaSyd+DyQRrsQjhbSeS7qe4nEw8aQw=
+github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962/go.mod h1:kC29dT1vFpj7py2OvG1khBdQpo3kInWP+6QipLbdngo=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.15 h1:qkLXKzb1QoVatRyd/YlXZ/Kg0m5K3SPuoD82jjSOaBc=

--- a/agent/pkg/osauth/auth.go
+++ b/agent/pkg/osauth/auth.go
@@ -1,55 +1,117 @@
 package osauth
 
-/*
-#cgo LDFLAGS: -lcrypt
-#define _GNU_SOURCE 1
-#include <stdlib.h>
-#include <stdio.h>
-#include <shadow.h>
-#include <string.h>
-#include <pwd.h>
-#include <crypt.h>
-*/
-import "C"
-
 import (
-	"unsafe"
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/GehirnInc/crypt"
+	_ "github.com/GehirnInc/crypt/md5_crypt"    // GehirnInc/crypt uses blank imports for crypto subpackages
+	_ "github.com/GehirnInc/crypt/sha256_crypt" // GehirnInc/crypt uses blank imports for crypto subpackages
+	_ "github.com/GehirnInc/crypt/sha512_crypt" // GehirnInc/crypt uses blank imports for crypto subpackages
+	"github.com/sirupsen/logrus"
 )
 
 var DefaultShadowFilename = "/etc/shadow"
 
-func AuthUser(user, passwd string) bool {
-	cuser := C.CString(user)
-	defer C.free(unsafe.Pointer(cuser))
+type ShadowEntry struct {
+	Username    string // Login name
+	Password    string // Hashed password
+	Lastchanged int    // Days since Jan 1, 1970 that password was last changed
+	Minimum     int    // The minimum number of days required between password changes i.e. the number of days left before the user is allowed to change his/her password
+	Maximum     int    // The maximum number of days the password is valid (after that user is forced to change his/her password)
+	Warn        int    // The number of days before password is to expire that user is warned that his/her password must be changed
+	Inactive    int    // The number of days after password expires that account is disabled
+	Expire      int    // Days since Jan 1, 1970 that account is disabled i.e. an absolute date specifying when the login may no longer be used.
+}
 
-	cpasswd := C.CString(passwd)
-	defer C.free(unsafe.Pointer(cpasswd))
-
-	cfilename := C.CString(DefaultShadowFilename)
-	defer C.free(unsafe.Pointer(cfilename))
-
-	cmode := C.CString("r")
-	defer C.free(unsafe.Pointer(cmode))
-
-	f := C.fopen(cfilename, cmode)
-	defer C.fclose(f)
-
-	var pwd *C.struct_spwd
-	for {
-		if pwd = C.fgetspent(f); pwd == nil {
-			return false
-		}
-
-		if C.strcmp(cuser, pwd.sp_namp) == 0 {
-			break
-		}
-	}
-
-	if pwd == nil {
+func AuthUser(username, passwd string) bool {
+	shadowFile, err := os.Open(DefaultShadowFilename)
+	if err != nil {
+		// TODO: log error
+		logrus.Error("Could not open /etc/shadow")
 		return false
 	}
 
-	crypted := C.crypt(cpasswd, pwd.sp_pwdp)
+	defer shadowFile.Close()
 
-	return C.strcmp(crypted, pwd.sp_pwdp) == 0
+	entries, err := parseShadowReader(shadowFile)
+	if err != nil {
+		logrus.Printf("Could not parse shadowfile %v", err)
+		return false
+	}
+
+	if entry, ok := entries[username]; ok {
+		if entry.Password != "" {
+			crypt := crypt.NewFromHash(entry.Password)
+			if crypt == nil {
+				logrus.Error("Could not detect password crypto algorithm from shadow entry")
+				return false
+			}
+
+			err := crypt.Verify(entry.Password, []byte(passwd))
+			return err == nil
+		}
+		logrus.Error("Password entry is empty")
+		return false
+	}
+
+	logrus.Warn("User not found")
+	return false
+}
+
+func parseShadowReader(r io.Reader) (map[string]ShadowEntry, error) {
+	lines := bufio.NewReader(r)
+	entries := make(map[string]ShadowEntry)
+	for {
+		line, _, err := lines.ReadLine()
+		if err != nil {
+			break
+		}
+
+		if len(line) == 0 || strings.HasPrefix(string(line), "#") {
+			continue
+		}
+
+		entry, err := parseShadowLine(string(line))
+		if err != nil {
+			return nil, err
+		}
+
+		entries[entry.Username] = entry
+	}
+	return entries, nil
+}
+
+func parseShadowLine(line string) (ShadowEntry, error) {
+	result := ShadowEntry{}
+	parts := strings.Split(strings.TrimSpace(line), ":")
+	if len(parts) != 9 {
+		return result, fmt.Errorf("Shadow line had wrong number of parts %d != 9", len(parts))
+	}
+	result.Username = strings.TrimSpace(parts[0])
+	result.Password = strings.TrimSpace(parts[1])
+
+	result.Lastchanged = parseIntString(parts[2])
+	result.Minimum = parseIntString(parts[3])
+	result.Maximum = parseIntString(parts[4])
+	result.Warn = parseIntString(parts[5])
+	result.Inactive = parseIntString(parts[6])
+	result.Expire = parseIntString(parts[7])
+
+	return result, nil
+}
+
+func parseIntString(value string) int {
+	if value != "" {
+		return 0
+	}
+	number, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0
+	}
+	return number
 }

--- a/agent/sshd/cmd.go
+++ b/agent/sshd/cmd.go
@@ -12,9 +12,6 @@ import (
 )
 
 func newCmd(u *osauth.User, shell, term, host string, command ...string) *exec.Cmd {
-	uid, _ := strconv.Atoi(u.UID)
-	gid, _ := strconv.Atoi(u.GID)
-
 	user, _ := user.Lookup(u.Username)
 	userGroups, _ := user.GroupIds()
 
@@ -25,7 +22,7 @@ func newCmd(u *osauth.User, shell, term, host string, command ...string) *exec.C
 		groups = append(groups, uint32(igid))
 	}
 	if len(groups) == 0 {
-		groups = append(groups, uint32(gid))
+		groups = append(groups, u.GID)
 	}
 
 	cmd := exec.Command(command[0], command[1:]...)
@@ -37,6 +34,6 @@ func newCmd(u *osauth.User, shell, term, host string, command ...string) *exec.C
 	}
 	cmd.Dir = u.HomeDir
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid), Groups: groups}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: u.UID, Gid: u.GID, Groups: groups}
 	return cmd
 }

--- a/agent/sshd/server.go
+++ b/agent/sshd/server.go
@@ -1,13 +1,11 @@
 package sshd
 
 import (
-	"C"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"os/exec"
-	"strconv"
 	"sync"
 	"time"
 
@@ -118,9 +116,7 @@ func (s *Server) sessionHandler(session sshserver.Session) {
 
 		u := osauth.LookupUser(session.User())
 
-		uid, _ := strconv.Atoi(u.UID)
-
-		os.Chown(pts.Name(), uid, -1)
+		os.Chown(pts.Name(), int(u.UID), -1)
 
 		remoteAddr := session.RemoteAddr()
 


### PR DESCRIPTION
Closes #596 

CGO is really not necessary for the simple file parsing
github.com/GehirnInc/crypt can provide the needed crypto functions

Removing the CGO dependency for the agent makes cross compilation much easier, and can enable easier workflows when the agent is not running inside of docker

Currently I have left a big comment that parses additional parts of /etc/shadow
In my opinion it is unnecessary, but it would make sense to be in there for completeness or later use... So please let me know

Also my change to the User type, changing UID and GUID to ints is not strictly necessary and therefore up for discussion

I did test the new implementation on a Pi running RaspberryPiOS lite and it works fine

Let me know what you think =D