### PR TITLE
fix(ui): remove unused unmount on terminal

### DIFF
--- a/ui/src/components/Terminal/TerminalDialog.vue
+++ b/ui/src/components/Terminal/TerminalDialog.vue
@@ -136,7 +136,6 @@ import {
   ref,
   computed,
   watch,
-  onUnmounted,
 } from "vue";
 import { useField } from "vee-validate";
 import "xterm/css/xterm.css";
@@ -372,10 +371,6 @@ const close = () => {
   resetFieldValidation();
   store.dispatch("modal/toggleTerminal", "");
 };
-
-onUnmounted(() => {
-  close();
-});
 
 defineExpose({ open, showTerminal, showLoginForm, encodeURLParams, connect, privateKey, xterm, fitAddon, ws, close });
 </script>


### PR DESCRIPTION
This commit is aimed to fix a bug which was generated by the unmount function
on the TerminalDialog, which was trying to close the terminal twice, causing
interface bugs.
