### PR TITLE
api: add a way to track the remote IP

### DIFF
--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -64,7 +64,7 @@ func (h *Handler) AuthDevice(c apicontext.Context) error {
 		return err
 	}
 
-	res, err := h.service.AuthDevice(c.Ctx(), &req)
+	res, err := h.service.AuthDevice(c.Ctx(), &req, c.Request().Header.Get("X-Real-IP"))
 	if err != nil {
 		return err
 	}

--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -23,7 +23,7 @@ import (
 )
 
 type AuthService interface {
-	AuthDevice(ctx context.Context, req *models.DeviceAuthRequest) (*models.DeviceAuthResponse, error)
+	AuthDevice(ctx context.Context, req *models.DeviceAuthRequest, remoteAdrr string) (*models.DeviceAuthResponse, error)
 	AuthUser(ctx context.Context, req models.UserAuthRequest) (*models.UserAuthResponse, error)
 	AuthGetToken(ctx context.Context, tenant string) (*models.UserAuthResponse, error)
 	AuthPublicKey(ctx context.Context, req *models.PublicKeyAuthRequest) (*models.PublicKeyAuthResponse, error)
@@ -32,7 +32,7 @@ type AuthService interface {
 	PublicKey() *rsa.PublicKey
 }
 
-func (s *service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest) (*models.DeviceAuthResponse, error) {
+func (s *service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest, remoteAdrr string) (*models.DeviceAuthResponse, error) {
 	uid := sha256.Sum256(structhash.Dump(req.DeviceAuth, 1))
 
 	key := hex.EncodeToString(uid[:])
@@ -65,12 +65,13 @@ func (s *service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest)
 		}, nil
 	}
 	device := models.Device{
-		UID:       hex.EncodeToString(uid[:]),
-		Identity:  req.Identity,
-		Info:      req.Info,
-		PublicKey: req.PublicKey,
-		TenantID:  req.TenantID,
-		LastSeen:  clock.Now(),
+		UID:        hex.EncodeToString(uid[:]),
+		Identity:   req.Identity,
+		Info:       req.Info,
+		PublicKey:  req.PublicKey,
+		TenantID:   req.TenantID,
+		LastSeen:   clock.Now(),
+		RemoteAddr: remoteAdrr,
 	}
 
 	// The order here is critical as we don't want to register devices if the tenant id is invalid

--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -43,10 +43,11 @@ func TestAuthDevice(t *testing.T) {
 	now := clock.Now()
 	uid := sha256.Sum256(structhash.Dump(authReq.DeviceAuth, 1))
 	device := &models.Device{
-		UID:      hex.EncodeToString(uid[:]),
-		Identity: authReq.Identity,
-		TenantID: authReq.TenantID,
-		LastSeen: now,
+		UID:        hex.EncodeToString(uid[:]),
+		Identity:   authReq.Identity,
+		TenantID:   authReq.TenantID,
+		LastSeen:   now,
+		RemoteAddr: "0.0.0.0",
 	}
 
 	namespace := &models.Namespace{Name: "group1", Owner: "hash1", TenantID: "tenant"}
@@ -67,13 +68,14 @@ func TestAuthDevice(t *testing.T) {
 	assert.NoError(t, err)
 	defer patch.Unpatch() //nolint:errcheck
 
-	authRes, err := s.AuthDevice(ctx, authReq)
+	authRes, err := s.AuthDevice(ctx, authReq, "0.0.0.0")
 	assert.NoError(t, err)
 
 	assert.Equal(t, device.UID, authRes.UID)
 	assert.Equal(t, device.Name, authRes.Name)
 	assert.Equal(t, namespace.Name, authRes.Namespace)
 	assert.NotEmpty(t, authRes.Token)
+	assert.Equal(t, device.RemoteAddr, "0.0.0.0")
 
 	mock.AssertExpectations(t)
 }

--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -39,6 +39,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration27,
 		migration28,
 		migration29,
+		migration30,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_30.go
+++ b/api/store/mongo/migrations/migration_30.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration30 = migrate.Migration{
+	Version:     30,
+	Description: "add remote_addr field to collection devices",
+	Up: func(db *mongo.Database) error {
+		logrus.Info("Applying migration 30 - Up")
+		if _, err := db.Collection("devices").UpdateMany(context.TODO(), bson.M{}, bson.M{"$set": bson.M{"remote_addr": ""}}); err != nil {
+			return err
+		}
+
+		return nil
+	},
+	Down: func(db *mongo.Database) error {
+		logrus.Info("Applying migration 30 - Down")
+
+		return nil
+	},
+}

--- a/api/store/mongo/migrations/migration_30_test.go
+++ b/api/store/mongo/migrations/migration_30_test.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/pkg/dbtest"
+	"github.com/stretchr/testify/assert"
+	migrate "github.com/xakep666/mongo-migrate"
+)
+
+func TestMigration30(t *testing.T) {
+	db := dbtest.DBServer{}
+	defer db.Stop()
+
+	migrations := GenerateMigrations()[:30]
+
+	migrates := migrate.NewMigrate(db.Client().Database("test"), migrations...)
+	err := migrates.Up(migrate.AllAvailable)
+	assert.NoError(t, err)
+
+	version, _, err := migrates.Version()
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(30), version)
+}

