### PR TITLE
fix(ui): open version validation

### DIFF
--- a/ui/src/components/Namespace/NamespaceInstructions.vue
+++ b/ui/src/components/Namespace/NamespaceInstructions.vue
@@ -81,5 +81,5 @@ const showNoNamespace = computed({
   },
 });
 
-const openVersion = computed(() => !envVariables.isCloud || !envVariables.isEnterprise);
+const openVersion = computed(() => !envVariables.isCloud && !envVariables.isEnterprise);
 </script>


### PR DESCRIPTION
This pull request fixes an issue where the validation for open versions
is being true to cloud or enterprise, since which being true is not
open, the new rule changes the logic to an AND.
