### PR TITLE
ui: device list page improvements

### DIFF
--- a/ui/src/components/device/DeviceList.vue
+++ b/ui/src/components/device/DeviceList.vue
@@ -41,11 +41,10 @@
           <div v-if="item.tags[0]">
             <v-tooltip
               bottom
-              :disabled="!item.tags[0]"
+              :disabled="!showTag(item.tags[0])"
             >
               <template #activator="{ on, attrs }">
                 <v-chip
-                  class="short justify-center"
                   v-bind="attrs"
                   v-on="on"
                 >
@@ -58,42 +57,41 @@
               </span>
             </v-tooltip>
 
-            <div v-if="item.tags.length > 1">
-              <v-menu
-                open-on-hover
-                bottom
-                offset-y
-              >
-                <template #activator="{ on, attrs }">
-                  <v-btn
+            <v-menu
+              v-if="item.tags.length > 1"
+              open-on-hover
+              bottom
+              offset-y
+            >
+              <template #activator="{ on, attrs }">
+                <v-btn
+                  text
+                  small
+                  v-bind="attrs"
+                  v-on="on"
+                >
+                  <div
                     text
                     small
+                    flat
                     v-bind="attrs"
+                    class="test justify-center"
                     v-on="on"
                   >
-                    <div
-                      text
-                      small
-                      flat
-                      v-bind="attrs"
-                      class="test justify-center"
-                      v-on="on"
-                    >
-                      {{ `+ ${item.tags.length - 1}` }}
-                    </div>
-                  </v-btn>
-                </template>
+                    {{ `+ ${item.tags.length - 1}` }}
+                  </div>
+                </v-btn>
+              </template>
 
