### PR TITLE
ui: move rename namespace to component

### DIFF
--- a/ui/src/components/namespace/NamespaceRename.vue
+++ b/ui/src/components/namespace/NamespaceRename.vue
@@ -1,0 +1,139 @@
+<template>
+  <fragment>
+    <ValidationObserver
+      ref="obs"
+      v-slot="{ passes }"
+    >
+      <v-row>
+        <v-col>
+          <h3>
+            Namespace
+          </h3>
+        </v-col>
+
+        <v-spacer />
+
+        <v-col
+          md="auto"
+          class="ml-auto"
+        >
+          <v-tooltip
+            bottom
+            :disabled="hasAuthorizationRenameNamespace"
+          >
+            <template #activator="{ on }">
+              <div v-on="on">
+                <v-btn
+                  :disabled="!hasAuthorizationRenameNamespace"
+                  color="primary"
+                  @click="passes(editNamespace)"
+                >
+                  Rename Namespace
+                </v-btn>
+              </div>
+            </template>
+
+            <span>
+              You don't have this kind of authorization.
+            </span>
+          </v-tooltip>
+        </v-col>
+      </v-row>
+
+      <div class="mt-4 mb-2">
+        <ValidationProvider
+          v-slot="{ errors }"
+          ref="providerName"
+          vid="name"
+          name="Priority"
+          rules="required|rfc1123|noDot|namespace"
+        >
+          <v-text-field
+            v-model="name"
+            class="ml-3"
+            label="Name"
+            :error-messages="errors"
+            required
+            data-test="name-text"
+          />
+        </ValidationProvider>
+      </div>
+    </ValidationObserver>
+  </fragment>
+</template>
+
+<script>
+
+import {
+  ValidationObserver,
+  ValidationProvider,
+} from 'vee-validate';
+
+import hasPermission from '@/components/filter/permission';
+
+export default {
+  name: 'NamespaceAddComponent',
+
+  filters: { hasPermission },
+
+  components: {
+    ValidationProvider,
+    ValidationObserver,
+  },
+
+  data() {
+    return {
+      name: '',
+    };
+  },
+
+  computed: {
+    namespace() {
+      return this.$store.getters['namespaces/get'];
+    },
+
+    tenant() {
+      return this.$store.getters['auth/tenant'];
+    },
+
+    hasAuthorizationRenameNamespace() {
+      const role = this.$store.getters['auth/role'];
+      if (role !== '') {
+        return hasPermission(
+          this.$authorizer.role[role],
+          this.$actions.namespace.rename,
+        );
+      }
+
+      return false;
+    },
+  },
+
+  created() {
+    this.name = this.namespace.name;
+  },
+
+  methods: {
+    async editNamespace() {
+      try {
+        await this.$store.dispatch('namespaces/put', { id: this.tenant, name: this.name });
+        await this.$store.dispatch('namespaces/get', this.tenant);
+        this.$store.dispatch('snackbar/showSnackbarSuccessAction', this.$success.namespaceEdit);
+      } catch (error) {
+        if (error.response.status === 400) {
+          this.$refs.obs.setErrors({
+            namespace: this.$errors.form.invalid('namespace', 'nonStandardCharacters'),
+          });
+        } else if (error.response.status === 409) {
+          this.$refs.obs.setErrors({
+            namespace: this.$errors.form.invalid('namespace', 'nameUsed'),
+          });
+        } else {
+          this.$store.dispatch('snackbar/showSnackbarErrorAction', this.$errors.snackbar.namespaceEdit);
+        }
+      }
+    },
+  },
+};
+
+</script>

