### PR TITLE
pkg: set request retrials for http client

### DIFF
--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"net/url"
 	"path"
 
@@ -25,6 +26,9 @@ var (
 func NewClient(opts ...Opt) Client {
 	httpClient := resty.New()
 	httpClient.SetRetryCount(math.MaxInt32)
+	httpClient.AddRetryCondition(func(r *resty.Response, err error) bool {
+		return r.StatusCode() >= http.StatusInternalServerError && r.StatusCode() != http.StatusNotImplemented
+	})
 
 	c := &client{
 		host:   apiHost,

--- a/pkg/api/internalclient/client.go
+++ b/pkg/api/internalclient/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"net/url"
 	"path"
 
@@ -27,6 +28,9 @@ type Opt func(*client) error
 func NewClient(opts ...Opt) Client {
 	httpClient := resty.New()
 	httpClient.SetRetryCount(math.MaxInt32)
+	httpClient.AddRetryCondition(func(r *resty.Response, err error) bool {
+		return r.StatusCode() >= http.StatusInternalServerError && r.StatusCode() != http.StatusNotImplemented
+	})
 
 	c := &client{
 		host:   apiHost,


### PR DESCRIPTION
Also adds error check when requesting to `/devices/auth` through client,
which was causing agent panics in case of agent service initializing
before the api.

Signed-off-by: Vagner S. Nornberg <vagner.nornberg@ossystems.com.br>