### PR TITLE
feat(ui): add TTL support and expiration management

### DIFF
--- a/ui/src/api/client/api.ts
+++ b/ui/src/api/client/api.ts
@@ -1211,17 +1211,23 @@ export interface CreatePublicKey200Response {
  */
 export interface CreateTunnelRequest {
     /**
-     * The host address by the tunnel.
+     * Tunnel\'s agent host address
      * @type {string}
      * @memberof CreateTunnelRequest
      */
-    'host'?: string;
+    'host': string;
     /**
-     * The port number used by the tunnel.
+     * Tunnel\'s agent port number
      * @type {number}
      * @memberof CreateTunnelRequest
      */
-    'port'?: number;
+    'port': number;
+    /**
+     * Tunnel\'s time to live in seconds
+     * @type {number}
+     * @memberof CreateTunnelRequest
+     */
+    'ttl': number;
 }
 /**
  * 
@@ -2658,6 +2664,12 @@ export interface Session {
      * @memberof Session
      */
     'position'?: SessionPosition;
+    /**
+     * 
+     * @type {SessionEvents}
+     * @memberof Session
+     */
+    'events'?: SessionEvents;
 }
 
 export const SessionTypeEnum = {
@@ -2667,6 +2679,50 @@ export const SessionTypeEnum = {
 
 export type SessionTypeEnum = typeof SessionTypeEnum[keyof typeof SessionTypeEnum];
 
+/**
+ * Session\'s events
+ * @export
+ * @interface SessionEvents
+ */
+export interface SessionEvents {
+    /**
+     * Session\'s set of types
+     * @type {Array<string>}
+     * @memberof SessionEvents
+     */
+    'types'?: Array<string>;
+    /**
+     * Session\'s list of events
+     * @type {Array<SessionEventsItemsInner>}
+     * @memberof SessionEvents
+     */
+    'items'?: Array<SessionEventsItemsInner>;
+}
+/**
+ * 
+ * @export
+ * @interface SessionEventsItemsInner
+ */
+export interface SessionEventsItemsInner {
+    /**
+     * The type of the event
+     * @type {string}
+     * @memberof SessionEventsItemsInner
+     */
+    'type'?: string;
+    /**
+     * The time the event occurred in ISO 8601 format
+     * @type {string}
+     * @memberof SessionEventsItemsInner
+     */
+    'timestamp'?: string;
+    /**
+     * Additional data related to the event
+     * @type {object}
+     * @memberof SessionEventsItemsInner
+     */
+    'data'?: object;
+}
 /**
  * Session\'s geolocation position
  * @export
@@ -2763,7 +2819,7 @@ export interface Support {
  */
 export interface Tunnel {
     /**
-     * The unique address associated with the tunnel
+     * Tunnel\'s unique address
      * @type {string}
      * @memberof Tunnel
      */
@@ -2781,17 +2837,35 @@ export interface Tunnel {
      */
     'device'?: string;
     /**
-     * The host address by the tunnel.
+     * Tunnel\'s agent host address
      * @type {string}
      * @memberof Tunnel
      */
     'host'?: string;
     /**
-     * The port number used by the tunnel.
+     * Tunnel\'s agent port number
      * @type {number}
      * @memberof Tunnel
      */
     'port'?: number;
+    /**
+     * Tunnel\'s time to live in seconds
+     * @type {number}
+     * @memberof Tunnel
+     */
+    'ttl'?: number;
+    /**
+     * Tunnel\'s expiration date
+     * @type {string}
+     * @memberof Tunnel
+     */
+    'expires_in'?: string;
+    /**
+     * Tunnel\'s creation date
+     * @type {string}
+     * @memberof Tunnel
+     */
+    'created_at'?: string;
 }
 /**
  * 
@@ -8067,10 +8141,12 @@ export const DevicesApiAxiosParamCreator = function (configuration?: Configurati
          * List the tunnels per devices.
          * @summary List tunnels
          * @param {string} uid Device\&#39;s UID
+         * @param {number} [page] Page number
+         * @param {number} [perPage] Items per page
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listTunnels: async (uid: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listTunnels: async (uid: string, page?: number, perPage?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'uid' is not null or undefined
             assertParamExists('listTunnels', 'uid', uid)
             const localVarPath = `/api/devices/{uid}/tunnels`
@@ -8089,6 +8165,14 @@ export const DevicesApiAxiosParamCreator = function (configuration?: Configurati
             // authentication jwt required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (page !== undefined) {
+                localVarQueryParameter['page'] = page;
+            }
+
+            if (perPage !== undefined) {
+                localVarQueryParameter['per_page'] = perPage;
+            }
 
 
     
@@ -8410,11 +8494,13 @@ export const DevicesApiFp = function(configuration?: Configuration) {
          * List the tunnels per devices.
          * @summary List tunnels
          * @param {string} uid Device\&#39;s UID
+         * @param {number} [page] Page number
+         * @param {number} [perPage] Items per page
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listTunnels(uid: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Tunnel>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listTunnels(uid, options);
+        async listTunnels(uid: string, page?: number, perPage?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Tunnel>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listTunnels(uid, page, perPage, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -8598,11 +8684,13 @@ export const DevicesApiFactory = function (configuration?: Configuration, basePa
          * List the tunnels per devices.
          * @summary List tunnels
          * @param {string} uid Device\&#39;s UID
+         * @param {number} [page] Page number
+         * @param {number} [perPage] Items per page
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listTunnels(uid: string, options?: any): AxiosPromise<Array<Tunnel>> {
-            return localVarFp.listTunnels(uid, options).then((request) => request(axios, basePath));
+        listTunnels(uid: string, page?: number, perPage?: number, options?: any): AxiosPromise<Array<Tunnel>> {
+            return localVarFp.listTunnels(uid, page, perPage, options).then((request) => request(axios, basePath));
         },
         /**
          * Update device\'s data.
@@ -8803,12 +8891,14 @@ export class DevicesApi extends BaseAPI {
      * List the tunnels per devices.
      * @summary List tunnels
      * @param {string} uid Device\&#39;s UID
+     * @param {number} [page] Page number
+     * @param {number} [perPage] Items per page
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DevicesApi
      */
-    public listTunnels(uid: string, options?: AxiosRequestConfig) {
-        return DevicesApiFp(this.configuration).listTunnels(uid, options).then((request) => request(this.axios, this.basePath));
+    public listTunnels(uid: string, page?: number, perPage?: number, options?: AxiosRequestConfig) {
+        return DevicesApiFp(this.configuration).listTunnels(uid, page, perPage, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -15204,10 +15294,12 @@ export const TunnelsApiAxiosParamCreator = function (configuration?: Configurati
          * List the tunnels per devices.
          * @summary List tunnels
          * @param {string} uid Device\&#39;s UID
+         * @param {number} [page] Page number
+         * @param {number} [perPage] Items per page
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listTunnels: async (uid: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listTunnels: async (uid: string, page?: number, perPage?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'uid' is not null or undefined
             assertParamExists('listTunnels', 'uid', uid)
             const localVarPath = `/api/devices/{uid}/tunnels`
@@ -15226,6 +15318,14 @@ export const TunnelsApiAxiosParamCreator = function (configuration?: Configurati
             // authentication jwt required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (page !== undefined) {
+                localVarQueryParameter['page'] = page;
+            }
+
+            if (perPage !== undefined) {
+                localVarQueryParameter['per_page'] = perPage;
+            }
 
 
     
@@ -15276,11 +15376,13 @@ export const TunnelsApiFp = function(configuration?: Configuration) {
          * List the tunnels per devices.
          * @summary List tunnels
          * @param {string} uid Device\&#39;s UID
+         * @param {number} [page] Page number
+         * @param {number} [perPage] Items per page
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listTunnels(uid: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Tunnel>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listTunnels(uid, options);
+        async listTunnels(uid: string, page?: number, perPage?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Tunnel>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listTunnels(uid, page, perPage, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -15319,11 +15421,13 @@ export const TunnelsApiFactory = function (configuration?: Configuration, basePa
          * List the tunnels per devices.
          * @summary List tunnels
          * @param {string} uid Device\&#39;s UID
+         * @param {number} [page] Page number
+         * @param {number} [perPage] Items per page
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listTunnels(uid: string, options?: any): AxiosPromise<Array<Tunnel>> {
-            return localVarFp.listTunnels(uid, options).then((request) => request(axios, basePath));
+        listTunnels(uid: string, page?: number, perPage?: number, options?: any): AxiosPromise<Array<Tunnel>> {
+            return localVarFp.listTunnels(uid, page, perPage, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -15365,12 +15469,14 @@ export class TunnelsApi extends BaseAPI {
      * List the tunnels per devices.
      * @summary List tunnels
      * @param {string} uid Device\&#39;s UID
+     * @param {number} [page] Page number
+     * @param {number} [perPage] Items per page
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TunnelsApi
      */
-    public listTunnels(uid: string, options?: AxiosRequestConfig) {
-        return TunnelsApiFp(this.configuration).listTunnels(uid, options).then((request) => request(this.axios, this.basePath));
+    public listTunnels(uid: string, page?: number, perPage?: number, options?: AxiosRequestConfig) {
+        return TunnelsApiFp(this.configuration).listTunnels(uid, page, perPage, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/ui/src/components/Tunnels/TunnelList.vue
+++ b/ui/src/components/Tunnels/TunnelList.vue
@@ -18,6 +18,7 @@
           v-for="(tunnel, i) in tunnelList"
           :key="i"
           :data-test="`device-tunnel-row-${i}`"
+          :class="formatKey(tunnel.expires_in) ? 'text-warning' : ''"
         >
           <td class="text-center" data-test="device-tunnel-url">
             <a
@@ -36,6 +37,13 @@
 
           <td class="text-center" data-test="device-tunnel-port">
             {{ tunnel.port }}
+          </td>
+
+          <td
+            class="text-center"
+            data-test="device-tunnel-expiration-date"
+          >
+            {{ formatDate(tunnel.expires_in) }}
           </td>
 
           <td class="text-center" data-test="device-tunnel-actions">
@@ -58,6 +66,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
+import moment from "moment";
 import { useStore } from "@/store";
 import TunnelDelete from "./TunnelDelete.vue";
 import { envVariables } from "@/envVariables";
@@ -93,10 +102,35 @@ const headers = [
     value: "port",
   },
   {
+    text: "Expiration Date",
+    value: "expires_in",
+  },
+  {
     text: "Actions",
     value: "actions",
   },
 ];
+
+const now = moment().utc();
+
+const formatKey = (date: string) => {
+  if (date === "0001-01-01T00:00:00Z") return false;
+
+  const expiryDate = moment(date);
+
+  return now.isAfter(expiryDate);
+};
+
+const formatDate = (expiresIn: string) => {
+  if (expiresIn === "0001-01-01T00:00:00Z") return "Never Expires";
+
+  const expirationDate = moment(expiresIn);
+  const format = "MMM D YYYY, h:mm:s";
+
+  return now.isAfter(expirationDate)
+    ? `Expired on ${expirationDate.format(format)}.`
+    : `Expires on ${expirationDate.format(format)}.`;
+};
 
 defineExpose({ getTunnels });
 </script>

--- a/ui/src/interfaces/ITunnel.ts
+++ b/ui/src/interfaces/ITunnel.ts
@@ -9,7 +9,8 @@ export interface ITunnel {
 export interface ITunnelCreate {
   uid: string,
   host: string,
-  port: number
+  port: number,
+  ttl: number
 }
 
 export interface ITunnelDelete{

--- a/ui/src/store/api/tunnels.ts
+++ b/ui/src/store/api/tunnels.ts
@@ -2,11 +2,12 @@ import { tunnelApi } from "../../api/http";
 
 const getTunnels = (uid: string) => tunnelApi.listTunnels(uid);
 
-const createTunnel = (uid: string, host: string, port: number) => tunnelApi.createTunnel(
+const createTunnel = (uid: string, host: string, port: number, ttl: number) => tunnelApi.createTunnel(
   uid,
   {
     host,
     port,
+    ttl,
   },
 );
 

--- a/ui/src/store/modules/tunnels.ts
+++ b/ui/src/store/modules/tunnels.ts
@@ -37,8 +37,8 @@ export const tunnels: Module<TunnelsState, State> = {
     },
 
     async create(_, data: ITunnelCreate) {
-      const { uid, host, port } = data;
-      const res = await apiTunnel.createTunnel(uid, host, port);
+      const { uid, host, port, ttl } = data;
+      const res = await apiTunnel.createTunnel(uid, host, port, ttl);
       return res;
     },
   },

--- a/ui/tests/components/Tunnels/TunnelCreate.spec.ts
+++ b/ui/tests/components/Tunnels/TunnelCreate.spec.ts
@@ -165,6 +165,7 @@ describe("Tunnel Create", async () => {
     expect(dialog.find('[data-test="create-dialog-title"]').exists()).toBe(true);
     expect(dialog.find('[data-test="tunnel-create-alert"]').exists()).toBe(false);
     expect(dialog.find('[data-test="tunnel-create-text"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="timeout-combobox"]').exists()).toBe(true);
     expect(dialog.find('[data-test="address-text"]').exists()).toBe(true);
     expect(dialog.find('[data-test="port-text"]').exists()).toBe(true);
     expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);
@@ -181,6 +182,7 @@ describe("Tunnel Create", async () => {
 
     await wrapper.findComponent('[data-test="address-text"]').setValue("127.0.0.1");
     await wrapper.findComponent('[data-test="port-text"]').setValue(8080);
+    await wrapper.findComponent('[data-test="timeout-combobox"]').setValue(-1);
 
     await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
 
@@ -189,6 +191,7 @@ describe("Tunnel Create", async () => {
     expect(StoreSpy).toHaveBeenCalledWith("tunnels/create", {
       uid: "fake-uid",
       host: "127.0.0.1",
+      ttl: -1,
       port: 8080,
     });
   });
@@ -201,6 +204,7 @@ describe("Tunnel Create", async () => {
 
     await wrapper.findComponent('[data-test="address-text"]').setValue("bad-address");
     await wrapper.findComponent('[data-test="port-text"]').setValue("bad-port");
+    await wrapper.findComponent('[data-test="timeout-combobox"]').setValue(-1);
 
     await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
 

--- a/ui/tests/components/Tunnels/TunnelList.spec.ts
+++ b/ui/tests/components/Tunnels/TunnelList.spec.ts
@@ -159,11 +159,12 @@ describe("Tunnel List", () => {
 
   it("Renders table headers", () => {
     const headers = wrapper.findAll('[data-test^="device-tunnels-header-"]');
-    expect(headers.length).toBe(4);
+    expect(headers.length).toBe(5);
     expect(headers[0].text()).toBe("Address");
     expect(headers[1].text()).toBe("Host");
     expect(headers[2].text()).toBe("Port");
-    expect(headers[3].text()).toBe("Actions");
+    expect(headers[3].text()).toBe("Expiration Date");
+    expect(headers[4].text()).toBe("Actions");
   });
 
   it("Renders table rows", async () => {

--- a/ui/tests/components/Tunnels/__snapshots__/TunnelList.spec.ts.snap
+++ b/ui/tests/components/Tunnels/__snapshots__/TunnelList.spec.ts.snap
@@ -10,7 +10,8 @@ exports[`Tunnel List > Renders the component 1`] = `
           <th class="text-center" data-test="device-tunnels-header-0"><span>Address</span></th>
           <th class="text-center" data-test="device-tunnels-header-1"><span>Host</span></th>
           <th class="text-center" data-test="device-tunnels-header-2"><span>Port</span></th>
-          <th class="text-center" data-test="device-tunnels-header-3"><span>Actions</span></th>
+          <th class="text-center" data-test="device-tunnels-header-3"><span>Expiration Date</span></th>
+          <th class="text-center" data-test="device-tunnels-header-4"><span>Actions</span></th>
         </tr>
       </thead>
       <div class="pa-4 text-subtitle-2" data-test="device-tunnels-empty">


### PR DESCRIPTION
# Description

This PR introduces Time-To-Live (TTL) support and expiration management for tunnels. It includes updates to the API, frontend components, and tests to accommodate the new TTL feature. Users can now specify a tunnel's TTL when creating it and view its expiration details in the tunnel list.
Changes
API Updates

    Added ttl field:
        CreateTunnelRequest and Tunnel interfaces now support ttl for tunnel creation.
        Backend API methods (listTunnels, createTunnel) updated to handle TTL and pagination (page, perPage).
    New expiration fields:
        expires_in added to Tunnel to represent expiration details.

Frontend Updates

    TunnelCreate.vue:
        Added a combobox for TTL selection with predefined timeouts (e.g., 1 minute, 1 hour, 1 week).
        Validates TTL input using yup.
    TunnelList.vue:
        Displays expiration date (expires_in) in a new column.
        Highlights expired tunnels with a warning style.

## Utilities

    Used moment for expiration date formatting and expiration checks.

## Tests

    Updated TunnelCreate.spec.ts and TunnelList.spec.ts to verify TTL functionality.
    Added snapshot updates for TunnelList.

## How to Test

    Create a tunnel with TTL:
        Navigate to the "Create Tunnel" modal and select a TTL value.
        Verify the tunnel is created with the specified TTL.

    View tunnel expiration:
        Navigate to the "Tunnel List" page.
        Confirm expiration dates are displayed and expired tunnels are highlighted.

    Run tests:
        Execute unit tests to ensure functionality (yarn test).

## Checklist

- [x] Added TTL functionality to API and frontend.
- [x] Updated tests and snapshots.
- [x] Verified backward compatibility with existing features.
- [x] Added documentation or comments where necessary.