### PR TITLE
ui: fix default value of tagChoices

### DIFF
--- a/ui/src/components/firewall_rule/FirewallRuleFormDialogEdit.vue
+++ b/ui/src/components/firewall_rule/FirewallRuleFormDialogEdit.vue
@@ -163,8 +163,10 @@
 
             <ValidationProvider
               v-if="choiceFilter==='tags'"
+              v-slot="{ errors }"
               name="Tags"
-              rules="required"
+              vid="tagsLength"
+              rules="tagRequired|tagsLength"
             >
               <v-select
                 v-model="tagChoices"
@@ -173,11 +175,9 @@
                 attach
                 chips
                 label="Rule device tag restriction"
-                :rules="[validateLength]"
-                :error-messages="errMsg"
+                :error-messages="errors"
                 :menu-props="{ top: true, maxHeight: 150, offsetY: true }"
                 multiple
-                required
               />
             </ValidationProvider>
           </v-card-text>
@@ -238,12 +238,10 @@ export default {
       choiceUsername: 'all',
       choiceFilter: 'all',
       choiceIP: 'all',
-      validateLength: true,
       usernameField: '',
       hostnameField: '',
       ipField: '',
-      tagChoices: [''],
-      errMsg: '',
+      tagChoices: [],
       sourceIPFieldChoices: [
         {
           filterName: 'all',
@@ -327,20 +325,6 @@ export default {
     showDialog(val) {
       if (val) {
         this.setLocalVariable();
-      }
-    },
-
-    tagChoices(list) {
-      if (list.length > 3) {
-        this.validateLength = false;
-        this.$nextTick(() => this.tagChoices.pop());
-        this.errMsg = 'The maximum capacity has reached';
-      } else if (list.length === 0) {
-        this.validateLength = false;
-        this.errMsg = 'You must choose at least one tag';
-      } else if (list.length <= 2) {
-        this.validateLength = true;
-        this.errMsg = '';
       }
     },
   },
@@ -470,8 +454,6 @@ export default {
       this.choiceUsername = 'all';
       this.choiceFilter = 'all';
       this.choiceIP = 'all';
-      this.validateLength = true;
-      this.errMsg = '';
     },
 
     update() {
@@ -481,7 +463,6 @@ export default {
 
     close() {
       this.$emit('update:show', false);
-      this.tagChoices = [''];
       this.resetChoices();
       this.$refs.obs.reset();
     },

--- a/ui/src/vee-validate.js
+++ b/ui/src/vee-validate.js
@@ -67,6 +67,20 @@ extend('tag', (value) => {
   return true;
 });
 
+extend('tagRequired', {
+  ...required,
+  message: 'You must choose at least one tag',
+});
+
+extend('tagsLength', {
+  validate(value) {
+    if (value.length > 3) {
+      return 'The maximum capacity has reached';
+    }
+    return true;
+  },
+});
+
 extend('comparePasswords', {
   validate(value, { currentPassword }) {
     if (value === currentPassword) {

--- a/ui/tests/unit/components/firewall_rule/FirewallRuleFormDialogEdit.spec.js
+++ b/ui/tests/unit/components/firewall_rule/FirewallRuleFormDialogEdit.spec.js
@@ -239,6 +239,7 @@ describe('FirewallRuleFormDialog', () => {
       expect(wrapper.vm.choiceIP).toBe('all');
       expect(wrapper.vm.usernameField).toBe('');
       expect(wrapper.vm.ipField).toBe('');
+      expect(wrapper.vm.tagChoices).toStrictEqual([]);
       expect(wrapper.vm.hostnameField).toStrictEqual('');
     });
 


### PR DESCRIPTION
Define its default value as empty list and uses vee-validate instead
of watcher.