### PR TITLE
test(routes): implementing test cases of tag validation

### DIFF
--- a/api/routes/device_test.go
+++ b/api/routes/device_test.go
@@ -24,30 +24,46 @@ import (
 func TestGetDevice(t *testing.T) {
 	mock := new(mocks.Service)
 
-	cases := []struct {
-		title           string
-		uid             string
-		requiredMocks   func()
+	type Expected struct {
 		expectedSession *models.Device
 		expectedStatus  int
+	}
+	cases := []struct {
+		title         string
+		uid           string
+		requiredMocks func()
+		expected      Expected
 	}{
 		{
-			title: "returns Ok for a existing device",
-			uid:   "123",
-			requiredMocks: func() {
-				mock.On("GetDevice", gomock.Anything, models.UID("123")).Return(&models.Device{}, nil)
+			title:         "fails when bind fails to validate uid",
+			uid:           "",
+			requiredMocks: func() {},
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusNotFound,
 			},
-			expectedSession: &models.Device{},
-			expectedStatus:  http.StatusOK,
 		},
 		{
-			title: "returns Not Found for a non-existing device",
+			title: "fails when try to get a non-existing device",
 			uid:   "1234",
 			requiredMocks: func() {
 				mock.On("GetDevice", gomock.Anything, models.UID("1234")).Return(nil, svc.ErrDeviceNotFound)
 			},
-			expectedSession: nil,
-			expectedStatus:  http.StatusNotFound,
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusNotFound,
+			},
+		},
+		{
+			title: "success when try to get a existing device",
+			uid:   "123",
+			requiredMocks: func() {
+				mock.On("GetDevice", gomock.Anything, models.UID("123")).Return(&models.Device{}, nil)
+			},
+			expected: Expected{
+				expectedSession: &models.Device{},
+				expectedStatus:  http.StatusOK,
+			},
 		},
 	}
 
@@ -63,14 +79,14 @@ func TestGetDevice(t *testing.T) {
 			e := NewRouter(mock)
 			e.ServeHTTP(rec, req)
 
-			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+			assert.Equal(t, tc.expected.expectedStatus, rec.Result().StatusCode)
 
 			var session *models.Device
 			if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
 				assert.ErrorIs(t, io.EOF, err)
 			}
 
-			assert.Equal(t, tc.expectedSession, session)
+			assert.Equal(t, tc.expected.expectedSession, session)
 		})
 	}
 }
@@ -85,20 +101,26 @@ func TestDeleteDevice(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok when deleting an existing device",
-			uid:   "123",
-			requiredMocks: func() {
-				mock.On("DeleteDevice", gomock.Anything, models.UID("123"), "").Return(nil)
-			},
-			expectedStatus: http.StatusOK,
+			title:          "fails when bind fails to validate uid",
+			uid:            "",
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusNotFound,
 		},
 		{
-			title: "returns Not Found when deleting a non-existing device ",
+			title: "fails when try to deleting a non-existing device",
 			uid:   "1234",
 			requiredMocks: func() {
 				mock.On("DeleteDevice", gomock.Anything, models.UID("1234"), "").Return(svc.ErrDeviceNotFound)
 			},
 			expectedStatus: http.StatusNotFound,
+		},
+		{
+			title: "success when try to deleting an existing device",
+			uid:   "123",
+			requiredMocks: func() {
+				mock.On("DeleteDevice", gomock.Anything, models.UID("123"), "").Return(nil)
+			},
+			expectedStatus: http.StatusOK,
 		},
 	}
 
