### PR TITLE
gateway: mount /etc/resolve.conf within the container via kickstart

### DIFF
--- a/agent/selfupdater/updater_docker.go
+++ b/agent/selfupdater/updater_docker.go
@@ -112,6 +112,21 @@ func (d *dockerUpdater) CompleteUpdate() error {
 			}
 		}
 
+		// Append /etc/resolv.conf to mount if old container
+		// version is less than v0.7.3 since /etc/resolv.conf
+		// is required inside the container to update host
+		// networking after boot.
+		v0_7_3, _ := semver.NewVersion("v0.7.3")
+		if v.LessThan(v0_7_3) {
+			parent.info.HostConfig.Mounts = []mount.Mount{
+				{
+					Type:   mount.TypeBind,
+					Source: "/etc/resolv.conf",
+					Target: "/etc/resolv.conf",
+				},
+			}
+		}
+
 		_, err = d.updateContainer(parent, container.info.Config.Image, parent.info.Name, false)
 		if err != nil {
 			return err

--- a/gateway/kickstart.sh
+++ b/gateway/kickstart.sh
@@ -46,6 +46,7 @@ $SUDO docker run -d \
        -v /var/run/docker.sock:/var/run/docker.sock \
        -v /etc/passwd:/etc/passwd \
        -v /etc/group:/etc/group \
+       -v /etc/resolv.conf:/etc/resolv.conf \
        -v /var/run:/var/run \
        -v /var/log:/var/log \
        -e SHELLHUB_SERVER_ADDRESS={{scheme}}://{{host}} \


### PR DESCRIPTION
This commit mounts the host's `/etc/resolv.conf` file into the shellhub container via the `/gateway/kickstart.sh` file .

This is necessary to handle a situation where the host's `/etc/resolv.conf` file changes AFTER the shellhub container is started. As noted in the docker documentation (https://docs.docker.com/config/containers/container-networking/#dns-services)

> By default, a container inherits the DNS settings of the host, as defined in the /etc/resolv.conf configuration file. Containers that use the default bridge network get a copy of this file, whereas containers that use a custom network use Docker’s embedded DNS server, which forwards external DNS lookups to the DNS servers configured on the host.

The implication of "get a copy of this file" is that future changes to the host's file will not propogate to the container.

Fixes #593 