### PR TITLE
refactor(ui): update container view

### DIFF
--- a/ui/src/components/Containers/Container.vue
+++ b/ui/src/components/Containers/Container.vue
@@ -1,14 +1,38 @@
 <template>
-  <v-card class="bg-v-theme-surface">
-    <v-tabs background-color="secondary" stacked color="primary">
-      <v-tab to="/containers"> Container List </v-tab>
-      <v-tab to="/containers/pending"> Pending </v-tab>
-      <v-tab to="/containers/rejected"> Rejected </v-tab>
-    </v-tabs>
-    <v-divider />
-  </v-card>
+  <v-btn-group
+    divided
+    class="mb-4 border"
+  >
+    <v-btn
+      v-for="state in states"
+      :to="state.to"
+      variant="flat"
+      :active="isActive(state.to)"
+      active-color="secondary"
+      class="bg-background"
+      v-bind:key="state.to"
+    >
+      {{ state.title }}
+    </v-btn>
+  </v-btn-group>
 
-  <v-card>
+  <div>
     <router-view />
-  </v-card>
+  </div>
 </template>
+
+<script setup lang="ts">
+import { useRoute } from "vue-router";
+
+const states = [
+  { to: "/containers", title: "Accepted" },
+  { to: "/containers/pending", title: "Pending" },
+  { to: "/containers/rejected", title: "Rejected" },
+];
+
+const isActive = (to: string) => {
+  const route = useRoute();
+  return route.path === to;
+};
+
+</script>

--- a/ui/src/views/Containers.vue
+++ b/ui/src/views/Containers.vue
@@ -8,25 +8,25 @@
       <v-text-field
         v-if="show"
         label="Search by hostname"
-        variant="underlined"
+        variant="outlined"
         color="primary"
         single-line
         hide-details
         v-model.trim="filter"
         v-on:keyup="searchDevices"
-        append-inner-icon="mdi-magnify"
-        density="comfortable"
+        prepend-inner-icon="mdi-magnify"
+        density="compact"
         data-test="search-text"
       />
     </v-col>
 
-    <div class="d-flex mt-4" data-test="device-header-component-group">
+    <div class="d-flex" data-test="device-header-component-group">
       <TagSelector variant="container" v-if="isContainerList" />
     </div>
   </div>
-  <v-card :loading="loading" class="mt-2" v-if="show" data-test="device-table-component">
+  <div class="mt-2" v-if="show" data-test="device-table-component">
     <Containers />
-  </v-card>
+  </div>
 
   <BoxMessage
     v-if="!show"

--- a/ui/tests/components/Containers/Container.spec.ts
+++ b/ui/tests/components/Containers/Container.spec.ts
@@ -2,7 +2,7 @@ import { mount, VueWrapper } from "@vue/test-utils";
 import { createVuetify } from "vuetify";
 import MockAdapter from "axios-mock-adapter";
 import { expect, describe, it, beforeEach, vi } from "vitest";
-import { VTab } from "vuetify/lib/components/index.mjs";
+import { VBtn } from "vuetify/lib/components/index.mjs";
 import { store, key } from "@/store";
 import Containers from "@/components/Containers/Container.vue";
 import { router } from "@/router";
@@ -170,9 +170,9 @@ describe("Device", () => {
   });
 
   it("Contains the correct tabs", () => {
-    const tabs = wrapper.findAllComponents(VTab);
+    const tabs = wrapper.findAllComponents(VBtn);
     expect(tabs).toHaveLength(3); // Three tabs expected
-    expect(tabs[0].text()).toBe("Container List");
+    expect(tabs[0].text()).toBe("Accepted");
     expect(tabs[1].text()).toBe("Pending");
     expect(tabs[2].text()).toBe("Rejected");
   });

