### PR TITLE
feat(ui): auto-open terminal on specific route

### DIFF
--- a/ui/src/components/Terminal/TerminalDialog.vue
+++ b/ui/src/components/Terminal/TerminalDialog.vue
@@ -172,6 +172,7 @@ import { FitAddon } from "xterm-addon-fit";
 import * as yup from "yup";
 import axios from "axios";
 import { useEventListener } from "@vueuse/core";
+import { useRoute } from "vue-router";
 import { useStore } from "../../store";
 import {
   createKeyFingerprint,
@@ -210,6 +211,7 @@ const props = defineProps({
   },
 });
 const store = useStore();
+const route = useRoute();
 const tabActive = ref("Password");
 const showPassword = ref(false);
 const showLoginForm = ref(true);
@@ -370,6 +372,12 @@ const open = () => {
     xterm.value.reset();
   }
 };
+
+watch(() => route.path, (Path) => {
+  if (Path === `/devices/${props.uid}/terminal`) {
+    open();
+  }
+}, { immediate: true });
 
 const resetFieldValidation = () => {
   resetUsername();

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -318,6 +318,11 @@ export const routes: Array<RouteRecordRaw> = [
     component: DeviceDetails,
   },
   {
+    path: "/devices/:id/terminal",
+    name: "DeviceTerminal",
+    component: DeviceDetails,
+  },
+  {
     path: "/sessions",
     name: "Sessions",
     component: Sessions,


### PR DESCRIPTION
# Description:

This PR enhances the terminal dialog behavior by automatically opening it when navigating to the /devices/:id/terminal route.

## Changes:

    TerminalDialog.vue
        Added useRoute from Vue Router.
        Watched the route path to toggle showTerminal when the user navigates to /devices/:id/terminal.

    router/index.ts
        Defined a new route /devices/:id/terminal mapped to DeviceDetails to enable direct access to the terminal view.

## Why?

This improves user experience by allowing direct navigation to a device's terminal without requiring manual interaction.


## Testing:

    Navigated to /devices/:id/terminal, and the terminal opened automatically.
    Verified that other routes did not trigger unintended behavior.