### PR TITLE
ui: remove exit case in onclose event in terminal dialog

### DIFF
--- a/ui/src/components/terminal/TerminalDialog.vue
+++ b/ui/src/components/terminal/TerminalDialog.vue
@@ -204,7 +204,6 @@ export default {
 
       this.ws.onclose = () => {
         this.attachAddon.dispose();
-        this.show = false;
       };
     },
   },


### PR DESCRIPTION
This fixes temporarily dialog close when form data is entered incorrectly.
While ws doesn't handle specific cases, the exit command can't be managed.