@@ -124,26 +146,23 @@ func TestRenameDevice(t *testing.T) {
 
 	cases := []struct {
 		title          string
-		updatePayload  requests.DeviceRename
+		renamePayload  requests.DeviceRename
 		tenant         string
 		requiredMocks  func(req requests.DeviceRename)
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok when renaming an existing device",
-			updatePayload: requests.DeviceRename{
-				DeviceParam: requests.DeviceParam{UID: "123"},
-				Name:        "name",
+			title: "fails when bind fails to validate uid",
+			renamePayload: requests.DeviceRename{
+				DeviceParam: requests.DeviceParam{UID: ""},
 			},
-			tenant: "tenant-id",
-			requiredMocks: func(req requests.DeviceRename) {
-				mock.On("RenameDevice", gomock.Anything, models.UID("123"), req.Name, "tenant-id").Return(nil)
-			},
-			expectedStatus: http.StatusOK,
+			tenant:         "tenant-id",
+			requiredMocks:  func(req requests.DeviceRename) {},
+			expectedStatus: http.StatusNotFound,
 		},
 		{
-			title: "returns Not Found when renaming a non-existing device",
-			updatePayload: requests.DeviceRename{
+			title: "fails when try to rename a non-existing device",
+			renamePayload: requests.DeviceRename{
 				DeviceParam: requests.DeviceParam{UID: "1234"},
 				Name:        "name",
 			},
@@ -153,18 +172,30 @@ func TestRenameDevice(t *testing.T) {
 			},
 			expectedStatus: http.StatusNotFound,
 		},
+		{
+			title: "success when try to rename an existing device",
+			renamePayload: requests.DeviceRename{
+				DeviceParam: requests.DeviceParam{UID: "123"},
+				Name:        "name",
+			},
+			tenant: "tenant-id",
+			requiredMocks: func(req requests.DeviceRename) {
+				mock.On("RenameDevice", gomock.Anything, models.UID("123"), req.Name, "tenant-id").Return(nil)
+			},
+			expectedStatus: http.StatusOK,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.title, func(t *testing.T) {
-			tc.requiredMocks(tc.updatePayload)
+			tc.requiredMocks(tc.renamePayload)
 
-			jsonData, err := json.Marshal(tc.updatePayload)
+			jsonData, err := json.Marshal(tc.renamePayload)
 			if err != nil {
 				assert.NoError(t, err)
 			}
 
-			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/devices/%s", tc.updatePayload.UID), strings.NewReader(string(jsonData)))
+			req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/devices/%s", tc.renamePayload.UID), strings.NewReader(string(jsonData)))
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", guard.RoleOwner)
 			req.Header.Set("X-Tenant-ID", tc.tenant)
@@ -181,30 +212,46 @@ func TestRenameDevice(t *testing.T) {
 func TestGetDeviceByPublicURLAddress(t *testing.T) {
 	mock := new(mocks.Service)
 
-	cases := []struct {
-		title           string
-		address         string
-		requiredMocks   func()
-		expectedStatus  int
+	type Expected struct {
 		expectedSession *models.Device
+		expectedStatus  int
+	}
+	cases := []struct {
+		title         string
+		address       string
+		requiredMocks func()
+		expected      Expected
 	}{
 		{
-			title:   "returns Ok when searching a device by the public URL address",
-			address: "example",
-			requiredMocks: func() {
-				mock.On("GetDeviceByPublicURLAddress", gomock.Anything, "example").Return(&models.Device{}, nil)
+			title:         "fails when bind fails to validate uid",
+			address:       "",
+			requiredMocks: func() {},
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusNotFound,
 			},
-			expectedSession: &models.Device{},
-			expectedStatus:  http.StatusOK,
 		},
 		{
-			title:   "returns Not Found when searching a device by the public URL address",
+			title:   "fails when try to searching a device by the public URL address",
 			address: "exampleaddress",
 			requiredMocks: func() {
 				mock.On("GetDeviceByPublicURLAddress", gomock.Anything, "exampleaddress").Return(nil, svc.ErrDeviceNotFound)
 			},
-			expectedSession: nil,
-			expectedStatus:  http.StatusNotFound,
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusNotFound,
+			},
+		},
+		{
+			title:   "success when try to searching a device by the public URL address",
+			address: "example",
+			requiredMocks: func() {
+				mock.On("GetDeviceByPublicURLAddress", gomock.Anything, "example").Return(&models.Device{}, nil)
+			},
+			expected: Expected{
+				expectedSession: &models.Device{},
+				expectedStatus:  http.StatusOK,
+			},
 		},
 	}
 
@@ -220,14 +267,14 @@ func TestGetDeviceByPublicURLAddress(t *testing.T) {
 			e := NewRouter(mock)
 			e.ServeHTTP(rec, req)
 
-			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+			assert.Equal(t, tc.expected.expectedStatus, rec.Result().StatusCode)
 
 			var session *models.Device
 			if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
 				assert.ErrorIs(t, io.EOF, err)
 			}
 
-			assert.Equal(t, tc.expectedSession, session)
+			assert.Equal(t, tc.expected.expectedSession, session)
 		})
 	}
 }
@@ -252,18 +299,20 @@ func TestGetDeviceList(t *testing.T) {
 	}
 
 	filteb64 := base64.StdEncoding.EncodeToString(jsonData)
-
-	cases := []struct {
-		title           string
-		filter          string
-		queryPayload    filterQuery
-		tenant          string
-		requiredMocks   func(query filterQuery)
+	type Expected struct {
 		expectedSession []models.Device
 		expectedStatus  int
+	}
+	cases := []struct {
+		title         string
+		filter        string
+		queryPayload  filterQuery
+		tenant        string
+		requiredMocks func(query filterQuery)
+		expected      Expected
 	}{
 		{
-			title: "returns Ok when a device list existing",
+			title: "fails when try to get a device list existing",
 			queryPayload: filterQuery{
 				Filter:  filteb64,
 				Status:  models.DeviceStatus("online"),
@@ -287,10 +336,44 @@ func TestGetDeviceList(t *testing.T) {
 					assert.NoError(t, err)
 				}
 
-				mock.On("ListDevices", gomock.Anything, "tenant-id", query.Query, filters, query.Status, query.SortBy, query.OrderBy).Return([]models.Device{}, 1, nil)
+				mock.On("ListDevices", gomock.Anything, "tenant-id", query.Query, filters, query.Status, query.SortBy, query.OrderBy).Return(nil, 0, svc.ErrDeviceNotFound).Once()
 			},
-			expectedSession: []models.Device{},
-			expectedStatus:  http.StatusOK,
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusNotFound,
+			},
+		},
+		{
+			title: "fails when try to get a device list existing",
+			queryPayload: filterQuery{
+				Filter:  filteb64,
+				Status:  models.DeviceStatus("online"),
+				SortBy:  "name",
+				OrderBy: "asc",
+				Query: paginator.Query{
+					Page:    1,
+					PerPage: 10,
+				},
+			},
+			tenant: "tenant-id",
+			requiredMocks: func(query filterQuery) {
+				query.Normalize()
+				raw, err := base64.StdEncoding.DecodeString(query.Filter)
+				if err != nil {
+					assert.NoError(t, err)
+				}
+
+				var filters []models.Filter
+				if err := json.Unmarshal(raw, &filters); len(raw) > 0 && err != nil {
+					assert.NoError(t, err)
+				}
+
+				mock.On("ListDevices", gomock.Anything, "tenant-id", query.Query, filters, query.Status, query.SortBy, query.OrderBy).Return([]models.Device{}, 1, nil).Once()
+			},
+			expected: Expected{
+				expectedSession: []models.Device{},
+				expectedStatus:  http.StatusOK,
+			},
 		},
 	}
 
@@ -312,14 +395,14 @@ func TestGetDeviceList(t *testing.T) {
 			e := NewRouter(mock)
 			e.ServeHTTP(rec, req)
 
-			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+			assert.Equal(t, tc.expected.expectedStatus, rec.Result().StatusCode)
 
 			var session []models.Device
 			if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
 				assert.ErrorIs(t, io.EOF, err)
 			}
 
-			assert.Equal(t, tc.expectedSession, session)
+			assert.Equal(t, tc.expected.expectedSession, session)
 		})
 	}
 }
