### PR TITLE
api: use const key instead of hard-coded value to get JWT from middleware

### DIFF
--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -25,7 +25,7 @@ const (
 )
 
 func (h *Handler) AuthRequest(c gateway.Context) error {
-	token, ok := c.Get("user").(*jwt.Token)
+	token, ok := c.Get(middleware.DefaultJWTConfig.ContextKey).(*jwt.Token)
 	if !ok {
 		return svc.ErrTypeAssertion
 	}


### PR DESCRIPTION
Just to make it easier to understand what is going on.
