### PR TITLE
ui: Revert "ui: bump sass-loader from 10.2.0 to 11.1.1 in /ui"

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -56,7 +56,7 @@
     "mock-local-storage": "^1.1.17",
     "node-sass": "^6.0.0",
     "sass": "^1.32.11",
-    "sass-loader": "^11.1.1",
+    "sass-loader": "^10.1.1",
     "stylus": "^0.54.8",
     "stylus-loader": "^6.0.0",
     "vue-cli-plugin-vuetify": "^2.3.1",


### PR DESCRIPTION
This reverts commit 838c216e1f10e1486793188839cc5be415040b93.