### PR TITLE
fix error at session update when accepting a device

### DIFF
--- a/api/services/device.go
+++ b/api/services/device.go
@@ -206,7 +206,7 @@ func (s *service) UpdateDeviceStatus(ctx context.Context, tenant string, uid mod
 	}
 
 	if sameMacDev != nil && sameMacDev.UID != device.UID {
-		if err := s.store.SessionUpdateDeviceUID(ctx, models.UID(sameMacDev.UID), models.UID(device.UID)); err != nil {
+		if err := s.store.SessionUpdateDeviceUID(ctx, models.UID(sameMacDev.UID), models.UID(device.UID)); err != nil && err != store.ErrNoDocuments {
 			return err
 		}
 


### PR DESCRIPTION
PR #3118 introduced the following code in `SessionUpdateDeviceUID`:
```go
// [...]
if session.MatchedCount < 1 {
	return store.ErrNoDocuments
}
// [...]
```
Due to this, the subsequent code snippet will result in an error:
```go
// [...]
if sameMacDev != nil && sameMacDev.UID != device.UID {
	if err := s.store.SessionUpdateDeviceUID(ctx, models.UID(sameMacDev.UID), models.UID(device.UID)); err != nil {
		return err
	}
}
// [...]
```
This PR fix the issue.