### PR TITLE
api, pkg: remove function to get all roles and remove unused action

### DIFF
--- a/api/pkg/guard/guard.go
+++ b/api/pkg/guard/guard.go
@@ -46,12 +46,12 @@ func EvaluateSubject(ctx context.Context, s store.Store, tenantID, activeID, rol
 		return false
 	}
 
-	return authorizer.EvaluateRole(roleActive, rolePassive)
+	return authorizer.CheckRole(roleActive, rolePassive)
 }
 
 // EvaluatePermission checks if a namespace's member has the role that allows an action.
 func EvaluatePermission(role string, action int, service func() error) error {
-	if !authorizer.EvaluatePermission(role, action) {
+	if !authorizer.CheckPermission(role, action) {
 		return ErrForbidden
 	}
 

--- a/api/pkg/guard/guard_test.go
+++ b/api/pkg/guard/guard_test.go
@@ -232,21 +232,19 @@ func TestEvaluatePermission(t *testing.T) {
 		expected      bool
 	}{
 		{
-			description: "EvaluatePermission success when user is the observer",
+			description: "CheckPermission success when user is the observer",
 			role:        authorizer.MemberRoleObserver,
 			actions: []int{
 				authorizer.Actions.Device.Connect,
 
 				authorizer.Actions.Session.Details,
-
-				authorizer.Actions.Namespace.Create,
 			},
 			requiredMocks: func() {
 			},
 			expected: true,
 		},
 		{
-			description: "EvaluatePermission success when user is the operator",
+			description: "CheckPermission success when user is the operator",
 			role:        authorizer.MemberRoleOperator,
 			actions: []int{
 				authorizer.Actions.Device.Accept,
@@ -255,15 +253,13 @@ func TestEvaluatePermission(t *testing.T) {
 				authorizer.Actions.Device.Rename,
 
 				authorizer.Actions.Session.Details,
-
-				authorizer.Actions.Namespace.Create,
 			},
 			requiredMocks: func() {
 			},
 			expected: true,
 		},
 		{
-			description: "EvaluatePermission success when user is the administrator",
+			description: "CheckPermission success when user is the administrator",
 			role:        authorizer.MemberRoleAdministrator,
 			actions: []int{
 				authorizer.Actions.Device.Accept,
@@ -285,7 +281,6 @@ func TestEvaluatePermission(t *testing.T) {
 				authorizer.Actions.PublicKey.Edit,
 				authorizer.Actions.PublicKey.Remove,
 
-				authorizer.Actions.Namespace.Create,
 				authorizer.Actions.Namespace.Rename,
 				authorizer.Actions.Namespace.AddMember,
 				authorizer.Actions.Namespace.RemoveMember,
@@ -297,7 +292,7 @@ func TestEvaluatePermission(t *testing.T) {
 			expected: true,
 		},
 		{
-			description: "EvaluatePermission success when user is the owner",
+			description: "CheckPermission success when user is the owner",
 			role:        authorizer.MemberRoleOwner,
 			actions: []int{
 				authorizer.Actions.Device.Accept,
@@ -319,7 +314,6 @@ func TestEvaluatePermission(t *testing.T) {
 				authorizer.Actions.PublicKey.Edit,
 				authorizer.Actions.PublicKey.Remove,
 
-				authorizer.Actions.Namespace.Create,
 				authorizer.Actions.Namespace.Rename,
 				authorizer.Actions.Namespace.AddMember,
 				authorizer.Actions.Namespace.RemoveMember,

--- a/pkg/authorizer/actions.go
+++ b/pkg/authorizer/actions.go
@@ -29,7 +29,7 @@ type publicKeyActions struct {
 }
 
 type namespaceActions struct {
-	Create, Rename, AddMember, RemoveMember, EditMember, EnableSessionRecord, Delete int
+	Rename, AddMember, RemoveMember, EditMember, EnableSessionRecord, Delete int
 }
 
 type billingActions struct {
@@ -63,7 +63,6 @@ var Actions = actions{
 		Remove: PublicKeyRemove,
 	},
 	Namespace: namespaceActions{
-		Create:              NamespaceCreate,
 		Rename:              NamespaceRename,
 		AddMember:           NamespaceAddMember,
 		RemoveMember:        NamespaceRemoveMember,

--- a/pkg/authorizer/authorizer_test.go
+++ b/pkg/authorizer/authorizer_test.go
@@ -15,28 +15,28 @@ func TestEvaluateRole(t *testing.T) {
 			name: "Fail when the first role is not great than the second one",
 			exec: func(t *testing.T) {
 				t.Helper()
-				assert.False(t, EvaluateRole(MemberRoleAdministrator, MemberRoleOwner))
+				assert.False(t, CheckRole(MemberRoleAdministrator, MemberRoleOwner))
 			},
 		},
 		{
 			name: "Fail when a role is not valid",
 			exec: func(t *testing.T) {
 				t.Helper()
-				assert.False(t, EvaluateRole("invalidRole", MemberRoleOperator))
+				assert.False(t, CheckRole("invalidRole", MemberRoleOperator))
 			},
 		},
 		{
 			name: "Fail when both roles are equals",
 			exec: func(t *testing.T) {
 				t.Helper()
-				assert.False(t, EvaluateRole(MemberRoleOperator, MemberRoleOperator))
+				assert.False(t, CheckRole(MemberRoleOperator, MemberRoleOperator))
 			},
 		},
 		{
 			name: "Success when the first role is great than the second one",
 			exec: func(t *testing.T) {
 				t.Helper()
-				assert.True(t, EvaluateRole(MemberRoleAdministrator, MemberRoleOperator))
+				assert.True(t, CheckRole(MemberRoleAdministrator, MemberRoleOperator))
 			},
 		},
 	}
@@ -85,7 +85,7 @@ func TestEvaluatePermission(t *testing.T) {
 				t.Helper()
 				ty := "observer"
 				action := Actions.Firewall.Create
-				assert.False(t, EvaluatePermission(ty, action))
+				assert.False(t, CheckPermission(ty, action))
 			},
 		},
 		{
@@ -94,7 +94,7 @@ func TestEvaluatePermission(t *testing.T) {
 				t.Helper()
 				ty := "owner"
 				action := Actions.Firewall.Create
-				assert.True(t, EvaluatePermission(ty, action))
+				assert.True(t, CheckPermission(ty, action))
 			},
 		},
 	}

--- a/pkg/authorizer/permissions.go
+++ b/pkg/authorizer/permissions.go
@@ -1,5 +1,7 @@
 package authorizer
 
+type Permissions []int
+
 const (
 	DeviceAccept = iota
 	DeviceReject
@@ -21,7 +23,6 @@ const (
 	PublicKeyEdit
 	PublicKeyRemove
 
-	NamespaceCreate
 	NamespaceRename
 	NamespaceAddMember
 	NamespaceRemoveMember
@@ -39,16 +40,13 @@ const (
 	BillingGetSubscription
 )
 
-type permissions []int
-
-var observerPermissions = permissions{
+var observerPermissions = Permissions{
 	DeviceConnect,
 	DeviceDetails,
 	SessionDetails,
-	NamespaceCreate,
 }
 
-var operatorPermissions = permissions{
+var operatorPermissions = Permissions{
 	DeviceAccept,
 	DeviceReject,
 	DeviceConnect,
@@ -56,11 +54,9 @@ var operatorPermissions = permissions{
 	DeviceDetails,
 
 	SessionDetails,
-
-	NamespaceCreate,
 }
 
-var adminPermissions = permissions{
+var adminPermissions = Permissions{
 	DeviceAccept,
 	DeviceReject,
 	DeviceRemove,
@@ -81,7 +77,6 @@ var adminPermissions = permissions{
 	PublicKeyEdit,
 	PublicKeyRemove,
 
-	NamespaceCreate,
 	NamespaceRename,
 	NamespaceAddMember,
 	NamespaceRemoveMember,
@@ -89,7 +84,7 @@ var adminPermissions = permissions{
 	NamespaceEnableSessionRecord,
 }
 
-var ownerPermissions = permissions{
+var ownerPermissions = Permissions{
 	DeviceAccept,
 	DeviceReject,
 	DeviceRemove,
@@ -110,7 +105,6 @@ var ownerPermissions = permissions{
 	PublicKeyEdit,
 	PublicKeyRemove,
 
-	NamespaceCreate,
 	NamespaceRename,
 	NamespaceAddMember,
 	NamespaceRemoveMember,


### PR DESCRIPTION
While the development API's token feature, I've noticed some issues
that could be problematic when a new member's role is added. When a
new role needs to be added, the developer should change many places
, what could lead to a probable error.

Changing from function to a map will decrease that possibility, no
more loop are needed and the code is simplified.

At this commit, the namespace's create action was also removed due
to uselessness. It is "useless" because no matter your role on a
namespace, the user might create a new one as itself as owner.