### PR TITLE
ui: set sass loader version less than 11

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -56,7 +56,7 @@
     "mock-local-storage": "^1.1.17",
     "node-sass": "^6.0.0",
     "sass": "^1.32.11",
-    "sass-loader": "^10.1.1",
+    "sass-loader": "<11",
     "stylus": "^0.54.8",
     "stylus-loader": "^6.0.0",
     "vue-cli-plugin-vuetify": "^2.3.1",


### PR DESCRIPTION
This commit set the version less than 11, because the sass loader
version 11 ou higher, doesn't work with vue 2.6.12.