### PR TITLE
fix(api): set `CreatedAt` on namespace creation

### DIFF
--- a/api/store/mongo/namespace.go
+++ b/api/store/mongo/namespace.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/api/store/mongo/queries"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
@@ -182,6 +183,8 @@ func (s *Store) NamespaceGetPreferred(ctx context.Context, tenantID, userID stri
 }
 
 func (s *Store) NamespaceCreate(ctx context.Context, namespace *models.Namespace) (*models.Namespace, error) {
+	namespace.CreatedAt = clock.Now()
+
 	_, err := s.db.Collection("namespaces").InsertOne(ctx, namespace)
 	if err != nil {
 		return nil, err

--- a/api/store/mongo/namespace_test.go
+++ b/api/store/mongo/namespace_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/shellhub-io/shellhub/api/store/mongo"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/clock"
+	clockmocks "github.com/shellhub-io/shellhub/pkg/clock/mocks"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -432,6 +434,12 @@ func TestNamespaceGetPreferred(t *testing.T) {
 }
 
 func TestNamespaceCreate(t *testing.T) {
+	now := time.Now()
+
+	clockMock := new(clockmocks.Clock)
+	clockMock.On("Now").Return(now)
+	clock.DefaultBackend = clockMock
+
 	type Expected struct {
 		ns  *models.Namespace
 		err error
@@ -461,9 +469,10 @@ func TestNamespaceCreate(t *testing.T) {
 			fixtures: []string{},
 			expected: Expected{
 				ns: &models.Namespace{
-					Name:     "namespace-1",
-					Owner:    "507f1f77bcf86cd799439011",
-					TenantID: "00000000-0000-4000-0000-000000000000",
+					CreatedAt: now,
+					Name:      "namespace-1",
+					Owner:     "507f1f77bcf86cd799439011",
+					TenantID:  "00000000-0000-4000-0000-000000000000",
 					Members: []models.Member{
 						{
 							ID:   "507f1f77bcf86cd799439011",


### PR DESCRIPTION
Ensures that `CreatedAt` is correctly set when a new namespace is created.