### PR TITLE
fix(ui): re-add `style` prop to Notification component

### DIFF
--- a/ui/src/components/AppBar/Notifications/Notification.vue
+++ b/ui/src/components/AppBar/Notifications/Notification.vue
@@ -116,6 +116,12 @@ import DeviceActionButton from "../../../components/Devices/DeviceActionButton.v
 import handleError from "../../../utils/handleError";
 
 const store = useStore();
+defineProps({
+  style: {
+    type: [String, Object],
+    default: undefined,
+  },
+});
 const show = ref(false);
 const inANamespace = ref(false);
 


### PR DESCRIPTION
Introduced the `style` prop again in the Notification component to allow
customizable styling. The prop supports both string and object types,
with a default value of `undefined`.
