### PR TITLE
feat(api): preferred namespace

### DIFF
--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -198,6 +198,9 @@ func TestAuthUser(t *testing.T) {
 					Password: models.UserPassword{
 						Hash: "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b",
 					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
+					},
 				}
 
 				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
@@ -230,6 +233,9 @@ func TestAuthUser(t *testing.T) {
 					},
 					Password: models.UserPassword{
 						Hash: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
+					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
 					},
 				}
 
@@ -270,6 +276,9 @@ func TestAuthUser(t *testing.T) {
 					},
 					Password: models.UserPassword{
 						Hash: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
+					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
 					},
 				}
 
@@ -318,6 +327,9 @@ func TestAuthUser(t *testing.T) {
 					},
 					Password: models.UserPassword{
 						Hash: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
+					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
 					},
 				}
 
@@ -376,6 +388,9 @@ func TestAuthUser(t *testing.T) {
 					Password: models.UserPassword{
 						Hash: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
 					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
+					},
 				}
 
 				mock.
@@ -395,16 +410,22 @@ func TestAuthUser(t *testing.T) {
 					Return(nil).
 					Once()
 				mock.
-					On("NamespaceGetFirst", ctx, "65fdd16b5f62f93184ec8a39").
-					Return(nil, nil).
+					On("NamespaceGetPreferred", ctx, "", "65fdd16b5f62f93184ec8a39").
+					Return(nil, errors.New("error", "layer", 0)).
 					Once()
 
 				clockMock := new(clockmock.Clock)
 				clock.DefaultBackend = clockMock
 				clockMock.On("Now").Return(now)
 
+				cacheMock.
+					On("Set", ctx, "token_65fdd16b5f62f93184ec8a39", testifymock.Anything, time.Hour*72).
+					Return(nil).
+					Once()
+
+				preferredNamespace := ""
 				mock.
-					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now}).
+					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now, PreferredNamespace: &preferredNamespace}).
 					Return(errors.New("error", "", 0)).
 					Once()
 			},
@@ -449,6 +470,9 @@ func TestAuthUser(t *testing.T) {
 					Password: models.UserPassword{
 						Hash: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
 					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
+					},
 				}
 
 				mock.
@@ -468,20 +492,22 @@ func TestAuthUser(t *testing.T) {
 					Return(nil).
 					Once()
 				mock.
-					On("NamespaceGetFirst", ctx, "65fdd16b5f62f93184ec8a39").
-					Return(nil, nil).
+					On("NamespaceGetPreferred", ctx, "", "65fdd16b5f62f93184ec8a39").
+					Return(nil, errors.New("error", "layer", 0)).
 					Once()
 
 				clockMock := new(clockmock.Clock)
 				clock.DefaultBackend = clockMock
 				clockMock.On("Now").Return(now)
 
-				mock.
-					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now}).
-					Return(nil).
-					Once()
 				cacheMock.
 					On("Set", ctx, "token_65fdd16b5f62f93184ec8a39", testifymock.Anything, time.Hour*72).
+					Return(nil).
+					Once()
+
+				preferredNamespace := ""
+				mock.
+					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now, PreferredNamespace: &preferredNamespace}).
 					Return(nil).
 					Once()
 			},
@@ -522,6 +548,9 @@ func TestAuthUser(t *testing.T) {
 					Password: models.UserPassword{
 						Hash: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
 					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "00000000-0000-4000-0000-000000000000",
+					},
 				}
 
 				mock.
@@ -552,7 +581,7 @@ func TestAuthUser(t *testing.T) {
 				}
 
 				mock.
-					On("NamespaceGetFirst", ctx, "65fdd16b5f62f93184ec8a39").
+					On("NamespaceGetPreferred", ctx, "00000000-0000-4000-0000-000000000000", "65fdd16b5f62f93184ec8a39").
 					Return(ns, nil).
 					Once()
 
@@ -560,12 +589,103 @@ func TestAuthUser(t *testing.T) {
 				clock.DefaultBackend = clockMock
 				clockMock.On("Now").Return(now)
 
-				mock.
-					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now}).
-					Return(nil).
-					Once()
 				cacheMock.
 					On("Set", ctx, "token_00000000-0000-4000-0000-00000000000065fdd16b5f62f93184ec8a39", testifymock.Anything, time.Hour*72).
