### PR TITLE
ui: remove mixins in devices components

### DIFF
--- a/ui/src/components/device/Device.vue
+++ b/ui/src/components/device/Device.vue
@@ -159,30 +159,6 @@ export default {
         }
       }
     },
-
-    formatSortObject(field, isDesc) {
-      let formatedField = null;
-      let formatedStatus = false;
-      let ascOrDesc = 'asc';
-
-      if (field !== undefined) {
-        formatedField = field === 'hostname' ? 'name' : field; // customize to api field
-      }
-
-      if (isDesc !== undefined) {
-        formatedStatus = isDesc;
-      }
-
-      if (formatedStatus === true) {
-        ascOrDesc = 'desc';
-      }
-
-      return {
-        field: formatedField,
-        status: formatedStatus,
-        statusString: ascOrDesc,
-      };
-    },
   },
 };
 

--- a/ui/src/components/device/DeviceList.vue
+++ b/ui/src/components/device/DeviceList.vue
@@ -162,8 +162,8 @@ import TerminalDialog from '@/components/terminal/TerminalDialog';
 import DeviceIcon from '@/components/device/DeviceIcon';
 import DeviceDelete from '@/components/device/DeviceDelete';
 import TagFormDialog from '@/components/setting/tag/TagFormDialog';
-import formatOrdering from '@/components/device/Device';
 import { lastSeen } from '@/components/filter/date';