--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -24,12 +24,12 @@ server {
         auth_request /auth;
         auth_request_set $tenant_id $upstream_http_x_tenant_id;
         auth_request_set $username $upstream_http_x_username;
-	auth_request_set $id $upstream_http_x_id;
+        auth_request_set $id $upstream_http_x_id;
         error_page 500 =401 /auth;
         rewrite ^/api/(.*)$ /api/$1 break;
         proxy_set_header X-Tenant-ID $tenant_id;
         proxy_set_header X-Username $username;
-	proxy_set_header X-ID $id;
+        proxy_set_header X-ID $id;
         proxy_pass http://api:8080;
     }
 
@@ -197,6 +197,11 @@ server {
     location /api/devices/auth {
         auth_request off;
         rewrite ^/api/(.*)$ /api/$1 break;
+        {{ if bool (env.Getenv "SHELLHUB_PROXY") -}}
+        proxy_set_header X-Real-IP $proxy_protocol_addr;
+        {{ else -}}
+        proxy_set_header X-Real-IP $x_real_ip;
+        {{ end -}}
         proxy_pass http://api:8080;
     }
 

--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -7,17 +7,18 @@ import (
 )
 
 type Device struct {
-	UID       string          `json:"uid"`
-	Name      string          `json:"name" bson:"name,omitempty" validate:"required,hostname_rfc1123,excludes=."`
-	Identity  *DeviceIdentity `json:"identity"`
-	Info      *DeviceInfo     `json:"info"`
-	PublicKey string          `json:"public_key" bson:"public_key"`
-	TenantID  string          `json:"tenant_id" bson:"tenant_id"`
-	LastSeen  time.Time       `json:"last_seen" bson:"last_seen"`
-	Online    bool            `json:"online" bson:",omitempty"`
-	Namespace string          `json:"namespace" bson:",omitempty"`
-	Status    string          `json:"status" bson:"status,omitempty" validate:"oneof=accepted rejected pending unused`
-	CreatedAt time.Time       `json:"created_at" bson:"created_at"`
+	UID        string          `json:"uid"`
+	Name       string          `json:"name" bson:"name,omitempty" validate:"required,hostname_rfc1123,excludes=."`
+	Identity   *DeviceIdentity `json:"identity"`
+	Info       *DeviceInfo     `json:"info"`
+	PublicKey  string          `json:"public_key" bson:"public_key"`
+	TenantID   string          `json:"tenant_id" bson:"tenant_id"`
+	LastSeen   time.Time       `json:"last_seen" bson:"last_seen"`
+	Online     bool            `json:"online" bson:",omitempty"`
+	Namespace  string          `json:"namespace" bson:",omitempty"`
+	Status     string          `json:"status" bson:"status,omitempty" validate:"oneof=accepted rejected pending unused`
+	CreatedAt  time.Time       `json:"created_at" bson:"created_at"`
+	RemoteAddr string          `json:"remote_addr" bson:"remote_addr"`
 }
 
 type DeviceAuthClaims struct {


### PR DESCRIPTION
When the devices request a auth the system is capable to store
the remote address who's make the request.

Signed-off-by: asakiz <asakizin@gmail.com>