### PR TITLE
api: fix device list by usage query

### DIFF
--- a/api/store/mongo/device_store.go
+++ b/api/store/mongo/device_store.go
@@ -276,6 +276,22 @@ func (s *Store) DeviceListByUsage(ctx context.Context, tenant string) ([]models.
 			},
 		},
 		{
+			"$lookup": bson.M{
+				"from":         "namespaces",
+				"localField":   "tenant_id",
+				"foreignField": "tenant_id",
+				"as":           "namespace",
+			},
+		},
+		{
+			"$addFields": bson.M{
+				"namespace": "$namespace.name",
+			},
+		},
+		{
+			"$unwind": "$namespace",
+		},
+		{
 			"$project": bson.M{
 				"sessions":      0,
 				"sessionsCount": 0,

--- a/api/store/mongo/device_store_test.go
+++ b/api/store/mongo/device_store_test.go
@@ -251,6 +251,7 @@ func TestDeviceListByUsage(t *testing.T) {
 
 	for i, device := range devices {
 		assert.Equal(t, expectedUIDs[i], device.UID)
+		assert.Equal(t, "namespace", device.Namespace)
 	}
 }
 


### PR DESCRIPTION
The namespace name field was missing when returning value.

Signed-off-by: Vagner S. Nornberg <vagner.nornberg@ossystems.com.br>