### PR TITLE
docker: update autossl image

### DIFF
--- a/docker-compose.autossl.yml
+++ b/docker-compose.autossl.yml
@@ -8,7 +8,7 @@ services:
       timeout: 10s
       retries: 10
   autossl:
-    image: valian/docker-nginx-auto-ssl:1.2.0
+    image: shellhubio/docker-nginx-auto-ssl:1.0.0
     restart: unless-stopped
     depends_on:
       - gateway


### PR DESCRIPTION
We are using our own 'docker-nginx-auto-ssl' image because upstream is using the latest tag (bad practice) instead of a specific versioned tag.