### PR TITLE
api: update store device toplist to a more effective query

### DIFF
--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -490,6 +490,29 @@ func (_m *Service) GetDevice(ctx context.Context, uid models.UID) (*models.Devic
 	return r0, r1
 }
 
+// GetDeviceMostUsed provides a mock function with given fields: ctx, tenant
+func (_m *Service) GetDeviceMostUsed(ctx context.Context, tenant string) ([]models.UID, error) {
+	ret := _m.Called(ctx, tenant)
+
+	var r0 []models.UID
+	if rf, ok := ret.Get(0).(func(context.Context, string) []models.UID); ok {
+		r0 = rf(ctx, tenant)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.UID)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, tenant)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNamespace provides a mock function with given fields: ctx, tenantID
 func (_m *Service) GetNamespace(ctx context.Context, tenantID string) (*models.Namespace, error) {
 	ret := _m.Called(ctx, tenantID)

--- a/api/store/device_store.go
+++ b/api/store/device_store.go
@@ -23,6 +23,6 @@ type DeviceStore interface {
 	DeviceGetByName(ctx context.Context, name string, tenantID string) (*models.Device, error)
 	DeviceGetByUID(ctx context.Context, uid models.UID, tenantID string) (*models.Device, error)
 	DeviceSetPosition(ctx context.Context, uid models.UID, position models.DevicePosition) error
-	DeviceListByUsage(ctx context.Context, tenantID string) ([]models.Device, error)
+	DeviceListByUsage(ctx context.Context, tenantID string) ([]models.UID, error)
 	DeviceChooser(ctx context.Context, tenantID string, chosen []string) error
 }

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -343,15 +343,15 @@ func (_m *Store) DeviceList(ctx context.Context, pagination paginator.Query, fil
 }
 
 // DeviceListByUsage provides a mock function with given fields: ctx, tenantID
-func (_m *Store) DeviceListByUsage(ctx context.Context, tenantID string) ([]models.Device, error) {
+func (_m *Store) DeviceListByUsage(ctx context.Context, tenantID string) ([]models.UID, error) {
 	ret := _m.Called(ctx, tenantID)
 
-	var r0 []models.Device
-	if rf, ok := ret.Get(0).(func(context.Context, string) []models.Device); ok {
+	var r0 []models.UID
+	if rf, ok := ret.Get(0).(func(context.Context, string) []models.UID); ok {
 		r0 = rf(ctx, tenantID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]models.Device)
+			r0 = ret.Get(0).([]models.UID)
 		}
 	}
 


### PR DESCRIPTION
The previous query related to top usage of devices had some performance issues,
this commit updates the previous store function use to use a faster aggregation.

Signed-off-by: Vagner S. Nornberg <vagner.nornberg@ossystems.com.br>