### PR TITLE
fix(agent): use raw command to fix issues with quoted arguments.

### DIFF
--- a/pkg/agent/server/modes/host/sessioner.go
+++ b/pkg/agent/server/modes/host/sessioner.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"strings"
 	"sync"
 
 	gliderssh "github.com/gliderlabs/ssh"
@@ -214,7 +213,7 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 		term = "xterm"
 	}
 
-	cmd := command.NewCmd(user, shell, term, *s.deviceName, shell, "-c", strings.Join(session.Command(), " "))
+	cmd := command.NewCmd(user, shell, term, *s.deviceName, shell, "-c", session.RawCommand())
 
 	wg := &sync.WaitGroup{}
 	if sIsPty {


### PR DESCRIPTION
While `session.Command()` tokenizes command arguments by spaces, resulting in incorrect parsing of quoted arguments, `session.RawCommand()` preserves the command string intact, ensuring proper handling of quoted arguments.

Fixes: #3545
