### PR TITLE
ssh,agent: add support for local port forward and dynamic port forwarding

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -73,7 +73,6 @@ func NewServer(api client.Client, authData *models.DeviceAuthResponse, privateKe
 		Handler:                server.sessionHandler,
 		SessionRequestCallback: server.sessionRequestCallback,
 		RequestHandlers:        gliderssh.DefaultRequestHandlers,
-		ChannelHandlers:        gliderssh.DefaultChannelHandlers,
 		SubsystemHandlers: map[string]gliderssh.SubsystemHandler{
 			SFTPSubsystemName: server.sftpSubsystemHandler,
 		},
@@ -89,6 +88,17 @@ func NewServer(api client.Client, authData *models.DeviceAuthResponse, privateKe
 			}
 
 			return &sshConn{conn, closeCallback, ctx}
+		},
+		LocalPortForwardingCallback: func(ctx gliderssh.Context, destinationHost string, destinationPort uint32) bool {
+			return true
+		},
+		ReversePortForwardingCallback: func(ctx gliderssh.Context, destinationHost string, destinationPort uint32) bool {
+			return false
+		},
+		ChannelHandlers: map[string]gliderssh.ChannelHandler{
+			"session":       gliderssh.DefaultSessionHandler,
+			"direct-tcpip":  gliderssh.DirectTCPIPHandler,
+			"dynamic-tcpip": gliderssh.DirectTCPIPHandler,
 		},
 	}
 

