### PR TITLE
gateway: add route to hit mocked API from OpenAPI.

### DIFF
--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -44,9 +44,15 @@ server {
     }
 
     {{ if eq (env.Getenv "SHELLHUB_ENV") "development" -}}
-    location /openapi {
+    location /openapi/preview {
         set $upstream openapi:8080;
-        rewrite ^/openapi/?(.*)$ /$1 break;
+        rewrite ^/openapi/preview/?(.*)$ /$1 break;
+        proxy_pass http://$upstream;
+    }
+
+    location /openapi/mock {
+        set $upstream openapi:4010;
+        rewrite ^/openapi/mock/?(.*)$ /$1 break;
         proxy_pass http://$upstream;
     }
     {{- end }}


### PR DESCRIPTION
On that commit, I've changed the URL to preview the OpenAPI, from
`localhost/openapi` to `localhost/openapi/preview` and added a new
one: `/localhost/mock` to enable mock test.