### PR TITLE
fix(api): correctly decode devices in DeviceList

### DIFF
--- a/api/store/mongo/device_store.go
+++ b/api/store/mongo/device_store.go
@@ -164,11 +164,10 @@ func (s *Store) DeviceList(ctx context.Context, pagination paginator.Query, filt
 	}
 	defer cursor.Close(ctx)
 
-	device := new(models.Device)
 	for cursor.Next(ctx) {
-		err = cursor.Decode(&device)
+		device := new(models.Device)
 
-		if err != nil {
+		if err = cursor.Decode(&device); err != nil {
 			return devices, count, err
 		}
 


### PR DESCRIPTION
Previously, the `device` variable was declared outside the loop,
leading to potential issues due to reusing the same object
for decoding multiple devices.

This commit fixes the issue by declaring `device` within the loop,
ensuring that each device is decoded independently.
