### PR TITLE
ui: added non route page 404

### DIFF
--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -157,6 +157,15 @@ const routes: Array<RouteRecordRaw> = [
       },
     ],
   },
+  {
+    path: "/:catchAll(.*)",
+    redirect: { name: "NotFound" },
+  },
+  {
+    path: "/404",
+    name: "NotFound",
+    component: () => import("../views/NotFound.vue"),
+  },
 ];
 
 const router = createRouter({

--- a/ui/src/views/NotFound.vue
+++ b/ui/src/views/NotFound.vue
@@ -2,16 +2,15 @@
   <v-container>
     <v-row align="center" justify="center">
       <v-col cols="12" md="6" class="text-center">
-        <h1 class="text-h2 font-weight-bold mt-6 mb-4">Whoops!</h1>
+        <h1 class="text-h3 font-weight-bold mt-6 mb-4">Whoops!</h1>
         <v-row align="center" justify="center" class="mb-4">
-          <v-icon size="120" color="primary">mdi-bug</v-icon>
-          <h1 class="text-h1 font-weight-bold mt-4 mb-2">404</h1>
+          <v-icon size="110" color="primary">mdi-cloud-off-outline</v-icon>
+          <h1 class="text-h1 font-weight-bold mt-4 mb-2 text-primary">404</h1>
         </v-row>
         <p class="mb-5 font-weight-bold text-h3">Page not found</p>
-        <p class="mb-2 font-weight-bold">The requested URL was not found on the server. You can go back to the dashboard
+        <p class="mb-4 font-weight-bold text-h6">The requested URL was not found on the server. You can go back to the dashboard
           by clicking the button below.</p>
-        <br>
-        <v-btn color="primary" @click="$router.push({ name: 'Dashboard' })">Go to Dashboard</v-btn>
+        <v-btn color="primary" @click="$router.push({ name: 'Dashboard' })" data-test="dashboard-btn">Go to Dashboard</v-btn>
       </v-col>
     </v-row>
   </v-container>

--- a/ui/src/views/NotFound.vue
+++ b/ui/src/views/NotFound.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-container>
+    <v-row align="center" justify="center">
+      <v-col cols="12" md="6" class="text-center">
+        <h1 class="text-h2 font-weight-bold mt-6 mb-4">Whoops!</h1>
+        <v-row align="center" justify="center" class="mb-4">
+          <v-icon size="120" color="primary">mdi-bug</v-icon>
+          <h1 class="text-h1 font-weight-bold mt-4 mb-2">404</h1>
+        </v-row>
+        <p class="mb-5 font-weight-bold text-h3">Page not found</p>
+        <p class="mb-2 font-weight-bold">The requested URL was not found on the server. You can go back to the dashboard
+          by clicking the button below.</p>
+        <br>
+        <v-btn color="primary" @click="$router.push({ name: 'Dashboard' })">Go to Dashboard</v-btn>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "NotFound",
+});
+</script>

--- a/ui/tests/views/NotFound.spec.ts
+++ b/ui/tests/views/NotFound.spec.ts
@@ -1,0 +1,35 @@
+import { mount, VueWrapper } from "@vue/test-utils";
+import { createVuetify } from "vuetify";
+import { vi, expect, describe, it, beforeEach } from "vitest";
+import NotFound from "@/views/NotFound.vue";
+
+describe("NotFound.vue", () => {
+  let wrapper: VueWrapper<InstanceType<typeof NotFound>>;
+  const vuetify = createVuetify();
+  const $router = { push: vi.fn() };
+
+  beforeEach(async () => {
+    wrapper = mount(NotFound, {
+      global: {
+        plugins: [vuetify],
+        mocks: {
+          $router,
+        },
+      },
+    });
+  });
+
+  it("renders the correct text", () => {
+    expect(wrapper.find("h1.text-h3.font-weight-bold.mt-6.mb-4").text()).toMatch("Whoops!");
+    expect(wrapper.find("h1.text-h1.font-weight-bold.mt-4.mb-2.text-primary").text()).toMatch("404");
+    expect(wrapper.find("p.font-weight-bold.text-h3").text()).toMatch("Page not found");
+    // eslint-disable-next-line vue/max-len
+    expect(wrapper.find("p.font-weight-bold.text-h6").text()).toMatch("The requested URL was not found on the server. You can go back to the dashboard by clicking the button below.");
+    expect(wrapper.find('[data-test="dashboard-btn"]').exists()).toBe(true);
+  });
+
+  it("navigates to dashboard on button click", async () => {
+    await wrapper.find('[data-test="dashboard-btn"]').trigger("click");
+    expect($router.push).toHaveBeenCalledWith({ name: "Dashboard" });
+  });
+});


### PR DESCRIPTION
# Description
This Pull Request has changes for the `NotFound.vue` view which was added for non route urls to show.

This PR closes #2700

## Added Changes
Added `NotFound.vue` view
Added `NotFound` unitary test
Changed Router to show the new view when no known url is on the website

## Testing Instructions

Put the URL with any not used routes.
Observe the new 404 not found page.