### PR TITLE
ui: fix add private key

### DIFF
--- a/ui/src/store/modules/private_key.ts
+++ b/ui/src/store/modules/private_key.ts
@@ -50,14 +50,16 @@ export function createPrivateKeyModule() {
 
     actions: {
       fetch: async (context) => {
-        const privateKeys = JSON.parse(localStorage.getItem("privateKeys") || "");
+        // @ts-expect-error
+        const privateKeys = JSON.parse(localStorage.getItem("privateKeys"));
         if (privateKeys !== null) {
           context.commit("fetchPrivateKey", privateKeys);
         }
       },
 
       set: async (context, privateKey) => {
-        const privateKeys = JSON.parse(localStorage.getItem("privateKeys") || "") || [];
+        // @ts-expect-error
+        const privateKeys = JSON.parse(localStorage.getItem("privateKeys")) || [];
 
         privateKeys.forEach((pk: IPrivateKey) => {
           if (pk.data === privateKey.data && pk.name === privateKey.name) {
@@ -89,7 +91,7 @@ export function createPrivateKeyModule() {
       },
 
       remove: async (context, data) => {
-        // @ts-ignore
+        // @ts-expect-error
         const privateKeys = JSON.parse(localStorage.getItem("privateKeys")) || [];
 
         if (privateKeys !== null) {


### PR DESCRIPTION
This error was occurred because, when the user doesn't have private keys, the old code tries to parse an empty string in an object.

closes #2554 