+					Return(nil).
+					Once()
+
+				preferredNamespace := "00000000-0000-4000-0000-000000000000"
+				mock.
+					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now, PreferredNamespace: &preferredNamespace}).
+					Return(nil).
+					Once()
+			},
+			expected: Expected{
+				res: &models.UserAuthResponse{
+					ID:     "65fdd16b5f62f93184ec8a39",
+					Name:   "john doe",
+					User:   "john_doe",
+					Email:  "john.doe@test.com",
+					Tenant: "00000000-0000-4000-0000-000000000000",
+					Token:  "must ignore",
+				},
+				lockout:  0,
+				mfaToken: "",
+				err:      nil,
+			},
+		},
+		{
+			description: "succeeds to authenticate with a namespace (and empty preferred namespace)",
+			sourceIP:    "127.0.0.1",
+			req: &requests.UserAuth{
+				Identifier: "john_doe",
+				Password:   "secret",
+			},
+			requiredMocks: func() {
+				user := &models.User{
+					ID:        "65fdd16b5f62f93184ec8a39",
+					Confirmed: true,
+					LastLogin: now,
+					MFA: models.UserMFA{
+						Enabled: false,
+					},
+					UserData: models.UserData{
+						Username: "john_doe",
+						Email:    "john.doe@test.com",
+						Name:     "john doe",
+					},
+					Password: models.UserPassword{
+						Hash: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
+					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
+					},
+				}
+
+				mock.
+					On("UserGetByUsername", ctx, "john_doe").
+					Return(user, nil).
+					Once()
+				cacheMock.
+					On("HasAccountLockout", ctx, "127.0.0.1", "65fdd16b5f62f93184ec8a39").
+					Return(int64(0), 0, nil).
+					Once()
+				hashMock.
+					On("CompareWith", "secret", "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi").
+					Return(true).
+					Once()
+				cacheMock.
+					On("ResetLoginAttempts", ctx, "127.0.0.1", "65fdd16b5f62f93184ec8a39").
+					Return(nil).
+					Once()
+
+				ns := &models.Namespace{
+					TenantID: "00000000-0000-4000-0000-000000000000",
+					Members: []models.Member{
+						{
+							ID:   "65fdd16b5f62f93184ec8a39",
+							Role: "owner",
+						},
+					},
+				}
+
+				mock.
+					On("NamespaceGetPreferred", ctx, "", "65fdd16b5f62f93184ec8a39").
+					Return(ns, nil).
+					Once()
+
+				clockMock := new(clockmock.Clock)
+				clock.DefaultBackend = clockMock
+				clockMock.On("Now").Return(now)
+
+				cacheMock.
+					On("Set", ctx, "token_00000000-0000-4000-0000-00000000000065fdd16b5f62f93184ec8a39", testifymock.Anything, time.Hour*72).
+					Return(nil).
+					Once()
+
+				preferredNamespace := "00000000-0000-4000-0000-000000000000"
+				mock.
+					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now, PreferredNamespace: &preferredNamespace}).
 					Return(nil).
 					Once()
 			},
@@ -606,6 +726,9 @@ func TestAuthUser(t *testing.T) {
 					Password: models.UserPassword{
 						Hash: "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b",
 					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
+					},
 				}
 
 				mock.
