### PR TITLE
fix(ui): fix build step

### DIFF
--- a/ui/src/components/Billing/BillingIcon.vue
+++ b/ui/src/components/Billing/BillingIcon.vue
@@ -18,19 +18,6 @@
 <script lang="ts">
 /* eslint-disable */
 import { defineComponent, ref } from "vue";
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { faCreditCard } from '@fortawesome/free-regular-svg-icons';
-import { faCcAmex, faCcDinersClub, faCcDiscover, faCcJcb, faCcMastercard, faCcVisa } from '@fortawesome/free-brands-svg-icons';
-
-library.add(
-  faCreditCard,
-  faCcAmex,
-  faCcDinersClub,
-  faCcDiscover,
-  faCcJcb,
-  faCcMastercard,
-  faCcVisa
-);
 
 export default defineComponent({
   props: {


### PR DESCRIPTION
Fix following error during build step:

```
src/components/Billing/BillingIcon.vue(26,3): error TS2345:
Argument of type 'IconDefinition' is not assignable to parameter
of type 'IconDefinitionOrPack'.
```
