### PR TITLE
chore: update cli service in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,8 @@ services:
       start_period: 10s
   cli:
     image: shellhubio/cli:${SHELLHUB_VERSION}
-    scale: 0
+    stop_signal: SIGKILL
+    command: /bin/sleep infinity
     environment:
       - SHELLHUB_LOG_LEVEL=${SHELLHUB_LOG_LEVEL}
       - SHELLHUB_LOG_FORMAT=${SHELLHUB_LOG_FORMAT}


### PR DESCRIPTION
- Add stop_signal: SIGKILL for immediate container shutdown
- Set command to `/bin/sleep infinity` to keep the container running indefinitely
