### PR TITLE
chore(api,pkg): rename method to update device status and request model

### DIFF
--- a/api/routes/device.go
+++ b/api/routes/device.go
@@ -22,7 +22,7 @@ const (
 	OfflineDeviceURL            = "/devices/:uid/offline"
 	HeartbeatDeviceURL          = "/devices/:uid/heartbeat"
 	LookupDeviceURL             = "/lookup"
-	UpdateStatusURL             = "/devices/:uid/:status"
+	UpdateDeviceStatusURL       = "/devices/:uid/:status"
 	CreateTagURL                = "/devices/:uid/tags"      // Add a tag to a device.
 	UpdateTagURL                = "/devices/:uid/tags"      // Update device's tags with a new set.
 	RemoveTagURL                = "/devices/:uid/tags/:tag" // Delete a tag from a device.
@@ -176,7 +176,7 @@ func (h *Handler) OfflineDevice(c gateway.Context) error {
 		return err
 	}
 
-	if err := h.service.UpdateDeviceStatus(c.Ctx(), models.UID(req.UID), false); err != nil {
+	if err := h.service.OffineDevice(c.Ctx(), models.UID(req.UID), false); err != nil {
 		return err
 	}
 
@@ -201,8 +201,8 @@ func (h *Handler) LookupDevice(c gateway.Context) error {
 	return c.JSON(http.StatusOK, device)
 }
 
-func (h *Handler) UpdatePendingStatus(c gateway.Context) error {
-	var req requests.DevicePendingStatus
+func (h *Handler) UpdateDeviceStatus(c gateway.Context) error {
+	var req requests.DeviceUpdateStatus
 	if err := c.Bind(&req); err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func (h *Handler) UpdatePendingStatus(c gateway.Context) error {
 		"unused":  "unused",
 	}
 	err := guard.EvaluatePermission(c.Role(), guard.Actions.Device.Accept, func() error {
-		err := h.service.UpdatePendingStatus(c.Ctx(), models.UID(req.UID), models.DeviceStatus(status[req.Status]), tenant)
+		err := h.service.UpdateDeviceStatus(c.Ctx(), models.UID(req.UID), models.DeviceStatus(status[req.Status]), tenant)
 
 		return err
 	})

--- a/api/routes/device_test.go
+++ b/api/routes/device_test.go
@@ -337,7 +337,7 @@ func TestOfflineDevice(t *testing.T) {
 			title: "returns Ok for setting an existing device as offline",
 			uid:   "123",
 			requiredMocks: func() {
-				mock.On("UpdateDeviceStatus", gomock.Anything, models.UID("123"), false).Return(nil)
+				mock.On("OffineDevice", gomock.Anything, models.UID("123"), false).Return(nil)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -345,7 +345,7 @@ func TestOfflineDevice(t *testing.T) {
 			title: "returns Not Found for setting a non-existing device as offline",
 			uid:   "1234",
 			requiredMocks: func() {
-				mock.On("UpdateDeviceStatus", gomock.Anything, models.UID("1234"), false).Return(svc.ErrNotFound)
+				mock.On("OffineDevice", gomock.Anything, models.UID("1234"), false).Return(svc.ErrNotFound)
 			},
 			expectedStatus: http.StatusNotFound,
 		},

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -56,7 +56,7 @@ func NewRouter(service services.Service) *echo.Echo {
 	internalAPI.POST(OfflineDeviceURL, gateway.Handler(handler.OfflineDevice))
 	internalAPI.POST(HeartbeatDeviceURL, gateway.Handler(handler.HeartbeatDevice))
 	internalAPI.GET(LookupDeviceURL, gateway.Handler(handler.LookupDevice))
-	publicAPI.PATCH(UpdateStatusURL, gateway.Handler(handler.UpdatePendingStatus))
+	publicAPI.PATCH(UpdateDeviceStatusURL, gateway.Handler(handler.UpdateDeviceStatus))
 
 	publicAPI.POST(CreateTagURL, gateway.Handler(handler.CreateDeviceTag))
 	publicAPI.DELETE(RemoveTagURL, gateway.Handler(handler.RemoveDeviceTag))

--- a/api/services/device.go
+++ b/api/services/device.go
@@ -25,8 +25,8 @@ type DeviceService interface {
 	DeleteDevice(ctx context.Context, uid models.UID, tenant string) error
 	RenameDevice(ctx context.Context, uid models.UID, name, tenant string) error
 	LookupDevice(ctx context.Context, namespace, name string) (*models.Device, error)
-	UpdateDeviceStatus(ctx context.Context, uid models.UID, online bool) error
-	UpdatePendingStatus(ctx context.Context, uid models.UID, status models.DeviceStatus, tenant string) error
+	OffineDevice(ctx context.Context, uid models.UID, online bool) error
+	UpdateDeviceStatus(ctx context.Context, uid models.UID, status models.DeviceStatus, tenant string) error
 	SetDevicePosition(ctx context.Context, uid models.UID, ip string) error
 	DeviceHeartbeat(ctx context.Context, uid models.UID) error
 	UpdateDevice(ctx context.Context, tenant string, uid models.UID, name *string, publicURL *bool) error
@@ -171,7 +171,7 @@ func (s *service) LookupDevice(ctx context.Context, namespace, name string) (*mo
 	return device, nil
 }
 
-func (s *service) UpdateDeviceStatus(ctx context.Context, uid models.UID, online bool) error {
+func (s *service) OffineDevice(ctx context.Context, uid models.UID, online bool) error {
 	err := s.store.DeviceSetOnline(ctx, uid, online)
 	if err == store.ErrNoDocuments {
 		return NewErrDeviceNotFound(uid, err)
@@ -180,7 +180,7 @@ func (s *service) UpdateDeviceStatus(ctx context.Context, uid models.UID, online
 	return err
 }
 
-func (s *service) UpdatePendingStatus(ctx context.Context, uid models.UID, status models.DeviceStatus, tenant string) error {
+func (s *service) UpdateDeviceStatus(ctx context.Context, uid models.UID, status models.DeviceStatus, tenant string) error {
 	validateStatus := map[string]bool{
 		"accepted": true,
 		"pending":  true,

--- a/api/services/device_test.go
+++ b/api/services/device_test.go
@@ -763,7 +763,7 @@ func TestLookupDevice(t *testing.T) {
 	mock.AssertExpectations(t)
 }
 
-func TestUpdateDeviceStatus(t *testing.T) {
+func TestOffineDevice(t *testing.T) {
 	mock := new(mocks.Store)
 
 	ctx := context.TODO()
@@ -802,7 +802,7 @@ func TestUpdateDeviceStatus(t *testing.T) {
 			tc.requiredMocks()
 
 			service := NewService(store.Store(mock), privateKey, publicKey, storecache.NewNullCache(), clientMock, nil)
-			err := service.UpdateDeviceStatus(ctx, tc.uid, tc.online)
+			err := service.OffineDevice(ctx, tc.uid, tc.online)
 			assert.Equal(t, tc.expected, err)
 		})
 	}
@@ -810,7 +810,7 @@ func TestUpdateDeviceStatus(t *testing.T) {
 	mock.AssertExpectations(t)
 }
 
-func TestUpdatePendingStatus(t *testing.T) {
+func TestUpdateDeviceStatus(t *testing.T) {
 	mock := new(mocks.Store)
 
 	ctx := context.TODO()
@@ -1319,7 +1319,7 @@ func TestUpdatePendingStatus(t *testing.T) {
 			tc.requiredMocks()
 
 			service := NewService(store.Store(mock), privateKey, publicKey, storecache.NewNullCache(), clientMock, nil)
-			err := service.UpdatePendingStatus(ctx, tc.uid, tc.status, tc.tenant)
+			err := service.UpdateDeviceStatus(ctx, tc.uid, tc.status, tc.tenant)
 			assert.Equal(t, tc.expected, err)
 		})
 	}

--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -961,6 +961,20 @@ func (_m *Service) LookupDevice(ctx context.Context, namespace string, name stri
 	return r0, r1
 }
 
+// OffineDevice provides a mock function with given fields: ctx, uid, online
+func (_m *Service) OffineDevice(ctx context.Context, uid models.UID, online bool) error {
+	ret := _m.Called(ctx, uid, online)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, models.UID, bool) error); ok {
+		r0 = rf(ctx, uid, online)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // PublicKey provides a mock function with given fields:
 func (_m *Service) PublicKey() *rsa.PublicKey {
 	ret := _m.Called()
@@ -1202,13 +1216,13 @@ func (_m *Service) UpdateDevice(ctx context.Context, tenant string, uid models.U
 	return r0
 }
 
-// UpdateDeviceStatus provides a mock function with given fields: ctx, uid, online
-func (_m *Service) UpdateDeviceStatus(ctx context.Context, uid models.UID, online bool) error {
-	ret := _m.Called(ctx, uid, online)
+// UpdateDeviceStatus provides a mock function with given fields: ctx, uid, status, tenant
+func (_m *Service) UpdateDeviceStatus(ctx context.Context, uid models.UID, status models.DeviceStatus, tenant string) error {
+	ret := _m.Called(ctx, uid, status, tenant)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, models.UID, bool) error); ok {
-		r0 = rf(ctx, uid, online)
+	if rf, ok := ret.Get(0).(func(context.Context, models.UID, models.DeviceStatus, string) error); ok {
+		r0 = rf(ctx, uid, status, tenant)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1237,20 +1251,6 @@ func (_m *Service) UpdatePasswordUser(ctx context.Context, id string, currentPas
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
 		r0 = rf(ctx, id, currentPassword, newPassword)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpdatePendingStatus provides a mock function with given fields: ctx, uid, status, tenant
-func (_m *Service) UpdatePendingStatus(ctx context.Context, uid models.UID, status models.DeviceStatus, tenant string) error {
-	ret := _m.Called(ctx, uid, status, tenant)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, models.UID, models.DeviceStatus, string) error); ok {
-		r0 = rf(ctx, uid, status, tenant)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/api/requests/device.go
+++ b/pkg/api/requests/device.go
@@ -34,13 +34,8 @@ type DeviceLookup struct {
 	IPAddress string `query:"ip_address" validate:""`
 }
 
-// DeviceUpdateStatus is the structure to represent the request data for device update status endpoint.
+// DeviceStatus is the structure to represent the request data for update device status to pending endpoint.
 type DeviceUpdateStatus struct {
-	DeviceParam
-}
-
-// DevicePendingStatus is the structure to represent the request data for update device status to pending endpoint.
-type DevicePendingStatus struct {
 	DeviceParam
 	Status string `param:"status" validate:"required,oneof=accept reject pending unused"`
 }


### PR DESCRIPTION
It only renames the methods, without refactoring the logic, what will be fixed next.