### PR TITLE
feat: Introduce CVE-2024-3094 vulnerability support

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.22.1-alpine3.19 AS base
 
 ARG GOPROXY
 
-RUN apk add --update git ca-certificates build-base openssh-client
+RUN apk add --update git ca-certificates build-base openssh-client xz xz-dev
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 


### PR DESCRIPTION
Hey everyone,

As part of our ongoing commitment to staying up-to-date with the
latest security standards, I'm excited to introduce support
for the CVE-2024-3094 vulnerability in ShellHub!

In line with industry best practices, we've decided to ensure that
ShellHub remains at the forefront of security technology.
With this latest feature addition, ShellHub now proudly supports
the CVE-2024-3094 vulnerability, just like OpenSSH.
We understand the importance of maintaining parity with other
widely-used tools, and this addition ensures that ShellHub users
can rest assured knowing that their systems are protected against
this specific vulnerability.

Feel free to test it out and let us know your thoughts.
We're always striving to improve ShellHub and ensure it meets
the highest security standards.

Happy April Fools' Day!
