### PR TITLE
fix(gateway): adjust MFA authentication redirect

### DIFF
--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -333,6 +333,18 @@ server {
     location /api/user/mfa {
         {{ set_upstream "cloud-api" 8080 }}
 
+        auth_request     /auth;
+        auth_request_set $id $upstream_http_x_id;
+        error_page       500 =401 /auth;
+        proxy_set_header X-Real-IP $x_real_ip;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-ID $id;
+        proxy_pass       http://upstream_router;
+    }
+
+    location ~^/api/user/mfa/(auth|recover|reset)(?:/.*)?$ {
+        {{ set_upstream "cloud-api" 8080 }}
+
         auth_request     off;
         proxy_set_header X-Real-IP $x_real_ip;
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
Certain MFA endpoints require authentication credentials, such as the 'X-ID' header. We've implemented a new routing rule to differentiate between endpoints that need prior authentication and those that don't.