### PR TITLE
chore(qa): update node version on QA

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -113,11 +113,11 @@ jobs:
           args: ${{ matrix.lint_args }} ./...
           skip-pkg-cache: true
 
-      - name: Set up Node.JS 18.16.0 [UI]
+      - name: Set up Node.JS 21.4.0 [UI]
         if: matrix.project == 'ui' && steps.filter.outputs.ui == 'true' && github.event.pull_request.draft == false
         uses: actions/setup-node@v4
         with:
-          node-version: "18.16.0"
+          node-version: "21.4.0"
 
       - name: Cache node modules [UI]
         if: matrix.project == 'ui' && steps.filter.outputs.ui == 'true' && github.event.pull_request.draft == false


### PR DESCRIPTION
This commit is aimed to update the node version to 21.4 on QA workflow.
