### PR TITLE
fix(gateway): SSL certificate generation using Certbot

### DIFF
--- a/gateway/conf.d/shellhub.conf
+++ b/gateway/conf.d/shellhub.conf
@@ -42,6 +42,12 @@ server {
         proxy_redirect off;
     }
 
+    location ^~ /.well-known/acme-challenge/ {
+        default_type "text/plain";
+
+        root /var/www/letsencrypt;
+    }
+
     location /api {
         set $upstream api:8080;
 

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -45,7 +45,9 @@ if [ "$SHELLHUB_ENV" != "development" ] && [ "$SHELLHUB_AUTO_SSL" == "true" ]; t
     if [ ! -f /etc/letsencrypt/live/$SHELLHUB_DOMAIN/fullchain.pem ]; then
         echo "Generating SSL certificate"
 
-        certbot certonly --non-interactive --agree-tos --register-unsafely-without-email --standalone --preferred-challenges http -n -d $SHELLHUB_DOMAIN
+        mkdir -p /var/www/letsencrypt
+
+        certbot certonly --non-interactive --agree-tos --register-unsafely-without-email --webroot --webroot-path /var/www/letsencrypt --preferred-challenges http -n -d $SHELLHUB_DOMAIN
         if [ $? -ne 0 ]; then
             echo "Failed to generate SSL certificate"
             exit 1


### PR DESCRIPTION
* Added a new location block to handle ACME challenges for SSL certificate
generation using Certbot
* Updated Certbot command to use webroot mode instead of standalone mode
