### PR TITLE
agent: Fixes utmp/wtmp recording on 64-bit systems

### DIFF
--- a/agent/sshd/utmp_timeval_time32.go
+++ b/agent/sshd/utmp_timeval_time32.go
@@ -1,0 +1,52 @@
+// +build !arm64
+
+package sshd
+
+/*	The Utmpx struct is derived from the Linux definition (man 5 utmpx).
+
+	On all Linux systems (both 32-bit and 64-bit) except for
+	arm64/aarch64, a utmp record is 384 bytes in length and the
+	Session, Tv.Sec and Tv.Usec fields are all 32 bits in length.
+
+	On arm64/aarch64, a utmp record is 400 bytes in length and the
+	Session, Tv.Sec and Tv.Usec fields are all 64 bits in length.
+
+	There are two versions of this file, one for arm64/aarch64 and
+	one for all other architectures.
+*/
+
+import (
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+type TimeVal struct {
+	Sec  int32 // Seconds since epoch
+	Usec int32 // Microseconds
+}
+
+type Utmpx struct {
+	Type     int16        // UserProcess or DeadProcess
+	Padding  [2]byte      // Padding to align rest of struct
+	Pid      int32        // PID of the ShellHub agent
+	Line     [32]byte     // tty associated with the process
+	ID       [4]byte      // Index, last 4 characters of Line
+	User     [32]byte     // Username
+	Host     [256]byte    // Source IP address
+	Exit     ExitStatus   // Exit status - not used
+	Session  int32        // Session ID - not used
+	Tv       TimeVal      // Time entry was made
+	AddrV6   [4]uint32    // Source IP address. IPv4 in AddrV6[0]
+	Reserved [20]byte     // Not used
+}
+
+// This function writes the current time into the utmp record
+func utmpSetTime(u Utmpx) Utmpx {
+	a := unix.Timeval{}
+	if err := unix.Gettimeofday(&a); err != nil {
+		logrus.Warn(err)
+	}
+
+	u.Tv.Sec, u.Tv.Usec = int32(a.Sec), int32(a.Usec)
+	return u
+}

--- a/agent/sshd/utmp_timeval_time64.go
+++ b/agent/sshd/utmp_timeval_time64.go
@@ -1,0 +1,53 @@
+// +build arm64
+
+package sshd
+
+/*	The Utmpx struct is derived from the Linux definition (man 5 utmpx).
+
+	On all Linux systems (both 32-bit and 64-bit) except for
+	arm64/aarch64, a utmp record is 384 bytes in length and the
+	Session, Tv.Sec and Tv.Usec fields are all 32 bits in length.
+
+	On arm64/aarch64, a utmp record is 400 bytes in length and the
+	Session, Tv.Sec and Tv.Usec fields are all 64 bits in length.
+
+	There are two versions of this file, one for arm64/aarch64 and
+	one for all other architectures.
+*/
+
+import (
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+type TimeVal struct {
+	Sec  int64 // Seconds since epoch
+	Usec int64 // Microseconds
+}
+
+type Utmpx struct {
+	Type     int16        // UserProcess or DeadProcess
+	Padding1 [2]byte      // Padding to align rest of struct
+	Pid      int32        // PID of the ShellHub agent
+	Line     [32]byte     // tty associated with the process
+	ID       [4]byte      // Index, last 4 characters of Line
+	User     [32]byte     // Username
+	Host     [256]byte    // Source IP address
+	Exit     ExitStatus   // Exit status - not used
+	Session  int64        // Session ID - not used
+	Tv       TimeVal      // Time entry was made
+	AddrV6   [4]uint32    // Source IP address. IPv4 in AddrV6[0]
+	Reserved [20]byte     // Not used
+	Padding2 [4]byte      // Padding to align the next record
+}
+
+// This function writes the current time into the utmp record
+func utmpSetTime(u Utmpx) Utmpx {
+	a := unix.Timeval{}
+	if err := unix.Gettimeofday(&a); err != nil {
+		logrus.Warn(err)
+	}
+
+	u.Tv.Sec, u.Tv.Usec = a.Sec, a.Usec
+	return u
+}


### PR DESCRIPTION
This change fixes the incorrect formatting of utmp records on some
64-bit systems.

The change writes correct utmp records on:

  32-bit systems where session and time fields in utmp records are 32-bits
  64-bit systems where session and time fields in utmp records are 32-bits
  64-bit systems where session and time fields in utmp records are 64-bits

The only known case where a 64-bit system writes 64-bit session and time
fields is arm64/aarch64 architecture in, for example, Raspberry Pi
64-bit operating systems.

This change has been tested on:
  Debian 10.8.0 32-bit
  Debian 10.8.0 64-bit
  Fedora 33 64-bit
  Gentoo R-Pi 64-bit
  OpenSUSE Leap 15.2 64-bit
  R-Pi OS Latest 32-bit
  R-Pi OS Latest 64-bit
  Ubuntu 20.4 x86 LTS 64-bit
  Ubuntu 20.10 x86 64-bit
  Ubuntu 20.10 R-Pi 32-bit
  Ubuntu 20.10 R-Pi 64-bit

Fixes https://github.com/shellhub-io/shellhub/issues/765