### PR TITLE
gateway: Fix /info to use X-Forwarded-Host to generate URLs

### DIFF
--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -182,11 +182,16 @@ server {
         default_type application/json;
 
         content_by_lua_block {
-            local host_with_port=ngx.var.http_host
-            local host_no_port=ngx.var.host
+            local host_with_port=ngx.var.http_x_forwarded_host ~= '' and ngx.var.http_x_forwarded_host or ngx.var.http_host
+            local host_no_port=ngx.var.http_x_forwarded_host ~= '' and ngx.var.http_x_forwarded_host or ngx.var.host
             local ssh_port=os.getenv("SHELLHUB_SSH_PORT")
             local version=os.getenv("SHELLHUB_VERSION")
             local json = require('cjson')
+
+            if ngx.var.http_x_forwarded_port ~= nil and ngx.var.http_x_forwarded_port ~= '' then
+                host_with_port = host_no_port .. ":" .. ngx.var.http_x_forwarded_port
+            end
+
             local data = {version=version, endpoints={api=host_with_port, ssh=host_no_port .. ":" .. ssh_port}}
             ngx.say(json.encode(data))
         }


### PR DESCRIPTION
Use X-Forwarded-Host header (if present) to determine which host
to use for URL generation. This may be used where a L7 reverse
proxy is in-front of ShellHub gateway service.