@@ -334,20 +417,26 @@ func TestOfflineDevice(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok for setting an existing device as offline",
-			uid:   "123",
-			requiredMocks: func() {
-				mock.On("OffineDevice", gomock.Anything, models.UID("123"), false).Return(nil)
-			},
-			expectedStatus: http.StatusOK,
+			title:          "fails when bind fails to validate uid",
+			uid:            "",
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			title: "returns Not Found for setting a non-existing device as offline",
+			title: "fails when try to setting a non-existing device as offline",
 			uid:   "1234",
 			requiredMocks: func() {
 				mock.On("OffineDevice", gomock.Anything, models.UID("1234"), false).Return(svc.ErrNotFound)
 			},
 			expectedStatus: http.StatusNotFound,
+		},
+		{
+			title: "success when try to setting an existing device as offline",
+			uid:   "123",
+			requiredMocks: func() {
+				mock.On("OffineDevice", gomock.Anything, models.UID("123"), false).Return(nil)
+			},
+			expectedStatus: http.StatusOK,
 		},
 	}
 
@@ -372,27 +461,59 @@ func TestOfflineDevice(t *testing.T) {
 func TestLookupDevice(t *testing.T) {
 	mock := new(mocks.Service)
 
-	tests := []struct {
-		title           string
-		request         requests.DeviceLookup
-		requiredMocks   func(requests.DeviceLookup)
+	type Expected struct {
 		expectedSession *models.Device
 		expectedStatus  int
+	}
+	tests := []struct {
+		title         string
+		request       requests.DeviceLookup
+		requiredMocks func(requests.DeviceLookup)
+		expected      Expected
 	}{
 		{
-			title: "returns Ok for look up of a existing device",
+			title: "fails when bind fails to validate uid",
+			request: requests.DeviceLookup{
+				Username:  "user1",
+				IPAddress: "192.168.1.100",
+			},
+			requiredMocks: func(req requests.DeviceLookup) {},
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusBadRequest,
+			},
+		},
+		{
+			title: "fails when try to look up of a existing device",
 			request: requests.DeviceLookup{
 				Domain:    "example.com",
 				Name:      "device1",
 				Username:  "user1",
 				IPAddress: "192.168.1.100",
 			},
-
+			requiredMocks: func(req requests.DeviceLookup) {
+				mock.On("LookupDevice", gomock.Anything, req.Domain, req.Name).Return(nil, svc.ErrDeviceNotFound).Once()
+			},
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusNotFound,
+			},
+		},
+		{
+			title: "success when try to look up of a existing device",
+			request: requests.DeviceLookup{
+				Domain:    "example.com",
+				Name:      "device1",
+				Username:  "user1",
+				IPAddress: "192.168.1.100",
+			},
 			requiredMocks: func(req requests.DeviceLookup) {
 				mock.On("LookupDevice", gomock.Anything, req.Domain, req.Name).Return(&models.Device{}, nil)
 			},
-			expectedSession: &models.Device{},
-			expectedStatus:  http.StatusOK,
+			expected: Expected{
+				expectedSession: &models.Device{},
+				expectedStatus:  http.StatusOK,
+			},
 		},
 	}
 
@@ -413,14 +534,14 @@ func TestLookupDevice(t *testing.T) {
 			e := NewRouter(mock)
 			e.ServeHTTP(rec, req)
 
-			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+			assert.Equal(t, tc.expected.expectedStatus, rec.Result().StatusCode)
 
 			var session *models.Device
 			if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
 				assert.ErrorIs(t, io.EOF, err)
 			}
 
-			assert.Equal(t, tc.expectedSession, session)
+			assert.Equal(t, tc.expected.expectedSession, session)
 		})
 	}
 }
