### PR TITLE
fix(ui): improve container height and theme compatibility

### DIFF
--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -88,7 +88,7 @@
     <v-main data-test="main">
       <slot>
         <v-container
-          class="pa-8 full-width-height"
+          class="pa-8"
           fluid
           data-test="container"
         >
@@ -219,7 +219,8 @@ defineExpose({
 }
 
 .v-container {
-  background-image: linear-gradient(155deg, rgb(102,122,204,0.1) 0%, transparent 30%), url(/bg.svg);
+  min-height: calc(100vh - 64px);
+  background-image: linear-gradient(155deg, rgb(var(--v-theme-primary),0.10) 0%, transparent 30%), url(/bg.svg);
   background-position: 0% 0;
   background-repeat: no-repeat;
   background-size: auto;

--- a/ui/tests/layouts/__snapshots__/AppLayout.spec.ts.snap
+++ b/ui/tests/layouts/__snapshots__/AppLayout.spec.ts.snap
@@ -188,7 +188,7 @@ exports[`App Layout Component > Renders the component 1`] = `
   </transition-stub>
   </header>
   <main data-v-e7291ef4=\\"\\" class=\\"v-main\\" style=\\"--v-layout-left: 0px; --v-layout-right: 0px; --v-layout-top: 64px; --v-layout-bottom: 0px; transition: none;\\" data-test=\\"main\\">
-    <div data-v-e7291ef4=\\"\\" class=\\"v-container v-container--fluid v-locale--is-ltr pa-8 full-width-height\\" data-test=\\"container\\">
+    <div data-v-e7291ef4=\\"\\" class=\\"v-container v-container--fluid v-locale--is-ltr pa-8\\" data-test=\\"container\\">
       <!---->
     </div>
   </main>


### PR DESCRIPTION
- Set `min-height` for `.v-container` to maintain viewport height
  with header offset
- Updated `background-image` color to use CSS variable for theme
  compatibility with dynamic primary color
