### PR TITLE
ui: refactor dashboard component to use props to show not found alert

### DIFF
--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -166,10 +166,10 @@ const router = new Router({
       path: '*',
       name: 'NotFound',
       component: Dashboard,
-      redirect: () => {
-        localStorage.setItem('flag', true);
-        return '/';
+      props: {
+        notFound: true,
       },
+      redirect: () => '/',
     },
   ],
 });

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <fragment>
     <v-alert
-      v-if="flag"
+      v-if="notFound"
       text
       color="#bd4147"
       outlined
@@ -85,9 +85,16 @@ export default {
     DeviceAdd,
   },
 
+  props: {
+    notFound: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+
   data() {
     return {
-      flag: false,
       items: [
         {
           title: 'Registered Devices',


### PR DESCRIPTION
This avoids unnecessary usage of localStorage to store data that does not need to be persisted between page refresh/reload.