--- a/ui/tests/components/Containers/__snapshots__/Container.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/Container.spec.ts.snap
@@ -1,135 +1,39 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Device > Renders correctly 1`] = `
-"<div class=\\"v-card v-theme--light v-card--density-default v-card--variant-elevated bg-v-theme-surface\\">
-  <!---->
-  <div class=\\"v-card__loader\\">
-    <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
-      <!---->
-      <div class=\\"v-progress-linear__background\\"></div>
-      <div class=\\"v-progress-linear__buffer\\" style=\\"width: 0%;\\"></div>
-      <transition-stub name=\\"fade-transition\\" appear=\\"false\\" persisted=\\"false\\" css=\\"true\\">
-        <div class=\\"v-progress-linear__indeterminate\\">
-          <div class=\\"v-progress-linear__indeterminate long\\"></div>
-          <div class=\\"v-progress-linear__indeterminate short\\"></div>
-        </div>
-      </transition-stub>
-      <!---->
-    </div>
-  </div>
-  <!---->
-  <!---->
-  <div class=\\"v-slide-group v-slide-group--mobile v-tabs v-tabs--horizontal v-tabs--align-tabs-start v-tabs--stacked v-tabs--density-default\\" tabindex=\\"-1\\" role=\\"tablist\\" background-color=\\"secondary\\">
+"<div class=\\"v-btn-group v-btn-group--divided v-theme--light v-btn-group--density-default mb-4 border\\"><a class=\\"v-btn v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-flat bg-background\\" style=\\"height: auto;\\" href=\\"/containers\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\">Accepted</span>
     <!---->
-    <div class=\\"v-slide-group__container\\">
-      <div class=\\"v-slide-group__content\\"><a class=\\"v-btn v-tab-item--selected v-tab--selected v-btn--stacked v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text v-tab\\" tabindex=\\"0\\" href=\\"/containers\\" role=\\"tab\\" aria-selected=\\"true\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
-          <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"> Container List <div class=\\"v-tab__slider\\"></div></span>
-          <!---->
-          <!---->
-        </a><a class=\\"v-btn v-btn--stacked v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text v-tab\\" tabindex=\\"-1\\" href=\\"/containers/pending\\" role=\\"tab\\" aria-selected=\\"false\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
-          <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"> Pending <div class=\\"v-tab__slider\\"></div></span>
-          <!---->
-          <!---->
-        </a><a class=\\"v-btn v-btn--stacked v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text v-tab\\" tabindex=\\"-1\\" href=\\"/containers/rejected\\" role=\\"tab\\" aria-selected=\\"false\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
-          <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"> Rejected <div class=\\"v-tab__slider\\"></div></span>
-          <!---->
-          <!---->
-        </a></div>
-    </div>
     <!---->
-  </div>
+  </a><a class=\\"v-btn v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-flat bg-background\\" style=\\"height: auto;\\" href=\\"/containers/pending\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\">Pending</span>
+    <!---->
+    <!---->
+  </a><a class=\\"v-btn v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-flat bg-background\\" style=\\"height: auto;\\" href=\\"/containers/rejected\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\">Rejected</span>
+    <!---->
+    <!---->
+  </a></div>
+<div>
   <!---->
-  <hr class=\\"v-divider v-theme--light\\" aria-orientation=\\"horizontal\\" role=\\"separator\\">
-  <!---->
-  <!----><span class=\\"v-card__underlay\\"></span>
-</div>
-<div class=\\"v-card v-theme--light v-card--density-default v-card--variant-elevated\\">
-  <!---->
-  <div class=\\"v-card__loader\\">
-    <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
-      <!---->
-      <div class=\\"v-progress-linear__background\\"></div>
-      <div class=\\"v-progress-linear__buffer\\" style=\\"width: 0%;\\"></div>
-      <transition-stub name=\\"fade-transition\\" appear=\\"false\\" persisted=\\"false\\" css=\\"true\\">
-        <div class=\\"v-progress-linear__indeterminate\\">
-          <div class=\\"v-progress-linear__indeterminate long\\"></div>
-          <div class=\\"v-progress-linear__indeterminate short\\"></div>
-        </div>
-      </transition-stub>
-      <!---->
-    </div>
-  </div>
-  <!---->
-  <!---->
-  <!---->
-  <!---->
-  <!----><span class=\\"v-card__underlay\\"></span>
 </div>"
 `;
 
 exports[`Device > Renders the component 1`] = `
