### PR TITLE
fix(gateway): fix "worker_connections are not enough" error

### DIFF
--- a/gateway/conf.d/shellhub.conf
+++ b/gateway/conf.d/shellhub.conf
@@ -1,6 +1,6 @@
 server {
     {{ if and (bool (env.Getenv "SHELLHUB_AUTO_SSL")) (ne (env.Getenv "SHELLHUB_ENV") "development") -}}
-    listen 443 ssl{{ if bool (env.Getenv "SHELLHUB_PROXY") }} proxy_protocol{{ end }};
+    listen 443 reuseport ssl{{ if bool (env.Getenv "SHELLHUB_PROXY") }} proxy_protocol{{ end }};
     ssl_certificate /etc/letsencrypt/live/{{ env.Getenv "SHELLHUB_DOMAIN" }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ env.Getenv "SHELLHUB_DOMAIN" }}/privkey.pem;
 
@@ -15,7 +15,7 @@ server {
 
     ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
     {{ else -}}
-    listen 80{{ if bool (env.Getenv "SHELLHUB_PROXY") }} proxy_protocol{{ end }};
+    listen 80 reuseport{{ if bool (env.Getenv "SHELLHUB_PROXY") }} proxy_protocol{{ end }};
     {{- end }}
     {{ if bool (env.Getenv "SHELLHUB_PROXY") }}
     set_real_ip_from ::/0;


### PR DESCRIPTION
Fix the issue of inadequate distribution of client connections
among worker processes by enabling the `reuseport` option.
This enhancement allows the kernel to efficiently distribute
incoming connections across multiple worker processes, resolving
the 'worker_connections are not enough' error.
