### PR TITLE
fix(ssh): allow multiplexed connection

### DIFF
--- a/ssh/server/channels/session.go
+++ b/ssh/server/channels/session.go
@@ -175,21 +175,6 @@ func DefaultSessionHandler(opts DefaultSessionHandlerOptions) gliderssh.ChannelH
 
 				switch req.Type {
 				case ShellRequestType, ExecRequestType, SubsystemRequestType:
-					// Once the session has been set up, a program is started at the remote end.  The program can be a
-					// shell, an application program, or a subsystem with a host-independent name.  **Only one of these
-					// requests can succeed per channel.**
-					//
-					// https://www.rfc-editor.org/rfc/rfc4254#section-6.5
-					if sess.Handled {
-						logger.Warn("fail to start a new session before ending the previous one")
-
-						if err := req.Reply(false, nil); err != nil {
-							logger.WithError(err).Error("failed to reply the client when data pipe already started")
-						}
-
-						continue
-					}
-
 					if err := req.Reply(ok, nil); err != nil {
 						logger.WithError(err).Error("failed to reply the client with right response for pipe request type")
 
@@ -209,7 +194,7 @@ func DefaultSessionHandler(opts DefaultSessionHandlerOptions) gliderssh.ChannelH
 					// encrypted tunnel.
 					//
 					// https://www.rfc-editor.org/rfc/rfc4254#section-6.5
-					go pipe(ctx, sess, client, agent, req.Type, opts)
+					go pipe(sess, client, agent, req.Type, opts)
 				case PtyRequestType:
 					var pty session.Pty
 

--- a/ssh/server/channels/utils.go
+++ b/ssh/server/channels/utils.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"sync"
 
-	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/ssh/session"
@@ -13,18 +12,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
-func pipe(ctx gliderssh.Context, sess *session.Session, client gossh.Channel, agent gossh.Channel, req string, opts DefaultSessionHandlerOptions) {
-	defer func() {
-		ctx.Lock()
-		sess.Handled = false
-		ctx.Unlock()
-	}()
-
-	// NOTICE: avoid multiple pipe data in same channel due to protocol limitaion.
-	ctx.Lock()
-	sess.Handled = true
-	ctx.Unlock()
-
+func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, req string, opts DefaultSessionHandlerOptions) {
 	defer log.
 		WithFields(log.Fields{"session": sess.UID, "sshid": sess.SSHID}).
 		Trace("data pipe between client and agent has done")

--- a/ssh/session/session.go
+++ b/ssh/session/session.go
@@ -54,8 +54,6 @@ type Data struct {
 	Lookup map[string]string
 	// Pty is the PTY dimension.
 	Pty Pty
-	// Handled check if the session is already handling a "shell", "exec" or a "subsystem".
-	Handled bool
 }
 
 // TODO: implement [io.Read] and [io.Write] on session to simplify the data piping.


### PR DESCRIPTION
A Multiplexing connection can send more than one channel request over the same socket, making possible reuse the authentication method used by the master in the derivate ones.

To support it, we should only allow the GliderSSH's server to dial with the connection on the agent's side, removing our intervention on the protocol flow, that enforces the channel limitation, just sending the device's response to the client.

Closes #3656