### PR TITLE
pkg: update dbserver to mongo 4.4.4

### DIFF
--- a/api/pkg/dbtest/dbserver.go
+++ b/api/pkg/dbtest/dbserver.go
@@ -103,7 +103,7 @@ func (dbs *DBServer) start() {
 	}
 
 	args := []string{
-		"run", "--rm", fmt.Sprintf("--net=%s", dbs.network), "mongo:4.2.8",
+		"run", "--rm", fmt.Sprintf("--net=%s", dbs.network), "mongo:4.4.4",
 		"--bind_ip", "127.0.0.1",
 		"--port", strconv.Itoa(addr.Port),
 		"--nojournal",


### PR DESCRIPTION
this fix is necessary to test migrations that use mongo 4.4 new structures like in PR #1019 