### PR TITLE
feat(ui): add validation modal for conflicted device names

### DIFF
--- a/ui/src/components/AppBar/Notifications/Notification.vue
+++ b/ui/src/components/AppBar/Notifications/Notification.vue
@@ -68,6 +68,7 @@
             <DeviceActionButton
               v-if="hasAuthorization"
               :uid="item.uid"
+              :name="item.name"
               :notification-status="true"
               :show="!getStatusNotifications"
               action="accept"

--- a/ui/src/components/Devices/DeviceAcceptWarning.vue
+++ b/ui/src/components/Devices/DeviceAcceptWarning.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-dialog
+    v-if="hasAuthorization"
+    v-model="showMessage"
+    transition="dialog-bottom-transition"
+    width="650"
+    data-test="device-accept-warning-dialog"
+  >
+    <v-card class="bg-v-theme-surface" data-test="card-dialog">
+      <v-card-title class="pa-3 bg-primary" data-test="card-title">
+        You already have a device using the same name
+      </v-card-title>
+
+      <v-card-text class="mt-4 mb-3 pb-1">
+        <p class="mb-2" data-test="card-text">
+          <strong>{{ device }} </strong> name is already taken by another accepted device,
+          please choose another name.
+        </p>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer />
+
+        <v-btn variant="text" data-test="close-btn" @click="close()"> Close </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { actions, authorizer } from "@/authorizer";
+import hasPermission from "@/utils/permission";
+import { useStore } from "@/store";
+
+const store = useStore();
+const device = computed(() => store.getters["devices/getDeviceToBeRenamed"]);
+
+const hasAuthorization = computed(() => {
+  const role = store.getters["auth/role"];
+  if (role !== "") {
+    return hasPermission(
+      authorizer.role[role],
+      actions.billing.subscribe,
+    );
+  }
+
+  return false;
+});
+
+const close = () => {
+  if (store.getters["users/deviceDuplicationError"]) {
+    store.dispatch("users/setDeviceDuplicationOnAcceptance", false);
+  }
+};
+
+const showMessage = computed({
+  get() {
+    return (
+      (store.getters["users/deviceDuplicationError"])
+    );
+  },
+  set() {
+    close();
+  },
+});
+
+defineExpose({ showMessage });
+</script>

