### PR TITLE
gateway: add Let's Encrypt volume to Dockerfile

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,6 +12,8 @@ RUN mkdir -p /etc/nginx/default.d
 
 RUN mkdir /app
 
+VOLUME /etc/letsencrypt
+
 WORKDIR /app
 
 COPY ./gateway/entrypoint.sh /


### PR DESCRIPTION
This commit updates the gateway Dockerfile to add a Let's Encrypt volume
so that SSL certificates can be easily managed outside of the container
