### PR TITLE
fix(ui): retrieve tags when selecting the filter tags option for public keys

### DIFF
--- a/ui/src/components/PublicKeys/PublicKeyAdd.vue
+++ b/ui/src/components/PublicKeys/PublicKeyAdd.vue
@@ -251,6 +251,12 @@ watch(tagChoices, (list) => {
   }
 });
 
+watch(choiceFilter, async () => {
+  if (choiceFilter.value === "tags") {
+    await store.dispatch("tags/fetch");
+  }
+});
+
 watch(publicKeyData, async () => {
   if (publicKeyData.value !== "") {
     setPublicKeyDataError("Field is required");
@@ -306,6 +312,7 @@ const setLocalVariable = () => {
   choiceFilter.value = "all";
   choiceUsername.value = "all";
 };
+
 watch(dialog, (value) => {
   if (!value) {
     setLocalVariable();

--- a/ui/src/components/PublicKeys/PublicKeyEdit.vue
+++ b/ui/src/components/PublicKeys/PublicKeyEdit.vue
@@ -247,6 +247,12 @@ const hasTags = computed(() => {
   return Reflect.ownKeys(keyObject.filter)[0] === "tags";
 });
 
+watch(choiceFilter, async () => {
+  if (choiceFilter.value === "tags") {
+    await store.dispatch("tags/fetch");
+  }
+});
+
 const tagNames = computed({
   get() {
     return store.getters["tags/list"];


### PR DESCRIPTION
This Pull Request addresses a missing feature where the tags list was not fetched
when the user entered the public keys add or edit section and selected the
filter tags option. The tags are now correctly retrieved when this option
is chosen.
