### PR TITLE
api: add custom logging middleware

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/labstack/echo/v4"
@@ -49,7 +51,8 @@ func startServer() error {
 	logrus.Info("Starting API server")
 
 	e := echo.New()
-	e.Use(middleware.Logger())
+	e.Use(logMiddleware)
+	e.Use(middleware.RequestID())
 
 	// Populates configuration based on environment variables prefixed with 'API_'
 	var cfg config
@@ -186,4 +189,63 @@ func startServer() error {
 	e.Logger.Fatal(e.Start(":8080"))
 
 	return nil
+}
+
+func logMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	log := logrus.New()
+	log.SetFormatter(&logrus.JSONFormatter{})
+
+	return func(c echo.Context) error {
+		level := logrus.InfoLevel
+
+		// Assign request tracking ID to log entry
+		entry := logrus.NewEntry(log).WithFields(logrus.Fields{
+			"id": c.Request().Header.Get(echo.HeaderXRequestID),
+		})
+
+		// Set context log entry
+		c.Set("log", entry)
+
+		// Request started log entry
+		entry = entry.WithFields(logrus.Fields{
+			"remote_ip":  c.RealIP(),
+			"host":       c.Request().Host,
+			"uri":        c.Request().RequestURI,
+			"method":     c.Request().Method,
+			"user_agent": c.Request().UserAgent(),
+		})
+
+		entry.Info("request started")
+
+		// Measure request execution time
+		start := time.Now()
+		err := next(c)
+		elapsed := time.Since(start)
+
+		// Append error fields to log entry if request has returned an error
+		if err != nil {
+			level = logrus.ErrorLevel
+			entry = entry.WithFields(logrus.Fields{
+				"error": err.Error(),
+			})
+
+			c.Error(err)
+		}
+
+		bytesIn := c.Request().Header.Get(echo.HeaderContentLength)
+		if bytesIn == "" {
+			bytesIn = "0"
+		}
+
+		// Request finished log entry
+		entry.WithFields(logrus.Fields{
+			"status":        c.Response().Status,
+			"latency":       strconv.FormatInt(elapsed.Nanoseconds()/1000, 10),
+			"latency_human": elapsed.String(),
+			"bytes_in":      bytesIn,
+			"bytes_out":     strconv.FormatInt(c.Response().Size, 10),
+		}).Log(level, "request finished")
+
+		return nil
+	}
 }


### PR DESCRIPTION
We have built our own log middleware to ensure proper log entries order. It also enables request tracing using X-Request-ID header.