@@ -435,20 +556,26 @@ func TestHeartbeatDevice(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok for heartbeat of a existing device",
-			uid:   "123",
-			requiredMocks: func() {
-				mock.On("DeviceHeartbeat", gomock.Anything, models.UID("123")).Return(nil)
-			},
-			expectedStatus: http.StatusOK,
+			title:          "fails when bind fails to validate uid",
+			uid:            "",
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			title: "returns Not Found for heartbeat non-existing device",
+			title: "fails when try to heartbeat non-existing device",
 			uid:   "1234",
 			requiredMocks: func() {
-				mock.On("DeviceHeartbeat", gomock.Anything, models.UID("1234")).Return(svc.ErrNotFound)
+				mock.On("DeviceHeartbeat", gomock.Anything, models.UID("1234")).Return(svc.ErrNotFound).Once()
 			},
 			expectedStatus: http.StatusNotFound,
+		},
+		{
+			title: "success when try to heartbeat of a existing device",
+			uid:   "123",
+			requiredMocks: func() {
+				mock.On("DeviceHeartbeat", gomock.Anything, models.UID("123")).Return(nil).Once()
+			},
+			expectedStatus: http.StatusOK,
 		},
 	}
 
@@ -475,32 +602,81 @@ func TestRemoveDeviceTag(t *testing.T) {
 
 	cases := []struct {
 		title          string
-		updatePayload  requests.DeviceCreateTag
-		requiredMocks  func(req requests.DeviceCreateTag)
+		updatePayload  requests.DeviceRemoveTag
+		requiredMocks  func(req requests.DeviceRemoveTag)
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok for remove device tag of a existing device",
-			updatePayload: requests.DeviceCreateTag{
+			title: "fails when bind fails to validate uid",
+			updatePayload: requests.DeviceRemoveTag{
+				DeviceParam: requests.DeviceParam{UID: ""},
+				TagBody:     requests.TagBody{Tag: "tag"},
+			},
+			requiredMocks:  func(req requests.DeviceRemoveTag) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because the tag does not have a min of 3 characters",
+			updatePayload: requests.DeviceRemoveTag{
+				TagBody: requests.TagBody{Tag: "tg"},
+			},
+			expectedStatus: http.StatusBadRequest,
+			requiredMocks:  func(req requests.DeviceRemoveTag) {},
+		},
+		{
+			title: "fails when validate because the tag does not have a max of 255 characters",
+			updatePayload: requests.DeviceRemoveTag{
+				TagBody: requests.TagBody{Tag: "BCD3821E12F7A6D89295D86E277F2C365D7A4C3FCCD75D8A2F46C0A556A8EBAAF0845C85D50241FC2F9806D8668FF75D262FDA0A055784AD36D8CA7D2BB600C9BCD3821E12F7A6D89295D86E277F2C365D7A4C3FCCD75D8A2F46C0A556A8EBAAF0845C85D50241FC2F9806D8668FF75D262FDA0A055784AD36D8CA7D2BB600C9"},
+			},
+			expectedStatus: http.StatusBadRequest,
+			requiredMocks:  func(req requests.DeviceRemoveTag) {},
+		},
+		{
+			title: "fails when validate because have a '/' with in your characters",
+			updatePayload: requests.DeviceRemoveTag{
+				TagBody: requests.TagBody{Tag: "test/"},
+			},
+			expectedStatus: http.StatusBadRequest,
+			requiredMocks:  func(req requests.DeviceRemoveTag) {},
+		},
+		{
+			title: "fails when validate because have a '&' with in your characters",
+			updatePayload: requests.DeviceRemoveTag{
+				TagBody: requests.TagBody{Tag: "test&"},
+			},
+			expectedStatus: http.StatusBadRequest,
+			requiredMocks:  func(req requests.DeviceRemoveTag) {},
+		},
+		{
+			title: "fails when validate because have a '@' with in your characters",
+			updatePayload: requests.DeviceRemoveTag{
+				TagBody: requests.TagBody{Tag: "test@"},
+			},
+			expectedStatus: http.StatusBadRequest,
+			requiredMocks:  func(req requests.DeviceRemoveTag) {},
+		},
+		{
+			title: "fails when try to remove a non-existing device tag",
+			updatePayload: requests.DeviceRemoveTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				TagBody:     requests.TagBody{Tag: "tag"},
+			},
+			requiredMocks: func(req requests.DeviceRemoveTag) {
+				mock.On("RemoveDeviceTag", gomock.Anything, models.UID("1234"), req.Tag).Return(svc.ErrNotFound)
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			title: "success when try to remove a existing device tag",
+			updatePayload: requests.DeviceRemoveTag{
 				DeviceParam: requests.DeviceParam{UID: "123"},
 				TagBody:     requests.TagBody{Tag: "tag"},
 			},
 
-			requiredMocks: func(req requests.DeviceCreateTag) {
+			requiredMocks: func(req requests.DeviceRemoveTag) {
 				mock.On("RemoveDeviceTag", gomock.Anything, models.UID("123"), req.Tag).Return(nil)
 			},
 			expectedStatus: http.StatusOK,
-		},
-		{
-			title: "returns Not Found for remove device tag of a non-existing device",
-			updatePayload: requests.DeviceCreateTag{
-				DeviceParam: requests.DeviceParam{UID: "1234"},
-				TagBody:     requests.TagBody{Tag: "tag"},
-			},
-			requiredMocks: func(req requests.DeviceCreateTag) {
-				mock.On("RemoveDeviceTag", gomock.Anything, models.UID("1234"), req.Tag).Return(svc.ErrNotFound)
-			},
-			expectedStatus: http.StatusNotFound,
 		},
 	}
 
@@ -537,7 +713,78 @@ func TestCreateDeviceTag(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok for create device tag of a existing device",
+			title: "fails when bind fails to validate uid",
+			updatePayload: requests.DeviceCreateTag{
+				DeviceParam: requests.DeviceParam{UID: ""},
+				TagBody:     requests.TagBody{Tag: "tag"},
+			},
+			requiredMocks: func(req requests.DeviceCreateTag) {
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because the tag does not have a min of 3 characters",
+			updatePayload: requests.DeviceCreateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				TagBody:     requests.TagBody{Tag: "tg"},
+			},
+			requiredMocks: func(req requests.DeviceCreateTag) {
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because the tag does not have a max of 255 characters",
+			updatePayload: requests.DeviceCreateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				TagBody:     requests.TagBody{Tag: "BCD3821E12F7A6D89295D86E277F2C365D7A4C3FCCD75D8A2F46C0A556A8EBAAF0845C85D50241FC2F9806D8668FF75D262FDA0A055784AD36D8CA7D2BB600C9BCD3821E12F7A6D89295D86E277F2C365D7A4C3FCCD75D8A2F46C0A556A8EBAAF0845C85D50241FC2F9806D8668FF75D262FDA0A055784AD36D8CA7D2BB600C9"},
+			},
+			requiredMocks: func(req requests.DeviceCreateTag) {
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because have a '@' with in your characters",
+			updatePayload: requests.DeviceCreateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				TagBody:     requests.TagBody{Tag: "test@"},
+			},
+			requiredMocks: func(req requests.DeviceCreateTag) {
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because have a '/' with in your characters",
+			updatePayload: requests.DeviceCreateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				TagBody:     requests.TagBody{Tag: "test/"},
+			},
+			requiredMocks: func(req requests.DeviceCreateTag) {
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because have a '&' with in your characters",
+			updatePayload: requests.DeviceCreateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				TagBody:     requests.TagBody{Tag: "test&"},
+			},
+			requiredMocks: func(req requests.DeviceCreateTag) {
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when try to create a non-existing device tag",
+			updatePayload: requests.DeviceCreateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				TagBody:     requests.TagBody{Tag: "tag"},
+			},
+			requiredMocks: func(req requests.DeviceCreateTag) {
+				mock.On("CreateDeviceTag", gomock.Anything, models.UID("1234"), req.Tag).Return(svc.ErrNotFound)
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			title: "fails when try to create a existing device tag",
 			updatePayload: requests.DeviceCreateTag{
 				DeviceParam: requests.DeviceParam{UID: "123"},
 				TagBody:     requests.TagBody{Tag: "tag"},
@@ -547,17 +794,6 @@ func TestCreateDeviceTag(t *testing.T) {
 				mock.On("CreateDeviceTag", gomock.Anything, models.UID("123"), req.Tag).Return(nil)
 			},
 			expectedStatus: http.StatusOK,
-		},
-		{
-			title: "returns Not Found for create device tag of a non-existing device",
-			updatePayload: requests.DeviceCreateTag{
-				DeviceParam: requests.DeviceParam{UID: "1234"},
-				TagBody:     requests.TagBody{Tag: "tag"},
-			},
-			requiredMocks: func(req requests.DeviceCreateTag) {
-				mock.On("CreateDeviceTag", gomock.Anything, models.UID("1234"), req.Tag).Return(svc.ErrNotFound)
-			},
-			expectedStatus: http.StatusNotFound,
 		},
 	}
 
@@ -594,7 +830,81 @@ func TestUpdateDeviceTag(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok for update device tag of a existing device",
+			title: "fails when bind fails to validate uid",
+			updatePayload: requests.DeviceUpdateTag{
+				DeviceParam: requests.DeviceParam{UID: ""},
+				Tags:        []string{"tag1", "tag2"},
+			},
+			requiredMocks:  func(req requests.DeviceUpdateTag) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because have a duplicate tag",
+			updatePayload: requests.DeviceUpdateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				Tags:        []string{"tagduplicated", "tagduplicated"},
+			},
+			requiredMocks:  func(req requests.DeviceUpdateTag) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because have a '@' with in your characters",
+			updatePayload: requests.DeviceUpdateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				Tags:        []string{"test@"},
+			},
+			requiredMocks:  func(req requests.DeviceUpdateTag) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because have a '/' with in your characters",
+			updatePayload: requests.DeviceUpdateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				Tags:        []string{"test/"},
+			},
+			requiredMocks:  func(req requests.DeviceUpdateTag) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because have a '&' with in your characters",
+			updatePayload: requests.DeviceUpdateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				Tags:        []string{"test&"},
+			},
+			requiredMocks:  func(req requests.DeviceUpdateTag) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because the tag does not have a min of 3 characters",
+			updatePayload: requests.DeviceUpdateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				Tags:        []string{"tg"},
+			},
+			requiredMocks:  func(req requests.DeviceUpdateTag) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when validate because the tag does not have a max of 255 characters",
+			updatePayload: requests.DeviceUpdateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				Tags:        []string{"BCD3821E12F7A6D89295D86E277F2C365D7A4C3FCCD75D8A2F46C0A556A8EBAAF0845C85D50241FC2F9806D8668FF75D262FDA0A055784AD36D8CA7D2BB600C9BCD3821E12F7A6D89295D86E277F2C365D7A4C3FCCD75D8A2F46C0A556A8EBAAF0845C85D50241FC2F9806D8668FF75D262FDA0A055784AD36D8CA7D2BB600C9"},
+			},
+			requiredMocks:  func(req requests.DeviceUpdateTag) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			title: "fails when try to update a existing device tag",
+			updatePayload: requests.DeviceUpdateTag{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				Tags:        []string{"tag1", "tag2"},
+			},
+			requiredMocks: func(req requests.DeviceUpdateTag) {
+				mock.On("UpdateDeviceTag", gomock.Anything, models.UID("1234"), req.Tags).Return(svc.ErrNotFound)
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			title: "success when try to update a existing device tag",
 			updatePayload: requests.DeviceUpdateTag{
 				DeviceParam: requests.DeviceParam{UID: "123"},
 				Tags:        []string{"tag1", "tag2"},
@@ -604,17 +914,6 @@ func TestUpdateDeviceTag(t *testing.T) {
 				mock.On("UpdateDeviceTag", gomock.Anything, models.UID("123"), req.Tags).Return(nil)
 			},
 			expectedStatus: http.StatusOK,
-		},
-		{
-			title: "returns Not Found for update device tag of a non-existing device",
-			updatePayload: requests.DeviceUpdateTag{
-				DeviceParam: requests.DeviceParam{UID: "1234"},
-				Tags:        []string{"tag1", "tag2"},
-			},
-			requiredMocks: func(req requests.DeviceUpdateTag) {
-				mock.On("UpdateDeviceTag", gomock.Anything, models.UID("1234"), req.Tags).Return(svc.ErrNotFound)
-			},
-			expectedStatus: http.StatusNotFound,
 		},
 	}
 
