### PR TITLE
ui: restore navigation drawer to show on mobile

### DIFF
--- a/ui/src/components/app_bar/AppBar.vue
+++ b/ui/src/components/app_bar/AppBar.vue
@@ -5,7 +5,10 @@
       app
       flat
     >
-      <v-app-bar-nav-icon class="hidden-lg-and-up" />
+      <v-app-bar-nav-icon
+        class="hidden-lg-and-up"
+        @click.stop="updateDrawer()"
+      />
 
       <router-link to="/" />
 
@@ -186,6 +189,10 @@ export default {
     toggleDarkMode() {
       this.$store.dispatch('layout/setStatusDarkMode', !this.getStatusDarkMode);
       this.$vuetify.theme.dark = this.getStatusDarkMode;
+    },
+
+    updateDrawer() {
+      this.$store.dispatch('layout/setStatusNavigationDrawer', true);
     },
   },
 };

--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -1,6 +1,7 @@
 <template>
   <fragment>
     <v-navigation-drawer
+      v-model="showNavigationDrawer"
       app
       dark
     >
@@ -138,6 +139,15 @@ export default {
 
     hasSpinner() {
       return this.$store.getters['spinner/getStatus'];
+    },
+
+    showNavigationDrawer: {
+      get() {
+        return !this.$store.getters['mobile/isMobile'] || this.$store.getters['layout/getStatusNavigationDrawer'];
+      },
+      set(status) {
+        this.$store.dispatch('layout/setStatusNavigationDrawer', status);
+      },
     },
   },
 

--- a/ui/src/store/modules/layout.js
+++ b/ui/src/store/modules/layout.js
@@ -6,11 +6,13 @@ export default {
   state: {
     layout: 'appLayout',
     statusDarkMode: localStorage.getItem('statusDarkMode') === 'true' || localStorage.getItem('statusDarkMode') === null,
+    statusNavigationDrawer: true,
   },
 
   getters: {
     getLayout: (state) => state.layout,
     getStatusDarkMode: (state) => state.statusDarkMode,
+    getStatusNavigationDrawer: (state) => state.statusNavigationDrawer,
   },
 
   mutations: {
@@ -20,6 +22,10 @@ export default {
 
     setStatusDarkMode: (state, status) => {
       Vue.set(state, 'statusDarkMode', status);
+    },
+
+    setStatusNavigationDrawer: (state, status) => {
+      Vue.set(state, 'statusNavigationDrawer', status);
     },
   },
 
@@ -31,6 +37,10 @@ export default {
     setStatusDarkMode(context, status) {
       context.commit('setStatusDarkMode', status);
       localStorage.setItem('statusDarkMode', status);
+    },
+
+    setStatusNavigationDrawer(context, status) {
+      context.commit('setStatusNavigationDrawer', status);
     },
   },
 };

--- a/ui/tests/unit/layouts/AppLayout.spec.js
+++ b/ui/tests/unit/layouts/AppLayout.spec.js
@@ -27,6 +27,7 @@ describe('AppLayout', () => {
   const isMobile = false;
   const numberNamespaces = 0;
   const hasSpinner = false;
+  const statusNavigationDrawer = false;
   const isEnterprise = false;
 
   const admins = [
@@ -82,16 +83,19 @@ describe('AppLayout', () => {
       numberNamespaces,
       isMobile,
       hasSpinner,
+      statusNavigationDrawer,
     },
     getters: {
       'auth/isLoggedIn': (state) => state.isLoggedIn,
       'namespaces/getNumberNamespaces': (state) => state.numberNamespaces,
       'mobile/isMobile': (state) => state.isMobile,
       'spinner/getStatus': (state) => state.hasSpinner,
+      'layout/getStatusNavigationDrawer': (state) => state.statusNavigationDrawer,
     },
     actions: {
       'privatekeys/fetch': () => {},
       'mobile/setIsMobileStatus': () => {},
+      'layout/setStatusNavigationDrawer': () => {},
     },
   });
 

--- a/ui/tests/unit/layouts/__snapshots__/AppLayout.spec.js.snap
+++ b/ui/tests/unit/layouts/__snapshots__/AppLayout.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`AppLayout Is enterprise and has namespace Renders the component 1`] = `
 <fragment-stub>
-  <v-navigation-drawer-stub app="true" mobilebreakpoint="1264" dark="true" height="100vh" minivariantwidth="56" src="" tag="nav" width="256">
+  <v-navigation-drawer-stub app="true" mobilebreakpoint="1264" dark="true" height="100vh" minivariantwidth="56" src="" tag="nav" width="256" value="true">
     <v-list-item-stub activeclass="" tag="div">
       <v-list-item-content-stub tag="div">
         <v-list-item-title-stub tag="div" class="d-flex justify-center">
@@ -83,7 +83,7 @@ exports[`AppLayout Is enterprise and has namespace Renders the component 1`] = `
 
 exports[`AppLayout Is not enterprise Renders the component 1`] = `
 <fragment-stub>
-  <v-navigation-drawer-stub app="true" mobilebreakpoint="1264" dark="true" height="100vh" minivariantwidth="56" src="" tag="nav" width="256">
+  <v-navigation-drawer-stub app="true" mobilebreakpoint="1264" dark="true" height="100vh" minivariantwidth="56" src="" tag="nav" width="256" value="true">
     <v-list-item-stub activeclass="" tag="div">
       <v-list-item-content-stub tag="div">
         <v-list-item-title-stub tag="div" class="d-flex justify-center">

--- a/ui/tests/unit/store/Layouts.spec.js
+++ b/ui/tests/unit/store/Layouts.spec.js
@@ -17,4 +17,13 @@ describe('Stats', () => {
     store.commit('layout/setStatusDarkMode', false);
     expect(store.getters['layout/getStatusDarkMode']).toEqual(false);
   });
+
+  // Verify the default value of the navigation drawer status
+  it('Returns navigation drawer default variable', () => {
+    expect(store.getters['layout/getStatusNavigationDrawer']).toEqual(true);
+  });
+  it('Verify initial state change for setStatusNavigationDrawer mutation', () => {
+    store.commit('layout/setStatusNavigationDrawer', false);
+    expect(store.getters['layout/getStatusNavigationDrawer']).toEqual(false);
+  });
 });


### PR DESCRIPTION
This commit restores navigation drawer that were removed this commit #1588.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>