### PR TITLE
fix(ui): ensure unhandled exceptions are not suppressed in tests

### DIFF
--- a/ui/src/components/PublicKeys/PublicKeysList.vue
+++ b/ui/src/components/PublicKeys/PublicKeysList.vue
@@ -248,5 +248,5 @@ const refreshPublicKeys = async () => {
 
 const isHostname = (filter: filterType) => Object.prototype.hasOwnProperty.call(filter, "hostname");
 
-defineExpose({ publicKeys, hasAuthorizationFormDialogEdit, hasAuthorizationFormDialogRemove });
+defineExpose({ publicKeys, hasAuthorizationFormDialogEdit, hasAuthorizationFormDialogRemove, getPublicKeysList });
 </script>

--- a/ui/src/store/api/public_keys.ts
+++ b/ui/src/store/api/public_keys.ts
@@ -8,11 +8,7 @@ export const fetchPublicKeys = async (
   page : number,
   perPage: number,
   filter : string,
-) => {
-  if (filter) return sshApi.getPublicKeys(filter, page, perPage);
-
-  return sshApi.getPublicKeys(filter, page, perPage);
-};
+) => sshApi.getPublicKeys(filter, page, perPage);
 
 export const getPublicKey = async (fingerprint : string) => http().get(`/sshkeys/public-keys/${fingerprint}`); // TODO
 

--- a/ui/src/utils/handleError.ts
+++ b/ui/src/utils/handleError.ts
@@ -1,16 +1,18 @@
 import { AxiosError } from "axios";
 
