### PR TITLE
Fix as many lints as possible

### DIFF
--- a/agent/selfupdater/updater_docker.go
+++ b/agent/selfupdater/updater_docker.go
@@ -84,7 +84,7 @@ func (d *dockerUpdater) CompleteUpdate() error {
 		// since /dev from host is required inside container to mount a pseudo-tty
 		if v.LessThan(v0_4_0) {
 			parent.info.HostConfig.Mounts = []mount.Mount{
-				mount.Mount{
+				{
 					Type:   mount.TypeBind,
 					Source: "/dev",
 					Target: "/dev",
@@ -98,12 +98,12 @@ func (d *dockerUpdater) CompleteUpdate() error {
 		v0_5_0, _ := semver.NewVersion("v0.5.0")
 		if v.LessThan(v0_5_0) {
 			parent.info.HostConfig.Mounts = []mount.Mount{
-				mount.Mount{
+				{
 					Type:   mount.TypeBind,
 					Source: "/var/run",
 					Target: "/var/run",
 				},
-				mount.Mount{
+				{
 					Type:   mount.TypeBind,
 					Source: "/var/log",
 					Target: "/var/log",

--- a/api/authsvc/service_test.go
+++ b/api/authsvc/service_test.go
@@ -62,7 +62,7 @@ func TestAuthDevice(t *testing.T) {
 	// Mock time.Now using monkey patch
 	patch, err := mpatch.PatchMethod(time.Now, func() time.Time { return now })
 	assert.NoError(t, err)
-	defer patch.Unpatch()
+	defer patch.Unpatch() //nolint:errcheck
 
 	authRes, err := s.AuthDevice(ctx, authReq)
 	assert.NoError(t, err)

--- a/api/deviceadm/service_test.go
+++ b/api/deviceadm/service_test.go
@@ -20,11 +20,11 @@ func TestListDevices(t *testing.T) {
 	ctx := context.TODO()
 
 	devices := []models.Device{
-		models.Device{UID: "uid"},
+		{UID: "uid"},
 	}
 
 	filters := []models.Filter{
-		models.Filter{
+		{
 			Type:   "property",
 			Params: &models.PropertyParams{Name: "hostname", Operator: "eq"}},
 	}

--- a/api/pkg/dbtest/dbserver.go
+++ b/api/pkg/dbtest/dbserver.go
@@ -132,7 +132,11 @@ func (dbs *DBServer) monitor() error {
 		cmd := exec.Command("/bin/sh", "-c", "docker ps --filter ancestor=mongo")
 		cmd.Stdout = os.Stderr
 		cmd.Stderr = os.Stderr
-		cmd.Run()
+		err := cmd.Run()
+		if err != nil {
+			return err
+		}
+
 		fmt.Fprintf(os.Stderr, "----------------------------------------\n")
 
 		panic("mongod container died unexpectedly")

--- a/api/pkg/dbtest/dbserver.go
+++ b/api/pkg/dbtest/dbserver.go
@@ -50,7 +50,7 @@ func init() {
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "---- Failed to initialize dbtest:\n")
-		fmt.Fprintf(os.Stderr, out.String())
+		fmt.Fprint(os.Stderr, out.String())
 		panic("Docker is not installed or is not running properly")
 	}
 }

--- a/api/routes/session.go
+++ b/api/routes/session.go
@@ -24,7 +24,9 @@ func GetSessionList(c apicontext.Context) error {
 	svc := sessionmngr.NewService(c.Store())
 
 	query := paginator.NewQuery()
-	c.Bind(query)
+	if err := c.Bind(query); err != nil {
+		return err
+	}
 
 	// TODO: normalize is not required when request is privileged
 	query.Normalize()

--- a/api/routes/sshkeys.go
+++ b/api/routes/sshkeys.go
@@ -25,7 +25,9 @@ func GetPublicKeys(c apicontext.Context) error {
 	svc := sshkeys.NewService(c.Store())
 
 	query := paginator.NewQuery()
-	c.Bind(query)
+	if err := c.Bind(query); err != nil {
+		return err
+	}
 
 	// TODO: normalize is not required when request is privileged
 	query.Normalize()

--- a/api/routes/user.go
+++ b/api/routes/user.go
@@ -18,7 +18,7 @@ func UpdateUser(c apicontext.Context) error {
 		Username        string `json:"username"`
 		Email           string `json:"email"`
 		CurrentPassword string `json:"currentPassword"`
-		NewPassword     string `json: "newPassword"`
+		NewPassword     string `json:"newPassword"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return err

--- a/api/sessionmngr/service_test.go
+++ b/api/sessionmngr/service_test.go
@@ -18,7 +18,7 @@ func TestListSessions(t *testing.T) {
 	ctx := context.TODO()
 
 	sessions := []models.Session{
-		models.Session{UID: "uid"},
+		{UID: "uid"},
 	}
 
 	query := paginator.Query{Page: 1, PerPage: 10}

--- a/api/store/mongo/migrations.go
+++ b/api/store/mongo/migrations.go
@@ -401,7 +401,7 @@ var migrations = []migrate.Migration{
 		Version: 15,
 		Up: func(db *mongo.Database) error {
 			_, err := db.Collection("namespaces").UpdateMany(context.TODO(), bson.M{}, []bson.M{
-				bson.M{
+				{
 					"$set": bson.M{
 						"name": bson.M{"$toLower": "$name"},
 					},

--- a/api/store/mongo/store.go
+++ b/api/store/mongo/store.go
@@ -1364,6 +1364,9 @@ func (s *Store) ListNamespaces(ctx context.Context, pagination paginator.Query, 
 
 	namespaces := make([]models.Namespace, 0)
 	cursor, err := s.db.Collection("namespaces").Aggregate(ctx, query)
+	if err != nil {
+		return nil, 0, err
+	}
 	defer cursor.Close(ctx)
 
 	for cursor.Next(ctx) {

--- a/api/store/mongo/store.go
+++ b/api/store/mongo/store.go
@@ -1100,6 +1100,10 @@ func (s *Store) ListUsers(ctx context.Context, pagination paginator.Query, filte
 	}...)
 
 	queryMatch, err := buildFilterQuery(filters)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	if len(queryMatch) > 0 {
 		query = append(query, queryMatch...)
 	}

--- a/api/store/mongo/store.go
+++ b/api/store/mongo/store.go
@@ -1440,7 +1440,7 @@ func buildPaginationQuery(pagination paginator.Query) []bson.M {
 	}
 
 	return []bson.M{
-		bson.M{"$skip": pagination.PerPage * (pagination.Page - 1)},
-		bson.M{"$limit": pagination.PerPage},
+		{"$skip": pagination.PerPage * (pagination.Page - 1)},
+		{"$limit": pagination.PerPage},
 	}
 }

--- a/api/store/mongo/store_test.go
+++ b/api/store/mongo/store_test.go
@@ -23,8 +23,12 @@ func TestAddDevice(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -45,7 +49,7 @@ func TestAddDevice(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 }
 
@@ -57,8 +61,12 @@ func TestGetDevice(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -79,7 +87,7 @@ func TestGetDevice(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 	d, err := mongostore.GetDevice(ctx, models.UID(device.UID))
 	assert.NoError(t, err)
@@ -94,8 +102,12 @@ func TestRenameDevice(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -116,7 +128,7 @@ func TestRenameDevice(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 	err = mongostore.RenameDevice(ctx, models.UID(device.UID), "newHostname")
 	assert.NoError(t, err)
@@ -129,8 +141,12 @@ func TestLookupDevice(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -151,8 +167,9 @@ func TestLookupDevice(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "device")
+	err = mongostore.AddDevice(ctx, device, "device")
 	assert.NoError(t, err)
+
 	err = mongostore.UpdatePendingStatus(ctx, models.UID(device.UID), "accepted")
 	d, err := mongostore.LookupDevice(ctx, "name", "device")
 	assert.NoError(t, err)
@@ -167,8 +184,12 @@ func TestUpdatePendingStatus(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -189,8 +210,9 @@ func TestUpdatePendingStatus(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "device")
+	err = mongostore.AddDevice(ctx, device, "device")
 	assert.NoError(t, err)
+
 	err = mongostore.UpdatePendingStatus(ctx, models.UID(device.UID), "accepted")
 	assert.NoError(t, err)
 }
@@ -202,8 +224,12 @@ func TestUpdateDeviceStatus(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -224,7 +250,7 @@ func TestUpdateDeviceStatus(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 	err = mongostore.UpdateDeviceStatus(ctx, models.UID(device.UID), true)
 	assert.NoError(t, err)
@@ -237,8 +263,12 @@ func TestCreateSession(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -259,7 +289,7 @@ func TestCreateSession(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -283,8 +313,12 @@ func TestGetSession(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -305,7 +339,7 @@ func TestGetSession(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -330,8 +364,12 @@ func TestListSessions(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -352,7 +390,7 @@ func TestListSessions(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -378,8 +416,12 @@ func TestSetSessionAuthenticated(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -400,7 +442,7 @@ func TestSetSessionAuthenticated(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -425,8 +467,12 @@ func TestKeepAliveSession(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -447,7 +493,7 @@ func TestKeepAliveSession(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -471,8 +517,12 @@ func TestDeactivateSession(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -493,7 +543,7 @@ func TestDeactivateSession(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -518,8 +568,12 @@ func TestRecordSession(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -540,7 +594,7 @@ func TestRecordSession(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -565,8 +619,13 @@ func TestGetRecord(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -587,7 +646,7 @@ func TestGetRecord(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -616,8 +675,13 @@ func TestGetUserByUsername(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email", ID: "owner"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
 	u, err := mongostore.GetUserByUsername(ctx, "username")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, u)
@@ -631,7 +695,10 @@ func TestGetUserByEmail(t *testing.T) {
 	ctx := context.TODO()
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
 	u, err := mongostore.GetUserByEmail(ctx, "email")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, u)
@@ -645,8 +712,12 @@ func TestGetDeviceByMac(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -667,7 +738,7 @@ func TestGetDeviceByMac(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 	d, err := mongostore.GetDeviceByMac(ctx, "mac", "tenant", "pending")
 	assert.NoError(t, err)
@@ -682,8 +753,12 @@ func TestGetDeviceByName(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -704,7 +779,7 @@ func TestGetDeviceByName(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "hostname")
+	err = mongostore.AddDevice(ctx, device, "hostname")
 	assert.NoError(t, err)
 	d, err := mongostore.GetDeviceByName(ctx, "hostname", "tenant")
 	assert.NoError(t, err)
@@ -719,8 +794,12 @@ func TestGetDeviceByUID(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -741,7 +820,7 @@ func TestGetDeviceByUID(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 	d, err := mongostore.GetDeviceByUID(ctx, models.UID(device.UID), "tenant")
 	assert.NoError(t, err)
@@ -870,8 +949,12 @@ func TestListDevices(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
@@ -892,7 +975,7 @@ func TestListDevices(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	devices, count, err := mongostore.ListDevices(ctx, paginator.Query{Page: -1, PerPage: -1}, nil, "", "last_seen", "asc")
@@ -934,8 +1017,13 @@ func TestUpdateUID(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
 			TenantID: "tenant",
@@ -955,7 +1043,7 @@ func TestUpdateUID(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 	err = mongostore.UpdateUID(ctx, models.UID(device.UID), models.UID("newUID"))
 	assert.NoError(t, err)
@@ -969,11 +1057,15 @@ func TestUpdateUser(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	result, _ := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	result, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	objID := result.InsertedID.(primitive.ObjectID).Hex()
-	err := mongostore.UpdateUser(ctx, "newUsername", "newEmail", "password", "newPassword", objID)
+	err = mongostore.UpdateUser(ctx, "newUsername", "newEmail", "password", "newPassword", objID)
 	assert.NoError(t, err)
 }
 
@@ -985,11 +1077,15 @@ func TestUpdateUserFromAdmin(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	result, _ := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	result, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	objID := result.InsertedID.(primitive.ObjectID).Hex()
-	err := mongostore.UpdateUserFromAdmin(ctx, "newUsername", "newEmail", "password", objID)
+	err = mongostore.UpdateUserFromAdmin(ctx, "newUsername", "newEmail", "password", objID)
 	assert.NoError(t, err)
 }
 
@@ -1001,8 +1097,13 @@ func TestGetDataUserSecurity(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email", ID: "hash1"}
 	namespace := &models.Namespace{Name: "group1", Owner: "hash1", TenantID: "a736a52b-5777-4f92-b0b8-e359bf484713", Settings: &models.NamespaceSettings{SessionRecord: true}}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
 	returnedStatus, err := mongostore.GetDataUserSecurity(ctx, namespace.TenantID)
 	assert.Equal(t, returnedStatus, namespace.Settings.SessionRecord)
 	assert.NoError(t, err)
@@ -1015,9 +1116,14 @@ func TestUpdateDataUserSecurity(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email", ID: "hash1"}
 	namespace := &models.Namespace{Name: "group1", Owner: "hash1", TenantID: "a736a52b-5777-4f92-b0b8-e359bf484713", Settings: &models.NamespaceSettings{SessionRecord: true}}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
-	err := mongostore.UpdateDataUserSecurity(ctx, false, namespace.TenantID)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
+	err = mongostore.UpdateDataUserSecurity(ctx, false, namespace.TenantID)
 	assert.NoError(t, err)
 }
 
@@ -1048,26 +1154,33 @@ func TestListUsersWithFilter(t *testing.T) {
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	result, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
 	namespace := models.Namespace{Name: "name", Owner: result.InsertedID.(primitive.ObjectID).Hex(), TenantID: "tenant"}
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	user = models.User{Name: "name", Username: "username-1", Password: "password", Email: "email-1"}
 	result, err = db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+
 	namespace = models.Namespace{Name: "name", Owner: result.InsertedID.(primitive.ObjectID).Hex(), TenantID: "tenant"}
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	user = models.User{Name: "name", Username: "username-2", Password: "password", Email: "email-2"}
 	result, err = db.Client().Database("test").Collection("users").InsertOne(ctx, user)
 	namespace = models.Namespace{Name: "name", Owner: result.InsertedID.(primitive.ObjectID).Hex(), TenantID: "tenant"}
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 	namespace = models.Namespace{Name: "name", Owner: result.InsertedID.(primitive.ObjectID).Hex(), TenantID: "tenant"}
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	user = models.User{Name: "name", Username: "username-3", Password: "password", Email: "email-3"}
 	result, err = db.Client().Database("test").Collection("users").InsertOne(ctx, user)
 	namespace = models.Namespace{Name: "name", Owner: result.InsertedID.(primitive.ObjectID).Hex(), TenantID: "tenant"}
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 	namespace = models.Namespace{Name: "name", Owner: result.InsertedID.(primitive.ObjectID).Hex(), TenantID: "tenant"}
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 
 	filters := []models.Filter{
 		{
@@ -1090,8 +1203,10 @@ func TestGetStats(t *testing.T) {
 	mongostore := NewStore(db.Client().Database("test"))
 	user := models.User{Name: "name", Username: "username", Password: "password", Email: "email"}
 	namespace := models.Namespace{Name: "name", Owner: "owner", TenantID: "tenant"}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
 	authReq := &models.DeviceAuthRequest{
 		DeviceAuth: &models.DeviceAuth{
 			TenantID: "tenant",
@@ -1111,7 +1226,7 @@ func TestGetStats(t *testing.T) {
 		LastSeen: time.Now(),
 	}
 
-	err := mongostore.AddDevice(ctx, device, "")
+	err = mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
 	session := models.Session{
@@ -1370,9 +1485,14 @@ func TestListPublicKeys(t *testing.T) {
 	key := models.PublicKey{
 		Data: []byte("teste"), Fingerprint: "fingerprint", CreatedAt: time.Now(), TenantID: "tenant1", PublicKeyFields: models.PublicKeyFields{Name: "teste"},
 	}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
-	db.Client().Database("test").Collection("public_keys").InsertOne(ctx, key)
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("public_keys").InsertOne(ctx, key)
+	assert.NoError(t, err)
 
 	_, count, err := mongostore.ListPublicKeys(ctx, paginator.Query{Page: -1, PerPage: -1})
 	assert.Equal(t, 1, count)
@@ -1390,9 +1510,14 @@ func TestListGetPublicKey(t *testing.T) {
 	key := models.PublicKey{
 		Data: []byte("teste"), Fingerprint: "fingerprint", CreatedAt: time.Now(), TenantID: "tenant1", PublicKeyFields: models.PublicKeyFields{Name: "teste"},
 	}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
-	db.Client().Database("test").Collection("public_keys").InsertOne(ctx, key)
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("public_keys").InsertOne(ctx, key)
+	assert.NoError(t, err)
 
 	k, err := mongostore.GetPublicKey(ctx, key.Fingerprint, key.TenantID)
 	assert.NoError(t, err)
@@ -1421,9 +1546,15 @@ func TestUpdatePublicKey(t *testing.T) {
 	update := &models.PublicKeyUpdate{
 		PublicKeyFields: models.PublicKeyFields{Name: "teste2"},
 	}
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
-	db.Client().Database("test").Collection("public_keys").InsertOne(ctx, key)
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("public_keys").InsertOne(ctx, key)
+	assert.NoError(t, err)
 
 	k, err := mongostore.UpdatePublicKey(ctx, key.Fingerprint, key.TenantID, update)
 	assert.NoError(t, err)
@@ -1445,10 +1576,15 @@ func TestDeletePublicKey(t *testing.T) {
 		Data: []byte("teste"), Fingerprint: "fingerprint", TenantID: "tenant", PublicKeyFields: models.PublicKeyFields{Name: "teste1"},
 	}
 
-	db.Client().Database("test").Collection("public_keys").InsertOne(ctx, newKey)
-	db.Client().Database("test").Collection("users").InsertOne(ctx, user)
-	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	_, err := db.Client().Database("test").Collection("public_keys").InsertOne(ctx, newKey)
+	assert.NoError(t, err)
 
-	err := mongostore.DeletePublicKey(ctx, newKey.Fingerprint, newKey.TenantID)
+	_, err = db.Client().Database("test").Collection("users").InsertOne(ctx, user)
+	assert.NoError(t, err)
+
+	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+	assert.NoError(t, err)
+
+	err = mongostore.DeletePublicKey(ctx, newKey.Fingerprint, newKey.TenantID)
 	assert.NoError(t, err)
 }

--- a/api/store/mongo/store_test.go
+++ b/api/store/mongo/store_test.go
@@ -1070,7 +1070,7 @@ func TestListUsersWithFilter(t *testing.T) {
 	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
 
 	filters := []models.Filter{
-		models.Filter{
+		{
 			Type:   "property",
 			Params: &models.PropertyParams{Name: "namespaces", Operator: "gt", Value: "1"}},
 	}

--- a/api/store/mongo/store_test.go
+++ b/api/store/mongo/store_test.go
@@ -365,7 +365,7 @@ func TestListSessions(t *testing.T) {
 
 	_, err = mongostore.CreateSession(ctx, session)
 	assert.NoError(t, err)
-	sessions, count, err := mongostore.ListSessions(ctx, paginator.Query{-1, -1})
+	sessions, count, err := mongostore.ListSessions(ctx, paginator.Query{Page: -1, PerPage: -1})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 	assert.NotEmpty(t, sessions)
@@ -786,7 +786,7 @@ func TestGetFirewallRule(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	rules, count, err := mongostore.ListFirewallRules(ctx, paginator.Query{-1, -1})
+	rules, count, err := mongostore.ListFirewallRules(ctx, paginator.Query{Page: -1, PerPage: -1})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
@@ -816,7 +816,7 @@ func TestUpdateFirewallRule(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	rules, count, err := mongostore.ListFirewallRules(ctx, paginator.Query{-1, -1})
+	rules, count, err := mongostore.ListFirewallRules(ctx, paginator.Query{Page: -1, PerPage: -1})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 	assert.NotEmpty(t, rules)
@@ -853,7 +853,7 @@ func TestDeleteFirewallRule(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	rules, count, err := mongostore.ListFirewallRules(ctx, paginator.Query{-1, -1})
+	rules, count, err := mongostore.ListFirewallRules(ctx, paginator.Query{Page: -1, PerPage: -1})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 	assert.NotEmpty(t, rules)
@@ -895,7 +895,7 @@ func TestListDevices(t *testing.T) {
 	err := mongostore.AddDevice(ctx, device, "")
 	assert.NoError(t, err)
 
-	devices, count, err := mongostore.ListDevices(ctx, paginator.Query{-1, -1}, nil, "", "last_seen", "asc")
+	devices, count, err := mongostore.ListDevices(ctx, paginator.Query{Page: -1, PerPage: -1}, nil, "", "last_seen", "asc")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 	assert.NotEmpty(t, devices)
@@ -920,7 +920,7 @@ func TestListFirewallRules(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	rules, count, err := mongostore.ListFirewallRules(ctx, paginator.Query{-1, -1})
+	rules, count, err := mongostore.ListFirewallRules(ctx, paginator.Query{Page: -1, PerPage: -1})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 	assert.NotEmpty(t, rules)
@@ -1032,7 +1032,7 @@ func TestListUsers(t *testing.T) {
 	userID := result.InsertedID.(primitive.ObjectID).Hex()
 	namespace := models.Namespace{Name: "name", Owner: userID, TenantID: "tenant"}
 	_, err = db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
-	users, count, err := mongostore.ListUsers(ctx, paginator.Query{-1, -1}, nil)
+	users, count, err := mongostore.ListUsers(ctx, paginator.Query{Page: -1, PerPage: -1}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 	assert.NotEmpty(t, users)
@@ -1075,7 +1075,7 @@ func TestListUsersWithFilter(t *testing.T) {
 			Params: &models.PropertyParams{Name: "namespaces", Operator: "gt", Value: "1"}},
 	}
 
-	users, count, err := mongostore.ListUsers(ctx, paginator.Query{-1, -1}, filters)
+	users, count, err := mongostore.ListUsers(ctx, paginator.Query{Page: -1, PerPage: -1}, filters)
 	assert.NoError(t, err)
 	assert.Equal(t, len(users), count)
 	assert.Equal(t, 2, count)
@@ -1236,7 +1236,7 @@ func testListNamespaces(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, count, err := mongostore.ListNamespaces(ctx, paginator.Query{-1, -1}, nil, false)
+	_, count, err := mongostore.ListNamespaces(ctx, paginator.Query{Page: -1, PerPage: -1}, nil, false)
 	assert.Equal(t, 1, count)
 	assert.NoError(t, err)
 }
@@ -1374,7 +1374,7 @@ func TestListPublicKeys(t *testing.T) {
 	db.Client().Database("test").Collection("namespaces").InsertOne(ctx, namespace)
 	db.Client().Database("test").Collection("public_keys").InsertOne(ctx, key)
 
-	_, count, err := mongostore.ListPublicKeys(ctx, paginator.Query{-1, -1})
+	_, count, err := mongostore.ListPublicKeys(ctx, paginator.Query{Page: -1, PerPage: -1})
 	assert.Equal(t, 1, count)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
I am fixing the easy lint errors, which can be found by `golangci-lint` prior add it to CI. It'll probably be multiple PRs to clean it all as there are many issues, and I don't want to hold it for too long to avoid conflicts. 