### PR TITLE
fix(ui): added class to center loading on appLayout

### DIFF
--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -82,8 +82,9 @@
 
     <v-overlay
       :model-value="hasSpinner"
+      :scrim="false"
       contained
-      content-class="w-100 h-100"
+      class="align-center justify-center w-100 h-100"
       data-test="overlay"
     >
       <v-progress-circular


### PR DESCRIPTION
This Pull Request is aimed to fix an issue where the loading progress
would be on the top-left of the screen.