--- a/ui/src/components/Devices/DeviceActionButton.vue
+++ b/ui/src/components/Devices/DeviceActionButton.vue
@@ -72,6 +72,11 @@ import handleError from "../../utils/handleError";
 
 export default defineComponent({
   props: {
+    name: {
+      type: String,
+      required: false,
+      default: "Device",
+    },
     uid: {
       type: String,
       required: true,
@@ -188,8 +193,16 @@ export default defineComponent({
       } catch (error: unknown) {
         if (axios.isAxiosError(error)) {
           const axiosError = error as AxiosError;
-          if (axiosError.response?.status === 402) {
-            store.dispatch("users/setStatusUpdateAccountDialogByDeviceAction", true);
+          switch (axiosError.response?.status) {
+            case 402:
+              store.dispatch("users/setStatusUpdateAccountDialogByDeviceAction", true);
+              break;
+            case 409:
+              store.dispatch("devices/setDeviceToBeRenamed", props.name);
+              store.dispatch("users/setDeviceDuplicationOnAcceptance", true);
+              break;
+            default:
+              return;
           }
         }
         close();

--- a/ui/src/components/Devices/DevicePendingList.vue
+++ b/ui/src/components/Devices/DevicePendingList.vue
@@ -44,6 +44,7 @@
               <v-list class="bg-v-theme-surface" lines="two" density="compact">
                 <DeviceActionButton
                   :uid="item.uid"
+                  :name="item.name"
                   action="accept"
                   :show="showDeviceAcceptButton"
                   data-test="DeviceActionButtonAccept-component"

--- a/ui/src/components/Devices/DeviceRejectedList.vue
+++ b/ui/src/components/Devices/DeviceRejectedList.vue
@@ -44,6 +44,7 @@
               <v-list class="bg-v-theme-surface" lines="two" density="compact">
                 <DeviceActionButton
                   :uid="item.uid"
+                  :name="item.name"
                   action="accept"
                   data-test="DeviceActionButtonAccept-component"
                   @update="refreshDevices"

--- a/ui/src/components/Devices/DeviceRename.vue
+++ b/ui/src/components/Devices/DeviceRename.vue
@@ -114,7 +114,7 @@ const rename = async () => {
     if (axios.isAxiosError(error)) {
       const axiosError = error as AxiosError;
       if (axiosError.response?.status === 400) {
-        setEditNameError("nonStandardCharacters");
+        setEditNameError("The characters being used are invalid");
       } else if (error.response?.status === 409) {
         setEditNameError("The name already exists in the namespace");
       }

--- a/ui/src/components/User/UserWarning.vue
+++ b/ui/src/components/User/UserWarning.vue
@@ -27,6 +27,11 @@
     @update="showAnnouncements = false"
     data-test="announcementsModal-component"
   />
+
+  <DeviceAcceptWarning
+    v-model:show="showDeviceWarning"
+    @update="showDeviceWarning = false"
+  />
 </template>
 
 <script lang="ts">
@@ -40,6 +45,7 @@ import BillingWarning from "../Billing/BillingWarning.vue";
 import DeviceChooser from "../Devices/DeviceChooser.vue";
 import AnnouncementsModal from "../Announcements/AnnouncementsModal.vue";
 import handleError from "@/utils/handleError";
+import DeviceAcceptWarning from "../Devices/DeviceAcceptWarning.vue";
 
 export default defineComponent({
   inheritAttrs: false,
@@ -48,7 +54,7 @@ export default defineComponent({
     const showInstructions = ref(false);
     const show = ref<boolean>(false);
     const showAnnouncements = ref<boolean>(false);
-
+    const showDeviceWarning = computed(() => store.getters["users/deviceDuplicationError"]);
     const hasNamespaces = computed(
       () => store.getters["namespaces/getNumberNamespaces"] !== 0,
     );
@@ -175,6 +181,7 @@ export default defineComponent({
       hasDevices,
       stats,
       showInstructions,
+      showDeviceWarning,
       isBillingEnabled,
       namespaceHasBeenShown,
       showScreenWelcome,
@@ -190,6 +197,7 @@ export default defineComponent({
     BillingWarning,
     DeviceChooser,
     AnnouncementsModal,
+    DeviceAcceptWarning,
   },
 });
 </script>

--- a/ui/src/store/modules/devices.ts
+++ b/ui/src/store/modules/devices.ts
@@ -19,6 +19,7 @@ export interface DevicesState {
   devicesForUserToChoose: Array<IDevice>;
   numberdevicesForUserToChoose: number;
   devicesSelected: Array<IDevice>;
+  deviceName: string,
   }
 
 export const devices: Module<DevicesState, State> = {
@@ -37,6 +38,7 @@ export const devices: Module<DevicesState, State> = {
     devicesForUserToChoose: [],
     numberdevicesForUserToChoose: 0,
     devicesSelected: [],
+    deviceName: "",
   },
 
   getters: {
@@ -55,6 +57,7 @@ export const devices: Module<DevicesState, State> = {
     getDevicesForUserToChoose: (state) => state.devicesForUserToChoose,
     getNumberForUserToChoose: (state) => state.numberdevicesForUserToChoose,
     getDevicesSelected: (state) => state.devicesSelected,
+    getDeviceToBeRenamed: (state) => state.deviceName,
   },
 
   mutations: {
@@ -123,6 +126,10 @@ export const devices: Module<DevicesState, State> = {
     clearListDevicesForUserToChoose: (state) => {
       state.devicesForUserToChoose = [];
       state.numberdevicesForUserToChoose = 0;
+    },
+
+    updateDeviceToBeRenamed(state, device) {
+      state.deviceName = device;
     },
   },
 
@@ -315,6 +322,10 @@ export const devices: Module<DevicesState, State> = {
         console.error(error);
         throw error;
       }
+    },
+
+    setDeviceToBeRenamed(context, device) {
+      context.commit("updateDeviceToBeRenamed", device);
     },
   },
 };

--- a/ui/src/store/modules/users.ts
+++ b/ui/src/store/modules/users.ts
@@ -5,6 +5,8 @@ import { State } from "..";
 export interface UsersState {
   statusUpdateAccountDialog: boolean;
   statusUpdateAccountDialogByDeviceAction: boolean;
+  deviceDuplicationError: boolean,
+
 }
 
 export const users: Module<UsersState, State> = {
@@ -12,6 +14,7 @@ export const users: Module<UsersState, State> = {
   state: {
     statusUpdateAccountDialog: false,
     statusUpdateAccountDialogByDeviceAction: false,
+    deviceDuplicationError: false,
   },
 
   getters: {
@@ -19,6 +22,7 @@ export const users: Module<UsersState, State> = {
     statusUpdateAccountDialogByDeviceAction(state) {
       return state.statusUpdateAccountDialogByDeviceAction;
     },
+    deviceDuplicationError: (state) => state.deviceDuplicationError,
   },
 
   mutations: {
@@ -28,6 +32,9 @@ export const users: Module<UsersState, State> = {
 
     updateStatusUpdateAccountDialogByDeviceAction(state, status) {
       state.statusUpdateAccountDialogByDeviceAction = status;
+    },
+    updateDeviceDuplicationError(state, status) {
+      state.deviceDuplicationError = status;
     },
   },
 
@@ -101,6 +108,10 @@ export const users: Module<UsersState, State> = {
 
     setStatusUpdateAccountDialogByDeviceAction(context, status) {
       context.commit("updateStatusUpdateAccountDialogByDeviceAction", status);
+    },
+
+    setDeviceDuplicationOnAcceptance(context, status) {
+      context.commit("updateDeviceDuplicationError", status);
     },
   },
 };

--- a/ui/tests/components/Devices/__snapshots__/DeviceAcceptWarning.spec.ts
+++ b/ui/tests/components/Devices/__snapshots__/DeviceAcceptWarning.spec.ts
@@ -1,0 +1,117 @@
+import { createVuetify } from "vuetify";
+import { DOMWrapper, mount, VueWrapper } from "@vue/test-utils";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import MockAdapter from "axios-mock-adapter";
+import { nextTick } from "vue";
+import DeviceAcceptWarning from "@/components/Devices/DeviceAcceptWarning.vue";
+import { namespacesApi } from "@/api/http";
+import { store, key } from "@/store";
+import { router } from "@/router";
+import { envVariables } from "@/envVariables";
+import { SnackbarPlugin } from "@/plugins/snackbar";
+
+type DeviceAcceptWarningWrapper = VueWrapper<InstanceType<typeof DeviceAcceptWarning>>;
+
+const members = [
+  {
+    id: "xxxxxxxx",
+    username: "test",
+    role: "owner",
+  },
+];
+
+const namespaceData = {
+  name: "test",
+  owner: "xxxxxxxx",
+  tenant_id: "fake-tenant-data",
+  members,
+  max_devices: 3,
+  devices_count: 3,
+  devices: 2,
+  created_at: "",
+};
+
+const authData = {
+  status: "",
+  token: "",
+  user: "test",
+  name: "test",
+  tenant: "fake-tenant-data",
+  email: "test@test.com",
+  id: "xxxxxxxx",
+  role: "owner",
+};
+
+describe("Device Accept Warning", () => {
+  let wrapper: DeviceAcceptWarningWrapper;
+  const vuetify = createVuetify();
+
+  let mockNamespace: MockAdapter;
+
+  beforeEach(() => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    vi.useFakeTimers();
+    mockNamespace = new MockAdapter(namespacesApi.getAxios());
+    envVariables.isCloud = true;
+
+    mockNamespace.onGet("http://localhost:3000/api/namespaces/fake-tenant-data").reply(200, namespaceData);
+
+    store.commit("auth/authSuccess", authData);
+    store.commit("namespaces/setNamespace", namespaceData);
+    store.dispatch("users/setDeviceDuplicationOnAcceptance", true);
+
+    wrapper = mount(DeviceAcceptWarning, {
+      global: {
+        plugins: [[store, key], vuetify, router, SnackbarPlugin],
+      },
+      sync: false,
+      attachTo: el,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("Is a Vue instance", () => {
+    expect(wrapper.vm).toBeTruthy();
+  });
+
+  it("Renders the component", () => {
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("Renders the template with data", () => {
+    const wrapper = new DOMWrapper(document.body);
+
+    expect(wrapper.find('[data-test="device-accept-warning-dialog"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="card-dialog"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="card-title"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="card-text"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="close-btn"]').exists()).toBe(true);
+  });
+
+  it("Closes the template", async () => {
+    const wrapper = new DOMWrapper(document.body);
+    const spyStore = vi.spyOn(store, "dispatch");
+
+    await wrapper.find('[data-test="close-btn"]').trigger("click");
+    expect(spyStore).toHaveBeenCalledWith("users/setDeviceDuplicationOnAcceptance", false);
+  });
+
+  it("Reads the conflicted device name", async () => {
+    store.dispatch("devices/setDeviceToBeRenamed", "device");
+    const dialogWrapper = new DOMWrapper(document.body);
+    wrapper.vm.showMessage = true;
+
+    await nextTick(); // Wait for the next tick to ensure the prop is updated
+
+    const actualText = dialogWrapper.find('[data-test="card-text"]').text();
+    const expectedText = "device name is already taken by another accepted device, please choose another name.";
+    await nextTick();
+    expect(actualText).toEqual(expectedText);
+  });
+});

--- a/ui/tests/components/Devices/__snapshots__/__snapshots__/DeviceAcceptWarning.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/__snapshots__/DeviceAcceptWarning.spec.ts.snap
@@ -1,0 +1,6 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Device Accept Warning > Renders the component 1`] = `
+"<!--teleport start-->
+<!--teleport end-->"
+`;


### PR DESCRIPTION
This PR is aimed to validate when the user tries to accept a device
that has the same name as an already accepted device.
