### PR TITLE
ui: disable closing dialog when user clicks outside dialog

### DIFF
--- a/ui/src/components/device/DeviceChooser.vue
+++ b/ui/src/components/device/DeviceChooser.vue
@@ -2,6 +2,7 @@
   <v-dialog
     v-if="isOwner"
     v-model="show"
+    persistent
     max-width="900"
   >
     <v-card data-test="deviceChooser-dialog">


### PR DESCRIPTION
This commit adds the functionality to interact only with dialog buttons to
perform actions.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>