### PR TITLE
agent: remove /host prefix from working directory

### DIFF
--- a/agent/sshd/cmd_docker.go
+++ b/agent/sshd/cmd_docker.go
@@ -13,7 +13,7 @@ import (
 )
 
 func newCmd(u *osauth.User, shell, term, host string, command ...string) *exec.Cmd {
-	nscommand, _ := nsenterCommandWrapper(u.UID, u.GID, fmt.Sprintf("/host/%s", u.HomeDir), command...)
+	nscommand, _ := nsenterCommandWrapper(u.UID, u.GID, u.HomeDir, command...)
 
 	cmd := exec.Command(nscommand[0], nscommand[1:]...) //nolint:gosec
 	cmd.Env = []string{


### PR DESCRIPTION
Since nsenter already change root directory, we don't need
to manually specify the rootfs (/host).