### PR TITLE
fix /info to omit http host port from ssh host name

### DIFF
--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -182,11 +182,12 @@ server {
         default_type application/json;
 
         content_by_lua_block {
-            local host=ngx.var.http_host
+            local host_with_port=ngx.var.http_host
+            local host_no_port=ngx.var.host
             local ssh_port=os.getenv("SHELLHUB_SSH_PORT")
             local version=os.getenv("SHELLHUB_VERSION")
             local json = require('cjson')
-            local data = {version=version, endpoints={api=host, ssh=host .. ":" .. ssh_port}}
+            local data = {version=version, endpoints={api=host_with_port, ssh=host_no_port .. ":" .. ssh_port}}
             ngx.say(json.encode(data))
         }
     }


### PR DESCRIPTION
If a nonstandard port is used for HTTP, it is included in ngx.var.http_host. Thus, when ":<ssh_port>" is appended, the result is that there are two port numbers appended to the value of the ssh endpoint in the /info api.  The solution is to use ngx.var.host rather than ngx.var.http_host for this case.