### PR TITLE
chore(docker-compose): dynamic network

### DIFF
--- a/.env
+++ b/.env
@@ -119,3 +119,12 @@ SHELLHUB_CONNECTOR_TENANT_ID=
 # Agents 0.5.x or earlier do not validate the public key request and may panic.
 # Please refer to: https://github.com/shellhub-io/shellhub/issues/3453
 SHELLHUB_ALLOW_PUBLIC_KEY_ACCESS_BELLOW_0_6_0=false
+
+# Specifies the network name utilized by Docker Compose. As all services (except for the gateway and SSH) persistently operate
+# on the port 8080, running multiple instances may result in collision errors.
+#
+# To illustrate, envision two distinct ShellHub instances denoted as "A" and "B". In instance "A", a gateway operates on port
+# 11111, and in instance "B", a gateway operates on port 22222. Since both APIs function on port 8080 and both instances
+# share the same network, gateway "A" might inadvertently request data from "B" (and vice versa) when the networks are identical.
+SHELLHUB_NETWORK=shellhub_network
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,4 +145,4 @@ secrets:
 
 networks:
   shellhub:
-    name: shellhub_network
+    name: ${SHELLHUB_NETWORK}


### PR DESCRIPTION
Introduces a new `SHELLHUB_NETWORK` variable, which allows the docker compose to dynamically create a network.

While always binding the same network seem convenient, it can lead to collision errors when running multiple Docker Compose instances (e.g., testcontainers) because each instance shares the same network.

To illustrate, consider two distinct ShellHub instances denoted as "A" and "B". In instance "A", a gateway operates on port 11111, and in instance "B", a gateway operates on port 22222. Since both APIs works on port 8080 and both instances share the same network, gateway "A" might inadvertently request data from "B" (and vice versa) when the networks are identical