### PR TITLE
docker: remove SHELLHUB_REDIRECT_TO_HTTPS and simplify docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -22,10 +22,6 @@ SHELLHUB_PROXY=false
 # Automatic HTTPS with Let's Encrypt
 SHELLHUB_AUTO_SSL=false
 
-# Redirect requests from HTTP port to HTTPS port
-# NOTICE: In order to enable HTTPS redirection, you need to have HTTPS enabled
-SHELLHUB_REDIRECT_TO_HTTPS=false
-
 # Domain of the server
 # NOTICE: Only required if automatic HTTPS is enabled
 # Values: a valid domain name

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -42,7 +42,7 @@ set +o allexport
 
 COMPOSE_FILE="docker-compose.yml"
 
-[ "$SHELLHUB_AUTO_SSL" = "true" ] && SSL_COMPOSE_FILE=autossl || SSL_COMPOSE_FILE=nossl
+[ "$SHELLHUB_AUTO_SSL" = "true" ] && SSL_COMPOSE_FILE=autossl
 
 COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.${SSL_COMPOSE_FILE}.yml"
 

--- a/docker-compose.nossl.yml
+++ b/docker-compose.nossl.yml
@@ -1,6 +1,0 @@
-version: '3.7'
-
-services:
-  gateway:
-    ports:
-      - "${SHELLHUB_HTTP_PORT}:80"


### PR DESCRIPTION
This commit removes the SHELLHUB_REDIRECT_TO_HTTPS variable from the
.env file and simplifies the docker-compose files.
The docker-compose.nossl.yml file is removed and the SSL_COMPOSE_FILE
variable in the bin/docker-compose script is updated to only include
the autossl suffix if SHELLHUB_AUTO_SSL is true.