--- a/ui/tests/unit/components/namespaces/NamespaceRename.spec.js
+++ b/ui/tests/unit/components/namespaces/NamespaceRename.spec.js
@@ -1,0 +1,243 @@
+import Vuex from 'vuex';
+import { mount, createLocalVue } from '@vue/test-utils';
+import { ValidationProvider, ValidationObserver } from 'vee-validate';
+import flushPromises from 'flush-promises';
+import Vuetify from 'vuetify';
+import NamespaceRename from '@/components/namespace/NamespaceRename';
+import '@/vee-validate';
+import { actions, authorizer } from '../../../../src/authorizer';
+
+describe('SettingNamespace', () => {
+  const localVue = createLocalVue();
+  const vuetify = new Vuetify();
+  localVue.use(Vuex);
+  localVue.component('ValidationProvider', ValidationProvider);
+  localVue.component('ValidationObserver', ValidationObserver);
+
+  document.body.setAttribute('data-app', true);
+
+  let wrapper;
+
+  const role = ['owner', 'operator'];
+
+  const hasAuthorizationRenameNamespace = {
+    owner: true,
+    operator: false,
+  };
+
+  const members = [
+    {
+      id: 'xxxxxxxx',
+      type: 'owner',
+      username: 'user1',
+    },
+    {
+      id: 'xxxxxxxy',
+      type: 'observer',
+      username: 'user2',
+    },
+  ];
+
+  const openNamespace = {
+    name: 'namespace',
+    members,
+    owner: 'owner',
+    tenant_id: 'xxxxxxxx',
+    devices_count: 1,
+    max_devices: 3,
+  };
+
+  const hostedNamespace = { ...openNamespace, max_devices: -1 };
+
+  const invalidNamespaces = [
+    '\'', '"', '!', '@', '#', '$', '%', '¨', '&', '*', '(', ')', '-', '_', '=', '+', '´', '`', '[',
+    '{', '~', '^', ']', ',', '<', '..', '>', ';', ':', '/', '?',
+  ];
+
+  const invalidMinAndMaxCharacters = [
+    's', 'sh', 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+  ];
+
+  const tests = [
+    {
+      description: 'Open version',
+      variables: {
+        namespace: openNamespace,
+        tenant: 'xxxxxxxx',
+        hasTenant: true,
+        isEnterprise: false,
+      },
+      data: {
+        name: openNamespace.name,
+      },
+      computed: {
+        namespace: openNamespace,
+        tenant: 'xxxxxxxx',
+      },
+      template: {
+        'name-text': true,
+      },
+    },
+    {
+      description: 'Hosted version',
+      variables: {
+        namespace: hostedNamespace,
+        tenant: 'xxxxxxxx',
+        hasTenant: true,
+        isEnterprise: true,
+      },
+      data: {
+        name: hostedNamespace.name,
+      },
+      computed: {
+        namespace: hostedNamespace,
+        tenant: 'xxxxxxxx',
+      },
+      template: {
+        'name-text': true,
+      },
+    },
+  ];
+
+  const storeVuex = (namespace, tenant, currentrole) => new Vuex.Store({
+    namespaced: true,
+    state: {
+      namespace,
+      tenant,
+      currentrole,
+    },
+    getters: {
+      'namespaces/get': (state) => state.namespace,
+      'auth/tenant': (state) => state.tenant,
+      'auth/role': (state) => state.currentrole,
+    },
+    actions: {
+      'namespaces/put': () => {},
+      'namespaces/get': () => {},
+      'namespaces/removeUser': () => {},
+      'snackbar/showSnackbarSuccessAction': () => {},
+      'snackbar/showSnackbarErrorAction': () => {},
+    },
+  });
+
+  tests.forEach((test) => {
+    role.forEach((currentrole) => {
+      describe(`${test.description} ${currentrole}`, () => {
+        beforeEach(async () => {
+          jest.spyOn(Storage.prototype, 'getItem').mockReturnValue('e359bf484715');
+
+          wrapper = mount(NamespaceRename, {
+            store: storeVuex(
+              test.variables.namespace,
+              test.variables.tenant,
+              currentrole,
+            ),
+            localVue,
+            stubs: ['fragment'],
+            vuetify,
+            mocks: {
+              $authorizer: authorizer,
+              $actions: actions,
+            },
+          });
+        });
+
+        ///////
+        // Component Rendering
+        //////
+
+        it('Is a Vue instance', () => {
+          expect(wrapper).toBeTruthy();
+        });
+        it('Renders the component', () => {
+          expect(wrapper.html()).toMatchSnapshot();
+        });
+
+        ///////
+        // Data checking
+        //////
+
+        it('Compare data with default value', () => {
+          Object.keys(test.data).forEach((item) => {
+            expect(wrapper.vm[item]).toEqual(test.data[item]);
+          });
+        });
+        it('Process data in the computed', () => {
+          Object.keys(test.computed).forEach((item) => {
+            expect(wrapper.vm[item]).toEqual(test.computed[item]);
+          });
+          expect(wrapper.vm.hasAuthorizationRenameNamespace)
+            .toEqual(hasAuthorizationRenameNamespace[currentrole]);
+        });
+
+        //////
+        // HTML validation
+        //////
+
+        it('Renders the template with data', () => {
+          Object.keys(test.template).forEach((item) => {
+            expect(wrapper.find(`[data-test="${item}"]`).exists()).toBe(test.template[item]);
+          });
+        });
+
+        //////
+        // In this case, invalid RFC1123.
+        //////
+
+        invalidNamespaces.forEach((inamespace) => {
+          it(`Shows invalid namespace error for ${inamespace}`, async () => {
+            wrapper.setData({ name: inamespace });
+            await flushPromises();
+
+            const validator = wrapper.vm.$refs.providerName;
+
+            await validator.validate();
+            expect(validator.errors[0]).toBe('You entered an invalid RFC1123 name');
+          });
+        });
+
+        //////
+        // In this case, password should be 3-30 characters long.
+        //////
+
+        invalidMinAndMaxCharacters.forEach((character) => {
+          it(`Shows invalid namespace error for ${character}`, async () => {
+            wrapper.setData({ name: character });
+            await flushPromises();
+
+            const validator = wrapper.vm.$refs.providerName;
+
+            await validator.validate();
+            expect(validator.errors[0]).toBe('Your namespace should be 3-30 characters long');
+          });
+        });
+
+        it('Show validation messages', async () => {
+          //////
+          // In this case, validate fields required.
+          //////
+
+          wrapper.setData({ name: '' });
+          await flushPromises();
+
+          let validator = wrapper.vm.$refs.providerName;
+
+          await validator.validate();
+          expect(validator.errors[0]).toBe('This field is required');
+
+          //////
+          // In this case, must not contain dots.
+          //////
+
+          wrapper.setData({ name: 'ShelHub.' });
+          await flushPromises();
+
+          validator = wrapper.vm.$refs.providerName;
+
+          await validator.validate();
+          expect(validator.errors[0]).toBe('The name must not contain dots');
+        });
+      });
+    });
+  });
+});

