### PR TITLE
ui: remove unnecessary requests

### DIFF
--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -128,10 +128,18 @@ export default {
     currentInANamespace() {
       return localStorage.getItem('tenant') !== '';
     },
+
+    hasNamespace() {
+      return this.$store.getters['namespaces/getNumberNamespaces'] > 0;
+    },
   },
 
-  created() {
-    this.$store.dispatch('stats/get');
+  watch: {
+    hasNamespace(status) {
+      if (status) {
+        this.$store.dispatch('stats/get');
+      }
+    },
   },
 
   mounted() {

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -130,7 +130,6 @@ export default {
 
       this.$store.dispatch('auth/loginToken', this.$route.query.token).then(() => {
         this.$store.dispatch('layout/setLayout', 'appLayout');
-        this.$store.dispatch('notifications/fetch');
         this.$router.push({ name: 'dashboard' }).catch(() => {});
       });
     }


### PR DESCRIPTION
When the user doesn't have a namespace, two requests are called and they
shouldn't. For stats and peding device requests.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>