### PR TITLE
fix(ui): retrieve tags when selecting the filter tags option for firewall

### DIFF
--- a/ui/src/components/firewall/FirewallRuleAdd.vue
+++ b/ui/src/components/firewall/FirewallRuleAdd.vue
@@ -195,6 +195,7 @@ export interface FirewallRuleType {
   filter?: filterType;
 }
 
+const store = useStore();
 const emit = defineEmits(["update"]);
 const dialog = ref(false);
 const action = ref("create");
@@ -313,8 +314,6 @@ const rules = ref({
   required: (value: string) => !!value || "Required.",
 });
 
-const store = useStore();
-
 const tagNames = computed(() => store.getters["tags/list"]);
 
 const hasAuthorization = computed(() => {
@@ -401,6 +400,12 @@ const close = () => {
   dialog.value = false;
   resetRuleFirewall();
 };
+
+watch(choiceFilter, async () => {
+  if (choiceFilter.value === "tags") {
+    await store.dispatch("tags/fetch");
+  }
+});
 
 const update = () => {
   emit("update");

--- a/ui/src/components/firewall/FirewallRuleEdit.vue
+++ b/ui/src/components/firewall/FirewallRuleEdit.vue
@@ -192,6 +192,7 @@ const props = defineProps({
   },
 });
 
+const store = useStore();
 const emit = defineEmits(["update"]);
 const showDialog = ref(false);
 const choiceUsername = ref("all");
@@ -297,9 +298,13 @@ const rules = ref({
 
 const errMsg = ref("");
 
-const store = useStore();
-
 const tagNames = computed(() => store.getters["tags/list"]);
+
+watch(choiceFilter, async () => {
+  if (choiceFilter.value === "tags") {
+    await store.dispatch("tags/fetch");
+  }
+});
 
 const selectRestriction = () => {
   if (choiceUsername.value === "all") {


### PR DESCRIPTION
Similar to the PR #4184

This Pull Request addresses a missing feature where the tags list was not fetched
when the user entered the firewall add or edit section and selected the
filter tags option. The tags are now correctly retrieved when this option
is chosen.
