### PR TITLE
fix(ui): remove unused binding in MemberEdit component

### DIFF
--- a/ui/src/components/Team/Member/MemberEdit.vue
+++ b/ui/src/components/Team/Member/MemberEdit.vue
@@ -2,7 +2,6 @@
   <div>
     <v-list-item
       @click="showDialog = true"
-      v-bind="$props"
       :disabled="notHasAuthorization"
       data-test="member-edit-btn"
     >

--- a/ui/tests/components/Team/Member/__snapshots__/MemberEdit.spec.ts.snap
+++ b/ui/tests/components/Team/Member/__snapshots__/MemberEdit.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Member Edit > Renders the component 1`] = `
 "<div>
-  <div class=\\"v-list-item v-list-item--link v-theme--light v-list-item--density-default rounded-0 v-list-item--variant-text\\" tabindex=\\"0\\" aria-selected=\\"false\\" member=\\"[object Object]\\" nothasauthorization=\\"false\\" data-test=\\"member-edit-btn\\"><span class=\\"v-list-item__overlay\\"></span><span class=\\"v-list-item__underlay\\"></span>
+  <div class=\\"v-list-item v-list-item--link v-theme--light v-list-item--density-default rounded-0 v-list-item--variant-text\\" tabindex=\\"0\\" aria-selected=\\"false\\" data-test=\\"member-edit-btn\\"><span class=\\"v-list-item__overlay\\"></span><span class=\\"v-list-item__underlay\\"></span>
     <!---->
     <div class=\\"v-list-item__content\\" data-no-activator=\\"\\">
       <!---->


### PR DESCRIPTION
The `v-bind="$props"` directive was removed from the `MemberEdit.vue`
component. This binding was unnecessary and has been cleaned up
to simplify the code.
