### PR TITLE
docker: improved container build time

### DIFF
--- a/.env
+++ b/.env
@@ -51,6 +51,12 @@ SHELLHUB_ENTERPRISE_ADMIN_PASSWORD=
 # Internal to our cloud service. - don't worry about it
 SHELLHUB_CLOUD=false
 
+# Set Go modules proxy cache URL (development only)
+#SHELLHUB_GOPROXY=http://localhost:3333
+
+# Set NPM proxy cache URL (development only)
+#SHELLHUB_NPM_REGISTRY=http://localhost:4873
+
 # Webhook config
 SHELLHUB_WEBHOOK_URL=""
 SHELLHUB_WEBHOOK_PORT=""

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,6 +1,8 @@
 # base stage
 FROM golang:1.16.4-alpine3.13 AS base
 
+ARG GOPROXY
+
 RUN apk add --update git ca-certificates build-base bash util-linux setpriv
 
 RUN ln -sf /bin/bash /bin/sh
@@ -19,6 +21,7 @@ RUN go mod download
 FROM base AS builder
 
 ARG SHELLHUB_VERSION=latest
+ARG GOPROXY
 
 COPY ./pkg $GOPATH/src/github.com/shellhub-io/shellhub/pkg
 COPY ./agent .
@@ -33,6 +36,9 @@ RUN go build -tags docker -ldflags "-X main.AgentVersion=${SHELLHUB_VERSION}"
 
 # development stage
 FROM base AS development
+
+ARG GOPROXY
+ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl openssh-client
 RUN go get github.com/markbates/refresh && go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.37.1

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,8 @@
 # base stage
 FROM golang:1.16.4-alpine3.13 AS base
 
+ARG GOPROXY
+
 RUN apk add --no-cache git ca-certificates
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
@@ -16,6 +18,8 @@ RUN go mod download
 # builder stage
 FROM base AS builder
 
+ARG GOPROXY
+
 COPY ./pkg $GOPATH/src/github.com/shellhub-io/shellhub/pkg
 COPY ./api .
 
@@ -29,6 +33,9 @@ RUN go build
 
 # development stage
 FROM base AS development
+
+ARG GOPROXY
+ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl build-base docker-cli
 RUN go get github.com/markbates/refresh && \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,9 @@ services:
       context: .
       dockerfile: ssh/Dockerfile
       target: development
+      network: host
+      args:
+        - GOPROXY=${SHELLHUB_GOPROXY}
     volumes:
       - ./ssh:/go/src/github.com/shellhub-io/shellhub/ssh
       - ./pkg:/go/src/github.com/shellhub-io/shellhub/pkg
@@ -18,6 +21,9 @@ services:
       context: .
       dockerfile: api/Dockerfile
       target: development
+      network: host
+      args:
+        - GOPROXY=${SHELLHUB_GOPROXY}
     volumes:
       - ./api:/go/src/github.com/shellhub-io/shellhub/api
       - ./pkg:/go/src/github.com/shellhub-io/shellhub/pkg
@@ -28,6 +34,9 @@ services:
       context: .
       dockerfile: ui/Dockerfile
       target: development
+      network: host
+      args:
+        - NPM_CONFIG_REGISTRY=${SHELLHUB_NPM_REGISTRY}
     volumes:
       - ./ui:/src
     environment:
@@ -47,8 +56,11 @@ services:
       context: .
       dockerfile: agent/Dockerfile
       target: development
+      network: host
       args:
-        SHELLHUB_VERSION: latest
+        - SHELLHUB_VERSION=latest
+        - GOPROXY=${SHELLHUB_GOPROXY}
+
     privileged: true
     network_mode: host
     pid: host

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -1,6 +1,8 @@
 # base stage
 FROM golang:1.16.4-alpine3.13 AS base
 
+ARG GOPROXY
+
 RUN apk add --update git ca-certificates build-base openssh-client
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
@@ -16,6 +18,8 @@ RUN go mod download
 # builder stage
 FROM base AS builder
 
+ARG GOPROXY
+
 COPY ./pkg $GOPATH/src/github.com/shellhub-io/shellhub/pkg
 COPY ./ssh .
 
@@ -29,6 +33,9 @@ RUN go build -tags internal_api
 
 # development stage
 FROM base AS development
+
+ARG GOPROXY
+ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl
 RUN go get github.com/markbates/refresh && go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.37.1

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:12.16.0-alpine as base
 
+ARG NPM_CONFIG_REGISTRY
+
 RUN apk add --update build-base python
 
 WORKDIR /app
@@ -10,6 +12,9 @@ RUN npm install
 
 FROM base as development
 
+ARG NPM_CONFIG_REGISTRY
+ARG ENV ${NPM_CONFIG_REGISTRY}
+
 WORKDIR /src
 
 COPY --from=base /app/node_modules /node_modules
@@ -19,6 +24,8 @@ COPY ui/scripts /scripts
 CMD ["/scripts/entrypoint-dev.sh"]
 
 FROM base as builder
+
+ARG NPM_CONFIG_REGISTRY
 
 WORKDIR /app
 


### PR DESCRIPTION
To enable go modules cache add following to `.env.override`:

```
SHELLHUB_GOPROXY=http://<ADDRESS>
```

Replace `<ADDRESS>` with the address proxy cache URL.

For caching go modules Athens (https://docs.gomods.io) is the recommended
proxy cache but you can use anything else.

To run Athens on `http://localhost:3333`:

```
docker run \
       --name athens \
       -e ATHENS_DISK_STORAGE_ROOT=/var/cache/misc \
       -e ATHENS_STORAGE_TYPE=disk \
       --restart always -d -p '3333:3000' gomods/athens:latest
```

To enable npm modules cache add following to `.env.override`:

```
SHELLHUB_NPM_REGISTRY=http://<ADDRESS>
```

For caching npm modules, Verdaccio (https://verdaccio.org/) is the recommended
proxy cache but you can use anything else.

To run Verdaccio on `http://localhost:4873`:

```
docker run --name verdaccio --restart always -d -p 4873:4873 verdaccio/verdaccio
```

This closes #941.