### PR TITLE
fix(namespace,api,cli): fixing default announcements

### DIFF
--- a/api/services/namespace.go
+++ b/api/services/namespace.go
@@ -90,9 +90,13 @@ func (s *service) CreateNamespace(ctx context.Context, namespace requests.Namesp
 		},
 		Settings: &models.NamespaceSettings{
 			SessionRecord:          true,
-			ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+			ConnectionAnnouncement: "",
 		},
 		TenantID: namespace.TenantID,
+	}
+
+	if envs.IsCommunity() {
+		ns.Settings.ConnectionAnnouncement = models.DefaultAnnouncementMessage
 	}
 
 	if ok, err := s.validator.Struct(ns); !ok || err != nil {

--- a/api/services/namespace_test.go
+++ b/api/services/namespace_test.go
@@ -493,6 +493,8 @@ func TestCreateNamespace(t *testing.T) {
 				}
 
 				mock.On("UserGetByID", ctx, user.ID, false).Return(user, 0, nil).Once()
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("false").Once()
+				envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("false").Once()
 			},
 			expected: Expected{
 				nil,
@@ -531,6 +533,8 @@ func TestCreateNamespace(t *testing.T) {
 				var isCloud bool
 				mock.On("UserGetByID", ctx, user.ID, false).Return(user, 0, nil).Once()
 				envMock.On("Get", "SHELLHUB_CLOUD").Return(strconv.FormatBool(isCloud)).Once()
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("false").Once()
+				envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("false").Once()
 				mock.On("NamespaceGetByName", ctx, "namespace").Return(model, nil).Once()
 			},
 			expected: Expected{
@@ -570,6 +574,8 @@ func TestCreateNamespace(t *testing.T) {
 				var isCloud bool
 				mock.On("UserGetByID", ctx, user.ID, false).Return(user, 0, nil).Once()
 				envMock.On("Get", "SHELLHUB_CLOUD").Return(strconv.FormatBool(isCloud)).Once()
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("false").Once()
+				envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("false").Once()
 				mock.On("NamespaceGetByName", ctx, "namespace").Return(model, errors.New("error")).Once()
 			},
 			expected: Expected{
@@ -611,6 +617,8 @@ func TestCreateNamespace(t *testing.T) {
 				mock.On("NamespaceGetByName", ctx, "namespace").Return(nil, nil).Once()
 				mock.On("NamespaceCreate", ctx, notCloudNamespace).Return(nil, errors.New("error")).Once()
 				envMock.On("Get", "SHELLHUB_CLOUD").Return(strconv.FormatBool(isCloud)).Once()
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("false").Once()
+				envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("false").Once()
 			},
 			expected: Expected{
 				nil, NewErrNamespaceCreateStore(errors.New("error")),
@@ -650,6 +658,8 @@ func TestCreateNamespace(t *testing.T) {
 				mock.On("NamespaceGetByName", ctx, "namespace").Return(nil, nil).Once()
 				mock.On("NamespaceCreate", ctx, notCloudNamespace).Return(notCloudNamespace, nil).Once()
 				envMock.On("Get", "SHELLHUB_CLOUD").Return(strconv.FormatBool(isCloud)).Once()
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("false").Once()
+				envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("false").Once()
 			},
 			expected: Expected{
 				&models.Namespace{
@@ -692,7 +702,7 @@ func TestCreateNamespace(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: "",
 					},
 					TenantID:   "xxxxx",
 					MaxDevices: -1,
@@ -701,6 +711,8 @@ func TestCreateNamespace(t *testing.T) {
 				mock.On("NamespaceGetByName", ctx, "namespace").Return(nil, nil).Once()
 				mock.On("NamespaceCreate", ctx, notCloudNamespace).Return(nil, nil).Once()
 				envMock.On("Get", "SHELLHUB_CLOUD").Return(strconv.FormatBool(isCloud)).Once()
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("false").Once()
+				envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("true").Once()
 			},
 			expected: Expected{
 				&models.Namespace{
@@ -711,7 +723,7 @@ func TestCreateNamespace(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: "",
 					},
 					TenantID:   "xxxxx",
 					MaxDevices: -1,
@@ -743,7 +755,7 @@ func TestCreateNamespace(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: "",
 					},
 					TenantID:   "xxxxx",
 					MaxDevices: 3,
@@ -752,6 +764,8 @@ func TestCreateNamespace(t *testing.T) {
 				mock.On("NamespaceGetByName", ctx, "namespace").Return(nil, nil).Once()
 				mock.On("NamespaceCreate", ctx, cloudNamespace).Return(nil, nil).Once()
 				envMock.On("Get", "SHELLHUB_CLOUD").Return(strconv.FormatBool(isCloud)).Once()
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("true").Once()
+				envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("true").Once()
 			},
 			expected: Expected{
 				&models.Namespace{
@@ -762,7 +776,7 @@ func TestCreateNamespace(t *testing.T) {
 					},
 					Settings: &models.NamespaceSettings{
 						SessionRecord:          true,
-						ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+						ConnectionAnnouncement: "",
 					},
 					TenantID:   "xxxxx",
 					MaxDevices: 3,
@@ -777,10 +791,12 @@ func TestCreateNamespace(t *testing.T) {
 
 			service := NewService(store.Store(mock), privateKey, publicKey, storecache.NewNullCache(), clientMock)
 			returnedNamespace, err := service.CreateNamespace(ctx, tc.namespace, tc.ownerID)
+
 			assert.Equal(t, tc.expected, Expected{returnedNamespace, err})
+
+			mock.AssertExpectations(t)
 		})
 	}
-	mock.AssertExpectations(t)
 }
 
 func TestEditNamespace(t *testing.T) {

--- a/api/store/mongo/migrations/migration_74.go
+++ b/api/store/mongo/migrations/migration_74.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 
+	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/sirupsen/logrus"
 	migrate "github.com/xakep666/mongo-migrate"
@@ -24,9 +25,14 @@ var migration74 = migrate.Migration{
 			"settings.connection_announcement": "",
 		}
 
+		annoucementMsg := ""
+		if envs.IsCommunity() {
+			annoucementMsg = models.DefaultAnnouncementMessage
+		}
+
 		update := bson.M{
 			"$set": bson.M{
-				"settings.connection_announcement": models.DefaultAnnouncementMessage,
+				"settings.connection_announcement": annoucementMsg,
 			},
 		}
 

--- a/api/store/mongo/migrations/migration_74_test.go
+++ b/api/store/mongo/migrations/migration_74_test.go
@@ -6,26 +6,29 @@ import (
 	"testing"
 
 	"github.com/shellhub-io/shellhub/pkg/envs"
-	envMocks "github.com/shellhub-io/shellhub/pkg/envs/mocks"
+	env_mocks "github.com/shellhub-io/shellhub/pkg/envs/mocks"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	migrate "github.com/xakep666/mongo-migrate"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+var envMock *env_mocks.Backend
+
 func TestMigration74(t *testing.T) {
 	ctx := context.Background()
 
-	mock := &envMocks.Backend{}
-	envs.DefaultBackend = mock
+	envMock = &env_mocks.Backend{}
+	envs.DefaultBackend = envMock
 
 	cases := []struct {
-		description string
-		setup       func() error
-		test        func() error
+		description  string
+		setup        func() error
+		requireMocks func()
+		test         func() error
 	}{
 		{
-			description: "Success to apply up on migration 74",
+			description: "Success to apply up on migration 74, without message on cloud",
 			setup: func() error {
 				_, err := c.
 					Database("test").
@@ -36,6 +39,50 @@ func TestMigration74(t *testing.T) {
 					})
 
 				return err
+			},
+			requireMocks: func() {
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("true").Once()
+			},
+			test: func() error {
+				migrations := GenerateMigrations()[73:74]
+				migrates := migrate.NewMigrate(c.Database("test"), migrations...)
+				err := migrates.Up(context.Background(), migrate.AllAvailable)
+				if err != nil {
+					return err
+				}
+
+				query := c.
+					Database("test").
+					Collection("namespaces").
+					FindOne(context.TODO(), bson.M{"tenant_id": "00000000-0000-4000-0000-000000000000"})
+
+				ns := new(models.Namespace)
+				if err := query.Decode(ns); err != nil {
+					return errors.New("unable to find the namespace")
+				}
+
+				if ns.Settings.ConnectionAnnouncement != "" {
+					return errors.New("unable to apply the migration")
+				}
+
+				return nil
+			},
+		}, {
+			description: "Success to apply up on migration 74, with message on community",
+			setup: func() error {
+				_, err := c.
+					Database("test").
+					Collection("namespaces").
+					InsertOne(ctx, models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Settings: &models.NamespaceSettings{},
+					})
+
+				return err
+			},
+			requireMocks: func() {
+				envMock.On("Get", "SHELLHUB_CLOUD").Return("false").Once()
+				envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("false").Once()
 			},
 			test: func() error {
 				migrations := GenerateMigrations()[73:74]
@@ -74,6 +121,7 @@ func TestMigration74(t *testing.T) {
 
 				return err
 			},
+			requireMocks: func() {},
 			test: func() error {
 				migrations := GenerateMigrations()[73:74]
 				migrates := migrate.NewMigrate(c.Database("test"), migrations...)
@@ -104,12 +152,16 @@ func TestMigration74(t *testing.T) {
 	for _, test := range cases {
 		tc := test
 		t.Run(tc.description, func(t *testing.T) {
+			tc.requireMocks()
+
 			t.Cleanup(func() {
 				assert.NoError(t, srv.Reset())
 			})
 
 			assert.NoError(t, tc.setup())
 			assert.NoError(t, tc.test())
+
+			envMock.AssertExpectations(t)
 		})
 	}
 }


### PR DESCRIPTION
Fixing default announcements so they can only not be triggered on the enterprise and cloud edition

this PR is a change to the features added on https://github.com/shellhub-io/shellhub/pull/3984