### PR TITLE
Revert "ui: bump typescript from 5.6.3 to 5.7.2 in /ui"

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9376,9 +9376,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
This reverts commit ee2c3c7a2460d7dddb238e030ef5732d04478f49.

See: https://github.com/vuejs/language-tools/issues/5018
