### PR TITLE
api: generate jwt token with user id data

### DIFF
--- a/api/authsvc/service.go
+++ b/api/authsvc/service.go
@@ -234,13 +234,13 @@ func (s *service) AuthPublicKey(ctx context.Context, req *models.PublicKeyAuthRe
 	}, nil
 }
 
-func (s *service) AuthSwapToken(ctx context.Context, username, tenant string) (*models.UserAuthResponse, error) {
+func (s *service) AuthSwapToken(ctx context.Context, id, tenant string) (*models.UserAuthResponse, error) {
 	namespace, err := s.store.GetNamespace(ctx, tenant)
 	if err != nil {
 		return nil, err
 	}
 
-	user, err := s.store.GetUserByUsername(ctx, username)
+	user, err := s.store.GetUserByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -251,6 +251,7 @@ func (s *service) AuthSwapToken(ctx context.Context, username, tenant string) (*
 				Username: user.Username,
 				Admin:    true,
 				Tenant:   namespace.TenantID,
+				ID:       user.ID,
 				AuthClaims: models.AuthClaims{
 					Claims: "user",
 				},

--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -132,12 +132,12 @@ func AuthGetToken(c apicontext.Context) error {
 func AuthSwapToken(c apicontext.Context) error {
 	svc := authsvc.NewService(c.Store(), nil, nil)
 
-	username := ""
-	if v := c.Username(); v != nil {
-		username = v.ID
+	id := ""
+	if v := c.ID(); v != nil {
+		id = v.ID
 	}
 
-	res, err := svc.AuthSwapToken(c.Ctx(), username, c.Param("tenant"))
+	res, err := svc.AuthSwapToken(c.Ctx(), id, c.Param("tenant"))
 	if err != nil {
 		return echo.ErrUnauthorized
 	}


### PR DESCRIPTION
The store.ListNamespaces function uses the ID from context to build
the scoped query to list all namespaces. When the ID is missing all
namespaces is returned.

This commit fixes the issue when listing namespaces which not belongs
to issued token owner.