### PR TITLE
ui: add token error on Validation Account page

### DIFF
--- a/ui/src/views/ValidationAccount.vue
+++ b/ui/src/views/ValidationAccount.vue
@@ -65,6 +65,15 @@
           another email with the activation link.
         </v-card-text>
 
+        <v-card-text
+          v-if="verifyActivationProcessingStatus === 'failed-token'"
+          class="d-flex align-center justify-center"
+          data-test="failed-cardText"
+        >
+          Your account activation token has expired. Go to the login page, login to receive
+          another email with the activation link.
+        </v-card-text>
+
         <v-card-subtitle
           class="d-flex align-center justify-center pa-4 mx-auto pt-2"
           data-test="isCloud-card"
@@ -115,8 +124,22 @@ export default {
 
         this.activationProcessingStatus = 'success';
         setTimeout(() => this.$router.push({ path: '/login' }), 4000);
-      } catch {
-        this.activationProcessingStatus = 'failed';
+      } catch (error) {
+        if (error && error.response) {
+          switch (error.response.status) {
+          case 400:
+            this.activationProcessingStatus = 'failed';
+            break;
+          case 404:
+            this.activationProcessingStatus = 'failed-token';
+            break;
+          default:
+            this.activationProcessingStatus = 'failed';
+            break;
+          }
+        } else {
+          this.activationProcessingStatus = 'failed';
+        }
         this.$store.dispatch('snackbar/showSnackbarErrorAction', this.$errors.snackbar.validationAccount);
       }
     },

--- a/ui/tests/unit/views/__snapshots__/ValidationAccount.spec.js.snap
+++ b/ui/tests/unit/views/__snapshots__/ValidationAccount.spec.js.snap
@@ -20,6 +20,7 @@ exports[`ValidationAccount Failed to verify account Renders the component 1`] = 
         There was a problem activating your account. Go to the login page, login to receive
         another email with the activation link.
       </v-card-text-stub>
+      <!---->
       <v-card-subtitle-stub tag="div" data-test="isCloud-card" class="d-flex align-center justify-center pa-4 mx-auto pt-2">
         Back to
         <router-link-stub to="[object Object]" tag="a" ariacurrentvalue="page" event="click" class="ml-1">
@@ -49,6 +50,7 @@ exports[`ValidationAccount Success to verify account Renders the component 1`] =
       <v-card-text-stub tag="div" data-test="success-cardText" class="d-flex align-center justify-center">
         Congrats and welcome to ShellHub.
       </v-card-text-stub>
+      <!---->
       <!---->
       <v-card-subtitle-stub tag="div" data-test="isCloud-card" class="d-flex align-center justify-center pa-4 mx-auto pt-2">
         Back to


### PR DESCRIPTION
Added expired token message on `ValidationAccount` page.
![image](https://user-images.githubusercontent.com/21010565/203870810-bce4377d-c776-4d5a-810c-27d91be180f8.png)