--- a/ui/tests/unit/components/namespaces/__snapshots__/NamespaceRename.spec.js.snap
+++ b/ui/tests/unit/components/namespaces/__snapshots__/NamespaceRename.spec.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SettingNamespace Hosted version operator Renders the component 1`] = `
+<fragment-stub><span><div class="row"><div class="col"><h3>
+          Namespace
+        </h3></div> <div class="spacer"></div> <div class="ml-auto col-md-auto col"><div><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--has-bg theme--light v-size--default"><span class="v-btn__content">
+                Rename Namespace
+              </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span></div>
+  </div>
+  <div class="mt-4 mb-2"><span><div class="v-input ml-3 v-input--is-label-active v-input--is-dirty theme--light v-text-field"><div class="v-input__control"><div class="v-input__slot"><div class="v-text-field__slot"><label for="input-1499" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Name</label><input required="required" data-test="name-text" id="input-1499" type="text"></div></div><div class="v-text-field__details"><div class="v-messages theme--light"><transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub></div></div></div></div></span></div>
+  </span>
+</fragment-stub>
+`;
+
+exports[`SettingNamespace Hosted version owner Renders the component 1`] = `
+<fragment-stub><span><div class="row"><div class="col"><h3>
+          Namespace
+        </h3></div> <div class="spacer"></div> <div class="ml-auto col-md-auto col"><div><button type="button" class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default primary"><span class="v-btn__content">
+                Rename Namespace
+              </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span></div>
+  </div>
+  <div class="mt-4 mb-2"><span><div class="v-input ml-3 v-input--is-label-active v-input--is-dirty theme--light v-text-field"><div class="v-input__control"><div class="v-input__slot"><div class="v-text-field__slot"><label for="input-1007" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Name</label><input required="required" data-test="name-text" id="input-1007" type="text"></div></div><div class="v-text-field__details"><div class="v-messages theme--light"><transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub></div></div></div></div></span></div>
+  </span>
+</fragment-stub>
+`;
+
+exports[`SettingNamespace Open version operator Renders the component 1`] = `
+<fragment-stub><span><div class="row"><div class="col"><h3>
+          Namespace
+        </h3></div> <div class="spacer"></div> <div class="ml-auto col-md-auto col"><div><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--has-bg theme--light v-size--default"><span class="v-btn__content">
+                Rename Namespace
+              </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span></div>
+  </div>
+  <div class="mt-4 mb-2"><span><div class="v-input ml-3 v-input--is-label-active v-input--is-dirty theme--light v-text-field"><div class="v-input__control"><div class="v-input__slot"><div class="v-text-field__slot"><label for="input-515" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Name</label><input required="required" data-test="name-text" id="input-515" type="text"></div></div><div class="v-text-field__details"><div class="v-messages theme--light"><transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub></div></div></div></div></span></div>
+  </span>
+</fragment-stub>
+`;
+
+exports[`SettingNamespace Open version owner Renders the component 1`] = `
+<fragment-stub><span><div class="row"><div class="col"><h3>
+          Namespace
+        </h3></div> <div class="spacer"></div> <div class="ml-auto col-md-auto col"><div><button type="button" class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default primary"><span class="v-btn__content">
+                Rename Namespace
+              </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span></div>
+  </div>
+  <div class="mt-4 mb-2"><span><div class="v-input ml-3 v-input--is-label-active v-input--is-dirty theme--light v-text-field"><div class="v-input__control"><div class="v-input__slot"><div class="v-text-field__slot"><label for="input-23" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Name</label><input required="required" data-test="name-text" id="input-23" type="text"></div></div><div class="v-text-field__details"><div class="v-messages theme--light"><transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub></div></div></div></div></span></div>
+  </span>
+</fragment-stub>
+`;

--- a/ui/tests/unit/components/setting/__snapshots__/SettingNamespace.spec.js.snap
+++ b/ui/tests/unit/components/setting/__snapshots__/SettingNamespace.spec.js.snap
@@ -1,621 +1,159 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SettingNamespace Hosted version operator Renders the component 1`] = `
+exports[`SettingNamespace Hosted version Renders the component 1`] = `
 <fragment-stub>
-  <div class="container">
-    <div class="row mt-4 align-center justify-center">
-      <div class="col-sm-8 col">
+  <v-container-stub tag="div">
+    <v-row-stub tag="div" align="center" justify="center" class="mt-4">
+      <v-col-stub sm="8" tag="div">
         <div data-test="tenant-div" class="mt-6">
-          <div class="row mb-2">
-            <div class="col-md-auto col">
-              <div class="v-card v-sheet theme--light elevation-0 rounded-0">
+          <v-row-stub tag="div" class="mb-2">
+            <v-col-stub md="auto" tag="div">
+              <v-card-stub loaderheight="4" tag="div" elevation="0" tile="true">
                 Tenant ID:
-              </div>
-            </div>
-            <div class="ml-auto col-md-auto col">
-              <div class="auto v-card v-sheet theme--light elevation-0 rounded-0"><span class="v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content"><span>
+              </v-card-stub>
+            </v-col-stub>
+            <v-col-stub md="auto" tag="div" class="ml-auto">
+              <v-card-stub loaderheight="4" tag="div" elevation="0" tile="true" class="auto">
+                <v-chip-stub activeclass="" tag="span" active="true" closeicon="$delete" closelabel="$vuetify.close" filtericon="$complete"><span>
                     xxxxxxxx
