### PR TITLE
pkg: fix wrong url escaping in `buildURL()` method

### DIFF
--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 
 	resty "github.com/go-resty/resty/v2"
 	"github.com/shellhub-io/shellhub/pkg/models"
@@ -100,8 +99,7 @@ func (c *client) GetDevice(uid string) (*models.Device, error) {
 }
 
 func buildURL(c *client, uri string) string {
-	u, _ := url.Parse(fmt.Sprintf("%s://%s:%d", c.scheme, c.host, c.port))
-	u.Path = path.Join(u.Path, uri)
+	u, _ := url.Parse(fmt.Sprintf("%s://%s:%d%s", c.scheme, c.host, c.port, uri))
 
 	return u.String()
 }


### PR DESCRIPTION
When the buildURL method was called with query string params
the question mark (?) char was escaped (as %3F),
which is not expected in HTTP request.
