### PR TITLE
feat(api): add configuration management to BaseAPI

### DIFF
--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -100,6 +100,8 @@ export const createNewClient = () => Function;
 declare module "./client/base" {
   interface BaseAPI {
     getAxios(): AxiosInstance;
+    getConfiguration(): Configuration | undefined;
+    setConfiguration(configuration: Configuration): void;
   }
 }
 
@@ -108,8 +110,39 @@ BaseAPI.prototype.getAxios = function getAxios(this: BaseAPI): AxiosInstance {
   return this.axios;
 };
 
+/** Returns the configuration */
+BaseAPI.prototype.getConfiguration = function getConfiguration(this: BaseAPI): Configuration | undefined {
+  return this.configuration;
+};
+
+/** Sets the configuration */
+BaseAPI.prototype.setConfiguration = function setConfiguration(this: BaseAPI, configuration: Configuration): void {
+  this.configuration = configuration;
+};
+
+// Reloads the configuration for all APIs
+const reloadConfiguration = () => {
+  [
+    sessionsApi,
+    devicesApi,
+    containersApi,
+    systemApi,
+    namespacesApi,
+    apiKeysApi,
+    sshApi,
+    tagsApi,
+    usersApi,
+    mfaApi,
+    billingApi,
+    rulesApi,
+  ].forEach((api) => {
+    api.setConfiguration(configuration);
+  });
+};
+
 export {
   configuration,
+  reloadConfiguration,
   sessionsApi,
   devicesApi,
   containersApi,

--- a/ui/src/store/modules/auth.ts
+++ b/ui/src/store/modules/auth.ts
@@ -5,6 +5,10 @@ import * as apiAuth from "../api/auth";
 import * as apiNamespace from "../api/namespaces";
 import { IUserLogin } from "@/interfaces/IUserLogin";
 import { State } from "..";
+import {
+  configuration as apiConfiguration,
+  reloadConfiguration as reloadApiConfiguration,
+} from "@/api/http";
 
 const { reset, toggle } = useChatWoot();
 export interface AuthState {
@@ -211,7 +215,8 @@ export const auth: Module<AuthState, State> = {
     async loginToken(context, token) {
       context.commit("authRequest");
 
-      localStorage.setItem("token", token);
+      apiConfiguration.accessToken = token;
+      reloadApiConfiguration();
 
       try {
         const resp = await apiAuth.info();

--- a/ui/src/store/plugins/api.ts
+++ b/ui/src/store/plugins/api.ts
@@ -1,9 +1,10 @@
-import { configuration } from "@/api/http";
+import { configuration, reloadConfiguration } from "@/api/http";
 
 const apiPlugin = (store) => {
   store.subscribe((mutation, state) => {
     if (mutation.type === "auth/authSuccess") {
       configuration.accessToken = state.auth.token;
+      reloadConfiguration();
     }
   });
 };

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -193,6 +193,8 @@ onMounted(async () => {
   await store.dispatch("namespaces/clearNamespaceList");
   await store.dispatch("auth/logout");
   await store.dispatch("auth/loginToken", route.query.token);
+
+  window.location.href = "/";
 });
 
 const login = async () => {


### PR DESCRIPTION
- Introduced `getConfiguration` and `setConfiguration` methods to `BaseAPI`.
- Added a `reloadConfiguration` function to reapply settings across APIs.
- Updated the auth module to integrate configuration updates on login.
- Enhanced `apiPlugin` to reload configuration after authentication success.
- Redirected users to the home page post-login in `Login.vue`.