-"<div class=\\"v-card v-theme--light v-card--density-default v-card--variant-elevated bg-v-theme-surface\\">
-  <!---->
-  <div class=\\"v-card__loader\\">
-    <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
-      <!---->
-      <div class=\\"v-progress-linear__background\\"></div>
-      <div class=\\"v-progress-linear__buffer\\" style=\\"width: 0%;\\"></div>
-      <transition-stub name=\\"fade-transition\\" appear=\\"false\\" persisted=\\"false\\" css=\\"true\\">
-        <div class=\\"v-progress-linear__indeterminate\\">
-          <div class=\\"v-progress-linear__indeterminate long\\"></div>
-          <div class=\\"v-progress-linear__indeterminate short\\"></div>
-        </div>
-      </transition-stub>
-      <!---->
-    </div>
-  </div>
-  <!---->
-  <!---->
-  <div class=\\"v-slide-group v-slide-group--mobile v-tabs v-tabs--horizontal v-tabs--align-tabs-start v-tabs--stacked v-tabs--density-default\\" tabindex=\\"-1\\" role=\\"tablist\\" background-color=\\"secondary\\">
+"<div class=\\"v-btn-group v-btn-group--divided v-theme--light v-btn-group--density-default mb-4 border\\"><a class=\\"v-btn v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-flat bg-background\\" style=\\"height: auto;\\" href=\\"/containers\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\">Accepted</span>
     <!---->
-    <div class=\\"v-slide-group__container\\">
-      <div class=\\"v-slide-group__content\\"><a class=\\"v-btn v-tab-item--selected v-tab--selected v-btn--stacked v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text v-tab\\" tabindex=\\"0\\" href=\\"/containers\\" role=\\"tab\\" aria-selected=\\"true\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
-          <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"> Container List <div class=\\"v-tab__slider\\"></div></span>
-          <!---->
-          <!---->
-        </a><a class=\\"v-btn v-btn--stacked v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text v-tab\\" tabindex=\\"-1\\" href=\\"/containers/pending\\" role=\\"tab\\" aria-selected=\\"false\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
-          <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"> Pending <div class=\\"v-tab__slider\\"></div></span>
-          <!---->
-          <!---->
-        </a><a class=\\"v-btn v-btn--stacked v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text v-tab\\" tabindex=\\"-1\\" href=\\"/containers/rejected\\" role=\\"tab\\" aria-selected=\\"false\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
-          <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"> Rejected <div class=\\"v-tab__slider\\"></div></span>
-          <!---->
-          <!---->
-        </a></div>
-    </div>
     <!---->
-  </div>
+  </a><a class=\\"v-btn v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-flat bg-background\\" style=\\"height: auto;\\" href=\\"/containers/pending\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\">Pending</span>
+    <!---->
+    <!---->
+  </a><a class=\\"v-btn v-btn--flat v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-flat bg-background\\" style=\\"height: auto;\\" href=\\"/containers/rejected\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\">Rejected</span>
+    <!---->
+    <!---->
+  </a></div>
+<div>
   <!---->
-  <hr class=\\"v-divider v-theme--light\\" aria-orientation=\\"horizontal\\" role=\\"separator\\">
-  <!---->
-  <!----><span class=\\"v-card__underlay\\"></span>
-</div>
-<div class=\\"v-card v-theme--light v-card--density-default v-card--variant-elevated\\">
-  <!---->
-  <div class=\\"v-card__loader\\">
-    <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
-      <!---->
-      <div class=\\"v-progress-linear__background\\"></div>
-      <div class=\\"v-progress-linear__buffer\\" style=\\"width: 0%;\\"></div>
-      <transition-stub name=\\"fade-transition\\" appear=\\"false\\" persisted=\\"false\\" css=\\"true\\">
-        <div class=\\"v-progress-linear__indeterminate\\">
-          <div class=\\"v-progress-linear__indeterminate long\\"></div>
-          <div class=\\"v-progress-linear__indeterminate short\\"></div>
-        </div>
-      </transition-stub>
-      <!---->
-    </div>
-  </div>
-  <!---->
-  <!---->
-  <!---->
-  <!---->
-  <!----><span class=\\"v-card__underlay\\"></span>
 </div>"
 `;


### PR DESCRIPTION
- Replaced `v-tabs` with `v-btn-group` for container navigation
  with active state highlighting
- Modified search field to use "outlined" variant with `prepend-inner-icon`
  for better alignment and spacing
- Removed redundant `v-card` wrappers for layout simplification