-                  </span> <i aria-hidden="true" class="v-icon notranslate v-icon--right mdi mdi-content-copy theme--light" data-clipboard-click-handler="$261" data-clipboard-success-handler="$262"></i></span></span></div>
+                  </span>
+                  <v-icon-stub right="" data-clipboard-click-handler="$17" data-clipboard-success-handler="$18">
+                    mdi-content-copy
+                  </v-icon-stub>
+                </v-chip-stub>
+              </v-card-stub>
+            </v-col-stub>
+          </v-row-stub>
+          <v-divider-stub></v-divider-stub>
+          <v-divider-stub></v-divider-stub>
+        </div>
+        <div data-test="editOperation-div" class="mt-6">
+          <namespacerename-stub data-test="namespaceRename-component"></namespacerename-stub>
+          <v-divider-stub></v-divider-stub>
+          <v-divider-stub></v-divider-stub>
+        </div>
+        <div data-test="userOperation-div" class="mt-6">
+          <v-row-stub tag="div">
+            <v-col-stub tag="div">
+              <h3>
+                Members
+              </h3>
+            </v-col-stub>
+            <v-spacer-stub tag="div"></v-spacer-stub>
+            <div>
+              <v-col-stub md="auto" tag="div" class="ml-auto">
+                <namespacememberformdialog-stub member="[object Object]" adduser="true" data-test="namespaceMemberFormDialogAdd-component"></namespacememberformdialog-stub>
+              </v-col-stub>
             </div>
-          </div>
-          <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-          <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
+          </v-row-stub>
+          <namespacememberlist-stub namespace="[object Object]"></namespacememberlist-stub>
+          <v-divider-stub></v-divider-stub>
+          <v-divider-stub></v-divider-stub>
         </div>
-        <div data-test="editOperation-div" class="mt-6"><span><div class="row"><div class="col"><h3>
-                  Namespace
-                </h3></div> <div class="spacer"></div> <div class="ml-auto col-md-auto col"><div><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--has-bg theme--light v-size--default"><span class="v-btn__content">
-                        Rename Namespace
-                      </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-      </div>
-    </div>
-    <div class="mt-4 mb-2"><span><div class="v-input ml-3 v-input--is-label-active v-input--is-dirty theme--light v-text-field"><div class="v-input__control"><div class="v-input__slot"><div class="v-text-field__slot"><label for="input-6089" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Name</label><input required="required" data-test="name-text" id="input-6089" type="text"></div></div><div class="v-text-field__details"><div class="v-messages theme--light"><transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub></div></div></div></div></span></div></span>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <div data-test="userOperation-div" class="mt-6">
-    <div class="row">
-      <div class="col">
-        <h3>
-          Members
-        </h3>
-      </div>
-      <div class="spacer"></div>
-      <div>
-        <div class="ml-auto col-md-auto col">
-          <fragment-stub data-test="namespaceMemberFormDialogAdd-component">
-            <div><button type="button" disabled="disabled" class="mr-2 v-btn v-btn--disabled v-btn--has-bg theme--light v-size--default" data-test="add-btn"><span class="v-btn__content">
-          Add Member
-        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-            <div role="dialog" class="v-dialog__container">
-              <!---->
-            </div>
-          </fragment-stub>
+        <div data-test="securityOperation-div" class="mt-6">
+          <settingsecurity-stub hastenant="true"></settingsecurity-stub>
+          <v-divider-stub></v-divider-stub>
+          <v-divider-stub></v-divider-stub>
         </div>
-      </div>
-    </div>
-    <fragment-stub>
-      <div class="mt-5">
-        <div class="v-data-table elevation-0 theme--light" data-test="dataTable-field">
-          <div class="v-data-table__wrapper">
-            <table>
-              <colgroup>
-                <col class="">
-                <col class="">
-                <col class="">
-              </colgroup>
-              <thead class="v-data-table-header">
-                <tr>
-                  <th role="columnheader" scope="col" aria-label="Username" class="text-start"><span>Username</span></th>
-                  <th role="columnheader" scope="col" aria-label="Role" class="text-center"><span>Role</span></th>
-                  <th role="columnheader" scope="col" aria-label="Actions" class="text-end"><span>Actions</span></th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="">
-                  <td class="text-start"><i aria-hidden="true" class="v-icon notranslate mdi mdi-account theme--light"></i>
-                    user1
-                  </td>
-                  <td class="text-center">
-
-                  </td>
-                  <td class="text-end"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <tr class="">
-                  <td class="text-start"><i aria-hidden="true" class="v-icon notranslate mdi mdi-account theme--light"></i>
-                    user2
-                  </td>
-                  <td class="text-center">
-
-                  </td>
-                  <td class="text-end"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </fragment-stub>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <div data-test="securityOperation-div" class="mt-6">
-    <form novalidate="novalidate" class="v-form">
-      <div class="row">
-        <div class="mb-6 col">
+        <div data-test="deleteOperation-div" class="mt-6">
           <h3 class="mb-5">
-            Security
+            Danger Zone
           </h3>
