### PR TITLE
add index for tenant_id on recorded_sessions

### DIFF
--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -71,6 +71,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration59,
 		migration60,
 		migration61,
+		migration62,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_62.go
+++ b/api/store/mongo/migrations/migration_62.go
@@ -1,0 +1,62 @@
+package migrations
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var migration62 = migrate.Migration{
+	Version:     62,
+	Description: "create index for tenant_id on recorded_sessions",
+	Up: func(database *mongo.Database) error {
+		log.WithFields(log.Fields{
+			"component": "migration",
+			"version":   62,
+			"action":    "Up",
+		}).Info("Applying migration up")
+
+		indexName := "tenant_id"
+		_, err := database.Collection("recorded_sessions").Indexes().CreateOne(context.Background(), mongo.IndexModel{
+			Keys: bson.M{
+				"tenant_id": 1,
+			},
+			Options: &options.IndexOptions{ //nolint:exhaustruct
+				Name: &indexName,
+			},
+		})
+		if err != nil {
+			log.WithFields(log.Fields{
+				"component": "migration",
+				"version":   62,
+				"action":    "Up",
+			}).WithError(err).Info("Error while trying to apply migration 62")
+
+			return err
+		}
+
+		log.WithFields(log.Fields{
+			"component": "migration",
+			"version":   62,
+			"action":    "Up",
+		}).Info("Succeeds to to apply migration 62")
+
+		return nil
+	},
+	Down: func(database *mongo.Database) error {
+		log.WithFields(log.Fields{
+			"component": "migration",
+			"version":   62,
+			"action":    "Down",
+		}).Info("Applying migration down")
+		if _, err := database.Collection("recorded_sessions").Indexes().DropOne(context.Background(), "tenant_id"); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/api/store/mongo/migrations/migration_62_test.go
+++ b/api/store/mongo/migrations/migration_62_test.go
@@ -1,0 +1,130 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/pkg/dbtest"
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	envMocks "github.com/shellhub-io/shellhub/pkg/envs/mocks"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMigration62Up(t *testing.T) {
+	logrus.Info("Testing Migration 62")
+
+	db := dbtest.DBServer{}
+	defer db.Stop()
+
+	cases := []struct {
+		description string
+		mocks       func()
+		expected    func() error
+	}{
+		{
+			description: "Success to apply up on migration 62",
+			mocks: func() {
+				mock := &envMocks.Backend{}
+				envs.DefaultBackend = mock
+				mock.On("Get", "SHELLHUB_CLOUD").Return("true").Once()
+			},
+			expected: func() error {
+				cursor, err := db.Client().Database("test").Collection("recorded_sessions").Indexes().List(context.Background())
+				if err != nil {
+					return err
+				}
+
+				var found bool
+				for cursor.Next(context.Background()) {
+					var index bson.M
+					if err := cursor.Decode(&index); err != nil {
+						return err
+					}
+
+					if index["name"] == "tenant_id" {
+						found = true
+					}
+				}
+
+				if !found {
+					return errors.New("index not created")
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.mocks()
+
+			migrations := GenerateMigrations()[61:62]
+			migrates := migrate.NewMigrate(db.Client().Database("test"), migrations...)
+			assert.NoError(t, migrates.Up(migrate.AllAvailable))
+
+			assert.NoError(t, tc.expected())
+		})
+	}
+}
+
+func TestMigration62Down(t *testing.T) {
+	logrus.Info("Testing Migration 62")
+
+	db := dbtest.DBServer{}
+	defer db.Stop()
+
+	mock := &envMocks.Backend{}
+	envs.DefaultBackend = mock
+
+	cases := []struct {
+		description string
+		mocks       func()
+		expected    func() error
+	}{
+		{
+			description: "Success to apply down on migration 62",
+			mocks:       func() {},
+			expected: func() error {
+				cursor, err := db.Client().Database("test").Collection("recorded_sessions").Indexes().List(context.Background())
+				if err != nil {
+					return errors.New("index not dropped")
+				}
+
+				var found bool
+				for cursor.Next(context.Background()) {
+					var index bson.M
+					if err := cursor.Decode(&index); err != nil {
+						return err
+					}
+
+					if index["name"] == "tenant_id" {
+						found = true
+					}
+				}
+
+				if found {
+					return errors.New("index not dropped")
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.mocks()
+
+			migrations := GenerateMigrations()[61:62]
+			migrates := migrate.NewMigrate(db.Client().Database("test"), migrations...)
+			assert.NoError(t, migrates.Down(migrate.AllAvailable))
+
+			assert.NoError(t, tc.expected())
+		})
+	}
+}


### PR DESCRIPTION
Given that 'recorded_sessions' can constitute up to 99% of the entire database, certain operations may experience prolonged blocking, disrupting the current context and leading to unexpected errors. To mitigate this issue, we are now implementing a new index on the 'tenant_id' field.