### PR TITLE
ui: fixed white overlay changing it to transparent

### DIFF
--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -61,10 +61,10 @@
       </slot>
     </v-main>
 
-    <v-overlay v-model="hasSpinner">
-      <div class="full-width-height d-flex justify-center align-center">
+    <v-overlay :scrim="false" disabled v-model="hasSpinner">
+      <v-col class="full-width-height d-flex justify-center align-center">
         <v-progress-circular indeterminate size="64" alt="Request loading" />
-      </div>
+      </v-col>
     </v-overlay>
   </v-app>
 


### PR DESCRIPTION
## Description

The `app-layout` previous background was unnecessary and detracted from the overall polished appearance of our application.

## Steps to Reproduce

1. Run the `Shellhub.io`
2. Observe the request response from the `AppLayout` releasing the blinking loading screen.

## Expected Behavior

The `add-devices` script shouldn't emit a blinking background at every request.

## Environment

- Operating System: All


### Edition

Community, Cloud

### Version

v0.11.7
