### PR TITLE
feat(ui): close dialog on Escape key press

### DIFF
--- a/ui/src/components/Terminal/TerminalDialog.vue
+++ b/ui/src/components/Terminal/TerminalDialog.vue
@@ -17,6 +17,7 @@
       :fullscreen="!showLoginForm || $vuetify.display.smAndDown"
       :max-width="$vuetify.display.smAndDown ? undefined : $vuetify.display.thresholds.sm"
       @click:outside="close"
+      @keyup.esc="close()"
     >
       <v-card data-test="terminal-card" class="bg-v-theme-surface">
         <v-card-title


### PR DESCRIPTION
# Description

This PR enhances the terminal dialog by allowing users to close it using the Escape key. This improves usability and accessibility, especially for keyboard users.

## Changes

    Added @keyup.esc="close()" to TerminalDialog.vue
    Ensures the terminal dialog closes when the Escape key is pressed

## Why?

    Improves user experience by providing a familiar keyboard shortcut
    Enhances accessibility for users who prefer keyboard navigation

## Testing

    Open the terminal dialog
    Press the Escape key and verify that the dialog closes
    Ensure existing functionality (clicking outside to close) still works as expected