### PR TITLE
feat(gateway): change redirect status code from 301 to 308

### DIFF
--- a/gateway/conf.d/shellhub.conf
+++ b/gateway/conf.d/shellhub.conf
@@ -408,6 +408,6 @@ server {
 server {
     listen 80 default_server;
 
-    return 301 https://$host$request_uri;
+    return 308 https://$host$request_uri;
 }
 {{- end }}


### PR DESCRIPTION
This change updates the HTTP redirect status code from 301
to 308 in the gateway service.

The 308 status code preserves the original HTTP method and
request body during redirection, providing better
consistency and behavior for our use case.
