### PR TITLE
fix: hide tmp file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 ./*.md
 ./bin
 ./ui/node_modules
+./agent/tmp


### PR DESCRIPTION
This PR try to hide agent tmp files from Docker during tests