### PR TITLE
Restrict user access using public keys

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -166,7 +166,7 @@ func startServer() error {
 	publicAPI.DELETE(routes.DeletePublicKeyURL, apicontext.Handler(handler.DeletePublicKey))
 	internalAPI.GET(routes.GetPublicKeyURL, apicontext.Handler(handler.GetPublicKey))
 	internalAPI.POST(routes.CreatePrivateKeyURL, apicontext.Handler(handler.CreatePrivateKey))
-	internalAPI.POST(routes.EvaluateKeyURL, apicontext.Handler(handler.EvaluateKeyHostname))
+	internalAPI.POST(routes.EvaluateKeyURL, apicontext.Handler(handler.EvaluateKey))
 
 	publicAPI.GET(routes.ListNamespaceURL, apicontext.Handler(handler.GetNamespaceList))
 	publicAPI.GET(routes.GetNamespaceURL, apicontext.Handler(handler.GetNamespace))

--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -378,6 +378,27 @@ func (_m *Service) EvaluateKeyHostname(ctx context.Context, key *models.PublicKe
 	return r0, r1
 }
 
+// EvaluateKeyUsername provides a mock function with given fields: ctx, key, username
+func (_m *Service) EvaluateKeyUsername(ctx context.Context, key *models.PublicKey, username string) (bool, error) {
+	ret := _m.Called(ctx, key, username)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, *models.PublicKey, string) bool); ok {
+		r0 = rf(ctx, key, username)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *models.PublicKey, string) error); ok {
+		r1 = rf(ctx, key, username)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetDevice provides a mock function with given fields: ctx, uid
 func (_m *Service) GetDevice(ctx context.Context, uid models.UID) (*models.Device, error) {
 	ret := _m.Called(ctx, uid)

--- a/api/services/sshkeys.go
+++ b/api/services/sshkeys.go
@@ -17,6 +17,7 @@ import (
 
 type SSHKeysService interface {
 	EvaluateKeyHostname(ctx context.Context, key *models.PublicKey, dev models.Device) (bool, error)
+	EvaluateKeyUsername(ctx context.Context, key *models.PublicKey, username string) (bool, error)
 	ListPublicKeys(ctx context.Context, pagination paginator.Query) ([]models.PublicKey, int, error)
 	GetPublicKey(ctx context.Context, fingerprint, tenant string) (*models.PublicKey, error)
 	CreatePublicKey(ctx context.Context, key *models.PublicKey, tenant string) error
@@ -35,6 +36,19 @@ func (s *service) EvaluateKeyHostname(ctx context.Context, key *models.PublicKey
 	}
 
 	ok, err := regexp.MatchString(key.Hostname, dev.Name)
+	if err != nil {
+		return false, err
+	}
+
+	return ok, nil
+}
+
+func (s *service) EvaluateKeyUsername(ctx context.Context, key *models.PublicKey, username string) (bool, error) {
+	if key.Username == "" {
+		return true, nil
+	}
+
+	ok, err := regexp.MatchString(key.Username, username)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/api/client/client_internal.go
+++ b/pkg/api/client/client_internal.go
@@ -25,7 +25,7 @@ type internalAPI interface {
 	LookupDevice()
 	GetPublicKey(fingerprint, tenant string) (*models.PublicKey, error)
 	CreatePrivateKey() (*models.PrivateKey, error)
-	EvaluateKey(fingerprint string, dev *models.Device) (bool, error)
+	EvaluateKey(fingerprint string, dev *models.Device, username string) (bool, error)
 	DevicesOffline(id string) error
 	FirewallEvaluate(lookup map[string]string) []error
 	PatchSessions(uid string) []error
@@ -52,10 +52,10 @@ func (c *client) GetPublicKey(fingerprint, tenant string) (*models.PublicKey, er
 	return pubKey, nil
 }
 
-func (c *client) EvaluateKey(fingerprint string, dev *models.Device) (bool, error) {
+func (c *client) EvaluateKey(fingerprint string, dev *models.Device, username string) (bool, error) {
 	var evaluate *bool
 
-	resp, _, errs := c.http.Post(buildURL(c, fmt.Sprintf("/internal/sshkeys/public-keys/evaluate/%s", fingerprint))).Send(dev).EndStruct(&evaluate)
+	resp, _, errs := c.http.Post(buildURL(c, fmt.Sprintf("/internal/sshkeys/public-keys/evaluate/%s/%s", fingerprint, username))).Send(dev).EndStruct(&evaluate)
 	if len(errs) > 0 {
 		var err error
 		for _, e := range errs {

--- a/pkg/models/publickey.go
+++ b/pkg/models/publickey.go
@@ -10,6 +10,7 @@ import (
 type PublicKeyFields struct {
 	Name     string `json:"name"`
 	Hostname string `json:"hostname" bson:"hostname,omitempty" validate:"regexp"`
+	Username string `json:"username" bson:"username,omitempty" validate:"regexp"`
 }
 
 func (p *PublicKeyFields) Validate() error {

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -199,6 +199,7 @@ func (s *Server) publicKeyHandler(ctx sshserver.Context, pubKey sshserver.Public
 
 	c := client.NewClient()
 
+	username := parts[0]
 	target = parts[1]
 	var lookup map[string]string
 	if !strings.Contains(parts[1], ".") {
@@ -239,7 +240,7 @@ func (s *Server) publicKeyHandler(ctx sshserver.Context, pubKey sshserver.Public
 			return false
 		}
 
-		if ok, err := apiClient.EvaluateKey(fingerprint, device); !ok || err != nil {
+		if ok, err := apiClient.EvaluateKey(fingerprint, device, username); !ok || err != nil {
 			return false
 		}
 	}

--- a/ssh/ssh2ws.go
+++ b/ssh/ssh2ws.go
@@ -58,7 +58,7 @@ func HandlerWebsocket(ws *websocket.Conn) {
 			return
 		}
 
-		if ok, err := apiClient.EvaluateKey(fingerprint, device); !ok || err != nil {
+		if ok, err := apiClient.EvaluateKey(fingerprint, device, parts[0]); !ok || err != nil {
 			if err != nil {
 				fmt.Println(err) //nolint:forbidigo
 			}

--- a/ui/src/components/public_key/KeyFormDialog.vue
+++ b/ui/src/components/public_key/KeyFormDialog.vue
@@ -107,6 +107,19 @@
             </ValidationProvider>
 
             <ValidationProvider
+              v-if="action == 'public'"
+              v-slot="{ errors }"
+              name="Username"
+              data-test="username-validationProvider"
+            >
+              <v-text-field
+                v-model="keyLocal.username"
+                label="Username"
+                :error-messages="errors"
+              />
+            </ValidationProvider>
+
+            <ValidationProvider
               v-slot="{ errors }"
               ref="providerData"
               vid="key"

--- a/ui/src/components/public_key/PublicKeyList.vue
+++ b/ui/src/components/public_key/PublicKeyList.vue
@@ -26,6 +26,10 @@
           {{ item.hostname }}
         </template>
 
+        <template #[`item.username`]="{ item }">
+          {{ item.username }}
+        </template>
+
         <template #[`item.created_at`]="{ item }">
           {{ item.created_at | moment("ddd, MMM Do YY, h:mm:ss a") }}
         </template>
@@ -78,6 +82,11 @@ export default {
         {
           text: 'Hostname',
           value: 'hostname',
+          align: 'center',
+        },
+        {
+          text: 'Username',
+          value: 'username',
           align: 'center',
         },
         {

--- a/ui/src/store/api/public_keys.js
+++ b/ui/src/store/api/public_keys.js
@@ -4,6 +4,7 @@ export const postPublicKey = async (data) => http().post('/sshkeys/public-keys',
   name: data.name,
   data: data.data,
   hostname: data.hostname,
+  username: data.username,
 });
 
 export const fetchPublicKeys = async (perPage, page) => http().get(`/sshkeys/public-keys?per_page=${perPage}&page=${page}`);
@@ -14,6 +15,7 @@ export const putPublicKey = async (data) => http().put(`/sshkeys/public-keys/${d
   name: data.name,
   data: data.data,
   hostname: data.hostname,
+  username: data.username,
 });
 
 export const removePublicKey = async (fingerprint) => http().delete(`/sshkeys/public-keys/${fingerprint}`);

--- a/ui/tests/unit/components/public_key/KeyFormDialog.spec.js
+++ b/ui/tests/unit/components/public_key/KeyFormDialog.spec.js
@@ -411,6 +411,7 @@ describe('KeyFormDialog', () => {
     });
     it('Renders the template with data', () => {
       expect(wrapper.find('[data-test="keyFormDialog-card"]').exists()).toEqual(true);
+      expect(wrapper.find('[data-test="username-validationProvider"]').exists()).toEqual(true);
       expect(wrapper.find('[data-test="cancel-btn"]').exists()).toEqual(true);
       expect(wrapper.find('[data-test="create-btn"]').exists()).toEqual(true);
       expect(wrapper.find('[data-test="edit-btn"]').exists()).toEqual(false);
@@ -513,6 +514,7 @@ describe('KeyFormDialog', () => {
     });
     it('Renders the template with data', () => {
       expect(wrapper.find('[data-test="keyFormDialog-card"]').exists()).toEqual(true);
+      expect(wrapper.find('[data-test="username-validationProvider"]').exists()).toEqual(true);
       expect(wrapper.find('[data-test="cancel-btn"]').exists()).toEqual(true);
       expect(wrapper.find('[data-test="create-btn"]').exists()).toEqual(false);
       expect(wrapper.find('[data-test="edit-btn"]').exists()).toEqual(true);
@@ -628,6 +630,7 @@ describe('KeyFormDialog', () => {
     });
     it('Renders the template with data', () => {
       expect(wrapper.find('[data-test="keyFormDialog-card"]').exists()).toEqual(true);
+      expect(wrapper.find('[data-test="username-validationProvider"]').exists()).toEqual(false);
       expect(wrapper.find('[data-test="cancel-btn"]').exists()).toEqual(true);
       expect(wrapper.find('[data-test="create-btn"]').exists()).toEqual(true);
       expect(wrapper.find('[data-test="edit-btn"]').exists()).toEqual(false);
@@ -743,6 +746,7 @@ describe('KeyFormDialog', () => {
     });
     it('Renders the template with data', () => {
       expect(wrapper.find('[data-test="keyFormDialog-card"]').exists()).toEqual(true);
+      expect(wrapper.find('[data-test="username-validationProvider"]').exists()).toEqual(false);
       expect(wrapper.find('[data-test="cancel-btn"]').exists()).toEqual(true);
       expect(wrapper.find('[data-test="create-btn"]').exists()).toEqual(false);
       expect(wrapper.find('[data-test="edit-btn"]').exists()).toEqual(true);

--- a/ui/tests/unit/components/public_key/PublicKeyList.spec.js
+++ b/ui/tests/unit/components/public_key/PublicKeyList.spec.js
@@ -45,6 +45,11 @@ describe('PublicKeyList', () => {
       align: 'center',
     },
     {
+      text: 'Username',
+      value: 'username',
+      align: 'center',
+    },
+    {
       text: 'Created At',
       value: 'created_at',
       align: 'center',

--- a/ui/tests/unit/components/public_key/__snapshots__/PublicKeyList.spec.js.snap
+++ b/ui/tests/unit/components/public_key/__snapshots__/PublicKeyList.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`PublicKeyList Renders the component 1`] = `
 <fragment-stub>
   <v-card-text-stub class="pa-0">
-    <v-data-table-stub mobilebreakpoint="600" items="[object Object],[object Object]" options="[object Object]" sortby="started_at" sortdesc="true" customsort="[Function]" page="1" itemsperpage="10" groupby="" groupdesc="" customgroup="[Function]" locale="en-US" disablesort="true" customfilter="[Function]" serveritemslength="2" itemkey="fingerprint" value="" expanded="" noresultstext="$vuetify.dataIterator.noResultsText" nodatatext="$vuetify.noDataText" loadingtext="$vuetify.dataIterator.loadingText" footerprops="[object Object]" selectablekey="isSelectable" loaderheight="4" headers="[object Object],[object Object],[object Object],[object Object],[object Object]" expandicon="$expand" itemclass="" data-test="publickeyList-dataTable"></v-data-table-stub>
+    <v-data-table-stub mobilebreakpoint="600" items="[object Object],[object Object]" options="[object Object]" sortby="started_at" sortdesc="true" customsort="[Function]" page="1" itemsperpage="10" groupby="" groupdesc="" customgroup="[Function]" locale="en-US" disablesort="true" customfilter="[Function]" serveritemslength="2" itemkey="fingerprint" value="" expanded="" noresultstext="$vuetify.dataIterator.noResultsText" nodatatext="$vuetify.noDataText" loadingtext="$vuetify.dataIterator.loadingText" footerprops="[object Object]" selectablekey="isSelectable" loaderheight="4" headers="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" expandicon="$expand" itemclass="" data-test="publickeyList-dataTable"></v-data-table-stub>
   </v-card-text-stub>
 </fragment-stub>
 `;


### PR DESCRIPTION
First, It was just added a new field, `usernames`, that is a `regexp` expression for all allowed usernames.

```http
POST http://localhost:80/api/sshkeys/public-keys

{"name":"PublicKeyName","usernames": ".*","data":"...","hostname":".*"}
```


After that, I have checked if the `username´ who want to connect match.