### PR TITLE
feat(cli): use 'run' instead of 'exec' for docker-compose commands

### DIFF
--- a/bin/add-namespace
+++ b/bin/add-namespace
@@ -9,4 +9,4 @@ DOCKER_COMPOSE=$(evaluate_docker_compose)
 NAMESPACE=$1
 OWNER=$2
 
-exec $DOCKER_COMPOSE exec cli ./cli add-namespace "$NAMESPACE" "$OWNER" "$TENANT_ID"
+exec $DOCKER_COMPOSE run cli ./cli add-namespace "$NAMESPACE" "$OWNER" "$TENANT_ID"

--- a/bin/add-user
+++ b/bin/add-user
@@ -10,4 +10,4 @@ USERNAME=$1
 PASSWORD=$2
 EMAIL=$3
 
-exec $DOCKER_COMPOSE exec cli ./cli add-user $USERNAME $PASSWORD $EMAIL
+exec $DOCKER_COMPOSE run cli ./cli add-user $USERNAME $PASSWORD $EMAIL

--- a/bin/add-user-namespace
+++ b/bin/add-user-namespace
@@ -10,4 +10,4 @@ USERNAME=$1
 NAMESPACE=$2
 ROLE=$3
 
-exec $DOCKER_COMPOSE exec cli ./cli add-user-namespace $USERNAME $NAMESPACE $ROLE
+exec $DOCKER_COMPOSE run cli ./cli add-user-namespace $USERNAME $NAMESPACE $ROLE

--- a/bin/cli
+++ b/bin/cli
@@ -9,4 +9,4 @@ shift $@ # remove the first argument; script name.
 
 DOCKER_COMPOSE=$(evaluate_docker_compose)
 
-exec $DOCKER_COMPOSE exec cli ./cli $@
+exec $DOCKER_COMPOSE run cli ./cli $@

--- a/bin/del-namespace
+++ b/bin/del-namespace
@@ -8,4 +8,4 @@ DOCKER_COMPOSE=$(evaluate_docker_compose)
 
 NAMESPACE=$1
 
-exec $DOCKER_COMPOSE exec cli ./cli del-namespace $NAMESPACE
+exec $DOCKER_COMPOSE run cli ./cli del-namespace $NAMESPACE

--- a/bin/del-user
+++ b/bin/del-user
@@ -8,4 +8,4 @@ DOCKER_COMPOSE=$(evaluate_docker_compose)
 
 USERNAME=$1
 
-exec $DOCKER_COMPOSE exec cli ./cli del-user $USERNAME
+exec $DOCKER_COMPOSE run cli ./cli del-user $USERNAME

--- a/bin/del-user-namespace
+++ b/bin/del-user-namespace
@@ -9,4 +9,4 @@ DOCKER_COMPOSE=$(evaluate_docker_compose)
 USERNAME=$1
 NAMESPACE=$2
 
-exec $DOCKER_COMPOSE exec cli ./cli del-user-namespace $USERNAME $NAMESPACE
+exec $DOCKER_COMPOSE run cli ./cli del-user-namespace $USERNAME $NAMESPACE

--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -32,27 +32,4 @@ WORKDIR=$(dirname $(readlink_f $0))/../
 
 cd $WORKDIR
 
