### PR TITLE
gateway: Uses a different variable name in auth location block

### DIFF
--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -258,10 +258,10 @@ server {
     }
 
     location /auth {
-        set $upstream api:8080;
+        set $upstream_auth api:8080;
         internal;
         rewrite ^/(.*)$ /internal/$1 break;
-        proxy_pass http://$upstream;
+        proxy_pass http://$upstream_auth;
     }
 
     location /ws {


### PR DESCRIPTION
Uses a different variable name in auth location block due to subrequests
of auth_request module that share variables with their parent requests,
which causes variable override.