### PR TITLE
api: perform correct type assertion for jwt.Token type

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20210110162100-a92cc753f88e // indirect
 	github.com/go-redis/cache/v8 v8.4.3
 	github.com/go-redis/redis/v8 v8.11.4
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/labstack/echo/v4 v4.6.1

--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -3,7 +3,7 @@ package routes
 import (
 	"net/http"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	jwt "github.com/golang-jwt/jwt"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/mitchellh/mapstructure"


### PR DESCRIPTION
Since echo is using github.com/golang-jwt/jwt we need too to avoid type assertion error with jwt.Token type