### PR TITLE
fix(api): fix echo bind for headers what needs to be explicit

### DIFF
--- a/api/pkg/echo/handlers/binder.go
+++ b/api/pkg/echo/handlers/binder.go
@@ -19,5 +19,11 @@ func (b *Binder) Bind(s interface{}, c echo.Context) error {
 		return errors.NewErrUnprocessableEntity(err.Unwrap())
 	}
 
+	if err := binder.BindHeaders(c, s); err != nil {
+		err := err.(*echo.HTTPError) //nolint:forcetypeassert
+
+		return errors.NewErrUnprocessableEntity(err.Unwrap())
+	}
+
 	return nil
 }


### PR DESCRIPTION
The echo's bind function does not bind header implicite, we must convert our binder to echo's default one and ask it to bind the headers.