### PR TITLE
fix(ui): remove null setFilter store method from quickconnection

### DIFF
--- a/ui/src/components/QuickConnection/QuickConnection.vue
+++ b/ui/src/components/QuickConnection/QuickConnection.vue
@@ -166,7 +166,7 @@ watch(dialog, async (value) => {
 });
 
 onUnmounted(async () => {
-  await store.dispatch("devices/setFilter", null);
+  await store.dispatch("devices/setFilter", "");
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
This pull request solves a filter=null bug from the device GET request by removing the null from the filter attribute in the setFilter store method presented in the QuickConnection Component.
