### PR TITLE
fix(ui): adjust settings inputs to use flat variant when not editing

### DIFF
--- a/ui/src/components/Namespace/NamespaceEdit.vue
+++ b/ui/src/components/Namespace/NamespaceEdit.vue
@@ -35,11 +35,12 @@
           color="primary"
           variant="text"
           data-test="change-connection-btn"
-          :disabled="connectionAnnouncementError"
+          :disabled="!!connectionAnnouncementError"
           @click="updateAnnouncement()"
         >
           Save Announcement
         </v-btn>
+
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/ui/src/components/Setting/SettingNamespace.vue
+++ b/ui/src/components/Setting/SettingNamespace.vue
@@ -43,7 +43,7 @@
                   color="primary"
                   variant="flat"
                   data-test="save-changes-btn"
-                  :disabled="nameError"
+                  :disabled="!!nameError"
                 >Save Changes</v-btn>
               </template>
             </div>
@@ -73,7 +73,7 @@
                 required
                 :hide-details="!nameError"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : ''"
+                :variant="editDataStatus ? 'outlined' : 'flat'"
                 data-test="name-input"
               />
             </template>

--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -76,7 +76,7 @@
                 required
                 :hide-details="!nameError"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : ''"
+                :variant="editDataStatus ? 'outlined' : 'flat'"
                 data-test="name-input"
               />
             </template>
@@ -96,7 +96,7 @@
                 :disabled="!editDataStatus"
                 :readonly="!editDataStatus"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : ''"
+                :variant="editDataStatus ? 'outlined' : 'flat'"
                 required
                 :hide-details="!usernameError"
                 data-test="username-input"
@@ -118,7 +118,7 @@
                 :disabled="!editDataStatus"
                 :readonly="!editDataStatus"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : ''"
+                :variant="editDataStatus ? 'outlined' : 'flat'"
                 required
                 :hide-details="!emailError"
                 data-test="email-input"
@@ -140,7 +140,7 @@
                 :disabled="!editDataStatus"
                 :readonly="!editDataStatus"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : ''"
+                :variant="editDataStatus ? 'outlined' : 'flat'"
                 required
                 :hide-details="!recoveryEmailError"
                 data-test="recovery-email-input"

--- a/ui/src/components/User/UserDelete.vue
+++ b/ui/src/components/User/UserDelete.vue
@@ -44,7 +44,7 @@ import handleError from "@/utils/handleError";
 
 const store = useStore();
 const router = useRouter();
-const show = defineModel("show");
+const show = defineModel<boolean>({ default: false });
 
 const deleteAccount = async () => {
   try {

--- a/ui/tests/components/Setting/__snapshots__/SettingNamespace.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingNamespace.spec.ts.snap
@@ -66,7 +66,7 @@ exports[`Setting Namespace > Renders the component 1`] = `
             <div data-v-80a16399=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-input--readonly v-text-field\\" data-test=\\"name-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--active v-field--center-affix v-field--disabled v-field--dirty v-field--no-label v-field--variant- v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--active v-field--center-affix v-field--disabled v-field--dirty v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">

--- a/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
@@ -78,7 +78,7 @@ exports[`Settings Namespace > Renders the component 1`] = `
             <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field\\" data-test=\\"name-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant- v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
@@ -128,7 +128,7 @@ exports[`Settings Namespace > Renders the component 1`] = `
             <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field\\" data-test=\\"username-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant- v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
@@ -178,7 +178,7 @@ exports[`Settings Namespace > Renders the component 1`] = `
             <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field\\" data-test=\\"email-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant- v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
@@ -228,7 +228,7 @@ exports[`Settings Namespace > Renders the component 1`] = `
             <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field\\" data-test=\\"recovery-email-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant- v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">


### PR DESCRIPTION
This Pull Request resolves an error in the build method caused by the Vuetify
variant attribute being set to an empty string. The fix introduces a
paragraph element to replace the input field when it is not in editing mode.
