### PR TITLE
fix: resolve golangci-lint warnings in #4462

### DIFF
--- a/devscripts/lint-code
+++ b/devscripts/lint-code
@@ -44,13 +44,13 @@ go() {
         # Run golangci-lint on a running container
         docker-compose \
             -f docker-compose.yml -f docker-compose.dev.yml \
-            exec $container golangci-lint run ./... $EXTRA_ARGS
+            exec $container golangci-lint run ./... $EXTRA_ARGS --timeout=2m
     done
 
     echo "Running Golang linter on pkg"
     docker-compose \
 	    -f docker-compose.yml -f docker-compose.dev.yml \
-	    exec api sh -c "(cd ../pkg; golangci-lint run $EXTRA_ARGS ./... )"
+	    exec api sh -c "(cd ../pkg; golangci-lint run $EXTRA_ARGS ./...  --timeout=2m )"
 }
 
 vue() {


### PR DESCRIPTION
fix: resolve golangci-lint warnings in #4462

- Update golangci-lint for they last version and resolve reported issues in api, ssh, agent, and pkg projects. 
- Includes fixes for unused parameters and style violations while maintaining existing functionality.
- issue of reference #4462