### PR TITLE
refactor(cli): centralize service check logic in `exit_if_not_running`

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -14,14 +14,6 @@ cd $(dirname $(readlink_f $0))/../
 
 DOCKER_COMPOSE=$(evaluate_docker_compose)
 
-# Disable "exit on error" for service check
-set +e
-
-SERVICES=$($DOCKER_COMPOSE ps -q | grep -v INFO: | xargs docker inspect -f '{{.State.Running}}' 2>/dev/null | grep -c 'true')
-
-# Re-enable "exit on error" after service check
-set -e
-
-[ ! "$SERVICES" -gt 0 ] && exit_with_error
+exit_if_not_running
 
 exec $DOCKER_COMPOSE exec cli ./cli $@

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,17 @@
 #!/bin/sh
 
+. "$(dirname "$0")/utils"
+
 echo "🌟 Welcome to the ShellHub Setup Script"
 echo ""
+
+exit_if_not_running
+
+if curl -s http://localhost/info | grep -q '"setup":true'; then
+  echo "✅ Setup has already been completed. No further action is required."
+  exit 0
+fi
+
 echo "📋 This script will generate a valid URL to set up your ShellHub instance."
 echo "❗ Important: The ShellHub instance cannot be on localhost. Please ensure you provide a valid public IP address or hostname."
 echo ""

--- a/bin/utils
+++ b/bin/utils
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 # Evaluate the appropriate Docker Compose command based on availability and V2 compatibility.
 #
 # If a compatible command is found, it is set to $COMPOSE_COMMAND. If no compatible command
@@ -45,6 +43,15 @@ readlink_f() {
      else
          readlink -f "$1"
      fi)
+}
+
+exit_if_not_running() {
+  local DOCKER_COMPOSE
+  DOCKER_COMPOSE=$(evaluate_docker_compose)
+
+  SERVICES=$($DOCKER_COMPOSE ps -q | grep -v INFO: | xargs docker inspect -f '{{.State.Running}}' 2>/dev/null | grep -c 'true')
+
+  [ "$SERVICES" -le 0 ] && { echo "🚫 ERROR: ShellHub is not running. Exiting."; exit 1; }
 }
 
 set -o allexport


### PR DESCRIPTION
- Refactored the service check logic by moving it to a reusable
  function, `exit_if_not_running`, in `utils`.
- Updated `cli` and `setup` scripts to use this centralized function,
  reducing redundancy and improving maintainability.
- Added `exit_if_not_running` invocation in `setup` to ensure ShellHub
  is running before proceeding.
