### PR TITLE
fix(api): correct binding of query parameters

### DIFF
--- a/api/pkg/echo/handlers/binder.go
+++ b/api/pkg/echo/handlers/binder.go
@@ -25,5 +25,11 @@ func (b *Binder) Bind(s interface{}, c echo.Context) error {
 		return errors.NewErrUnprocessableEntity(err.Unwrap())
 	}
 
+	if err := binder.BindQueryParams(c, s); err != nil {
+		err := err.(*echo.HTTPError) //nolint:forcetypeassert
+
+		return errors.NewErrUnprocessableEntity(err.Unwrap())
+	}
+
 	return nil
 }


### PR DESCRIPTION
This commit addresses two issues:
1. Ensures proper percent encoding in query parameters.
2. Enables the API to retrieve query parameters in POST, PUT, and PATCH routes.