-          <div class="ml-3">
-            <div class="v-input v-input--is-disabled theme--light v-input--selection-controls v-input--checkbox">
-              <div class="v-input__control">
-                <div class="v-input__slot">
-                  <div class="v-input--selection-controls__input"><i aria-hidden="true" class="v-icon notranslate mdi mdi-checkbox-blank-outline theme--light"></i><input aria-checked="false" disabled="disabled" id="input-6115" role="checkbox" type="checkbox" value="">
-                    <div class="v-input--selection-controls__ripple"></div>
-                  </div><label for="input-6115" class="v-label v-label--is-disabled theme--light" style="left: 0px; position: relative;">Enable session record</label>
-                </div>
-                <div class="v-messages theme--light">
-                  <transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub>
-                </div>
+          <v-row-stub tag="div" class="mt-4 mb-2">
+            <v-col-stub tag="div" class="ml-3">
+              <h4>
+                Delete this namespace
+              </h4>
+              <div class="ml-2">
+                <p>
+                  After deleting a namespace, there is no going back. Be sure.
+                </p>
               </div>
-            </div>
-            <p>
-              Session record is a feature that allows you to check logged activity when
-              connecting to a device.
-            </p>
-          </div>
+            </v-col-stub>
+            <v-col-stub md="auto" tag="div" class="ml-auto mb-4">
+              <namespacedelete-stub nstenant="xxxxxxxx" data-test="namespaceDelete-component"></namespacedelete-stub>
+            </v-col-stub>
+          </v-row-stub>
         </div>
