### PR TITLE
api: convert namespace to lower-case before inserting into db

### DIFF
--- a/api/nsadm/service.go
+++ b/api/nsadm/service.go
@@ -61,6 +61,7 @@ func (s *service) CreateNamespace(ctx context.Context, namespace *models.Namespa
 	if user == nil {
 		return nil, ErrUnauthorized
 	}
+	namespace.Name = strings.ToLower(namespace.Name)
 	namespace.Owner = user.ID
 	members := []string{user.ID}
 	namespace.Members = &members

--- a/api/store/mongo/migrations.go
+++ b/api/store/mongo/migrations.go
@@ -396,6 +396,22 @@ var migrations = []migrate.Migration{
 			return err
 		},
 	},
+	{
+		Version: 15,
+		Up: func(db *mongo.Database) error {
+			_, err := db.Collection("namespaces").UpdateMany(context.TODO(), bson.M{}, []bson.M{
+				bson.M{
+					"$set": bson.M{
+						"name": bson.M{"$toLower": "$name"},
+					},
+				},
+			})
+			return err
+		},
+		Down: func(db *mongo.Database) error {
+			return nil
+		},
+	},
 }
 
 func ApplyMigrations(db *mongo.Database) error {


### PR DESCRIPTION
This fixes #700
    
Also add a migration to convert existing namespace to lowercase
