### PR TITLE
Convert standalone mongodb instance to local replicaset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,11 @@ services:
   mongo:
     image: mongo:4.4.8
     restart: unless-stopped
+    healthcheck:
+      test: "test $$(echo \"rs.initiate({ _id: 'rs', members: [ { _id: 0, host: 'localhost:27017' } ] }).ok || rs.status().ok\" | mongo --quiet) -eq 1"
+      interval: 30s
+      start_period: 10s
+    command: ["--replSet", "rs", "--bind_ip_all"]
     networks:
       - shellhub
   scheduler:


### PR DESCRIPTION
We need to use replicaset in order to support multi-document ACID transactions.