@@ -625,8 +748,8 @@ func TestAuthUser(t *testing.T) {
 					Return(nil).
 					Once()
 				mock.
-					On("NamespaceGetFirst", ctx, "65fdd16b5f62f93184ec8a39").
-					Return(nil, nil).
+					On("NamespaceGetPreferred", ctx, "", "65fdd16b5f62f93184ec8a39").
+					Return(nil, errors.New("error", "layer", 0)).
 					Once()
 
 				clockMock := new(clockmock.Clock)
@@ -637,16 +760,19 @@ func TestAuthUser(t *testing.T) {
 					On("HasAccountLockout", ctx, "127.0.0.1", "65fdd16b5f62f93184ec8a39").
 					Return(int64(0), 0, nil).
 					Once()
+
+				cacheMock.
+					On("Set", ctx, "token_65fdd16b5f62f93184ec8a39", testifymock.Anything, time.Hour*72).
+					Return(nil).
+					Once()
 				hashMock.
 					On("Do", "secret").
 					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi", nil).
 					Once()
+
+				preferredNamespace := ""
 				mock.
-					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now, Password: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi"}).
-					Return(nil).
-					Once()
-				cacheMock.
-					On("Set", ctx, "token_65fdd16b5f62f93184ec8a39", testifymock.Anything, time.Hour*72).
+					On("UserUpdate", ctx, user.ID, &models.UserChanges{LastLogin: now, PreferredNamespace: &preferredNamespace, Password: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi"}).
 					Return(nil).
 					Once()
 			},

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -1150,29 +1150,29 @@ func (_m *Store) NamespaceGetByName(ctx context.Context, name string) (*models.N
 	return r0, r1
 }
 
-// NamespaceGetFirst provides a mock function with given fields: ctx, id
-func (_m *Store) NamespaceGetFirst(ctx context.Context, id string) (*models.Namespace, error) {
-	ret := _m.Called(ctx, id)
+// NamespaceGetPreferred provides a mock function with given fields: ctx, tenantID, userID
+func (_m *Store) NamespaceGetPreferred(ctx context.Context, tenantID string, userID string) (*models.Namespace, error) {
+	ret := _m.Called(ctx, tenantID, userID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for NamespaceGetFirst")
+		panic("no return value specified for NamespaceGetPreferred")
 	}
 
 	var r0 *models.Namespace
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*models.Namespace, error)); ok {
-		return rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*models.Namespace, error)); ok {
+		return rf(ctx, tenantID, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *models.Namespace); ok {
-		r0 = rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *models.Namespace); ok {
+		r0 = rf(ctx, tenantID, userID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Namespace)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, id)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, tenantID, userID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -79,6 +79,8 @@ func GenerateMigrations() []migrate.Migration {
 		migration67,
 		migration68,
 		migration69,
+		migration70,
+		migration71,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_70.go
+++ b/api/store/mongo/migrations/migration_70.go
@@ -1,0 +1,61 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration70 = migrate.Migration{
+	Version:     70,
+	Description: "Adding the 'preferences' attribute to the user if it does not already exist.",
+	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		logrus.WithFields(logrus.Fields{
+			"component": "migration",
+			"version":   70,
+			"action":    "Up",
+		}).Info("Applying migration")
+
+		filter := bson.M{
+			"preferences": bson.M{"$exists": false},
+		}
+
+		update := bson.M{
+			"$set": bson.M{
+				"preferences": bson.M{},
+			},
+		}
+
+		_, err := db.
+			Collection("users").
+			UpdateMany(ctx, filter, update)
+
+		return err
+	}),
+	Down: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		logrus.WithFields(logrus.Fields{
+			"component": "migration",
+			"version":   70,
+			"action":    "Down",
+		}).Info("Reverting migration")
+
+		filter := bson.M{
+			"preferences": bson.M{"$exists": true},
+		}
+
+		update := bson.M{
+			"$unset": bson.M{
+				"preferences": "",
+			},
+		}
+
+		_, err := db.
+			Collection("users").
+			UpdateMany(ctx, filter, update)
+
+		return err
+	}),
+}

--- a/api/store/mongo/migrations/migration_70_test.go
+++ b/api/store/mongo/migrations/migration_70_test.go
@@ -1,0 +1,119 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	envmock "github.com/shellhub-io/shellhub/pkg/envs/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMigration70Up(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &envmock.Backend{}
+	envs.DefaultBackend = mock
+
+	cases := []struct {
+		description string
+		setup       func() error
+		test        func() error
+	}{
+		{
+			description: "Success to apply up on migration 70",
+			setup: func() error {
+				_, err := c.
+					Database("test").
+					Collection("users").
+					InsertOne(ctx, map[string]interface{}{
+						"name": "john doe",
+					})
+
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Cleanup(func() {
+				assert.NoError(t, srv.Reset())
+			})
+
+			assert.NoError(t, tc.setup())
+
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[69])
+			require.NoError(t, migrates.Up(context.Background(), migrate.AllAvailable))
+
+			query := c.
+				Database("test").
+				Collection("users").
+				FindOne(context.TODO(), bson.M{"name": "john doe"})
+
+			user := make(map[string]interface{})
+			require.NoError(t, query.Decode(&user))
+
+			_, ok := user["preferences"]
+			require.Equal(t, true, ok)
+		})
+	}
+}
+
+func TestMigration70Down(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &envmock.Backend{}
+	envs.DefaultBackend = mock
+
+	cases := []struct {
+		description string
+		setup       func() error
+		test        func() error
+	}{
+		{
+			description: "Success to apply up on migration 70",
+			setup: func() error {
+				_, err := c.
+					Database("test").
+					Collection("users").
+					InsertOne(ctx, map[string]interface{}{
+						"name":        "john doe",
+						"preferences": map[string]interface{}{},
+					})
+
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Cleanup(func() {
+				assert.NoError(t, srv.Reset())
+			})
+
+			assert.NoError(t, tc.setup())
+
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[69])
+			require.NoError(t, migrates.Up(context.Background(), migrate.AllAvailable))
+			require.NoError(t, migrates.Down(context.Background(), migrate.AllAvailable))
+
+			query := c.
+				Database("test").
+				Collection("users").
+				FindOne(context.TODO(), bson.M{"name": "john doe"})
+
+			user := make(map[string]interface{})
+			require.NoError(t, query.Decode(&user))
+
+			_, ok := user["preferences"]
+			require.Equal(t, false, ok)
+		})
+	}
+}

