### PR TITLE
gateway: update proxy_pass config to use var for upstream server

### DIFF
--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -397,10 +397,12 @@ server {
    server_name ~^(?<namespace>.+)\.(?<device>.+)\..+$;
 
    location / { #~ ^/(.*)$ {
+       set $upstream ssh:8080;
+
        rewrite ^/(.*)$ /ssh/http break;
        proxy_set_header X-Namespace $namespace;
        proxy_set_header X-Device $device;
        proxy_set_header X-Path /$1$is_args$args;
-       proxy_pass http://ssh:8080;
+       proxy_pass http://$upstream;
    }
 }


### PR DESCRIPTION
This commit updates the `proxy_pass` configuration to use a
variable for the upstram server instead of a hardcoded value.

By using a variable in the `proxy_pass` configuration, the DNS
resolution occurs dynamically rather than when nginx starts up.
This will prevent nginx from exiting with a
"host not found in upstream" error if the host is not yet
available on the network.
