### PR TITLE
fix: ui new connection button pre-load rerouting to login page

### DIFF
--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -1,57 +1,59 @@
 <template>
   <v-app :theme="getStatusDarkMode" v-bind="$attrs">
-    <v-navigation-drawer
-      theme="dark"
-      v-model="showNavigationDrawer"
-      app
-      class="bg-v-theme-surface"
-    >
-      <v-app-bar-title>
-        <router-link to="/" class="text-decoration-none">
-          <div class="d-flex justify-center pa-4 pb-2">
-            <v-img
-              class="d-sm-flex hidden-sm-and-down"
-              :src="Logo"
-              max-width="140"
-              alt="Shell logo, a cloud with the writing 'ShellHub' on the right side"
-            />
-          </div>
-        </router-link>
-        <v-divider class="ma-2" />
-      </v-app-bar-title>
-
-      <div class="pa-2">
-        <Namespace data-test="namespace-component" />
-        <v-divider class="ma-2" />
-      </div>
-
-      <v-list class="bg-v-theme-surface">
-        <v-list-item
-          v-for="item in visibleItems"
-          :key="item.title"
-          :to="item.path"
-          lines="two"
-          class="mb-2"
-          :disabled="disableItem(item.title)"
-        >
-          <div class="d-flex align-center">
-            <div class="mr-3">
-              <v-icon>
-                {{ item.icon }}
-              </v-icon>
+    <v-lazy>
+      <v-navigation-drawer
+        theme="dark"
+        v-model="showNavigationDrawer"
+        app
+        class="bg-v-theme-surface"
+      >
+        <v-app-bar-title>
+          <router-link to="/" class="text-decoration-none">
+            <div class="d-flex justify-center pa-4 pb-2">
+              <v-img
+                class="d-sm-flex hidden-sm-and-down"
+                :src="Logo"
+                max-width="140"
+                alt="Shell logo, a cloud with the writing 'ShellHub' on the right side"
+              />
             </div>
+          </router-link>
+          <v-divider class="ma-2" />
+        </v-app-bar-title>
 
-            <v-list-item-title :data-test="item.icon + '-listItem'">
-              {{ item.title }}
-            </v-list-item-title>
-          </div>
-        </v-list-item>
-        <v-col class="d-flex align-end justify-center">
-          <NewConnection />
-        </v-col>
-      </v-list>
-    </v-navigation-drawer>
+        <div class="pa-2">
+          <Namespace data-test="namespace-component" />
+          <v-divider class="ma-2" />
+        </div>
 
+        <v-list class="bg-v-theme-surface">
+          <v-list-item
+            v-for="item in visibleItems"
+            :key="item.title"
+            :to="item.path"
+            lines="two"
+            class="mb-2"
+            :disabled="disableItem(item.title)"
+          >
+            <div class="d-flex align-center">
+              <div class="mr-3">
+                <v-icon>
+                  {{ item.icon }}
+                </v-icon>
+              </div>
+
+              <v-list-item-title :data-test="item.icon + '-listItem'">
+                {{ item.title }}
+              </v-list-item-title>
+            </div>
+          </v-list-item>
+          <v-col class="d-flex align-end justify-center">
+            <NewConnection />
+          </v-col>
+
+        </v-list>
+      </v-navigation-drawer>
+    </v-lazy>
     <SnackbarComponent />
 
     <AppBar />


### PR DESCRIPTION
# Description

This PR fixes the issue and closes #2754  by modifying the code responsible for pre-loading the namespaces and everything in the App Side Bar. Now, they will only be loaded when the user is logged in and on a page that requires them. This will prevent the infinite loop and allow users to update their passwords without being redirected to the login page.

Overall, this PR improves the user experience and ensures that the App Side Bar components are loaded only when needed, reducing unnecessary loading times and errors.

## Expected Behavior

`Namespaces` and the `NewConnection` in the App Side Bar should only be loaded when the user is logged in and on a page that requires them.

## Actual Behavior

`Namespaces` and the `NewConnection`  in the App Side Bar were being pre-loaded even when the user was on an external route page or not logged in. This caused some parts to fail to load properly and triggered an error catch that redirected the user to the login page, resulting in an infinite loop.

## Environment

- Operating System: All

### Edition

Community, Cloud

### Version

v0.12