### PR TITLE
ui: fix app layout after JWT expires

### DIFF
--- a/ui/src/store/helpers/http.js
+++ b/ui/src/store/helpers/http.js
@@ -25,6 +25,8 @@ export default () => {
     if (error.response.status === 401) {
       await store.dispatch('auth/logout');
       await router.push({ name: 'login' }).catch(() => {});
+
+      store.dispatch('layout/setLayout', 'simpleLayout');
     }
     throw error;
   });


### PR DESCRIPTION
When the request returns status code 401 is necessary to set the simple layout
type.

This closes #1587.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>