### PR TITLE
fix(api): use device name custom rule for field validation

### DIFF
--- a/pkg/api/requests/device.go
+++ b/pkg/api/requests/device.go
@@ -79,7 +79,7 @@ type DeviceInfo struct {
 type DeviceAuth struct {
 	Info      *DeviceInfo     `json:"info" validate:"required"`
 	Sessions  []string        `json:"sessions,omitempty"`
-	Hostname  string          `json:"hostname,omitempty" validate:"required_without=Identity,omitempty,hostname_rfc1123" hash:"-"`
+	Hostname  string          `json:"hostname,omitempty" validate:"required_without=Identity,omitempty,device_name" hash:"-"`
 	Identity  *DeviceIdentity `json:"identity,omitempty" validate:"required_without=Hostname,omitempty"`
 	PublicKey string          `json:"public_key" validate:"required"`
 	TenantID  string          `json:"tenant_id" validate:"required"`


### PR DESCRIPTION
We have been using the `hostname_rfc1123` for validating the device name, which isn't compatible with [Docker's daemon naming convention](https://github.com/moby/moby/blob/master/daemon/names/names.go#L6), causing containers with `underscore` to be denied by the server for invalid entity format.

Closes #3291