### PR TITLE
ui: fix notifications

### DIFF
--- a/ui/src/components/app_bar/AppBar.vue
+++ b/ui/src/components/app_bar/AppBar.vue
@@ -46,9 +46,7 @@
         </v-icon>
       </v-chip>
 
-      <Notification
-        :in-a-namespace="hasNamespaces"
-      />
+      <Notification />
 
       <v-menu
         offset-y

--- a/ui/src/components/app_bar/notification/Notification.vue
+++ b/ui/src/components/app_bar/notification/Notification.vue
@@ -96,18 +96,12 @@ export default {
     DeviceActionButton,
   },
 
-  props: {
-    inANamespace: {
-      type: Boolean,
-      required: true,
-    },
-  },
-
   data() {
     return {
       listNotifications: [],
       numberNotifications: 0,
       shown: false,
+      inANamespace: false,
     };
   },
 
@@ -128,12 +122,20 @@ export default {
     isOwner() {
       return this.$store.getters['namespaces/owner'];
     },
+
+    hasNamespace() {
+      return this.$store.getters['namespaces/getNumberNamespaces'] !== 0;
+    },
   },
 
-  async created() {
-    if (this.inANamespace) {
-      await this.getNotifications();
-    }
+  watch: {
+    hasNamespace(status) {
+      this.inANamespace = status;
+
+      if (status) {
+        this.getNotifications();
+      }
+    },
   },
 
   methods: {


### PR DESCRIPTION
The problem is that the variable hasNamespaces passed in the props,
sometimes the resquest was not finished in time. In order to solve
the problem, the status change in the store is checked directly.