### PR TITLE
api: change null JSON's responses to empty body

### DIFF
--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -40,7 +40,7 @@ func (h *Handler) AuthRequest(c apicontext.Context) error {
 		c.Response().Header().Set("X-Username", claims.Username)
 		c.Response().Header().Set("X-ID", claims.ID)
 
-		return nil
+		return c.NoContent(http.StatusOK)
 	case "device":
 		var claims models.DeviceAuthClaims
 
@@ -51,7 +51,7 @@ func (h *Handler) AuthRequest(c apicontext.Context) error {
 		// Extract device UID from JWT
 		c.Response().Header().Set(api.DeviceUIDHeader, claims.UID)
 
-		return nil
+		return c.NoContent(http.StatusOK)
 	}
 
 	return echo.ErrUnauthorized
@@ -89,7 +89,7 @@ func (h *Handler) AuthUser(c apicontext.Context) error {
 	if err != nil {
 		switch err {
 		case svc.ErrForbidden:
-			return c.JSON(http.StatusForbidden, nil)
+			return c.NoContent(http.StatusForbidden)
 		default:
 			return echo.ErrUnauthorized
 		}

--- a/api/routes/device.go
+++ b/api/routes/device.go
@@ -81,7 +81,7 @@ func (h *Handler) DeleteDevice(c apicontext.Context) error {
 		return err
 	}
 
-	return nil
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) RenameDevice(c apicontext.Context) error {
@@ -121,7 +121,7 @@ func (h *Handler) OfflineDevice(c apicontext.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) LookupDevice(c apicontext.Context) error {
@@ -175,7 +175,7 @@ func (h *Handler) UpdatePendingStatus(c apicontext.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) CreateTag(c apicontext.Context) error {
@@ -202,7 +202,7 @@ func (h *Handler) CreateTag(c apicontext.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) DeleteTag(c apicontext.Context) error {
@@ -217,7 +217,7 @@ func (h *Handler) DeleteTag(c apicontext.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) RenameTag(c apicontext.Context) error {
@@ -244,7 +244,7 @@ func (h *Handler) RenameTag(c apicontext.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) ListTag(c apicontext.Context) error {
@@ -282,5 +282,5 @@ func (h *Handler) UpdateTag(c apicontext.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }

--- a/api/routes/nsadm.go
+++ b/api/routes/nsadm.go
@@ -116,7 +116,7 @@ func (h *Handler) DeleteNamespace(c apicontext.Context) error {
 		}
 	}
 
-	return nil
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) EditNamespace(c apicontext.Context) error {
@@ -235,7 +235,7 @@ func (h *Handler) EditSessionRecordStatus(c apicontext.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) GetSessionRecord(c apicontext.Context) error {

--- a/api/routes/session.go
+++ b/api/routes/session.go
@@ -85,13 +85,13 @@ func (h *Handler) FinishSession(c apicontext.Context) error {
 }
 
 func (h *Handler) RecordSession(c apicontext.Context) error {
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) PlaySession(c apicontext.Context) error {
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) DeleteRecordedSession(c apicontext.Context) error {
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }

--- a/api/routes/user.go
+++ b/api/routes/user.go
@@ -35,7 +35,7 @@ func (h *Handler) UpdateUserData(c apicontext.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) UpdateUserPassword(c apicontext.Context) error {
@@ -64,11 +64,11 @@ func (h *Handler) UpdateUserPassword(c apicontext.Context) error {
 	if err := h.service.UpdatePasswordUser(c.Ctx(), req.CurrentPassword, req.NewPassword, ID); err != nil {
 		switch {
 		case err == services.ErrUnauthorized:
-			return c.JSON(http.StatusForbidden, nil)
+			return c.NoContent(http.StatusForbidden)
 		default:
 			return err
 		}
 	}
 
-	return c.JSON(http.StatusOK, nil)
+	return c.NoContent(http.StatusOK)
 }


### PR DESCRIPTION
The `echo` returns a `200` HTTP code when the routing function return a nil,
but it is not explicit for the dev, so I have guessed, for the sake of
simplicity, change it to an empty body with the `200` status.

Another point is the responses which return a JSON, but with `null` inside the
body. I believe it could be a simply `no body` too with the original
status.