### PR TITLE
agent: support non-root to run

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/shellhub-io/shellhub v0.5.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 // indirect
 	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073

--- a/agent/pkg/osauth/auth_test.go
+++ b/agent/pkg/osauth/auth_test.go
@@ -1,0 +1,34 @@
+package osauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyPasswordHashPass(t *testing.T) {
+	hashPassword := "$6$CMWxpgkq.ZosUW8N$gN/MkheCdS9SsPrFS6oOd/k.TMvY2KHztJE5pDMRdN35zr00dyxQr3pYGM4rtPPduUIrEFCwuB7oVgzDbiMfN."
+	passwd := "123"
+
+	result := VerifyPasswordHash(hashPassword, passwd)
+
+	assert.True(t, result)
+}
+
+func TestVerifyPasswordHashFail(t *testing.T) {
+	hashPassword := "$6$CMWxpgkq.ZosUW8N$gN/MkheCdS9SsPrFS6oOd/k.TMvY2KHztJE5pDMRdN35zr00dyxQr3pYGM4rtPPduUIrEFCwuB7oVgzDbiMfN."
+	passwd := "test"
+
+	result := VerifyPasswordHash(hashPassword, passwd)
+
+	assert.False(t, result)
+}
+
+func TestVerifyPasswordHashMD5Pass(t *testing.T) {
+	hashPassword := "$1$YW4a91HG$31CtH9bzW/oyJ1VOD.H/d/"
+	passwd := "test"
+
+	result := VerifyPasswordHash(hashPassword, passwd)
+
+	assert.True(t, result)
+}

--- a/agent/sshd/cmd.go
+++ b/agent/sshd/cmd.go
@@ -3,6 +3,7 @@
 package sshd
 
 import (
+	"os"
 	"os/exec"
 	"os/user"
 	"strconv"
@@ -33,7 +34,10 @@ func newCmd(u *osauth.User, shell, term, host string, command ...string) *exec.C
 		"SHELLHUB_HOST=" + host,
 	}
 	cmd.Dir = u.HomeDir
-	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: u.UID, Gid: u.GID, Groups: groups}
+
+	if os.Geteuid() == 0 {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: u.UID, Gid: u.GID, Groups: groups}
+	}
 	return cmd
 }


### PR DESCRIPTION
ShellHub run as single user mode.

Since in the mode, not allow to be other accounts.
We don't need root permission to switch users.


Closes: #618

```
$ SHELLHUB_SIMPLE_PASSWORD=$(openssl passwd -1) ./agent
Password: 
Verifying - Password: 
Verify failure
This application is configured via the environment. The following environment
variables can be used:

KEY                            TYPE       DEFAULT    REQUIRED    DESCRIPTION
SHELLHUB_SERVER_ADDRESS        String                true        
SHELLHUB_PRIVATE_KEY           String                true        
SHELLHUB_TENANT_ID             String                true        
SHELLHUB_KEEPALIVE_INTERVAL    Integer    30                     
SHELLHUB_PREFERRED_HOSTNAME    String                            
SHELLHUB_SIMPLE_PASSWORD       String                            SHELLHUB_SIMPLE_PASSWORD=$(openssl passwd -1) ./agent
FATA[0000] required key SERVER_ADDRESS missing value   
```