### PR TITLE
api: fix down on migration 42

### DIFF
--- a/api/store/mongo/migrations/migration_42.go
+++ b/api/store/mongo/migrations/migration_42.go
@@ -31,7 +31,7 @@ var migration42 = migrate.Migration{
 					{"$unset", "hostname"},
 				},
 				{
-					{"$merge", bson.M{"into": "public_keys"}},
+					{"$merge", bson.M{"into": "public_keys", "whenMatched": "replace"}},
 				},
 			},
 		)
@@ -54,7 +54,7 @@ var migration42 = migrate.Migration{
 					{"$match", bson.M{}},
 				},
 				{
-					{"$set", bson.M{"hostname": "$hostname"}},
+					{"$set", bson.M{"hostname": "$filter.hostname"}},
 				},
 				{
 					{"$unset", "filter"},

--- a/api/store/mongo/migrations/migration_42_test.go
+++ b/api/store/mongo/migrations/migration_42_test.go
@@ -33,7 +33,7 @@ func TestMigration42(t *testing.T) {
 		PublicKeyFields `bson:",inline"`
 	}
 
-	keyOld := PublicKey{
+	keyOld := &PublicKey{
 		Fingerprint: "fingerprint",
 		TenantID:    "tenant",
 		PublicKeyFields: PublicKeyFields{
@@ -43,7 +43,7 @@ func TestMigration42(t *testing.T) {
 		},
 	}
 
-	keyNew := models.PublicKey{
+	keyNew := &models.PublicKey{
 		Fingerprint: "fingerprint",
 		TenantID:    "tenant",
 		PublicKeyFields: models.PublicKeyFields{
@@ -79,7 +79,7 @@ func TestMigration42(t *testing.T) {
 				err = result.Decode(key)
 				assert.NoError(t, err)
 
-				assert.Equal(t, keyNew, *key)
+				assert.Equal(t, keyNew, key)
 			},
 		},
 		{
@@ -99,7 +99,7 @@ func TestMigration42(t *testing.T) {
 				err = result.Decode(key)
 				assert.NoError(t, err)
 
-				assert.Equal(t, keyOld, *key)
+				assert.Equal(t, keyOld, key)
 			},
 		},
 	}


### PR DESCRIPTION
Indeed, the down migration 42 is not broken, but the variable inside the mongo
pipeline was not correct, what could cause some unwanted behavior.