### PR TITLE
docker: add linter configuration to agent and api dockerfiles

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -51,6 +51,7 @@ RUN go mod download
 
 COPY ./agent/entrypoint-dev.sh /entrypoint.sh
 COPY ./.revive.toml /
+COPY ./.golangci.yaml /
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/agent
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -48,6 +48,7 @@ RUN go mod download
 
 COPY ./api/entrypoint-dev.sh /entrypoint.sh
 COPY ./.revive.toml /
+COPY ./.golangci.yaml /
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/api
 


### PR DESCRIPTION
local linter in devscripts was using default configuration instead the .golangci.yaml config file

this commit copy the configuration file to each container by Dockerfile