### PR TITLE
fix(api): correct variable names in GetToken API

### DIFF
--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -181,7 +181,7 @@ func (h *Handler) AuthGetToken(c gateway.Context) error {
 		return err
 	}
 
-	res, err := h.service.AuthGetToken(c.Ctx(), req.Tenant)
+	res, err := h.service.AuthGetToken(c.Ctx(), req.ID)
 	if err != nil {
 		return err
 	}

--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -27,7 +27,7 @@ type AuthService interface {
 	AuthUncacheToken(ctx context.Context, tenant, id string) error
 	AuthDevice(ctx context.Context, req requests.DeviceAuth, remoteAddr string) (*models.DeviceAuthResponse, error)
 	AuthUser(ctx context.Context, req requests.UserAuth) (*models.UserAuthResponse, error)
-	AuthGetToken(ctx context.Context, tenant string) (*models.UserAuthResponse, error)
+	AuthGetToken(ctx context.Context, id string) (*models.UserAuthResponse, error)
 	AuthPublicKey(ctx context.Context, req requests.PublicKeyAuth) (*models.PublicKeyAuthResponse, error)
 	AuthSwapToken(ctx context.Context, ID, tenant string) (*models.UserAuthResponse, error)
 	AuthUserInfo(ctx context.Context, username, tenant, token string) (*models.UserAuthResponse, error)

--- a/pkg/api/requests/auth.go
+++ b/pkg/api/requests/auth.go
@@ -2,7 +2,7 @@ package requests
 
 // AuthTokenGet is the structure to represent the request data for get auth token endpoint.
 type AuthTokenGet struct {
-	TenantParam
+	UserParam
 }
 
 // AuthTokenSwap is the structure to represent the request data for swap auth token endpoint.


### PR DESCRIPTION
This commit addresses a bug related to variable names in the GetToken API. The goal is to change the name from 'tenant' to 'id' since the provided value is the ID, not the tenant. This adjustment ensures accuracy and consistency in the API behavior.