### PR TITLE
feat: migration for add field type on namespace

### DIFF
--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -91,6 +91,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration79,
 		migration80,
 		migration81,
+		migration82,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_82.go
+++ b/api/store/mongo/migrations/migration_82.go
@@ -1,0 +1,68 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
+)
+
+var migration82 = migrate.Migration{
+	Version:     82,
+	Description: "Adding the 'namespaces.type' attribute to the namespaces if it does not already exist.",
+	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		logrus.WithFields(logrus.Fields{
+			"component": "migration",
+			"version":   82,
+			"action":    "Up",
+		}).Info("Applying migration")
+
+		filter := bson.M{
+			"type": bson.M{"$in": []interface{}{nil, ""}},
+		}
+
+		update := bson.M{
+			"$set": bson.M{
+				"type": models.TypeTeam,
+			},
+		}
+
+		_, err := db.
+			Collection("namespaces",
+				options.Collection().SetWriteConcern(writeconcern.Majority()),
+			).
+			UpdateMany(ctx, filter, update)
+
+		return err
+	}),
+	Down: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		logrus.WithFields(logrus.Fields{
+			"component": "migration",
+			"version":   82,
+			"action":    "Down",
+		}).Info("Reverting migration")
+
+		filter := bson.M{
+			"type": bson.M{"$in": []interface{}{nil, ""}},
+		}
+
+		update := bson.M{
+			"$unset": bson.M{
+				"type": models.TypeTeam,
+			},
+		}
+
+		_, err := db.
+			Collection("namespaces",
+				options.Collection().SetWriteConcern(writeconcern.Majority()),
+			).
+			UpdateMany(ctx, filter, update)
+
+		return err
+	}),
+}

--- a/api/store/mongo/migrations/migration_82_test.go
+++ b/api/store/mongo/migrations/migration_82_test.go
@@ -1,0 +1,78 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	envMocks "github.com/shellhub-io/shellhub/pkg/envs/mocks"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMigration82(t *testing.T) {
+	ctx := context.Background()
+
+	mock := &envMocks.Backend{}
+	envs.DefaultBackend = mock
+
+	cases := []struct {
+		description string
+		setup       func() error
+		test        func() error
+	}{
+		{
+			description: "Success to apply up on migration 82",
+			setup: func() error {
+				_, err := c.
+					Database("test").
+					Collection("namespaces").
+					InsertOne(ctx, models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Settings: &models.NamespaceSettings{},
+					})
+
+				return err
+			},
+			test: func() error {
+				migrations := GenerateMigrations()[81:82]
+				migrates := migrate.NewMigrate(c.Database("test"), migrations...)
+				err := migrates.Up(context.Background(), migrate.AllAvailable)
+				if err != nil {
+					return err
+				}
+
+				query := c.
+					Database("test").
+					Collection("namespaces").
+					FindOne(context.TODO(), bson.M{"tenant_id": "00000000-0000-4000-0000-000000000000"})
+
+				ns := new(models.Namespace)
+				if err := query.Decode(ns); err != nil {
+					return errors.New("unable to find the namespace")
+				}
+
+				if ns.Type != models.TypeTeam {
+					return errors.New("unable to apply the migration")
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, test := range cases {
+		tc := test
+		t.Run(tc.description, func(t *testing.T) {
+			t.Cleanup(func() {
+				assert.NoError(t, srv.Reset())
+			})
+
+			assert.NoError(t, tc.setup())
+			assert.NoError(t, tc.test())
+		})
+	}
+}


### PR DESCRIPTION
Implement new field on migration, for namespace

- following ideas from https://github.com/shellhub-io/issues/issues/30 and https://github.com/shellhub-io/cloud/issues/2025
- Add `type` as new field for namespace model since https://github.com/shellhub-io/shellhub/pull/4237
