### PR TITLE
env: Add SHELLHUB_PUBLIC_URL_DOMAIN env

### DIFF
--- a/.env
+++ b/.env
@@ -31,6 +31,10 @@ SHELLHUB_REDIRECT_TO_HTTPS=false
 # Values: a valid domain name
 SHELLHUB_DOMAIN=localhost
 
+# Public URL domain
+# It is used to generate the public URL for accessing devices via HTTP
+SHELLHUB_PUBLIC_URL_DOMAIN=
+
 # Enable geoip (geolocation)
 # NOTICE: When true, SHELLHUB_MAXMIND_LICENSE is required
 SHELLHUB_GEOIP=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
     image: shellhubio/gateway:${SHELLHUB_VERSION}
     restart: unless-stopped
     environment:
+      - SHELLHUB_DOMAIN=${SHELLHUB_DOMAIN}
+      - SHELLHUB_PUBLIC_URL_DOMAIN=${SHELLHUB_PUBLIC_URL_DOMAIN}
       - SHELLHUB_VERSION=${SHELLHUB_VERSION}
       - SHELLHUB_SSH_PORT=${SHELLHUB_SSH_PORT}
       - SHELLHUB_PROXY=${SHELLHUB_PROXY}

--- a/gateway/shellhub.conf
+++ b/gateway/shellhub.conf
@@ -392,12 +392,13 @@ server {
     }
 }
 
+{{- $PUBLIC_URL_DOMAIN := or (env.Getenv "SHELLHUB_PUBLIC_URL_DOMAIN") (env.Getenv "SHELLHUB_DOMAIN") }}
 server {
    listen 80;
-   server_name ~^(?<namespace>.+)\.(?<device>.+)\..+$;
+   server_name ~^(?<namespace>.+)\.(?<device>.+)\.{{ $PUBLIC_URL_DOMAIN }}$;
    resolver 127.0.0.11 ipv6=off;
 
-   location / { #~ ^/(.*)$ {
+   location / {
        set $upstream ssh:8080;
 
        rewrite ^/(.*)$ /ssh/http break;


### PR DESCRIPTION
This commit adds the `SHELLHUB_PUBLIC_URL_DOMAIN` environment variable to the `.env` file, which is used to define the public URL domain for accessing devices via HTTP in a ShellHub instance.

The value of this variable is used in the `gateway/shellhub.conf` file to generate the public URL for HTTP access.

The `docker-compose.yml` file is also updated to pass this variable to the gateway container.

NOTE: If `SHELLHUB_PUBLIC_URL_DOMAIN` is not defined, the value of `SHELLHUB_DOMAIN` is used as the default value.
