### PR TITLE
feat(gateway): redirect 'DELETE /api/user' to cloud

### DIFF
--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -101,6 +101,36 @@ server {
         proxy_pass http://upstream_router;
     }
 
+    location /api/user {
+        {{ set_upstream "api" 8080 }}
+
+        {{/*
+            The route for deleting users is available only in cloud instances. 
+            Community users must use the CLI, while enterprise users have access 
+            to the admin dashboard.
+        */}}
+        if ($request_method = DELETE) {
+            {{ set_upstream "cloud-api" 8080 }}
+        }
+
+        auth_request       /auth;
+        auth_request_set   $tenant_id $upstream_http_x_tenant_id;
+        auth_request_set   $username $upstream_http_x_username;
+        auth_request_set   $id $upstream_http_x_id;
+        auth_request_set   $api_key $upstream_http_x_api_key;
+        auth_request_set   $role $upstream_http_x_role;
+        error_page         500 =401 /auth;
+        proxy_http_version 1.1;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   X-Api-Key $api_key;
+        proxy_set_header   X-ID $id;
+        proxy_set_header   X-Request-ID $request_id;
+        proxy_set_header   X-Role $role;
+        proxy_set_header   X-Tenant-ID $tenant_id;
+        proxy_set_header   X-Username $username;
+        proxy_pass         http://upstream_router;
+    }
+
     location ~ ^/(install.sh|kickstart.sh)$ {
         {{ set_upstream "api" 8080 }}
 


### PR DESCRIPTION
A new `location /api/user` has been added. This location functions similarly to `/api`, but redirects DELETE requests to the cloud upstream.