### PR TITLE
docker: upgrade mongodb version from 3.4-series to 4.2-series

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -57,6 +57,8 @@ fi
 [ "$SHELLHUB_ENTERPRISE" = "true" ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.enterprise.yml"
 [ -f docker-compose.override.yml ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.override.yml"
 
+[ -n "$EXTRA_COMPOSE_FILE" ] && COMPOSE_FILE="${COMPOSE_FILE}:${EXTRA_COMPOSE_FILE}"
+
 export COMPOSE_FILE
 
-docker-compose $*
+docker-compose "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     networks:
       - shellhub
   mongo:
-    image: mongo:3.4.19
+    image: mongo:4.2.12
     networks:
       - shellhub
 


### PR DESCRIPTION
With the EOL MongoDB 3.4-series we need to upgrade to 4.2-series.
    
This commit upgrade from 3.4-series to 4.2.12, which is the latest stable version of 4.2-series keeping existing databases without user intervention.
