### PR TITLE
ui: refactor UI notification tests

### DIFF
--- a/ui/tests/unit/components/app_bar/notification/Notification.spec.js
+++ b/ui/tests/unit/components/app_bar/notification/Notification.spec.js
@@ -57,7 +57,7 @@ describe('Notification', () => {
     state: {
       notifications,
       numberNotifications,
-      owner: false,
+      owner: !owner,
     },
     getters: {
       'notifications/list': (state) => state.notifications,
@@ -65,8 +65,7 @@ describe('Notification', () => {
       'namespaces/owner': (state) => state.owner,
     },
     actions: {
-      'notifications/fetch': () => {
-      },
+      'notifications/fetch': () => {},
     },
   });
 
@@ -83,8 +82,7 @@ describe('Notification', () => {
       'namespaces/owner': (state) => state.owner,
     },
     actions: {
-      'notifications/fetch': () => {
-      },
+      'notifications/fetch': () => {},
     },
   });
 
@@ -93,63 +91,187 @@ describe('Notification', () => {
     state: {
       notifications: noNotifications,
       numberNotifications: 0,
+      owner,
     },
     getters: {
       'notifications/list': (state) => state.notifications,
       'notifications/getNumberNotifications': (state) => state.numberNotifications,
+      'namespaces/owner': (state) => state.owner,
     },
     actions: {
-      'notifications/fetch': () => {
-      },
+      'notifications/fetch': () => {},
     },
   });
 
-  beforeEach(() => {
-    wrapper = shallowMount(Notification, {
-      store: storeOwner,
-      localVue,
-      stubs: ['fragment', 'router-link'],
-      propsData: { inANamespace },
+  ///////
+  // In this case, when the user owns the namespace and the focus of
+  // the test is notifications rendering. And the button available
+  // for the user to accept the pending device.
+  ///////
+
+  describe('Owner with notifications', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(Notification, {
+        store: storeOwner,
+        localVue,
+        stubs: ['fragment', 'router-link'],
+        propsData: { inANamespace },
+      });
+    });
+
+    ///////
+    // Component Rendering
+    //////
+
+    it('Is a Vue instance', () => {
+      expect(wrapper).toBeTruthy();
+    });
+    it('Renders the component', () => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    ///////
+    // Data and Props checking
+    //////
+
+    it('Compare data with default value', () => {
+      expect(wrapper.vm.listNotifications).toEqual([]);
+      expect(wrapper.vm.numberNotifications).toEqual(0);
+      expect(wrapper.vm.shown).toEqual(false);
+      expect(wrapper.vm.inANamespace).toEqual(false);
+      expect(wrapper.vm.defaultSize).toEqual(24);
+    });
+    it('Process data in the computed', () => {
+      expect(wrapper.vm.getListNotifications).toEqual(notifications);
+      expect(wrapper.vm.getNumberNotifications).toEqual(numberNotifications);
+      expect(wrapper.vm.getStatusNotifications).toEqual(false);
+      expect(wrapper.vm.isOwner).toEqual(owner);
+      expect(wrapper.vm.hasNamespace).toEqual(true);
+    });
+
+    //////
+    // HTML validation
+    //////
+
+    it('Renders the template with components', () => {
+      Object.keys(notifications).forEach((field) => {
+        expect(wrapper.find(`[data-test="${notifications[field].uid}-field"]`).text()).toEqual(notifications[field].name);
+        expect(wrapper.find(`[data-test="${notifications[field].uid}-btn"]`).exists()).toEqual(true);
+      });
     });
   });
 
-  it('Is a Vue instance', () => {
-    expect(wrapper).toBeTruthy();
-  });
-  it('Renders the component', () => {
-    expect(wrapper.html()).toMatchSnapshot();
-  });
-  it('Renders the template with data', () => {
-    wrapper = shallowMount(Notification, {
-      store: storeNotOwner,
-      localVue,
-      stubs: ['fragment', 'router-link'],
-      propsData: { inANamespace },
+  ///////
+  // In this case, when the user doesn't own the namespace and the
+  // focus of the test is notifications rendering. And the button
+  // unavailable for the user to accept the pending device.
+  ///////
+
+  describe('Doesn\'t own the namespace with notifications', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(Notification, {
+        store: storeNotOwner,
+        localVue,
+        stubs: ['fragment', 'router-link'],
+        propsData: { inANamespace },
+      });
     });
 
-    Object.keys(notifications).forEach((field) => {
-      expect(wrapper.find(`[data-test="${notifications[field].uid}-field"]`).text()).toEqual(notifications[field].name);
-      expect(wrapper.find(`[data-test="${notifications[field].uid}-btn"]`).exists()).toEqual(false);
+    ///////
+    // Component Rendering
+    //////
+
+    it('Is a Vue instance', () => {
+      expect(wrapper).toBeTruthy();
     });
-  });
-  it('Hides button for user not owner', () => {
-    Object.keys(notifications).forEach((field) => {
-      expect(wrapper.find(`[data-test="${notifications[field].uid}-field"]`).text()).toEqual(notifications[field].name);
-      expect(wrapper.find(`[data-test="${notifications[field].uid}-btn"]`).exists()).toEqual(true);
-    });
-  });
-  it('Shows message when no notifications appear on list', () => {
-    wrapper = shallowMount(Notification, {
-      store: storeNoNotifications,
-      localVue,
-      stubs: ['fragment', 'router-link'],
-      propsData: { inANamespace },
+    it('Renders the component', () => {
+      expect(wrapper.html()).toMatchSnapshot();
     });
 
-    expect(wrapper.find('[data-test="noNotifications"]').exists()).toEqual(true);
-    expect(wrapper.find('[data-test="noNotifications"]').text()).toEqual('You don\'t have notifications');
+    ///////
+    // Data and Props checking
+    //////
+
+    it('Compare data with default value', () => {
+      expect(wrapper.vm.listNotifications).toEqual([]);
+      expect(wrapper.vm.numberNotifications).toEqual(0);
+      expect(wrapper.vm.shown).toEqual(false);
+      expect(wrapper.vm.inANamespace).toEqual(false);
+      expect(wrapper.vm.defaultSize).toEqual(24);
+    });
+    it('Process data in the computed', () => {
+      expect(wrapper.vm.getListNotifications).toEqual(notifications);
+      expect(wrapper.vm.getNumberNotifications).toEqual(numberNotifications);
+      expect(wrapper.vm.getStatusNotifications).toEqual(false);
+      expect(wrapper.vm.isOwner).toEqual(!owner);
+      expect(wrapper.vm.hasNamespace).toEqual(true);
+    });
+
+    //////
+    // HTML validation
+    //////
+
+    it('Renders the template with components', () => {
+      Object.keys(notifications).forEach((field) => {
+        expect(wrapper.find(`[data-test="${notifications[field].uid}-field"]`).text()).toEqual(notifications[field].name);
+        expect(wrapper.find(`[data-test="${notifications[field].uid}-btn"]`).exists()).toEqual(false);
+      });
+    });
   });
-  it('Receives data in props', () => {
-    expect(wrapper.vm.inANamespace).toEqual(inANamespace);
+
+  ///////
+  // In this case, when the user owns the namespace and the focus of
+  // the test rendering is the message that the user has no
+  // notification.
+  ///////
+
+  describe('Owner without notifications', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(Notification, {
+        store: storeNoNotifications,
+        localVue,
+        stubs: ['fragment', 'router-link'],
+        propsData: { inANamespace },
+      });
+    });
+
+    ///////
+    // Component Rendering
+    //////
+
+    it('Is a Vue instance', () => {
+      expect(wrapper).toBeTruthy();
+    });
+    it('Renders the component', () => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    ///////
+    // Data and Props checking
+    //////
+
+    it('Compare data with default value', () => {
+      expect(wrapper.vm.listNotifications).toEqual([]);
+      expect(wrapper.vm.numberNotifications).toEqual(0);
+      expect(wrapper.vm.shown).toEqual(false);
+      expect(wrapper.vm.inANamespace).toEqual(false);
+      expect(wrapper.vm.defaultSize).toEqual(24);
+    });
+    it('Process data in the computed', () => {
+      expect(wrapper.vm.getListNotifications).toEqual([]);
+      expect(wrapper.vm.getNumberNotifications).toEqual(0);
+      expect(wrapper.vm.getStatusNotifications).toEqual(true);
+      expect(wrapper.vm.isOwner).toEqual(owner);
+      expect(wrapper.vm.hasNamespace).toEqual(true);
+    });
+
+    //////
+    // HTML validation
+    //////
+
+    it('Renders the template with components', () => {
+      expect(wrapper.find('[data-test="noNotifications"]').exists()).toEqual(true);
+      expect(wrapper.find('[data-test="noNotifications"]').text()).toEqual('You don\'t have notifications');
+    });
   });
 });

--- a/ui/tests/unit/components/app_bar/notification/__snapshots__/Notification.spec.js.snap
+++ b/ui/tests/unit/components/app_bar/notification/__snapshots__/Notification.spec.js.snap
@@ -1,6 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Notification Renders the component 1`] = `
+exports[`Notification Doesn't own the namespace with notifications Renders the component 1`] = `
+<v-menu-stub opendelay="0" closedelay="0" contentclass="" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" openonclick="true" closeonclick="true" maxheight="auto" offsety="true" origin="top left" transition="v-menu-transition">
+  <v-card-stub loaderheight="4" tag="div">
+    <v-subheader-stub>Pending Devices</v-subheader-stub>
+    <v-divider-stub></v-divider-stub>
+    <v-list-stub tag="div" class="pa-0">
+      <v-list-item-group-stub activeclass="v-item--active" tag="div" v-model="1">
+        <v-list-item-stub activeclass="" tag="div">
+          <v-list-item-content-stub>
+            <v-list-item-title-stub>
+              <router-link-stub to="[object Object]" data-test="a582b47a42d-field">
+                39-5e-2a
+              </router-link-stub>
+            </v-list-item-title-stub>
+          </v-list-item-content-stub>
+          <v-list-item-action-stub>
+            <!---->
+          </v-list-item-action-stub>
+        </v-list-item-stub>
+        <v-list-item-stub activeclass="" tag="div">
+          <v-list-item-content-stub>
+            <v-list-item-title-stub>
+              <router-link-stub to="[object Object]" data-test="a582b47a42e-field">
+                39-5e-2b
+              </router-link-stub>
+            </v-list-item-title-stub>
+          </v-list-item-content-stub>
+          <v-list-item-action-stub>
+            <!---->
+          </v-list-item-action-stub>
+        </v-list-item-stub>
+      </v-list-item-group-stub>
+    </v-list-stub>
+    <v-divider-stub></v-divider-stub>
+    <v-btn-stub tag="button" activeclass="" link="true" to="/devices/pending" small="true" block="true" type="button">
+      Show all Pending Devices
+    </v-btn-stub>
+  </v-card-stub>
+</v-menu-stub>
+`;
+
+exports[`Notification Owner with notifications Renders the component 1`] = `
 <v-menu-stub opendelay="0" closedelay="0" contentclass="" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" openonclick="true" closeonclick="true" maxheight="auto" offsety="true" origin="top left" transition="v-menu-transition">
   <v-card-stub loaderheight="4" tag="div">
     <v-subheader-stub>Pending Devices</v-subheader-stub>
@@ -37,6 +78,16 @@ exports[`Notification Renders the component 1`] = `
     <v-btn-stub tag="button" activeclass="" link="true" to="/devices/pending" small="true" block="true" type="button">
       Show all Pending Devices
     </v-btn-stub>
+  </v-card-stub>
+</v-menu-stub>
+`;
+
+exports[`Notification Owner without notifications Renders the component 1`] = `
+<v-menu-stub opendelay="0" closedelay="0" contentclass="" maxwidth="auto" nudgebottom="0" nudgeleft="0" nudgeright="0" nudgetop="0" nudgewidth="0" openonclick="true" closeonclick="true" maxheight="auto" offsety="true" origin="top left" transition="v-menu-transition">
+  <v-card-stub loaderheight="4" tag="div">
+    <v-subheader-stub data-test="noNotifications">
+      You don't have notifications
+    </v-subheader-stub>
   </v-card-stub>
 </v-menu-stub>
 `;


### PR DESCRIPTION
Tests are refactored according to the document found on the project's wiki.

The tests are refactored to improve the visualization of the cases that
are tested.

The tests includes:
- Namespace owner with notifications;
- Doesn't own the namespace with notifications;
- Namespace owner without notifications.