### PR TITLE
devscripts: add gen-mock script

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -31,7 +31,9 @@ RUN go build
 FROM base AS development
 
 RUN apk add --update openssl build-base docker-cli
-RUN go get github.com/markbates/refresh && go get github.com/mgechev/revive
+RUN go get github.com/markbates/refresh && \
+    go get github.com/mgechev/revive && \
+    go get github.com/vektra/mockery/v2/.../
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/devscripts/README.md
+++ b/devscripts/README.md
@@ -16,3 +16,4 @@ They are not intented for regular use by end users.
 * `get-devices`: Get devices from API
 * `lint-code`: Run code linter
 * `test-unit`: Run unit test
+* `gen-mock`: Generate/update mock objects for testing

--- a/devscripts/gen-mock
+++ b/devscripts/gen-mock
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# This script is used to generate/update mock objects for testing
+
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml \
+	       exec api mockery --name Store --dir ./store/ --output ./store/mocks --filename store.go


### PR DESCRIPTION
The `gen-mock` script is used to generate/update mock objects for unit testing go code.