### PR TITLE
pkg: improve regex pattern for identifying Docker container IDs

### DIFF
--- a/pkg/dockerutils/utils.go
+++ b/pkg/dockerutils/utils.go
@@ -26,7 +26,7 @@ func CurrentContainerID() (string, error) {
 		return "", err
 	}
 
-	re := regexp.MustCompilePOSIX(`([0-9]+:[a-z_,=]+.*docker[/-]| (/@)?/var/lib/docker/containers/)([0-9a-f]{64})`)
+	re := regexp.MustCompilePOSIX(`([0-9]+:[a-z_,=]+.*docker[/-]|(/@)?/var/.+/docker(/.+)?/containers/)([0-9a-f]{64})`)
 	match := re.FindSubmatch(content)
 	if match == nil || len(match) != 4 {
 		return "", nil


### PR DESCRIPTION
This commit updates the regex pattern used to identify Docker container IDs.
The updated pattern is more flexible and should match a wider range of Docker setups.