+import formatDeviceSort from '@/components/filter/object';
 
 export default {
   name: 'DeviceList',
@@ -176,8 +176,6 @@ export default {
   },
 
   filters: { lastSeen },
-
-  mixins: [formatOrdering],
 
   data() {
     return {
@@ -249,7 +247,10 @@ export default {
     async getDevices() {
       let sortStatusMap = {};
 
-      sortStatusMap = this.formatSortObject(this.pagination.sortBy[0], this.pagination.sortDesc[0]);
+      sortStatusMap = formatDeviceSort(
+        this.pagination.sortBy[0],
+        this.pagination.sortDesc[0],
+      );
 
       const data = {
         perPage: this.pagination.itemsPerPage,

--- a/ui/src/components/device/DevicePendingList.vue
+++ b/ui/src/components/device/DevicePendingList.vue
@@ -57,7 +57,7 @@
 
 import DeviceIcon from '@/components/device/DeviceIcon';
 import DeviceActionButton from '@/components/device/DeviceActionButton';
-import formatOrdering from '@/components/device/Device';
+import formatDeviceSort from '@/components/filter/object';
 
 export default {
   name: 'DeviceList',
@@ -66,8 +66,6 @@ export default {
     DeviceIcon,
     DeviceActionButton,
   },
-
-  mixins: [formatOrdering],
 
   data() {
     return {
@@ -127,7 +125,10 @@ export default {
     async getPendingDevices() {
       let sortStatusMap = {};
 
-      sortStatusMap = this.formatSortObject(this.pagination.sortBy[0], this.pagination.sortDesc[0]);
+      sortStatusMap = formatDeviceSort(
+        this.pagination.sortBy[0],
+        this.pagination.sortDesc[0],
+      );
 
       const data = {
         perPage: this.pagination.itemsPerPage,

--- a/ui/src/components/device/DeviceRejectedList.vue
+++ b/ui/src/components/device/DeviceRejectedList.vue
@@ -57,7 +57,7 @@
 
 import DeviceIcon from '@/components/device//DeviceIcon';
 import DeviceActionButton from '@/components/device/DeviceActionButton';
-import formatOrdering from '@/components/device//Device';
+import formatDeviceSort from '@/components/filter/object';
 
 export default {
   name: 'DeviceList',
@@ -66,8 +66,6 @@ export default {
     DeviceIcon,
     DeviceActionButton,
   },
-
-  mixins: [formatOrdering],
 
   data() {
     return {
@@ -127,7 +125,10 @@ export default {
     async getRejectedDevices() {
       let sortStatusMap = {};
 
-      sortStatusMap = this.formatSortObject(this.pagination.sortBy[0], this.pagination.sortDesc[0]);
+      sortStatusMap = formatDeviceSort(
+        this.pagination.sortBy[0],
+        this.pagination.sortDesc[0],
+      );
 
       const data = {
         perPage: this.pagination.itemsPerPage,

--- a/ui/src/components/filter/object.js
+++ b/ui/src/components/filter/object.js
@@ -1,0 +1,25 @@
+const formatDeviceSort = (field, isDesc) => {
+  let formatedField = null;
+  let formatedStatus = false;
+  let ascOrDesc = 'asc';
+
+  if (field !== undefined) {
+    formatedField = field === 'hostname' ? 'name' : field; // customize to api field
+  }
+
+  if (isDesc !== undefined) {
+    formatedStatus = isDesc;
+  }
+
+  if (formatedStatus === true) {
+    ascOrDesc = 'desc';
+  }
+
+  return {
+    field: formatedField,
+    status: formatedStatus,
+    statusString: ascOrDesc,
+  };
+};
+
+export { formatDeviceSort as default };

--- a/ui/tests/unit/components/device/Device.spec.js
+++ b/ui/tests/unit/components/device/Device.spec.js
@@ -96,24 +96,6 @@ describe('Device', () => {
 
       expect(wrapper.vm.search).toEqual('ShellHub');
     });
-    it('Process data in methods', () => {
-      const inputs = [
-        { field: undefined, isDesc: undefined },
-        { field: 'hostname', isDesc: undefined },
-        { field: 'hostname', isDesc: true },
-      ];
-
-      const output = [
-        { field: null, status: false, statusString: 'asc' },
-        { field: 'name', status: false, statusString: 'asc' },
-        { field: 'name', status: true, statusString: 'desc' },
-      ];
-
-      Object.keys(inputs).forEach((index) => {
-        expect(wrapper.vm.formatSortObject(inputs[index].field, inputs[index].isDesc))
-          .toEqual(output[index]);
-      });
-    });
 
     //////
     // HTML validation
@@ -174,24 +156,6 @@ describe('Device', () => {
       wrapper.setData({ search: 'ShellHub' });
 
       expect(wrapper.vm.search).toEqual('ShellHub');
-    });
-    it('Process data in methods', () => {
-      const inputs = [
-        { field: undefined, isDesc: undefined },
-        { field: 'hostname', isDesc: undefined },
-        { field: 'hostname', isDesc: true },
-      ];
-
-      const output = [
-        { field: null, status: false, statusString: 'asc' },
-        { field: 'name', status: false, statusString: 'asc' },
-        { field: 'name', status: true, statusString: 'desc' },
-      ];
-
-      Object.keys(inputs).forEach((index) => {
-        expect(wrapper.vm.formatSortObject(inputs[index].field, inputs[index].isDesc))
-          .toEqual(output[index]);
-      });
     });
 
     //////

--- a/ui/tests/unit/components/device/__snapshots__/DevicePendingList.spec.js.snap
+++ b/ui/tests/unit/components/device/__snapshots__/DevicePendingList.spec.js.snap
@@ -155,10 +155,10 @@ exports[`DevicePendingList Renders the component 1`] = `
       <div class="v-data-footer">
         <div class="v-data-footer__select">Rows per page:<div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
             <div class="v-input__control">
-              <div role="button" aria-haspopup="listbox" aria-expanded="false" aria-owns="list-157" class="v-input__slot">
+              <div role="button" aria-haspopup="listbox" aria-expanded="false" aria-owns="list-156" class="v-input__slot">
                 <div class="v-select__slot">
                   <div class="v-select__selections">
-                    <div class="v-select__selection v-select__selection--comma">10</div><input aria-label="Rows per page:" id="input-157" readonly="readonly" type="text" aria-readonly="false" autocomplete="off">
+                    <div class="v-select__selection v-select__selection--comma">10</div><input aria-label="Rows per page:" id="input-156" readonly="readonly" type="text" aria-readonly="false" autocomplete="off">
                   </div>
                   <div class="v-input__append-inner">
                     <div class="v-input__icon v-input__icon--append"><i aria-hidden="true" class="v-icon notranslate mdi mdi-menu-down theme--light"></i></div>

--- a/ui/tests/unit/components/device/__snapshots__/DeviceRejectedList.spec.js.snap
+++ b/ui/tests/unit/components/device/__snapshots__/DeviceRejectedList.spec.js.snap
@@ -59,10 +59,10 @@ exports[`DeviceRejectedList Renders the component 1`] = `
       <div class="v-data-footer">
         <div class="v-data-footer__select">Rows per page:<div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
             <div class="v-input__control">
-              <div role="button" aria-haspopup="listbox" aria-expanded="false" aria-owns="list-61" class="v-input__slot">
+              <div role="button" aria-haspopup="listbox" aria-expanded="false" aria-owns="list-60" class="v-input__slot">
                 <div class="v-select__slot">
                   <div class="v-select__selections">
-                    <div class="v-select__selection v-select__selection--comma">10</div><input aria-label="Rows per page:" id="input-61" readonly="readonly" type="text" aria-readonly="false" autocomplete="off">
+                    <div class="v-select__selection v-select__selection--comma">10</div><input aria-label="Rows per page:" id="input-60" readonly="readonly" type="text" aria-readonly="false" autocomplete="off">
                   </div>
                   <div class="v-input__append-inner">
                     <div class="v-input__icon v-input__icon--append"><i aria-hidden="true" class="v-icon notranslate mdi mdi-menu-down theme--light"></i></div>

--- a/ui/tests/unit/components/filter/Object.spec.js
+++ b/ui/tests/unit/components/filter/Object.spec.js
@@ -1,0 +1,59 @@
+import formatDeviceSort from '@/components/filter/object';
+
+describe('Device', () => {
+  it('Verify formatDeviceSort', () => {
+    const inputData = [
+      [undefined, undefined],
+      ['online', false],
+      ['online', true],
+      ['hostname', false],
+      ['hostname', true],
+      ['tag', false],
+      ['tag', true],
+    ];
+
+    const expectedData = [
+      {
+        field: null,
+        status: false,
+        statusString: 'asc',
+      },
+      {
+        field: 'online',
+        status: false,
+        statusString: 'asc',
+      },
+      {
+        field: 'online',
+        status: true,
+        statusString: 'desc',
+      },
+      {
+        field: 'name',
+        status: false,
+        statusString: 'asc',
+      },
+      {
+        field: 'name',
+        status: true,
+        statusString: 'desc',
+      },
+      {
+        field: 'tag',
+        status: false,
+        statusString: 'asc',
+      },
+      {
+        field: 'tag',
+        status: true,
+        statusString: 'desc',
+      },
+    ];
+
+    inputData.forEach((input, index) => {
+      const actual = formatDeviceSort(input[0], input[1]);
+
+      expect(actual).toEqual(expectedData[index]);
+    });
+  });
+});


### PR DESCRIPTION
This commit removes mixins, because when a component uses it, all options in
the mixin will be "mixed" into the component's own options.

This is causing the actions in create device to be called again on the other
related components.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>