### PR TITLE
revert: downgrade golang from 1.23 to 1.22

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,5 +1,5 @@
 # base stage
-FROM golang:1.23.0-alpine3.19 AS base
+FROM golang:1.22.6-alpine3.19 AS base
 
 ARG GOPROXY
 

--- a/agent/Dockerfile.amd64
+++ b/agent/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19
+FROM golang:1.22.6-alpine3.19
 
 ARG SHELLHUB_VERSION=latest
 

--- a/agent/Dockerfile.arm64v8
+++ b/agent/Dockerfile.arm64v8
@@ -1,6 +1,6 @@
 # docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
-FROM arm64v8/golang:1.23.0-alpine3.19
+FROM arm64v8/golang:1.22.6-alpine3.19
 
 ARG SHELLHUB_VERSION=latest
 

--- a/agent/Dockerfile.i386
+++ b/agent/Dockerfile.i386
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19
+FROM golang:1.22.6-alpine3.19
 
 ARG SHELLHUB_VERSION=latest
 

--- a/agent/Dockerfile.test
+++ b/agent/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19
+FROM golang:1.22.6-alpine3.19
 
 ARG GOPROXY
 

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -1,5 +1,5 @@
 # base stage
-FROM golang:1.23.0-alpine3.19 AS base
+FROM golang:1.22.6-alpine3.19 AS base
 
 ARG GOPROXY
 


### PR DESCRIPTION
- **Revert "docker: agent: bump golang in /agent"**
- **Revert "docker: agent: bump arm64v8/golang in /agent"**
- **Revert "docker: ssh: bump golang in /ssh"**
