### PR TITLE
refactor(ui): add custom timeout option for tunnel creation

### DIFF
--- a/ui/src/components/Tunnels/TunnelCreate.vue
+++ b/ui/src/components/Tunnels/TunnelCreate.vue
@@ -9,13 +9,15 @@
       <div class="mr-2" data-test="create-icon">
         <v-icon>mdi-web-plus</v-icon>
       </div>
-
       <v-list-item-title> Create Tunnel </v-list-item-title>
     </div>
   </v-list-item>
+
   <v-dialog v-model="dialog" max-width="450" @click:outside="close()">
     <v-card data-test="tunnel-create-dialog" class="bg-v-theme-surface">
-      <v-card-title class="bg-primary" data-test="create-dialog-title"> Create Device Tunnel </v-card-title>
+      <v-card-title class="bg-primary" data-test="create-dialog-title">
+        Create Device Tunnel
+      </v-card-title>
       <v-container>
         <v-alert
           v-if="alertText"
@@ -51,18 +53,28 @@
           </v-row>
           <v-row>
             <v-col>
-              <v-combobox
-                v-model.number="timeout"
+              <v-select
+                v-model="selectedTimeout"
                 :items="predefinedTimeouts"
                 item-title="text"
                 item-value="value"
-                :rules="[validateTimeout]"
                 label="Timeout (in seconds)"
                 variant="outlined"
                 data-test="timeout-combobox"
-                @update:model-value="onTimeoutChange"
               />
-
+            </v-col>
+          </v-row>
+          <v-row v-if="selectedTimeout === 'custom'">
+            <v-col>
+              <v-text-field
+                v-model.number="customTimeout"
+                label="Custom Timeout (in seconds)"
+                type="number"
+                min="1"
+                max="2624016"
+                variant="outlined"
+                data-test="custom-timeout"
+              />
             </v-col>
           </v-row>
         </v-card-text>
@@ -79,66 +91,24 @@
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from "vue";
 import { useField } from "vee-validate";
 import * as yup from "yup";
 import axios, { AxiosError } from "axios";
-import { ref } from "vue";
 import hasPermission from "@/utils/permission";
 import { actions, authorizer } from "@/authorizer";
 import { useStore } from "@/store";
-import {
-  INotificationsError,
-  INotificationsSuccess,
-} from "@/interfaces/INotifications";
 import handleError from "@/utils/handleError";
+import { INotificationsError, INotificationsSuccess } from "@/interfaces/INotifications";
 
-const props = defineProps({
-  uid: {
-    type: String,
-    required: true,
-  },
-});
-
+const props = defineProps({ uid: { type: String, required: true } });
 const emit = defineEmits(["update"]);
 const store = useStore();
-const dialog = defineModel({ default: false });
+const dialog = ref(false);
+const alertText = ref();
+const customTimeout = ref<number>(60);
 
