### PR TITLE
fix(ui): typo on INamespaceInvite interface

### DIFF
--- a/ui/src/interfaces/INamespace.ts
+++ b/ui/src/interfaces/INamespace.ts
@@ -24,7 +24,7 @@ export interface INamespace {
 }
 
 export interface INamespaceInvite {
-  tenant_id: string;
+  tenant: string;
   sig: string;
 }
 


### PR DESCRIPTION
This commit changes an typo that was found on the INamespaceInvite interface,
which is a "tenant_id" instead of "tenant".
