### PR TITLE
ui: add dispatches in namespace and tags components

### DIFF
--- a/ui/src/components/device/DeviceDelete.vue
+++ b/ui/src/components/device/DeviceDelete.vue
@@ -98,6 +98,8 @@ export default {
 
         if (this.redirect) {
           this.$router.push('/devices');
+        } else {
+          await this.$store.dispatch('tags/fetch');
         }
 
         this.$store.dispatch('snackbar/showSnackbarSuccessAction', this.$success.deviceDelete);

--- a/ui/src/components/namespace/Namespace.vue
+++ b/ui/src/components/namespace/Namespace.vue
@@ -1,7 +1,9 @@
 <template>
   <fragment>
     <v-list v-if="hasNamespace">
-      <v-list-group>
+      <v-list-group
+        v-model="listing"
+      >
         <template #activator>
           <v-list-item-content>
             <v-list-item-title class="primary--text primary--icon">
@@ -49,6 +51,7 @@ export default {
   data() {
     return {
       inANamespace: false,
+      listing: false,
     };
   },
 
@@ -74,6 +77,12 @@ export default {
     hasNamespace(status) {
       this.inANamespace = status;
       this.getNamespace();
+    },
+
+    listing(val) {
+      if (val) {
+        this.getNamespaces();
+      }
     },
   },
 

--- a/ui/src/components/tag/TagFormUpdate.vue
+++ b/ui/src/components/tag/TagFormUpdate.vue
@@ -153,6 +153,12 @@ export default {
       try {
         this.errorMsg = '';
         await this.$store.dispatch('devices/updateDeviceTag', data);
+        await this.$store.dispatch('tags/setTags', {
+          data: data.tags,
+          headers: {
+            'x-total-count': data.tags.length,
+          },
+        });
         this.$store.dispatch('snackbar/showSnackbarSuccessAction', this.$success.deviceTagUpdate);
 
         this.update();

--- a/ui/src/components/tag/TagSelector.vue
+++ b/ui/src/components/tag/TagSelector.vue
@@ -18,6 +18,7 @@
               v-bind="attrs"
               data-test="tags-btn"
               outlined
+              :disabled="getListTags.length==0"
               v-on="on"
               @click="getTags"
             >

--- a/ui/src/store/modules/tags.js
+++ b/ui/src/store/modules/tags.js
@@ -46,6 +46,10 @@ export default {
       await apiDevice.updateTag(data);
     },
 
+    setTags: (context, data) => {
+      context.commit('setTags', data);
+    },
+
     remove: async (context, name) => {
       await apiDevice.removeTag(name);
     },

--- a/ui/tests/unit/components/tag/__snapshots__/TagSelector.spec.js.snap
+++ b/ui/tests/unit/components/tag/__snapshots__/TagSelector.spec.js.snap
@@ -18,7 +18,7 @@ exports[`TagSelector With tags Renders the component 1`] = `
 
 exports[`TagSelector Without tags Renders the component 1`] = `
 <fragment-stub>
-  <div class="mr-4"><span class="v-badge v-badge--bordered v-badge--overlap theme--light"><button type="button" class="v-btn v-btn--outlined theme--light v-size--default primary--text" data-test="tags-btn" role="button" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content">
+  <div class="mr-4"><span class="v-badge v-badge--bordered v-badge--overlap theme--light"><button type="button" disabled="disabled" class="v-btn v-btn--disabled v-btn--outlined theme--light v-size--default" data-test="tags-btn" role="button" aria-haspopup="true" aria-expanded="false"><span class="v-btn__content">
             Tags
             <i aria-hidden="true" class="v-icon notranslate v-icon--right mdi mdi-chevron-down theme--light"></i></span></button><span class="v-badge__wrapper"><transition-stub name="scale-rotate-transition"><span aria-atomic="true" aria-label="Badge" aria-live="polite" role="status" class="v-badge__badge primary" style="bottom: calc(100% - 12px); left: calc(100% - 12px); display: none;"></span></transition-stub></span></span>
     <div class="v-menu">

--- a/ui/tests/unit/store/Tags.spec.js
+++ b/ui/tests/unit/store/Tags.spec.js
@@ -24,4 +24,8 @@ describe('Tags', () => {
     store.dispatch('tags/clearSelectedTags');
     expect(store.getters['tags/selected']).toEqual([]);
   });
+  it('Verify initial state change for setTags mutation', () => {
+    store.dispatch('tags/setTags', { data: tags, headers: { 'x-total-count': tags.length } });
+    expect(store.getters['tags/list']).toEqual(tags);
+  });
 });


### PR DESCRIPTION
It also fixes the following:

- Leaves the button disabled when tags are empty.
- Fetches namespace list when clicking menu namespace.

This Closes #1688.

Signed-off-by: Vagner S. Nornberg <vagner.nornberg@ossystems.com.br>