### PR TITLE
ssh: update message when user can't access device

### DIFF
--- a/ssh/session.go
+++ b/ssh/session.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	ErrInvalidSessionTarget = errors.New("invalid session target")
-	ErrBillingBlock         = errors.New("reached the device limit, update to premium or choose up to 3 devices")
+	ErrBillingBlock         = errors.New("you reached the free device limit, please upgrade to the premium plan or choose up to 3 devices")
 )
 
 type Session struct {


### PR DESCRIPTION
This commit improves the error message on the terminal when the user has more
than 3 devices and is not enabled for billing.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>