### PR TITLE
fix: namespace creation not permitted for user

### DIFF
--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -287,6 +287,7 @@ func (s *service) AuthUser(ctx context.Context, req *requests.UserAuth, sourceIP
 		Tenant:        tenantID,
 		Role:          role,
 		Token:         token,
+		MaxNamespaces: user.MaxNamespaces,
 	}
 
 	return res, 0, "", nil
@@ -351,6 +352,7 @@ func (s *service) CreateUserToken(ctx context.Context, req *requests.CreateUserT
 		Tenant:        namespace.TenantID,
 		Role:          memberInfo.Role.String(),
 		Token:         token,
+		MaxNamespaces: user.MaxNamespaces,
 	}, nil
 }
 

--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -117,6 +117,7 @@ var (
 	ErrAuthInvalid                  = errors.New("auth invalid", ErrLayer, ErrCodeInvalid)
 	ErrAuthUnathorized              = errors.New("auth unauthorized", ErrLayer, ErrCodeUnauthorized)
 	ErrNamespaceLimitReached        = errors.New("namespace limit reached", ErrLayer, ErrCodeLimit)
+	ErrNamespaceCreationIsForbidden = errors.New("namespace creation not permitted for user", ErrLayer, ErrCodeForbidden)
 	ErrDeviceRemovedCount           = errors.New("device removed count", ErrLayer, ErrCodeNotFound)
 	ErrDeviceRemovedInsert          = errors.New("device removed insert", ErrLayer, ErrCodeStore)
 	ErrDeviceRemovedFull            = errors.New("device removed full", ErrLayer, ErrCodePayment)
@@ -430,6 +431,11 @@ func NewErrBadRequest(err error) error {
 // NewErrNamespaceLimitReached a error to be used when the user namespace limit number is reached.
 func NewErrNamespaceLimitReached(limit int, err error) error {
 	return NewErrLimit(ErrNamespaceLimitReached, limit, err)
+}
+
+// NewErrNamespaceCreationIsForbidden a error, since user have no permition to add a new namespace
+func NewErrNamespaceCreationIsForbidden(limit int, err error) error {
+	return NewErrLimit(ErrNamespaceCreationIsForbidden, limit, err)
 }
 
 func NewErrDeviceRemovedCount(next error) error {

--- a/api/services/namespace.go
+++ b/api/services/namespace.go
@@ -77,9 +77,11 @@ func (s *service) CreateNamespace(ctx context.Context, req *requests.NamespaceCr
 		return nil, NewErrUserNotFound(req.UserID, err)
 	}
 
-	// When MaxNamespaces is less than or equal to zero, it means that the user has no limit
-	// of namespaces.
-	if user.MaxNamespaces > 0 {
+	// When MaxNamespaces is less than zero, it means that the user has no limit
+	// of namespaces. If the value is zero, it means he has no right to create a new namespace
+	if user.MaxNamespaces == 0 {
+		return nil, NewErrNamespaceCreationIsForbidden(user.MaxNamespaces, nil)
+	} else if user.MaxNamespaces > 0 {
 		info, err := s.store.UserGetInfo(ctx, req.UserID)
 		switch {
 		case err != nil:

--- a/api/services/namespace_test.go
+++ b/api/services/namespace_test.go
@@ -403,6 +403,27 @@ func TestCreateNamespace(t *testing.T) {
 			},
 		},
 		{
+			description: "fails when user reachs the zero namespaces",
+			req: &requests.NamespaceCreate{
+				UserID:   "000000000000000000000000",
+				Name:     "namespace",
+				TenantID: "00000000-0000-4000-0000-000000000000",
+			},
+			requiredMocks: func() {
+				storeMock.
+					On("UserGetByID", ctx, "000000000000000000000000", false).
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 0,
+					}, 0, nil).
+					Once()
+			},
+			expected: Expected{
+				ns:  nil,
+				err: NewErrNamespaceCreationIsForbidden(0, nil),
+			},
+		},
+		{
 			description: "fails when user reachs the max namespaces",
 			req: &requests.NamespaceCreate{
 				UserID:   "000000000000000000000000",
@@ -412,7 +433,10 @@ func TestCreateNamespace(t *testing.T) {
 			requiredMocks: func() {
 				storeMock.
 					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(&models.User{ID: "000000000000000000000000", MaxNamespaces: 1}, 0, nil).
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 1,
+					}, 0, nil).
 					Once()
 				storeMock.
 					On("UserGetInfo", ctx, "000000000000000000000000").
@@ -439,8 +463,21 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
+					On("UserGetInfo", ctx, "000000000000000000000000").
+					Return(
+						&models.UserInfo{
+							OwnedNamespaces:      []models.Namespace{{}},
+							AssociatedNamespaces: []models.Namespace{},
+						},
+						nil,
+					).
+					Once()
+				storeMock.
 					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(&models.User{ID: "000000000000000000000000"}, 0, nil).
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 3,
+					}, 0, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -461,8 +498,21 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
+					On("UserGetInfo", ctx, "000000000000000000000000").
+					Return(
+						&models.UserInfo{
+							OwnedNamespaces:      []models.Namespace{{}},
+							AssociatedNamespaces: []models.Namespace{},
+						},
+						nil,
+					).
+					Once()
+				storeMock.
 					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(&models.User{ID: "000000000000000000000000"}, 0, nil).
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 3,
+					}, 0, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -483,8 +533,21 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
+					On("UserGetInfo", ctx, "000000000000000000000000").
+					Return(
+						&models.UserInfo{
+							OwnedNamespaces:      []models.Namespace{{}},
+							AssociatedNamespaces: []models.Namespace{},
+						},
+						nil,
+					).
+					Once()
+				storeMock.
 					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(&models.User{ID: "000000000000000000000000"}, 0, nil).
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 3,
+					}, 0, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -546,8 +609,21 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
+					On("UserGetInfo", ctx, "000000000000000000000000").
+					Return(
+						&models.UserInfo{
+							OwnedNamespaces:      []models.Namespace{{}},
+							AssociatedNamespaces: []models.Namespace{},
+						},
+						nil,
+					).
+					Once()
+				storeMock.
 					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(&models.User{ID: "000000000000000000000000"}, 0, nil).
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 3,
+					}, 0, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -646,8 +722,21 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
+					On("UserGetInfo", ctx, "000000000000000000000000").
+					Return(
+						&models.UserInfo{
+							OwnedNamespaces:      []models.Namespace{{}},
+							AssociatedNamespaces: []models.Namespace{},
+						},
+						nil,
+					).
+					Once()
+				storeMock.
 					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(&models.User{ID: "000000000000000000000000"}, 0, nil).
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 3,
+					}, 0, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -750,14 +839,27 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
+					On("UserGetInfo", ctx, "000000000000000000000000").
+					Return(
+						&models.UserInfo{
+							OwnedNamespaces:      []models.Namespace{{}},
+							AssociatedNamespaces: []models.Namespace{},
+						},
+						nil,
+					).
+					Once()
+				// envs.IsCommunity = false
+				storeMock.
 					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(&models.User{ID: "000000000000000000000000"}, 0, nil).
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 3,
+					}, 0, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
 					Return(nil, store.ErrNoDocuments).
 					Once()
-				// envs.IsCommunity = false
 				envMock.
 					On("Get", "SHELLHUB_CLOUD").
 					Return("true").

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -118,6 +118,7 @@ type UserAuthResponse struct {
 	RecoveryEmail string `json:"recovery_email"`
 	Role          string `json:"role"`
 	MFA           bool   `json:"mfa"`
+	MaxNamespaces int    `json:"max_namespaces"`
 }
 
 // NOTE: This struct has been moved to the cloud repo as it is only used in a cloud context;


### PR DESCRIPTION
create a new limit for user namespace creation, so that now, if MaxNamespaces is a negative value, the user will have no namespace creation limit, if it has a value of zero, the user will not be able to create a new namespace and if it is greater than zero, the behavior will be the same as before