### PR TITLE
cicd: refactors linters configuration

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -106,7 +106,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: ${{ matrix.project }}
-          version: v3.4.0
+          version: v1.51.2
           args: ${{ matrix.lint_args }}
           skip-pkg-cache: true
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,31 @@ output:
   uniq-by-line: true
   sort-results: true
 
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - revive
+    - gosimple
+    - govet
+    - ineffassign
+    - exportloopref
+    - staticcheck
+    - unconvert
+    - unused
+    - misspell
+    - goimports
+    - typecheck
+    - errcheck
+    - whitespace
+    - depguard
+    - stylecheck
+    - nlreturn
+    - nilerr
+
 linters-settings:
+  staticcheck:
+    checks: ["all", "-SA1029"]
   depguard:
     list-type: blacklist
     include-go-root: true
@@ -15,74 +39,9 @@ linters-settings:
     packages-with-error-message:
       - github.com/satori/go.uuid: "Uuid generation is only allowed using 'github.com/shellhub-io/shellhub/pkg/uuid'"
       - github.com/dgrijalva/jwt-go: "dgrijalva/jwt-go is deprecated please use 'github.com/golang-jwt/jwt'"
-
-  stylecheck:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.20"
-    # https://staticcheck.io/docs/options#checks
-    checks: [ "all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022" ]
-    # https://staticcheck.io/docs/options#dot_import_whitelist
-    dot-import-whitelist:
-      - fmt
-    # https://staticcheck.io/docs/options#initialisms
-    initialisms: [ "ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS" ]
-    # https://staticcheck.io/docs/options#http_status_code_whitelist
-    http-status-code-whitelist: [ "200", "400", "404", "500" ]
-
-  unused:
-    # Select the Go version to target. The default is '1.13'.
-    go: "1.20"
-
   whitespace:
-    multi-if: true   # Enforces newlines (or comments) after every multi-line if statement
-    multi-func: true # Enforces newlines (or comments) after every multi-line function signature
-
-linters:
-  enable-all: true
-  disable:
-    - gomoddirectives
-    - bodyclose
-    - cyclop
-    - dupl
-    - errorlint
-    - exhaustivestruct
-    - funlen
-    - gci
-    - gocognit
-    - godox
-    - goerr113
-    - golint
-    - gomnd
-    - interfacer
-    - lll
-    - maligned
-    - noctx
-    - paralleltest
-    - testpackage
-    - wrapcheck
-    - wsl
-
-    # we use it inside pkg/
-    - gochecknoinits
-    - gochecknoglobals
-    - tagliatelle
-
-issues:
-  exclude:
-    # govet: unkeyed fields use
-    - composite
-    - Using the variable on range scope `tc` in function literal
-
-  exclude-rules:
-    - linters:
-        - staticcheck
-
-      # TODO: We should rework the code to avoid this issue; this will be done
-      # during more deep code rework so for now, we'll skip it.
-      text: "SA1029:"
-
-    - linters:
-        - govet
-
-      # validate is unknown but it is a valid tag.
-      text: "structtag: struct field tag .* validate:"
+    multi-if: true
+    multi-func: true
+  govet:
+    disable:
+      - composites

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/agent
 
-go 1.17
+go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962

--- a/agent/server/utmp/utmp.go
+++ b/agent/server/utmp/utmp.go
@@ -218,7 +218,7 @@ func updWtmp(u Utmpx) {
 		}).Warn("Lock failed")
 	}
 
-	fileSize, err := file.Seek(0, os.SEEK_END)
+	fileSize, err := file.Seek(0, io.SeekEnd)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
 			"file": WtmpxFile,

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/api
 
-go 1.17
+go 1.18
 
 require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/cli
 
-go 1.17
+go 1.18
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-playground/validator/v10 v10.11.2

--- a/ssh/go.mod
+++ b/ssh/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/ssh
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gliderlabs/ssh v0.3.5


### PR DESCRIPTION
This commit updates the linters configuration file to disable
all linters by default and enable only the necessary ones.
Also, the deprecated linters have been replaced.

As a result, all `go.mod` files were updated to require Go 1.18
