### PR TITLE
ui: mock timezone to tests

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,6 +19,7 @@
         "moment-duration-format": "^2.3.2",
         "node-rsa": "^1.1.1",
         "sshpk": "^1.16.1",
+        "timezone-mock": "^1.2.2",
         "tmp": "^0.2.1",
         "v-clipboard": "^2.2.3",
         "vee-validate": "^3.4.13",
@@ -18790,6 +18791,11 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/timezone-mock": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.2.2.tgz",
+      "integrity": "sha512-/tKX2gEuZHs/APPLLryuwBfMBa7esdfIICqHVmcnCr7tMfl3X+L8aXzuAsnaoB6nIFQp9N03e5Gt1QiKPlUmPw=="
+    },
     "node_modules/timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -23329,7 +23335,6 @@
       "integrity": "sha512-pM7CR3yXB6L8Gfn6EmX7FLNE3+V/15I3o33GkSNsWvgsMp6HVGXKkXgojrcfUUauyL1LZOdvTmu4enU2RePGHw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -23342,7 +23347,6 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }
@@ -36622,6 +36626,11 @@
       "requires": {
         "process": "~0.11.0"
       }
+    },
+    "timezone-mock": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/timezone-mock/-/timezone-mock-1.2.2.tgz",
+      "integrity": "sha512-/tKX2gEuZHs/APPLLryuwBfMBa7esdfIICqHVmcnCr7tMfl3X+L8aXzuAsnaoB6nIFQp9N03e5Gt1QiKPlUmPw=="
     },
     "timsort": {
       "version": "0.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "moment-duration-format": "^2.3.2",
     "node-rsa": "^1.1.1",
     "sshpk": "^1.16.1",
+    "timezone-mock": "^1.2.2",
     "tmp": "^0.2.1",
     "v-clipboard": "^2.2.3",
     "vee-validate": "^3.4.13",

--- a/ui/tests/unit/components/device/DeviceDetails.spec.js
+++ b/ui/tests/unit/components/device/DeviceDetails.spec.js
@@ -1,5 +1,6 @@
 import Vuex from 'vuex';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
+import timezoneMock from 'timezone-mock';
 import DeviceDetails from '@/components/device/DeviceDetails';
 
 describe('DeviceDetails', () => {
@@ -68,6 +69,8 @@ describe('DeviceDetails', () => {
 
   describe('Online', () => {
     beforeEach(() => {
+      timezoneMock.register('UTC');
+
       wrapper = shallowMount(DeviceDetails, {
         store: storeDeviceOnline,
         localVue,
@@ -136,6 +139,8 @@ describe('DeviceDetails', () => {
 
   describe('Offline', () => {
     beforeEach(() => {
+      timezoneMock.register('UTC');
+
       wrapper = shallowMount(DeviceDetails, {
         store: storeDeviceOffline,
         localVue,

--- a/ui/tests/unit/components/filter/Date.spec.js
+++ b/ui/tests/unit/components/filter/Date.spec.js
@@ -1,8 +1,15 @@
+import timezoneMock from 'timezone-mock';
 import { formatDate } from '@/components/filter/date';
 
 describe('Date', () => {
+  const date = '2020-05-18T13:27:02.498Z';
+
+  beforeEach(() => {
+    timezoneMock.register('UTC');
+  });
+
   it('Verify formatDate', () => {
-    const actual = formatDate('2020-05-18T13:27:02.498Z');
+    const actual = formatDate(date);
 
     expect(actual).toEqual('Monday, May 18th 2020, 1:27:02 pm');
   });

--- a/ui/tests/unit/components/session/SessionDetails.spec.js
+++ b/ui/tests/unit/components/session/SessionDetails.spec.js
@@ -1,5 +1,6 @@
 import Vuex from 'vuex';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
+import timezoneMock from 'timezone-mock';
 import SessionDetails from '@/components/session/SessionDetails';
 
 describe('SessionDetails', () => {
@@ -92,6 +93,8 @@ describe('SessionDetails', () => {
 
   describe('Recorded is true and device is online', () => {
     beforeEach(() => {
+      timezoneMock.register('UTC');
+
       wrapper = shallowMount(SessionDetails, {
         store: storeRecordedTrue,
         localVue,
@@ -154,6 +157,8 @@ describe('SessionDetails', () => {
 
   describe('Recorded is false and device is online', () => {
     beforeEach(() => {
+      timezoneMock.register('UTC');
+
       wrapper = shallowMount(SessionDetails, {
         store: storeRecordedFalse,
         localVue,
@@ -216,6 +221,8 @@ describe('SessionDetails', () => {
 
   describe('Recorded is false and device is offline', () => {
     beforeEach(() => {
+      timezoneMock.register('UTC');
+
       wrapper = shallowMount(SessionDetails, {
         store: storeRecordedFalseAndOffline,
         localVue,

--- a/ui/tests/unit/components/session/SessionList.spec.js
+++ b/ui/tests/unit/components/session/SessionList.spec.js
@@ -1,6 +1,7 @@
 import Vuex from 'vuex';
 import { mount, createLocalVue } from '@vue/test-utils';
 import Vuetify from 'vuetify';
+import timezoneMock from 'timezone-mock';
 import SessionList from '@/components/session/SessionList';
 
 describe('SessionList', () => {
@@ -134,6 +135,8 @@ describe('SessionList', () => {
   });
 
   beforeEach(() => {
+    timezoneMock.register('UTC');
+
     wrapper = mount(SessionList, {
       store,
       localVue,


### PR DESCRIPTION
This commit mock the timezone so that when running the local tests there is no
error with a different timezone than the container.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>