### PR TITLE
pkg: removed defer that was closing connection early

### DIFF
--- a/pkg/revdial/revdial.go
+++ b/pkg/revdial/revdial.go
@@ -334,7 +334,6 @@ func (ln *Listener) grabConn(path string) {
 
 		return
 	}
-	defer wsConn.Close()
 
 	failPickup := func(err error) {
 		wsConn.Close()


### PR DESCRIPTION
As it is done by `wsconnadapter` automatically, we don't need
to defer close connection in `grabConn` func.