@@ -653,7 +952,19 @@ func TestUpdateDevice(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok for updating device of a existing device",
+			title: "fails when try to uodate a existing device",
+			updatePayload: requests.DeviceUpdate{
+				DeviceParam: requests.DeviceParam{UID: "1234"},
+				Name:        &name,
+				PublicURL:   &url,
+			},
+			requiredMocks: func(req requests.DeviceUpdate) {
+				mock.On("UpdateDevice", gomock.Anything, "tenant-id", models.UID("1234"), req.Name, req.PublicURL).Return(svc.ErrNotFound)
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			title: "success when try to update a existing device",
 			updatePayload: requests.DeviceUpdate{
 				DeviceParam: requests.DeviceParam{UID: "123"},
 				Name:        &name,
@@ -664,18 +975,6 @@ func TestUpdateDevice(t *testing.T) {
 				mock.On("UpdateDevice", gomock.Anything, "tenant-id", models.UID("123"), req.Name, req.PublicURL).Return(nil)
 			},
 			expectedStatus: http.StatusOK,
-		},
-		{
-			title: "returns Not Found for updating device of a non-existing device",
-			updatePayload: requests.DeviceUpdate{
-				DeviceParam: requests.DeviceParam{UID: "1234"},
-				Name:        &name,
-				PublicURL:   &url,
-			},
-			requiredMocks: func(req requests.DeviceUpdate) {
-				mock.On("UpdateDevice", gomock.Anything, "tenant-id", models.UID("1234"), req.Name, req.PublicURL).Return(svc.ErrNotFound)
-			},
-			expectedStatus: http.StatusNotFound,
 		},
 	}
 

--- a/api/routes/healthcheck_test.go
+++ b/api/routes/healthcheck_test.go
@@ -22,7 +22,7 @@ func TestEvaluateHealth(t *testing.T) {
 		expectedErr   error
 	}{
 		{
-			title:       "returns Ok for evaluate health",
+			title:       "success when try to make a evaluate health",
 			expectedErr: nil,
 		},
 	}

--- a/api/routes/stats_test.go
+++ b/api/routes/stats_test.go
@@ -26,7 +26,7 @@ func TestGetSystemInfo(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			title: "returns Ok if a system exists",
+			title: "success when try to get infos of a existing system",
 			request: requests.SystemGetInfo{
 				Host: "example.com",
 				Port: 0,
@@ -76,7 +76,7 @@ func TestGetStats(t *testing.T) {
 		requiredMocks  func()
 	}{
 		{
-			title: "returns Ok if a stats exists",
+			title: "success when try to get an stats",
 			reqStats: &models.Stats{
 				RegisteredDevices: 10,
 				OnlineDevices:     5,


### PR DESCRIPTION
This commit implements more test cases for the 'routes' layer.

The added test cases are the structure tag validation, 
the objective with these cases is to make sure that all the tests 
are complying with the established validation rules.