### PR TITLE
fix(ssh): force exit when exec command is run on agent less than 0.9.3

### DIFF
--- a/ssh/go.mod
+++ b/ssh/go.mod
@@ -3,6 +3,7 @@ module github.com/shellhub-io/shellhub/ssh
 go 1.20
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/gliderlabs/ssh v0.3.5
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/ssh/go.sum
+++ b/ssh/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
Agent version less than 0.9.3 does not support SSH exec command, what makes some request for it hang foverever. Version great than that, closes correctly and return the status code from the ran command.