### PR TITLE
feat(ui): improve fullscreen behavior and terminal rendering

### DIFF
--- a/ui/tests/components/Containers/__snapshots__/ContainerList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerList.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`Container List > Renders the component 1`] = `
           <tbody data-v-046d4556="">
             <tr data-v-787abe29="">
               <td data-v-787abe29="" class="text-center">
-                <div data-v-787abe29="" data-test="terminalDialog-component"><button type="button" class="v-btn v-btn--disabled v-theme--light text-normal v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" disabled="" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <div data-v-abcb598c="" data-v-787abe29="" data-test="terminalDialog-component"><button data-v-abcb598c="" type="button" class="v-btn v-btn--disabled v-theme--light text-normal v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" disabled="" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                     <!----><span class="v-btn__content" data-no-activator="">Offline</span>
                     <!---->
                     <!---->
@@ -63,7 +63,7 @@ exports[`Container List > Renders the component 1`] = `
             </tr>
             <tr data-v-787abe29="">
               <td data-v-787abe29="" class="text-center">
-                <div data-v-787abe29="" data-test="terminalDialog-component"><button type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <div data-v-abcb598c="" data-v-787abe29="" data-test="terminalDialog-component"><button data-v-abcb598c="" type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                     <!----><span class="v-btn__content" data-no-activator="">Connect</span>
                     <!---->
                     <!---->

--- a/ui/tests/components/Devices/__snapshots__/DeviceList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DeviceList.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`Device List > Renders the component 1`] = `
           <tbody data-v-046d4556="">
             <tr data-v-787abe29="">
               <td data-v-787abe29="" class="text-center">
-                <div data-v-787abe29="" data-test="terminalDialog-component"><button type="button" class="v-btn v-btn--disabled v-theme--light text-normal v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" disabled="" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <div data-v-abcb598c="" data-v-787abe29="" data-test="terminalDialog-component"><button data-v-abcb598c="" type="button" class="v-btn v-btn--disabled v-theme--light text-normal v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" disabled="" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                     <!----><span class="v-btn__content" data-no-activator="">Offline</span>
                     <!---->
                     <!---->
@@ -63,7 +63,7 @@ exports[`Device List > Renders the component 1`] = `
             </tr>
             <tr data-v-787abe29="">
               <td data-v-787abe29="" class="text-center">
-                <div data-v-787abe29="" data-test="terminalDialog-component"><button type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <div data-v-abcb598c="" data-v-787abe29="" data-test="terminalDialog-component"><button data-v-abcb598c="" type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                     <!----><span class="v-btn__content" data-no-activator="">Connect</span>
                     <!---->
                     <!---->

--- a/ui/tests/components/QuickConnection/__snapshots__/QuickConnectionList.spec.ts.snap
+++ b/ui/tests/components/QuickConnection/__snapshots__/QuickConnectionList.spec.ts.snap
@@ -28,7 +28,7 @@ exports[`Quick Connection List > Renders the component 1`] = `
           <!---->
           <!---->
           <div data-v-7c65953f="" class="v-row v-row--no-gutters align-center">
-            <div data-v-7c65953f="" data-test="terminalDialog-component">
+            <div data-v-abcb598c="" data-v-7c65953f="" data-test="terminalDialog-component">
               <!--v-if-->
               <!---->
               <!---->

--- a/ui/tests/components/Terminal/__snapshots__/TerminalDialog.spec.ts.snap
+++ b/ui/tests/components/Terminal/__snapshots__/TerminalDialog.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Terminal Dialog > Renders the component 1`] = `
-"<div>
+"<div data-v-abcb598c="">
   <!--v-if-->
   <!---->
   <!---->

--- a/ui/tests/views/__snapshots__/DetailsDevice.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/DetailsDevice.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`Details Device > Renders the component 1`] = `
   <!---->
   <div class="v-card-title pa-4 d-flex align-center justify-space-between">
     <div class="d-flex align-center">
-      <div data-test="terminalDialog-component"><button type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <div data-v-abcb598c="" data-test="terminalDialog-component"><button data-v-abcb598c="" type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator="">Connect</span>
           <!---->
           <!---->
@@ -105,7 +105,7 @@ exports[`Details Device > Renders the component when device has no last seen dat
   <!---->
   <div class="v-card-title pa-4 d-flex align-center justify-space-between">
     <div class="d-flex align-center">
-      <div data-test="terminalDialog-component"><button type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <div data-v-abcb598c="" data-test="terminalDialog-component"><button data-v-abcb598c="" type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator="">Connect</span>
           <!---->
           <!---->
@@ -186,7 +186,7 @@ exports[`Details Device > Renders the component when device has no tags 1`] = `
   <!---->
   <div class="v-card-title pa-4 d-flex align-center justify-space-between">
     <div class="d-flex align-center">
-      <div data-test="terminalDialog-component"><button type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <div data-v-abcb598c="" data-test="terminalDialog-component"><button data-v-abcb598c="" type="button" class="v-btn v-theme--light text-success v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator="">Connect</span>
           <!---->
           <!---->
@@ -267,7 +267,7 @@ exports[`Details Device > Renders the component when device is offline 1`] = `
   <!---->
   <div class="v-card-title pa-4 d-flex align-center justify-space-between">
     <div class="d-flex align-center">
-      <div data-test="terminalDialog-component"><button type="button" class="v-btn v-btn--disabled v-theme--light text-normal v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn" disabled=""><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <div data-v-abcb598c="" data-test="terminalDialog-component"><button data-v-abcb598c="" type="button" class="v-btn v-btn--disabled v-theme--light text-normal v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined" data-test="connect-btn" disabled=""><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator="">Offline</span>
           <!---->
           <!---->


### PR DESCRIPTION
- Adjust fullscreen logic to depend on `showLoginForm`
- Ensure terminal rendering is contained within a positioned div
- Remove unnecessary `v-card-item` wrapping the terminal
- Improve terminal initialization and WebSocket connection handling
- Add event listener for window resize to properly fit terminal
- Remove `variant="underlined"` from input fields for consistency
- Fix WebSocket initialization and resize handling
- Adjust styles to properly position the terminal
