### PR TITLE
pkg: removed defer that was closing connection early

### DIFF
--- a/pkg/api/client/client_public.go
+++ b/pkg/api/client/client_public.go
@@ -74,7 +74,6 @@ func (c *client) NewReverseListener(token string) (*revdial.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	listener := revdial.NewListener(wsconnadapter.New(conn),
 		func(ctx context.Context, path string) (*websocket.Conn, *http.Response, error) {


### PR DESCRIPTION
As it is done by `wsconnadapter` automatically, we don't need
to defer close connection in `NewReverseListener` func.