### PR TITLE
fix(api): correct typo in 'OfflineDevice'

### DIFF
--- a/api/routes/device.go
+++ b/api/routes/device.go
@@ -175,7 +175,7 @@ func (h *Handler) OfflineDevice(c gateway.Context) error {
 		return err
 	}
 
-	if err := h.service.OffineDevice(c.Ctx(), models.UID(req.UID), false); err != nil {
+	if err := h.service.OfflineDevice(c.Ctx(), models.UID(req.UID), false); err != nil {
 		return err
 	}
 

--- a/api/routes/device_test.go
+++ b/api/routes/device_test.go
@@ -429,7 +429,7 @@ func TestOfflineDevice(t *testing.T) {
 			title: "fails when try to setting a non-existing device as offline",
 			uid:   "1234",
 			requiredMocks: func() {
-				mock.On("OffineDevice", gomock.Anything, models.UID("1234"), false).Return(svc.ErrNotFound)
+				mock.On("OfflineDevice", gomock.Anything, models.UID("1234"), false).Return(svc.ErrNotFound)
 			},
 			expectedStatus: http.StatusNotFound,
 		},
@@ -437,7 +437,7 @@ func TestOfflineDevice(t *testing.T) {
 			title: "success when try to setting an existing device as offline",
 			uid:   "123",
 			requiredMocks: func() {
-				mock.On("OffineDevice", gomock.Anything, models.UID("123"), false).Return(nil)
+				mock.On("OfflineDevice", gomock.Anything, models.UID("123"), false).Return(nil)
 			},
 			expectedStatus: http.StatusOK,
 		},

--- a/api/services/device.go
+++ b/api/services/device.go
@@ -24,7 +24,7 @@ type DeviceService interface {
 	DeleteDevice(ctx context.Context, uid models.UID, tenant string) error
 	RenameDevice(ctx context.Context, uid models.UID, name, tenant string) error
 	LookupDevice(ctx context.Context, namespace, name string) (*models.Device, error)
-	OffineDevice(ctx context.Context, uid models.UID, online bool) error
+	OfflineDevice(ctx context.Context, uid models.UID, online bool) error
 	UpdateDeviceStatus(ctx context.Context, tenant string, uid models.UID, status models.DeviceStatus) error
 	UpdateDevice(ctx context.Context, tenant string, uid models.UID, name *string, publicURL *bool) error
 }
@@ -176,7 +176,7 @@ func (s *service) LookupDevice(ctx context.Context, namespace, name string) (*mo
 	return device, nil
 }
 
-func (s *service) OffineDevice(ctx context.Context, uid models.UID, online bool) error {
+func (s *service) OfflineDevice(ctx context.Context, uid models.UID, online bool) error {
 	err := s.store.DeviceSetOnline(ctx, uid, clock.Now(), online)
 	if err == store.ErrNoDocuments {
 		return NewErrDeviceNotFound(uid, err)

--- a/api/services/device_test.go
+++ b/api/services/device_test.go
@@ -1612,7 +1612,7 @@ func TestLookupDevice(t *testing.T) {
 	mock.AssertExpectations(t)
 }
 
-func TestOffineDevice(t *testing.T) {
+func TestOfflineDevice(t *testing.T) {
 	mock := new(mocks.Store)
 
 	ctx := context.TODO()
@@ -1653,7 +1653,7 @@ func TestOffineDevice(t *testing.T) {
 			tc.requiredMocks()
 
 			service := NewService(store.Store(mock), privateKey, publicKey, storecache.NewNullCache(), clientMock, nil)
-			err := service.OffineDevice(ctx, tc.uid, tc.online)
+			err := service.OfflineDevice(ctx, tc.uid, tc.online)
 			assert.Equal(t, tc.expected, err)
 		})
 	}

--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -1326,12 +1326,12 @@ func (_m *Service) LookupDevice(ctx context.Context, namespace string, name stri
 	return r0, r1
 }
 
-// OffineDevice provides a mock function with given fields: ctx, uid, online
-func (_m *Service) OffineDevice(ctx context.Context, uid models.UID, online bool) error {
+// OfflineDevice provides a mock function with given fields: ctx, uid, online
+func (_m *Service) OfflineDevice(ctx context.Context, uid models.UID, online bool) error {
 	ret := _m.Called(ctx, uid, online)
 
 	if len(ret) == 0 {
-		panic("no return value specified for OffineDevice")
+		panic("no return value specified for OfflineDevice")
 	}
 
 	var r0 error


### PR DESCRIPTION
The service's `OfflineDevice` method was previously misspelled as `OffineDevice`. This has been corrected.