### PR TITLE
feat(gateway): add support for invitation links

### DIFF
--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -187,6 +187,32 @@ server {
     }
 
     {{ if $cfg.EnableEnterprise -}}
+    location ~^/api/namespaces/[^/]+/members/invites$ {
+        {{ set_upstream "cloud-api" 8080 }}
+
+        auth_request       /auth;
+        auth_request_set   $tenant_id $upstream_http_x_tenant_id;
+        auth_request_set   $username $upstream_http_x_username;
+        auth_request_set   $id $upstream_http_x_id;
+        auth_request_set   $api_key $upstream_http_x_api_key;
+        auth_request_set   $role $upstream_http_x_role;
+        error_page         500 =401 /auth;
+        proxy_http_version 1.1;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   X-Forwarded-Host $host;
+        proxy_set_header   X-Forwarded-Port $x_forwarded_port;
+        proxy_set_header   X-Forwarded-Proto $x_forwarded_proto;
+        proxy_set_header   X-Api-Key $api_key;
+        proxy_set_header   X-ID $id;
+        proxy_set_header   X-Request-ID $request_id;
+        proxy_set_header   X-Role $role;
+        proxy_set_header   X-Tenant-ID $tenant_id;
+        proxy_set_header   X-Username $username;
+        proxy_pass         http://upstream_router;
+    }
+    {{ end -}}
+
+    {{ if $cfg.EnableEnterprise -}}
     location ~ ^/api/namespaces/([^/]+)/support$ {
         {{ set_upstream "cloud-api" 8080 }}
 


### PR DESCRIPTION
- Redirects requests to `/api/namespaces/{tenant-id}/members/invites` to the `cloud-api`.
- Supports the new invitation links feature, enabling users to generate and manage namespace invitations.