### PR TITLE
agent: set agent platform during initialization

### DIFF
--- a/agent/init_docker.go
+++ b/agent/init_docker.go
@@ -4,13 +4,21 @@
 package main
 
 import (
+	"os"
+
 	"github.com/shellhub-io/shellhub/agent/pkg/osauth"
 	"github.com/shellhub-io/shellhub/agent/pkg/sysinfo"
 )
 
-var AgentPlatform = "docker"
+var AgentPlatform string
 
 func init() {
+	if _, err := os.Stat("/.dockerenv"); os.IsNotExist(err) {
+		AgentPlatform = "bundle"
+	} else {
+		AgentPlatform = "docker"
+	}
+
 	osauth.DefaultShadowFilename = "/host/etc/shadow"
 	sysinfo.DefaultOSReleaseFilename = "/host/etc/os-release"
 }


### PR DESCRIPTION
As bundle install method uses the same binary used by docker container we need to detect in runtime if we are running in docker environment or somewhere