### PR TITLE
ui: changed device page list to disable if theres no more pages

### DIFF
--- a/ui/src/components/DataTable.vue
+++ b/ui/src/components/DataTable.vue
@@ -41,9 +41,13 @@
         />
       </div>
       <div class="d-flex align-center">
-        <v-btn icon="mdi-chevron-left" variant="plain" @click="$emit('clickPreviousPage')" />
+        <v-btn icon="mdi-chevron-left" variant="plain" @click="$emit('clickPreviousPage')" :disabled="pageQuantity <= 1" />
         <span class="text-subtitle-2">{{ actualPage }} of {{ pageQuantity }}</span>
-        <v-btn icon="mdi-chevron-right" variant="plain" @click="$emit('clickNextPage')" />
+        <v-btn
+          icon="mdi-chevron-right"
+          variant="plain"
+          @click="$emit('clickNextPage')"
+          :disabled="pageQuantity <= 1 || actualPage == pageQuantity" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Description
This Pull Request has changes for the `DataTable.vue`  to disable the arrow page choosers to disable when there's no pages

This PR closes #2723 

## Added Changes

Changed the arrow keys to disable when there no other page to move in.

## Testing Instructions

1. Move to the devices list.
2. Click the arrows to move to other pages.
3. Observe the behavior for changing pages to non-existent ones.
