### PR TITLE
refactor(api): simplify user authentication

### DIFF
--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -18,17 +18,15 @@ import (
 )
 
 const (
-	AuthRequestURL  = "/auth"
-	AuthDeviceURL   = "/devices/auth"
-	AuthDeviceURLV2 = "/auth/device"
-	AuthUserURL     = "/login"
-	AuthUserURLV2   = "/auth/user"
-
+	AuthRequestURL           = "/auth"
+	AuthDeviceURL            = "/devices/auth"
+	AuthDeviceURLV2          = "/auth/device"
+	AuthUserURL              = "/login"
+	AuthUserURLV2            = "/auth/user"
 	AuthUserTokenInternalURL = "/auth/token/:id"     //nolint:gosec
 	AuthUserTokenPublicURL   = "/auth/token/:tenant" //nolint:gosec
-
-	AuthPublicKeyURL = "/auth/ssh"
-	AuthMFAURL       = "/auth/mfa"
+	AuthPublicKeyURL         = "/auth/ssh"
+	AuthMFAURL               = "/auth/mfa"
 )
 
 const (
@@ -192,53 +190,18 @@ func (h *Handler) AuthUser(c gateway.Context) error {
 	return c.JSON(http.StatusOK, res)
 }
 
-func (h *Handler) AuthUserInfo(c gateway.Context) error {
-	username := c.Request().Header.Get("X-Username")
-	tenant := c.Request().Header.Get("X-Tenant-ID")
-	token := c.Request().Header.Get(echo.HeaderAuthorization)
+func (h *Handler) CreateUserToken(c gateway.Context) error {
+	req := new(requests.CreateUserToken)
 
-	res, err := h.service.AuthUserInfo(c.Ctx(), username, tenant, token)
-	if err != nil {
+	if err := c.Bind(req); err != nil {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, res)
-}
-
-func (h *Handler) AuthGetToken(c gateway.Context) error {
-	var req requests.AuthTokenGet
-
-	if err := c.Bind(&req); err != nil {
+	if err := c.Validate(req); err != nil {
 		return err
 	}
 
-	if err := c.Validate(&req); err != nil {
-		return err
-	}
-
-	res, err := h.service.AuthGetToken(c.Ctx(), req.ID)
-	if err != nil {
-		return err
-	}
-
-	return c.JSON(http.StatusOK, res)
-}
-
-func (h *Handler) AuthSwapToken(c gateway.Context) error {
-	var req requests.AuthTokenSwap
-	if err := c.Bind(&req); err != nil {
-		return err
-	}
-
-	if err := c.Validate(&req); err != nil {
-		return err
-	}
-	var id string
-	if v := c.ID(); v != nil {
-		id = v.ID
-	}
-
-	res, err := h.service.AuthSwapToken(c.Ctx(), id, req.Tenant)
+	res, err := h.service.CreateUserToken(c.Ctx(), req)
 	if err != nil {
 		return err
 	}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -30,7 +30,7 @@ func NewRouter(service services.Service) *echo.Echo {
 	internalAPI := e.Group("/internal")
 
 	internalAPI.GET(AuthRequestURL, gateway.Handler(handler.AuthRequest), gateway.Middleware(AuthMiddleware))
-	internalAPI.GET(AuthUserTokenInternalURL, gateway.Handler(handler.AuthGetToken))
+	internalAPI.GET(AuthUserTokenInternalURL, gateway.Handler(handler.CreateUserToken)) // TODO: same as defined in public API. remove it.
 
 	internalAPI.GET(GetDeviceByPublicURLAddress, gateway.Handler(handler.GetDeviceByPublicURLAddress))
 	internalAPI.POST(OfflineDeviceURL, gateway.Handler(handler.OfflineDevice))
@@ -50,13 +50,13 @@ func NewRouter(service services.Service) *echo.Echo {
 	publicAPI := e.Group("/api")
 	publicAPI.GET(HealthCheckURL, gateway.Handler(handler.EvaluateHealth))
 
+	publicAPI.GET(AuthUserURLV2, gateway.Handler(handler.CreateUserToken))                                  // TODO: method POST
+	publicAPI.GET(AuthUserTokenPublicURL, gateway.Handler(handler.CreateUserToken), middleware.BlockAPIKey) // TODO: method POST
 	publicAPI.POST(AuthDeviceURL, gateway.Handler(handler.AuthDevice))
 	publicAPI.POST(AuthDeviceURLV2, gateway.Handler(handler.AuthDevice))
 	publicAPI.POST(AuthUserURL, gateway.Handler(handler.AuthUser))
 	publicAPI.POST(AuthUserURLV2, gateway.Handler(handler.AuthUser))
-	publicAPI.GET(AuthUserURLV2, gateway.Handler(handler.AuthUserInfo))
 	publicAPI.POST(AuthPublicKeyURL, gateway.Handler(handler.AuthPublicKey))
-	publicAPI.GET(AuthUserTokenPublicURL, gateway.Handler(handler.AuthSwapToken), middleware.BlockAPIKey)
 
 	publicAPI.POST(CreateAPIKeyURL, gateway.Handler(handler.CreateAPIKey), middleware.BlockAPIKey, middleware.RequiresPermission(auth.APIKeyCreate))
 	publicAPI.GET(ListAPIKeysURL, gateway.Handler(handler.ListAPIKeys))

--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -152,36 +152,6 @@ func (_m *Service) AuthDevice(ctx context.Context, req requests.DeviceAuth, remo
 	return r0, r1
 }
 
-// AuthGetToken provides a mock function with given fields: ctx, id
-func (_m *Service) AuthGetToken(ctx context.Context, id string) (*models.UserAuthResponse, error) {
-	ret := _m.Called(ctx, id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AuthGetToken")
-	}
-
-	var r0 *models.UserAuthResponse
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*models.UserAuthResponse, error)); ok {
-		return rf(ctx, id)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *models.UserAuthResponse); ok {
-		r0 = rf(ctx, id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.UserAuthResponse)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // AuthIsCacheToken provides a mock function with given fields: ctx, tenant, id
 func (_m *Service) AuthIsCacheToken(ctx context.Context, tenant string, id string) (bool, error) {
 	ret := _m.Called(ctx, tenant, id)
@@ -233,36 +203,6 @@ func (_m *Service) AuthPublicKey(ctx context.Context, req requests.PublicKeyAuth
 
 	if rf, ok := ret.Get(1).(func(context.Context, requests.PublicKeyAuth) error); ok {
 		r1 = rf(ctx, req)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// AuthSwapToken provides a mock function with given fields: ctx, id, tenant
-func (_m *Service) AuthSwapToken(ctx context.Context, id string, tenant string) (*models.UserAuthResponse, error) {
-	ret := _m.Called(ctx, id, tenant)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AuthSwapToken")
-	}
-
-	var r0 *models.UserAuthResponse
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*models.UserAuthResponse, error)); ok {
-		return rf(ctx, id, tenant)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *models.UserAuthResponse); ok {
-		r0 = rf(ctx, id, tenant)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.UserAuthResponse)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, id, tenant)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -330,36 +270,6 @@ func (_m *Service) AuthUser(ctx context.Context, req *requests.UserAuth, sourceI
 	}
 
 	return r0, r1, r2, r3
-}
-
-// AuthUserInfo provides a mock function with given fields: ctx, username, tenant, token
-func (_m *Service) AuthUserInfo(ctx context.Context, username string, tenant string, token string) (*models.UserAuthResponse, error) {
-	ret := _m.Called(ctx, username, tenant, token)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AuthUserInfo")
-	}
-
-	var r0 *models.UserAuthResponse
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (*models.UserAuthResponse, error)); ok {
-		return rf(ctx, username, tenant, token)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *models.UserAuthResponse); ok {
-		r0 = rf(ctx, username, tenant, token)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.UserAuthResponse)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, username, tenant, token)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // BillingEvaluate provides a mock function with given fields: _a0, _a1
@@ -569,6 +479,36 @@ func (_m *Service) CreateSession(ctx context.Context, session requests.SessionCr
 
 	if rf, ok := ret.Get(1).(func(context.Context, requests.SessionCreate) error); ok {
 		r1 = rf(ctx, session)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateUserToken provides a mock function with given fields: ctx, req
+func (_m *Service) CreateUserToken(ctx context.Context, req *requests.CreateUserToken) (*models.UserAuthResponse, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateUserToken")
+	}
+
+	var r0 *models.UserAuthResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *requests.CreateUserToken) (*models.UserAuthResponse, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *requests.CreateUserToken) *models.UserAuthResponse); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.UserAuthResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *requests.CreateUserToken) error); ok {
+		r1 = rf(ctx, req)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/api/requests/auth.go
+++ b/pkg/api/requests/auth.go
@@ -9,3 +9,8 @@ type AuthTokenGet struct {
 type AuthTokenSwap struct {
 	TenantParam
 }
+
+type CreateUserToken struct {
+	UserID   string `header:"X-ID" validate:"required"`
+	TenantID string `param:"tenant" validate:"omitempty,uuid"`
+}


### PR DESCRIPTION
Currently, there are four functions to authenticate a user: `AuthUser`, `AuthGetToken`, `AuthSwapToken`, and `AuthUserInfo`. While the first method authenticates a user with credentials, the subsequent three perform similar tasks involving token retrieval and generation.
    
To streamline this process, we are removing these three methods and introducing a new, unified method called `CreateUserToken`, consolidating the functionality of the previous three methods into one. The new method will be used in the place of the old methods.