### PR TITLE
ui: Set sass loader version less than 11

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -52,8 +52,8 @@
         "font-logos": "^0.16.0",
         "mock-local-storage": "^1.1.17",
         "node-sass": "^5.0.0",
-        "sass": "^1.32.10",
-        "sass-loader": "^10.1.1",
+        "sass": "1.32.8",
+        "sass-loader": "<11",
         "stylus": "^0.54.8",
         "stylus-loader": "^4.3.3",
         "vue-cli-plugin-vuetify": "^2.3.1",
@@ -9515,6 +9515,7 @@
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.21.tgz",
       "integrity": "sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"
@@ -11885,6 +11886,7 @@
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
       "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -16537,6 +16539,7 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
       "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -19424,12 +19427,12 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.32.10",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.10.tgz",
-      "integrity": "sha512-Nx0pcWoonAkn7CRp0aE/hket1UP97GiR1IFw3kcjV3pnenhWgZEWUf0ZcfPOV2fK52fnOcK3JdC/YYZ9E47DTQ==",
+      "version": "1.32.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+      "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0"
+        "chokidar": ">=2.0.0 <4.0.0"
       },
       "bin": {
         "sass": "sass.js"
@@ -40654,12 +40657,12 @@
       }
     },
     "sass": {
-      "version": "1.32.10",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.10.tgz",
-      "integrity": "sha512-Nx0pcWoonAkn7CRp0aE/hket1UP97GiR1IFw3kcjV3pnenhWgZEWUf0ZcfPOV2fK52fnOcK3JdC/YYZ9E47DTQ==",
+      "version": "1.32.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+      "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
       "dev": true,
       "requires": {
-        "chokidar": ">=3.0.0 <4.0.0"
+        "chokidar": ">=2.0.0 <4.0.0"
       }
     },
     "sass-graph": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -56,7 +56,7 @@
     "mock-local-storage": "^1.1.17",
     "node-sass": "^5.0.0",
     "sass": "1.32.8",
-    "sass-loader": "^10.1.1",
+    "sass-loader": "<11",
     "stylus": "^0.54.8",
     "stylus-loader": "^4.3.3",
     "vue-cli-plugin-vuetify": "^2.3.1",


### PR DESCRIPTION
This commit set the version less than 11, because the sass loader
version 11 ou higher, doesn't work with vue 2.6.12.