-      </div>
-    </form>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <div data-test="deleteOperation-div" class="mt-6">
-    <h3 class="mb-5">
-      Danger Zone
-    </h3>
-    <div class="row mt-4 mb-2">
-      <div class="ml-3 col">
-        <h4>
-          Delete this namespace
-        </h4>
-        <div class="ml-2">
-          <p>
-            After deleting a namespace, there is no going back. Be sure.
-          </p>
-        </div>
-      </div>
-      <div class="ml-auto mb-4 col-md-auto col">
-        <fragment-stub data-test="namespaceDelete-component">
-          <div><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--outlined theme--light v-size--default" data-test="delete-btn"><span class="v-btn__content">
-          Delete namespace
-        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-          <div role="dialog" class="v-dialog__container">
-            <!---->
-          </div>
-        </fragment-stub>
-      </div>
-    </div>
-  </div>
-  </div>
-  </div>
-  </div>
+      </v-col-stub>
+    </v-row-stub>
+  </v-container-stub>
 </fragment-stub>
 `;
 
-exports[`SettingNamespace Hosted version owner Renders the component 1`] = `
+exports[`SettingNamespace Open version Renders the component 1`] = `
 <fragment-stub>
-  <div class="container">
-    <div class="row mt-4 align-center justify-center">
-      <div class="col-sm-8 col">
+  <v-container-stub tag="div">
+    <v-row-stub tag="div" align="center" justify="center" class="mt-4">
+      <v-col-stub sm="8" tag="div">
         <div data-test="tenant-div" class="mt-6">
-          <div class="row mb-2">
-            <div class="col-md-auto col">
-              <div class="v-card v-sheet theme--light elevation-0 rounded-0">
+          <v-row-stub tag="div" class="mb-2">
+            <v-col-stub md="auto" tag="div">
+              <v-card-stub loaderheight="4" tag="div" elevation="0" tile="true">
                 Tenant ID:
-              </div>
-            </div>
-            <div class="ml-auto col-md-auto col">
-              <div class="auto v-card v-sheet theme--light elevation-0 rounded-0"><span class="v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content"><span>
+              </v-card-stub>
+            </v-col-stub>
+            <v-col-stub md="auto" tag="div" class="ml-auto">
+              <v-card-stub loaderheight="4" tag="div" elevation="0" tile="true" class="auto">
+                <v-chip-stub activeclass="" tag="span" active="true" closeicon="$delete" closelabel="$vuetify.close" filtericon="$complete"><span>
                     xxxxxxxx
-                  </span> <i aria-hidden="true" class="v-icon notranslate v-icon--right mdi mdi-content-copy theme--light" data-clipboard-click-handler="$175" data-clipboard-success-handler="$176"></i></span></span></div>
+                  </span>
+                  <v-icon-stub right="" data-clipboard-click-handler="$3" data-clipboard-success-handler="$4">
+                    mdi-content-copy
+                  </v-icon-stub>
+                </v-chip-stub>
+              </v-card-stub>
+            </v-col-stub>
+          </v-row-stub>
+          <v-divider-stub></v-divider-stub>
+          <v-divider-stub></v-divider-stub>
+        </div>
+        <div data-test="editOperation-div" class="mt-6">
+          <namespacerename-stub data-test="namespaceRename-component"></namespacerename-stub>
+          <v-divider-stub></v-divider-stub>
+          <v-divider-stub></v-divider-stub>
+        </div>
+        <div data-test="userOperation-div" class="mt-6">
+          <v-row-stub tag="div">
+            <v-col-stub tag="div">
+              <h3>
+                Members
+              </h3>
+            </v-col-stub>
+            <v-spacer-stub tag="div"></v-spacer-stub>
+            <div>
+              <v-col-stub md="auto" tag="div" class="ml-auto">
+                <namespacememberformdialog-stub member="[object Object]" adduser="true" data-test="namespaceMemberFormDialogAdd-component"></namespacememberformdialog-stub>
+              </v-col-stub>
             </div>
-          </div>
-          <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-          <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
+          </v-row-stub>
+          <namespacememberlist-stub namespace="[object Object]"></namespacememberlist-stub>
+          <v-divider-stub></v-divider-stub>
+          <v-divider-stub></v-divider-stub>
         </div>
-        <div data-test="editOperation-div" class="mt-6"><span><div class="row"><div class="col"><h3>
-                  Namespace
-                </h3></div> <div class="spacer"></div> <div class="ml-auto col-md-auto col"><div><button type="button" class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default primary"><span class="v-btn__content">
-                        Rename Namespace
-                      </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-      </div>
-    </div>
-    <div class="mt-4 mb-2"><span><div class="v-input ml-3 v-input--is-label-active v-input--is-dirty theme--light v-text-field"><div class="v-input__control"><div class="v-input__slot"><div class="v-text-field__slot"><label for="input-3853" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Name</label><input required="required" data-test="name-text" id="input-3853" type="text"></div></div><div class="v-text-field__details"><div class="v-messages theme--light"><transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub></div></div></div></div></span></div></span>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <div data-test="userOperation-div" class="mt-6">
-    <div class="row">
-      <div class="col">
-        <h3>
-          Members
-        </h3>
-      </div>
-      <div class="spacer"></div>
-      <div>
-        <div class="ml-auto col-md-auto col">
-          <fragment-stub data-test="namespaceMemberFormDialogAdd-component">
-            <div><button type="button" class="mr-2 v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default primary" data-test="add-btn"><span class="v-btn__content">
-          Add Member
-        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-            <div role="dialog" class="v-dialog__container">
-              <!---->
-            </div>
-          </fragment-stub>
-        </div>
-      </div>
-    </div>
-    <fragment-stub>
-      <div class="mt-5">
-        <div class="v-data-table elevation-0 theme--light" data-test="dataTable-field">
-          <div class="v-data-table__wrapper">
-            <table>
-              <colgroup>
-                <col class="">
-                <col class="">
-                <col class="">
-              </colgroup>
-              <thead class="v-data-table-header">
-                <tr>
-                  <th role="columnheader" scope="col" aria-label="Username" class="text-start"><span>Username</span></th>
-                  <th role="columnheader" scope="col" aria-label="Role" class="text-center"><span>Role</span></th>
-                  <th role="columnheader" scope="col" aria-label="Actions" class="text-end"><span>Actions</span></th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="">
-                  <td class="text-start"><i aria-hidden="true" class="v-icon notranslate mdi mdi-account theme--light"></i>
-                    user1
-                  </td>
-                  <td class="text-center">
-
-                  </td>
-                  <td class="text-end"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <tr class="">
-                  <td class="text-start"><i aria-hidden="true" class="v-icon notranslate mdi mdi-account theme--light"></i>
-                    user2
-                  </td>
-                  <td class="text-center">
-
-                  </td>
-                  <td class="text-end"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </fragment-stub>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <div data-test="securityOperation-div" class="mt-6">
-    <form novalidate="novalidate" class="v-form">
-      <div class="row">
-        <div class="mb-6 col">
+        <!---->
+        <div data-test="deleteOperation-div" class="mt-6">
           <h3 class="mb-5">
-            Security
+            Danger Zone
           </h3>
-          <div class="ml-3">
-            <div class="v-input theme--light v-input--selection-controls v-input--checkbox">
-              <div class="v-input__control">
-                <div class="v-input__slot">
-                  <div class="v-input--selection-controls__input"><i aria-hidden="true" class="v-icon notranslate mdi mdi-checkbox-blank-outline theme--light"></i><input aria-checked="false" id="input-3879" role="checkbox" type="checkbox" value="">
-                    <div class="v-input--selection-controls__ripple"></div>
-                  </div><label for="input-3879" class="v-label theme--light" style="left: 0px; position: relative;">Enable session record</label>
-                </div>
-                <div class="v-messages theme--light">
-                  <transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub>
-                </div>
+          <v-row-stub tag="div" class="mt-4 mb-2">
+            <v-col-stub tag="div" class="ml-3">
+              <h4>
+                Delete this namespace
+              </h4>
+              <div class="ml-2">
+                <p>
+                  After deleting a namespace, there is no going back. Be sure.
+                </p>
               </div>
-            </div>
-            <p>
-              Session record is a feature that allows you to check logged activity when
-              connecting to a device.
-            </p>
-          </div>
+            </v-col-stub>
+            <v-col-stub md="auto" tag="div" class="ml-auto mb-4">
+              <namespacedelete-stub nstenant="xxxxxxxx" data-test="namespaceDelete-component"></namespacedelete-stub>
+            </v-col-stub>
+          </v-row-stub>
         </div>
-      </div>
-    </form>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <div data-test="deleteOperation-div" class="mt-6">
-    <h3 class="mb-5">
-      Danger Zone
-    </h3>
-    <div class="row mt-4 mb-2">
-      <div class="ml-3 col">
-        <h4>
-          Delete this namespace
-        </h4>
-        <div class="ml-2">
-          <p>
-            After deleting a namespace, there is no going back. Be sure.
-          </p>
-        </div>
-      </div>
-      <div class="ml-auto mb-4 col-md-auto col">
-        <fragment-stub data-test="namespaceDelete-component">
-          <div><button type="button" class="v-btn v-btn--outlined theme--light v-size--default red--text text--darken-1" data-test="delete-btn"><span class="v-btn__content">
-          Delete namespace
-        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-          <div role="dialog" class="v-dialog__container">
-            <!---->
-          </div>
-        </fragment-stub>
-      </div>
-    </div>
-  </div>
-  </div>
-  </div>
-  </div>
-</fragment-stub>
-`;
-
-exports[`SettingNamespace Open version operator Renders the component 1`] = `
-<fragment-stub>
-  <div class="container">
-    <div class="row mt-4 align-center justify-center">
-      <div class="col-sm-8 col">
-        <div data-test="tenant-div" class="mt-6">
-          <div class="row mb-2">
-            <div class="col-md-auto col">
-              <div class="v-card v-sheet theme--light elevation-0 rounded-0">
-                Tenant ID:
-              </div>
-            </div>
-            <div class="ml-auto col-md-auto col">
-              <div class="auto v-card v-sheet theme--light elevation-0 rounded-0"><span class="v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content"><span>
-                    xxxxxxxx
-                  </span> <i aria-hidden="true" class="v-icon notranslate v-icon--right mdi mdi-content-copy theme--light" data-clipboard-click-handler="$89" data-clipboard-success-handler="$90"></i></span></span></div>
-            </div>
-          </div>
-          <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-          <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-        </div>
-        <div data-test="editOperation-div" class="mt-6"><span><div class="row"><div class="col"><h3>
-                  Namespace
-                </h3></div> <div class="spacer"></div> <div class="ml-auto col-md-auto col"><div><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--has-bg theme--light v-size--default"><span class="v-btn__content">
-                        Rename Namespace
-                      </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-      </div>
-    </div>
-    <div class="mt-4 mb-2"><span><div class="v-input ml-3 v-input--is-label-active v-input--is-dirty theme--light v-text-field"><div class="v-input__control"><div class="v-input__slot"><div class="v-text-field__slot"><label for="input-1953" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Name</label><input required="required" data-test="name-text" id="input-1953" type="text"></div></div><div class="v-text-field__details"><div class="v-messages theme--light"><transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub></div></div></div></div></span></div></span>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <div data-test="userOperation-div" class="mt-6">
-    <div class="row">
-      <div class="col">
-        <h3>
-          Members
-        </h3>
-      </div>
-      <div class="spacer"></div>
-      <div>
-        <div class="ml-auto col-md-auto col">
-          <fragment-stub data-test="namespaceMemberFormDialogAdd-component">
-            <div><button type="button" disabled="disabled" class="mr-2 v-btn v-btn--disabled v-btn--has-bg theme--light v-size--default" data-test="add-btn"><span class="v-btn__content">
-          Add Member
-        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-            <div role="dialog" class="v-dialog__container">
-              <!---->
-            </div>
-          </fragment-stub>
-        </div>
-      </div>
-    </div>
-    <fragment-stub>
-      <div class="mt-5">
-        <div class="v-data-table elevation-0 theme--light" data-test="dataTable-field">
-          <div class="v-data-table__wrapper">
-            <table>
-              <colgroup>
-                <col class="">
-                <col class="">
-                <col class="">
-              </colgroup>
-              <thead class="v-data-table-header">
-                <tr>
-                  <th role="columnheader" scope="col" aria-label="Username" class="text-start"><span>Username</span></th>
-                  <th role="columnheader" scope="col" aria-label="Role" class="text-center"><span>Role</span></th>
-                  <th role="columnheader" scope="col" aria-label="Actions" class="text-end"><span>Actions</span></th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="">
-                  <td class="text-start"><i aria-hidden="true" class="v-icon notranslate mdi mdi-account theme--light"></i>
-                    user1
-                  </td>
-                  <td class="text-center">
-
-                  </td>
-                  <td class="text-end"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <tr class="">
-                  <td class="text-start"><i aria-hidden="true" class="v-icon notranslate mdi mdi-account theme--light"></i>
-                    user2
-                  </td>
-                  <td class="text-center">
-
-                  </td>
-                  <td class="text-end"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </fragment-stub>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <!---->
-  <div data-test="deleteOperation-div" class="mt-6">
-    <h3 class="mb-5">
-      Danger Zone
-    </h3>
-    <div class="row mt-4 mb-2">
-      <div class="ml-3 col">
-        <h4>
-          Delete this namespace
-        </h4>
-        <div class="ml-2">
-          <p>
-            After deleting a namespace, there is no going back. Be sure.
-          </p>
-        </div>
-      </div>
-      <div class="ml-auto mb-4 col-md-auto col">
-        <fragment-stub data-test="namespaceDelete-component">
-          <div><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--outlined theme--light v-size--default" data-test="delete-btn"><span class="v-btn__content">
-          Delete namespace
-        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-          <div role="dialog" class="v-dialog__container">
-            <!---->
-          </div>
-        </fragment-stub>
-      </div>
-    </div>
-  </div>
-  </div>
-  </div>
-  </div>
-</fragment-stub>
-`;
-
-exports[`SettingNamespace Open version owner Renders the component 1`] = `
-<fragment-stub>
-  <div class="container">
-    <div class="row mt-4 align-center justify-center">
-      <div class="col-sm-8 col">
-        <div data-test="tenant-div" class="mt-6">
-          <div class="row mb-2">
-            <div class="col-md-auto col">
-              <div class="v-card v-sheet theme--light elevation-0 rounded-0">
-                Tenant ID:
-              </div>
-            </div>
-            <div class="ml-auto col-md-auto col">
-              <div class="auto v-card v-sheet theme--light elevation-0 rounded-0"><span class="v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content"><span>
-                    xxxxxxxx
-                  </span> <i aria-hidden="true" class="v-icon notranslate v-icon--right mdi mdi-content-copy theme--light" data-clipboard-click-handler="$3" data-clipboard-success-handler="$4"></i></span></span></div>
-            </div>
-          </div>
-          <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-          <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-        </div>
-        <div data-test="editOperation-div" class="mt-6"><span><div class="row"><div class="col"><h3>
-                  Namespace
-                </h3></div> <div class="spacer"></div> <div class="ml-auto col-md-auto col"><div><button type="button" class="v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default primary"><span class="v-btn__content">
-                        Rename Namespace
-                      </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-      </div>
-    </div>
-    <div class="mt-4 mb-2"><span><div class="v-input ml-3 v-input--is-label-active v-input--is-dirty theme--light v-text-field"><div class="v-input__control"><div class="v-input__slot"><div class="v-text-field__slot"><label for="input-61" class="v-label v-label--active theme--light" style="left: 0px; position: absolute;">Name</label><input required="required" data-test="name-text" id="input-61" type="text"></div></div><div class="v-text-field__details"><div class="v-messages theme--light"><transition-group-stub tag="div" name="message-transition" class="v-messages__wrapper"></transition-group-stub></div></div></div></div></span></div></span>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <div data-test="userOperation-div" class="mt-6">
-    <div class="row">
-      <div class="col">
-        <h3>
-          Members
-        </h3>
-      </div>
-      <div class="spacer"></div>
-      <div>
-        <div class="ml-auto col-md-auto col">
-          <fragment-stub data-test="namespaceMemberFormDialogAdd-component">
-            <div><button type="button" class="mr-2 v-btn v-btn--is-elevated v-btn--has-bg theme--light v-size--default primary" data-test="add-btn"><span class="v-btn__content">
-          Add Member
-        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-            <div role="dialog" class="v-dialog__container">
-              <!---->
-            </div>
-          </fragment-stub>
-        </div>
-      </div>
-    </div>
-    <fragment-stub>
-      <div class="mt-5">
-        <div class="v-data-table elevation-0 theme--light" data-test="dataTable-field">
-          <div class="v-data-table__wrapper">
-            <table>
-              <colgroup>
-                <col class="">
-                <col class="">
-                <col class="">
-              </colgroup>
-              <thead class="v-data-table-header">
-                <tr>
-                  <th role="columnheader" scope="col" aria-label="Username" class="text-start"><span>Username</span></th>
-                  <th role="columnheader" scope="col" aria-label="Role" class="text-center"><span>Role</span></th>
-                  <th role="columnheader" scope="col" aria-label="Actions" class="text-end"><span>Actions</span></th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="">
-                  <td class="text-start"><i aria-hidden="true" class="v-icon notranslate mdi mdi-account theme--light"></i>
-                    user1
-                  </td>
-                  <td class="text-center">
-
-                  </td>
-                  <td class="text-end"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <tr class="">
-                  <td class="text-start"><i aria-hidden="true" class="v-icon notranslate mdi mdi-account theme--light"></i>
-                    user2
-                  </td>
-                  <td class="text-center">
-
-                  </td>
-                  <td class="text-end"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button>
-                    <div class="v-menu">
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </fragment-stub>
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-    <hr role="separator" aria-orientation="horizontal" class="v-divider theme--light">
-  </div>
-  <!---->
-  <div data-test="deleteOperation-div" class="mt-6">
-    <h3 class="mb-5">
-      Danger Zone
-    </h3>
-    <div class="row mt-4 mb-2">
-      <div class="ml-3 col">
-        <h4>
-          Delete this namespace
-        </h4>
-        <div class="ml-2">
-          <p>
-            After deleting a namespace, there is no going back. Be sure.
-          </p>
-        </div>
-      </div>
-      <div class="ml-auto mb-4 col-md-auto col">
-        <fragment-stub data-test="namespaceDelete-component">
-          <div><button type="button" class="v-btn v-btn--outlined theme--light v-size--default red--text text--darken-1" data-test="delete-btn"><span class="v-btn__content">
-          Delete namespace
-        </span></button></div><span class="v-tooltip v-tooltip--bottom"><!----></span>
-          <div role="dialog" class="v-dialog__container">
-            <!---->
-          </div>
-        </fragment-stub>
-      </div>
-    </div>
-  </div>
-  </div>
-  </div>
-  </div>
+      </v-col-stub>
+    </v-row-stub>
+  </v-container-stub>
 </fragment-stub>
 `;


### PR DESCRIPTION
This commit removes the part of the code responsible for renaming the
namespace to a new component responsible for just that functionality.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>