-set -o allexport
-
-env_override=${ENV_OVERRIDE:-./.env.override}
-if [ -f "$env_override" ]; then
-    echo "INFO: Loading $env_override"
-    . "$env_override"
-fi
-
-set +o allexport
-
-COMPOSE_FILE="docker-compose.yml"
-
-[ "$SHELLHUB_AUTO_SSL" = "true" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.autossl.yml"
-[ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.dev.yml:docker-compose.agent.yml"
-[ "$SHELLHUB_ENTERPRISE" = "true" ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.enterprise.yml"
-[ "$SHELLHUB_CONNECTOR" = "true" ] && [ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.connector.dev.yml"
-[ "$SHELLHUB_CONNECTOR" = "true"  ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.connector.yml"
-[ -f docker-compose.override.yml ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.override.yml"
-
-[ -f "$EXTRA_COMPOSE_FILE" ] && COMPOSE_FILE="${COMPOSE_FILE}:${EXTRA_COMPOSE_FILE}"
-
-export COMPOSE_FILE
-
 exec $DOCKER_COMPOSE "$@"

--- a/bin/reset-user-password
+++ b/bin/reset-user-password
@@ -9,4 +9,4 @@ DOCKER_COMPOSE=$(evaluate_docker_compose)
 USERNAME=$1
 PASSWORD=$2
 
-exec $DOCKER_COMPOSE exec cli ./cli reset-user-password $USERNAME $PASSWORD
+exec $DOCKER_COMPOSE run cli ./cli reset-user-password $USERNAME $PASSWORD

--- a/bin/utils
+++ b/bin/utils
@@ -23,3 +23,25 @@ evaluate_docker_compose() {
     echo "$COMPOSE_COMMAND"
 }
 
+set -o allexport
+
+env_override=${ENV_OVERRIDE:-./.env.override}
+if [ -f "$env_override" ]; then
+    echo "INFO: Loading $env_override"
+    . "$env_override"
+fi
+
+set +o allexport
+
+COMPOSE_FILE="docker-compose.yml"
+
+[ "$SHELLHUB_AUTO_SSL" = "true" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.autossl.yml"
+[ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.dev.yml:docker-compose.agent.yml"
+[ "$SHELLHUB_ENTERPRISE" = "true" ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.enterprise.yml"
+[ "$SHELLHUB_CONNECTOR" = "true" ] && [ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.connector.dev.yml"
+[ "$SHELLHUB_CONNECTOR" = "true"  ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.connector.yml"
+[ -f docker-compose.override.yml ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.override.yml"
+
+[ -f "$EXTRA_COMPOSE_FILE" ] && COMPOSE_FILE="${COMPOSE_FILE}:${EXTRA_COMPOSE_FILE}"
+
+export COMPOSE_FILE

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -30,25 +30,24 @@ WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/cli
 RUN go build
 
 # development stage
-FROM base AS development
+FROM builder AS development
 
 RUN apk add --update openssl build-base docker-cli
-RUN go install github.com/markbates/refresh@v1.11.1 && \
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 
 RUN go mod download
 
-COPY ./cli/entrypoint-dev.sh /entrypoint.sh
+COPY ./cli/entrypoint-dev.sh /entrypoint-dev.sh
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/cli
 
-ENTRYPOINT ["/entrypoint.sh"]
+RUN go build
+
+ENTRYPOINT ["/entrypoint-dev.sh"]
 
 # production stage
 FROM alpine:3.19.1 AS production
 
 COPY --from=builder /go/src/github.com/shellhub-io/shellhub/cli/cli /cli
-
-ENTRYPOINT /cli

--- a/cli/entrypoint-dev.sh
+++ b/cli/entrypoint-dev.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-refresh run &
+go build
 
-sleep infinity
+exec "$@"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-gomplate -f /etc/nginx/conf.d/shellhub.conf -o /etc/nginx/conf.d/shellhub.conf
-
-exec "$@"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,7 +66,6 @@ services:
       context: .
       dockerfile: cli/Dockerfile
       target: development
-    entrypoint: /entrypoint.sh
     environment:
       - SHELLHUB_ENTERPRISE=${SHELLHUB_ENTERPRISE}
       - SHELLHUB_CLOUD=${SHELLHUB_CLOUD}
@@ -75,6 +74,3 @@ services:
       - ./pkg:/go/src/github.com/shellhub-io/shellhub/pkg
       - ./api:/go/src/github.com/shellhub-io/shellhub/api
       - ./.golangci.yaml:/.golangci.yaml
-    depends_on:
-      - api
-      - mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,14 +104,10 @@ services:
       start_period: 10s
   cli:
     image: shellhubio/cli:${SHELLHUB_VERSION}
-    entrypoint: /bin/sleep infinity
-    restart: unless-stopped
+    scale: 0
     environment:
       - SHELLHUB_LOG_LEVEL=${SHELLHUB_LOG_LEVEL}
       - SHELLHUB_LOG_FORMAT=${SHELLHUB_LOG_FORMAT}
-    depends_on:
-      - api
-      - mongo
     networks:
       - shellhub
   mongo:


### PR DESCRIPTION
Changed the docker-compose commands in the CLI scripts to use 'run'
instead of 'exec', eliminating the need for the CLI service to be
continuously running.
