### PR TITLE
agent: docker-compose.dev.yml started agent container with hard-coded SHELLHUB_SERVER_ADDRESS

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,7 +53,7 @@ services:
     network_mode: host
     pid: host
     environment:
-      - SHELLHUB_SERVER_ADDRESS=http://172.17.0.1
+      - SHELLHUB_SERVER_ADDRESS=http://localhost:${SHELLHUB_HTTP_PORT}
       - SHELLHUB_PRIVATE_KEY=/go/src/github.com/shellhub-io/shellhub/agent/shellhub.key
       - SHELLHUB_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       - SHELLHUB_VERSION=${SHELLHUB_VERSION}


### PR DESCRIPTION

docker-compose.dev.yml starts an extra container in which a dev/test instance of the agent is run with
SHELLHUB_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.  This container runs in the host network and pid
namespace, which is necessary so that it can launch SSHD child shells on behalf of the host.

However, The host network environment varies from host to host and depending on docker bridge configuration.
The docker-compose file had hardcoded the address of the gateway from the host's network as http://172.17.0.1,
with an implicit gateway port of 80.  This will not work on hosts with different bridge configuration or
when SHELLHUB_HTTP_PORT is not 80.

Since the dev agent is on the host network, localhost works to refer to a gateway running on the same host as
the dev agent.  So the solution is to use localhost:${SHELLHUB_HTTP_PORT}...