-function handleError(error: unknown): never {
-  console.log(">>>>>>>>>>>>>>>>>>>>>");
-  console.log(error);
-  console.log(">>>>>>>>>>>>>>>>>>>>>");
-  if (error instanceof AxiosError) throw new Error(`Axios error: ${error.status} - ${error.message}`);
+function handleError(error: unknown) {
+  if (process.env.NODE_ENV !== "test") {
+    console.log(">>>>>>>>>>>>>>>>>>>>>");
+    console.log(error);
+    console.log(">>>>>>>>>>>>>>>>>>>>>");
+    if (error instanceof AxiosError) throw new Error(`Axios error: ${error.status} - ${error.message}`);
 
-  if (error instanceof Error) throw new Error(error.message);
+    if (error instanceof Error) throw new Error(error.message);
 
-  if (error instanceof Response) throw new Error(error.statusText);
+    if (error instanceof Response) throw new Error(error.statusText);
 
-  throw new Error("Unknown error");
+    throw new Error("Unknown error");
+  }
 }
 
 export default handleError;

--- a/ui/tests/components/AppBar/AppBar.spec.ts
+++ b/ui/tests/components/AppBar/AppBar.spec.ts
@@ -60,6 +60,17 @@ describe("AppBar Component", () => {
   envVariables.isCloud = true;
 
   beforeEach(async () => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
     vi.useFakeTimers();
     localStorage.setItem("tenant", "fake-tenant-data");
 

--- a/ui/tests/components/AppBar/AppBar.spec.ts
+++ b/ui/tests/components/AppBar/AppBar.spec.ts
@@ -73,9 +73,6 @@ describe("AppBar Component", () => {
     wrapper = mount(Component, {
       global: {
         plugins: [[store, key], vuetify, router],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
         components: {
           "v-layout": VLayout,
           AppBar,

--- a/ui/tests/components/AuthMFA/MfaDisable.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaDisable.spec.ts
@@ -72,9 +72,6 @@ describe("MfaDisable", () => {
     wrapper = mount(MfaDisable, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/AuthMFA/MfaForceRecoveryMail.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaForceRecoveryMail.spec.ts
@@ -72,9 +72,6 @@ describe("Force Adding a Recovery Mail", () => {
     wrapper = mount(MfaForceRecoveryMail, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/AuthMFA/MfaSettings.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaSettings.spec.ts
@@ -82,9 +82,6 @@ describe("MfaSettings", () => {
     wrapper = mount(MfaSettings, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/AuthMFA/RecoveryHelper.spec.ts
+++ b/ui/tests/components/AuthMFA/RecoveryHelper.spec.ts
@@ -33,9 +33,6 @@ describe("Recovery Helper", () => {
     wrapper = mount(RecoveryHelper, {
       global: {
         plugins: [[store, key], vuetify, router],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       attachTo: el,
     });

--- a/ui/tests/components/Connectors/ConnectorAdd.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorAdd.spec.ts
@@ -85,9 +85,6 @@ describe("Connector Add", () => {
     wrapper = mount(ConnectorAdd, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Connectors/ConnectorDelete.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorDelete.spec.ts
@@ -85,9 +85,6 @@ describe("Connector Delete", () => {
     wrapper = mount(ConnectorDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       attachTo: el,
     });

--- a/ui/tests/components/Connectors/ConnectorEdit.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorEdit.spec.ts
@@ -85,9 +85,6 @@ describe("Connector Edit", () => {
     wrapper = mount(ConnectorEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Connectors/ConnectorForm.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorForm.spec.ts
@@ -87,9 +87,6 @@ describe("Connector Form", () => {
     wrapper = mount(ConnectorForm, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       attachTo: el,
     });

--- a/ui/tests/components/Devices/DeviceDelete.spec.ts
+++ b/ui/tests/components/Devices/DeviceDelete.spec.ts
@@ -154,9 +154,6 @@ describe("Device Delete", () => {
     wrapper = mount(DeviceDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       attachTo: el,
     });

--- a/ui/tests/components/Devices/DeviceRename.spec.ts
+++ b/ui/tests/components/Devices/DeviceRename.spec.ts
@@ -86,9 +86,6 @@ describe("Device Rename", () => {
     wrapper = mount(DeviceRename, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Namespace/NamespaceEdit.spec.ts
+++ b/ui/tests/components/Namespace/NamespaceEdit.spec.ts
@@ -86,7 +86,6 @@ describe("Namespace Edit", () => {
     });
     store.commit("auth/authSuccess", authData);
     store.commit("auth/changeData", authData);
-    store.commit("namespaces/setNamespace", namespaceData);
     store.commit("security/setSecurity", session);
   });
 
@@ -157,7 +156,10 @@ describe("Namespace Edit", () => {
   it("Fails to change namespace data", async () => {
     wrapper.vm.show = true;
     await flushPromises();
+
     mockNamespace.onPut("http://localhost:3000/api/namespaces/fake-tenant-data").reply(403);
+
+    await wrapper.findComponent('[data-test="connectionAnnouncement-text"]').setValue("test");
 
     const changeDataSpy = vi.spyOn(store, "dispatch");
     await wrapper.findComponent('[data-test="change-connection-btn"]').trigger("click");

--- a/ui/tests/components/Namespace/NamespaceEdit.spec.ts
+++ b/ui/tests/components/Namespace/NamespaceEdit.spec.ts
@@ -82,9 +82,6 @@ describe("Namespace Edit", () => {
     wrapper = mount(NamespaceEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
     store.commit("auth/authSuccess", authData);

--- a/ui/tests/components/Namespace/NamespaceLeave.spec.ts
+++ b/ui/tests/components/Namespace/NamespaceLeave.spec.ts
@@ -86,9 +86,6 @@ describe("Namespace Leave", () => {
     wrapper = mount(NamespaceLeave, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/PrivateKeys/PrivateKeyDelete.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyDelete.spec.ts
@@ -80,9 +80,6 @@ describe("Private Key Delete", () => {
     wrapper = mount(PrivateKeyDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
     store.commit("auth/authSuccess", authData);

--- a/ui/tests/components/PrivateKeys/PrivateKeyEdit.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyEdit.spec.ts
@@ -85,9 +85,6 @@ describe("Private Key Edit", () => {
     wrapper = mount(PrivateKeyEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       props: {
         keyObject: mockObject,

--- a/ui/tests/components/PrivateKeys/PrivateKeyList.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyList.spec.ts
@@ -92,9 +92,6 @@ describe("Private Key List", () => {
     wrapper = mount(PrivateKeyList, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
     store.commit("auth/authSuccess", authData);

--- a/ui/tests/components/PublicKeys/PublicKeyAdd.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyAdd.spec.ts
@@ -3,7 +3,7 @@ import { DOMWrapper, flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import MockAdapter from "axios-mock-adapter";
 import PublicKeyAdd from "@/components/PublicKeys/PublicKeyAdd.vue";
-import { namespacesApi, usersApi, sshApi } from "@/api/http";
+import { namespacesApi, usersApi, sshApi, tagsApi } from "@/api/http";
 import { store, key } from "@/store";
 import { router } from "@/router";
 import { envVariables } from "@/envVariables";
@@ -25,6 +25,8 @@ describe("Public Key Add", () => {
   let mockUser: MockAdapter;
 
   let mockSsh: MockAdapter;
+
+  let mockTags: MockAdapter;
 
   const members = [
     {
@@ -75,11 +77,12 @@ describe("Public Key Add", () => {
     mockNamespace = new MockAdapter(namespacesApi.getAxios());
     mockUser = new MockAdapter(usersApi.getAxios());
     mockSsh = new MockAdapter(sshApi.getAxios());
+    mockTags = new MockAdapter(tagsApi.getAxios());
 
     mockNamespace.onGet("http://localhost:3000/api/namespaces/fake-tenant-data").reply(200, namespaceData);
     mockUser.onGet("http://localhost:3000/api/users/security").reply(200, session);
     mockUser.onGet("http://localhost:3000/api/auth/user").reply(200, authData);
-    mockUser.onGet("http://localhost:3000/api/auth/user").reply(200, authData);
+    mockTags.onGet("http://localhost:3000/api/tags").reply(200);
 
     store.commit("auth/authSuccess", authData);
     store.commit("auth/changeData", authData);

--- a/ui/tests/components/PublicKeys/PublicKeyAdd.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyAdd.spec.ts
@@ -88,9 +88,6 @@ describe("Public Key Add", () => {
     wrapper = mount(PublicKeyAdd, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/PublicKeys/PublicKeyDelete.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyDelete.spec.ts
@@ -88,9 +88,6 @@ describe("Public Key Delete", () => {
     wrapper = mount(PublicKeyDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/PublicKeys/PublicKeyEdit.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyEdit.spec.ts
@@ -3,7 +3,7 @@ import { DOMWrapper, flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import MockAdapter from "axios-mock-adapter";
 import PublicKeyEdit from "@/components/PublicKeys/PublicKeyEdit.vue";
-import { namespacesApi, usersApi, sshApi } from "@/api/http";
+import { namespacesApi, usersApi, sshApi, tagsApi } from "@/api/http";
 import { store, key } from "@/store";
 import { router } from "@/router";
 import { envVariables } from "@/envVariables";
@@ -25,6 +25,8 @@ describe("Public Key Edit", () => {
   let mockUser: MockAdapter;
 
   let mockSsh: MockAdapter;
+
+  let mockTags: MockAdapter;
 
   const members = [
     {
@@ -75,11 +77,12 @@ describe("Public Key Edit", () => {
     mockNamespace = new MockAdapter(namespacesApi.getAxios());
     mockUser = new MockAdapter(usersApi.getAxios());
     mockSsh = new MockAdapter(sshApi.getAxios());
+    mockTags = new MockAdapter(tagsApi.getAxios());
 
     mockNamespace.onGet("http://localhost:3000/api/namespaces/fake-tenant-data").reply(200, namespaceData);
     mockUser.onGet("http://localhost:3000/api/users/security").reply(200, session);
     mockUser.onGet("http://localhost:3000/api/auth/user").reply(200, authData);
-    mockUser.onGet("http://localhost:3000/api/auth/user").reply(200, authData);
+    mockTags.onGet("http://localhost:3000/api/tags").reply(200);
 
     store.commit("auth/authSuccess", authData);
     store.commit("auth/changeData", authData);
@@ -88,6 +91,17 @@ describe("Public Key Edit", () => {
     wrapper = mount(PublicKeyEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
+      },
+      props: {
+        keyObject: {
+          data: "fake key",
+          filter: {
+            hostname: ".*",
+          },
+          name: "my edited public key",
+          username: ".*",
+          fingerprint: "fingerprint123",
+        },
       },
     });
   });
@@ -128,15 +142,6 @@ describe("Public Key Edit", () => {
   });
 
   it("Allows editing a public key with username restriction", async () => {
-    await wrapper.setProps({ keyObject: {
-      data: "fake key",
-      filter: {
-        hostname: ".*",
-      },
-      name: "my edited public key",
-      username: ".*",
-      fingerprint: "fingerprint123",
-    } });
     mockSsh.onPut("http://localhost:3000/api/sshkeys/public-keys/fingerprint123").reply(200);
     const pkEdit = vi.spyOn(store, "dispatch");
     await wrapper.findComponent('[data-test="public-key-edit-title-btn"]').trigger("click");

--- a/ui/tests/components/PublicKeys/PublicKeyEdit.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyEdit.spec.ts
@@ -88,9 +88,6 @@ describe("Public Key Edit", () => {
     wrapper = mount(PublicKeyEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/PublicKeys/PublicKeyList.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyList.spec.ts
@@ -64,7 +64,12 @@ describe("Public Key List", () => {
   const res = {
     data: [
       {
-        data: "test-key",
+        data: `LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRR
+        UJBUVVBQTRHTkFEQ0JpUUtCZ1FDTHlMRjdUT0VhbFphdE5RcUlRQTdtd1d3WQoxcU5wN
+        Elzcm8ya04zdTdIUEh1WmN1VGxlRS94MWpXNFZSTUJTaWMrZzNxak5VaS9YVCtMYndzO
+        VRmN0ZqVUxLCnEwUzduRGRWNGRjYmYwdHJROWM4K3gvOHEvcURUWk13SC9sRXdVQ1hXQ
+        TF5YW5JVjllT1RMUURld0VnRUFHYzQKeDFOQ2NaWTVUY3dZanprNTN3SURBUUFCCi0t
+        LS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==`,
         fingerprint: "fake-fingerprint",
         created_at: "2020-05-01T00:00:00.000Z",
         tenant_id: "fake-tenant",

--- a/ui/tests/components/PublicKeys/PublicKeyList.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyList.spec.ts
@@ -103,9 +103,6 @@ describe("Public Key List", () => {
     wrapper = mount(PublicKeysList, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/QuickConnection/QuickConnection.spec.ts
+++ b/ui/tests/components/QuickConnection/QuickConnection.spec.ts
@@ -107,9 +107,6 @@ describe("Quick Connection", () => {
     wrapper = mount(QuickConnection, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Setting/SettingNamespace.spec.ts
+++ b/ui/tests/components/Setting/SettingNamespace.spec.ts
@@ -114,9 +114,6 @@ describe("Setting Namespace", () => {
     wrapper = mount(SettingNamespace, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Setting/SettingProfile.spec.ts
+++ b/ui/tests/components/Setting/SettingProfile.spec.ts
@@ -91,9 +91,6 @@ describe("Settings Namespace", () => {
     wrapper = mount(SettingProfile, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Tags/TagEdit.spec.ts
+++ b/ui/tests/components/Tags/TagEdit.spec.ts
@@ -122,9 +122,6 @@ describe("Tag Form Edit", async () => {
     wrapper = mount(TagEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
     await wrapper.setProps({ tag: "tag-test" });

--- a/ui/tests/components/Team/ApiKeys/ApiKeyDelete.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyDelete.spec.ts
@@ -109,9 +109,6 @@ describe("Api Key Delete", () => {
     wrapper = mount(ApiKeyDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
     await wrapper.setProps({ keyId: "fake-id" });

--- a/ui/tests/components/Team/ApiKeys/ApiKeyEdit.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyEdit.spec.ts
@@ -109,9 +109,6 @@ describe("Api Key Edit", () => {
     wrapper = mount(ApiKeyEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Team/ApiKeys/ApiKeyGenerate.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyGenerate.spec.ts
@@ -113,9 +113,6 @@ describe("Api Key Generate", () => {
     wrapper = mount(ApiKeyGenerate, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Team/ApiKeys/ApiKeyList.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyList.spec.ts
@@ -107,9 +107,6 @@ describe("Api Key List", () => {
     wrapper = mount(ApiKeyList, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Team/Member/MemberDelete.spec.ts
+++ b/ui/tests/components/Team/Member/MemberDelete.spec.ts
@@ -85,9 +85,6 @@ describe("Member Delete", () => {
     wrapper = mount(MemberDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       attachTo: el,
     });

--- a/ui/tests/components/Terminal/TerminalDialog.spec.ts
+++ b/ui/tests/components/Terminal/TerminalDialog.spec.ts
@@ -118,9 +118,6 @@ describe("Terminal Dialog", async () => {
     wrapper = mount(TerminalDialog, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Tunnels/TunnelCreate.spec.ts
+++ b/ui/tests/components/Tunnels/TunnelCreate.spec.ts
@@ -131,9 +131,6 @@ describe("Tunnel Create", async () => {
     wrapper = mount(TunnelCreate, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       props: {
         uid: "fake-uid",

--- a/ui/tests/components/Tunnels/TunnelDelete.spec.ts
+++ b/ui/tests/components/Tunnels/TunnelDelete.spec.ts
@@ -124,9 +124,6 @@ describe("Tunnel Delete", async () => {
     wrapper = mount(TunnelDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       props: {
         uid: "fake-uid",

--- a/ui/tests/components/Tunnels/TunnelList.spec.ts
+++ b/ui/tests/components/Tunnels/TunnelList.spec.ts
@@ -138,9 +138,6 @@ describe("Tunnel List", () => {
     wrapper = mount(TunnelList, {
       global: {
         plugins: [[store, key], vuetify, [router], SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Users/ChangePassword.spec.ts
+++ b/ui/tests/components/Users/ChangePassword.spec.ts
@@ -59,9 +59,6 @@ describe("Change Password", () => {
     wrapper = mount(ChangePassword, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Users/PaywallDialog.spec.ts
+++ b/ui/tests/components/Users/PaywallDialog.spec.ts
@@ -106,9 +106,6 @@ describe("PaywallDialog", async () => {
     wrapper = mount(PaywallDialog, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Users/UserDelete.spec.ts
+++ b/ui/tests/components/Users/UserDelete.spec.ts
@@ -60,9 +60,6 @@ describe("User Delete", () => {
     wrapper = mount(UserDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Welcome/Welcome.spec.ts
+++ b/ui/tests/components/Welcome/Welcome.spec.ts
@@ -70,9 +70,6 @@ describe("Welcome", () => {
     wrapper = mount(Welcome, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Welcome/WelcomeFourthScreen.spec.ts
+++ b/ui/tests/components/Welcome/WelcomeFourthScreen.spec.ts
@@ -63,9 +63,6 @@ describe("Welcome Fourth Screen", () => {
     wrapper = mount(WelcomeFourthScreen, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/Welcome/WelcomeSecondScreen.spec.ts
+++ b/ui/tests/components/Welcome/WelcomeSecondScreen.spec.ts
@@ -66,9 +66,6 @@ describe("Welcome Second Screen", () => {
     wrapper = mount(WelcomeSecondScreen, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/firewall/FirewallRuleAdd.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleAdd.spec.ts
@@ -6,7 +6,7 @@ import { store, key } from "@/store";
 import FirewallRuleAdd from "@/components/firewall/FirewallRuleAdd.vue";
 import { envVariables } from "@/envVariables";
 import { router } from "@/router";
-import { namespacesApi, rulesApi } from "@/api/http";
+import { namespacesApi, rulesApi, tagsApi } from "@/api/http";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 import { INotificationsError } from "@/interfaces/INotifications";
 
@@ -24,6 +24,8 @@ describe("Firewall Rule Add", () => {
   let mockNamespace: MockAdapter;
 
   let mockFirewall: MockAdapter;
+
+  let mockTags: MockAdapter;
 
   const members = [
     {
@@ -64,8 +66,10 @@ describe("Firewall Rule Add", () => {
 
     mockNamespace = new MockAdapter(namespacesApi.getAxios());
     mockFirewall = new MockAdapter(rulesApi.getAxios());
+    mockTags = new MockAdapter(tagsApi.getAxios());
 
     mockNamespace.onGet("http://localhost:3000/api/namespaces/fake-tenant-data").reply(200, namespaceData);
+    mockTags.onGet("http://localhost:3000/api/tags").reply(200);
 
     store.commit("auth/authSuccess", authData);
     store.commit("namespaces/setNamespace", namespaceData);

--- a/ui/tests/components/firewall/FirewallRuleAdd.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleAdd.spec.ts
@@ -73,9 +73,6 @@ describe("Firewall Rule Add", () => {
     wrapper = mount(FirewallRuleAdd, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/firewall/FirewallRuleDelete.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleDelete.spec.ts
@@ -73,9 +73,6 @@ describe("Firewall Rule Delete", () => {
     wrapper = mount(FirewallRuleDelete, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/firewall/FirewallRuleEdit.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleEdit.spec.ts
@@ -6,7 +6,7 @@ import { store, key } from "@/store";
 import FirewallRuleEdit from "@/components/firewall/FirewallRuleEdit.vue";
 import { envVariables } from "@/envVariables";
 import { router } from "@/router";
-import { namespacesApi, rulesApi } from "@/api/http";
+import { namespacesApi, rulesApi, tagsApi } from "@/api/http";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 import { INotificationsError } from "@/interfaces/INotifications";
 
@@ -24,6 +24,8 @@ describe("Firewall Rule Edit", () => {
   let mockNamespace: MockAdapter;
 
   let mockFirewall: MockAdapter;
+
+  let mockTags: MockAdapter;
 
   const members = [
     {
@@ -77,8 +79,10 @@ describe("Firewall Rule Edit", () => {
 
     mockNamespace = new MockAdapter(namespacesApi.getAxios());
     mockFirewall = new MockAdapter(rulesApi.getAxios());
+    mockTags = new MockAdapter(tagsApi.getAxios());
 
     mockNamespace.onGet("http://localhost:3000/api/namespaces/fake-tenant-data").reply(200, namespaceData);
+    mockTags.onGet("http://localhost:3000/api/tags").reply(200);
 
     store.commit("auth/authSuccess", authData);
     store.commit("namespaces/setNamespace", namespaceData);
@@ -86,6 +90,11 @@ describe("Firewall Rule Edit", () => {
     wrapper = mount(FirewallRuleEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
+      },
+      props: {
+        firewallRule: {
+          action: "",
+        },
       },
     });
   });

--- a/ui/tests/components/firewall/FirewallRuleEdit.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleEdit.spec.ts
@@ -86,9 +86,6 @@ describe("Firewall Rule Edit", () => {
     wrapper = mount(FirewallRuleEdit, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/components/firewall/FirewallRuleList.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleList.spec.ts
@@ -102,9 +102,6 @@ describe("Firewall Rule List", () => {
     wrapper = mount(FirewallRuleList, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/ConfirmAccount.spec.ts
+++ b/ui/tests/views/ConfirmAccount.spec.ts
@@ -28,9 +28,6 @@ describe("Login", () => {
     wrapper = mount(ConfirmAccount, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/DetailsDevice.spec.ts
+++ b/ui/tests/views/DetailsDevice.spec.ts
@@ -137,9 +137,6 @@ describe("Details Device", () => {
     wrapper = mount(DetailsDevice, {
       global: {
         plugins: [[store, key], vuetify, [router], SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/DetailsSessions.spec.ts
+++ b/ui/tests/views/DetailsSessions.spec.ts
@@ -146,9 +146,6 @@ describe("Details Sessions", () => {
     wrapper = mount(DetailsSessions, {
       global: {
         plugins: [[store, key], vuetify, [router], SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/Devices.spec.ts
+++ b/ui/tests/views/Devices.spec.ts
@@ -100,9 +100,6 @@ describe("Devices View", () => {
     wrapper = mount(Devices, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/FirewallRules.spec.ts
+++ b/ui/tests/views/FirewallRules.spec.ts
@@ -108,9 +108,6 @@ describe("Firewall Rules", () => {
     wrapper = mount(FirewallRules, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/Home.spec.ts
+++ b/ui/tests/views/Home.spec.ts
@@ -89,9 +89,6 @@ describe("Home", () => {
     wrapper = mount(Home, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/MfaResetValidation.spec.ts
+++ b/ui/tests/views/MfaResetValidation.spec.ts
@@ -68,9 +68,6 @@ describe("Validate Recovery Mail", () => {
     wrapper = mount(MfaResetValidation, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/NamespaceInviteCard.spec.ts
+++ b/ui/tests/views/NamespaceInviteCard.spec.ts
@@ -82,9 +82,6 @@ describe("Namespace Invite Dialog (Invalid User)", () => {
     wrapper = mount(NamespaceInviteCard, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });
@@ -124,9 +121,6 @@ describe("Namespace Invite Dialog", () => {
     wrapper = mount(NamespaceInviteCard, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/NotFound.spec.ts
+++ b/ui/tests/views/NotFound.spec.ts
@@ -14,9 +14,6 @@ describe("Not Found Page", () => {
     wrapper = mount(NotFound, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/PublicKeys.spec.ts
+++ b/ui/tests/views/PublicKeys.spec.ts
@@ -109,9 +109,6 @@ describe("Public Keys", () => {
     wrapper = mount(PublicKeys, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/Sessions.spec.ts
+++ b/ui/tests/views/Sessions.spec.ts
@@ -138,9 +138,6 @@ describe("Sessions View", () => {
     wrapper = mount(Sessions, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/Settings.spec.ts
+++ b/ui/tests/views/Settings.spec.ts
@@ -16,9 +16,6 @@ describe("Settings View", () => {
     wrapper = mount(Settings, {
       global: {
         plugins: [[store, key], vuetify, router],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/TeamApiKeys.spec.ts
+++ b/ui/tests/views/TeamApiKeys.spec.ts
@@ -116,9 +116,6 @@ describe("Team Api Keys", () => {
     wrapper = mount(TeamApiKeys, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/TeamMembers.spec.ts
+++ b/ui/tests/views/TeamMembers.spec.ts
@@ -103,9 +103,6 @@ describe("Team Members", () => {
     wrapper = mount(TeamMembers, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });

--- a/ui/tests/views/UpdatePassword.spec.ts
+++ b/ui/tests/views/UpdatePassword.spec.ts
@@ -28,9 +28,6 @@ describe("Update Password", () => {
     wrapper = mount(UpdatePassword, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });


### PR DESCRIPTION
Removed `errorHandler` configuration from test components to
allow unhandled exceptions to surface during tests.
This prevents silent error suppression and ensures test
failures are properly reported.
