### PR TITLE
ui: fix to show message tooltip on device renaming

### DIFF
--- a/ui/src/components/device/DeviceRename.vue
+++ b/ui/src/components/device/DeviceRename.vue
@@ -1,11 +1,8 @@
 <template>
   <fragment>
-    <v-tooltip
-      bottom
-      :disabled="isOwner"
-    >
+    <v-tooltip bottom>
       <template #activator="{ on }">
-        <div v-on="on">
+        <span v-on="on">
           <v-icon
             :disabled="!isOwner"
             v-on="on"
@@ -13,11 +10,14 @@
           >
             mdi-pencil
           </v-icon>
-        </div>
+        </span>
       </template>
 
       <div>
-        <span v-if="isOwner">
+        <span
+          v-if="isOwner"
+          data-test="tooltipOwner-text"
+        >
           Edit
         </span>
 

--- a/ui/tests/unit/components/device/DeviceRename.spec.js
+++ b/ui/tests/unit/components/device/DeviceRename.spec.js
@@ -1,9 +1,11 @@
 import Vuex from 'vuex';
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
 import DeviceRename from '@/components/device/DeviceRename';
+import Vuetify from 'vuetify';
 
 describe('DeviceRename', () => {
   const localVue = createLocalVue();
+  const vuetify = new Vuetify();
   localVue.use(Vuex);
 
   let wrapper;
@@ -32,15 +34,17 @@ describe('DeviceRename', () => {
   });
 
   beforeEach(() => {
-    wrapper = shallowMount(DeviceRename, {
+    wrapper = mount(DeviceRename, {
       store,
       localVue,
       stubs: ['fragment'],
       propsData: { name, uid },
+      vuetify,
     });
   });
 
   it('Is a Vue instance', () => {
+    document.body.setAttribute('data-app', true);
     expect(wrapper).toBeTruthy();
   });
   it('Renders the component', () => {
@@ -54,5 +58,17 @@ describe('DeviceRename', () => {
     expect(wrapper.vm.dialog).toEqual(false);
     expect(wrapper.vm.invalid).toEqual(false);
     expect(wrapper.vm.editName).toEqual('39-5e-2a');
+  });
+  it('Show message tooltip to user owner', async (done) => {
+    const icons = wrapper.findAll('.v-icon');
+    const helpIcon = icons.at(0);
+    helpIcon.trigger('mouseenter');
+    await wrapper.vm.$nextTick();
+
+    expect(icons.length).toBe(1);
+    requestAnimationFrame(() => {
+      expect(wrapper.find('[data-test="tooltipOwner-text"]').text()).toEqual('Edit');
+      done();
+    });
   });
 });


### PR DESCRIPTION
The commit displays the message edit when the user owns the namespace.