### PR TITLE
ssh: wait remote command to exit

### DIFF
--- a/ssh/session.go
+++ b/ssh/session.go
@@ -304,6 +304,13 @@ func (s *Session) connect(passwd string, key *rsa.PrivateKey, session sshserver.
 			return nil
 		}
 
+		if err := client.Wait(); err != nil {
+			logrus.WithFields(logrus.Fields{
+				"session": s.UID,
+				"err":     err,
+			}).Error("Failed to wait remote command to exit")
+		}
+
 		<-done
 	}
 


### PR DESCRIPTION
This fixes unexpected behaviour when getting command output from `CombinedOutput()` (x/crypto/ssh.*Session.CombinedOutput) which returns an empty buffer.