### PR TITLE
fix(agent): implement method to generate CMD command to FreeBSD

### DIFF
--- a/pkg/agent/server/modes/host/utils_freebsd.go
+++ b/pkg/agent/server/modes/host/utils_freebsd.go
@@ -6,11 +6,15 @@ import (
 	"os"
 	"os/exec"
 
+	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/pkg/agent/pkg/osauth"
 	"github.com/shellhub-io/shellhub/pkg/agent/server/modes/host/command"
 )
 
-func newShellCmd(deviceName string, username string, term string, envs []string) *exec.Cmd {
+func generateShellCmd(deviceName string, session gliderssh.Session, term string) *exec.Cmd {
+	username := session.User()
+	envs := session.Environ()
+
 	shell := os.Getenv("SHELL")
 
 	user, err := osauth.LookupUser(username)


### PR DESCRIPTION
After a small simplification on the method to generate SHELL and EXEC
commands on Agent, we have forgotten to update to the FreeBSD version of
the same file. To fix it, we have added a patch file on the ports, and
created this commit afterward.

Refs: https://github.com/shellhub-io/ports/pull/8