### PR TITLE
fix(ui): returned namespace add template and buttons

### DIFF
--- a/ui/src/components/Namespace/NamespaceAdd.vue
+++ b/ui/src/components/Namespace/NamespaceAdd.vue
@@ -1,16 +1,16 @@
 <template>
   <v-dialog v-model="model" @click:outside="close" :max-width="dialogMaxWidth">
     <v-card data-test="namespaceAdd-card" class="bg-v-theme-surface rounded" rounded>
-      <v-card-title class="bg-primary d-flex justify-space-between align-center text-h5 pa-4">
-        New Namespace
-        <v-btn
-          icon="mdi-close"
-          variant="text"
-          @click="close"
-        />
-      </v-card-title>
-      <v-container>
-        <template v-if="!openVersion">
+      <template v-if="!openVersion">
+        <v-card-title class="bg-primary d-flex justify-space-between align-center text-h5 pa-4">
+          New Namespace
+          <v-btn
+            icon="mdi-close"
+            variant="text"
+            @click="close"
+          />
+        </v-card-title>
+        <v-container>
           <v-card-text class="pb-0">
             <v-text-field
               v-model="namespaceName"
@@ -33,7 +33,6 @@
                 </ul>
               </v-col>
             </v-row>
-
           </v-card-text>
           <v-divider />
           <v-card-actions>
@@ -41,29 +40,29 @@
             <v-btn data-test="close-btn" @click="close">Close</v-btn>
             <v-btn color="primary" variant="outlined" data-test="add-btn" @click="addNamespace" :disabled="!fieldMeta.valid">Submit</v-btn>
           </v-card-actions>
-        </template>
-        <template v-else>
-          <v-card-title class="bg-primary">Add a namespace using the CLI</v-card-title>
-          <v-card-text class="mt-4 mb-0 pb-1 mb-4">
-            <p class="text-body-2">
-              In the Community Edition of ShellHub, namespaces must be added using the administration CLI.
-              For detailed instructions on how to add namespaces, please refer to the documentation at the ShellHub
-              Administration Guide.
+        </v-container>
+      </template>
+      <template v-else>
+        <v-card-title class="bg-primary">Add a namespace using the CLI</v-card-title>
+        <v-card-text class="mt-4 mb-0 pb-1 mb-4">
+          <p class="text-body-2">
+            In the Community Edition of ShellHub, namespaces must be added using the administration CLI.
+            For detailed instructions on how to add namespaces, please refer to the documentation at the ShellHub
+            Administration Guide.
+          </p>
+          <div id="cli-instructions" class="mt-3 text-body-2">
+            <p class="text-caption mb-0 mt-3" data-test="openContentSecond-text">
+              Check the
+              <a
+                :href="'https://docs.shellhub.io/self-hosted/administration'"
+                target="_blank"
+                rel="noopener noreferrer"
+              >ShellHub Administration Guide</a>
+              for more information.
             </p>
-            <div id="cli-instructions" class="mt-3 text-body-2">
-              <p class="text-caption mb-0 mt-3" data-test="openContentSecond-text">
-                Check the
-                <a
-                  :href="'https://docs.shellhub.io/self-hosted/administration'"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >ShellHub Administration Guide</a>
-                for more information.
-              </p>
-            </div>
-          </v-card-text>
-        </template>
-      </v-container>
+          </div>
+        </v-card-text>
+      </template>
     </v-card>
   </v-dialog>
 </template>

--- a/ui/src/components/Namespace/NamespaceInstructions.vue
+++ b/ui/src/components/Namespace/NamespaceInstructions.vue
@@ -2,7 +2,6 @@
   <v-dialog v-model="showNoNamespace" :retain-focus="false" persistent max-width="650px">
     <v-card
       v-model="showNoNamespace"
-
       class="bg-v-theme-surface"
     >
       <v-card-title class="bg-primary">
@@ -35,11 +34,17 @@
         </div>
       </v-card-text>
 
-      <v-card-actions>
+      <v-card-actions v-if="!openVersion">
         <v-spacer />
         <div>
+          <v-btn
+            color="primary"
+            @click="showNamespaceAdd = true"
+            data-test="save-btn">
+            Add Namespace
+          </v-btn>
           <NamespaceAdd
-            v-if="!openVersion"
+            v-model="showNamespaceAdd"
             enableSwitchIn
             data-test="namespaceAdd-component"
           />
@@ -50,7 +55,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { envVariables } from "../../envVariables";
 import NamespaceAdd from "./NamespaceAdd.vue";
 
@@ -62,6 +67,8 @@ const props = defineProps({
 });
 
 const emit = defineEmits(["update"]);
+
+const showNamespaceAdd = ref(false);
 
 const showNoNamespace = computed({
   get() {


### PR DESCRIPTION
This Pull Request fixes the Namespace Instructions buttons and template rules back to
new users that didn't have a namespace.
