### PR TITLE
ui: add device filter by tag when clicking tag in device list

### DIFF
--- a/ui/src/components/device/Device.vue
+++ b/ui/src/components/device/Device.vue
@@ -117,7 +117,7 @@ export default {
     },
 
     isDeviceList() {
-      return this.$router.currentRoute.fullPath === '/devices';
+      return this.$router.currentRoute.name === 'listDevices';
     },
   },
 

--- a/ui/src/components/setting/tag/TagSelector.vue
+++ b/ui/src/components/setting/tag/TagSelector.vue
@@ -51,15 +51,19 @@
 export default {
   name: 'TagSelector',
 
-  data() {
-    return {
-      selectedTags: [],
-    };
-  },
-
   computed: {
     getListTags() {
       return this.$store.getters['tags/list'];
+    },
+
+    selectedTags: {
+      get() {
+        return this.$store.getters['tags/selected'];
+      },
+
+      set(item) {
+        this.$store.dispatch('tags/setSelected', item);
+      },
     },
   },
 

--- a/ui/src/store/modules/tags.js
+++ b/ui/src/store/modules/tags.js
@@ -7,11 +7,13 @@ export default {
   state: {
     tags: [],
     numberTags: 0,
+    selected: [],
   },
 
   getters: {
     list: (state) => state.tags,
     getNumberTags: (state) => state.numberTags,
+    selected: (state) => state.selected,
   },
 
   mutations: {
@@ -19,11 +21,19 @@ export default {
       Vue.set(state, 'tags', res.data);
       Vue.set(state, 'numberTags', parseInt(res.headers['x-total-count'], 10));
     },
+
+    setSelected: (state, data) => {
+      Vue.set(state, 'selected', data);
+    },
   },
 
   actions: {
     post: async (context, data) => {
       await apiDevice.postTag(data);
+    },
+
+    setSelected: async (context, data) => {
+      context.commit('setSelected', data);
     },
 
     fetch: async (context) => {
@@ -38,6 +48,10 @@ export default {
 
     remove: async (context, name) => {
       await apiDevice.removeTag(name);
+    },
+
+    clearSelectedTags: (context) => {
+      context.commit('setSelected', []);
     },
   },
 };

--- a/ui/tests/unit/components/device/DeviceList.spec.js
+++ b/ui/tests/unit/components/device/DeviceList.spec.js
@@ -118,14 +118,13 @@ describe('DeviceList', () => {
     actions: {
       'modals/showAddDevice': () => {
       },
-      'devices/fetch': () => {
-      },
-      'devices/rename': () => {
-      },
-      'devices/resetListDevices': () => {
-      },
-      'stats/get': () => {
-      },
+      'devices/fetch': () => {},
+      'devices/rename': () => {},
+      'tags/clearSelectedTags': () => {},
+      'devices/resetListDevices': () => {},
+      'tags/setSelected': () => {},
+      'devices/setFilter': () => {},
+      'stats/get': () => {},
     },
   });
 
@@ -143,7 +142,10 @@ describe('DeviceList', () => {
       'modals/showAddDevice': () => {},
       'devices/fetch': () => {},
       'devices/rename': () => {},
+      'tags/clearSelectedTags': () => {},
       'devices/resetListDevices': () => {},
+      'tags/setSelected': () => {},
+      'devices/setFilter': () => {},
       'stats/get': () => {},
     },
   });
@@ -185,6 +187,7 @@ describe('DeviceList', () => {
       expect(wrapper.vm.hostname).toEqual('localhost');
       expect(wrapper.vm.pagination).toEqual(pagination);
       expect(wrapper.vm.headers).toEqual(headers);
+      expect(wrapper.vm.selectedTags).toEqual([]);
     });
     it('Process data in the computed', () => {
       expect(wrapper.vm.getListDevices).toEqual(devices);
@@ -216,7 +219,7 @@ describe('DeviceList', () => {
   // In this case, it is tested when device is offline.
   ///////
 
-  describe('Device online', () => {
+  describe('Device offline', () => {
     beforeEach(() => {
       wrapper = mount(DeviceList, {
         store: storeDevicesOffline,
@@ -249,6 +252,7 @@ describe('DeviceList', () => {
       expect(wrapper.vm.hostname).toEqual('localhost');
       expect(wrapper.vm.pagination).toEqual(pagination);
       expect(wrapper.vm.headers).toEqual(headers);
+      expect(wrapper.vm.selectedTags).toEqual([]);
     });
     it('Process data in the computed', () => {
       expect(wrapper.vm.getListDevices).toEqual(devicesOffline);

--- a/ui/tests/unit/components/device/__snapshots__/DeviceList.spec.js.snap
+++ b/ui/tests/unit/components/device/__snapshots__/DeviceList.spec.js.snap
@@ -1,5 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DeviceList Device offline Renders the component 1`] = `
+<fragment-stub>
+  <div class="v-card__text pa-0">
+    <div class="v-data-table elevation-1 v-data-table--has-bottom theme--light" data-test="dataTable-field">
+      <div class="v-data-table__wrapper">
+        <table>
+          <colgroup>
+            <col class="">
+            <col class="">
+            <col class="">
+            <col class="">
+            <col class="">
+            <col class="">
+          </colgroup>
+          <thead class="v-data-table-header">
+            <tr>
+              <th role="columnheader" scope="col" aria-label="Online: Not sorted. Activate to sort ascending." aria-sort="none" class="text-center sortable"><span>Online</span><i aria-hidden="true" class="v-icon notranslate v-data-table-header__icon mdi mdi-arrow-up theme--light" style="font-size: 18px;"></i></th>
+              <th role="columnheader" scope="col" aria-label="Hostname: Not sorted. Activate to sort ascending." aria-sort="none" class="text-center sortable"><span>Hostname</span><i aria-hidden="true" class="v-icon notranslate v-data-table-header__icon mdi mdi-arrow-up theme--light" style="font-size: 18px;"></i></th>
+              <th role="columnheader" scope="col" aria-label="Operating System" class="text-center"><span>Operating System</span></th>
+              <th role="columnheader" scope="col" aria-label="SSHID" class="text-center"><span>SSHID</span></th>
+              <th role="columnheader" scope="col" aria-label="Tags" class="text-center"><span>Tags</span></th>
+              <th role="columnheader" scope="col" aria-label="Actions" class="text-center"><span>Actions</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="">
+              <td class="text-center">
+                <fragment-stub data-test="terminalDialog-component"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--outlined theme--light v-size--small" data-test="connect-btn"><span class="v-btn__content">
+      Offline
+    </span></button>
+                  <div role="dialog" class="v-dialog__container">
+                    <!---->
+                  </div>
+                </fragment-stub>
+              </td>
+              <td class="text-center">
+                <router-link-stub to="[object Object]">
+                  39-5e-2a
+                </router-link-stub>
+              </td>
+              <td class="text-center">
+                <fragment-stub data-test="deviceIcon-component"><i aria-hidden="true" data-test="type-icon" class="v-icon notranslate icons fl fl-linuxmint theme--light"></i></fragment-stub>
+                Linux Mint 19.3
+              </td>
+              <td class="text-center"><span class="list-itens v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content">
+          user.39-5e-2a@localhost
+          <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
+              <td class="text-center">
+                <div class="mt-1"><span class="ml-1 mb-1 v-chip v-chip--clickable v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                device1
+              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="ml-1 mb-1 v-chip v-chip--clickable v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                device2
+              </span></span></div>
+              </td>
+              <td class="text-center"><span class="v-chip v-chip--clickable theme--light v-size--default transparent"><span class="v-chip__content"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button></span></span>
+                <div class="v-menu">
+                  <!---->
+                </div>
+              </td>
+            </tr>
+            <tr class="">
+              <td class="text-center">
+                <fragment-stub data-test="terminalDialog-component"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--outlined theme--light v-size--small" data-test="connect-btn"><span class="v-btn__content">
+      Offline
+    </span></button>
+                  <div role="dialog" class="v-dialog__container">
+                    <!---->
+                  </div>
+                </fragment-stub>
+              </td>
+              <td class="text-center">
+                <router-link-stub to="[object Object]">
+                  39-5e-2b
+                </router-link-stub>
+              </td>
+              <td class="text-center">
+                <fragment-stub data-test="deviceIcon-component"><i aria-hidden="true" data-test="type-icon" class="v-icon notranslate icons fl fl-linuxmint theme--light"></i></fragment-stub>
+                Linux Mint 19.3
+              </td>
+              <td class="text-center"><span class="list-itens v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content">
+          user.39-5e-2b@localhost
+          <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
+              <td class="text-center">
+                <div class="mt-1"><span class="ml-1 mb-1 v-chip v-chip--clickable v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                device1
+              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="ml-1 mb-1 v-chip v-chip--clickable v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                device2
+              </span></span></div>
+              </td>
+              <td class="text-center"><span class="v-chip v-chip--clickable theme--light v-size--default transparent"><span class="v-chip__content"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button></span></span>
+                <div class="v-menu">
+                  <!---->
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="v-data-footer">
+        <div class="v-data-footer__select">Rows per page:<div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
+            <div class="v-input__control">
+              <div role="button" aria-haspopup="listbox" aria-expanded="false" aria-owns="list-458" class="v-input__slot">
+                <div class="v-select__slot">
+                  <div class="v-select__selections">
+                    <div class="v-select__selection v-select__selection--comma">10</div><input aria-label="Rows per page:" id="input-458" readonly="readonly" type="text" aria-readonly="false" autocomplete="off">
+                  </div>
+                  <div class="v-input__append-inner">
+                    <div class="v-input__icon v-input__icon--append"><i aria-hidden="true" class="v-icon notranslate mdi mdi-menu-down theme--light"></i></div>
+                  </div><input type="hidden" value="10">
+                </div>
+                <div class="v-menu">
+                  <!---->
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="v-data-footer__pagination">1-2 of 2</div>
+        <div class="v-data-footer__icons-before"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--icon v-btn--round v-btn--text theme--light v-size--default" aria-label="Previous page"><span class="v-btn__content"><i aria-hidden="true" class="v-icon notranslate mdi mdi-chevron-left theme--light"></i></span></button></div>
+        <div class="v-data-footer__icons-after"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--icon v-btn--round v-btn--text theme--light v-size--default" aria-label="Next page"><span class="v-btn__content"><i aria-hidden="true" class="v-icon notranslate mdi mdi-chevron-right theme--light"></i></span></button></div>
+      </div>
+    </div>
+  </div>
+</fragment-stub>
+`;
+
 exports[`DeviceList Device online Renders the component 1`] = `
 <fragment-stub>
   <div class="v-card__text pa-0">
@@ -48,9 +174,9 @@ exports[`DeviceList Device online Renders the component 1`] = `
           user.39-5e-2a@localhost
           <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
               <td class="text-center">
-                <div class="mt-1"><span class="ml-1 mb-1 v-chip v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                <div class="mt-1"><span class="ml-1 mb-1 v-chip v-chip--clickable v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
                 device1
-              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="ml-1 mb-1 v-chip v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="ml-1 mb-1 v-chip v-chip--clickable v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
                 device2
               </span></span></div>
               </td>
@@ -83,9 +209,9 @@ exports[`DeviceList Device online Renders the component 1`] = `
           user.39-5e-2b@localhost
           <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
               <td class="text-center">
-                <div class="mt-1"><span class="ml-1 mb-1 v-chip v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+                <div class="mt-1"><span class="ml-1 mb-1 v-chip v-chip--clickable v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
                 device1
-              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="ml-1 mb-1 v-chip v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
+              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="ml-1 mb-1 v-chip v-chip--clickable v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
                 device2
               </span></span></div>
               </td>
@@ -105,132 +231,6 @@ exports[`DeviceList Device online Renders the component 1`] = `
                 <div class="v-select__slot">
                   <div class="v-select__selections">
                     <div class="v-select__selection v-select__selection--comma">10</div><input aria-label="Rows per page:" id="input-101" readonly="readonly" type="text" aria-readonly="false" autocomplete="off">
-                  </div>
-                  <div class="v-input__append-inner">
-                    <div class="v-input__icon v-input__icon--append"><i aria-hidden="true" class="v-icon notranslate mdi mdi-menu-down theme--light"></i></div>
-                  </div><input type="hidden" value="10">
-                </div>
-                <div class="v-menu">
-                  <!---->
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="v-data-footer__pagination">1-2 of 2</div>
-        <div class="v-data-footer__icons-before"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--icon v-btn--round v-btn--text theme--light v-size--default" aria-label="Previous page"><span class="v-btn__content"><i aria-hidden="true" class="v-icon notranslate mdi mdi-chevron-left theme--light"></i></span></button></div>
-        <div class="v-data-footer__icons-after"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--icon v-btn--round v-btn--text theme--light v-size--default" aria-label="Next page"><span class="v-btn__content"><i aria-hidden="true" class="v-icon notranslate mdi mdi-chevron-right theme--light"></i></span></button></div>
-      </div>
-    </div>
-  </div>
-</fragment-stub>
-`;
-
-exports[`DeviceList Device online Renders the component 2`] = `
-<fragment-stub>
-  <div class="v-card__text pa-0">
-    <div class="v-data-table elevation-1 v-data-table--has-bottom theme--light" data-test="dataTable-field">
-      <div class="v-data-table__wrapper">
-        <table>
-          <colgroup>
-            <col class="">
-            <col class="">
-            <col class="">
-            <col class="">
-            <col class="">
-            <col class="">
-          </colgroup>
-          <thead class="v-data-table-header">
-            <tr>
-              <th role="columnheader" scope="col" aria-label="Online: Not sorted. Activate to sort ascending." aria-sort="none" class="text-center sortable"><span>Online</span><i aria-hidden="true" class="v-icon notranslate v-data-table-header__icon mdi mdi-arrow-up theme--light" style="font-size: 18px;"></i></th>
-              <th role="columnheader" scope="col" aria-label="Hostname: Not sorted. Activate to sort ascending." aria-sort="none" class="text-center sortable"><span>Hostname</span><i aria-hidden="true" class="v-icon notranslate v-data-table-header__icon mdi mdi-arrow-up theme--light" style="font-size: 18px;"></i></th>
-              <th role="columnheader" scope="col" aria-label="Operating System" class="text-center"><span>Operating System</span></th>
-              <th role="columnheader" scope="col" aria-label="SSHID" class="text-center"><span>SSHID</span></th>
-              <th role="columnheader" scope="col" aria-label="Tags" class="text-center"><span>Tags</span></th>
-              <th role="columnheader" scope="col" aria-label="Actions" class="text-center"><span>Actions</span></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="">
-              <td class="text-center">
-                <fragment-stub data-test="terminalDialog-component"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--outlined theme--light v-size--small" data-test="connect-btn"><span class="v-btn__content">
-      Offline
-    </span></button>
-                  <div role="dialog" class="v-dialog__container">
-                    <!---->
-                  </div>
-                </fragment-stub>
-              </td>
-              <td class="text-center">
-                <router-link-stub to="[object Object]">
-                  39-5e-2a
-                </router-link-stub>
-              </td>
-              <td class="text-center">
-                <fragment-stub data-test="deviceIcon-component"><i aria-hidden="true" data-test="type-icon" class="v-icon notranslate icons fl fl-linuxmint theme--light"></i></fragment-stub>
-                Linux Mint 19.3
-              </td>
-              <td class="text-center"><span class="list-itens v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content">
-          user.39-5e-2a@localhost
-          <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
-              <td class="text-center">
-                <div class="mt-1"><span class="ml-1 mb-1 v-chip v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
-                device1
-              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="ml-1 mb-1 v-chip v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
-                device2
-              </span></span></div>
-              </td>
-              <td class="text-center"><span class="v-chip v-chip--clickable theme--light v-size--default transparent"><span class="v-chip__content"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button></span></span>
-                <div class="v-menu">
-                  <!---->
-                </div>
-              </td>
-            </tr>
-            <tr class="">
-              <td class="text-center">
-                <fragment-stub data-test="terminalDialog-component"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--outlined theme--light v-size--small" data-test="connect-btn"><span class="v-btn__content">
-      Offline
-    </span></button>
-                  <div role="dialog" class="v-dialog__container">
-                    <!---->
-                  </div>
-                </fragment-stub>
-              </td>
-              <td class="text-center">
-                <router-link-stub to="[object Object]">
-                  39-5e-2b
-                </router-link-stub>
-              </td>
-              <td class="text-center">
-                <fragment-stub data-test="deviceIcon-component"><i aria-hidden="true" data-test="type-icon" class="v-icon notranslate icons fl fl-linuxmint theme--light"></i></fragment-stub>
-                Linux Mint 19.3
-              </td>
-              <td class="text-center"><span class="list-itens v-chip v-chip--no-color theme--light v-size--default"><span class="v-chip__content">
-          user.39-5e-2b@localhost
-          <button type="button" class="v-icon notranslate v-icon--link v-icon--right mdi mdi-content-copy theme--light" style="font-size: 16px;"></button></span></span></td>
-              <td class="text-center">
-                <div class="mt-1"><span class="ml-1 mb-1 v-chip v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
-                device1
-              </span></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="v-tooltip v-tooltip--bottom"><!----></span><span class="ml-1 mb-1 v-chip v-chip--no-color v-chip--outlined theme--light v-size--small" aria-haspopup="true" aria-expanded="false"><span class="v-chip__content">
-                device2
-              </span></span></div>
-              </td>
-              <td class="text-center"><span class="v-chip v-chip--clickable theme--light v-size--default transparent"><span class="v-chip__content"><button type="button" role="button" aria-haspopup="true" aria-expanded="false" class="v-icon notranslate icons v-icon--link mdi mdi-dots-horizontal theme--light" style="font-size: 16px;"></button></span></span>
-                <div class="v-menu">
-                  <!---->
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="v-data-footer">
-        <div class="v-data-footer__select">Rows per page:<div class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty theme--light v-text-field v-select">
-            <div class="v-input__control">
-              <div role="button" aria-haspopup="listbox" aria-expanded="false" aria-owns="list-458" class="v-input__slot">
-                <div class="v-select__slot">
-                  <div class="v-select__selections">
-                    <div class="v-select__selection v-select__selection--comma">10</div><input aria-label="Rows per page:" id="input-458" readonly="readonly" type="text" aria-readonly="false" autocomplete="off">
                   </div>
                   <div class="v-input__append-inner">
                     <div class="v-input__icon v-input__icon--append"><i aria-hidden="true" class="v-icon notranslate mdi mdi-menu-down theme--light"></i></div>

--- a/ui/tests/unit/components/setting/tag/TagSelector.spec.js
+++ b/ui/tests/unit/components/setting/tag/TagSelector.spec.js
@@ -19,8 +19,6 @@ describe('TagSelector', () => {
       description: 'Without tags',
       variables: {
         tags: [],
-      },
-      data: {
         selectedTags: [],
       },
       computed: {
@@ -34,8 +32,6 @@ describe('TagSelector', () => {
       description: 'With tags',
       variables: {
         tags: tagsGlobal,
-      },
-      data: {
         selectedTags: [],
       },
       computed: {
@@ -44,15 +40,18 @@ describe('TagSelector', () => {
     },
   ];
 
-  const storeVuex = (tags) => new Vuex.Store({
+  const storeVuex = (tags, selectedTags) => new Vuex.Store({
     namespaced: true,
     state: {
       tags,
+      selectedTags,
     },
     getters: {
       'tags/list': (state) => state.tags,
+      'tags/selected': (state) => state.selectedTags,
     },
     actions: {
+      'tags/setSelected': () => {},
       'tags/fetch': () => {},
       'devices/setFilter': () => {},
       'devices/refresh': () => {},
@@ -66,7 +65,10 @@ describe('TagSelector', () => {
       beforeEach(async () => {
         if (index === 0) {
           wrapper = mount(TagSelector, {
-            store: storeVuex(test.variables.tags),
+            store: storeVuex(
+              test.variables.tags,
+              test.variables.selectedTags,
+            ),
             localVue,
             stubs: ['fragment'],
             vuetify,
@@ -96,11 +98,6 @@ describe('TagSelector', () => {
       // Data checking
       //////
 
-      it('Compare data with default value', () => {
-        Object.keys(test.data).forEach((item) => {
-          expect(wrapper.vm[item]).toEqual(test.data[item]);
-        });
-      });
       it('Process data in the computed', () => {
         Object.keys(test.computed).forEach((item) => {
           expect(wrapper.vm[item]).toEqual(test.computed[item]);

--- a/ui/tests/unit/components/setting/tag/__snapshots__/TagSelector.spec.js.snap
+++ b/ui/tests/unit/components/setting/tag/__snapshots__/TagSelector.spec.js.snap
@@ -7,19 +7,19 @@ exports[`TagSelector With tags Renders the component 1`] = `
       <v-list-stub tag="div">
         <v-list-item-stub activeclass="" tag="div" data-test="ShellHub-item">
           <v-list-item-action-stub>
-            <v-checkbox-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="ShellHub" backgroundcolor="" ripple="true" valuecomparator="[Function]" inputvalue="" indeterminateicon="$checkboxIndeterminate" officon="$checkboxOff" onicon="$checkboxOn"></v-checkbox-stub>
+            <v-checkbox-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="ShellHub" backgroundcolor="" ripple="true" valuecomparator="[Function]" indeterminateicon="$checkboxIndeterminate" officon="$checkboxOff" onicon="$checkboxOn"></v-checkbox-stub>
           </v-list-item-action-stub>
           <v-list-item-title-stub tag="div" data-test="ShellHub-title">ShellHub</v-list-item-title-stub>
         </v-list-item-stub>
         <v-list-item-stub activeclass="" tag="div" data-test="Shell-item">
           <v-list-item-action-stub>
-            <v-checkbox-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="Shell" backgroundcolor="" ripple="true" valuecomparator="[Function]" inputvalue="" indeterminateicon="$checkboxIndeterminate" officon="$checkboxOff" onicon="$checkboxOn"></v-checkbox-stub>
+            <v-checkbox-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="Shell" backgroundcolor="" ripple="true" valuecomparator="[Function]" indeterminateicon="$checkboxIndeterminate" officon="$checkboxOff" onicon="$checkboxOn"></v-checkbox-stub>
           </v-list-item-action-stub>
           <v-list-item-title-stub tag="div" data-test="Shell-title">Shell</v-list-item-title-stub>
         </v-list-item-stub>
         <v-list-item-stub activeclass="" tag="div" data-test="Hub-item">
           <v-list-item-action-stub>
-            <v-checkbox-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="Hub" backgroundcolor="" ripple="true" valuecomparator="[Function]" inputvalue="" indeterminateicon="$checkboxIndeterminate" officon="$checkboxOff" onicon="$checkboxOn"></v-checkbox-stub>
+            <v-checkbox-stub errorcount="1" errormessages="" messages="" rules="" successmessages="" value="Hub" backgroundcolor="" ripple="true" valuecomparator="[Function]" indeterminateicon="$checkboxIndeterminate" officon="$checkboxOff" onicon="$checkboxOn"></v-checkbox-stub>
           </v-list-item-action-stub>
           <v-list-item-title-stub tag="div" data-test="Hub-title">Hub</v-list-item-title-stub>
         </v-list-item-stub>

--- a/ui/tests/unit/store/Tags.spec.js
+++ b/ui/tests/unit/store/Tags.spec.js
@@ -3,14 +3,25 @@ import store from '@/store';
 describe('Tags', () => {
   const numberTags = 3;
   const tags = ['tag1', 'tag2', 'tag3'];
+  const selected = ['tag1'];
 
-  it('Return public key default variables', () => {
+  it('Return default variables', () => {
     expect(store.getters['tags/list']).toEqual([]);
     expect(store.getters['tags/getNumberTags']).toEqual(0);
+    expect(store.getters['tags/selected']).toEqual([]);
   });
   it('Verify initial state change for setTags mutation', () => {
     store.commit('tags/setTags', { data: tags, headers: { 'x-total-count': numberTags } });
     expect(store.getters['tags/list']).toEqual(tags);
     expect(store.getters['tags/getNumberTags']).toEqual(numberTags);
+  });
+
+  it('Verify initial state change for setSelected mutation', () => {
+    store.commit('tags/setSelected', selected);
+    expect(store.getters['tags/selected']).toEqual(selected);
+  });
+  it('Verify clear change for setSelected mutation', () => {
+    store.dispatch('tags/clearSelectedTags');
+    expect(store.getters['tags/selected']).toEqual([]);
   });
 });


### PR DESCRIPTION
This commit uses the store to set the selected tags. This is used to work with
the tag dropdown, tagging selected tags.

Signed-off-by: Leonardo R.S. Joao <leonardo.joao@ossystems.com.br>