### PR TITLE
docker: replace `go get` with `go install`

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -41,7 +41,8 @@ ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl openssh-client
-RUN go get github.com/markbates/refresh && go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+RUN go install github.com/markbates/refresh@v1.11.1 && \
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -38,9 +38,9 @@ ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl build-base docker-cli
-RUN go get github.com/markbates/refresh && \
-    go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1 && \
-    go get github.com/vektra/mockery/v2/.../
+RUN go install github.com/markbates/refresh@v1.11.1 && \
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1 && \
+    go install github.com/vektra/mockery/v2/...@v2.9.2
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -33,9 +33,8 @@ RUN go build
 FROM base AS development
 
 RUN apk add --update openssl build-base docker-cli
-RUN go get github.com/markbates/refresh && \
-    go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1 && \
-    go get github.com/vektra/mockery/v2/.../
+RUN go install github.com/markbates/refresh@v1.11.1 && \
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -38,7 +38,8 @@ ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl
-RUN go get github.com/markbates/refresh && go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+RUN go install github.com/markbates/refresh@v1.11.1 && \
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 


### PR DESCRIPTION
```
go get: installing executables with 'go get' in module mode is deprecated.
	To adjust dependencies of the current module, use 'go get -d'.
	To install using requirements of the current module, use 'go install'.
	To install ignoring the current module, use 'go install' with a version,
	like 'go install example.com/cmd@latest'.
	See 'go help get' and 'go help install' for more information.
```