### PR TITLE
feat(ssh): simplify session, improve record, and record any PTY

### DIFF
--- a/ssh/server/server.go
+++ b/ssh/server/server.go
@@ -42,6 +42,7 @@ func NewServer(opts *Options, tunnel *httptunnel.Tunnel, cache cache.Cache) *Ser
 		Addr: ":2222",
 		ConnCallback: func(ctx gliderssh.Context, conn net.Conn) net.Conn {
 			ctx.SetValue("conn", conn)
+			ctx.SetValue("RECORD_URL", opts.RecordURL)
 
 			return conn
 		},
@@ -88,11 +89,7 @@ func NewServer(opts *Options, tunnel *httptunnel.Tunnel, cache cache.Cache) *Ser
 		// and the server. SSH channels serve as the infrastructure for executing commands, establishing shell sessions,
 		// and securely forwarding network services.
 		ChannelHandlers: map[string]gliderssh.ChannelHandler{
-			channels.SessionChannel: channels.DefaultSessionHandler(
-				channels.DefaultSessionHandlerOptions{
-					RecordURL: opts.RecordURL,
-				},
-			),
+			channels.SessionChannel:     channels.DefaultSessionHandler(),
 			channels.DirectTCPIPChannel: channels.DefaultDirectTCPIPHandler,
 		},
 		LocalPortForwardingCallback: func(ctx gliderssh.Context, dhost string, dport uint32) bool {


### PR DESCRIPTION
In previous refactoring, we have removed a bunch of operations from the server, letting both the parties communicate more freely. However, the session record kept doing the same blocking operations.

The SSH server acts as an intermediary between the Agent and Client, so reducing communication overhead can significantly improve session performance and overall user experience.

In a previous refactor, we reduced several blocking operations on the server, allowing for more efficient communication between the Agent and Client. However, the session record still relied on blocking operations, which limited performance.

The core idea of this improvement was removing more operations over the communication between Agent and Client communication, and turning session record frame asynchronous using channels.