### PR TITLE
Fix typo in variable name

### DIFF
--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -23,7 +23,7 @@ import (
 )
 
 type AuthService interface {
-	AuthDevice(ctx context.Context, req *models.DeviceAuthRequest, remoteAdrr string) (*models.DeviceAuthResponse, error)
+	AuthDevice(ctx context.Context, req *models.DeviceAuthRequest, remoteAddr string) (*models.DeviceAuthResponse, error)
 	AuthUser(ctx context.Context, req models.UserAuthRequest) (*models.UserAuthResponse, error)
 	AuthGetToken(ctx context.Context, tenant string) (*models.UserAuthResponse, error)
 	AuthPublicKey(ctx context.Context, req *models.PublicKeyAuthRequest) (*models.PublicKeyAuthResponse, error)
@@ -32,7 +32,7 @@ type AuthService interface {
 	PublicKey() *rsa.PublicKey
 }
 
-func (s *service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest, remoteAdrr string) (*models.DeviceAuthResponse, error) {
+func (s *service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest, remoteAddr string) (*models.DeviceAuthResponse, error) {
 	uid := sha256.Sum256(structhash.Dump(req.DeviceAuth, 1))
 
 	key := hex.EncodeToString(uid[:])
@@ -71,7 +71,7 @@ func (s *service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest,
 		PublicKey:  req.PublicKey,
 		TenantID:   req.TenantID,
 		LastSeen:   clock.Now(),
-		RemoteAddr: remoteAdrr,
+		RemoteAddr: remoteAddr,
 	}
 
 	// The order here is critical as we don't want to register devices if the tenant id is invalid

--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -41,13 +41,13 @@ func (_m *Service) AddNamespaceUser(ctx context.Context, tenantID string, userna
 	return r0, r1
 }
 
-// AuthDevice provides a mock function with given fields: ctx, req, remoteAdrr
-func (_m *Service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest, remoteAdrr string) (*models.DeviceAuthResponse, error) {
-	ret := _m.Called(ctx, req, remoteAdrr)
+// AuthDevice provides a mock function with given fields: ctx, req, remoteAddr
+func (_m *Service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest, remoteAddr string) (*models.DeviceAuthResponse, error) {
+	ret := _m.Called(ctx, req, remoteAddr)
 
 	var r0 *models.DeviceAuthResponse
 	if rf, ok := ret.Get(0).(func(context.Context, *models.DeviceAuthRequest, string) *models.DeviceAuthResponse); ok {
-		r0 = rf(ctx, req, remoteAdrr)
+		r0 = rf(ctx, req, remoteAddr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.DeviceAuthResponse)
@@ -56,7 +56,7 @@ func (_m *Service) AuthDevice(ctx context.Context, req *models.DeviceAuthRequest
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *models.DeviceAuthRequest, string) error); ok {
-		r1 = rf(ctx, req, remoteAdrr)
+		r1 = rf(ctx, req, remoteAddr)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This fixes the spelling of variable remoteAddr.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>