### PR TITLE
refactor(api,pkg): improve UpdateDeviceStatus service's method

### DIFF
--- a/api/routes/device.go
+++ b/api/routes/device.go
@@ -216,14 +216,14 @@ func (h *Handler) UpdateDeviceStatus(c gateway.Context) error {
 		tenant = c.Tenant().ID
 	}
 
-	status := map[string]string{
-		"accept":  "accepted",
-		"reject":  "rejected",
-		"pending": "pending",
-		"unused":  "unused",
+	status := map[string]models.DeviceStatus{
+		"accept":  models.DeviceStatusAccepted,
+		"reject":  models.DeviceStatusRejected,
+		"pending": models.DeviceStatusPending,
+		"unused":  models.DeviceStatusUnused,
 	}
 	err := guard.EvaluatePermission(c.Role(), guard.Actions.Device.Accept, func() error {
-		err := h.service.UpdateDeviceStatus(c.Ctx(), models.UID(req.UID), models.DeviceStatus(status[req.Status]), tenant)
+		err := h.service.UpdateDeviceStatus(c.Ctx(), tenant, models.UID(req.UID), status[req.Status])
 
 		return err
 	})

--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -117,6 +117,8 @@ var (
 	ErrDeviceRemovedDelete          = errors.New("device removed delete", ErrLayer, ErrCodeStore)
 	ErrDeviceRemovedGet             = errors.New("device removed get", ErrLayer, ErrCodeNotFound)
 	ErrBillingReportNamespaceDelete = errors.New("billing report namespace delete", ErrLayer, ErrCodePayment)
+	ErrBillingReportDevice          = errors.New("billing report device", ErrLayer, ErrCodePayment)
+	ErrBillingEvaluate              = errors.New("billing evaluate", ErrLayer, ErrCodePayment)
 )
 
 // NewErrNotFound returns an error with the ErrDataNotFound and wrap an error.
@@ -403,4 +405,16 @@ func NewErrDeviceRemovedGet(next error) error {
 
 func NewErrBillingReportNamespaceDelete(next error) error {
 	return NewErrInvalid(ErrBillingReportNamespaceDelete, nil, next)
+}
+
+func NewErrBillingReportDevice(next error) error {
+	return NewErrInvalid(ErrBillingReportDevice, nil, next)
+}
+
+func NewErrBillingEvaluate(next error) error {
+	return NewErrInvalid(ErrBillingEvaluate, nil, next)
+}
+
+func NewErrDeviceMaxDevicesReached(count int) error {
+	return NewErrLimit(ErrMaxDeviceCountReached, count, nil)
 }

--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -1216,13 +1216,13 @@ func (_m *Service) UpdateDevice(ctx context.Context, tenant string, uid models.U
 	return r0
 }
 
-// UpdateDeviceStatus provides a mock function with given fields: ctx, uid, status, tenant
-func (_m *Service) UpdateDeviceStatus(ctx context.Context, uid models.UID, status models.DeviceStatus, tenant string) error {
-	ret := _m.Called(ctx, uid, status, tenant)
+// UpdateDeviceStatus provides a mock function with given fields: ctx, tenant, uid, status
+func (_m *Service) UpdateDeviceStatus(ctx context.Context, tenant string, uid models.UID, status models.DeviceStatus) error {
+	ret := _m.Called(ctx, tenant, uid, status)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, models.UID, models.DeviceStatus, string) error); ok {
-		r0 = rf(ctx, uid, status, tenant)
+	if rf, ok := ret.Get(0).(func(context.Context, string, models.UID, models.DeviceStatus) error); ok {
+		r0 = rf(ctx, tenant, uid, status)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/envs/envs.go
+++ b/pkg/envs/envs.go
@@ -30,3 +30,9 @@ func IsCloud() bool {
 func HasBilling() bool {
 	return DefaultBackend.Get("SHELLHUB_BILLING") == ENABLED
 }
+
+// IsCommunity return true if the current ShellHub server instance is community.
+// It evaluates if the current ShellHub instance is neither enterprise or cloud .
+func IsCommunity() bool {
+	return (DefaultBackend.Get("SHELLHUB_CLOUD") != ENABLED && DefaultBackend.Get("SHELLHUB_ENTERPRISE") != ENABLED)
+}

--- a/pkg/models/namespace.go
+++ b/pkg/models/namespace.go
@@ -27,11 +27,8 @@ func (n *Namespace) HasMaxDevices() bool {
 }
 
 // HasMaxDevicesReached checks if the namespace has reached the maximum number of devices.
-//
-// This function sum the number of devices in the namespace with the number of devices that were removed from that one
-// and check if this sum is greater than the maximum number of devices.
-func (n *Namespace) HasMaxDevicesReached(removedDevices int64) bool {
-	return n.HasMaxDevices() && int64(n.DevicesCount)+removedDevices >= int64(n.MaxDevices)
+func (n *Namespace) HasMaxDevicesReached() bool {
+	return uint64(n.DevicesCount) >= uint64(n.MaxDevices)
 }
 
 type NamespaceSettings struct {


### PR DESCRIPTION
Improve the `UpdateDeviceStatus` service's method with a more readable and simpler logic.

## Tasks

- [x] Refactoring the method
- [x] Building tests
  - [x] Community
  - [x] Enterprise
  - [x] Cloud

## Flow

From the current implementation of `UpdateDeviceStatus` logic, I drew this flow chart to summarize what the method does today, and what It should do. 

> I'm still improving my charts; Any improvement suggestion is welcome.

```mermaid
flowchart TD
A[Start] --> B{Does Namespace exist?}
B --> |Fail| X([Return error])
B --> |Success| C{Does Device exist in this namespace?}
C --> |Fail| X
C --> |Success| D{Is the new device status 'accept'?}
D --> |No| F([Update device status to the new one])
D --> |Yes| E{Is the ShellHub instance Cloud?}
E --> |No| F
E --> |Yes| G{Has namespace a subscription enabled?}
G --> |Yes| H[/Report device to billing service/]
G --> |No| I{How many devices has been removed in the last 30 days?}
I --> |More or equal to 3| J[Block device acceptance] --> X
I --> |Less than 3| K{How many devices are accepted now?}
K --> |Less than 3| F
K --> |More or equal to 3| J
H --> L{Has report succeed?}
L --> |Yes| F
L --> |No| J
```