### PR TITLE
refactor(api): user detach info

### DIFF
--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -2068,36 +2068,6 @@ func (_m *Store) UserDelete(ctx context.Context, id string) error {
 	return r0
 }
 
-// UserDetachInfo provides a mock function with given fields: ctx, id
-func (_m *Store) UserDetachInfo(ctx context.Context, id string) (map[string][]*models.Namespace, error) {
-	ret := _m.Called(ctx, id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UserDetachInfo")
-	}
-
-	var r0 map[string][]*models.Namespace
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (map[string][]*models.Namespace, error)); ok {
-		return rf(ctx, id)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) map[string][]*models.Namespace); ok {
-		r0 = rf(ctx, id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string][]*models.Namespace)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // UserGetByEmail provides a mock function with given fields: ctx, email
 func (_m *Store) UserGetByEmail(ctx context.Context, email string) (*models.User, error) {
 	ret := _m.Called(ctx, email)
@@ -2188,6 +2158,36 @@ func (_m *Store) UserGetByUsername(ctx context.Context, username string) (*model
 
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = rf(ctx, username)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// UserGetInfo provides a mock function with given fields: ctx, id
+func (_m *Store) UserGetInfo(ctx context.Context, id string) (*models.UserInfo, error) {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UserGetInfo")
+	}
+
+	var r0 *models.UserInfo
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*models.UserInfo, error)); ok {
+		return rf(ctx, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *models.UserInfo); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.UserInfo)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/api/store/user.go
+++ b/api/store/user.go
@@ -35,6 +35,9 @@ type UserStore interface {
 	// NOTE: The changes parameter can accept pointers, in which case a zero value will be represented as "nil".
 	UserUpdate(ctx context.Context, id string, changes *models.UserChanges) error
 
-	UserDetachInfo(ctx context.Context, id string) (map[string][]*models.Namespace, error)
+	// UserGetInfo retrieves the user's information, like the owned and associated namespaces.
+	// It returns an error if the user is not part of any namespace.
+	UserGetInfo(ctx context.Context, id string) (userInfo *models.UserInfo, err error)
+
 	UserDelete(ctx context.Context, id string) error
 }

--- a/cli/services/users.go
+++ b/cli/services/users.go
@@ -76,20 +76,18 @@ func (s *service) UserDelete(ctx context.Context, input *inputs.UserDelete) erro
 		return ErrUserNotFound
 	}
 
-	detach, err := s.store.UserDetachInfo(ctx, user.ID)
+	userInfo, err := s.store.UserGetInfo(ctx, user.ID)
 	if err != nil {
 		return ErrNamespaceNotFound
 	}
 
-	// Delete all namespaces what the user is owner.
-	for _, ns := range detach["owner"] {
+	for _, ns := range userInfo.OwnedNamespaces {
 		if err := s.store.NamespaceDelete(ctx, ns.TenantID); err != nil {
 			return err
 		}
 	}
 
-	// Remove user from all namespaces what it is a member.
-	for _, ns := range detach["member"] {
+	for _, ns := range userInfo.AssociatedNamespaces {
 		if err := s.store.NamespaceRemoveMember(ctx, ns.TenantID, user.ID); err != nil {
 			return err
 		}

--- a/cli/services/users_test.go
+++ b/cli/services/users_test.go
@@ -241,7 +241,7 @@ func TestUserDelete(t *testing.T) {
 					},
 				}
 				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
-				mock.On("UserDetachInfo", ctx, "507f191e810c19729de860ea").Return(nil, errors.New("error")).Once()
+				mock.On("UserGetInfo", ctx, "507f191e810c19729de860ea").Return(nil, errors.New("error")).Once()
 			},
 			expected: ErrNamespaceNotFound,
 		},
@@ -259,7 +259,7 @@ func TestUserDelete(t *testing.T) {
 				}
 				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
 
-				namespaceOwned := []*models.Namespace{
+				namespaceOwned := []models.Namespace{
 					{
 						Name:     "namespace1",
 						Owner:    "507f191e810c19729de860ea",
@@ -281,7 +281,7 @@ func TestUserDelete(t *testing.T) {
 						CreatedAt: clock.Now(),
 					},
 				}
-				namespaceMember := []*models.Namespace{
+				namespaceMember := []models.Namespace{
 					{
 						Name:     "namespace3",
 						Owner:    "507f191e810c19729de86000",
@@ -310,9 +310,9 @@ func TestUserDelete(t *testing.T) {
 					},
 				}
 
-				mock.On("UserDetachInfo", ctx, "507f191e810c19729de860ea").Return(map[string][]*models.Namespace{
-					"owner":  namespaceOwned,
-					"member": namespaceMember,
+				mock.On("UserGetInfo", ctx, "507f191e810c19729de860ea").Return(&models.UserInfo{
+					OwnedNamespaces:      namespaceOwned,
+					AssociatedNamespaces: namespaceMember,
 				}, nil)
 
 				for _, v := range namespaceOwned {

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -171,3 +171,10 @@ func (c *UserConflicts) Distinct(user *User) {
 		c.Username = ""
 	}
 }
+
+type UserInfo struct {
+	// OwnedNamespaces are the namespaces where the user is the owner.
+	OwnedNamespaces []Namespace
+	// AssociatedNamespaces are the namespaces where the user is a member.
+	AssociatedNamespaces []Namespace
+}


### PR DESCRIPTION
Renamed the store's method `UserDetachInfo` to `UserGetInfo`. Introduced a new type `UserInfo` to serve as the return type, replacing the previous map with "owned" and "members" attributes.