### PR TITLE
fix(ui): device rename persisting the input on devices

### DIFF
--- a/ui/src/components/Devices/DeviceRename.vue
+++ b/ui/src/components/Devices/DeviceRename.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-list-item v-bind="$attrs" @click="showDialog = true">
+  <v-list-item v-bind="$attrs" @click="open()">
     <div class="d-flex align-center">
       <div class="mr-2">
         <v-icon data-test="rename-icon"> mdi-pencil </v-icon>
@@ -24,14 +24,14 @@
           :messages="messages"
           require
           variant="underlined"
-          data-test="hostname-field"
+          data-test="rename-field"
         />
       </v-card-text>
 
       <v-card-actions>
         <v-spacer />
 
-        <v-btn data-test="close-btn" variant="text" @click="showDialog = false">
+        <v-btn data-test="close-btn" variant="text" @click="close()">
           Close
         </v-btn>
 
@@ -48,8 +48,8 @@
   </v-dialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref, computed } from "vue";
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
 import { useField } from "vee-validate";
 import * as yup from "yup";
 import axios, { AxiosError } from "axios";
@@ -60,79 +60,74 @@ import {
 } from "../../interfaces/INotifications";
 import handleError from "@/utils/handleError";
 
-export default defineComponent({
-  props: {
-    uid: {
-      type: String,
-      required: true,
-    },
-
-    name: {
-      type: String,
-      required: true,
-    },
-  },
-  emits: ["new-hostname"],
-  setup(props, ctx) {
-    const name = computed(() => props.name);
-    const showDialog = ref(false);
-    const messages = ref(
-      "Examples: (foobar, foo-bar-ba-z-qux, foo-example, 127-0-0-1)",
-    );
-    const store = useStore();
-
-    const {
-      value: editName,
-      errorMessage: editNameError,
-      setErrors: setEditNameError,
-    } = useField<string | undefined>("name", yup.string().required(), {
-      initialValue: name.value,
-    });
-
-    const close = () => {
-      setEditNameError("");
-      showDialog.value = false;
-    };
-
-    const rename = async () => {
-      try {
-        await store.dispatch("devices/rename", {
-          uid: props.uid,
-          name: { name: editName.value },
-        });
-
-        ctx.emit("new-hostname", editName.value);
-        close();
-        store.dispatch(
-          "snackbar/showSnackbarSuccessAction",
-          INotificationsSuccess.deviceRename,
-        );
-      } catch (error: unknown) {
-        if (axios.isAxiosError(error)) {
-          const axiosError = error as AxiosError;
-          if (axiosError.response?.status === 400) {
-            setEditNameError("nonStandardCharacters");
-          } else if (error.response?.status === 409) {
-            setEditNameError("The name already exists in the namespace");
-          }
-          handleError(error);
-        } else {
-          store.dispatch(
-            "snackbar/showSnackbarErrorAction",
-            INotificationsError.deviceRename,
-          );
-          handleError(error);
-        }
-      }
-    };
-
-    return {
-      editName,
-      editNameError,
-      messages,
-      showDialog,
-      rename,
-    };
+const props = defineProps({
+  uid: {
+    type: String,
+    required: true,
   },
 });
+const emit = defineEmits(["new-hostname"]);
+const showDialog = ref(false);
+const messages = ref(
+  "Examples: (foobar, foo-bar-ba-z-qux, foo-example, 127-0-0-1)",
+);
+const store = useStore();
+const deviceName = computed(() => store.getters["devices/getName"]);
+const {
+  value: editName,
+  errorMessage: editNameError,
+  setErrors: setEditNameError,
+} = useField<string | undefined>("name", yup.string().required(), {
+  initialValue: deviceName.value,
+});
+
+const open = () => {
+  showDialog.value = true;
+  editName.value = deviceName.value;
+};
+
+const close = () => {
+  setEditNameError("");
+  showDialog.value = false;
+};
+
+watch(showDialog, (newValue, oldValue) => {
+  if (oldValue === true && newValue === false) {
+    close();
+  }
+});
+
+const rename = async () => {
+  try {
+    await store.dispatch("devices/rename", {
+      uid: props.uid,
+      name: { name: editName.value },
+    });
+
+    emit("new-hostname", editName.value);
+    close();
+    store.dispatch(
+      "snackbar/showSnackbarSuccessAction",
+      INotificationsSuccess.deviceRename,
+    );
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      const axiosError = error as AxiosError;
+      if (axiosError.response?.status === 400) {
+        setEditNameError("nonStandardCharacters");
+      } else if (error.response?.status === 409) {
+        setEditNameError("The name already exists in the namespace");
+      }
+      handleError(error);
+    } else {
+      store.dispatch(
+        "snackbar/showSnackbarErrorAction",
+        INotificationsError.deviceRename,
+      );
+      handleError(error);
+    }
+  }
+};
+
+defineExpose({ showDialog });
 </script>

--- a/ui/src/store/modules/devices.ts
+++ b/ui/src/store/modules/devices.ts
@@ -42,6 +42,7 @@ export const devices: Module<DevicesState, State> = {
   getters: {
     list: (state) => state.devices,
     get: (state) => state.device,
+    getName: (state) => state.device.name,
     getNumberDevices: (state) => state.numberDevices,
     getPage: (state) => state.page,
     getPerPage: (state) => state.perPage,

--- a/ui/tests/components/Devices/DeviceRename.spec.ts
+++ b/ui/tests/components/Devices/DeviceRename.spec.ts
@@ -1,0 +1,169 @@
+import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import { createVuetify } from "vuetify";
+import MockAdapter from "axios-mock-adapter";
+import { expect, describe, it, beforeEach, afterEach, vi } from "vitest";
+import { store, key } from "@/store";
+import DeviceRename from "@/components/Devices/DeviceRename.vue";
+import { envVariables } from "@/envVariables";
+import { router } from "@/router";
+import { namespacesApi, devicesApi } from "@/api/http";
+import { SnackbarPlugin } from "@/plugins/snackbar";
+
+type DeviceRenameWrapper = VueWrapper<InstanceType<typeof DeviceRename>>;
+
+describe("Device Rename", () => {
+  let wrapper: DeviceRenameWrapper;
+
+  const vuetify = createVuetify();
+
+  let mockNamespace: MockAdapter;
+
+  let mockDevice: MockAdapter;
+
+  const device = {
+    uid: "a582b47a42d",
+    name: "39-5e-2a",
+    identity: {
+      mac: "00:00:00:00:00:00",
+    },
+    info: {
+      id: "linuxmint",
+      pretty_name: "Linux Mint 19.3",
+      version: "",
+    },
+    public_key: "----- PUBLIC KEY -----",
+    tenant_id: "00000000",
+    last_seen: "2020-05-20T18:58:53.276Z",
+    online: false,
+    namespace: "user",
+    status: "accepted",
+  };
+
+  const members = [
+    {
+      id: "xxxxxxxx",
+      username: "test",
+      role: "owner",
+    },
+  ];
+
+  const namespaceData = {
+    name: "test",
+    owner: "test",
+    tenant_id: "fake-tenant-data",
+    members,
+    max_devices: 3,
+    devices_count: 3,
+    created_at: "",
+  };
+
+  const authData = {
+    status: "",
+    token: "",
+    user: "test",
+    name: "test",
+    tenant: "fake-tenant-data",
+    email: "test@test.com",
+    id: "xxxxxxxx",
+    role: "owner",
+  };
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("tenant", "fake-tenant-data");
+    envVariables.isCloud = true;
+
+    mockNamespace = new MockAdapter(namespacesApi.getAxios());
+    mockDevice = new MockAdapter(devicesApi.getAxios());
+
+    mockNamespace.onGet("http://localhost:3000/api/namespaces/fake-tenant-data").reply(200, namespaceData);
+    mockDevice.onGet("http://localhost:3000/api/devices/a582b47a42d").reply(200, device);
+
+    store.commit("auth/authSuccess", authData);
+    store.commit("namespaces/setNamespace", namespaceData);
+    store.commit("devices/setDevice", device);
+
+    wrapper = mount(DeviceRename, {
+      global: {
+        plugins: [[store, key], vuetify, router, SnackbarPlugin],
+        config: {
+          errorHandler: () => { /* ignore global error handler */ },
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it("Is a Vue instance", () => {
+    expect(wrapper.vm).toBeTruthy();
+  });
+
+  it("Renders the component", () => {
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("Data is defined", () => {
+    expect(wrapper.vm.$data).toBeDefined();
+  });
+
+  it("renders the component items", async () => {
+    expect(wrapper.findComponent('[data-test="rename-icon"]').exists()).toBe(true);
+    expect(wrapper.findComponent('[data-test="rename-title"]').exists()).toBe(true);
+
+    wrapper.vm.showDialog = true;
+
+    await flushPromises();
+    expect(wrapper.findComponent('[data-test="deviceRename-card"]').exists()).toBe(true);
+    expect(wrapper.findComponent('[data-test="text-title"]').exists()).toBe(true);
+    expect(wrapper.findComponent('[data-test="rename-field"]').exists()).toBe(true);
+    expect(wrapper.findComponent('[data-test="close-btn"]').exists()).toBe(true);
+    expect(wrapper.findComponent('[data-test="rename-btn"]').exists()).toBe(true);
+  });
+
+  it("renames sucessfully a device", async () => {
+    await wrapper.setProps({ uid: "a582b47a42d" });
+
+    wrapper.vm.showDialog = true;
+
+    await flushPromises();
+
+    mockDevice.onPut("http://localhost:3000/api/devices/a582b47a42d").reply(200);
+
+    const deviceSpy = vi.spyOn(store, "dispatch");
+
+    await wrapper.findComponent('[data-test="rename-field"]').setValue("renamed-device");
+    await wrapper.findComponent('[data-test="rename-btn"]').trigger("click");
+
+    await flushPromises();
+
+    expect(deviceSpy).toHaveBeenCalledWith("devices/rename", {
+      uid: "a582b47a42d",
+      name: { name: "renamed-device" },
+    });
+  });
+
+  it("renames sucessfully a device", async () => {
+    await wrapper.setProps({ uid: "a582b47a42d" });
+
+    wrapper.vm.showDialog = true;
+
+    await flushPromises();
+
+    mockDevice.onPut("http://localhost:3000/api/devices/a582b47a42d").reply(400);
+
+    const deviceSpy = vi.spyOn(store, "dispatch");
+
+    await wrapper.findComponent('[data-test="rename-field"]').setValue("badly renamed device");
+    await wrapper.findComponent('[data-test="rename-btn"]').trigger("click");
+
+    await flushPromises();
+
+    expect(deviceSpy).toHaveBeenCalledWith("devices/rename", {
+      uid: "a582b47a42d",
+      name: { name: "badly renamed device" },
+    });
+  });
+});

--- a/ui/tests/components/Devices/__snapshots__/DeviceRename.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DeviceRename.spec.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Device Rename > Renders the component 1`] = `
+"<div class=\\"v-list-item v-list-item--link v-theme--light v-list-item--density-default v-list-item--variant-text\\" tabindex=\\"0\\"><span class=\\"v-list-item__overlay\\"></span><span class=\\"v-list-item__underlay\\"></span>
+  <!---->
+  <div class=\\"v-list-item__content\\" data-no-activator=\\"\\">
+    <!---->
+    <!---->
+    <div class=\\"d-flex align-center\\">
+      <div class=\\"mr-2\\"><i class=\\"mdi-pencil mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\" data-test=\\"rename-icon\\"></i></div>
+      <div class=\\"v-list-item-title\\" data-test=\\"rename-title\\"> Rename </div>
+    </div>
+  </div>
+  <!---->
+</div>"
+`;


### PR DESCRIPTION
This Pull Request is intended to address an issue where input from the Device Rename
feature was persisting with every change in the v-text-field, even if the user
didn't complete the changes. It also resolved the same bug that was causing
unsaved changes in other devices to persist.
