### PR TITLE
fix(ui): resolve type error for v-dialog maxWidth property in TerminalDialog

### DIFF
--- a/ui/src/components/Terminal/TerminalDialog.vue
+++ b/ui/src/components/Terminal/TerminalDialog.vue
@@ -15,7 +15,7 @@
     <v-dialog
       v-model="showTerminal"
       :fullscreen="$vuetify.display.smAndDown"
-      :max-width="!$vuetify.display.smAndDown ? $vuetify.display.thresholds.sm : null"
+      :max-width="$vuetify.display.smAndDown ? undefined : $vuetify.display.thresholds.sm"
       @click:outside="close"
     >
       <v-card data-test="terminal-card" class="bg-v-theme-surface">


### PR DESCRIPTION
This Pull Request fixes a type error in the TerminalDialog component related to the
`maxWidth` property of the Vuetify `v-dialog`. The error occurred due to an
incorrect or missing type definition for the `maxWidth` prop, causing issues
during component rendering. This fix ensures proper type handling, resolving
the error and allowing the dialog to function as expected with defined maximum width.
