### PR TITLE
api: rename authenticated to confirmed in user model

### DIFF
--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -125,7 +125,7 @@ func (s *service) AuthUser(ctx context.Context, req models.UserAuthRequest) (*mo
 		}
 	}
 
-	if !user.Authenticated {
+	if !user.Confirmed {
 		return nil, ErrForbidden
 	}
 

--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -104,21 +104,21 @@ func TestAuthUser(t *testing.T) {
 		UserPassword: models.UserPassword{
 			Password: hex.EncodeToString(wrongPasswd[:]),
 		},
-		ID:            "id",
-		Authenticated: true,
-		LastLogin:     now,
+		ID:        "id",
+		Confirmed: true,
+		LastLogin: now,
 	}
 
-	userAuthenticated := &models.User{
+	userConfirmed := &models.User{
 		UserData: models.UserData{
 			Username: "user",
 		},
 		UserPassword: models.UserPassword{
 			Password: hex.EncodeToString(passwd[:]),
 		},
-		ID:            "id",
-		Authenticated: true,
-		LastLogin:     now,
+		ID:        "id",
+		Confirmed: true,
+		LastLogin: now,
 	}
 
 	userNotActivatedAccount := &models.User{
@@ -128,16 +128,16 @@ func TestAuthUser(t *testing.T) {
 		UserPassword: models.UserPassword{
 			Password: hex.EncodeToString(passwd[:]),
 		},
-		ID:            "id",
-		Authenticated: false,
-		LastLogin:     now,
+		ID:        "id",
+		Confirmed: false,
+		LastLogin: now,
 	}
 
 	namespace := &models.Namespace{Name: "group1", Owner: "hash1", TenantID: "tenant"}
 
-	mock.On("UserGetByUsername", ctx, authReq.Username).Return(userAuthenticated, nil).Once()
-	mock.On("NamespaceGetFirst", ctx, userAuthenticated.ID).Return(namespace, nil).Once()
-	mock.On("UserUpdateData", ctx, userAuthenticated, userAuthenticated.ID).Return(nil).Once()
+	mock.On("UserGetByUsername", ctx, authReq.Username).Return(userConfirmed, nil).Once()
+	mock.On("NamespaceGetFirst", ctx, userConfirmed.ID).Return(namespace, nil).Once()
+	mock.On("UserUpdateData", ctx, userConfirmed, userConfirmed.ID).Return(nil).Once()
 	clockMock.On("Now").Return(now).Twice()
 
 	authRes, err := s.AuthUser(ctx, *authReq)
@@ -186,9 +186,9 @@ func TestAuthUser(t *testing.T) {
 			description: "Successful authentication",
 			args:        *authReq,
 			requiredMocks: func() {
-				mock.On("UserGetByUsername", ctx, authReq.Username).Return(userAuthenticated, nil).Once()
-				mock.On("NamespaceGetFirst", ctx, userAuthenticated.ID).Return(namespace, nil).Once()
-				mock.On("UserUpdateData", ctx, userAuthenticated, userAuthenticated.ID).Return(nil).Once()
+				mock.On("UserGetByUsername", ctx, authReq.Username).Return(userConfirmed, nil).Once()
+				mock.On("NamespaceGetFirst", ctx, userConfirmed.ID).Return(namespace, nil).Once()
+				mock.On("UserUpdateData", ctx, userConfirmed, userConfirmed.ID).Return(nil).Once()
 				clockMock.On("Now").Return(now).Twice()
 			},
 			expected: Expected{authRes, nil},

--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -44,6 +44,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration32,
 		migration33,
 		migration34,
+		migration35,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_32_test.go
+++ b/api/store/mongo/migrations/migration_32_test.go
@@ -51,5 +51,5 @@ func TestMigration32(t *testing.T) {
 	var migratedUser *models.User
 	err = db.Client().Database("test").Collection("users").FindOne(context.TODO(), bson.M{"name": "name"}).Decode(&migratedUser)
 	assert.NoError(t, err)
-	assert.Equal(t, true, migratedUser.Authenticated)
+	assert.Equal(t, false, migratedUser.Confirmed)
 }

--- a/api/store/mongo/migrations/migration_35.go
+++ b/api/store/mongo/migrations/migration_35.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration35 = migrate.Migration{
+	Version:     35,
+	Description: "Rename the column authenticated to confirmed",
+	Up: func(db *mongo.Database) error {
+		logrus.WithFields(logrus.Fields{
+			"component": "migration",
+			"version":   35,
+			"action":    "Up",
+		}).Info("Applying migration")
+
+		return renameField(db, "users", "authenticated", "confirmed")
+	},
+	Down: func(db *mongo.Database) error {
+		logrus.WithFields(logrus.Fields{
+			"component": "migration",
+			"version":   35,
+			"action":    "Down",
+		}).Info("Applying migration")
+
+		return renameField(db, "users", "confirmed", "authenticated")
+	},
+}

--- a/api/store/mongo/migrations/migration_35_test.go
+++ b/api/store/mongo/migrations/migration_35_test.go
@@ -1,0 +1,53 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/pkg/dbtest"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMigration35(t *testing.T) {
+	logrus.Info("Testing Migration 35 - Test if the column authenticated was renamed to confirmed")
+
+	db := dbtest.DBServer{}
+	defer db.Stop()
+
+	type User struct {
+		ID            string          `json:"id,omitempty" bson:"_id,omitempty"`
+		Namespaces    int             `json:"namespaces" bson:"namespaces,omitempty"`
+		Authenticated bool            `json:"authenticated"`
+		UserData      models.UserData `bson:",inline"`
+	}
+
+	user := User{
+		ID:            "0",
+		Namespaces:    0,
+		Authenticated: true,
+		UserData: models.UserData{
+			Name:     "user",
+			Email:    "test@shellhub.com",
+			Username: "username",
+		},
+	}
+
+	_, err := db.Client().Database("test").Collection("users").InsertOne(context.TODO(), user)
+	assert.NoError(t, err)
+
+	var afterMigrationUser *User
+	err = db.Client().Database("test").Collection("users").FindOne(context.TODO(), bson.M{"username": "username"}).Decode(&afterMigrationUser)
+	assert.NoError(t, err)
+
+	migrates := migrate.NewMigrate(db.Client().Database("test"), GenerateMigrations()[34:35]...)
+	err = migrates.Up(migrate.AllAvailable)
+	assert.NoError(t, err)
+
+	var migratedUser *models.User
+	err = db.Client().Database("test").Collection("users").FindOne(context.TODO(), bson.M{"username": "username"}).Decode(&migratedUser)
+	assert.NoError(t, err)
+}

--- a/api/store/mongo/user_store.go
+++ b/api/store/mongo/user_store.go
@@ -280,7 +280,7 @@ func (s *Store) UserUpdateAccountStatus(ctx context.Context, id string) error {
 		return err
 	}
 
-	if _, err := s.db.Collection("users").UpdateOne(ctx, bson.M{"_id": objID}, bson.M{"$set": bson.M{"authenticated": true}}); err != nil {
+	if _, err := s.db.Collection("users").UpdateOne(ctx, bson.M{"_id": objID}, bson.M{"$set": bson.M{"confirmed": true}}); err != nil {
 		return err
 	}
 

--- a/api/store/mongo/user_store_test.go
+++ b/api/store/mongo/user_store_test.go
@@ -284,7 +284,7 @@ func TestUserUpdateAccountStatus(t *testing.T) {
 	assert.NoError(t, err)
 
 	us, _, err := mongostore.UserGetByID(data.Context, objID, false)
-	assert.Equal(t, us.Authenticated, true)
+	assert.Equal(t, us.Confirmed, true)
 	assert.NoError(t, err)
 }
 

--- a/cli/service.go
+++ b/cli/service.go
@@ -56,8 +56,8 @@ func (s *service) UserCreate(data Arguments) (string, error) {
 		UserPassword: models.UserPassword{
 			Password: hashPassword(password),
 		},
-		Authenticated: true,
-		CreatedAt:     clock.Now(),
+		Confirmed: true,
+		CreatedAt: clock.Now(),
 	}); err != nil && err.Error() == "duplicate" {
 		var errStrings []string
 

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -17,13 +17,13 @@ type UserPassword struct {
 }
 
 type User struct {
-	ID            string    `json:"id,omitempty" bson:"_id,omitempty"`
-	Namespaces    int       `json:"namespaces" bson:"namespaces,omitempty"`
-	Authenticated bool      `json:"authenticated"`
-	CreatedAt     time.Time `json:"created_at" bson:"created_at"`
-	LastLogin     time.Time `json:"last_login" bson:"last_login"`
-	UserData      `bson:",inline"`
-	UserPassword  `bson:",inline"`
+	ID           string    `json:"id,omitempty" bson:"_id,omitempty"`
+	Namespaces   int       `json:"namespaces" bson:"namespaces,omitempty"`
+	Confirmed    bool      `json:"confirmed"`
+	CreatedAt    time.Time `json:"created_at" bson:"created_at"`
+	LastLogin    time.Time `json:"last_login" bson:"last_login"`
+	UserData     `bson:",inline"`
+	UserPassword `bson:",inline"`
 }
 
 type UserAuthRequest struct {


### PR DESCRIPTION
Authenticated field does not mean correct field functionality,
this field was originally created to flag the user who has already
confirmed your email. So switching to confirmed seems more correct.

Signed-off-by: Juan Rios <juan.rios@ossystems.com.br>