### PR TITLE
fix(ui): conditional rendering for billing components

### DIFF
--- a/ui/src/components/Setting/SettingBilling.vue
+++ b/ui/src/components/Setting/SettingBilling.vue
@@ -1,7 +1,7 @@
 <template>
-  <BillingDialog v-model="dialogCheckout" @reload="reload" />
-  <v-container fluid>
-    <SettingOwnerInfo :is-owner="hasAuthorization" data-test="settings-owner-info-component" />
+  <SettingOwnerInfo :is-owner="hasAuthorization" v-if="!hasAuthorization" data-test="settings-owner-info-component" />
+  <v-container fluid v-else>
+    <BillingDialog v-model="dialogCheckout" @reload="reload" />
     <v-card
       variant="flat"
       class="bg-transparent"

--- a/ui/tests/components/Setting/__snapshots__/SettingBilling.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingBilling.spec.ts.snap
@@ -2,7 +2,8 @@
 
 exports[`Billing Settings Free Mode > Renders the component 1`] = `
 "<div data-v-d7a09f69=\\"\\" class=\\"v-container v-container--fluid v-locale--is-ltr\\">
-  <!--v-if-->
+  <!---->
+  <!---->
   <div data-v-d7a09f69=\\"\\" class=\\"v-card v-theme--light v-card--density-default v-card--variant-flat bg-transparent\\" data-test=\\"billing-card\\">
     <!---->
     <div class=\\"v-card__loader\\">


### PR DESCRIPTION
Adjusted SettingOwnerInfo to only render if the user lacks authorization
(v-if="!hasAuthorization").

Moved BillingDialog and its container to render only when the user has
authorization (v-else).

Updated related snapshot tests to reflect new conditional rendering logic.
