### PR TITLE
Avoid using `sh <(curl ...)` syntax as it does not work in Busybox

### DIFF
--- a/gateway/kickstart.sh
+++ b/gateway/kickstart.sh
@@ -4,7 +4,7 @@
 # generate the final script file. PLEASE NEVER RUN THIS FILE DIRECTLY, instead
 # run me with:
 #
-# sh <(curl -Ss "http://<SERVER-ADDRESS>/kickstart.sh?tenant_id=<TENANT-ID>")
+# curl -sSf "http://<SERVER-ADDRESS>/kickstart.sh?tenant_id=<TENANT-ID>" | sh
 #
 # Where:
 # <SERVER-ADDRESS> is the ShellHub server address

--- a/ui/src/components/device/DeviceAdd.vue
+++ b/ui/src/components/device/DeviceAdd.vue
@@ -113,7 +113,7 @@ export default {
       let port = '';
       if (window.location.port !== '') port = `:${this.port}`;
 
-      return `sh <(curl "${window.location.protocol}//${this.hostname}${port}/install.sh?tenant_id=${this.tenant}")`;
+      return `curl -sSf "${window.location.protocol}//${this.hostname}${port}/install.sh?tenant_id=${this.tenant}" | sh`;
     },
 
     copyCommand() {

--- a/ui/src/components/welcome/Welcome.vue
+++ b/ui/src/components/welcome/Welcome.vue
@@ -215,7 +215,7 @@ export default {
 
   methods: {
     command() {
-      return `sh <(curl "${window.location.protocol}//${this.curl.hostname}/install.sh?tenant_id=${this.curl.tenant}")`;
+      return `curl -sSf "${window.location.protocol}//${this.curl.hostname}/install.sh?tenant_id=${this.curl.tenant}" | sh`;
     },
 
     activePollingDevices() {

--- a/ui/tests/unit/components/device/DeviceAdd.spec.js
+++ b/ui/tests/unit/components/device/DeviceAdd.spec.js
@@ -59,7 +59,7 @@ describe('DeviceAdd', () => {
     expect(wrapper.vm.tenant).toBe('00000000');
   });
   it('Process data in methods', () => {
-    const command = 'sh <(curl "http://localhost/install.sh?tenant_id=00000000")';
+    const command = 'curl -sSf "http://localhost/install.sh?tenant_id=00000000" | sh';
     expect(wrapper.vm.command()).toBe(command);
 
     jest.spyOn(wrapper.vm, 'copyCommand');

--- a/ui/tests/unit/components/welcome/Welcome.spec.js
+++ b/ui/tests/unit/components/welcome/Welcome.spec.js
@@ -81,7 +81,7 @@ describe('Welcome', () => {
     expect(wrapper.vm.show).toEqual(show);
   });
   it('Process data in the methods', () => {
-    const command = `sh <(curl "http://localhost/install.sh?tenant_id=${tenant}")`;
+    const command = `curl -sSf "http://localhost/install.sh?tenant_id=${tenant}" | sh`;
     expect(wrapper.vm.command()).toEqual(command);
   });
   it('Compare data with default value', () => {

--- a/ui/tests/unit/components/welcome/WelcomeSecondScreen.spec.js
+++ b/ui/tests/unit/components/welcome/WelcomeSecondScreen.spec.js
@@ -8,7 +8,7 @@ describe('WelcomeSecondScreen', () => {
 
   let wrapper;
 
-  const command = 'sh <(curl "http://localhost/install.sh?tenant_id=a582b47a42e")';
+  const command = 'curl -sSf "http://localhost/install.sh?tenant_id=a582b47a42e" | sh';
 
   const store = new Vuex.Store({
     namespaced: true,


### PR DESCRIPTION
The installation script, using the `sh <(curl ...)` does not work on
Busybox shell. This has been detected in newer Torizon operating system.

We are now using:

```sh
curl -sSf ... | sh
```

This is the same format used in `htts://rustup.rs` to install the Rust
compiler and has been in use for quite some time by them.

This partially revert the change in #638, however, the commit log and
issue didn't provide enough information to reproduce the original issue
so in case it breaks something we'll need to find a testing case for it.

Reported-by: Guilherme Fernandes <guilherme.fernandes@toradex.com>
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>