### PR TITLE
feat(ui): update action triggers in lists to use v-btn for consistency

### DIFF
--- a/ui/src/components/Connector/ConnectorList.vue
+++ b/ui/src/components/Connector/ConnectorList.vue
@@ -63,9 +63,15 @@
         <td class="text-center" data-test="menu-key-component">
           <v-menu location="bottom" scrim eager>
             <template v-slot:activator="{ props }">
-              <v-chip v-bind="props" density="comfortable" size="small">
-                <v-icon>mdi-dots-horizontal</v-icon>
-              </v-chip>
+              <v-btn
+                v-bind="props"
+                variant="plain"
+                class="border rounded bg-v-theme-background"
+                density="comfortable"
+                size="default"
+                icon="mdi-format-list-bulleted"
+                data-test="connector-list-actions"
+              />
             </template>
             <v-list class="bg-v-theme-surface" lines="two" density="compact">
               <v-list-item @click="redirectToDetails(item.uid)">
@@ -252,7 +258,7 @@ watch(itemsPerPage, async (newItemsPerPage) => {
 });
 
 const redirectToDetails = (uid: string) => {
-  router.push({ name: "detailsConnectors", params: { id: uid } });
+  router.push({ name: "ConnectorDetails", params: { id: uid } });
 };
 
 const copyText = (value: string | undefined) => {

--- a/ui/src/components/Namespace/NamespaceApiKeyList.vue
+++ b/ui/src/components/Namespace/NamespaceApiKeyList.vue
@@ -31,9 +31,14 @@
           <td class="text-center" data-test="menu-key-component">
             <v-menu location="bottom" scrim eager>
               <template v-slot:activator="{ props }">
-                <v-chip v-bind="props" density="comfortable" size="small">
-                  <v-icon>mdi-dots-horizontal</v-icon>
-                </v-chip>
+                <v-btn
+                  v-bind="props"
+                  variant="plain"
+                  class="border rounded bg-v-theme-background"
+                  density="comfortable"
+                  size="default"
+                  icon="mdi-format-list-bulleted"
+                />
               </template>
               <v-list class="bg-v-theme-surface" lines="two" density="compact">
                 <v-tooltip

--- a/ui/src/components/Namespace/NamespaceMemberList.vue
+++ b/ui/src/components/Namespace/NamespaceMemberList.vue
@@ -54,9 +54,15 @@
               v-if="!isNamespaceOwner(member.role)"
             >
               <template v-slot:activator="{ props }">
-                <v-chip v-bind="props" density="comfortable" size="small">
-                  <v-icon>mdi-dots-horizontal</v-icon>
-                </v-chip>
+                <v-btn
+                  v-bind="props"
+                  variant="plain"
+                  class="border rounded bg-v-theme-background"
+                  density="comfortable"
+                  size="default"
+                  icon="mdi-format-list-bulleted"
+                  data-test="namespace-member-actions"
+                />
               </template>
               <v-list class="bg-v-theme-surface" lines="two" density="compact">
                 <v-tooltip

--- a/ui/src/components/PrivateKeys/PrivateKeyList.vue
+++ b/ui/src/components/PrivateKeys/PrivateKeyList.vue
@@ -26,17 +26,15 @@
             eager
           >
             <template v-slot:activator="{ props }">
-              <v-chip
+              <v-btn
                 v-bind="props"
-                class="bg-v-theme-surface"
-                data-test="privateKey-chip"
+                variant="plain"
+                class="border rounded bg-v-theme-background"
                 density="comfortable"
-                size="small"
-              >
-                <v-icon data-test="privateKey-menu-icon"
-                >mdi-dots-horizontal</v-icon
-                >
-              </v-chip>
+                size="default"
+                icon="mdi-format-list-bulleted"
+                data-test="privateKey-actions"
+              />
             </template>
             <v-list class="bg-v-theme-surface" lines="two" density="compact">
               <PrivateKeyEdit

--- a/ui/src/components/PublicKeys/PublicKeysList.vue
+++ b/ui/src/components/PublicKeys/PublicKeysList.vue
@@ -66,9 +66,15 @@
           <td class="text-center" data-test="public-key-actions">
             <v-menu location="bottom" scrim eager>
               <template v-slot:activator="{ props }">
-                <v-chip v-bind="props" density="comfortable" size="small">
-                  <v-icon>mdi-dots-horizontal</v-icon>
-                </v-chip>
+                <v-btn
+                  v-bind="props"
+                  variant="plain"
+                  class="border rounded bg-v-theme-background"
+                  density="comfortable"
+                  size="default"
+                  icon="mdi-format-list-bulleted"
+                  data-test="public-key-actions"
+                />
               </template>
               <v-list class="bg-v-theme-surface" lines="two" density="compact">
                 <v-tooltip

--- a/ui/src/components/Sessions/SessionList.vue
+++ b/ui/src/components/Sessions/SessionList.vue
@@ -90,9 +90,15 @@
           <td class="text-center">
             <v-menu location="bottom" scrim eager>
               <template v-slot:activator="{ props }">
-                <v-chip v-bind="props" density="comfortable" size="small">
-                  <v-icon>mdi-dots-horizontal</v-icon>
-                </v-chip>
+                <v-btn
+                  v-bind="props"
+                  variant="plain"
+                  class="border rounded bg-v-theme-background"
+                  density="comfortable"
+                  size="default"
+                  icon="mdi-format-list-bulleted"
+                  data-test="session-list-actions"
+                />
               </template>
               <v-list class="bg-v-theme-surface" lines="two" density="compact">
                 <v-list-item @click="redirectToSession(session.uid)">

--- a/ui/src/components/Tables/DeviceTable.vue
+++ b/ui/src/components/Tables/DeviceTable.vue
@@ -200,13 +200,15 @@
             eager
           >
             <template v-slot:activator="{ props }">
-              <v-chip
+              <v-btn
+                v-bind="props"
+                variant="plain"
+                class="border rounded bg-v-theme-background"
                 density="comfortable"
-                size="small"
-                data-test="sshid-chip"
-              >
-                <v-icon v-bind="props">mdi-dots-horizontal</v-icon>
-              </v-chip>
+                size="default"
+                icon="mdi-format-list-bulleted"
+                data-test="device-table-actions"
+              />
             </template>
             <v-list
               class="bg-v-theme-surface"

--- a/ui/src/components/Tags/TagList.vue
+++ b/ui/src/components/Tags/TagList.vue
@@ -17,9 +17,15 @@
         <td class="text-center">
           <v-menu location="bottom" scrim eager>
             <template v-slot:activator="{ props }">
-              <v-chip v-bind="props" density="comfortable" size="small">
-                <v-icon>mdi-dots-horizontal</v-icon>
-              </v-chip>
+              <v-btn
+                v-bind="props"
+                variant="plain"
+                class="border rounded bg-v-theme-background"
+                density="comfortable"
+                size="default"
+                icon="mdi-format-list-bulleted"
+                data-test="tag-list-actions"
+              />
             </template>
             <v-list class="bg-v-theme-surface" lines="two" density="compact">
               <v-tooltip location="bottom" class="text-center" :disabled="hasAuthorizationEdit()">

--- a/ui/src/components/firewall/FirewallRuleList.vue
+++ b/ui/src/components/firewall/FirewallRuleList.vue
@@ -75,9 +75,15 @@
           <td class="text-center">
             <v-menu location="bottom" scrim eager>
               <template v-slot:activator="{ props }">
-                <v-chip v-bind="props" density="comfortable" size="small" data-test="firewall-rules-action-menu">
-                  <v-icon>mdi-dots-horizontal</v-icon>
-                </v-chip>
+                <v-btn
+                  v-bind="props"
+                  variant="plain"
+                  class="border rounded bg-v-theme-background"
+                  density="comfortable"
+                  size="default"
+                  icon="mdi-format-list-bulleted"
+                  data-test="firewall-rules-actions"
+                />
               </template>
               <v-list class="bg-v-theme-surface" lines="two" density="compact">
                 <v-tooltip

--- a/ui/src/views/ConnectorDetails.vue
+++ b/ui/src/views/ConnectorDetails.vue
@@ -41,9 +41,14 @@
       </div>
       <v-menu location="bottom" scrim eager>
         <template v-slot:activator="{ props }">
-          <v-chip v-bind="props" density="comfortable" size="small">
-            <v-icon>mdi-dots-horizontal</v-icon>
-          </v-chip>
+          <v-btn
+            v-bind="props"
+            variant="plain"
+            class="border rounded bg-v-theme-background"
+            density="comfortable"
+            size="default"
+            icon="mdi-format-list-bulleted"
+          />
         </template>
         <v-list class="bg-v-theme-surface" lines="two" density="compact">
           <v-tooltip

--- a/ui/src/views/Connectors.vue
+++ b/ui/src/views/Connectors.vue
@@ -20,9 +20,9 @@
       <ConnectorAdd @update="getConnectors()" />
     </div>
   </div>
-  <v-card class="mt-2" data-test="device-table-component">
+  <div class="mt-2" data-test="connector-table-component">
     <ConnectorList />
-  </v-card>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/ui/src/views/DetailsDevice.vue
+++ b/ui/src/views/DetailsDevice.vue
@@ -18,9 +18,14 @@
       <div>
         <v-menu location="bottom" scrim eager>
           <template v-slot:activator="{ props }">
-            <v-chip density="comfortable" size="small">
-              <v-icon v-bind="props">mdi-dots-horizontal</v-icon>
-            </v-chip>
+            <v-btn
+              v-bind="props"
+              variant="plain"
+              class="border rounded bg-v-theme-background"
+              density="comfortable"
+              size="default"
+              icon="mdi-format-list-bulleted"
+            />
           </template>
           <v-list class="bg-v-theme-surface" lines="two" density="compact">
             <DeviceRename

--- a/ui/src/views/DetailsSessions.vue
+++ b/ui/src/views/DetailsSessions.vue
@@ -20,9 +20,14 @@
       <div>
         <v-menu location="bottom" scrim eager>
           <template v-slot:activator="{ props }">
-            <v-chip v-bind="props" density="comfortable" size="small" data-test="sessionMenu-chip">
-              <v-icon>mdi-dots-horizontal</v-icon>
-            </v-chip>
+            <v-btn
+              v-bind="props"
+              variant="plain"
+              class="border rounded bg-v-theme-background"
+              density="comfortable"
+              size="default"
+              icon="mdi-format-list-bulleted"
+            />
           </template>
           <v-list class="bg-v-theme-surface" lines="two" density="compact">
             <v-tooltip

--- a/ui/tests/components/Connectors/ConnectorList.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorList.spec.ts
@@ -213,6 +213,7 @@ describe("Device List", () => {
     expect(wrapper.findComponent('[data-test="ip-chip"]').exists()).toBe(true);
     expect(wrapper.findComponent('[data-test="secure-icon"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="menu-key-component"]').exists()).toBe(true);
+    expect(wrapper.findComponent('[data-test="connector-list-actions"]').exists()).toBe(true);
     expect(wrapper.findComponent('[data-test="mdi-information-list-item"]').exists()).toBe(true);
     expect(wrapper.findComponent('[data-test="no-connector-validate"]').exists()).toBe(false);
   });

--- a/ui/tests/components/Connectors/__snapshots__/ConnectorList.spec.ts.snap
+++ b/ui/tests/components/Connectors/__snapshots__/ConnectorList.spec.ts.snap
@@ -60,12 +60,11 @@ exports[`Device List > Renders the component 1`] = `
               <!----></span>
             </td>
             <td data-v-6fdd6bd6=\\"\\" class=\\"text-center\\"><i data-v-6fdd6bd6=\\"\\" class=\\"mdi-lock-open-alert mdi v-icon notranslate v-theme--light text-grey-darken-2 mr-1\\" style=\\"font-size: 26px; height: 26px; width: 26px;\\" aria-hidden=\\"true\\" data-test=\\"secure-icon\\"></i></td>
-            <td data-v-6fdd6bd6=\\"\\" class=\\"text-center\\" data-test=\\"menu-key-component\\"><span data-v-6fdd6bd6=\\"\\" class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-5\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-              <!---->
-              <!---->
-              <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-6fdd6bd6=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-              <!---->
-              <!----></span>
+            <td data-v-6fdd6bd6=\\"\\" class=\\"text-center\\" data-test=\\"menu-key-component\\"><button data-v-6fdd6bd6=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-5\\" data-test=\\"connector-list-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                <!---->
+                <!---->
+              </button>
               <!--teleport start-->
               <!--teleport end-->
             </td>

--- a/ui/tests/components/Containers/__snapshots__/ContainerPendingList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerPendingList.spec.ts.snap
@@ -20,12 +20,11 @@ exports[`Container Pending List > Renders the component 1`] = `
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><a data-v-787abe29=\\"\\" href=\\"/devices/a582b47a42d\\" class=\\"\\" data-test=\\"a582b47a42d-field\\">39-5e-2a</a></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><i data-v-787abe29=\\"\\" data-test=\\"device-icon\\" class=\\"fl-linuxmint mr-1 mr-2\\" style=\\"font-size: 20px;\\"></i><span data-v-787abe29=\\"\\">Linux Mint 19.3</span></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\">Wednesday, May 20th 2020, 6:58:53 pm</td>
-              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><span data-v-787abe29=\\"\\" class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" data-test=\\"sshid-chip\\"><!----><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-787abe29=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-                <!---->
-                <!----></span>
+              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><button data-v-787abe29=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\" data-test=\\"device-table-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
@@ -34,12 +33,11 @@ exports[`Container Pending List > Renders the component 1`] = `
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><a data-v-787abe29=\\"\\" href=\\"/devices/a582b47a42e\\" class=\\"\\" data-test=\\"a582b47a42e-field\\">39-5e-2b</a></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><i data-v-787abe29=\\"\\" data-test=\\"device-icon\\" class=\\"fl-linuxmint mr-1 mr-2\\" style=\\"font-size: 20px;\\"></i><span data-v-787abe29=\\"\\">Linux Mint 19.3</span></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\">Wednesday, May 20th 2020, 7:58:53 pm</td>
-              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><span data-v-787abe29=\\"\\" class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" data-test=\\"sshid-chip\\"><!----><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-787abe29=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\"></i></div>
-                <!---->
-                <!----></span>
+              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><button data-v-787abe29=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\" data-test=\\"device-table-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/tests/components/Containers/__snapshots__/ContainerRejectList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerRejectList.spec.ts.snap
@@ -20,12 +20,11 @@ exports[`Container Rejected List > Renders the component 1`] = `
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><a data-v-787abe29=\\"\\" href=\\"/devices/a582b47a42d\\" class=\\"\\" data-test=\\"a582b47a42d-field\\">39-5e-2a</a></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><i data-v-787abe29=\\"\\" data-test=\\"device-icon\\" class=\\"fl-linuxmint mr-1 mr-2\\" style=\\"font-size: 20px;\\"></i><span data-v-787abe29=\\"\\">Linux Mint 19.3</span></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\">Wednesday, May 20th 2020, 6:58:53 pm</td>
-              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><span data-v-787abe29=\\"\\" class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" data-test=\\"sshid-chip\\"><!----><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-787abe29=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-                <!---->
-                <!----></span>
+              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><button data-v-787abe29=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\" data-test=\\"device-table-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
@@ -34,12 +33,11 @@ exports[`Container Rejected List > Renders the component 1`] = `
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><a data-v-787abe29=\\"\\" href=\\"/devices/a582b47a42e\\" class=\\"\\" data-test=\\"a582b47a42e-field\\">39-5e-2b</a></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><i data-v-787abe29=\\"\\" data-test=\\"device-icon\\" class=\\"fl-linuxmint mr-1 mr-2\\" style=\\"font-size: 20px;\\"></i><span data-v-787abe29=\\"\\">Linux Mint 19.3</span></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\">Wednesday, May 20th 2020, 7:58:53 pm</td>
-              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><span data-v-787abe29=\\"\\" class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" data-test=\\"sshid-chip\\"><!----><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-787abe29=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\"></i></div>
-                <!---->
-                <!----></span>
+              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><button data-v-787abe29=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\" data-test=\\"device-table-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/tests/components/Devices/__snapshots__/DevicePendingList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DevicePendingList.spec.ts.snap
@@ -20,12 +20,11 @@ exports[`Device Pending List > Renders the component 1`] = `
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><a data-v-787abe29=\\"\\" href=\\"/devices/a582b47a42d\\" class=\\"\\" data-test=\\"a582b47a42d-field\\">39-5e-2a</a></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><i data-v-787abe29=\\"\\" data-test=\\"device-icon\\" class=\\"fl-linuxmint mr-1 mr-2\\" style=\\"font-size: 20px;\\"></i><span data-v-787abe29=\\"\\">Linux Mint 19.3</span></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\">Wednesday, May 20th 2020, 6:58:53 pm</td>
-              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><span data-v-787abe29=\\"\\" class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" data-test=\\"sshid-chip\\"><!----><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-787abe29=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-                <!---->
-                <!----></span>
+              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><button data-v-787abe29=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\" data-test=\\"device-table-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
@@ -34,12 +33,11 @@ exports[`Device Pending List > Renders the component 1`] = `
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><a data-v-787abe29=\\"\\" href=\\"/devices/a582b47a42e\\" class=\\"\\" data-test=\\"a582b47a42e-field\\">39-5e-2b</a></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><i data-v-787abe29=\\"\\" data-test=\\"device-icon\\" class=\\"fl-linuxmint mr-1 mr-2\\" style=\\"font-size: 20px;\\"></i><span data-v-787abe29=\\"\\">Linux Mint 19.3</span></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\">Wednesday, May 20th 2020, 7:58:53 pm</td>
-              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><span data-v-787abe29=\\"\\" class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" data-test=\\"sshid-chip\\"><!----><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-787abe29=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\"></i></div>
-                <!---->
-                <!----></span>
+              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><button data-v-787abe29=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\" data-test=\\"device-table-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/tests/components/Devices/__snapshots__/DeviceRejectedList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DeviceRejectedList.spec.ts.snap
@@ -20,12 +20,11 @@ exports[`Device Rejected List > Renders the component 1`] = `
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><a data-v-787abe29=\\"\\" href=\\"/devices/a582b47a42d\\" class=\\"\\" data-test=\\"a582b47a42d-field\\">39-5e-2a</a></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><i data-v-787abe29=\\"\\" data-test=\\"device-icon\\" class=\\"fl-linuxmint mr-1 mr-2\\" style=\\"font-size: 20px;\\"></i><span data-v-787abe29=\\"\\">Linux Mint 19.3</span></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\">Wednesday, May 20th 2020, 6:58:53 pm</td>
-              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><span data-v-787abe29=\\"\\" class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" data-test=\\"sshid-chip\\"><!----><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-787abe29=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-                <!---->
-                <!----></span>
+              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><button data-v-787abe29=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\" data-test=\\"device-table-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
@@ -34,12 +33,11 @@ exports[`Device Rejected List > Renders the component 1`] = `
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><a data-v-787abe29=\\"\\" href=\\"/devices/a582b47a42e\\" class=\\"\\" data-test=\\"a582b47a42e-field\\">39-5e-2b</a></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\"><i data-v-787abe29=\\"\\" data-test=\\"device-icon\\" class=\\"fl-linuxmint mr-1 mr-2\\" style=\\"font-size: 20px;\\"></i><span data-v-787abe29=\\"\\">Linux Mint 19.3</span></td>
               <td data-v-787abe29=\\"\\" class=\\"text-center\\">Wednesday, May 20th 2020, 7:58:53 pm</td>
-              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><span data-v-787abe29=\\"\\" class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" data-test=\\"sshid-chip\\"><!----><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-787abe29=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\"></i></div>
-                <!---->
-                <!----></span>
+              <td data-v-787abe29=\\"\\" class=\\"text-center\\"><button data-v-787abe29=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\" data-test=\\"device-table-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/tests/components/Namespace/__snapshots__/NamespaceApiKeyList.spec.ts.snap
+++ b/ui/tests/components/Namespace/__snapshots__/NamespaceApiKeyList.spec.ts.snap
@@ -20,12 +20,11 @@ exports[`Namespace Api Key List > Renders the component 1`] = `
               <td class=\\"text-warning\\"><i class=\\"mdi-clock-alert-outline mdi v-icon notranslate v-theme--light v-icon--size-default mr-1\\" aria-hidden=\\"true\\"></i> aaaa2</td>
               <td class=\\"text-warning text-center\\" data-test=\\"key-name\\">administrator</td>
               <td class=\\"text-warning text-center\\" data-test=\\"key-name\\">Expired on Jul 7 2024.</td>
-              <td class=\\"text-center\\" data-test=\\"menu-key-component\\"><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-2\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                <!---->
-                <!----></span>
+              <td class=\\"text-center\\" data-test=\\"menu-key-component\\"><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-2\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
@@ -34,12 +33,11 @@ exports[`Namespace Api Key List > Renders the component 1`] = `
               <td class=\\"text-warning\\"><i class=\\"mdi-clock-alert-outline mdi v-icon notranslate v-theme--light v-icon--size-default mr-1\\" aria-hidden=\\"true\\"></i> aaaa2</td>
               <td class=\\"text-warning text-center\\" data-test=\\"key-name\\">administrator</td>
               <td class=\\"text-warning text-center\\" data-test=\\"key-name\\">Expired on Jul 7 2024.</td>
-              <td class=\\"text-center\\" data-test=\\"menu-key-component\\"><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-8\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                <!---->
-                <!----></span>
+              <td class=\\"text-center\\" data-test=\\"menu-key-component\\"><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-8\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/tests/components/PrivateKeys/PrivateKeyList.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyList.spec.ts
@@ -122,7 +122,6 @@ describe("Private Key List", () => {
     expect(wrapper.find('[data-test="privateKey-thead"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="privateKey-name"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="privateKey-fingerprint"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="privateKey-chip"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="privateKey-menu-icon"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="privateKey-actions"]').exists()).toBe(true);
   });
 });

--- a/ui/tests/components/PublicKeys/PublicKeyList.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyList.spec.ts
@@ -1,5 +1,5 @@
 import { createVuetify } from "vuetify";
-import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import { mount, VueWrapper } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import MockAdapter from "axios-mock-adapter";
 import PublicKeysList from "@/components/PublicKeys/PublicKeysList.vue";

--- a/ui/tests/components/PublicKeys/__snapshots__/PublicKeyList.spec.ts.snap
+++ b/ui/tests/components/PublicKeys/__snapshots__/PublicKeyList.spec.ts.snap
@@ -26,12 +26,11 @@ exports[`Public Key List > Renders the component 1`] = `
               </td>
               <td class=\\"text-center\\" data-test=\\"public-key-username\\">All users</td>
               <td class=\\"text-center\\" data-test=\\"public-key-created-at\\">Fri, May 1st 20, 12:00:00 am</td>
-              <td class=\\"text-center\\" data-test=\\"public-key-actions\\"><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-0\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                <!---->
-                <!----></span>
+              <td class=\\"text-center\\" data-test=\\"public-key-actions\\"><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-0\\" data-test=\\"public-key-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/tests/components/Setting/__snapshots__/SettingTags.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingTags.spec.ts.snap
@@ -42,24 +42,22 @@ exports[`Setting Owner Info > Renders the component 1`] = `
             <tbody>
               <tr>
                 <td class=\\"text-center\\">1</td>
-                <td class=\\"text-center\\"><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-0\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                  <!---->
-                  <!---->
-                  <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                  <!---->
-                  <!----></span>
+                <td class=\\"text-center\\"><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-0\\" data-test=\\"tag-list-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                    <!---->
+                    <!---->
+                  </button>
                   <!--teleport start-->
                   <!--teleport end-->
                 </td>
               </tr>
               <tr>
                 <td class=\\"text-center\\">2</td>
-                <td class=\\"text-center\\"><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-6\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                  <!---->
-                  <!---->
-                  <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                  <!---->
-                  <!----></span>
+                <td class=\\"text-center\\"><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-6\\" data-test=\\"tag-list-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                    <!---->
+                    <!---->
+                  </button>
                   <!--teleport start-->
                   <!--teleport end-->
                 </td>

--- a/ui/tests/components/firewall/FirewallRuleList.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleList.spec.ts
@@ -129,6 +129,6 @@ describe("Firewall Rule List", () => {
     expect(wrapper.find('[data-test="firewall-rules-source-ip"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="firewall-rules-username"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="firewall-rules-filter"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="firewall-rules-action-menu"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="firewall-rules-actions"]').exists()).toBe(true);
   });
 });

--- a/ui/tests/components/firewall/__snapshots__/FirewallRuleList.spec.ts.snap
+++ b/ui/tests/components/firewall/__snapshots__/FirewallRuleList.spec.ts.snap
@@ -28,12 +28,11 @@ exports[`Firewall Rule List > Renders the component 1`] = `
               <td class=\\"text-center\\" data-test=\\"firewall-rules-filter\\">
                 <div>All devices</div>
               </td>
-              <td class=\\"text-center\\"><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-0\\" data-test=\\"firewall-rules-action-menu\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                <!---->
-                <!----></span>
+              <td class=\\"text-center\\"><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-0\\" data-test=\\"firewall-rules-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
@@ -50,12 +49,11 @@ exports[`Firewall Rule List > Renders the component 1`] = `
               <td class=\\"text-center\\" data-test=\\"firewall-rules-filter\\">
                 <div>All devices</div>
               </td>
-              <td class=\\"text-center\\"><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\" data-test=\\"firewall-rules-action-menu\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                <!---->
-                <!---->
-                <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                <!---->
-                <!----></span>
+              <td class=\\"text-center\\"><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-7\\" data-test=\\"firewall-rules-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                  <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                  <!---->
+                  <!---->
+                </button>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/tests/views/__snapshots__/DetailsDevice.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/DetailsDevice.spec.ts.snap
@@ -33,12 +33,11 @@ exports[`Details Device > Renders the component 1`] = `
         <!---->
       </div><span class=\\"ml-2\\">00-00-00-00-00-01</span>
     </div>
-    <div><span class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\"><!----><span class=\\"v-chip__underlay\\"></span>
-      <!---->
-      <!---->
-      <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-      <!---->
-      <!----></span>
+    <div><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+        <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+        <!---->
+        <!---->
+      </button>
       <!--teleport start-->
       <!--teleport end-->
     </div>
@@ -114,12 +113,11 @@ exports[`Details Device > Renders the component when device has no last seen dat
         <!---->
       </div><span class=\\"ml-2\\">00-00-00-00-00-01</span>
     </div>
-    <div><span class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\"><!----><span class=\\"v-chip__underlay\\"></span>
-      <!---->
-      <!---->
-      <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-      <!---->
-      <!----></span>
+    <div><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+        <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+        <!---->
+        <!---->
+      </button>
       <!--teleport start-->
       <!--teleport end-->
     </div>
@@ -195,12 +193,11 @@ exports[`Details Device > Renders the component when device has no tags 1`] = `
         <!---->
       </div><span class=\\"ml-2\\">00-00-00-00-00-01</span>
     </div>
-    <div><span class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\"><!----><span class=\\"v-chip__underlay\\"></span>
-      <!---->
-      <!---->
-      <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-      <!---->
-      <!----></span>
+    <div><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+        <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+        <!---->
+        <!---->
+      </button>
       <!--teleport start-->
       <!--teleport end-->
     </div>
@@ -276,12 +273,11 @@ exports[`Details Device > Renders the component when device is offline 1`] = `
         <!---->
       </div><span class=\\"ml-2\\">00-00-00-00-00-01</span>
     </div>
-    <div><span class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\"><!----><span class=\\"v-chip__underlay\\"></span>
-      <!---->
-      <!---->
-      <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-      <!---->
-      <!----></span>
+    <div><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+        <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+        <!---->
+        <!---->
+      </button>
       <!--teleport start-->
       <!--teleport end-->
     </div>
@@ -350,12 +346,11 @@ exports[`Details Device > Renders the component when device status is not accept
     <div class=\\"d-flex align-center\\">
       <!--v-if--><span class=\\"ml-2\\">00-00-00-00-00-01</span>
     </div>
-    <div><span class=\\"v-chip v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\"><!----><span class=\\"v-chip__underlay\\"></span>
-      <!---->
-      <!---->
-      <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable\\" role=\\"button\\" aria-hidden=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"></i></div>
-      <!---->
-      <!----></span>
+    <div><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+        <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+        <!---->
+        <!---->
+      </button>
       <!--teleport start-->
       <!--teleport end-->
     </div>

--- a/ui/tests/views/__snapshots__/DetailsSessions.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/DetailsSessions.spec.ts.snap
@@ -28,12 +28,11 @@ exports[`Details Sessions > Renders the component 1`] = `
       <!--teleport end-->
       <!--v-if-->
     </div>
-    <div><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\" data-test=\\"sessionMenu-chip\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-      <!---->
-      <!---->
-      <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-      <!---->
-      <!----></span>
+    <div><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-1\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+        <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+        <!---->
+        <!---->
+      </button>
       <!--teleport start-->
       <!--teleport end-->
     </div>

--- a/ui/tests/views/__snapshots__/FirewallRules.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/FirewallRules.spec.ts.snap
@@ -48,12 +48,11 @@ exports[`Firewall Rules > Renders the component 1`] = `
                 <td class=\\"text-center\\" data-test=\\"firewall-rules-filter\\">
                   <div>All devices</div>
                 </td>
-                <td class=\\"text-center\\"><span class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-2\\" data-test=\\"firewall-rules-action-menu\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                  <!---->
-                  <!---->
-                  <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                  <!---->
-                  <!----></span>
+                <td class=\\"text-center\\"><button type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-2\\" data-test=\\"firewall-rules-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                    <!---->
+                    <!---->
+                  </button>
                   <!--teleport start-->
                   <!--teleport end-->
                 </td>

--- a/ui/tests/views/__snapshots__/Sessions.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/Sessions.spec.ts.snap
@@ -51,12 +51,11 @@ exports[`Sessions View > Renders the component 1`] = `
                 <td data-v-459ab1b4=\\"\\" class=\\"text-center\\"><code data-v-459ab1b4=\\"\\" class=\\"v-code bg-tabs\\">192.168.0.1</code></td>
                 <td data-v-459ab1b4=\\"\\" class=\\"text-center\\"><span data-v-459ab1b4=\\"\\"></span></td>
                 <td data-v-459ab1b4=\\"\\" class=\\"text-center\\"><span data-v-459ab1b4=\\"\\"></span></td>
-                <td data-v-459ab1b4=\\"\\" class=\\"text-center\\"><span data-v-459ab1b4=\\"\\" class=\\"v-chip v-chip--link v-theme--light v-chip--density-comfortable v-chip--size-small v-chip--variant-tonal\\" draggable=\\"false\\" tabindex=\\"0\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-3\\"><span class=\\"v-chip__overlay\\"></span><span class=\\"v-chip__underlay\\"></span>
-                  <!---->
-                  <!---->
-                  <div class=\\"v-chip__content\\" data-no-activator=\\"\\"><i data-v-459ab1b4=\\"\\" class=\\"mdi-dots-horizontal mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></div>
-                  <!---->
-                  <!----></span>
+                <td data-v-459ab1b4=\\"\\" class=\\"text-center\\"><button data-v-459ab1b4=\\"\\" type=\\"button\\" class=\\"v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background\\" aria-haspopup=\\"menu\\" aria-expanded=\\"false\\" aria-owns=\\"v-menu-3\\" data-test=\\"session-list-actions\\"><span class=\\"v-btn__overlay\\"></span><span class=\\"v-btn__underlay\\"></span>
+                    <!----><span class=\\"v-btn__content\\" data-no-activator=\\"\\"><i class=\\"mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default\\" aria-hidden=\\"true\\"></i></span>
+                    <!---->
+                    <!---->
+                  </button>
                   <!--teleport start-->
                   <!--teleport end-->
                 </td>


### PR DESCRIPTION
Replaced v-chip with v-btn as the activator component across several list
components.

Updated button styles to align with the application's design system:

    variant="plain", border, rounded, and bg-v-theme-background.
    Added appropriate data-test attributes for testability.
    Changed icon to mdi-format-list-bulleted for consistent visual
    representation.

Renamed router navigation target from detailsConnectors to ConnectorDetails in
ConnectorList.vue.
