### PR TITLE
docker-compose: remove empty service from dev file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -100,7 +100,6 @@ services:
     depends_on:
     - api
     - mongo
-  mongo:
   autossl:
     image: tianon/true
   openapi:


### PR DESCRIPTION
This changes makes it compatible with docker-compose v2, which is more strict while parsing compose files than v1 and do not allow empty services.