### PR TITLE
ssh: add TTY package as a helper to write on SSH connection

### DIFF
--- a/ssh/pkg/tty/tty.go
+++ b/ssh/pkg/tty/tty.go
@@ -1,0 +1,94 @@
+// Package tty provides functions to write to a client TTY client.
+package tty
+
+import (
+	"fmt"
+
+	gliderssh "github.com/gliderlabs/ssh"
+)
+
+const (
+	ANSIClear      = "\x1Bc"
+	ANSIReset      = "\x1B[H\x1B[2J"
+	ANSIBell       = "\x07c"
+	ANSIBackspace  = "\x08c"
+	ANSIHorizontal = "\x09c"
+	ANSIVertical   = "\x0Bc"
+	ANSILineFeed   = "\x0Ac"
+	ANSIFormFeed   = "\x0Cc"
+	ANSICarriage   = "\x0Dc"
+	ANSIDelete     = "\x7Fc"
+)
+
+// Write writes the data to the client.
+func Write(client gliderssh.Session, agent gliderssh.Session, data string, args ...interface{}) error {
+	_, _, isPty := agent.Pty()
+	if !isPty {
+		return fmt.Errorf("cannot write to a non-pty client")
+	}
+
+	read, err := fmt.Fprintf(client, data, args...)
+	if err != nil {
+		return fmt.Errorf("failed to write to client: %w", err)
+	}
+
+	if read != len(data) {
+		return fmt.Errorf("failed to write to client: %w", fmt.Errorf("failed to write all data"))
+	}
+
+	return nil
+}
+
+func Log(client gliderssh.Session, agent gliderssh.Session, msg string) error {
+	return Write(client, agent, "%s\r\n", msg)
+}
+
+// Clear writes to the client the ANSI escape sequence to clear the screen.
+func Clear(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSIClear)
+}
+
+// Reset writes to the client the ANSI escape sequence to reset the cursor to home position (0, 0).
+func Reset(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSIReset)
+}
+
+// Bell writes to the client the ANSI escape sequence to ring the bell.
+func Bell(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSIBell)
+}
+
+// Backspace writes to the client the ANSI escape sequence to move the cursor back one space.
+func Backspace(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSIBackspace)
+}
+
+// Horizontal writes to the client the ANSI escape sequence to move the cursor to the next horizontal tab stop.
+func Horizontal(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSIHorizontal)
+}
+
+// Vertical writes to the client the ANSI escape sequence to move the cursor to the next vertical tab stop.
+func Vertical(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSIVertical)
+}
+
+// LineFeed writes to the client the ANSI escape sequence to move the cursor down one line.
+func LineFeed(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSILineFeed)
+}
+
+// FormFeed writes to the client the ANSI escape sequence to move the cursor to the next form feed.
+func FormFeed(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSIFormFeed)
+}
+
+// Carriage writes to the client the ANSI escape sequence to move the cursor to the beginning of the current line.
+func Carriage(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSICarriage)
+}
+
+// Delete writes to the client the ANSI escape sequence to delete the character at the cursor position.
+func Delete(client gliderssh.Session, agent gliderssh.Session) error {
+	return Write(client, agent, ANSIDelete)
+}

--- a/ssh/server/handler/sftp.go
+++ b/ssh/server/handler/sftp.go
@@ -95,7 +95,7 @@ func SFTPSubsystemHandler(tunnel *httptunnel.Tunnel) gliderssh.SubsystemHandler 
 func connectSFTP(ctx context.Context, client gliderssh.Session, sess *session.Session, api internalclient.Client, config *gossh.ClientConfig) error {
 	connection, reqs, err := sess.NewClientConnWithDeadline(config)
 	if err != nil {
-		return ErrAuthentification
+		return ErrAuthentication
 	}
 
 	agent, err := connection.NewSession()

--- a/ssh/session/session.go
+++ b/ssh/session/session.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shellhub-io/shellhub/ssh/pkg/metadata"
-
 	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/go-resty/resty/v2"
 	"github.com/shellhub-io/shellhub/pkg/api/internalclient"
@@ -18,6 +16,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/httptunnel"
 	"github.com/shellhub-io/shellhub/ssh/pkg/host"
+	"github.com/shellhub-io/shellhub/ssh/pkg/metadata"
 	log "github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 )


### PR DESCRIPTION
# Why 

I wonder a way to info the user about what is happening during the connection, avoid a blank screen when something is not responding on the desiring time.

# What

I have created a new package responsible to write on the SSH client connection some data. At this package, I have also coded some function to perform some basic operation on a TTY like: clean the screen, move the cursor or sing a bell.

The idea is to use this new package to creating a log like this, informing the user when something wrong happened or when something is taking longer to execute an action.

![Screenshot from 2023-01-25 15-01-49](https://user-images.githubusercontent.com/23109089/214647990-0306375b-0c09-4b84-9c9c-a8e6957987a5.png)
![Screenshot from 2023-01-25 15-04-01](https://user-images.githubusercontent.com/23109089/214647973-12e90bff-c577-41a3-8c7c-1941f212a4fb.png)
When the connection is successfully, the log is cleaned, and only the device TTY appears.
![Screenshot from 2023-01-25 15-08-13](https://user-images.githubusercontent.com/23109089/214647935-4a603a0c-8f7f-4803-ae86-5f4bcb7f5f49.png)