### PR TITLE
api: Returns conflict when inserting an existing namespace

### DIFF
--- a/api/nsadm/service_test.go
+++ b/api/nsadm/service_test.go
@@ -57,6 +57,7 @@ func TestCreateNamespace(t *testing.T) {
 
 	namespace := &models.Namespace{Name: "group1", Owner: "hash1"}
 
+	mock.On("NamespaceGetByName", ctx, namespace.Name).Return(nil, nil).Once()
 	mock.On("UserGetByID", ctx, user.ID).Return(user, nil).Once()
 	mock.On("NamespaceCreate", ctx, namespace).Return(namespace, nil).Once()
 

--- a/api/routes/nsadm.go
+++ b/api/routes/nsadm.go
@@ -54,11 +54,16 @@ func CreateNamespace(c apicontext.Context) error {
 	if v := c.ID(); v != nil {
 		id = v.ID
 	}
+
 	if _, err := svc.CreateNamespace(c.Ctx(), &namespace, id); err != nil {
-		if err == nsadm.ErrUnauthorized {
+		switch {
+		case err == nsadm.ErrUnauthorized:
 			return c.NoContent(http.StatusForbidden)
+		case err == nsadm.ErrConflictName:
+			return c.NoContent(http.StatusConflict)
+		default:
+			return err
 		}
-		return err
 	}
 
 	return c.JSON(http.StatusOK, namespace)


### PR DESCRIPTION
This commit also removes the data return from the namespace, as it's
not necessary.