### PR TITLE
pkg: fix regexp to match only containerIDs in correct path

### DIFF
--- a/pkg/dockerutils/utils.go
+++ b/pkg/dockerutils/utils.go
@@ -27,7 +27,7 @@ func CurrentContainerID() (string, error) {
 		return "", err
 	}
 
-	re := regexp.MustCompilePOSIX(`([0-9]+:[a-z_,=]+.*docker[/-]|/var/lib/docker/containers/)([0-9a-f]{64})`)
+	re := regexp.MustCompilePOSIX(`([0-9]+:[a-z_,=]+.*docker[/-]| /var/lib/docker/containers/)([0-9a-f]{64})`)
 	match := re.FindSubmatch(content)
 	if match == nil || len(match) != 3 {
 		return "", nil


### PR DESCRIPTION
the space is needed to match only paths started in /var