### PR TITLE
ui: add payment layout form in vuetify configs

### DIFF
--- a/ui/src/components/billing/BillingDialogPaymentMethod.vue
+++ b/ui/src/components/billing/BillingDialogPaymentMethod.vue
@@ -38,7 +38,7 @@
             </div>
           </div>
 
-          <v-card class="mt-6">
+          <v-card class="paymentForm mt-6">
             <v-col>
               <div ref="card" />
             </v-col>

--- a/ui/src/plugins/vuetify.js
+++ b/ui/src/plugins/vuetify.js
@@ -42,6 +42,7 @@ export default new Vuetify({
         background: '#18191B',
         tabs: '#1E1E1E',
         foreground: '#1E1E1E',
+        paymentForm: '#E0E0E0',
       },
       light: {
         primary: '#667acc',
@@ -49,6 +50,7 @@ export default new Vuetify({
         background: '#FFFFFF',
         tabs: '#FFFFFF',
         foreground: '#FFFFFF',
+        paymentForm: '#FFFFFF',
       },
     },
   },


### PR DESCRIPTION
Fixes the payment form dark layout.

Signed-off-by: Vagner S. Nornberg <vagner.nornberg@ossystems.com.br>