### PR TITLE
ui: Fix concurrent behavior in warning dialog

### DIFF
--- a/ui/src/components/user/UserWarning.vue
+++ b/ui/src/components/user/UserWarning.vue
@@ -69,6 +69,17 @@ export default {
   },
 
   methods: {
+    async statusWarning() {
+      const bill = this.$store.getters['namespaces/get'].billing;
+
+      if (bill === undefined) {
+        await this.$store.dispatch('namespaces/get', localStorage.getItem('tenant'));
+      }
+
+      return this.$store.getters['stats/stats'].registered_devices > 3
+        && !this.$store.getters['billing/active'];
+    },
+
     async showDialogs() {
       try {
         await this.getNamespaces();
@@ -121,8 +132,7 @@ export default {
     },
 
     async billingWarning() {
-      const status = this.$store.getters['stats/stats'].registered_devices > 3
-        && !this.$store.getters['billing/active'];
+      const status = await this.statusWarning();
       await this.$store.dispatch('devices/setDeviceChooserStatus', status);
     },
 

--- a/ui/tests/unit/components/user/UserWarning.spec.js
+++ b/ui/tests/unit/components/user/UserWarning.spec.js
@@ -51,6 +51,7 @@ describe('UserWarning', () => {
     'devices/setDeviceChooserStatus': () => {},
     'auth/setShowWelcomeScreen': () => {},
     'namespaces/fetch': () => {},
+    'namespaces/get': () => {},
     'snackbar/showSnackbarErrorAssociation': () => {},
     'snackbar/showSnackbarErrorLoading': () => {},
   };
@@ -250,6 +251,8 @@ describe('UserWarning', () => {
 
   describe('With devices and inactive billing', () => {
     beforeEach(() => {
+      localStorage.setItem('tenant', 'test');
+
       storeWithDevicesInactive.dispatch = jest.fn();
 
       wrapper = shallowMount(UserWarning, {
@@ -281,7 +284,9 @@ describe('UserWarning', () => {
     //////
     // Call actions
     //////
-    it('Dispatches on mount', () => {
+    it('Dispatches on mount', async () => {
+      expect(storeWithDevicesInactive.dispatch).toHaveBeenCalledWith('namespaces/get', 'test');
+      await wrapper.vm.$nextTick();
       expect(storeWithDevicesInactive.dispatch).toHaveBeenCalledWith('devices/setDeviceChooserStatus', true);
     });
 
@@ -364,7 +369,8 @@ describe('UserWarning', () => {
     //////
     // Call actions
     //////
-    it('Dispatches on mount', () => {
+    it('Dispatches on mount', async () => {
+      await wrapper.vm.$nextTick();
       expect(storeWithDevicesActive.dispatch).toHaveBeenCalledWith('devices/setDeviceChooserStatus', false);
     });
 


### PR DESCRIPTION
applayout component sometimes executes before the namespace state
is available through namespacemenu get, this fixes dialog show
making use of another request in this case.

Signed-off-by: Vagner S. Nornberg <vagner.nornberg@ossystems.com.br>