### PR TITLE
chore(agent): receive mode on initialization

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -85,7 +85,7 @@ func main() {
 				"mode":    mode,
 			}).Info("Starting ShellHub")
 
-			ag, err := agent.NewAgentWithConfig(cfg, new(agent.HostMode))
+			ag, err := agent.NewAgentWithConfig(cfg)
 			if err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"version":       AgentVersion,
@@ -93,7 +93,7 @@ func main() {
 				}).Fatal("Failed to create agent")
 			}
 
-			if err := ag.Initialize(); err != nil {
+			if err := ag.Initialize(new(agent.HostMode)); err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"version":       AgentVersion,
 					"configuration": cfg,

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -18,14 +18,14 @@ func ExampleNewAgentWithConfig() {
 		ServerAddress: "http://localhost:80",
 		TenantID:      "00000000-0000-4000-0000-000000000000",
 		PrivateKey:    "./shellhub.key",
-	}, new(HostMode))
+	})
 	if err != nil {
 		panic(err)
 	}
 }
 
 func ExampleNewAgent() {
-	_, err := NewAgent("http://localhost:80", "00000000-0000-4000-0000-000000000000", "./shellhub.key", new(HostMode))
+	_, err := NewAgent("http://localhost:80", "00000000-0000-4000-0000-000000000000", "./shellhub.key")
 	if err != nil {
 		panic(err)
 	}
@@ -212,26 +212,12 @@ func TestNewAgentWithConfig(t *testing.T) {
 			},
 		},
 		{
-			description: "fail when mode is nil",
-			config: &Config{
-				ServerAddress: "http://localhost",
-				TenantID:      "1c462afa-e4b6-41a5-ba54-7236a1770466",
-				PrivateKey:    "/tmp/shellhub.key",
-			},
-			mode: nil,
-			expected: expected{
-				agent: nil,
-				err:   ErrNewAgentWithConfigNilMode,
-			},
-		},
-		{
 			description: "success to create agent with config",
 			config:      config,
 			mode:        new(HostMode),
 			expected: expected{
 				agent: &Agent{
 					config: config,
-					mode:   new(HostMode),
 				},
 				err: nil,
 			},
@@ -240,7 +226,7 @@ func TestNewAgentWithConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			agent, err := NewAgentWithConfig(test.config, test.mode)
+			agent, err := NewAgentWithConfig(test.config)
 
 			assert.Equal(t, test.expected.agent, agent)
 			assert.ErrorIs(t, err, test.expected.err)

--- a/pkg/agent/connector/docker.go
+++ b/pkg/agent/connector/docker.go
@@ -234,7 +234,7 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 		}).Fatal("Failed to create connector mode")
 	}
 
-	ag, err := agent.NewAgentWithConfig(cfg, mode)
+	ag, err := agent.NewAgentWithConfig(cfg)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"id":            container.ID,
@@ -243,7 +243,7 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 		}).Fatal("Failed to create agent")
 	}
 
-	if err := ag.Initialize(); err != nil {
+	if err := ag.Initialize(mode); err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"id":            container.ID,
 			"configuration": cfg,


### PR DESCRIPTION
It was noticed that we could remove the `mode` field from the Agent's structure if we used it on the `Initialization` method, decreasing a bit the complexity of the structure and its requirements to be created. Beyond that, now we also create the SSH server in the initialization, taking advantage of this change.