### PR TITLE
shellhub: change RSA SSH key generation to AES256

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ api_public_key:
 
 # Generate required private key for ssh service
 ssh_private_key:
-	@$(KEYGEN) genrsa -out ssh_private_key 2048
+	@$(KEYGEN) genrsa -aes256 -out ssh_private_key 2048
 
 .PHONY: keygen
 # Generate required keys


### PR DESCRIPTION
Currently, the Shellhub has used RSA SHA1 for SSH connection. This commit
change the hashing algorithm from the default, SHA1, to AES256.

On the update of OpenSSH to version `8.8`, the RSA SHA1 key was deprecated,
making connection from clients from this version needs an extra param to
connect.

```
This release disables RSA signatures using the SHA-1 hash algorithm
by default. This change has been made as the SHA-1 hash algorithm is
cryptographically broken, and it is possible to create chosen-prefix
hash collisions for <USD$50K [1]
```

https://www.openssh.com/txt/release-8.8