### PR TITLE
new-ui: bugs found in 0.11-rc-4

### DIFF
--- a/new-ui/src/App.vue
+++ b/new-ui/src/App.vue
@@ -31,6 +31,8 @@ export default defineComponent({
     onMounted(async () => {
       if (!isLoggedIn.value) {
         store.dispatch("layout/setLayout", "simpleLayout");
+        await store.dispatch("auth/logout");
+        router.push("/login");
       }
 
       if (!hasLoggedID.value && isLoggedIn.value) {

--- a/new-ui/src/components/AppBar/Notifications/Notification.vue
+++ b/new-ui/src/components/AppBar/Notifications/Notification.vue
@@ -2,6 +2,7 @@
   <v-menu>
     <template v-slot:activator="{ props }">
       <v-badge
+        v-bind="$props"
         v-if="showNumberNotifications > 0"
         :content="showNumberNotifications"
         :value="showNumberNotifications"
@@ -11,10 +12,10 @@
         data-test="notifications-badge"
       >
         <v-icon
+          v-bind="props"
           class="ml-2 mr-2"
           color="primary"
           :size="defaultSize"
-          v-bind="props"
           aria-label="notifications-icon"
           @click="getNotifications()"
         >
@@ -22,11 +23,11 @@
         </v-icon>
       </v-badge>
       <v-icon
+        v-bind="props"
         v-else
         class="ml-2 mr-2"
         color="primary"
         :size="defaultSize"
-        v-bind="props"
         aria-label="notifications-icon"
         @click="getNotifications()"
       >
@@ -40,13 +41,12 @@
       offset-x="20"
     >
       <v-card-subtitle>Pending Devices</v-card-subtitle>
-
       <v-divider />
 
-      <v-list class="pa-0">
-        <v-list-group :v-model="1">
-          <v-list-item v-for="item in listNotifications" :key="item.uid">
-            <div>
+      <v-list class="pa-0" density="compact">
+        <v-list-item-group :v-model="1">
+          <v-list-item class="d-flex" v-for="item in listNotifications" :key="item.uid">
+            <template v-slot:prepend>
               <v-list-item-title>
                 <router-link
                   :to="{ name: 'detailsDevice', params: { id: item.uid } }"
@@ -55,7 +55,7 @@
                   {{ item.name }}
                 </router-link>
               </v-list-item-title>
-            </div>
+            </template>
 
             <v-list-item-action>
               <DeviceActionButton
@@ -69,7 +69,7 @@
               />
             </v-list-item-action>
           </v-list-item>
-        </v-list-group>
+        </v-list-item-group>
       </v-list>
 
       <v-divider />
@@ -109,11 +109,14 @@ import { useStore } from "../../../store";
 import { authorizer, actions } from "../../../authorizer";
 import hasPermission from "../../../utils/permission";
 import { INotificationsError } from "../../../interfaces/INotifications";
-// import DeviceActionButton from "../../../components/Devices/DeviceActionButton.vue";
+import DeviceActionButton from "../../../components/Devices/DeviceActionButton.vue";
 
 export default defineComponent({
   name: "Notification",
   inheritAttrs: false,
+  components: {
+    DeviceActionButton,
+  },
   setup() {
     const store = useStore();
     const numberNotifications = ref(0);
@@ -207,11 +210,6 @@ export default defineComponent({
       refresh,
       show,
     };
-  },
-  components: {
-    DeviceActionButton: defineAsyncComponent(
-      () => import("../../../components/Devices/DeviceActionButton.vue"),
-    ),
   },
 });
 </script>

--- a/new-ui/src/components/Billing/BillingWarning.vue
+++ b/new-ui/src/components/Billing/BillingWarning.vue
@@ -26,11 +26,12 @@
       <v-card-actions>
         <v-spacer />
 
-        <v-btn text data-test="close-btn" @click="close()"> Close </v-btn>
+        <v-btn variant="text" data-test="close-btn" @click="close()"> Close </v-btn>
 
         <v-btn
           to="/settings/billing"
-          text
+          variant="text"
+          color="primary"
           data-test="goToBilling-btn"
           @click="close()"
         >

--- a/new-ui/src/components/Devices/DeviceActionButton.vue
+++ b/new-ui/src/components/Devices/DeviceActionButton.vue
@@ -1,19 +1,21 @@
 <template>
   <v-list-item @click="dialog = !dialog">
     <v-btn
+      v-bind="$attrs"
       v-if="notificationStatus"
-      x-small
+      size="x-small"
       color="primary"
       data-test="notification-btn"
       @click="doAction()"
     >
-      {{ icon }}
+      <v-icon> {{ icon }} </v-icon>
       Accept
     </v-btn>
     <v-tooltip location="bottom" class="text-center" :disabled="hasAuthorization" v-else>
       <template v-slot:activator="{ props }">
         <span v-bind="props">
           <v-list-item-title data-test="action-item" v-on="props">
+            <v-icon> {{ icon }}</v-icon>
             {{ capitalizeText(action) }}
           </v-list-item-title>
         </span>
@@ -21,7 +23,7 @@
       <span> You don't have this kind of authorization. </span>
     </v-tooltip>
   </v-list-item>
-  <v-dialog max-width="450px" v-model="dialog" @click:outside="close">
+  <v-dialog max-width="450px" v-model="dialog" @click:outside="close" v-bind="$attrs">
     <v-card class="bg-v-theme-surface">
       <v-card-title class="text-h5 pa-5 bg-primary">
         Are you sure?

--- a/new-ui/src/components/Devices/DeviceRejectedList.vue
+++ b/new-ui/src/components/Devices/DeviceRejectedList.vue
@@ -24,21 +24,7 @@
             <span>{{ item.info.pretty_name }}</span>
           </td>
           <td class="text-center">
-            <v-chip>
-              <v-tooltip location="bottom">
-                <template v-slot:activator="{ props }">
-                  <span
-                    v-bind="props"
-                    @click="copyText(sshidAddress(item))"
-                    @keypress="copyText(sshidAddress(item))"
-                    class="hover-text"
-                  >
-                    {{ sshidAddress(item) }}
-                  </span>
-                </template>
-                <span>Copy ID</span>
-              </v-tooltip>
-            </v-chip>
+            {{ formatDate(item.last_seen) }}
           </td>
 
           <td class="text-center">
@@ -49,41 +35,19 @@
                 </v-chip>
               </template>
               <v-list class="bg-v-theme-surface" lines="two" density="compact">
-                <v-list-item @click="redirectToDevice(item)">
-                  <div class="d-flex align-center">
-                    <div class="mr-2">
-                      <v-icon> mdi-information </v-icon>
-                    </div>
+                <DeviceActionButton
+                  :uid="item.uid"
+                  action="accept"
+                  data-test="DeviceActionButtonAccept-component"
+                  @update="refreshDevices"
+                />
 
-                    <v-list-item-title data-test="mdi-information-list-item">
-                      Details
-                    </v-list-item-title>
-                  </div>
-                </v-list-item>
-
-                <v-list-item @click="redirectToDevice(item)">
-                  <div class="d-flex align-center">
-                    <div class="mr-2">
-                      <v-icon> mdi-tag </v-icon>
-                    </div>
-
-                    <v-list-item-title data-test="mdi-information-list-item">
-                      Edit tags
-                    </v-list-item-title>
-                  </div>
-                </v-list-item>
-
-                <v-list-item @click="redirectToDevice(item)">
-                  <div class="d-flex align-center">
-                    <div class="mr-2">
-                      <v-icon> mdi-delete </v-icon>
-                    </div>
-
-                    <v-list-item-title data-test="mdi-information-list-item">
-                      Remove
-                    </v-list-item-title>
-                  </div>
-                </v-list-item>
+                <DeviceActionButton
+                  :uid="item.uid"
+                  action="remove"
+                  data-test="deviceActionButtonRemove-component"
+                  @update="refreshDevices"
+                />
               </v-list>
             </v-menu>
           </td>
@@ -106,6 +70,7 @@ import {
   INotificationsCopy,
   INotificationsError,
 } from "../../interfaces/INotifications";
+import DeviceActionButton from "./DeviceActionButton.vue";
 
 export default defineComponent({
   setup() {
@@ -151,6 +116,7 @@ export default defineComponent({
           perPage: perPagaeValue,
           page: pageValue,
           filter: filter.value,
+          status: "rejected",
           sortStatusField: store.getters["devices/sortStatusField"],
           sortStatusString: store.getters["devices/sortStatusString"],
         });
@@ -214,6 +180,10 @@ export default defineComponent({
       router.push({ name: "deviceDetails", params: { id: deviceId } });
     };
 
+    const refreshDevices = () => {
+      getDevices(itemsPerPage.value, page.value);
+    };
+
     const sshidAddress = (item: any) => `${item.namespace}.${item.name}@${window.location.hostname}`;
 
     const copyText = (value: string | undefined) => {
@@ -262,9 +232,10 @@ export default defineComponent({
       redirectToDevice,
       sshidAddress,
       copyText,
+      refreshDevices,
     };
   },
-  components: { DataTable, DeviceIcon },
+  components: { DataTable, DeviceIcon, DeviceActionButton },
 });
 </script>
 

--- a/new-ui/src/components/Setting/SettingBilling.vue
+++ b/new-ui/src/components/Setting/SettingBilling.vue
@@ -311,8 +311,6 @@ export default defineComponent({
       if (active.value) {
         try {
           await store.dispatch("billing/getSubscription");
-          console.log("billing data", billing.value)
-          console.log("billing billingData", billingData.value)
           renderData.value = true;
         } catch (error: any) {
           renderData.value = false;

--- a/new-ui/src/components/Setting/SettingNamespace.vue
+++ b/new-ui/src/components/Setting/SettingNamespace.vue
@@ -8,7 +8,7 @@
           </v-col>
           <v-spacer />
           <v-col>
-            <v-card tile :elevation="0">
+            <v-card tile :elevation="0" class="bg-v-theme-surface">
               <v-chip>
                 <v-tooltip location="top">
                   <template v-slot:activator="{ props }">

--- a/new-ui/src/components/Setting/SettingProfile.vue
+++ b/new-ui/src/components/Setting/SettingProfile.vue
@@ -87,7 +87,7 @@
               <v-btn
                 color="primary"
                 @click="updatePassword"
-                :disabled="currentPasswordError !== '' || newPasswordConfirmError !== ''"
+                :disabled="hasUpdatePasswordError"
               > Save </v-btn>
             </div>
           </v-col>
@@ -285,6 +285,9 @@ export default defineComponent({
       currentPasswordError.value
         || newPasswordError.value
         || newPasswordConfirmError.value
+        || newPassword.value === ""
+        || newPasswordConfirm.value === ""
+        || currentPassword.value === ""
     ));
 
     const resetPasswordFields = () => {
@@ -355,6 +358,7 @@ export default defineComponent({
       showCurrentPassword,
       showNewPassword,
       showConfirmPassword,
+      hasUpdatePasswordError,
       updateUserData,
       updatePassword,
       cancel,

--- a/new-ui/src/components/firewall/FirewallRuleAdd.vue
+++ b/new-ui/src/components/firewall/FirewallRuleAdd.vue
@@ -406,6 +406,11 @@ export default defineComponent({
         return true;
       }
 
+      if (choiceFilter.value === "tags" && tagChoices.value.length === 0) {
+        errMsg.value = "You must choose at least one tag";
+        return true;
+      }
+
       return false;
     };
 

--- a/new-ui/src/components/firewall/FirewallRuleEdit.vue
+++ b/new-ui/src/components/firewall/FirewallRuleEdit.vue
@@ -439,6 +439,11 @@ export default defineComponent({
         return true;
       }
 
+      if (choiceFilter.value === "tags" && tagChoices.value.length === 0) {
+        errMsg.value = "This Field is required !";
+        return true;
+      }
+
       return false;
     };
 

--- a/new-ui/src/store/modules/devices.ts
+++ b/new-ui/src/store/modules/devices.ts
@@ -143,6 +143,7 @@ export const devices: Module<DevicesState, State> = {
           return res;
         }
 
+        commit("clearListDevices");
         return false;
       } catch (error) {
         commit("clearListDevices");

--- a/new-ui/src/store/modules/notifications.ts
+++ b/new-ui/src/store/modules/notifications.ts
@@ -35,7 +35,14 @@ export const notifications: Module<NotificationsState, State> = {
   actions: {
     fetch: async (context) => {
       try {
-        const res = await apiDevice.fetchDevices(10, 1, "", "pending", "", "");
+        const res = await apiDevice.fetchDevices(
+          1,
+          10,
+          "",
+          "pending",
+          null,
+          "",
+        );
         context.commit("setNotifications", res);
       } catch (error) {
         context.commit("clearListNotifications");

--- a/new-ui/src/views/UpdatePassword.vue
+++ b/new-ui/src/views/UpdatePassword.vue
@@ -92,7 +92,7 @@
 
 <script lang="ts">
 import { useField } from "vee-validate";
-import { defineComponent, onMounted, ref } from "vue";
+import { defineComponent, onMounted, ref, watch } from "vue";
 import { LocationQueryValue, useRoute, useRouter } from "vue-router";
 import * as yup from "yup";
 import Logo from "../assets/logo-inverted.png";
@@ -120,6 +120,7 @@ export default defineComponent({
     const {
       value: password,
       errorMessage: passwordError,
+      setErrors: setPasswordError,
     } = useField<string>(
       "password",
       yup
@@ -135,6 +136,8 @@ export default defineComponent({
     const {
       value: passwordConfirm,
       errorMessage: passwordConfirmError,
+      resetField: resetPasswordConfirm,
+      setErrors: setPasswordConfirmError,
     } = useField<string>(
       "passwordConfirm",
       yup
@@ -158,8 +161,40 @@ export default defineComponent({
       };
     });
 
+    watch(password, () => {
+      if (password.value === passwordConfirm.value) {
+        resetPasswordConfirm();
+      }
+
+      if (password.value !== passwordConfirm.value && passwordConfirm.value) {
+        setPasswordConfirmError("Passwords do not match");
+      }
+    });
+
+    const hasErros = () => {
+      if (password.value === "") {
+        setPasswordError("this is a required field");
+        return true;
+      }
+
+      if (passwordConfirm.value === "") {
+        setPasswordConfirmError("this is a required field");
+        return true;
+      }
+
+      if (passwordError.value) {
+        return true;
+      }
+
+      if (passwordConfirmError.value) {
+        return true;
+      }
+
+      return false;
+    };
+
     const updatePassword = async () => {
-      if (passwordError.value || passwordConfirmError.value) return;
+      if (hasErros()) return;
       try {
         data.value = {
           ...data.value,
@@ -172,7 +207,6 @@ export default defineComponent({
           INotificationsSuccess.updatingAccount,
         );
       } catch (error: any) {
-        console.log(error);
         store.dispatch(
           "snackbar/showSnackbarErrorAction",
           INotificationsError.updatingAccount,


### PR DESCRIPTION
- Don’t send request on Add/Edit firewall rule with empty tags field
- Update password, save button is disabled
- Tenant ID copy has a wrong background color
- Reset password if edit the second input first, the error “Password not match”
- Billing data in console log.
- Filtering devices accept, reject, pending. Show all in the pages.
- Billing warning not showing.
- Made dashboard request when user is not logged
- Fix devices pending on notification component
- Fix rejected devices lists page