### PR TITLE
agent: Disable deprecated interfacer linter from golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,6 +50,7 @@ linters:
     - goerr113
     - golint
     - gomnd
+    - interfacer
     - lll
     - maligned
     - noctx

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/rsa"
-	"net"
 	"net/url"
 	"os"
 	"runtime"
@@ -13,6 +12,7 @@ import (
 	"github.com/shellhub-io/shellhub/agent/pkg/sysinfo"
 	"github.com/shellhub-io/shellhub/pkg/api/client"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/pkg/revdial"
 )
 
 type Agent struct {
@@ -158,6 +158,6 @@ func (a *Agent) authorize() error {
 	return err
 }
 
-func (a *Agent) newReverseListener() (net.Listener, error) {
+func (a *Agent) newReverseListener() (*revdial.Listener, error) {
 	return a.cli.NewReverseListener(a.authData.Token)
 }

--- a/agent/tunnel.go
+++ b/agent/tunnel.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/shellhub-io/shellhub/pkg/revdial"
 )
 
 type Tunnel struct {
@@ -44,6 +45,6 @@ func NewTunnel() *Tunnel {
 }
 
 // Listen to reverse listener.
-func (t *Tunnel) Listen(l net.Listener) error {
+func (t *Tunnel) Listen(l *revdial.Listener) error {
 	return t.srv.Serve(l)
 }


### PR DESCRIPTION
Also revert changes suggested by interfacer linter