### PR TITLE
refactor: move dev agent service to it own compose file

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -45,7 +45,7 @@ set +o allexport
 COMPOSE_FILE="docker-compose.yml"
 
 [ "$SHELLHUB_AUTO_SSL" = "true" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.autossl.yml"
-[ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.dev.yml"
+[ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.dev.yml:docker-compose.agent.yml"
 [ "$SHELLHUB_ENTERPRISE" = "true" ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.enterprise.yml"
 [ "$SHELLHUB_CONNECTOR" = "true" ] && [ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.connector.dev.yml"
 [ "$SHELLHUB_CONNECTOR" = "true"  ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.connector.yml"

--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -1,0 +1,38 @@
+version: "3.7"
+
+services:
+  agent:
+    image: agent
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: agent/Dockerfile
+      target: development
+      network: host
+      args:
+        - SHELLHUB_VERSION=latest
+        - GOPROXY=${SHELLHUB_GOPROXY}
+        - SHELLHUB_LOG_LEVEL=${SHELLHUB_LOG_LEVEL}
+    privileged: true
+    network_mode: host
+    pid: host
+    environment:
+      - SHELLHUB_SERVER_ADDRESS=http://localhost:${SHELLHUB_HTTP_PORT}
+      - SHELLHUB_PRIVATE_KEY=/go/src/github.com/shellhub-io/shellhub/agent/shellhub.key
+      - SHELLHUB_TENANT_ID=00000000-0000-4000-0000-000000000000
+      - SHELLHUB_VERSION=${SHELLHUB_VERSION}
+      - SHELLHUB_LOG_LEVEL=${SHELLHUB_LOG_LEVEL}
+      - SHELLHUB_LOG_FORMAT=${SHELLHUB_LOG_FORMAT}
+    volumes:
+      - ./agent:/go/src/github.com/shellhub-io/shellhub/agent
+      - ./pkg:/go/src/github.com/shellhub-io/shellhub/pkg
+      - /:/host
+      - /dev:/dev
+      - /etc/passwd:/etc/passwd
+      - /etc/group:/etc/group
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./.golangci.yaml:/.golangci.yaml
+    depends_on:
+      - api
+      - ssh
+      - gateway

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -60,41 +60,6 @@ services:
     environment:
       - SHELLHUB_VERSION=latest
       - SHELLHUB_ENV=${SHELLHUB_ENV}
-  agent:
-    image: agent
-    restart: unless-stopped
-    build:
-      context: .
-      dockerfile: agent/Dockerfile
-      target: development
-      network: host
-      args:
-        - SHELLHUB_VERSION=latest
-        - GOPROXY=${SHELLHUB_GOPROXY}
-        - SHELLHUB_LOG_LEVEL=${SHELLHUB_LOG_LEVEL}
-    privileged: true
-    network_mode: host
-    pid: host
-    environment:
-      - SHELLHUB_SERVER_ADDRESS=http://localhost:${SHELLHUB_HTTP_PORT}
-      - SHELLHUB_PRIVATE_KEY=/go/src/github.com/shellhub-io/shellhub/agent/shellhub.key
-      - SHELLHUB_TENANT_ID=00000000-0000-4000-0000-000000000000
-      - SHELLHUB_VERSION=${SHELLHUB_VERSION}
-      - SHELLHUB_LOG_LEVEL=${SHELLHUB_LOG_LEVEL}
-      - SHELLHUB_LOG_FORMAT=${SHELLHUB_LOG_FORMAT}
-    volumes:
-      - ./agent:/go/src/github.com/shellhub-io/shellhub/agent
-      - ./pkg:/go/src/github.com/shellhub-io/shellhub/pkg
-      - /:/host
-      - /dev:/dev
-      - /etc/passwd:/etc/passwd
-      - /etc/group:/etc/group
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./.golangci.yaml:/.golangci.yaml
-    depends_on:
-      - api
-      - ssh
-      - gateway
   cli:
     image: cli
     build:


### PR DESCRIPTION
We moved the Agent's compose service to a dedicate compose file to allow more flexibility when running the dev environment, especially for the integration tests.

The current behavior hasn't changed; when the `SHELLHUB_ENV` is set to development, the Agent still starts together with the services, but now we could separate this process using a env variable more easily in the future.