### PR TITLE
fix(ssh): local port forwarding with no request type

### DIFF
--- a/ssh/server/channels/tcpip.go
+++ b/ssh/server/channels/tcpip.go
@@ -6,7 +6,10 @@ import (
 	"strconv"
 
 	gliderssh "github.com/gliderlabs/ssh"
+	"github.com/shellhub-io/shellhub/pkg/httptunnel"
 	"github.com/shellhub-io/shellhub/ssh/pkg/metadata"
+	"github.com/shellhub-io/shellhub/ssh/session"
+	log "github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -24,68 +27,164 @@ const (
 	DirectTCPIPChannel = "direct-tcpip"
 )
 
-// DefaultTCPIPHandler is the default handler for DirectTCPIPChannel and DynamicTCPIPChannel channels.
-//
-// It will reject the channel if the LocalPortForwardingCallback is not set or returns false.
-// Otherwise, it will dial the agent and proxy the channel.
-func DefaultTCPIPHandler(server *gliderssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
-	type channelData struct {
-		DestAddr   string
-		DestPort   uint32
-		OriginAddr string
-		OriginPort uint32
+func TunnelDefaultDirectTCPIPHandler(tunnel *httptunnel.Tunnel) func(server *gliderssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
+	return func(server *gliderssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
+		target := metadata.RestoreTarget(ctx)
+
+		log.WithFields(log.Fields{
+			"username": target.Username,
+			"sshid":    target.Data,
+		}).Info("handling direct-tcpip channel")
+
+		type channelData struct {
+			DestAddr   string
+			DestPort   uint32
+			OriginAddr string
+			OriginPort uint32
+		}
+
+		data := new(channelData)
+		if err := gossh.Unmarshal(newChan.ExtraData(), data); err != nil {
+			newChan.Reject(gossh.ConnectionFailed, "faild to parse forward data: "+err.Error()) //nolint:errcheck
+			log.WithError(err).WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Error("failed to parse forward data")
+
+			return
+		}
+
+		if server.LocalPortForwardingCallback == nil || !server.LocalPortForwardingCallback(ctx, data.DestAddr, data.DestPort) {
+			newChan.Reject(gossh.Prohibited, "port forwarding is disabled") //nolint:errcheck
+			log.WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Info("port forwarding is disabled")
+
+			return
+		}
+
+		dest := net.JoinHostPort(data.DestAddr, strconv.FormatInt(int64(data.DestPort), 10))
+		config, err := session.NewClientConfiguration(ctx)
+		if err != nil {
+			newChan.Reject(gossh.ConnectionFailed, "error creating client configuration: "+err.Error()) //nolint:errcheck
+			log.WithError(err).WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Error("error creating client configuration")
+
+			return
+		}
+
+		sess, err := session.NewSessionWithoutClient(ctx, tunnel)
+		if err != nil {
+			newChan.Reject(gossh.ConnectionFailed, "failed to create session") //nolint:errcheck
+			log.WithError(err).WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Error("failed to create session")
+
+			return
+		}
+
+		connection, _, err := sess.NewClientConnWithDeadline(config)
+		if err != nil {
+			newChan.Reject(gossh.ConnectionFailed, "failed creating client connection: "+err.Error()) //nolint:errcheck
+			log.WithError(err).WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Error("failed creating agent connection")
+
+			return
+		}
+
+		agent, err := connection.Dial("tcp", dest)
+		if err != nil {
+			newChan.Reject(gossh.ConnectionFailed, "failed dialing the agent to host and port: "+err.Error()) //nolint:errcheck
+			log.WithError(err).WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Error("failed dialing the agent to host and port")
+
+			return
+		}
+
+		channel, reqs, err := newChan.Accept()
+		if err != nil {
+			newChan.Reject(gossh.ConnectionFailed, "failed accepting the channel: "+err.Error()) //nolint:errcheck
+			log.WithError(err).WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Error("failed accepting the channel")
+
+			return
+		}
+
+		go gossh.DiscardRequests(reqs)
+
+		log.WithFields(log.Fields{
+			"username":    target.Username,
+			"sshid":       target.Data,
+			"origin_port": data.OriginAddr,
+			"origin_addr": data.OriginPort,
+			"dest_port":   data.DestPort,
+			"dest_addr":   data.DestAddr,
+		}).Info("piping data between client and agent")
+
+		// TODO: control the running state of these goroutines.
+		go func() {
+			log.WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Debug("copying data from client to agent")
+
+			defer channel.Close()
+			io.Copy(channel, agent) //nolint:errcheck
+		}()
+		go func() {
+			log.WithFields(log.Fields{
+				"username":    target.Username,
+				"sshid":       target.Data,
+				"origin_port": data.OriginAddr,
+				"origin_addr": data.OriginPort,
+				"dest_port":   data.DestPort,
+				"dest_addr":   data.DestAddr,
+			}).Debug("copying data from agent to client")
+
+			defer channel.Close()
+			io.Copy(agent, channel) //nolint:errcheck
+		}()
 	}
-
-	data := channelData{}
-	if err := gossh.Unmarshal(newChan.ExtraData(), &data); err != nil {
-		newChan.Reject(gossh.ConnectionFailed, "error parsing forward data: "+err.Error()) //nolint:errcheck
-
-		return
-	}
-
-	if server.LocalPortForwardingCallback == nil || !server.LocalPortForwardingCallback(ctx, data.DestAddr, data.DestPort) {
-		newChan.Reject(gossh.Prohibited, "port forwarding is disabled") //nolint:errcheck
-
-		return
-	}
-
-	if !metadata.RestoreEstablished(ctx) {
-		newChan.Reject(gossh.Prohibited, "connection between server and agent is not established yet") //nolint:errcheck
-
-		return
-	}
-
-	dest := net.JoinHostPort(data.DestAddr, strconv.FormatInt(int64(data.DestPort), 10))
-
-	agent := metadata.RestoreAgent(ctx)
-	if agent == nil {
-		newChan.Reject(gossh.ConnectionFailed, "error restoring the agent") //nolint:errcheck
-
-		return
-	}
-
-	dialed, err := agent.Dial("tcp", dest)
-	if err != nil {
-		newChan.Reject(gossh.ConnectionFailed, "error dialing the agent to host and port: "+err.Error()) //nolint:errcheck
-
-		return
-	}
-
-	channel, reqs, err := newChan.Accept()
-	if err != nil {
-		newChan.Reject(gossh.ConnectionFailed, "error accepting the channel: "+err.Error()) //nolint:errcheck
-
-		return
-	}
-
-	go gossh.DiscardRequests(reqs)
-
-	go func() {
-		defer channel.Close()
-		io.Copy(channel, dialed) //nolint:errcheck
-	}()
-	go func() {
-		defer channel.Close()
-		io.Copy(dialed, channel) //nolint:errcheck
-	}()
 }

--- a/ssh/server/handler/sftp.go
+++ b/ssh/server/handler/sftp.go
@@ -42,7 +42,7 @@ func SFTPSubsystemHandler(tunnel *httptunnel.Tunnel) gliderssh.SubsystemHandler 
 
 		config, err := session.NewClientConfiguration(ctx)
 		if err != nil {
-			writeError(sess, "Error while creating client configuration", err, err)
+			writeError(sess, "Error while creating client configuration", err, ErrConfiguration)
 
 			return
 		}

--- a/ssh/server/handler/ssh.go
+++ b/ssh/server/handler/ssh.go
@@ -53,6 +53,7 @@ var (
 	ErrTarget             = fmt.Errorf("failed to get client target")
 	ErrAuthentication     = fmt.Errorf("failed to authenticate to device")
 	ErrEnvs               = fmt.Errorf("failed to parse server envs")
+	ErrConfiguration      = fmt.Errorf("failed to create communication configuration")
 )
 
 type ConfigOptions struct {
@@ -104,7 +105,7 @@ func SSHHandler(tunnel *httptunnel.Tunnel) gliderssh.Handler {
 
 		config, err := session.NewClientConfiguration(ctx)
 		if err != nil {
-			writeError(sess, "Error while creating client configuration", err, err)
+			writeError(sess, "Error while creating client configuration", err, ErrConfiguration)
 
 			return
 		}

--- a/ssh/server/server.go
+++ b/ssh/server/server.go
@@ -40,6 +40,13 @@ func NewServer(opts *Options, tunnel *httptunnel.Tunnel) *Server {
 		SessionRequestCallback: func(client gliderssh.Session, request string) bool {
 			metadata.StoreRequest(client.Context(), request)
 
+			target := metadata.RestoreTarget(client.Context())
+			log.WithFields(log.Fields{
+				"username": target.Username,
+				"sshid":    target.Data,
+				"request":  request,
+			}).Info("Session request")
+
 			return true
 		},
 		Handler: handler.SSHHandler(tunnel),
@@ -54,7 +61,7 @@ func NewServer(opts *Options, tunnel *httptunnel.Tunnel) *Server {
 		},
 		ChannelHandlers: map[string]gliderssh.ChannelHandler{
 			"session":                   gliderssh.DefaultSessionHandler,
-			channels.DirectTCPIPChannel: channels.DefaultTCPIPHandler,
+			channels.DirectTCPIPChannel: channels.TunnelDefaultDirectTCPIPHandler(tunnel),
 		},
 	}
 

--- a/ssh/session/errors.go
+++ b/ssh/session/errors.go
@@ -1,0 +1,14 @@
+package session
+
+import "fmt"
+
+// Errors returned by the NewSession to the client.
+var (
+	ErrBillingBlock       = fmt.Errorf("Connection to this device is not available as your current namespace doesn't qualify for the free plan. To gain access, you'll need to contact the namespace owner to initiate an upgrade.\n\nFor a detailed estimate of costs based on your use-cases with ShellHub Cloud, visit our pricing page at https://www.shellhub.io/pricing. If you wish to upgrade immediately, navigate to https://cloud.shellhub.io/settings/billing. Your cooperation is appreciated.") //nolint:all
+	ErrFirewallBlock      = fmt.Errorf("you cannot connect to this device because a firewall rule block your connection")
+	ErrFirewallConnection = fmt.Errorf("failed to communicate to the firewall")
+	ErrFirewallUnknown    = fmt.Errorf("failed to evaluate the firewall rule")
+	ErrHost               = fmt.Errorf("failed to get the device address")
+	ErrFindDevice         = fmt.Errorf("failed to find the device")
+	ErrDial               = fmt.Errorf("failed to connect to device agent, please check the device connection")
+)

--- a/ssh/session/types.go
+++ b/ssh/session/types.go
@@ -1,0 +1,67 @@
+package session
+
+import (
+	"strings"
+
+	"github.com/shellhub-io/shellhub/ssh/pkg/metadata"
+)
+
+const (
+	Web     = "web"     // web terminal.
+	Term    = "term"    // interactive session
+	Exec    = "exec"    // command execution
+	HereDoc = "heredoc" // heredoc pty.
+	SCP     = "scp"     // scp.
+	SFTP    = "sftp"    // sftp subsystem.
+	Unk     = "unknown" // unknown.
+)
+
+// setPty sets the connection's pty.
+func (s *Session) setPty() {
+	pty, _, isPty := s.Client.Pty()
+	if isPty {
+		s.Term = pty.Term
+	}
+
+	s.Pty = isPty
+}
+
+// setType sets the connection`s type to session.
+//
+// Connection types possible are: Web, SFTP, SCP, Exec, HereDoc, Term, Unk (unknown)
+func (s *Session) setType() {
+	ctx := s.Client.Context()
+
+	env := loadEnv(s.Client.Environ())
+	if value, ok := env["WS"]; ok && value == "true" {
+		env["WS"] = "false"
+		s.Type = Web
+
+		return
+	}
+
+	if s.Client.Subsystem() == SFTP {
+		s.Type = SFTP
+
+		return
+	}
+
+	var cmd string
+	commands := s.Client.Command()
+	if len(commands) != 0 {
+		cmd = commands[0]
+	}
+
+	switch {
+	case !s.Pty && strings.HasPrefix(cmd, SCP):
+		s.Type = SCP
+	case !s.Pty && metadata.RestoreRequest(ctx) == "shell":
+		s.Type = HereDoc
+	case cmd != "":
+		s.Type = Exec
+	case s.Pty:
+		s.Type = Term
+	default:
+		s.Type = Unk
+	}
+}

--- a/ssh/session/utils.go
+++ b/ssh/session/utils.go
@@ -1,0 +1,59 @@
+package session
+
+import (
+	"context"
+	"strings"
+
+	gliderssh "github.com/gliderlabs/ssh"
+	"github.com/shellhub-io/shellhub/pkg/api/internalclient"
+	log "github.com/sirupsen/logrus"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// TODO: Evaluate if we can use a dedicated package for this.
+func loadEnv(env []string) map[string]string {
+	m := make(map[string]string, cap(env))
+
+	for _, s := range env {
+		sp := strings.Split(s, "=")
+		if len(sp) == 2 {
+			k := sp[0]
+			v := sp[1]
+			m[k] = v
+		}
+	}
+
+	return m
+}
+
+func HandleRequests(ctx context.Context, reqs <-chan *gossh.Request, c internalclient.Client, done <-chan struct{}) {
+	for {
+		select {
+		case req := <-reqs:
+			if req == nil {
+				break
+			}
+
+			switch req.Type {
+			case "keepalive":
+				if id, ok := ctx.Value(gliderssh.ContextKeySessionID).(string); ok {
+					if errs := c.KeepAliveSession(id); len(errs) > 0 {
+						log.Error(errs[0])
+					}
+				}
+
+				if err := req.Reply(false, nil); err != nil {
+					log.Error(err)
+				}
+			default:
+				if req.WantReply {
+					if err := req.Reply(false, nil); err != nil {
+						log.Error(err)
+					}
+				}
+			}
+		case <-done:
+			return
+		}
+	}
+}


### PR DESCRIPTION
When a client connects to the SSH server using an option that sets the request type to `none`, the Local Port Forward doesn't know which device to connect because the SSH Handler wasn't called.

To allow it, we have dialed to the device through the tunnel and authenticated it. In order to avoid a lot of duplication, we also have refactored how the SSH server creates session, and added a new kind of SSH session what doesn't depend on SSH request type.

Resolves #3233