### PR TITLE
feat(gateway): set custom value for backlog parameter

### DIFF
--- a/gateway/conf.d/shellhub.conf
+++ b/gateway/conf.d/shellhub.conf
@@ -1,6 +1,6 @@
 server {
     {{ if and (bool (env.Getenv "SHELLHUB_AUTO_SSL")) (ne (env.Getenv "SHELLHUB_ENV") "development") -}}
-    listen 443 reuseport ssl{{ if bool (env.Getenv "SHELLHUB_PROXY") }} proxy_protocol{{ end }};
+    listen 443 reuseport ssl{{ if bool (env.Getenv "SHELLHUB_PROXY") }} proxy_protocol{{ end }} backlog={{ env.Getenv "BACKLOG_SIZE" }};
     ssl_certificate /etc/letsencrypt/live/{{ env.Getenv "SHELLHUB_DOMAIN" }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ env.Getenv "SHELLHUB_DOMAIN" }}/privkey.pem;
 
@@ -15,7 +15,7 @@ server {
 
     ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
     {{ else -}}
-    listen 80 reuseport{{ if bool (env.Getenv "SHELLHUB_PROXY") }} proxy_protocol{{ end }};
+    listen 80 reuseport{{ if bool (env.Getenv "SHELLHUB_PROXY") }} proxy_protocol{{ end }} backlog={{ env.Getenv "BACKLOG_SIZE" }};
     {{- end }}
     {{ if bool (env.Getenv "SHELLHUB_PROXY") }}
     set_real_ip_from ::/0;
@@ -434,7 +434,7 @@ server {
 
 {{- $PUBLIC_URL_DOMAIN := or (env.Getenv "SHELLHUB_PUBLIC_URL_DOMAIN") (env.Getenv "SHELLHUB_DOMAIN") }}
 server {
-   listen 80;
+   listen 80 backlog={{ env.Getenv "BACKLOG_SIZE" }};
    server_name ~^(?<namespace>.+)\.(?<device>.+)\.{{ $PUBLIC_URL_DOMAIN }}$;
    resolver 127.0.0.11 ipv6=off;
 
@@ -450,7 +450,7 @@ server {
 
 {{ if and (bool (env.Getenv "SHELLHUB_AUTO_SSL")) (ne (env.Getenv "SHELLHUB_ENV") "development") -}}
 server {
-    listen 80 default_server;
+    listen 80 default_server backlog={{ env.Getenv "BACKLOG_SIZE" }};
 
     return 308 https://$host$request_uri;
 }

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -27,6 +27,7 @@ export WORKER_PROCESSES
 export MAX_WORKER_OPEN_FILES
 export MAX_WORKER_CONNECTIONS
 export HOST_IP=$(ip -4 route show default | awk '{ print $3 }')
+export BACKLOG_SIZE=$(sysctl -n net.core.somaxconn)
 
 wait_for_acme_webserver() {
   for i in `seq 30` ; do


### PR DESCRIPTION
Set the backlog value based on the kernel parameter `net.core.somaxconn`,
following the approach utilized in the NGINX Ingress controller for Kubernetes.

Referece: https://www.nginx.com/blog/tuning-nginx/