--- a/ssh/pkg/metadata/constants.go
+++ b/ssh/pkg/metadata/constants.go
@@ -1,4 +1,4 @@
-// Package metadata provides a way to store and retrieve data from a context.
+// Package metadata provides a way to store and retrieve data from an SSH ;context.
 package metadata
 
 const (
@@ -22,6 +22,10 @@ const (
 	device = "device"
 	// sshid is the key to store and restore the sshid from the context.
 	sshid = "sshid"
+	// agent is the key to store and restore the agent from the context.
+	agent = "agent"
+	// established is the key to store and restore the established state from the context.
+	established = "established"
 )
 
 const (

--- a/ssh/pkg/metadata/restore.go
+++ b/ssh/pkg/metadata/restore.go
@@ -1,20 +1,20 @@
 package metadata
 
 import (
-	"context"
-
+	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/pkg/api/internalclient"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/ssh/pkg/target"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 // restore restores a value from a context.
-func restore(ctx context.Context, key string) interface{} {
+func restore(ctx gliderssh.Context, key string) interface{} {
 	return ctx.Value(key)
 }
 
-// RestoreRequest restores the request type from context/ as metadata.
-func RestoreRequest(ctx context.Context) string {
+// RestoreRequest restores the request type from context as metadata.
+func RestoreRequest(ctx gliderssh.Context) string {
 	value := restore(ctx, request)
 	if value == nil {
 		return ""
@@ -23,8 +23,8 @@ func RestoreRequest(ctx context.Context) string {
 	return value.(string)
 }
 
-// RestoreAuthenticationMethod restores the authentication method from context/ as metadata.
-func RestoreAuthenticationMethod(ctx context.Context) AuthenticationMethod {
+// RestoreAuthenticationMethod restores the authentication method from context as metadata.
+func RestoreAuthenticationMethod(ctx gliderssh.Context) AuthenticationMethod {
 	value := restore(ctx, authentication)
 	if value == nil {
 		return 0
@@ -33,8 +33,8 @@ func RestoreAuthenticationMethod(ctx context.Context) AuthenticationMethod {
 	return value.(AuthenticationMethod)
 }
 
-// RestorePassword restores the password from context/ as metadata.
-func RestorePassword(ctx context.Context) string {
+// RestorePassword restores the password from context as metadata.
+func RestorePassword(ctx gliderssh.Context) string {
 	value := restore(ctx, password)
 	if value == nil {
 		return ""
@@ -43,8 +43,8 @@ func RestorePassword(ctx context.Context) string {
 	return value.(string)
 }
 
-// RestoreFingerprint restores the fingerprint from context/ as metadata.
-func RestoreFingerprint(ctx context.Context) string {
+// RestoreFingerprint restores the fingerprint from context as metadata.
+func RestoreFingerprint(ctx gliderssh.Context) string {
 	value := restore(ctx, fingerprint)
 	if value == nil {
 		return ""
@@ -53,8 +53,8 @@ func RestoreFingerprint(ctx context.Context) string {
 	return value.(string)
 }
 
-// RestoreTarget restores the target from context/ as metadata.
-func RestoreTarget(ctx context.Context) *target.Target {
+// RestoreTarget restores the target from context as metadata.
+func RestoreTarget(ctx gliderssh.Context) *target.Target {
 	value := restore(ctx, tag)
 	if value == nil {
 		return nil
@@ -63,8 +63,8 @@ func RestoreTarget(ctx context.Context) *target.Target {
 	return value.(*target.Target)
 }
 
-// RestoreAPI restores the API client from context/ as metadata.
-func RestoreAPI(ctx context.Context) internalclient.Client {
+// RestoreAPI restores the API client from context as metadata.
+func RestoreAPI(ctx gliderssh.Context) internalclient.Client {
 	value := restore(ctx, api)
 	if value == nil {
 		return nil
@@ -73,8 +73,8 @@ func RestoreAPI(ctx context.Context) internalclient.Client {
 	return value.(internalclient.Client)
 }
 
-// RestoreLookup restores the lookup from context/ as metadata.
-func RestoreLookup(ctx context.Context) map[string]string {
+// RestoreLookup restores the lookup from context as metadata.
+func RestoreLookup(ctx gliderssh.Context) map[string]string {
 	value := restore(ctx, lookup)
 	if value == nil {
 		return nil
@@ -83,12 +83,32 @@ func RestoreLookup(ctx context.Context) map[string]string {
 	return value.(map[string]string)
 }
 
-// RestoreDevice restores the device from context/ as metadata.
-func RestoreDevice(ctx context.Context) *models.Device {
+// RestoreDevice restores the device from context as metadata.
+func RestoreDevice(ctx gliderssh.Context) *models.Device {
 	value := restore(ctx, device)
 	if value == nil {
 		return nil
 	}
 
 	return value.(*models.Device)
+}
+
+// RestoreAgent restores the agent from context as metadata.
+func RestoreAgent(ctx gliderssh.Context) *gossh.Client {
+	value := restore(ctx, agent)
+	if value == nil {
+		return nil
+	}
+
+	return value.(*gossh.Client)
+}
+
+// RestoreEstablished restores the connection established status between server and agent from context as metadata.
+func RestoreEstablished(ctx gliderssh.Context) bool {
+	value := restore(ctx, established)
+	if value == nil {
+		return false
+	}
+
+	return value.(bool)
 }

--- a/ssh/pkg/metadata/store.go
+++ b/ssh/pkg/metadata/store.go
@@ -1,29 +1,27 @@
 package metadata
 
 import (
-	"context"
-
 	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/pkg/api/internalclient"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/ssh/pkg/target"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 // store stores a value into a context.
-func store(ctx context.Context, key string, value interface{}) {
-	c := ctx.(gliderssh.Context) //nolint:forcetypeassert
-	c.SetValue(key, value)
+func store(ctx gliderssh.Context, key string, value interface{}) {
+	ctx.SetValue(key, value)
 }
 
-// StoreRequest stores the request type in the context/ as metadata.
-func StoreRequest(ctx context.Context, value string) {
+// StoreRequest stores the request type in the context as metadata.
+func StoreRequest(ctx gliderssh.Context, value string) {
 	store(ctx, request, value)
 }
 
 // maybeStore stores a value into a context if it does not exist yet. If the value already exists, it will be returned.
 //
 // Its return must be cast.
-func maybeStore(ctx context.Context, key string, value interface{}) interface{} {
+func maybeStore(ctx gliderssh.Context, key string, value interface{}) interface{} {
 	if got := restore(ctx, key); got != nil {
 		return got
 	}
@@ -33,30 +31,30 @@ func maybeStore(ctx context.Context, key string, value interface{}) interface{} 
 	return value
 }
 
-// MaybeStoreSSHID stores the SSHID in the context/ as metadata if is not set yet.
-func MaybeStoreSSHID(ctx context.Context, value string) string {
+// MaybeStoreSSHID stores the SSHID in the context as metadata if is not set yet.
+func MaybeStoreSSHID(ctx gliderssh.Context, value string) string {
 	return maybeStore(ctx, sshid, value).(string)
 }
 
 type AuthenticationMethod int
 
 // StoreAuthenticationMethod stores the authentication method in the context/ as metadata.
-func StoreAuthenticationMethod(ctx context.Context, method AuthenticationMethod) {
+func StoreAuthenticationMethod(ctx gliderssh.Context, method AuthenticationMethod) {
 	store(ctx, authentication, method)
 }
 
-// StorePassword stores the password in the context/ as metadata.
-func StorePassword(ctx context.Context, value string) {
+// StorePassword stores the password in the context as metadata.
+func StorePassword(ctx gliderssh.Context, value string) {
 	store(ctx, password, value)
 }
 
-// MaybeStoreFingerprint stores the fingerprint in the context/ as metadata if is not set yet.
-func MaybeStoreFingerprint(ctx context.Context, value string) string {
+// MaybeStoreFingerprint stores the fingerprint in the context as metadata if is not set yet.
+func MaybeStoreFingerprint(ctx gliderssh.Context, value string) string {
 	return maybeStore(ctx, fingerprint, value).(string)
 }
 
-// MaybeStoreTarget stores the target in the context/ as metadata if is not set yet.
-func MaybeStoreTarget(ctx context.Context, sshid string) (*target.Target, error) {
+// MaybeStoreTarget stores the target in the context as metadata if is not set yet.
+func MaybeStoreTarget(ctx gliderssh.Context, sshid string) (*target.Target, error) {
 	value, err := target.NewTarget(sshid)
 	if err != nil {
 		return nil, err
@@ -65,7 +63,7 @@ func MaybeStoreTarget(ctx context.Context, sshid string) (*target.Target, error)
 	return maybeStore(ctx, tag, value).(*target.Target), nil
 }
 
-func MaybeSetAPI(ctx context.Context, client internalclient.Client) internalclient.Client {
+func MaybeSetAPI(ctx gliderssh.Context, client internalclient.Client) internalclient.Client {
 	value := maybeStore(ctx, api, client)
 	if value == nil {
 		return nil
@@ -74,8 +72,8 @@ func MaybeSetAPI(ctx context.Context, client internalclient.Client) internalclie
 	return value.(internalclient.Client)
 }
 
-// MaybeStoreLookup stores the lookup in the context/ as metadata if is not set yet.
-func MaybeStoreLookup(ctx context.Context, tag *target.Target, api internalclient.Client) (map[string]string, error) {
+// MaybeStoreLookup stores the lookup in the context as metadata if is not set yet.
+func MaybeStoreLookup(ctx gliderssh.Context, tag *target.Target, api internalclient.Client) (map[string]string, error) {
 	var value map[string]string
 	setValue := func(namespace, hostname string) {
 		value = map[string]string{
@@ -104,12 +102,22 @@ func MaybeStoreLookup(ctx context.Context, tag *target.Target, api internalclien
 	return maybeStore(ctx, lookup, value).(map[string]string), nil
 }
 
-// MaybeStoreDevice stores the device in the context/ as metadata if is not set yet.
-func MaybeStoreDevice(ctx context.Context, lookup map[string]string, api internalclient.Client) (*models.Device, []error) {
+// MaybeStoreDevice stores the device in the context as metadata if is not set yet.
+func MaybeStoreDevice(ctx gliderssh.Context, lookup map[string]string, api internalclient.Client) (*models.Device, []error) {
 	value, errs := api.DeviceLookup(lookup)
 	if len(errs) > 0 {
 		return nil, errs
 	}
 
 	return maybeStore(ctx, device, value).(*models.Device), nil
+}
+
+// MaybeStoreAgent stores the agent in the context as metadata if is not set yet.
+func MaybeStoreAgent(ctx gliderssh.Context, client *gossh.Client) *gossh.Client {
+	return maybeStore(ctx, agent, client).(*gossh.Client)
+}
+
+// MaybeStoreEstablished stores the connection established status between server and agent in the context as metadata if is not set yet.
+func MaybeStoreEstablished(ctx gliderssh.Context, value bool) bool {
+	return maybeStore(ctx, established, value).(bool)
 }

--- a/ssh/server/channels/tcpip.go
+++ b/ssh/server/channels/tcpip.go
@@ -1,0 +1,88 @@
+package channels
+
+import (
+	"io"
+	"net"
+	"strconv"
+
+	gliderssh "github.com/gliderlabs/ssh"
+	"github.com/shellhub-io/shellhub/ssh/pkg/metadata"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+const (
+	// DirectTCPIPChannel is the channel type for direct-tcpip channels.
+	// It is used for local port forwarding.
+	// e.g. `ssh -L 8080:localhost:80 user@sshid`.
+	DirectTCPIPChannel = "direct-tcpip"
+	// DynamicTCPIPChannel is the channel type for dynamic-tcpip channels.
+	// It is used for dynamic port forwarding.
+	// e.g. `ssh -D 1080 user@sshid`.
+	DynamicTCPIPChannel = "dynamic-tcpip"
+)
+
+// DefaultTCPIPHandler is the default handler for DirectTCPIPChannel and DynamicTCPIPChannel channels.
+//
+// It will reject the channel if the LocalPortForwardingCallback is not set or returns false.
+// Otherwise, it will dial the agent and proxy the channel.
+func DefaultTCPIPHandler(server *gliderssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
+	type channelData struct {
+		DestAddr   string
+		DestPort   uint32
+		OriginAddr string
+		OriginPort uint32
+	}
+
+	data := channelData{}
+	if err := gossh.Unmarshal(newChan.ExtraData(), &data); err != nil {
+		newChan.Reject(gossh.ConnectionFailed, "error parsing forward data: "+err.Error()) //nolint:errcheck
+
+		return
+	}
+
+	if server.LocalPortForwardingCallback == nil || !server.LocalPortForwardingCallback(ctx, data.DestAddr, data.DestPort) {
+		newChan.Reject(gossh.Prohibited, "port forwarding is disabled") //nolint:errcheck
+
+		return
+	}
+
+	if !metadata.RestoreEstablished(ctx) {
+		newChan.Reject(gossh.Prohibited, "connection between server and agent is not established yet") //nolint:errcheck
+
+		return
+	}
+
+	dest := net.JoinHostPort(data.DestAddr, strconv.FormatInt(int64(data.DestPort), 10))
+
+	agent := metadata.RestoreAgent(ctx)
+	if agent == nil {
+		newChan.Reject(gossh.ConnectionFailed, "error restoring the agent") //nolint:errcheck
+
+		return
+	}
+
+	dialed, err := agent.Dial("tcp", dest)
+	if err != nil {
+		newChan.Reject(gossh.ConnectionFailed, "error dialing the agent to host and port: "+err.Error()) //nolint:errcheck
+
+		return
+	}
+
+	channel, reqs, err := newChan.Accept()
+	if err != nil {
+		newChan.Reject(gossh.ConnectionFailed, "error accepting the channel: "+err.Error()) //nolint:errcheck
+
+		return
+	}
+
+	go gossh.DiscardRequests(reqs)
+
+	go func() {
+		defer channel.Close()
+		io.Copy(channel, dialed) //nolint:errcheck
+	}()
+	go func() {
+		defer channel.Close()
+		io.Copy(dialed, channel) //nolint:errcheck
+	}()
+}

--- a/ssh/server/handler/sftp.go
+++ b/ssh/server/handler/sftp.go
@@ -29,8 +29,7 @@ func SFTPSubsystemHandler(tunnel *httptunnel.Tunnel) gliderssh.SubsystemHandler 
 			"sshid": client.User(),
 		}).Info("SFTP connection closed")
 
-		ctx, cancel := context.WithCancel(client.Context())
-		defer cancel()
+		ctx := client.Context()
 
 		api := metadata.RestoreAPI(ctx)
 


### PR DESCRIPTION
```
I have added handlers to deal with data coming from `direct-tpcip` and
`dynamic-tcpip` channels, consequently enabling Local Port Forward and
Dynamic Port Forward.

e.g. `ssh -L 8080:localhost:80 user@host`
e.g. `ssh -D 1080 user@host`
```

https://github.com/shellhub-io/shellhub/issues/513