### PR TITLE
Feature/allow AllowTcpForwarding 

### DIFF
--- a/ssh/server/server.go
+++ b/ssh/server/server.go
@@ -46,6 +46,14 @@ func NewServer(opts *Options, tunnel *httptunnel.Tunnel) *Server {
 		SubsystemHandlers: map[string]gliderssh.SubsystemHandler{
 			handler.SFTPSubsystem: handler.SFTPSubsystemHandler(tunnel),
 		},
+                ChannelHandlers: map[string]gliderssh.ChannelHandler{
+                        "session":      gliderssh.DefaultSessionHandler,
+                        "direct-tcpip": gliderssh.DirectTCPIPHandler,
+                },
+                LocalPortForwardingCallback: gliderssh.LocalPortForwardingCallback(func(ctx gliderssh.Context, dhost string, dport uint32) bool {
+                        log.Println("Accepted forward", dhost, dport)
+                        return true
+                }),
 	}
 
 	if _, err := os.Stat(os.Getenv("PRIVATE_KEY")); os.IsNotExist(err) {

--- a/ssh/server/server.go
+++ b/ssh/server/server.go
@@ -51,7 +51,7 @@ func NewServer(opts *Options, tunnel *httptunnel.Tunnel) *Server {
                         "direct-tcpip": gliderssh.DirectTCPIPHandler,
                 },
                 LocalPortForwardingCallback: gliderssh.LocalPortForwardingCallback(func(ctx gliderssh.Context, dhost string, dport uint32) bool {
-                        log.Println("Accepted forward", dhost, dport)
+                        log.Info("Accepted forward", dhost, dport)
                         return true
                 }),
 	}


### PR DESCRIPTION
Hello shellhub developers,

First of all, thank you for this great project, it answers a real need when you have to connect to various linux machines distributed in non mastered network environment.

A feature that I was missing to be able to use shellhub in my ecosystem is the ability to perform port forwarding.

Other people have reported this need here: https://github.com/shellhub-io/shellhub/issues/90

I took the time to examine the code and make this feature work.

With this pull request it is possible to connect with ssh to a device and specify a port forwarding like this: 
```
ssh user@<shellhub_device>@<shellhub_host> -L 0.0.0.0:42667:192.168.8.13:443
```

What do you think of it?