### PR TITLE
Set the same network for autossl and gateway services

### DIFF
--- a/.env
+++ b/.env
@@ -24,7 +24,7 @@ SHELLHUB_AUTO_SSL=false
 
 # Redirect requests from HTTP port to HTTPS port
 # NOTICE: In order to enable HTTPS redirection, you need to have HTTPS enabled
-SHELLHUB_REDIRECT_TO_HTTPS=true
+SHELLHUB_REDIRECT_TO_HTTPS=false
 
 # Domain of the server
 # NOTICE: Only required if automatic HTTPS is enabled

--- a/docker-compose.autossl.yml
+++ b/docker-compose.autossl.yml
@@ -19,3 +19,5 @@ services:
     environment:
       ALLOWED_DOMAINS: '${SHELLHUB_DOMAIN}'
       SITES: '${SHELLHUB_DOMAIN}=gateway:80'
+    networks:
+      - shellhub


### PR DESCRIPTION
Set the same network for autossl and gateway services to allow communication with each other