### PR TITLE
api: change how public_key is merged when migration 42 is down

### DIFF
--- a/api/store/mongo/migrations/migration_42.go
+++ b/api/store/mongo/migrations/migration_42.go
@@ -60,7 +60,7 @@ var migration42 = migrate.Migration{
 					{"$unset", "filter"},
 				},
 				{
-					{"$merge", bson.M{"into": "public_keys"}},
+					{"$merge", bson.M{"into": "public_keys", "whenMatched": "replace"}},
 				},
 			},
 		)


### PR DESCRIPTION
Without this modification, when public_key is merged on pipeline end,
the field `filter` will remain.