### PR TITLE
ui: fix call requests on logout

### DIFF
--- a/ui/src/components/device/Device.vue
+++ b/ui/src/components/device/Device.vue
@@ -108,6 +108,10 @@ export default {
     showBoxMessage() {
       return !this.hasDevice && this.show;
     },
+
+    isLoggedIn() {
+      return this.$store.getters['auth/isLoggedIn'];
+    },
   },
 
   watch: {
@@ -117,14 +121,16 @@ export default {
   },
 
   async created() {
-    try {
-      await this.$store.dispatch('stats/get');
-      this.show = true;
-    } catch (error) {
-      if (error.response.status === 403) {
-        this.$store.dispatch('snackbar/showSnackbarErrorAssociation');
-      } else {
-        this.$store.dispatch('snackbar/showSnackbarErrorDefault');
+    if (this.isLoggedIn) {
+      try {
+        await this.$store.dispatch('stats/get');
+        this.show = true;
+      } catch (error) {
+        if (error.response.status === 403) {
+          this.$store.dispatch('snackbar/showSnackbarErrorAssociation');
+        } else {
+          this.$store.dispatch('snackbar/showSnackbarErrorDefault');
+        }
       }
     }
   },

--- a/ui/src/components/firewall_rule/FirewallRule.vue
+++ b/ui/src/components/firewall_rule/FirewallRule.vue
@@ -70,14 +70,20 @@ export default {
     showBoxMessage() {
       return !this.hasFirewallRule && this.show;
     },
+
+    isLoggedIn() {
+      return this.$store.getters['auth/isLoggedIn'];
+    },
   },
 
   async created() {
-    this.$store.dispatch('boxs/setStatus', true);
-    this.$store.dispatch('firewallrules/resetPagePerpage');
+    if (this.isLoggedIn) {
+      this.$store.dispatch('boxs/setStatus', true);
+      this.$store.dispatch('firewallrules/resetPagePerpage');
 
-    await this.refresh();
-    this.show = true;
+      await this.refresh();
+      this.show = true;
+    }
   },
 
   methods: {

--- a/ui/src/components/public_key/PublicKey.vue
+++ b/ui/src/components/public_key/PublicKey.vue
@@ -54,14 +54,20 @@ export default {
     showBoxMessage() {
       return !this.hasPublickey && this.show;
     },
+
+    isLoggedIn() {
+      return this.$store.getters['auth/isLoggedIn'];
+    },
   },
 
   async created() {
-    this.$store.dispatch('boxs/setStatus', true);
-    this.$store.dispatch('publickeys/resetPagePerpage');
+    if (this.isLoggedIn) {
+      this.$store.dispatch('boxs/setStatus', true);
+      this.$store.dispatch('publickeys/resetPagePerpage');
 
-    await this.refresh();
-    this.show = true;
+      await this.refresh();
+      this.show = true;
+    }
   },
 
   methods: {

--- a/ui/src/components/session/Session.vue
+++ b/ui/src/components/session/Session.vue
@@ -46,17 +46,23 @@ export default {
     showBoxMessage() {
       return !this.hasSession && this.show;
     },
+
+    isLoggedIn() {
+      return this.$store.getters['auth/isLoggedIn'];
+    },
   },
 
   async created() {
-    try {
-      this.$store.dispatch('boxs/setStatus', true);
-      this.$store.dispatch('sessions/resetPagePerpage');
+    if (this.isLoggedIn) {
+      try {
+        this.$store.dispatch('boxs/setStatus', true);
+        this.$store.dispatch('sessions/resetPagePerpage');
 
-      await this.$store.dispatch('sessions/refresh');
-      this.show = true;
-    } catch {
-      this.$store.dispatch('snackbar/showSnackbarErrorLoading', this.$errors.snackbar.sessionList);
+        await this.$store.dispatch('sessions/refresh');
+        this.show = true;
+      } catch {
+        this.$store.dispatch('snackbar/showSnackbarErrorLoading', this.$errors.snackbar.sessionList);
+      }
     }
   },
 };

--- a/ui/tests/unit/components/device/Device.spec.js
+++ b/ui/tests/unit/components/device/Device.spec.js
@@ -11,6 +11,7 @@ describe('Device', () => {
   let wrapper;
 
   const pendingDevices = 2;
+  const isLoggedIn = true;
 
   const store = new Vuex.Store({
     namespaced: true,
@@ -22,9 +23,11 @@ describe('Device', () => {
         pending_devices: pendingDevices,
         rejected_devices: 0,
       },
+      isLoggedIn,
     },
     getters: {
       'stats/stats': (state) => state.stats,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
     },
     actions: {
       'stats/get': () => {
@@ -36,61 +39,154 @@ describe('Device', () => {
     },
   });
 
-  beforeEach(() => {
-    wrapper = shallowMount(Device, {
-      store,
-      localVue,
-      stubs: ['fragment'],
+  const storeLogout = new Vuex.Store({
+    namespaced: true,
+    state: {
+      stats: {
+        registered_devices: 0,
+        online_devices: 0,
+        active_sessions: 0,
+        pending_devices: pendingDevices,
+        rejected_devices: 0,
+      },
+      isLoggedIn: !isLoggedIn,
+    },
+    getters: {
+      'stats/stats': (state) => state.stats,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
+    },
+    actions: {
+      'stats/get': () => {
+      },
+      'devices/setFilter': () => {
+      },
+      'devices/refresh': () => {
+      },
+    },
+  });
+
+  describe('Device', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(Device, {
+        store,
+        localVue,
+        stubs: ['fragment'],
+      });
+    });
+
+    it('Is a Vue instance', () => {
+      expect(wrapper).toBeTruthy();
+    });
+    it('Renders the component', () => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+    it('Process data in the computed', () => {
+      expect(wrapper.vm.getNumberPendingDevices).toEqual(pendingDevices);
+      expect(wrapper.vm.hasDevice).toEqual(true);
+      expect(wrapper.vm.showBoxMessage).toEqual(false);
+    });
+    it('Compare data with the default and defined value', () => {
+      expect(wrapper.vm.show).toEqual(true);
+      expect(wrapper.vm.search).toEqual('');
+
+      wrapper.setData({ search: 'ShellHub' });
+
+      expect(wrapper.vm.search).toEqual('ShellHub');
+    });
+    it('Process data in methods', () => {
+      const inputs = [
+        { field: undefined, isDesc: undefined },
+        { field: 'hostname', isDesc: undefined },
+        { field: 'hostname', isDesc: true },
+      ];
+
+      const output = [
+        { field: null, status: false, statusString: 'asc' },
+        { field: 'name', status: false, statusString: 'asc' },
+        { field: 'name', status: true, statusString: 'desc' },
+      ];
+
+      Object.keys(inputs).forEach((index) => {
+        expect(wrapper.vm.formatSortObject(inputs[index].field, inputs[index].isDesc))
+          .toEqual(output[index]);
+      });
+    });
+    it('Renders the template with components', () => {
+      expect(wrapper.find('[data-test="boxMessageDevice-component"]').exists()).toBe(false);
+    });
+    it('Renders the template with data', () => {
+      expect(wrapper.find('[data-test="search-text"]').exists()).toBe(true);
+
+      const textInputSearch = wrapper.find('[data-test="search-text"]');
+      textInputSearch.element.value = 'ShellHub';
+
+      expect(wrapper.find('[data-test="search-text"]').element.value).toEqual('ShellHub');
+      expect(wrapper.find('[data-test="badge-field"]').vm.$options.propsData.content).toEqual(pendingDevices);
     });
   });
 
-  it('Is a Vue instance', () => {
-    expect(wrapper).toBeTruthy();
-  });
-  it('Renders the component', () => {
-    expect(wrapper.html()).toMatchSnapshot();
-  });
-  it('Process data in the computed', () => {
-    expect(wrapper.vm.getNumberPendingDevices).toEqual(pendingDevices);
-    expect(wrapper.vm.hasDevice).toEqual(true);
-    expect(wrapper.vm.showBoxMessage).toEqual(false);
-  });
-  it('Compare data with the default and defined value', () => {
-    expect(wrapper.vm.show).toEqual(true);
-    expect(wrapper.vm.search).toEqual('');
+  ///////
+  // In this case, purpose is to test the completion of the logout.
+  // For this, the show variable must be false.
+  ///////
 
-    wrapper.setData({ search: 'ShellHub' });
-
-    expect(wrapper.vm.search).toEqual('ShellHub');
-  });
-  it('Process data in methods', () => {
-    const inputs = [
-      { field: undefined, isDesc: undefined },
-      { field: 'hostname', isDesc: undefined },
-      { field: 'hostname', isDesc: true },
-    ];
-
-    const output = [
-      { field: null, status: false, statusString: 'asc' },
-      { field: 'name', status: false, statusString: 'asc' },
-      { field: 'name', status: true, statusString: 'desc' },
-    ];
-
-    Object.keys(inputs).forEach((index) => {
-      expect(wrapper.vm.formatSortObject(inputs[index].field, inputs[index].isDesc))
-        .toEqual(output[index]);
+  describe('Device', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(Device, {
+        store: storeLogout,
+        localVue,
+        stubs: ['fragment'],
+      });
     });
-  });
-  it('Renders the template with components', () => {
-    expect(wrapper.find('[data-test="boxMessageDevice-component"]').exists()).toBe(false);
-  });
-  it('Renders the template with data', () => {
-    expect(wrapper.find('[data-test="search-text"]').exists()).toBe(true);
 
-    const textInputSearch = wrapper.find('[data-test="search-text"]');
-    textInputSearch.element.value = 'ShellHub';
+    it('Is a Vue instance', () => {
+      expect(wrapper).toBeTruthy();
+    });
+    it('Renders the component', () => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+    it('Process data in the computed', () => {
+      expect(wrapper.vm.getNumberPendingDevices).toEqual(pendingDevices);
+      expect(wrapper.vm.hasDevice).toEqual(true);
+      expect(wrapper.vm.showBoxMessage).toEqual(false);
+    });
+    it('Compare data with the default and defined value', () => {
+      expect(wrapper.vm.show).toEqual(false);
+      expect(wrapper.vm.search).toEqual('');
 
-    expect(wrapper.find('[data-test="search-text"]').element.value).toEqual('ShellHub');
-    expect(wrapper.find('[data-test="badge-field"]').vm.$options.propsData.content).toEqual(pendingDevices);
+      wrapper.setData({ search: 'ShellHub' });
+
+      expect(wrapper.vm.search).toEqual('ShellHub');
+    });
+    it('Process data in methods', () => {
+      const inputs = [
+        { field: undefined, isDesc: undefined },
+        { field: 'hostname', isDesc: undefined },
+        { field: 'hostname', isDesc: true },
+      ];
+
+      const output = [
+        { field: null, status: false, statusString: 'asc' },
+        { field: 'name', status: false, statusString: 'asc' },
+        { field: 'name', status: true, statusString: 'desc' },
+      ];
+
+      Object.keys(inputs).forEach((index) => {
+        expect(wrapper.vm.formatSortObject(inputs[index].field, inputs[index].isDesc))
+          .toEqual(output[index]);
+      });
+    });
+    it('Renders the template with components', () => {
+      expect(wrapper.find('[data-test="boxMessageDevice-component"]').exists()).toBe(false);
+    });
+    it('Renders the template with data', () => {
+      expect(wrapper.find('[data-test="search-text"]').exists()).toBe(true);
+
+      const textInputSearch = wrapper.find('[data-test="search-text"]');
+      textInputSearch.element.value = 'ShellHub';
+
+      expect(wrapper.find('[data-test="search-text"]').element.value).toEqual('ShellHub');
+      expect(wrapper.find('[data-test="badge-field"]').vm.$options.propsData.content).toEqual(pendingDevices);
+    });
   });
 });

--- a/ui/tests/unit/components/device/__snapshots__/Device.spec.js.snap
+++ b/ui/tests/unit/components/device/__snapshots__/Device.spec.js.snap
@@ -1,6 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Device Renders the component 1`] = `
+exports[`Device Device Renders the component 1`] = `
+<fragment-stub>
+  <div class="d-flex pa-0 align-center">
+    <h1>Devices</h1>
+    <v-spacer-stub></v-spacer-stub>
+    <v-text-field-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="" appendicon="mdi-magnify" backgroundcolor="" hidedetails="true" label="Search by hostname" loaderheight="2" clearicon="$clear" singleline="true" type="text" data-test="search-text" class="mx-6"></v-text-field-stub>
+    <v-spacer-stub></v-spacer-stub>
+    <deviceadd-stub></deviceadd-stub>
+  </div>
+  <v-card-stub loaderheight="4" tag="div" class="mt-2">
+    <v-app-bar-stub color="transparent" tag="header" extensionheight="48" flat="true" src="" value="true">
+      <v-tabs-stub activeclass="" nexticon="$next" previcon="$prev" slidersize="2">
+        <v-tab-stub to="/devices" ripple="true">
+          Device List
+        </v-tab-stub>
+        <v-tab-stub to="/devices/pending" ripple="true">
+          <v-badge-stub color="success" value="2" transition="scale-rotate-transition" content="2" label="$vuetify.badge" inline="true" overlap="true" data-test="badge-field">
+            Pending
+          </v-badge-stub>
+        </v-tab-stub>
+        <v-tab-stub to="/devices/rejected" ripple="true">
+          Rejected
+        </v-tab-stub>
+      </v-tabs-stub>
+    </v-app-bar-stub>
+    <v-divider-stub></v-divider-stub>
+  </v-card-stub>
+  <v-card-stub loaderheight="4" tag="div">
+    <router-view-stub name="default"></router-view-stub>
+    <!---->
+  </v-card-stub>
+</fragment-stub>
+`;
+
+exports[`Device Device Renders the component 2`] = `
 <fragment-stub>
   <div class="d-flex pa-0 align-center">
     <h1>Devices</h1>

--- a/ui/tests/unit/components/firewall_rule/FirewallRule.spec.js
+++ b/ui/tests/unit/components/firewall_rule/FirewallRule.spec.js
@@ -12,14 +12,17 @@ describe('FirewallRule', () => {
 
   const numberFirewallsEqualZero = 0;
   const numberFirewallsGreaterThanZero = 1;
+  const isLoggedIn = true;
 
   const storeWithoutFirewalls = new Vuex.Store({
     namespaced: true,
     state: {
       numberFirewalls: numberFirewallsEqualZero,
+      isLoggedIn,
     },
     getters: {
       'firewallrules/getNumberFirewalls': (state) => state.numberFirewalls,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
     },
     actions: {
       'boxs/setStatus': () => {},
@@ -33,9 +36,29 @@ describe('FirewallRule', () => {
     namespaced: true,
     state: {
       numberFirewalls: numberFirewallsGreaterThanZero,
+      isLoggedIn,
     },
     getters: {
       'firewallrules/getNumberFirewalls': (state) => state.numberFirewalls,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
+    },
+    actions: {
+      'boxs/setStatus': () => {},
+      'firewallrules/resetPagePerpage': () => {},
+      'firewallrules/refresh': () => {},
+      'snackbar/showSnackbarErrorLoading': () => {},
+    },
+  });
+
+  const storeWithoutFirewallsLogout = new Vuex.Store({
+    namespaced: true,
+    state: {
+      numberFirewalls: numberFirewallsEqualZero,
+      isLoggedIn: !isLoggedIn,
+    },
+    getters: {
+      'firewallrules/getNumberFirewalls': (state) => state.numberFirewalls,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
     },
     actions: {
       'boxs/setStatus': () => {},
@@ -130,6 +153,55 @@ describe('FirewallRule', () => {
     });
     it('Compare data with the default and defined value', () => {
       expect(wrapper.vm.show).toEqual(true);
+    });
+
+    //////
+    // HTML validation
+    //////
+
+    it('Renders the template with components', () => {
+      expect(wrapper.find('[data-test="firewallRuleCreate-component"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="boxMessageFirewall-component"]').exists()).toBe(false);
+    });
+  });
+
+  ///////
+  // In this case, purpose is to test the completion of the logout.
+  // For this, the show variable must be false.
+  ///////
+
+  describe('Without firewall rules', () => {
+    beforeEach(() => {
+      wrapper = mount(FirewallRule, {
+        store: storeWithoutFirewallsLogout,
+        localVue,
+        stubs: ['fragment'],
+        vuetify,
+      });
+    });
+
+    ///////
+    // Component Rendering
+    //////
+
+    it('Is a Vue instance', () => {
+      expect(wrapper).toBeTruthy();
+    });
+    it('Renders the component', () => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    ///////
+    // Data and Props checking
+    //////
+
+    it('Process data in the computed', () => {
+      expect(wrapper.vm.hasFirewallRule).toEqual(false);
+      expect(wrapper.vm.showBoxMessage).toEqual(false);
+    });
+    it('Compare data with the default', () => {
+      expect(wrapper.vm.show).toEqual(false);
+      expect(wrapper.vm.showHelp).toEqual(false);
     });
 
     //////

--- a/ui/tests/unit/components/firewall_rule/__snapshots__/FirewallRule.spec.js.snap
+++ b/ui/tests/unit/components/firewall_rule/__snapshots__/FirewallRule.spec.js.snap
@@ -75,3 +75,23 @@ exports[`FirewallRule Without firewall rules Renders the component 2`] = `
   </div>
 </fragment-stub>
 `;
+
+exports[`FirewallRule Without firewall rules Renders the component 3`] = `
+<fragment-stub>
+  <div class="d-flex pa-0 align-center">
+    <h1>Firewall Rules</h1> <button type="button" class="ml-2 v-btn v-btn--icon v-btn--round theme--light v-size--x-small"><span class="v-btn__content"><i aria-hidden="true" class="v-icon notranslate mdi mdi-help-circle theme--light"></i></span></button>
+    <div class="spacer"></div>
+    <div class="spacer"></div>
+    <fragment-stub data-test="firewallRuleCreate-component">
+      <div><button type="button" disabled="disabled" class="v-btn--active v-btn v-btn--disabled v-btn--text theme--light v-size--default" data-test="add-btn"><span class="v-btn__content">
+          Add Rule
+        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
+      <div role="dialog" class="v-dialog__container">
+        <!---->
+      </div>
+    </fragment-stub>
+  </div>
+  <!---->
+  <div class="mt-2 v-card v-sheet theme--light"></div>
+</fragment-stub>
+`;

--- a/ui/tests/unit/components/public_key/PublicKey.spec.js
+++ b/ui/tests/unit/components/public_key/PublicKey.spec.js
@@ -12,14 +12,17 @@ describe('Session', () => {
 
   const numberPublickeysEqualZero = 0;
   const numberPublickeysGreaterThanZero = 1;
+  const isLoggedIn = true;
 
   const storeWithoutPublickeys = new Vuex.Store({
     namespaced: true,
     state: {
       numberPublickeys: numberPublickeysEqualZero,
+      isLoggedIn,
     },
     getters: {
       'publickeys/getNumberPublicKeys': (state) => state.numberPublickeys,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
     },
     actions: {
       'publickeys/refresh': () => {},
@@ -33,9 +36,29 @@ describe('Session', () => {
     namespaced: true,
     state: {
       numberPublickeys: numberPublickeysGreaterThanZero,
+      isLoggedIn,
     },
     getters: {
       'publickeys/getNumberPublicKeys': (state) => state.numberPublickeys,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
+    },
+    actions: {
+      'publickeys/refresh': () => {},
+      'boxs/setStatus': () => {},
+      'publickeys/resetPagePerpage': () => {},
+      'snackbar/showSnackbarErrorLoading': () => {},
+    },
+  });
+
+  const storeWithoutPublickeysLogout = new Vuex.Store({
+    namespaced: true,
+    state: {
+      numberPublickeys: numberPublickeysEqualZero,
+      isLoggedIn: !isLoggedIn,
+    },
+    getters: {
+      'publickeys/getNumberPublicKeys': (state) => state.numberPublickeys,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
     },
     actions: {
       'publickeys/refresh': () => {},
@@ -128,6 +151,54 @@ describe('Session', () => {
     });
     it('Process data in the computed', () => {
       expect(wrapper.vm.hasPublickey).toEqual(true);
+      expect(wrapper.vm.showBoxMessage).toEqual(false);
+    });
+
+    //////
+    // HTML validation
+    //////
+
+    it('Renders the template with components', () => {
+      expect(wrapper.find('[data-test="publicKeyCreate-component"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="boxMessagePublicKey-component"]').exists()).toBe(false);
+    });
+  });
+
+  ///////
+  // In this case, purpose is to test the completion of the logout.
+  // For this, the show variable must be false.
+  ///////
+
+  describe('Without public key', () => {
+    beforeEach(() => {
+      wrapper = mount(publicKey, {
+        store: storeWithoutPublickeysLogout,
+        localVue,
+        stubs: ['fragment'],
+        vuetify,
+      });
+    });
+
+    ///////
+    // Component Rendering
+    //////
+
+    it('Is a Vue instance', () => {
+      expect(wrapper).toBeTruthy();
+    });
+    it('Renders the component', () => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    ///////
+    // Data and Props checking
+    //////
+
+    it('Compare data with the default and defined value', () => {
+      expect(wrapper.vm.show).toEqual(false);
+    });
+    it('Process data in the computed', () => {
+      expect(wrapper.vm.hasPublickey).toEqual(false);
       expect(wrapper.vm.showBoxMessage).toEqual(false);
     });
 

--- a/ui/tests/unit/components/public_key/__snapshots__/PublicKey.spec.js.snap
+++ b/ui/tests/unit/components/public_key/__snapshots__/PublicKey.spec.js.snap
@@ -71,3 +71,22 @@ exports[`Session Without public key Renders the component 2`] = `
   </div>
 </fragment-stub>
 `;
+
+exports[`Session Without public key Renders the component 3`] = `
+<fragment-stub>
+  <div class="d-flex pa-0 align-center">
+    <h1>Public Keys</h1>
+    <div class="spacer"></div>
+    <div class="spacer"></div>
+    <fragment-stub data-test="publicKeyCreate-component">
+      <div><button type="button" disabled="disabled" class="v-btn--active v-btn v-btn--disabled v-btn--text theme--light v-size--default" data-test="createKey-btn"><span class="v-btn__content">
+          Add public Key
+        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
+      <div role="dialog" class="v-dialog__container">
+        <!---->
+      </div>
+    </fragment-stub>
+  </div>
+  <div class="mt-2 v-card v-sheet theme--light"></div>
+</fragment-stub>
+`;

--- a/ui/tests/unit/components/session/Session.spec.js
+++ b/ui/tests/unit/components/session/Session.spec.js
@@ -12,14 +12,17 @@ describe('Session', () => {
 
   const numberSessionsEqualZero = 0;
   const numberSessionsGreaterThanZero = 1;
+  const isLoggedIn = true;
 
   const storeWithoutSessions = new Vuex.Store({
     namespaced: true,
     state: {
       numberSessions: numberSessionsEqualZero,
+      isLoggedIn,
     },
     getters: {
       'sessions/getNumberSessions': (state) => state.numberSessions,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
     },
     actions: {
       'sessions/refresh': () => {},
@@ -33,9 +36,29 @@ describe('Session', () => {
     namespaced: true,
     state: {
       numberSessions: numberSessionsGreaterThanZero,
+      isLoggedIn,
     },
     getters: {
       'sessions/getNumberSessions': (state) => state.numberSessions,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
+    },
+    actions: {
+      'sessions/refresh': () => {},
+      'boxs/setStatus': () => {},
+      'sessions/resetPagePerpage': () => {},
+      'snackbar/showSnackbarErrorLoading': () => {},
+    },
+  });
+
+  const storeWithoutSessionsLogout = new Vuex.Store({
+    namespaced: true,
+    state: {
+      numberSessions: numberSessionsEqualZero,
+      isLoggedIn: !isLoggedIn,
+    },
+    getters: {
+      'sessions/getNumberSessions': (state) => state.numberSessions,
+      'auth/isLoggedIn': (state) => state.isLoggedIn,
     },
     actions: {
       'sessions/refresh': () => {},
@@ -127,6 +150,53 @@ describe('Session', () => {
     });
     it('Process data in the computed', () => {
       expect(wrapper.vm.hasSession).toEqual(true);
+      expect(wrapper.vm.showBoxMessage).toEqual(false);
+    });
+
+    //////
+    // HTML validation
+    //////
+
+    it('Renders the template with components', () => {
+      expect(wrapper.find('[data-test="BoxMessageSession-component"]').exists()).toBe(false);
+    });
+  });
+
+  ///////
+  // In this case, purpose is to test the completion of the logout.
+  // For this, the show variable must be false.
+  ///////
+
+  describe('Without sessions', () => {
+    beforeEach(() => {
+      wrapper = mount(Session, {
+        store: storeWithoutSessionsLogout,
+        localVue,
+        stubs: ['fragment'],
+        vuetify,
+      });
+    });
+
+    ///////
+    // Component Rendering
+    //////
+
+    it('Is a Vue instance', () => {
+      expect(wrapper).toBeTruthy();
+    });
+    it('Renders the component', () => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    ///////
+    // Data and Props checking
+    //////
+
+    it('Compare data with the default and defined value', () => {
+      expect(wrapper.vm.show).toEqual(false);
+    });
+    it('Process data in the computed', () => {
+      expect(wrapper.vm.hasSession).toEqual(false);
       expect(wrapper.vm.showBoxMessage).toEqual(false);
     });
 

--- a/ui/tests/unit/components/session/__snapshots__/Session.spec.js.snap
+++ b/ui/tests/unit/components/session/__snapshots__/Session.spec.js.snap
@@ -52,3 +52,14 @@ exports[`Session Without sessions Renders the component 1`] = `
   </div>
 </fragment-stub>
 `;
+
+exports[`Session Without sessions Renders the component 2`] = `
+<fragment-stub>
+  <div class="d-flex pa-0 align-center">
+    <h1>Sessions</h1>
+    <div class="spacer"></div>
+    <div class="spacer"></div>
+  </div>
+  <div class="mt-2 v-card v-sheet theme--light"></div>
+</fragment-stub>
+`;


### PR DESCRIPTION
First, the error occurs when it comes from the second or next namespace
and click in logout. This causes a request to occur on devices, session,
firewall rules and namespaces.

This closes #935.