### PR TITLE
feat(ui): redesign terminal login form

### DIFF
--- a/ui/src/components/Terminal/TerminalDialog.vue
+++ b/ui/src/components/Terminal/TerminalDialog.vue
@@ -33,19 +33,9 @@
         </div>
 
         <div class="mt-2" v-if="showLoginForm">
-          <v-tabs align-tabs="center" color="primary" v-model="tabActive">
-            <v-tab value="Password" block data-test="password-tab" @click="resetFieldValidation">Password</v-tab>
-            <v-tab
-              value="PrivateKey"
-              @click="resetFieldValidation"
-              block
-              data-test="private-key-tab"
-            >Private Key</v-tab
-            >
-          </v-tabs>
 
           <v-card-text>
-            <v-window v-model="tabActive">
+            <v-window>
               <v-window-item value="Password">
                 <v-form lazy-validation @submit.prevent="connectWithPassword()">
                   <v-container>
@@ -66,12 +56,31 @@
                     </v-row>
                     <v-row>
                       <v-col>
+                        <v-select
+                          v-model="authenticationMethod"
+                          :items="['Password', 'Private Key']"
+                          label="Authentication method"
+                        />
+                      </v-col>
+                    </v-row>
+                    <v-row>
+                      <v-col>
+                        <v-select
+                          v-model="privateKey"
+                          v-if="authenticationMethod === 'Private Key'"
+                          :items="nameOfPrivateKeys"
+                          item-text="name"
+                          item-value="data"
+                          label="Private Key"
+                          hint="Select a private key file for authentication"
+                          persistent-hint
+                          data-test="privatekeys-select"
+                        />
                         <v-text-field
                           color="primary"
-                          :append-inner-icon="
-                            showPassword ? 'mdi-eye' : 'mdi-eye-off'
-                          "
+                          :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
                           v-model="password"
+                          v-if="authenticationMethod === 'Password'"
                           :error-messages="passwordError"
                           label="Password"
                           required
@@ -97,11 +106,12 @@
                     >
                       Connect
                     </v-btn>
+                    <v-spacer />
                   </v-card-actions>
                 </v-form>
               </v-window-item>
 
-              <v-window-item value="PrivateKey">
+              <v-window-item value="Private Key">
                 <v-form
                   lazy-validation
                   @submit.prevent="connectWithPrivateKey()">
@@ -118,20 +128,6 @@
                           persistent-placeholder
                           :validate-on-blur="true"
                           data-test="username-field-pk"
-                        />
-                      </v-col>
-                    </v-row>
-                    <v-row>
-                      <v-col>
-                        <v-select
-                          v-model="privateKey"
-                          :items="nameOfPrivateKeys"
-                          item-text="name"
-                          item-value="data"
-                          label="Private Key"
-                          hint="Select a private key file for authentication"
-                          persistent-hint
-                          data-test="privatekeys-select"
                         />
                       </v-col>
                     </v-row>
@@ -215,7 +211,7 @@ const props = defineProps({
 });
 const store = useStore();
 const route = useRoute();
-const tabActive = ref("Password");
+const authenticationMethod = ref("Password");
 const showPassword = ref(false);
 const showLoginForm = ref(true);
 const privateKey = ref("");


### PR DESCRIPTION
This commit unifies Password and Private Key tabs on terminal login form.
It allows the user to easily change the authentication method using just the keyboard.