### PR TITLE
fix(ui): show 'Image' instead 'Operating System' for containers

### DIFF
--- a/ui/src/components/Tables/DeviceTable.vue
+++ b/ui/src/components/Tables/DeviceTable.vue
@@ -305,7 +305,7 @@ const headers = [
     sortable: true,
   },
   {
-    text: "Operating System",
+    text: props.variant === "device" ? "Operating System" : "Image",
     value: "operating_system",
   },
   {
@@ -329,7 +329,7 @@ const headersSecondary = [
     sortable: true,
   },
   {
-    text: "Operating System",
+    text: props.variant === "device" ? "Operating System" : "Image",
     value: "operating_system",
   },
   {

--- a/ui/tests/components/Containers/__snapshots__/ContainerList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerList.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`Container List > Renders the component 1`] = `
             <tr data-v-046d4556="">
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="" tabindex="0" class="hover" aria-describedby="v-tooltip-0">Online <!----><!--teleport start--><!--teleport end--></span></th>
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="" tabindex="0" class="hover" aria-describedby="v-tooltip-1">Hostname <!----><!--teleport start--><!--teleport end--></span></th>
-              <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Operating System</span></th>
+              <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Image</span></th>
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">SSHID</span></th>
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Tags</span></th>
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Actions</span></th>

--- a/ui/tests/components/Containers/__snapshots__/ContainerPendingList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerPendingList.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`Container Pending List > Renders the component 1`] = `
           <thead data-v-046d4556="" class="bg-v-theme-background">
             <tr data-v-046d4556="">
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="" tabindex="0" class="hover" aria-describedby="v-tooltip-0">Hostname <!----><!--teleport start--><!--teleport end--></span></th>
-              <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Operating System</span></th>
+              <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Image</span></th>
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Request Time</span></th>
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Actions</span></th>
             </tr>

--- a/ui/tests/components/Containers/__snapshots__/ContainerRejectList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerRejectList.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`Container Rejected List > Renders the component 1`] = `
           <thead data-v-046d4556="" class="bg-v-theme-background">
             <tr data-v-046d4556="">
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="" tabindex="0" class="hover" aria-describedby="v-tooltip-0">Hostname <!----><!--teleport start--><!--teleport end--></span></th>
-              <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Operating System</span></th>
+              <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Image</span></th>
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Request Time</span></th>
               <th data-v-046d4556="" class="text-center"><span data-v-046d4556="">Actions</span></th>
             </tr>


### PR DESCRIPTION
Now the device table can show dinamically:
- Operating System: For devices
- Image: For containers