### PR TITLE
pkg: clean ID when formatting user

### DIFF
--- a/pkg/validator/format.go
+++ b/pkg/validator/format.go
@@ -16,6 +16,7 @@ func HashPassword(password string) string {
 
 // FormatUser apply some formation rules to a models.User and encrypt the password.
 func FormatUser(user *models.User) {
+	user.ID = ""
 	user.Username = strings.ToLower(user.Username)
 	user.Email = strings.ToLower(user.Email)
 	if user.Password != "" {


### PR DESCRIPTION
To register a user, the client sends a user's model to register.
This user's model has a field called ID, that the API's store generate.
However, currently an API's client may send a request with an ID,
generating an unwanted behavior: API returns a 500 error, but the
user is registered. Furthermore, this inserted user's cannot be deleted
by the Shellhub's UI interface.

Cleaning the input data was the easiest way to remove this behavior.