-const {
-  value: host,
-  errorMessage: hostError,
-  resetField: resetHostRole,
-} = useField<string>(
-  "host",
-  yup
-    .string()
-    .required(),
-  {
-    initialValue: "127.0.0.1",
-  },
-);
-
-const {
-  value: port,
-  errorMessage: portError,
-  resetField: resetPortRole,
-} = useField<number>(
-  "port",
-  yup
-    .number()
-    .integer()
-    .max(65535)
-    .required(),
-  {
-    initialValue: undefined,
-  },
-);
-
-interface Timeout {
-  value: number,
-  text: string,
-}
-
-const predefinedTimeouts = ref<Array<Timeout>>([
+const predefinedTimeouts = ref([
   { value: -1, text: "Unlimited Timeout" },
   { value: 60, text: "1 minute" },
   { value: 300, text: "5 minutes" },
@@ -147,97 +117,53 @@ const predefinedTimeouts = ref<Array<Timeout>>([
   { value: 86400, text: "1 day" },
   { value: 604800, text: "1 week" },
   { value: 2624016, text: "1 month" },
+  { value: "custom", text: "Custom Expiration" },
 ]);
 
-const {
-  value: timeout,
-} = useField<number>(
-  "timeout",
+const selectedTimeout = ref<number | "custom">(-1);
+const timeout = computed(() => (selectedTimeout.value === "custom" ? customTimeout.value : selectedTimeout.value));
+
+const { value: host, errorMessage: hostError, resetField: resetHost } = useField<string>(
+  "host",
+  yup
+    .string()
+    .required(),
+  { initialValue: "127.0.0.1" },
+);
+
+const { value: port, errorMessage: portError, resetField: resetPort } = useField<number>(
+  "port",
   yup
     .number()
     .integer()
-    .min(1, "Value must be 1 or greater")
-    .max(2624016, "Value cannot exceed 1 month in seconds")
-    .required("Timeout is required"),
-  { initialValue: -1 },
+    .max(65535)
+    .required(),
+  { initialValue: undefined },
 );
-
-const onTimeoutChange = (newValue: Timeout | number) => {
-  switch (typeof newValue) {
-    case "object": timeout.value = newValue.value; break;
-    case "number": timeout.value = newValue; break;
-    default: timeout.value = predefinedTimeouts.value[0].value; break;
-  }
-};
-
-const validateTimeout = (value: number) => {
-  if (Number.isNaN(value)) return "Value must be a number";
-  return true;
-};
 
 const hasAuthorizationCreateTunnel = () => {
   const role = store.getters["auth/role"];
-  if (role !== "") {
-    return hasPermission(
-      authorizer.role[role],
-      actions.tunnel.create,
-    );
-  }
-  return false;
+  return role !== "" && hasPermission(authorizer.role[role], actions.tunnel.create);
 };
 
-const alertText = ref();
+const hasErrors = () => !!(portError.value || hostError.value || !port.value || !host.value || !timeout.value);
 
-const hasErrors = () => !!(
-  portError.value
-  || hostError.value
-  || !port.value
-  || !host.value
-  || !timeout.value
-  || !validateTimeout
-);
-
-const resetFields = () => {
-  resetPortRole();
-  resetHostRole();
-};
-
-const close = () => {
-  resetFields();
-  dialog.value = false;
-};
-
-const update = () => {
-  emit("update");
-  close();
-};
+const resetFields = () => { resetPort(); resetHost(); selectedTimeout.value = -1; customTimeout.value = 60; };
+const close = () => { resetFields(); dialog.value = false; };
+const update = () => { emit("update"); close(); };
 
 const addTunnel = async () => {
   if (!hasErrors()) {
     try {
-      await store.dispatch("tunnels/create", {
-        uid: props.uid,
-        host: host.value,
-        port: port.value,
-        ttl: timeout.value,
-      });
-
-      store.dispatch(
-        "snackbar/showSnackbarSuccessAction",
-        INotificationsSuccess.tunnelCreate,
-      );
+      await store.dispatch("tunnels/create", { uid: props.uid, host: host.value, port: port.value, ttl: timeout.value });
+      store.dispatch("snackbar/showSnackbarSuccessAction", INotificationsSuccess.tunnelCreate);
       update();
-      resetFields();
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {
-        const axiosError = error as AxiosError;
-        if (axiosError.response?.status === 403) {
+        if ((error as AxiosError).response?.status === 403) {
           alertText.value = "This device has reached the maximum allowed number of tunnels";
         } else {
-          store.dispatch(
-            "snackbar/showSnackbarErrorAction",
-            INotificationsError.tunnelCreate,
-          );
+          store.dispatch("snackbar/showSnackbarErrorAction", INotificationsError.tunnelCreate);
           handleError(error);
         }
       }

--- a/ui/tests/components/Tunnels/TunnelCreate.spec.ts
+++ b/ui/tests/components/Tunnels/TunnelCreate.spec.ts
@@ -131,9 +131,6 @@ describe("Tunnel Create", async () => {
     wrapper = mount(TunnelCreate, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
       props: {
         uid: "fake-uid",
@@ -168,6 +165,7 @@ describe("Tunnel Create", async () => {
     expect(dialog.find('[data-test="timeout-combobox"]').exists()).toBe(true);
     expect(dialog.find('[data-test="address-text"]').exists()).toBe(true);
     expect(dialog.find('[data-test="port-text"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="custom-timeout"]').exists()).toBe(false);
     expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);
     expect(dialog.find('[data-test="create-tunnel-btn"]').exists()).toBe(true);
   });
@@ -192,6 +190,32 @@ describe("Tunnel Create", async () => {
       uid: "fake-uid",
       host: "127.0.0.1",
       ttl: -1,
+      port: 8080,
+    });
+  });
+
+  it("Successfully added tunnel (custom expiration)", async () => {
+    mockTunnels.onPost("http://localhost:3000/api/devices/fake-uid/tunnels").reply(200, tunnelResponse);
+
+    const StoreSpy = vi.spyOn(store, "dispatch");
+
+    await wrapper.findComponent('[data-test="tunnel-create-dialog-btn"]').trigger("click");
+
+    await flushPromises();
+
+    await wrapper.findComponent('[data-test="address-text"]').setValue("127.0.0.1");
+    await wrapper.findComponent('[data-test="port-text"]').setValue(8080);
+    await wrapper.findComponent('[data-test="timeout-combobox"]').setValue("custom");
+    await wrapper.findComponent('[data-test="custom-timeout"]').setValue(6000);
+
+    await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
+
+    await flushPromises();
+
+    expect(StoreSpy).toHaveBeenCalledWith("tunnels/create", {
+      uid: "fake-uid",
+      host: "127.0.0.1",
+      ttl: 6000,
       port: 8080,
     });
   });


### PR DESCRIPTION
# Description

This PR introduces support for a custom timeout option in the tunnel creation dialog. Instead of only selecting from predefined timeout values, users can now choose a "Custom Expiration" option and manually input a timeout in seconds.
Changes

    UI Updates:
        Replaced v-combobox with v-select for timeout selection.
        Added a v-text-field for custom timeout input, displayed when "Custom Expiration" is selected.
    Logic Improvements:
        Introduced selectedTimeout state to handle both predefined and custom values.
        Used a computed property for the ttl value to dynamically determine the timeout.
        Adjusted validation and form reset behavior to support custom timeout values.
    Testing Enhancements:
        Updated unit tests to check visibility and functionality of the new custom timeout input.
        Added a test case to verify tunnel creation with a custom expiration.

## How to Test

    Open the tunnel creation dialog.
    Select the timeout dropdown and choose "Custom Expiration".
    Enter a custom timeout value (e.g., 6000 seconds).
    Click "Create Tunnel" and verify that the correct timeout is sent in the request.

## Checklist

- [x] Code follows project guidelines.
- [x] UI changes tested manually.
- [x] Unit tests updated and passing.
- [x] No breaking changes introduced.