### PR TITLE
Rework docker-compose wrapper to support new options related to HTTPS

### DIFF
--- a/.env
+++ b/.env
@@ -20,10 +20,14 @@ SHELLHUB_SSH_PORT=22
 SHELLHUB_PROXY=false
 
 # Automatic HTTPS with Let's Encrypt
-# NOTICE: When enabling automatic HTTPS are recommended to set `SHELLHUB_HTTP_PORT=0` to avoid exposing plain HTTP service to the internet
 SHELLHUB_AUTO_SSL=false
 
-# Domain of the server (only required if automatic HTTPS is enabled)
+# Redirect requests from HTTP port to HTTPS port
+# NOTICE: In order to enable HTTPS redirection, you need to have HTTPS enabled
+SHELLHUB_REDIRECT_TO_HTTPS=true
+
+# Domain of the server
+# NOTICE: Only required if automatic HTTPS is enabled
 # Values: a valid domain name
 SHELLHUB_DOMAIN=localhost
 

--- a/.env
+++ b/.env
@@ -5,11 +5,15 @@
 SHELLHUB_VERSION=v0.4.3-rc.1
 
 # The HTTP listen port for the ShellHub web-based GUI, API and Reverse SSH tunnel.
-# Values: any free port on host (use 0 to disable listening on host)
+# Values: any free port on host
 SHELLHUB_HTTP_PORT=80
 
+# The HTTPS listen port for the ShellHub web-based GUI, API and Reverse SSH tunnel.
+# Values: any free port on host
+SHELLHUB_HTTPS_PORT=443
+
 # The SSH listen port for incoming SSH connections to devices
-# Values: any free port on host (use 0 to disable listening on host)
+# Values: any free port on host
 SHELLHUB_SSH_PORT=22
 
 # Set this variable to true if you are running a Layer 4 load balancer with proxy protocol in front of ShellHub

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -42,13 +42,20 @@ COMPOSE_FILE="docker-compose.yml"
 
 COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.${SSL_COMPOSE_FILE}.yml"
 
+if [ "$SHELLHUB_REDIRECT_TO_HTTPS" = "true" ]; then
+    if [ "$SHELLHUB_AUTO_SSL" != "true" ]; then
+	cat <<EOF >&2
+ERROR: In order to enable HTTPS redirection, you need to have HTTPS enabled
+EOF
+	exit 1
+    fi
+
+    COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.httptohttps.yml"
+fi
+
 [ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.dev.yml"
 [ "$SHELLHUB_HOSTED" = "true" ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.enterprise.yml"
 [ -f docker-compose.override.yml ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.override.yml"
-
-[ "$SHELLHUB_AUTO_SSL" = "true" ] && [ "$SHELLHUB_HTTP_PORT" != "0" ] && cat <<EOF >&2
-WARNING: When using SHELLHUB_AUTO_SSL=true you need to set SHELLHUB_HTTP_PORT=0 to avoid exposing plain HTTP service to the internet
-EOF
 
 export COMPOSE_FILE
 

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -38,7 +38,10 @@ set +o allexport
 
 COMPOSE_FILE="docker-compose.yml"
 
-[ "$SHELLHUB_AUTO_SSL" = "true" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.autossl.yml"
+[ "$SHELLHUB_AUTO_SSL" = "true" ] && SSL_COMPOSE_FILE=autossl || SSL_COMPOSE_FILE=nossl
+
+COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.${SSL_COMPOSE_FILE}.yml"
+
 [ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.dev.yml"
 [ "$SHELLHUB_HOSTED" = "true" ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.enterprise.yml"
 [ -f docker-compose.override.yml ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.override.yml"

--- a/docker-compose.autossl.yml
+++ b/docker-compose.autossl.yml
@@ -15,7 +15,6 @@ services:
     links:
       - gateway
     ports:
-      - 80:80
       - ${SHELLHUB_HTTPS_PORT}:443
     environment:
       ALLOWED_DOMAINS: '${SHELLHUB_DOMAIN}'

--- a/docker-compose.autossl.yml
+++ b/docker-compose.autossl.yml
@@ -16,7 +16,7 @@ services:
       - gateway
     ports:
       - 80:80
-      - 443:443
+      - ${SHELLHUB_HTTPS_PORT}:443
     environment:
       ALLOWED_DOMAINS: '${SHELLHUB_DOMAIN}'
       SITES: '${SHELLHUB_DOMAIN}=gateway:80'

--- a/docker-compose.autossl.yml
+++ b/docker-compose.autossl.yml
@@ -1,6 +1,12 @@
 version: '3.7'
 
 services:
+  gateway:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/info"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
   autossl:
     image: valian/docker-nginx-auto-ssl:1.2.0
     restart: on-failure

--- a/docker-compose.httptohttps.yml
+++ b/docker-compose.httptohttps.yml
@@ -1,0 +1,6 @@
+version: '3.7'
+
+services:
+  autossl:
+    ports:
+      - ${SHELLHUB_HTTP_PORT}:80

--- a/docker-compose.nossl.yml
+++ b/docker-compose.nossl.yml
@@ -1,0 +1,6 @@
+version: '3.7'
+
+services:
+  gateway:
+    ports:
+      - "${SHELLHUB_HTTP_PORT}:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,6 @@ services:
     depends_on:
       - api
       - ui
-    ports:
-      - "${SHELLHUB_HTTP_PORT}:80"
     networks:
       - shellhub
   mongo:


### PR DESCRIPTION
New options:

> The HTTPS listen port

`SHELLHUB_HTTPS_PORT`

> Redirect requests from HTTP port to HTTPS port

`SHELLHUB_REDIRECT_TO_HTTPS`

This also fixes #619 