### PR TITLE
ssh: fix break line and error messages sent to user

### DIFF
--- a/ssh/server/handler/sftp.go
+++ b/ssh/server/handler/sftp.go
@@ -85,7 +85,7 @@ func SFTPSubsystemHandler(tunnel *httptunnel.Tunnel) gliderssh.SubsystemHandler 
 		}
 
 		if err = connectSFTP(ctx, client, sess, api, config); err != nil {
-			sendAndInformError(client, err, ErrConnect)
+			sendAndInformError(client, err, err)
 
 			return
 		}
@@ -95,7 +95,7 @@ func SFTPSubsystemHandler(tunnel *httptunnel.Tunnel) gliderssh.SubsystemHandler 
 func connectSFTP(ctx context.Context, client gliderssh.Session, sess *session.Session, api internalclient.Client, config *gossh.ClientConfig) error {
 	connection, reqs, err := sess.NewClientConnWithDeadline(config)
 	if err != nil {
-		return err
+		return ErrAuthentification
 	}
 
 	agent, err := connection.NewSession()

--- a/ssh/server/handler/ssh.go
+++ b/ssh/server/handler/ssh.go
@@ -53,6 +53,7 @@ var (
 	ErrPty                = fmt.Errorf("failed to request the pty to agent")
 	ErrShell              = fmt.Errorf("failed to get the shell to agent")
 	ErrTarget             = fmt.Errorf("failed to get client target")
+	ErrAuthentification   = fmt.Errorf("failed to authenticate to device")
 )
 
 // sendAndInformError sends the external error to client and log the internal one to server.
@@ -159,7 +160,7 @@ func SSHHandler(tunnel *httptunnel.Tunnel) gliderssh.Handler {
 
 		err = connectSSH(ctx, client, sess, config, api, opts)
 		if err != nil {
-			sendAndInformError(client, err, ErrConnect)
+			sendAndInformError(client, err, err)
 
 			return
 		}
@@ -169,7 +170,7 @@ func SSHHandler(tunnel *httptunnel.Tunnel) gliderssh.Handler {
 func connectSSH(ctx context.Context, client gliderssh.Session, sess *session.Session, config *gossh.ClientConfig, api internalclient.Client, opts ConfigOptions) error {
 	connection, reqs, err := sess.NewClientConnWithDeadline(config)
 	if err != nil {
-		return err
+		return ErrAuthentification
 	}
 
 	defer connection.Close()

--- a/ssh/server/handler/ssh.go
+++ b/ssh/server/handler/ssh.go
@@ -59,7 +59,7 @@ var (
 func sendAndInformError(client io.Writer, internal, external error) {
 	log.Error(internal.Error())
 
-	client.Write([]byte(external.Error())) // nolint: errcheck
+	client.Write([]byte(fmt.Sprintf("%s\n", external.Error()))) // nolint: errcheck
 }
 
 type ConfigOptions struct {

--- a/ssh/session/session.go
+++ b/ssh/session/session.go
@@ -27,7 +27,7 @@ var (
 	ErrFirewallBlock = fmt.Errorf("you connot connect to this device because a firewall rule block your connection")
 	ErrHost          = fmt.Errorf("failed to get the device address")
 	ErrFindDevice    = fmt.Errorf("failed to find the device")
-	ErrDial          = fmt.Errorf("failed to tunnel the server to agent")
+	ErrDial          = fmt.Errorf("failed to connect to device agent, please check the device connection")
 )
 
 type Session struct {


### PR DESCRIPTION
I have fixed the missing breaking line when an error message is sent to the user, and I added the one when client cannot authenticate on device/agent.

![screenshot 1](https://user-images.githubusercontent.com/23109089/192555500-131d4948-d139-4722-b73a-6190def8e0d5.png)