--- a/api/store/mongo/migrations/migration_71.go
+++ b/api/store/mongo/migrations/migration_71.go
@@ -1,0 +1,63 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration71 = migrate.Migration{
+	Version:     71,
+	Description: "Adding the 'preferences.preferred_namespace' attribute to the user if it does not already exist.",
+	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		logrus.WithFields(logrus.Fields{
+			"component": "migration",
+			"version":   71,
+			"action":    "Up",
+		}).Info("Applying migration")
+
+		filter := bson.M{
+			"preferences":                     bson.M{"$exists": true},
+			"preferences.preferred_namespace": bson.M{"$exists": false},
+		}
+
+		update := bson.M{
+			"$set": bson.M{
+				"preferences.preferred_namespace": "",
+			},
+		}
+
+		_, err := db.
+			Collection("users").
+			UpdateMany(ctx, filter, update)
+
+		return err
+	}),
+	Down: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		logrus.WithFields(logrus.Fields{
+			"component": "migration",
+			"version":   71,
+			"action":    "Down",
+		}).Info("Reverting migration")
+
+		filter := bson.M{
+			"preferences":                     bson.M{"$exists": true},
+			"preferences.preferred_namespace": bson.M{"$exists": true},
+		}
+
+		update := bson.M{
+			"$unset": bson.M{
+				"preferences.preferred_namespace": "",
+			},
+		}
+
+		_, err := db.
+			Collection("users").
+			UpdateMany(ctx, filter, update)
+
+		return err
+	}),
+}

--- a/api/store/mongo/migrations/migration_71_test.go
+++ b/api/store/mongo/migrations/migration_71_test.go
@@ -1,0 +1,124 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	envmock "github.com/shellhub-io/shellhub/pkg/envs/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMigration71Up(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &envmock.Backend{}
+	envs.DefaultBackend = mock
+
+	cases := []struct {
+		description string
+		setup       func() error
+		test        func() error
+	}{
+		{
+			description: "Success to apply up on migration 71",
+			setup: func() error {
+				_, err := c.
+					Database("test").
+					Collection("users").
+					InsertOne(ctx, map[string]interface{}{
+						"name":        "john doe",
+						"preferences": map[string]interface{}{},
+					})
+
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Cleanup(func() {
+				assert.NoError(t, srv.Reset())
+			})
+
+			assert.NoError(t, tc.setup())
+
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[70])
+			require.NoError(t, migrates.Up(context.Background(), migrate.AllAvailable))
+
+			query := c.
+				Database("test").
+				Collection("users").
+				FindOne(context.TODO(), bson.M{"name": "john doe"})
+
+			user := make(map[string]interface{})
+			require.NoError(t, query.Decode(&user))
+
+			preferences := user["preferences"]
+			_, ok := preferences.(map[string]interface{})["preferred_namespace"]
+			require.Equal(t, true, ok)
+		})
+	}
+}
+
+func TestMigration71Down(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &envmock.Backend{}
+	envs.DefaultBackend = mock
+
+	cases := []struct {
+		description string
+		setup       func() error
+		test        func() error
+	}{
+		{
+			description: "Success to apply up on migration 71",
+			setup: func() error {
+				_, err := c.
+					Database("test").
+					Collection("users").
+					InsertOne(ctx, map[string]interface{}{
+						"name": "john doe",
+						"preferences": map[string]interface{}{
+							"preferred_namespace": "00000000-0000-4000-0000-000000000000",
+						},
+					})
+
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Cleanup(func() {
+				assert.NoError(t, srv.Reset())
+			})
+
+			assert.NoError(t, tc.setup())
+
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[70])
+			require.NoError(t, migrates.Up(context.Background(), migrate.AllAvailable))
+			require.NoError(t, migrates.Down(context.Background(), migrate.AllAvailable))
+
+			query := c.
+				Database("test").
+				Collection("users").
+				FindOne(context.TODO(), bson.M{"name": "john doe"})
+
+			user := make(map[string]interface{})
+			require.NoError(t, query.Decode(&user))
+
+			preferences := user["preferences"]
+			_, ok := preferences.(map[string]interface{})["preferred_namespace"]
+			require.Equal(t, false, ok)
+		})
+	}
+}

