### PR TITLE
Refactor/ssh api client

### DIFF
--- a/pkg/api/internalclient/mocks/internalclient.go
+++ b/pkg/api/internalclient/mocks/internalclient.go
@@ -446,8 +446,21 @@ func (_m *Client) NamespaceLookup(tenant string) (*models.Namespace, []error) {
 }
 
 // RecordSession provides a mock function with given fields: session, recordURL
-func (_m *Client) RecordSession(session *models.SessionRecorded, recordURL string) {
-	_m.Called(session, recordURL)
+func (_m *Client) RecordSession(session *models.SessionRecorded, recordURL string) error {
+	ret := _m.Called(session, recordURL)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecordSession")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*models.SessionRecorded, string) error); ok {
+		r0 = rf(session, recordURL)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // SessionAsAuthenticated provides a mock function with given fields: uid

--- a/pkg/api/internalclient/session.go
+++ b/pkg/api/internalclient/session.go
@@ -26,7 +26,7 @@ type sessionAPI interface {
 	KeepAliveSession(uid string) []error
 
 	// RecordSession records a session with the provided session information and record URL.
-	RecordSession(session *models.SessionRecorded, recordURL string)
+	RecordSession(session *models.SessionRecorded, recordURL string) error
 }
 
 func (c *client) SessionCreate(session requests.SessionCreate) error {
@@ -80,9 +80,11 @@ func (c *client) KeepAliveSession(uid string) []error {
 	return errors
 }
 
-func (c *client) RecordSession(session *models.SessionRecorded, recordURL string) {
-	_, _ = c.http.
+func (c *client) RecordSession(session *models.SessionRecorded, recordURL string) error {
+	_, err := c.http.
 		R().
 		SetBody(session).
 		Post(fmt.Sprintf("http://"+recordURL+"/internal/sessions/%s/record", session.UID))
+
+	return err
 }


### PR DESCRIPTION
The `Session` struct now includes an api attribute, representing an instance of `internalclient.Client`. Requests made by the session now utilize this instance instead of creating or restoring one within the context.

In alignment with this modification, we are introducing several new methods to the struct:

1. `Authenticate`: This method initiates a PATCH request to the API to authenticate the session.
2. `Record`: This method executes a POST request to the API to record the current state of the session.

Additionally, authentication is now centralized in a single location, rather than being invoked in each handler.