### PR TITLE
fix(ui): settings inputs to use variant plain with v-deep when not editing

### DIFF
--- a/ui/src/components/Setting/SettingNamespace.vue
+++ b/ui/src/components/Setting/SettingNamespace.vue
@@ -73,7 +73,7 @@
                 required
                 :hide-details="!nameError"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : 'flat'"
+                :variant="editDataStatus ? 'outlined' : 'plain'"
                 data-test="name-input"
               />
             </template>
@@ -346,5 +346,11 @@ const hasTenant = () => tenant.value !== "";
   max-width: 960px;
   margin-left: 0;
   padding: 0;
+}
+
+:deep(.v-field--variant-plain) {
+  --v-field-padding-start: 16px;
+  --v-field-padding-end: 16px;
+  --v-field-padding-bottom: 8px;
 }
 </style>

--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -76,7 +76,7 @@
                 required
                 :hide-details="!nameError"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : 'flat'"
+                :variant="editDataStatus ? 'outlined' : 'plain'"
                 data-test="name-input"
               />
             </template>
@@ -96,7 +96,7 @@
                 :disabled="!editDataStatus"
                 :readonly="!editDataStatus"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : 'flat'"
+                :variant="editDataStatus ? 'outlined' : 'plain'"
                 required
                 :hide-details="!usernameError"
                 data-test="username-input"
@@ -118,7 +118,7 @@
                 :disabled="!editDataStatus"
                 :readonly="!editDataStatus"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : 'flat'"
+                :variant="editDataStatus ? 'outlined' : 'plain'"
                 required
                 :hide-details="!emailError"
                 data-test="email-input"
@@ -140,7 +140,7 @@
                 :disabled="!editDataStatus"
                 :readonly="!editDataStatus"
                 density="compact"
-                :variant="editDataStatus ? 'outlined' : 'flat'"
+                :variant="editDataStatus ? 'outlined' : 'plain'"
                 required
                 :hide-details="!recoveryEmailError"
                 data-test="recovery-email-input"
@@ -412,5 +412,11 @@ onMounted(async () => {
   max-width: 960px;
   margin-left: 0;
   padding: 0;
+}
+
+:deep(.v-field--variant-plain) {
+  --v-field-padding-start: 16px;
+  --v-field-padding-end: 16px;
+  --v-field-padding-bottom: 8px;
 }
 </style>

--- a/ui/tests/components/Setting/__snapshots__/SettingNamespace.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingNamespace.spec.ts.snap
@@ -63,10 +63,10 @@ exports[`Setting Namespace > Renders the component 1`] = `
             <!---->
           </div>
           <div class=\\"v-card-item__append\\">
-            <div data-v-80a16399=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-input--readonly v-text-field\\" data-test=\\"name-input\\">
+            <div data-v-80a16399=\\"\\" class=\\"v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-input--readonly v-text-field v-input--plain-underlined\\" data-test=\\"name-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--active v-field--center-affix v-field--disabled v-field--dirty v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--active v-field--disabled v-field--dirty v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">

--- a/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
@@ -75,10 +75,10 @@ exports[`Settings Namespace > Renders the component 1`] = `
             <!---->
           </div>
           <div class=\\"v-card-item__append\\">
-            <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field\\" data-test=\\"name-input\\">
+            <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined\\" data-test=\\"name-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--disabled v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
@@ -125,10 +125,10 @@ exports[`Settings Namespace > Renders the component 1`] = `
             <!---->
           </div>
           <div class=\\"v-card-item__append\\">
-            <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field\\" data-test=\\"username-input\\">
+            <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined\\" data-test=\\"username-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--disabled v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
@@ -175,10 +175,10 @@ exports[`Settings Namespace > Renders the component 1`] = `
             <!---->
           </div>
           <div class=\\"v-card-item__append\\">
-            <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field\\" data-test=\\"email-input\\">
+            <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined\\" data-test=\\"email-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--disabled v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">
@@ -225,10 +225,10 @@ exports[`Settings Namespace > Renders the component 1`] = `
             <!---->
           </div>
           <div class=\\"v-card-item__append\\">
-            <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field\\" data-test=\\"recovery-email-input\\">
+            <div data-v-b3fa301d=\\"\\" class=\\"v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined\\" data-test=\\"recovery-email-input\\">
               <!---->
               <div class=\\"v-input__control\\">
-                <div class=\\"v-field v-field--center-affix v-field--disabled v-field--no-label v-field--variant-flat v-theme--light v-locale--is-ltr\\">
+                <div class=\\"v-field v-field--disabled v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr\\">
                   <div class=\\"v-field__overlay\\"></div>
                   <div class=\\"v-field__loader\\">
                     <div class=\\"v-progress-linear v-theme--light v-locale--is-ltr\\" style=\\"top: 0px; height: 0px; --v-progress-linear-height: 2px;\\" role=\\"progressbar\\" aria-hidden=\\"true\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\">


### PR DESCRIPTION
This Pull Request resolves an error in the build method caused by the Vuetify
variant attribute being set to an flat non-existent variant. The fix introduces
a plain variant edited with v-deep properties to replace the flat one when 
it is not in editing mode.