--- a/api/store/mongo/namespace_test.go
+++ b/api/store/mongo/namespace_test.go
@@ -295,7 +295,7 @@ func TestNamespaceGetByName(t *testing.T) {
 	}
 }
 
-func TestNamespaceGetFirst(t *testing.T) {
+func TestNamespaceGetPreferred(t *testing.T) {
 	type Expected struct {
 		ns  *models.Namespace
 		err error
@@ -303,13 +303,15 @@ func TestNamespaceGetFirst(t *testing.T) {
 
 	cases := []struct {
 		description string
-		member      string
+		tenantID    string
+		memberID    string
 		fixtures    []string
 		expected    Expected
 	}{
 		{
 			description: "fails when member is not found",
-			member:      "000000000000000000000000",
+			tenantID:    "",
+			memberID:    "000000000000000000000000",
 			fixtures:    []string{fixtureNamespaces},
 			expected: Expected{
 				ns:  nil,
@@ -317,8 +319,46 @@ func TestNamespaceGetFirst(t *testing.T) {
 			},
 		},
 		{
-			description: "succeeds when member is found",
-			member:      "507f1f77bcf86cd799439011",
+			description: "fauks when member is found but namespace not",
+			tenantID:    "00000000-0000-0000-0000-000000000000",
+			memberID:    "507f1f77bcf86cd799439011",
+			fixtures:    []string{fixtureNamespaces},
+			expected: Expected{
+				ns:  nil,
+				err: store.ErrNoDocuments,
+			},
+		},
+		{
+			description: "succeeds when member is found and tenantID is empty",
+			tenantID:    "",
+			memberID:    "507f1f77bcf86cd799439011",
+			fixtures:    []string{fixtureNamespaces},
+			expected: Expected{
+				ns: &models.Namespace{
+					CreatedAt: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+					Name:      "namespace-1",
+					Owner:     "507f1f77bcf86cd799439011",
+					TenantID:  "00000000-0000-4000-0000-000000000000",
+					Members: []models.Member{
+						{
+							ID:   "507f1f77bcf86cd799439011",
+							Role: auth.RoleOwner,
+						},
+						{
+							ID:   "6509e169ae6144b2f56bf288",
+							Role: auth.RoleObserver,
+						},
+					},
+					MaxDevices: -1,
+					Settings:   &models.NamespaceSettings{SessionRecord: true},
+				},
+				err: nil,
+			},
+		},
+		{
+			description: "succeeds when member is found and tenantID is not empty",
+			tenantID:    "00000000-0000-4000-0000-000000000000",
+			memberID:    "507f1f77bcf86cd799439011",
 			fixtures:    []string{fixtureNamespaces},
 			expected: Expected{
 				ns: &models.Namespace{
@@ -353,7 +393,7 @@ func TestNamespaceGetFirst(t *testing.T) {
 				assert.NoError(t, srv.Reset())
 			})
 
-			ns, err := s.NamespaceGetFirst(ctx, tc.member)
+			ns, err := s.NamespaceGetPreferred(ctx, tc.tenantID, tc.memberID)
 			assert.Equal(t, tc.expected, Expected{ns: ns, err: err})
 		})
 	}

--- a/api/store/namespace.go
+++ b/api/store/namespace.go
@@ -16,6 +16,12 @@ type NamespaceStore interface {
 	//
 	// It returns the namespace or an error if any.
 	NamespaceGet(ctx context.Context, tenantID string, countDevices bool) (*models.Namespace, error)
+	// NamespaceGetPreferred retrieves a namespace identified by the given tenantID where the user is a member.
+	// If the tenantID is an empty string, it defaults to the first namespace found where the user is a member
+	// (usually the first one to it was added).
+	//
+	// It returns the namespace or an error if any.
+	NamespaceGetPreferred(ctx context.Context, tenantID, userID string) (*models.Namespace, error)
 
 	NamespaceGetByName(ctx context.Context, name string) (*models.Namespace, error)
 	NamespaceCreate(ctx context.Context, namespace *models.Namespace) (*models.Namespace, error)
@@ -34,10 +40,10 @@ type NamespaceStore interface {
 	// the changes. It returns an error if any.
 	NamespaceUpdateMember(ctx context.Context, tenantID string, memberID string, changes *models.MemberChanges) error
 	// NamespaceRemoveMember removes a member with the specified memberID in the namespace with the specified tenantID.
+	// If the namespace's tenant ID is the member's preffered tenant ID, it will set the value to an empty string.
 	// It returns an error if any.
 	NamespaceRemoveMember(ctx context.Context, tenantID string, memberID string) error
 
-	NamespaceGetFirst(ctx context.Context, id string) (*models.Namespace, error)
 	NamespaceSetSessionRecord(ctx context.Context, sessionRecord bool, tenantID string) error
 	NamespaceGetSessionRecord(ctx context.Context, tenantID string) (bool, error)
 }

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -24,8 +24,9 @@ type User struct {
 	// check if MFA is active for the user.
 	//
 	// NOTE: MFA is available as a cloud-only feature and must be ignored in community.
-	MFA      UserMFA      `json:"mfa" bson:"mfa"`
-	Password UserPassword `bson:",inline"`
+	MFA         UserMFA         `json:"mfa" bson:"mfa"`
+	Preferences UserPreferences `json:"-" bson:"preferences"`
+	Password    UserPassword    `bson:",inline"`
 }
 
 type UserData struct {
@@ -47,6 +48,11 @@ type UserMFA struct {
 	Secret string `json:"-" bson:"secret"`
 	// RecoveryCodes are recovery tokens that the user can use to regain account access if they lose their MFA device.
 	RecoveryCodes []string `json:"-" bson:"recovery_codes"`
+}
+
+type UserPreferences struct {
+	// PreferredNamespace represents the namespace the user most recently authenticated with.
+	PreferredNamespace string `json:"-" bson:"preferred_namespace"`
 }
 
 type UserPassword struct {
@@ -138,13 +144,14 @@ type UserTokenRecover struct {
 // UserChanges specifies the attributes that can be updated for a user. Any zero values in this
 // struct must be ignored. If an attribute is a pointer type, its zero value is represented as `nil`.
 type UserChanges struct {
-	LastLogin     time.Time `bson:"last_login,omitempty"`
-	Name          string    `bson:"name,omitempty"`
-	Username      string    `bson:"username,omitempty"`
-	Email         string    `bson:"email,omitempty"`
-	RecoveryEmail string    `bson:"recovery_email,omitempty"`
-	Password      string    `bson:"password,omitempty"`
-	Confirmed     *bool     `bson:"confirmed,omitempty"`
+	LastLogin          time.Time `bson:"last_login,omitempty"`
+	Name               string    `bson:"name,omitempty"`
+	Username           string    `bson:"username,omitempty"`
+	Email              string    `bson:"email,omitempty"`
+	RecoveryEmail      string    `bson:"recovery_email,omitempty"`
+	Password           string    `bson:"password,omitempty"`
+	Confirmed          *bool     `bson:"confirmed,omitempty"`
+	PreferredNamespace *string   `bson:"preferences.preferred_namespace,omitempty"`
 }
 
 // UserConflicts holds user attributes that must be unique for each itam and can be utilized in queries


### PR DESCRIPTION
PreferredNamespace represents the namespace the user most recently authenticated with. This allows the user to authenticate using the most recently used namespace instead of the first one they were added to.

This value is updated every time the user logs in or creates a new authentication token. It is also automatically set to an empty value when the namespace is removed or the user is removed from the members list.

The preferred namespace will be stored under a new `preferences` sub-document in the user's collection. Two new migrations have been added to introduce this new document and attribute.