### PR TITLE
fix(ui): increased content padding on premium paywall

### DIFF
--- a/ui/src/components/User/PaywallDialog.vue
+++ b/ui/src/components/User/PaywallDialog.vue
@@ -2,12 +2,13 @@
   <v-dialog
     v-model="dialog"
     transition="dialog-bottom-transition"
-    width="650"
+    max-width="650"
     height="800"
-    persistent
+    @click:outside="close"
+    @keydown.esc="close"
   >
     <v-card color="background" data-test="card-dialog">
-      <v-container>
+      <v-container class="px-6">
         <v-row data-test="icon-crown">
           <v-col class="d-flex justify-center align-center">
             <div class="circle-one shadow d-flex justify-center align-center">


### PR DESCRIPTION
This Pull Request increases the content padding on the premium paywall to be
the same as the gap between the content cards and removed the persistent
property from the dialog.

Solves #4031
