### PR TITLE
chore: add configuration to restrict domains in Giscus

### DIFF
--- a/giscus.json
+++ b/giscus.json
@@ -1,0 +1,3 @@
+{
+    "origins": ["https://docs.shellhub.io"]
+}


### PR DESCRIPTION
This change allows limiting the domains that can load Giscus
within the repository's discussions using the 'origins' key.

This is done to prevent spammers and lammers, like those in
the #3761, from creating discussions through unauthorized
Giscus forms just to show off.

For everyone reading this commit, we want to emphasize that
we are an open community welcoming broad discussion and
collaboration. Contributions are highly encouraged,
and behaviors like this will not be tolerated in our community.
