### PR TITLE
cli, bin: refactor CLI commands basing it on resources

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# CLI script is a inferface to executes commands on the CLI service.
+# The CLI service contains a set of commands to manage users, namesapces and members.
+
+shift $@ # remove the first argument; script name.
+
+docker-compose exec cli ./cli $@

--- a/cli/main.go
+++ b/cli/main.go
@@ -47,10 +47,174 @@ func main() {
 	services := NewService(mongo.NewStore(client.Database(connStr.Database), cache))
 
 	rootCmd := &cobra.Command{Use: "cli"}
+
+	userCmd := &cobra.Command{
+		Use:   "user",
+		Short: "Manage users",
+		Long:  `Manage users`,
+	}
+	userCmd.AddCommand(&cobra.Command{
+		Use:     "create <username> <password> <email>",
+		Short:   "Create an user",
+		Long:    `Create an user`,
+		Example: `cli user create shellhub password`,
+		Args:    cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			user, err := services.UserCreate(args[0], args[1], args[2])
+			if err != nil {
+				return err
+			}
+
+			cmd.Println("User created successfully")
+			cmd.Println("Username:", user.Username)
+			cmd.Println("Email:", user.Email)
+
+			return nil
+		},
+	})
+	userCmd.AddCommand(&cobra.Command{
+		Use:     "delete <username>",
+		Short:   "Delete an user",
+		Long:    `Delete an user`,
+		Example: `cli user delete shellhub`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := services.UserDelete(args[0]); err != nil {
+				return err
+			}
+
+			cmd.Println("User deleted successfully")
+			cmd.Println("Username:", args[0])
+
+			return nil
+		},
+	})
+
+	userCmd.AddCommand(&cobra.Command{
+		Use:     "password <username> <password>",
+		Short:   "Change user password",
+		Long:    `Change user password`,
+		Example: `cli user password shellhub password`,
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := services.UserUpdate(args[0], args[1]); err != nil {
+				return err
+			}
+
+			cmd.Println("User password changed successfully")
+			cmd.Println("Username:", args[0])
+
+			return nil
+		},
+	})
+
+	namespaceCmd := &cobra.Command{
+		Use:   "namespace",
+		Short: "Manage namespaces",
+		Long:  `Manage namespaces`,
+	}
+	namespaceCmd.AddCommand(&cobra.Command{
+		Use:     "create <namespace> <owner>",
+		Short:   "create a namespace",
+		Long:    `create a namespace`,
+		Example: `cli namespace create shellhubspace shellhub`,
+		Args:    cobra.RangeArgs(2, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Avoid panic when TenantID isn't provided.
+			if len(args) == 2 {
+				args = append(args, "")
+			}
+
+			namespace, err := services.NamespaceCreate(args[0], args[1], args[2])
+			if err != nil {
+				return err
+			}
+
+			cmd.Println("Namespace created successfully")
+			cmd.Println("Namespace:", namespace.Name)
+			cmd.Println("Tenant:", namespace.TenantID)
+			cmd.Println("Owner:", namespace.Owner)
+
+			return nil
+		},
+	})
+	namespaceCmd.AddCommand(&cobra.Command{
+		Use:     "delete <namespace>",
+		Short:   "Delete a namespace",
+		Long:    `Delete a namespace`,
+		Example: `cli namespace delete shellhubspace`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, err := services.NamespaceRemoveMember(args[0], args[1])
+			if err != nil {
+				return err
+			}
+
+			cmd.Println("Namespace deleted successfully")
+			cmd.Println("Namespace:", namespace.Name)
+			cmd.Println("Tenant:", namespace.TenantID)
+			cmd.Println("Owner:", namespace.Owner)
+
+			return nil
+		},
+	})
+
+	memberCmd := &cobra.Command{
+		Use:   "member",
+		Short: "Manage members",
+		Long:  `Manage members`,
+	}
+	memberCmd.AddCommand(&cobra.Command{
+		Use:     "add <username> <namespace> <role>",
+		Short:   "Add a member",
+		Long:    `Add a member`,
+		Example: `cli member add shellhub shellhubspace`,
+		Args:    cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, err := services.NamespaceAddMember(args[0], args[1], args[2])
+			if err != nil {
+				return err
+			}
+
+			cmd.Println("Member added successfully")
+			cmd.Println("Namespace:", namespace.Name)
+			cmd.Println("Tenant:", namespace.TenantID)
+			cmd.Println("Member:", args[0])
+			cmd.Println("Role:", args[2])
+
+			return nil
+		},
+	})
+	memberCmd.AddCommand(&cobra.Command{
+		Use:     "remove <username> <namespace>",
+		Short:   "Remove a member",
+		Long:    `Remove a member`,
+		Example: `cli member remove shellhub shellhubspace`,
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			namespace, err := services.NamespaceRemoveMember(args[0], args[1])
+			if err != nil {
+				return err
+			}
+
+			cmd.Println("Member removed successfully")
+			cmd.Println("Namespace:", namespace.Name)
+			cmd.Println("Tenant:", namespace.TenantID)
+			cmd.Println("Member:", args[0])
+
+			return nil
+		},
+	})
+
+	rootCmd.AddCommand(userCmd)
+	rootCmd.AddCommand(namespaceCmd)
+	rootCmd.AddCommand(memberCmd)
+
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "add-user",
-		Short: "Usage: <username> <password> <email>",
-		Args:  cobra.ExactArgs(3),
+		Deprecated: "This command is deprecated and will be removed in a future release.",
+		Use:        "add-user",
+		Short:      "Usage: <username> <password> <email>",
+		Args:       cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			user, err := services.UserCreate(args[0], args[1], args[2])
 			if err != nil {
@@ -65,9 +229,10 @@ func main() {
 		},
 	},
 		&cobra.Command{
-			Use:   "del-user",
-			Short: "Usage: <username>",
-			Args:  cobra.ExactArgs(1),
+			Deprecated: "This command is deprecated and will be removed in a future release.",
+			Use:        "del-user",
+			Short:      "Usage: <username>",
+			Args:       cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if err := services.UserDelete(args[0]); err != nil {
 					return err
@@ -79,9 +244,10 @@ func main() {
 			},
 		},
 		&cobra.Command{
-			Use:   "reset-user-password",
-			Short: "Usage: <username> <password>",
-			Args:  cobra.ExactArgs(2),
+			Deprecated: "This command is deprecated and will be removed in a future release.",
+			Use:        "reset-user-password",
+			Short:      "Usage: <username> <password>",
+			Args:       cobra.ExactArgs(2),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if err := services.UserUpdate(args[0], args[1]); err != nil {
 					return err
@@ -93,9 +259,10 @@ func main() {
 			},
 		},
 		&cobra.Command{
-			Use:   "add-namespace",
-			Short: "Usage: <namespace> <owner>",
-			Args:  cobra.RangeArgs(2, 3),
+			Deprecated: "This command is deprecated and will be removed in a future release.",
+			Use:        "add-namespace",
+			Short:      "Usage: <namespace> <owner>",
+			Args:       cobra.RangeArgs(2, 3),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				// Avoid panic when TenantID isn't provided.
 				if len(args) == 2 {
@@ -115,9 +282,10 @@ func main() {
 			},
 		},
 		&cobra.Command{
-			Use:   "add-user-namespace",
-			Short: "Usage: <username> <namespace> <role>",
-			Args:  cobra.ExactArgs(3),
+			Deprecated: "This command is deprecated and will be removed in a future release.",
+			Use:        "add-user-namespace",
+			Short:      "Usage: <username> <namespace> <role>",
+			Args:       cobra.ExactArgs(3),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				ns, err := services.NamespaceAddMember(args[0], args[1], args[2])
 				if err != nil {
@@ -132,9 +300,10 @@ func main() {
 			},
 		},
 		&cobra.Command{
-			Use:   "del-user-namespace",
-			Short: "Usage <username> <namespace>",
-			Args:  cobra.ExactArgs(2),
+			Deprecated: "This command is deprecated and will be removed in a future release.",
+			Use:        "del-user-namespace",
+			Short:      "Usage <username> <namespace>",
+			Args:       cobra.ExactArgs(2),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				ns, err := services.NamespaceRemoveMember(args[0], args[1])
 				if err != nil {
@@ -148,9 +317,10 @@ func main() {
 			},
 		},
 		&cobra.Command{
-			Use:   "del-namespace",
-			Short: "Usage: <namespace>",
-			Args:  cobra.ExactArgs(1),
+			Deprecated: "This command is deprecated and will be removed in a future release.",
+			Use:        "del-namespace",
+			Short:      "Usage: <namespace>",
+			Args:       cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if err := services.NamespaceDelete(args[0]); err != nil {
 					return err


### PR DESCRIPTION
Refactoring CLI commands to work as a "resource command parameter" pattern. All commands are, now, based on the resource it works on.

Each resource has commands related to it. A user can be created, has its password edited and remove; a namespace can be created and deleted; a member can be added or removed from a namespace.

To interact with the new commands on the CLI service, a new script called "cli" on bin/ folder was created. It just runs a `docker-compose exec` passing the parameters to CLI service and return its output to who executed the script.

The old CLI commands and scripts to interact to CLI service still are on bin/ folder, but was tagged as deprecated, what makes it does not appear on helper or usage command.