### PR TITLE
fix(api): use `MinPerPage` when per_page is less than or equal to zero

### DIFF
--- a/pkg/api/query/paginator.go
+++ b/pkg/api/query/paginator.go
@@ -27,10 +27,15 @@ func NewPaginator() *Paginator {
 }
 
 // Normalize ensures valid values for Page and PerPage in the pagination query.
-// If query.PerPage is less than one, it is set to `DefaultPerPage`.
+// If query.PerPage is less than zero, it is set to `DefaultPerPage`.
 // If query.Page is less than one, it is set to `MinPage`.
 // The maximum allowed value for query.PerPage is `MaxPerPage`.
 func (p *Paginator) Normalize() {
-	p.PerPage = int(math.Max(math.Min(float64(p.PerPage), float64(MaxPerPage)), float64(DefaultPerPage)))
 	p.Page = int(math.Max(float64(MinPage), float64(p.Page)))
+
+	if p.PerPage == 0 {
+		p.PerPage = DefaultPerPage
+	} else {
+		p.PerPage = int(math.Max(math.Min(float64(p.PerPage), float64(MaxPerPage)), float64(MinPerPage)))
+	}
 }

--- a/pkg/api/query/paginator_test.go
+++ b/pkg/api/query/paginator_test.go
@@ -20,12 +20,17 @@ func TestPaginatorNormalize(t *testing.T) {
 		{
 			description: "set PerPage to DefaultPerParge when PerPage is lower than 1",
 			paginator:   &Paginator{Page: 1, PerPage: -2},
-			expected:    &Paginator{Page: 1, PerPage: 10},
+			expected:    &Paginator{Page: 1, PerPage: 1},
 		},
 		{
 			description: "set PerPage to MaxPerParge when PerPage is greater than 100",
 			paginator:   &Paginator{Page: 1, PerPage: 101},
 			expected:    &Paginator{Page: 1, PerPage: 100},
+		},
+		{
+			description: "set PerPage to DefaultPerPage when PerPage is 0",
+			paginator:   &Paginator{Page: 1, PerPage: 0},
+			expected:    &Paginator{Page: 1, PerPage: 10},
 		},
 		{
 			description: "successfully parse query",


### PR DESCRIPTION
fixes #4101