-                <v-list>
-                  <v-list-item
-                    v-for="(tag, index) in item.tags.slice(1,item.tags.length)"
-                    :key="index"
-                  >
-                    <v-list-item-title>{{ tag }}</v-list-item-title>
-                  </v-list-item>
-                </v-list>
-              </v-menu>
-            </div>
+              <v-list>
+                <v-list-item
+                  v-for="(tag, index) in item.tags.slice(1,item.tags.length)"
+                  :key="index"
+                >
+                  <v-list-item-title>{{ tag }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
           </div>
         </template>
 
@@ -233,14 +231,14 @@ export default {
           sortable: false,
         },
         {
-          text: 'Tags',
-          value: 'tags',
+          text: 'SSHID',
+          value: 'namespace',
           align: 'center',
           sortable: false,
         },
         {
-          text: 'SSHID',
-          value: 'namespace',
+          text: '',
+          value: 'tags',
           align: 'center',
           sortable: false,
         },

--- a/ui/tests/unit/components/device/DeviceList.spec.js
+++ b/ui/tests/unit/components/device/DeviceList.spec.js
@@ -42,14 +42,14 @@ describe('DeviceList', () => {
       sortable: false,
     },
     {
-      text: 'Tags',
-      value: 'tags',
+      text: 'SSHID',
+      value: 'namespace',
       align: 'center',
       sortable: false,
     },
     {
-      text: 'SSHID',
-      value: 'namespace',
+      text: '',
+      value: 'tags',
       align: 'center',
       sortable: false,
     },

--- a/ui/tests/unit/components/device/__snapshots__/DeviceList.spec.js.snap
+++ b/ui/tests/unit/components/device/__snapshots__/DeviceList.spec.js.snap
@@ -19,8 +19,8 @@ exports[`DeviceList Device online Renders the component 1`] = `
               <th role="columnheader" scope="col" aria-label="Online: Not sorted. Activate to sort ascending." aria-sort="none" class="text-center sortable"><span>Online</span><i aria-hidden="true" class="v-icon notranslate v-data-table-header__icon mdi mdi-arrow-up theme--light" style="font-size: 18px;"></i></th>
               <th role="columnheader" scope="col" aria-label="Hostname: Not sorted. Activate to sort ascending." aria-sort="none" class="text-center sortable"><span>Hostname</span><i aria-hidden="true" class="v-icon notranslate v-data-table-header__icon mdi mdi-arrow-up theme--light" style="font-size: 18px;"></i></th>
               <th role="columnheader" scope="col" aria-label="Operating System" class="text-center"><span>Operating System</span></th>
-              <th role="columnheader" scope="col" aria-label="Tags" class="text-center"><span>Tags</span></th>
               <th role="columnheader" scope="col" aria-label="SSHID" class="text-center"><span>SSHID</span></th>
+              <th role="columnheader" scope="col" aria-label="" class="text-center"><span></span></th>
               <th role="columnheader" scope="col" aria-label="Actions" class="text-center"><span>Actions</span></th>
             </tr>
           </thead>
@@ -36,22 +36,20 @@ exports[`DeviceList Device online Renders the component 1`] = `
                 <fragment-stub data-test="deviceIcon-component"><i aria-hidden="true" data-test="type-icon" class="v-icon notranslate icons fl fl-linuxmint theme--light"></i></fragment-stub>
                 Linux Mint 19.3
               </td>
-              <td class="text-center">
-                <div><span class="short justify-center v-chip v-chip--no-color theme--light v-size--default" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
-                device1
-              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span>
-                  <div><button type="button" class="v-btn v-btn--text theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content"><div text="" small="" flat="" aria-haspopup="true" aria-expanded="false" class="test justify-center">
-                    + 1
-                  </div></span></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </div>
-                </div>
-              </td>
               <td class="text-center"><span class="list-itens v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content">
           user.39-5e-2a@localhost
           <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
+              <td class="text-center">
+                <div><span class="v-chip v-chip--no-color theme--light v-size--default" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                device1
+              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span>
+                  <div class="v-menu">
+                    <!---->
+                  </div><button type="button" class="v-btn v-btn--text theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content"><div text="" small="" flat="" aria-haspopup="true" aria-expanded="false" class="test justify-center">
+                  + 1
+                </div></span></button>
+                </div>
+              </td>
               <td class="text-center"><span class="v-chip v-chip--clickable theme--light v-size--default transparent"><span class="v-chip__content"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button></span></span>
                 <div class="v-menu">
                   <!---->
@@ -69,22 +67,20 @@ exports[`DeviceList Device online Renders the component 1`] = `
                 <fragment-stub data-test="deviceIcon-component"><i aria-hidden="true" data-test="type-icon" class="v-icon notranslate icons fl fl-linuxmint theme--light"></i></fragment-stub>
                 Linux Mint 19.3
               </td>
-              <td class="text-center">
-                <div><span class="short justify-center v-chip v-chip--no-color theme--light v-size--default" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
-                device1
-              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span>
-                  <div><button type="button" class="v-btn v-btn--text theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content"><div text="" small="" flat="" aria-haspopup="true" aria-expanded="false" class="test justify-center">
-                    + 1
-                  </div></span></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </div>
-                </div>
-              </td>
               <td class="text-center"><span class="list-itens v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content">
           user.39-5e-2b@localhost
           <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
+              <td class="text-center">
+                <div><span class="v-chip v-chip--no-color theme--light v-size--default" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                device1
+              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span>
+                  <div class="v-menu">
+                    <!---->
+                  </div><button type="button" class="v-btn v-btn--text theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content"><div text="" small="" flat="" aria-haspopup="true" aria-expanded="false" class="test justify-center">
+                  + 1
+                </div></span></button>
+                </div>
+              </td>
               <td class="text-center"><span class="v-chip v-chip--clickable theme--light v-size--default transparent"><span class="v-chip__content"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button></span></span>
                 <div class="v-menu">
                   <!---->
@@ -141,8 +137,8 @@ exports[`DeviceList Device online Renders the component 2`] = `
               <th role="columnheader" scope="col" aria-label="Online: Not sorted. Activate to sort ascending." aria-sort="none" class="text-center sortable"><span>Online</span><i aria-hidden="true" class="v-icon notranslate v-data-table-header__icon mdi mdi-arrow-up theme--light" style="font-size: 18px;"></i></th>
               <th role="columnheader" scope="col" aria-label="Hostname: Not sorted. Activate to sort ascending." aria-sort="none" class="text-center sortable"><span>Hostname</span><i aria-hidden="true" class="v-icon notranslate v-data-table-header__icon mdi mdi-arrow-up theme--light" style="font-size: 18px;"></i></th>
               <th role="columnheader" scope="col" aria-label="Operating System" class="text-center"><span>Operating System</span></th>
-              <th role="columnheader" scope="col" aria-label="Tags" class="text-center"><span>Tags</span></th>
               <th role="columnheader" scope="col" aria-label="SSHID" class="text-center"><span>SSHID</span></th>
+              <th role="columnheader" scope="col" aria-label="" class="text-center"><span></span></th>
               <th role="columnheader" scope="col" aria-label="Actions" class="text-center"><span>Actions</span></th>
             </tr>
           </thead>
@@ -158,22 +154,20 @@ exports[`DeviceList Device online Renders the component 2`] = `
                 <fragment-stub data-test="deviceIcon-component"><i aria-hidden="true" data-test="type-icon" class="v-icon notranslate icons fl fl-linuxmint theme--light"></i></fragment-stub>
                 Linux Mint 19.3
               </td>
-              <td class="text-center">
-                <div><span class="short justify-center v-chip v-chip--no-color theme--light v-size--default" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
-                device1
-              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span>
-                  <div><button type="button" class="v-btn v-btn--text theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content"><div text="" small="" flat="" aria-haspopup="true" aria-expanded="false" class="test justify-center">
-                    + 1
-                  </div></span></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </div>
-                </div>
-              </td>
               <td class="text-center"><span class="list-itens v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content">
           user.39-5e-2a@localhost
           <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
+              <td class="text-center">
+                <div><span class="v-chip v-chip--no-color theme--light v-size--default" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                device1
+              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span>
+                  <div class="v-menu">
+                    <!---->
+                  </div><button type="button" class="v-btn v-btn--text theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content"><div text="" small="" flat="" aria-haspopup="true" aria-expanded="false" class="test justify-center">
+                  + 1
+                </div></span></button>
+                </div>
+              </td>
               <td class="text-center"><span class="v-chip v-chip--clickable theme--light v-size--default transparent"><span class="v-chip__content"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button></span></span>
                 <div class="v-menu">
                   <!---->
@@ -191,22 +185,20 @@ exports[`DeviceList Device online Renders the component 2`] = `
                 <fragment-stub data-test="deviceIcon-component"><i aria-hidden="true" data-test="type-icon" class="v-icon notranslate icons fl fl-linuxmint theme--light"></i></fragment-stub>
                 Linux Mint 19.3
               </td>
-              <td class="text-center">
-                <div><span class="short justify-center v-chip v-chip--no-color theme--light v-size--default" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
-                device1
-              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span>
-                  <div><button type="button" class="v-btn v-btn--text theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content"><div text="" small="" flat="" aria-haspopup="true" aria-expanded="false" class="test justify-center">
-                    + 1
-                  </div></span></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </div>
-                </div>
-              </td>
               <td class="text-center"><span class="list-itens v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content">
           user.39-5e-2b@localhost
           <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
+              <td class="text-center">
+                <div><span class="v-chip v-chip--no-color theme--light v-size--default" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                device1
+              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span>
+                  <div class="v-menu">
+                    <!---->
+                  </div><button type="button" class="v-btn v-btn--text theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content"><div text="" small="" flat="" aria-haspopup="true" aria-expanded="false" class="test justify-center">
+                  + 1
+                </div></span></button>
+                </div>
+              </td>
               <td class="text-center"><span class="v-chip v-chip--clickable theme--light v-size--default transparent"><span class="v-chip__content"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button></span></span>
                 <div class="v-menu">
                   <!---->


### PR DESCRIPTION
This commit moves 'Tags' column to second last position, removes the 'Tags'
text from column label, converts v-chip element to non-block (inline), and
hides tooltip when there is no other tags to show.

This closes #1612.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>