### PR TITLE
fix(wsconnadapter): prevent nil channel write in Close method

### DIFF
--- a/pkg/wsconnadapter/wsconnadapter.go
+++ b/pkg/wsconnadapter/wsconnadapter.go
@@ -134,8 +134,10 @@ func (a *Adapter) Close() error {
 	select {
 	case <-a.stopPingCh:
 	default:
-		a.stopPingCh <- struct{}{}
-		close(a.stopPingCh)
+		if a.stopPingCh != nil {
+			a.stopPingCh <- struct{}{}
+			close(a.stopPingCh)
+		}
 	}
 
 	return a.conn.Close()


### PR DESCRIPTION
Fix an issue in wsconnadapter where attempting to write to a nil
channel during the Close method could lead to a runtime panic.
