### PR TITLE
api: invalidate token when user's role change

### DIFF
--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -43,6 +43,11 @@ func (h *Handler) AuthRequest(c gateway.Context) error {
 			return err
 		}
 
+		// This forces any no cached token to be invalid, even if it not not expired.
+		if ok, err := h.service.AuthIsCacheToken(c.Ctx(), claims.Tenant, claims.ID); err != nil || !ok {
+			return svc.NewErrAuthUnathorized(err)
+		}
+
 		// Extract tenant and username from JWT
 		c.Response().Header().Set("X-Tenant-ID", claims.Tenant)
 		c.Response().Header().Set("X-Username", claims.Username)

--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -59,6 +59,20 @@ func (_m *Service) AddPublicKeyTag(ctx context.Context, tenant string, fingerpri
 	return r0
 }
 
+// AuthCacheToken provides a mock function with given fields: ctx, tenant, id, token
+func (_m *Service) AuthCacheToken(ctx context.Context, tenant string, id string, token string) error {
+	ret := _m.Called(ctx, tenant, id, token)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = rf(ctx, tenant, id, token)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // AuthDevice provides a mock function with given fields: ctx, req, remoteAddr
 func (_m *Service) AuthDevice(ctx context.Context, req request.DeviceAuth, remoteAddr string) (*models.DeviceAuthResponse, error) {
 	ret := _m.Called(ctx, req, remoteAddr)
@@ -98,6 +112,27 @@ func (_m *Service) AuthGetToken(ctx context.Context, tenant string) (*models.Use
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = rf(ctx, tenant)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AuthIsCacheToken provides a mock function with given fields: ctx, tenant, id
+func (_m *Service) AuthIsCacheToken(ctx context.Context, tenant string, id string) (bool, error) {
+	ret := _m.Called(ctx, tenant, id)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = rf(ctx, tenant, id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, tenant, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -149,6 +184,20 @@ func (_m *Service) AuthSwapToken(ctx context.Context, ID string, tenant string) 
 	}
 
 	return r0, r1
+}
+
+// AuthUncacheToken provides a mock function with given fields: ctx, tenant, id
+func (_m *Service) AuthUncacheToken(ctx context.Context, tenant string, id string) error {
+	ret := _m.Called(ctx, tenant, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, tenant, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // AuthUser provides a mock function with given fields: ctx, req


### PR DESCRIPTION
When a user login into a namespace, it got a JWT token containing
some information about it.

Unfortunately, this approach generated some problems related to
role update, when a user has its role changed by someone else.

Caching the token when a user login and cleaning this cache when
its role is updated, it helps to invalid a token after a role
update.