### PR TITLE
fix(agent): resolve segfault caused by non-thread-safe crypt function

### DIFF
--- a/pkg/agent/pkg/yescrypt/yescript.go
+++ b/pkg/agent/pkg/yescrypt/yescript.go
@@ -13,10 +13,11 @@ import "unsafe"
 
 // Verify verifies a yescrypt hash against a given key.
 func Verify(key, hash string) bool {
+	cdata := C.struct_crypt_data{}
 	ckey := C.CString(key)
 	chash := C.CString(hash)
 
-	out := C.crypt(ckey, chash)
+	out := C.crypt_r(ckey, chash, &cdata)
 
 	C.free(unsafe.Pointer(ckey))
 	C.free(unsafe.Pointer(chash))


### PR DESCRIPTION
Fixed a segfault issue caused by the use of the non-thread-safe crypt
function by replacing it with the thread-safe crypt_r function.
