### PR TITLE
feat(api)!: replace user.confirmed with user.status

### DIFF
--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -184,7 +184,7 @@ func (s *service) AuthUser(ctx context.Context, req *requests.UserAuth, sourceIP
 		return nil, 0, "", NewErrAuthUnathorized(nil)
 	}
 
-	if !user.Confirmed {
+	if user.Status != models.UserStatusConfirmed {
 		return nil, 0, "", NewErrUserNotConfirmed(nil)
 	}
 

--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -185,7 +185,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: false,
+					Status:    models.UserStatusNotConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -221,7 +221,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -264,7 +264,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -315,7 +315,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: true,
@@ -375,7 +375,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -434,7 +434,7 @@ func TestAuthUser(t *testing.T) {
 				mfaToken: "",
 				err: NewErrUserUpdate(&models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					UserData: models.UserData{
 						Username: "john_doe",
@@ -456,7 +456,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -534,7 +534,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -624,7 +624,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -715,7 +715,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -805,7 +805,7 @@ func TestAuthUser(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{
 					ID:        "65fdd16b5f62f93184ec8a39",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -942,7 +942,7 @@ func TestCreateUserToken(t *testing.T) {
 			requiredMocks: func(ctx context.Context) {
 				user := &models.User{
 					ID:        "000000000000000000000000",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -980,7 +980,7 @@ func TestCreateUserToken(t *testing.T) {
 			requiredMocks: func(ctx context.Context) {
 				user := &models.User{
 					ID:        "000000000000000000000000",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -1015,7 +1015,7 @@ func TestCreateUserToken(t *testing.T) {
 			requiredMocks: func(ctx context.Context) {
 				user := &models.User{
 					ID:        "000000000000000000000000",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -1055,7 +1055,7 @@ func TestCreateUserToken(t *testing.T) {
 			requiredMocks: func(ctx context.Context) {
 				user := &models.User{
 					ID:        "000000000000000000000000",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -1104,7 +1104,7 @@ func TestCreateUserToken(t *testing.T) {
 			requiredMocks: func(ctx context.Context) {
 				user := &models.User{
 					ID:        "000000000000000000000000",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,
@@ -1172,7 +1172,7 @@ func TestCreateUserToken(t *testing.T) {
 			requiredMocks: func(ctx context.Context) {
 				user := &models.User{
 					ID:        "000000000000000000000000",
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					LastLogin: now,
 					MFA: models.UserMFA{
 						Enabled: false,

--- a/api/services/setup.go
+++ b/api/services/setup.go
@@ -38,7 +38,7 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) error {
 		UserData: data,
 		Password: password,
 		// NOTE: user's created from the setup screen doesn't need to be confirmed.
-		Confirmed: true,
+		Status:    models.UserStatusConfirmed,
 		CreatedAt: clock.Now(),
 	}
 

--- a/api/services/setup_test.go
+++ b/api/services/setup_test.go
@@ -61,7 +61,7 @@ func TestSetup(t *testing.T) {
 					Once()
 
 				user := &models.User{
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					CreatedAt: now,
 					UserData: models.UserData{
 						Name:     "userteste",
@@ -98,7 +98,7 @@ func TestSetup(t *testing.T) {
 					Once()
 
 				user := &models.User{
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					CreatedAt: now,
 					UserData: models.UserData{
 						Name:     "userteste",
@@ -151,7 +151,7 @@ func TestSetup(t *testing.T) {
 					Once()
 
 				user := &models.User{
-					Confirmed: true,
+					Status:    models.UserStatusConfirmed,
 					CreatedAt: now,
 					UserData: models.UserData{
 						Name:     "userteste",

--- a/api/store/mongo/fixtures/users.json
+++ b/api/store/mongo/fixtures/users.json
@@ -1,7 +1,7 @@
 {
     "users": {
         "507f1f77bcf86cd799439011": {
-            "confirmed": true,
+            "status": "confirmed",
             "created_at": "2023-01-01T12:00:00.000Z",
             "last_login": "2023-01-01T12:00:00.000Z",
             "email": "john.doe@test.com",
@@ -12,7 +12,7 @@
             "username": "john_doe"
         },
         "608f32a2c7351f001f6475e0": {
-            "confirmed": true,
+            "status": "confirmed",
             "created_at": "2023-01-02T12:00:00.000Z",
             "last_login": "2023-01-02T12:00:00.000Z",
             "email": "jane.smith@test.com",
@@ -23,7 +23,7 @@
             "username": "jane_smith"
         },
         "709f45b5e812c1002f3a67e7": {
-            "confirmed": true,
+            "status": "confirmed",
             "created_at": "2023-01-03T12:00:00.000Z",
             "last_login": "2023-01-03T12:00:00.000Z",
             "email": "bob.johnson@test.com",
@@ -34,7 +34,7 @@
             "username": "bob_johnson"
         },
         "80fdcea1d7299c002f3a67e8": {
-            "confirmed": false,
+            "status": "not-confirmed",
             "created_at": "2023-01-04T12:00:00.000Z",
             "last_login": null,
             "email": "alex.rodriguez@test.com",

--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -84,6 +84,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration72,
 		migration73,
 		migration74,
+		migration75,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_32_test.go
+++ b/api/store/mongo/migrations/migration_32_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	migrate "github.com/xakep666/mongo-migrate"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 func TestMigration32(t *testing.T) {
@@ -47,9 +46,4 @@ func TestMigration32(t *testing.T) {
 	version, _, err = migrates.Version(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(32), version)
-
-	var migratedUser *models.User
-	err = c.Database("test").Collection("users").FindOne(context.TODO(), bson.M{"name": "name"}).Decode(&migratedUser)
-	assert.NoError(t, err)
-	assert.Equal(t, false, migratedUser.Confirmed)
 }

--- a/api/store/mongo/migrations/migration_38_test.go
+++ b/api/store/mongo/migrations/migration_38_test.go
@@ -33,7 +33,6 @@ func TestMigration38(t *testing.T) {
 	userNoCreatedAt := models.User{
 		ID:         "userNoCreatedID",
 		Namespaces: 0,
-		Confirmed:  false,
 		CreatedAt:  timeZero,
 		LastLogin:  timeNow,
 		UserData: models.UserData{
@@ -48,7 +47,6 @@ func TestMigration38(t *testing.T) {
 	userWithCreatedAt := models.User{
 		ID:         "userWithCreatedID",
 		Namespaces: 0,
-		Confirmed:  false,
 		CreatedAt:  timePast,
 		LastLogin:  timeNow,
 		UserData: models.UserData{

--- a/api/store/mongo/migrations/migration_59_test.go
+++ b/api/store/mongo/migrations/migration_59_test.go
@@ -77,7 +77,6 @@ func TestMigration59(t *testing.T) {
 					ID:             "652594bcc7b001c6f298df48",
 					Namespaces:     0,
 					MaxNamespaces:  0,
-					Confirmed:      false,
 					CreatedAt:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					LastLogin:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					EmailMarketing: false,

--- a/api/store/mongo/migrations/migration_75.go
+++ b/api/store/mongo/migrations/migration_75.go
@@ -1,0 +1,126 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	log "github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration75 = migrate.Migration{
+	Version:     75,
+	Description: "Convert user.confirmed to user.status",
+	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{
+			"component": "migration",
+			"version":   75,
+			"action":    "Up",
+		}).Info("Applying migration")
+
+		pipeline := []bson.M{
+			{
+				"$match": bson.M{
+					"confirmed": bson.M{
+						"$exists": true,
+					},
+					"status": bson.M{
+						"$exists": false,
+					},
+				},
+			},
+		}
+
+		cursor, err := db.Collection("users").Aggregate(ctx, pipeline)
+		if err != nil {
+			return err
+		}
+		defer cursor.Close(ctx)
+
+		updateModels := make([]mongo.WriteModel, 0)
+
+		for cursor.Next(ctx) {
+			user := make(map[string]interface{})
+			if err := cursor.Decode(&user); err != nil {
+				return err
+			}
+
+			updateModel := mongo.
+				NewUpdateOneModel().
+				SetFilter(bson.M{"_id": user["_id"]})
+
+			if confirmed := user["confirmed"]; confirmed == true {
+				updateModel.SetUpdate(bson.M{"$set": bson.M{"status": models.UserStatusConfirmed.String()}, "$unset": bson.M{"confirmed": ""}})
+			} else {
+				updateModel.SetUpdate(bson.M{"$set": bson.M{"status": models.UserStatusNotConfirmed.String()}, "$unset": bson.M{"confirmed": ""}})
+			}
+
+			updateModels = append(updateModels, updateModel)
+		}
+
+		if len(updateModels) == 0 {
+			return nil
+		}
+
+		_, err = db.Collection("users").BulkWrite(ctx, updateModels)
+
+		return err
+	}),
+	Down: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{
+			"component": "migration",
+			"version":   75,
+			"action":    "Down",
+		}).Info("Reverting migration")
+
+		pipeline := []bson.M{
+			{
+				"$match": bson.M{
+					"confirmed": bson.M{
+						"$exists": false,
+					},
+					"status": bson.M{
+						"$exists": true,
+					},
+				},
+			},
+		}
+
+		cursor, err := db.Collection("users").Aggregate(ctx, pipeline)
+		if err != nil {
+			return err
+		}
+		defer cursor.Close(ctx)
+
+		updateModels := make([]mongo.WriteModel, 0)
+
+		for cursor.Next(ctx) {
+			user := make(map[string]interface{})
+			if err := cursor.Decode(&user); err != nil {
+				return err
+			}
+
+			updateModel := mongo.
+				NewUpdateOneModel().
+				SetFilter(bson.M{"_id": user["_id"]})
+
+			if status := user["status"].(string); status == models.UserStatusConfirmed.String() {
+				updateModel.SetUpdate(bson.M{"$set": bson.M{"confirmed": true}, "$unset": bson.M{"status": ""}})
+			} else {
+				updateModel.SetUpdate(bson.M{"$set": bson.M{"confirmed": false}, "$unset": bson.M{"status": ""}})
+			}
+
+			updateModels = append(updateModels, updateModel)
+		}
+
+		if len(updateModels) == 0 {
+			return nil
+		}
+
+		_, err = db.Collection("users").BulkWrite(ctx, updateModels)
+
+		return err
+	}),
+}

--- a/api/store/mongo/migrations/migration_75_test.go
+++ b/api/store/mongo/migrations/migration_75_test.go
@@ -1,0 +1,164 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	envmock "github.com/shellhub-io/shellhub/pkg/envs/mocks"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestMigration75Up(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &envmock.Backend{}
+	envs.DefaultBackend = mock
+
+	cases := []struct {
+		description string
+		setup       func(primitive.ObjectID) error
+		expected    string
+	}{
+		{
+			description: "Success to apply up on migration 75 with confirmed == true",
+			setup: func(objID primitive.ObjectID) error {
+				_, err := c.
+					Database("test").
+					Collection("users").
+					InsertOne(ctx, map[string]interface{}{
+						"_id":       objID,
+						"confirmed": true,
+					})
+
+				return err
+			},
+			expected: models.UserStatusConfirmed.String(),
+		},
+		{
+			description: "Success to apply up on migration 75 with confirmed == false",
+			setup: func(objID primitive.ObjectID) error {
+				_, err := c.
+					Database("test").
+					Collection("users").
+					InsertOne(ctx, map[string]interface{}{
+						"_id":       objID,
+						"confirmed": false,
+					})
+
+				return err
+			},
+			expected: models.UserStatusNotConfirmed.String(),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.description, func(tt *testing.T) {
+			tt.Cleanup(func() {
+				assert.NoError(tt, srv.Reset())
+			})
+
+			objID := primitive.NewObjectID()
+			assert.NoError(tt, tc.setup(objID))
+
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[74])
+			require.NoError(tt, migrates.Up(context.Background(), migrate.AllAvailable))
+
+			query := c.
+				Database("test").
+				Collection("users").
+				FindOne(context.TODO(), bson.M{"_id": objID})
+
+			user := make(map[string]interface{})
+			require.NoError(tt, query.Decode(&user))
+
+			_, ok := user["confirmed"]
+			require.Equal(tt, false, ok)
+
+			status, ok := user["status"].(string)
+			require.Equal(tt, true, ok)
+			require.Equal(tt, tc.expected, status)
+		})
+	}
+}
+
+func TestMigration75Down(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &envmock.Backend{}
+	envs.DefaultBackend = mock
+
+	cases := []struct {
+		description string
+		setup       func(primitive.ObjectID) error
+		expected    bool
+	}{
+		{
+			description: "Success to apply up on migration 75 with status confirmed",
+			setup: func(objID primitive.ObjectID) error {
+				_, err := c.
+					Database("test").
+					Collection("users").
+					InsertOne(ctx, map[string]interface{}{
+						"_id":    objID,
+						"status": models.UserStatusConfirmed.String(),
+					})
+
+				return err
+			},
+			expected: true,
+		},
+		{
+			description: "Success to apply up on migration 75 with status unconfirmed",
+			setup: func(objID primitive.ObjectID) error {
+				_, err := c.
+					Database("test").
+					Collection("users").
+					InsertOne(ctx, map[string]interface{}{
+						"_id":    objID,
+						"status": models.UserStatusNotConfirmed.String(),
+					})
+
+				return err
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.description, func(tt *testing.T) {
+			tt.Cleanup(func() {
+				assert.NoError(tt, srv.Reset())
+			})
+
+			objID := primitive.NewObjectID()
+			assert.NoError(tt, tc.setup(objID))
+
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[74])
+			require.NoError(tt, migrates.Up(context.Background(), migrate.AllAvailable))
+			require.NoError(tt, migrates.Down(context.Background(), migrate.AllAvailable))
+
+			query := c.
+				Database("test").
+				Collection("users").
+				FindOne(context.TODO(), bson.M{"_id": objID})
+
+			user := make(map[string]interface{})
+			require.NoError(tt, query.Decode(&user))
+
+			_, ok := user["status"]
+			require.Equal(tt, false, ok)
+
+			confirmed, ok := user["confirmed"].(bool)
+			require.Equal(tt, true, ok)
+			require.Equal(tt, tc.expected, confirmed)
+		})
+	}
+}

--- a/api/store/mongo/user_test.go
+++ b/api/store/mongo/user_test.go
@@ -41,7 +41,7 @@ func TestUserList(t *testing.T) {
 						CreatedAt:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 						LastLogin:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 						EmailMarketing: true,
-						Confirmed:      true,
+						Status:         models.UserStatusConfirmed,
 						UserData: models.UserData{
 							Name:     "john doe",
 							Username: "john_doe",
@@ -57,7 +57,7 @@ func TestUserList(t *testing.T) {
 						CreatedAt:      time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC),
 						LastLogin:      time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC),
 						EmailMarketing: true,
-						Confirmed:      true,
+						Status:         models.UserStatusConfirmed,
 						UserData: models.UserData{
 							Name:     "Jane Smith",
 							Username: "jane_smith",
@@ -73,7 +73,7 @@ func TestUserList(t *testing.T) {
 						CreatedAt:      time.Date(2023, 1, 3, 12, 0, 0, 0, time.UTC),
 						LastLogin:      time.Date(2023, 1, 3, 12, 0, 0, 0, time.UTC),
 						EmailMarketing: true,
-						Confirmed:      true,
+						Status:         models.UserStatusConfirmed,
 						UserData: models.UserData{
 							Name:     "Bob Johnson",
 							Username: "bob_johnson",
@@ -88,7 +88,7 @@ func TestUserList(t *testing.T) {
 						ID:             "80fdcea1d7299c002f3a67e8",
 						CreatedAt:      time.Date(2023, 1, 4, 12, 0, 0, 0, time.UTC),
 						EmailMarketing: false,
-						Confirmed:      false,
+						Status:         models.UserStatusNotConfirmed,
 						UserData: models.UserData{
 							Name:     "Alex Rodriguez",
 							Username: "alex_rodriguez",
@@ -127,7 +127,7 @@ func TestUserList(t *testing.T) {
 						CreatedAt:      time.Date(2023, 1, 3, 12, 0, 0, 0, time.UTC),
 						LastLogin:      time.Date(2023, 1, 3, 12, 0, 0, 0, time.UTC),
 						EmailMarketing: true,
-						Confirmed:      true,
+						Status:         models.UserStatusConfirmed,
 						UserData: models.UserData{
 							Name:     "Bob Johnson",
 							Username: "bob_johnson",
@@ -243,7 +243,7 @@ func TestUserGetByUsername(t *testing.T) {
 					CreatedAt:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					LastLogin:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					EmailMarketing: true,
-					Confirmed:      true,
+					Status:         models.UserStatusConfirmed,
 					UserData: models.UserData{
 						Name:     "john doe",
 						Username: "john_doe",
@@ -305,7 +305,7 @@ func TestUserGetByEmail(t *testing.T) {
 					CreatedAt:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					LastLogin:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					EmailMarketing: true,
-					Confirmed:      true,
+					Status:         models.UserStatusConfirmed,
 					UserData: models.UserData{
 						Name:     "john doe",
 						Username: "john_doe",
@@ -371,7 +371,7 @@ func TestUserGetByID(t *testing.T) {
 					CreatedAt:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					LastLogin:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					EmailMarketing: true,
-					Confirmed:      true,
+					Status:         models.UserStatusConfirmed,
 					UserData: models.UserData{
 						Name:     "john doe",
 						Username: "john_doe",
@@ -397,7 +397,7 @@ func TestUserGetByID(t *testing.T) {
 					CreatedAt:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					LastLogin:      time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					EmailMarketing: true,
-					Confirmed:      true,
+					Status:         models.UserStatusConfirmed,
 					UserData: models.UserData{
 						Name:     "john doe",
 						Username: "john_doe",
@@ -505,9 +505,6 @@ func TestUserUpdate(t *testing.T) {
 		err     error
 	}
 
-	_true := true   // to be used as a pointer
-	_false := false // to be used as a pointer
-
 	cases := []struct {
 		description string
 		id          string
@@ -529,17 +526,18 @@ func TestUserUpdate(t *testing.T) {
 			description: "succeeds when updating string values",
 			id:          "507f1f77bcf86cd799439011",
 			changes: &models.UserChanges{
-				Name:  "New Value",
-				Email: "new.value@test.com",
+				Name:   "New Value",
+				Email:  "new.value@test.com",
+				Status: models.UserStatusNotConfirmed,
 			},
 			fixtures: []string{fixtureUsers},
 			expected: Expected{
 				changes: &models.UserChanges{
-					Confirmed: &_true,
 					LastLogin: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
 					Name:      "New Value",
 					Email:     "new.value@test.com",
 					Username:  "john_doe",
+					Status:    models.UserStatusNotConfirmed,
 					Password:  "fcf730b6d95236ecd3c9fc2d92d7b6b2bb061514961aec041d6c7a7192f592e4",
 				},
 				err: nil,
@@ -554,30 +552,11 @@ func TestUserUpdate(t *testing.T) {
 			fixtures: []string{fixtureUsers},
 			expected: Expected{
 				changes: &models.UserChanges{
-					Confirmed: &_true,
 					LastLogin: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
 					Name:      "john doe",
 					Email:     "john.doe@test.com",
 					Username:  "john_doe",
-					Password:  "fcf730b6d95236ecd3c9fc2d92d7b6b2bb061514961aec041d6c7a7192f592e4",
-				},
-				err: nil,
-			},
-		},
-		{
-			description: "succeeds when updating boolean values",
-			id:          "507f1f77bcf86cd799439011",
-			changes: &models.UserChanges{
-				Confirmed: &_false,
-			},
-			fixtures: []string{fixtureUsers},
-			expected: Expected{
-				changes: &models.UserChanges{
-					Confirmed: &_false,
-					LastLogin: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
-					Name:      "john doe",
-					Email:     "john.doe@test.com",
-					Username:  "john_doe",
+					Status:    models.UserStatusConfirmed,
 					Password:  "fcf730b6d95236ecd3c9fc2d92d7b6b2bb061514961aec041d6c7a7192f592e4",
 				},
 				err: nil,
@@ -605,10 +584,10 @@ func TestUserUpdate(t *testing.T) {
 			require.NoError(t, db.Collection("users").FindOne(ctx, bson.M{"_id": id}).Decode(user))
 
 			// Ensures that only the expected attributes have been updated.
-			require.Equal(t, *tc.expected.changes.Confirmed, user.Confirmed)
 			require.Equal(t, tc.expected.changes.LastLogin, user.LastLogin)
 			require.Equal(t, tc.expected.changes.Name, user.Name)
 			require.Equal(t, tc.expected.changes.Email, user.Email)
+			require.Equal(t, tc.expected.changes.Status, user.Status)
 			require.Equal(t, tc.expected.changes.Username, user.Username)
 			require.Equal(t, tc.expected.changes.Password, user.Password.Hash)
 		})

--- a/cli/services/users.go
+++ b/cli/services/users.go
@@ -53,7 +53,7 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 	user := &models.User{
 		UserData:      userData,
 		Password:      password,
-		Confirmed:     true,
+		Status:        models.UserStatusConfirmed,
 		CreatedAt:     clock.Now(),
 		MaxNamespaces: MaxNumberNamespacesCommunity,
 	}

--- a/cli/services/users_test.go
+++ b/cli/services/users_test.go
@@ -140,7 +140,7 @@ func TestUserCreate(t *testing.T) {
 						Plain: "secret",
 						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
 					},
-					Confirmed:     true,
+					Status:        models.UserStatusConfirmed,
 					CreatedAt:     clock.Now(),
 					MaxNamespaces: MaxNumberNamespacesCommunity,
 				}
@@ -173,7 +173,7 @@ func TestUserCreate(t *testing.T) {
 						Plain: "secret",
 						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
 					},
-					Confirmed:     true,
+					Status:        models.UserStatusConfirmed,
 					CreatedAt:     clock.Now(),
 					MaxNamespaces: MaxNumberNamespacesCommunity,
 				}
@@ -189,7 +189,7 @@ func TestUserCreate(t *testing.T) {
 					Plain: "secret",
 					Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
 				},
-				Confirmed:     true,
+				Status:        models.UserStatusConfirmed,
 				CreatedAt:     clock.Now(),
 				MaxNamespaces: MaxNumberNamespacesCommunity,
 			}, nil},

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -7,14 +7,30 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/validator"
 )
 
+type UserStatus string
+
+const (
+	// UserStatusNotConfirmed applies to cloud-only instances. This status is assigned to a user who has registered
+	// but has not yet confirmed their email address.
+	UserStatusNotConfirmed UserStatus = "not-confirmed"
+
+	// UserStatusConfirmed indicates that the user has completed the registration process and confirmed their email address.
+	// Users in community and enterprise instances will always be created with this status.
+	UserStatusConfirmed UserStatus = "confirmed"
+)
+
+func (s UserStatus) String() string {
+	return string(s)
+}
+
 type User struct {
-	ID             string    `json:"id,omitempty" bson:"_id,omitempty"`
-	Namespaces     int       `json:"namespaces" bson:"namespaces,omitempty"`
-	MaxNamespaces  int       `json:"max_namespaces" bson:"max_namespaces"`
-	Confirmed      bool      `json:"confirmed"`
-	CreatedAt      time.Time `json:"created_at" bson:"created_at"`
-	LastLogin      time.Time `json:"last_login" bson:"last_login"`
-	EmailMarketing bool      `json:"email_marketing" bson:"email_marketing"`
+	ID             string     `json:"id,omitempty" bson:"_id,omitempty"`
+	Status         UserStatus `json:"status" bson:"status"`
+	Namespaces     int        `json:"namespaces" bson:"namespaces,omitempty"`
+	MaxNamespaces  int        `json:"max_namespaces" bson:"max_namespaces"`
+	CreatedAt      time.Time  `json:"created_at" bson:"created_at"`
+	LastLogin      time.Time  `json:"last_login" bson:"last_login"`
+	EmailMarketing bool       `json:"email_marketing" bson:"email_marketing"`
 	UserData       `bson:",inline"`
 	// MFA contains attributes related to a user's MFA settings. Use [UserMFA.Enabled] to
 	// check if MFA is active for the user.
@@ -117,14 +133,14 @@ type UserTokenRecover struct {
 // UserChanges specifies the attributes that can be updated for a user. Any zero values in this
 // struct must be ignored. If an attribute is a pointer type, its zero value is represented as `nil`.
 type UserChanges struct {
-	LastLogin          time.Time `bson:"last_login,omitempty"`
-	Name               string    `bson:"name,omitempty"`
-	Username           string    `bson:"username,omitempty"`
-	Email              string    `bson:"email,omitempty"`
-	RecoveryEmail      string    `bson:"recovery_email,omitempty"`
-	Password           string    `bson:"password,omitempty"`
-	Confirmed          *bool     `bson:"confirmed,omitempty"`
-	PreferredNamespace *string   `bson:"preferences.preferred_namespace,omitempty"`
+	LastLogin          time.Time  `bson:"last_login,omitempty"`
+	Name               string     `bson:"name,omitempty"`
+	Username           string     `bson:"username,omitempty"`
+	Email              string     `bson:"email,omitempty"`
+	RecoveryEmail      string     `bson:"recovery_email,omitempty"`
+	Password           string     `bson:"password,omitempty"`
+	Status             UserStatus `bson:"status,omitempty"`
+	PreferredNamespace *string    `bson:"preferences.preferred_namespace,omitempty"`
 }
 
 // UserConflicts holds user attributes that must be unique for each itam and can be utilized in queries


### PR DESCRIPTION
The `user.confirmed` boolean attribute previously indicated whether a user’s email address was confirmed, limiting us to only two possible states. To provide greater flexibility and to represent more user statuses, this attribute has been replaced with a `user.status` field.

The new `user.status` field is a string (or a custom `UserStatus` type in Go). The constants `UserStatusConfirmed` and `UserStatusNotConfirmed` are introduced to represent the two states previously captured by the `confirmed` boolean.

Migration `75` has been added to update existing user records to align with the new schema.