### PR TITLE
api,pkg: add slot strategy to block device switching

### DIFF
--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -109,6 +109,10 @@ var (
 	ErrAuthInvalid               = errors.New("auth invalid", ErrLayer, ErrCodeInvalid)
 	ErrAuthUnathorized           = errors.New("auth unauthorized", ErrLayer, ErrCodeUnauthorized)
 	ErrNamespaceLimitReached     = errors.New("namespace limit reached", ErrLayer, ErrCodeLimit)
+	ErrSlotList                  = errors.New("slot list", ErrLayer, ErrCodeNotFound)
+	ErrSlotSet                   = errors.New("slot set", ErrLayer, ErrCodeStore)
+	ErrSlotOccupied              = errors.New("slot occupied", ErrLayer, ErrCodeInvalid)
+	ErrSlotsFull                 = errors.New("slots full", ErrLayer, ErrCodePayment)
 )
 
 // NewErrNotFound returns an error with the ErrDataNotFound and wrap an error.
@@ -371,4 +375,24 @@ func NewErrAuthUnathorized(err error) error {
 // NewErrNamespaceLimitReached a error to be used when the user namespace limit number is reached.
 func NewErrNamespaceLimitReached(limit int, err error) error {
 	return NewErrLimit(ErrNamespaceLimitReached, limit, err)
+}
+
+// ErrSlotList is the error returned when the slot list fails.
+func NewErrSlotList(next error) error {
+	return NewErrInvalid(ErrSlotList, nil, next)
+}
+
+// NewErrSlotSet returns an error to be used when the slot set fails.
+func NewErrSlotSet(next error) error {
+	return NewErrInvalid(ErrSlotSet, nil, next)
+}
+
+// NewErrSlotOccupied returns an error to be used when the slot is occupied.
+func NewErrSlotOccupied(next error) error {
+	return NewErrInvalid(ErrSlotOccupied, nil, next)
+}
+
+// NewErrSlotsFull returns an error to be used when the slots are full.
+func NewErrSlotsFull(next error, limit int) error {
+	return NewErrLimit(ErrSlotsFull, limit, next)
 }

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -1541,6 +1541,60 @@ func (_m *Store) SessionUpdateDeviceUID(ctx context.Context, oldUID models.UID, 
 	return r0
 }
 
+// SlotDelete provides a mock function with given fields: ctx, tenant, uid
+func (_m *Store) SlotDelete(ctx context.Context, tenant string, uid models.UID) error {
+	ret := _m.Called(ctx, tenant, uid)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, models.UID) error); ok {
+		r0 = rf(ctx, tenant, uid)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SlotSet provides a mock function with given fields: ctx, tenant, uid, status
+func (_m *Store) SlotSet(ctx context.Context, tenant string, uid models.UID, status string) error {
+	ret := _m.Called(ctx, tenant, uid, status)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, models.UID, string) error); ok {
+		r0 = rf(ctx, tenant, uid, status)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SlotsList provides a mock function with given fields: ctx, tenatn
+func (_m *Store) SlotsList(ctx context.Context, tenatn string) ([]models.Slot, error) {
+	ret := _m.Called(ctx, tenatn)
+
+	var r0 []models.Slot
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]models.Slot, error)); ok {
+		return rf(ctx, tenatn)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []models.Slot); ok {
+		r0 = rf(ctx, tenatn)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.Slot)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, tenatn)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // TagDelete provides a mock function with given fields: ctx, tenant, tag
 func (_m *Store) TagDelete(ctx context.Context, tenant string, tag string) error {
 	ret := _m.Called(ctx, tenant, tag)

--- a/api/store/mongo/slot_store.go
+++ b/api/store/mongo/slot_store.go
@@ -1,0 +1,48 @@
+package mongo
+
+import (
+	"context"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func (s *Store) SlotSet(ctx context.Context, tenant string, uid models.UID, status string) error {
+	_, err := s.db.Collection("slots").UpdateOne(ctx, bson.M{"tenant_id": tenant, "uid": uid}, bson.M{"$set": bson.M{"status": status, "updated_at": time.Now()}}, options.Update().SetUpsert(true))
+	if err != nil {
+		return FromMongoError(err)
+	}
+
+	return nil
+}
+
+// SlotDelete
+func (s *Store) SlotDelete(ctx context.Context, tenant string, uid models.UID) error {
+	_, err := s.db.Collection("slots").DeleteOne(ctx, bson.M{"tenant_id": tenant, "uid": uid})
+	if err != nil {
+		return FromMongoError(err)
+	}
+
+	return nil
+}
+
+func (s *Store) SlotsList(ctx context.Context, tenant string) ([]models.Slot, error) {
+	slots, err := s.db.Collection("slots").Find(ctx, bson.M{"tenant_id": tenant})
+	if err != nil {
+		return nil, FromMongoError(err)
+	}
+
+	var slotsList []models.Slot
+	for slots.Next(ctx) {
+		var slot models.Slot
+		if err := slots.Decode(&slot); err != nil {
+			return nil, FromMongoError(err)
+		}
+
+		slotsList = append(slotsList, slot)
+	}
+
+	return slotsList, nil
+}

--- a/api/store/slot_store.go
+++ b/api/store/slot_store.go
@@ -1,0 +1,13 @@
+package store
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+)
+
+type SlotStore interface {
+	SlotsList(ctx context.Context, tenatn string) ([]models.Slot, error)
+	SlotSet(ctx context.Context, tenant string, uid models.UID, status string) error
+	SlotDelete(ctx context.Context, tenant string, uid models.UID) error
+}

--- a/api/store/store.go
+++ b/api/store/store.go
@@ -15,4 +15,5 @@ type Store interface {
 	PrivateKeyStore
 	LicenseStore
 	StatsStore
+	SlotStore
 }

--- a/pkg/models/slot.go
+++ b/pkg/models/slot.go
@@ -1,0 +1,10 @@
+package models
+
+import "time"
+
+type Slot struct {
+	UID       UID       `json:"uid" bson:"uid"`
+	Tenant    string    `json:"tenant_id" bson:"tenant_id"`
+	Status    string    `json:"status" bson:"status"`
+	UpdatedAt time.Time `json:"updated_at" bson:"updated_at"`
+}


### PR DESCRIPTION
Here I introduce the concept of "slot", which is a way to control the number of
devices that namespace can have in a given time and when there is a device
limitation. The "slot" is a document that is created when a device is
"accepted" and its status change to "removed" when the device is deleted.
A "slot" with the status "removed" expires after a period of time, allowing a
new device to be accepted at its place.