### PR TITLE
feat(ui): add paywall check for chat support access

### DIFF
--- a/ui/src/components/User/PaywallChat.vue
+++ b/ui/src/components/User/PaywallChat.vue
@@ -1,0 +1,93 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    transition="dialog-bottom-transition"
+    max-width="600"
+    @click:outside="close"
+    @keydown.esc="close"
+  >
+    <v-card color="background" data-test="card-dialog">
+      <v-container>
+        <v-row data-test="icon-chat">
+          <v-col class="d-flex justify-center align-center">
+            <div class="circle-one shadow d-flex justify-center align-center">
+              <div class="circle-two shadow d-flex justify-center align-center">
+                <v-icon color="success" class="green-inner-shadow" size="108">
+                  mdi-chat-question
+                </v-icon>
+              </div>
+            </div>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col class="pb-0">
+            <h1 class="d-flex justify-center align-center text-center" data-test="upgrade-heading">
+              Upgrade to have access to chat support!
+            </h1>
+          </v-col>
+        </v-row>
+        <v-row class="px-6">
+          <v-col class="pt-1 pb-6">
+            <p class="d-flex justify-center align-center text-grey text-center" data-test="upgrade-description">
+              Get real-time assistance from our team with priority responses.
+              Skip the hassle of documentation — upgrade now and unlock direct chat support.
+            </p>
+            <p class="align-center text-grey text-center" data-test="upgrade-description2">
+              However, you can still use
+              <a href="https://docs.shellhub.io/" target="_blank" rel="noopener noreferrer" data-test="link-anchor">our Documentation</a>
+              to find answers to your questions and troubleshoot issues on your own.
+            </p>
+          </v-col>
+        </v-row>
+        <v-card-actions data-test="card-actions">
+          <v-btn @click="close()" class="mt-4" variant="text" data-test="close-btn">
+            Close
+          </v-btn>
+          <v-spacer />
+          <v-btn
+            color="primary"
+            variant="flat"
+            href="www.shellhub.io/pricing"
+            target="_blank"
+            rel="noreferrer noopener"
+            data-test="upgrade-btn">
+            Upgrade
+          </v-btn>
+        </v-card-actions>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+const dialog = defineModel({ default: false });
+
+const close = () => {
+  dialog.value = false;
+};
+
+defineExpose({ dialog });
+</script>
+
+<style scoped>
+.green-inner-shadow {
+  filter: drop-shadow(0px 0px 20px rgba(43, 255, 10, 0.45));
+}
+
+.shadow {
+  box-shadow: rgba(0, 0, 0, 0.35) 0px 15px 10px 0px;
+  border-radius: 50%;
+}
+
+.circle-one {
+  height: 15.625rem;
+  width: 15.625rem;
+  background: linear-gradient(180deg, rgba(0,0,0,0) 40%, rgba(76,175,80,0.1) 60%, rgba(76,175,80,0.75) 120%);
+}
+
+.circle-two {
+  height: 12.5rem;
+  width: 12.5rem;
+  background: linear-gradient(180deg, rgba(0,0,0,0) 60%, rgba(76,175,80,0.1) 75%, rgba(76,175,80,0.75) 120%);
+}
+</style>

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -40,7 +40,7 @@ app.use(VueGtag, {
   config: { id: envVariables.googleAnalyticsID || "" },
 });
 
-if ((envVariables.isCloud || envVariables.isEnterprise) && (envVariables.chatWootWebsiteToken && envVariables.chatWootBaseURL)) {
+if ((envVariables.isCloud) && (envVariables.chatWootWebsiteToken && envVariables.chatWootBaseURL)) {
   app.use(
     createChatWoot({
       init: {

--- a/ui/src/store/modules/auth.ts
+++ b/ui/src/store/modules/auth.ts
@@ -129,8 +129,6 @@ export const auth: Module<AuthState, State> = {
       state.email = "";
       state.role = "";
       state.mfa = false;
-      toggle("close");
-      reset();
     },
 
     changeData(state, data) {
@@ -363,6 +361,11 @@ export const auth: Module<AuthState, State> = {
       localStorage.removeItem("role");
       localStorage.removeItem("mfa");
       localStorage.removeItem("recovery_email");
+      const chatIsCreated = context.rootGetters["support/getCreatedStatus"];
+      if (chatIsCreated) {
+        toggle("close");
+        reset();
+      }
     },
 
     changeUserData(context, data) {

--- a/ui/src/store/modules/support.ts
+++ b/ui/src/store/modules/support.ts
@@ -1,27 +1,31 @@
 import { Module } from "vuex";
-import { useChatWoot } from "@productdevbook/chatwoot/vue";
 import * as apiSupport from "../api/namespaces";
 import { State } from "..";
 
-const { toggle } = useChatWoot();
-
 export interface SupportState {
   identifier: string;
+  chatCreated: boolean;
 }
 
 export const support: Module<SupportState, State> = {
   namespaced: true,
   state: {
     identifier: "",
+    chatCreated: false,
   },
 
   getters: {
     getIdentifier: (state) => state.identifier,
+    getCreatedStatus: (state) => state.chatCreated,
   },
 
   mutations: {
     setIdentifier: (state, identifier) => {
       state.identifier = identifier;
+    },
+
+    setCreatedStatus: (state, status) => {
+      state.chatCreated = status;
     },
   },
 
@@ -35,6 +39,5 @@ export const support: Module<SupportState, State> = {
         throw error;
       }
     },
-    toggle: () => { toggle("open"); },
   },
 };

--- a/ui/tests/components/AppBar/__snapshots__/AppBar.spec.ts.snap
+++ b/ui/tests/components/AppBar/__snapshots__/AppBar.spec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`AppBar Component > Renders the component 1`] = `
 "<div class="v-layout">
+  <!---->
+  <!---->
   <header class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar bg-background border-b-thin" style="top: 0px; z-index: 1004; transform: translateY(0px); position: fixed; transition: none; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
     <!---->
     <div class="v-toolbar__content" style="height: 64px;">

--- a/ui/tests/components/Users/PaywallChat.spec.ts
+++ b/ui/tests/components/Users/PaywallChat.spec.ts
@@ -1,0 +1,100 @@
+import { flushPromises, DOMWrapper, mount, VueWrapper } from "@vue/test-utils";
+import { createVuetify } from "vuetify";
+import MockAdapter from "axios-mock-adapter";
+import { expect, describe, it, beforeEach } from "vitest";
+import { store, key } from "@/store";
+import PaywallChat from "@/components/User/PaywallChat.vue";
+import { router } from "@/router";
+import { namespacesApi, devicesApi } from "@/api/http";
+import { SnackbarPlugin } from "@/plugins/snackbar";
+
+const vuetify = createVuetify();
+
+const namespaceData = {
+  name: "test",
+  owner: "xxxxxxxx",
+  tenant_id: "fake-tenant-data",
+  members: [{ id: "xxxxxxxx", username: "test", role: "owner" }],
+  max_devices: 3,
+  devices_count: 3,
+  devices: 2,
+  created_at: "",
+};
+
+const authData = {
+  status: "",
+  token: "",
+  user: "test",
+  name: "test",
+  tenant: "fake-tenant-data",
+  email: "test@test.com",
+  id: "xxxxxxxx",
+  role: "owner",
+};
+
+const stats = {
+  registered_devices: 3,
+  online_devices: 1,
+  active_sessions: 0,
+  pending_devices: 0,
+  rejected_devices: 0,
+};
+
+describe("PaywallChat", () => {
+  let wrapper: VueWrapper<InstanceType<typeof PaywallChat>>;
+  let mockNamespace: MockAdapter;
+  let mockDevices: MockAdapter;
+
+  beforeEach(async () => {
+    localStorage.setItem("tenant", "fake-tenant-data");
+
+    mockNamespace = new MockAdapter(namespacesApi.getAxios());
+    mockDevices = new MockAdapter(devicesApi.getAxios());
+    mockNamespace.onGet("/api/namespaces/fake-tenant-data").reply(200, namespaceData);
+    mockDevices.onGet("/api/stats").reply(200, stats);
+
+    store.commit("auth/authSuccess", authData);
+    store.commit("namespaces/setNamespace", namespaceData);
+
+    wrapper = mount(PaywallChat, {
+      global: {
+        plugins: [[store, key], vuetify, router, SnackbarPlugin],
+      },
+      attachTo: document.body,
+    });
+  });
+
+  it("is a Vue instance", () => {
+    expect(wrapper.vm).toBeTruthy();
+  });
+
+  it("renders the component", () => {
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("defines data properties", () => {
+    expect(wrapper.vm.$data).toBeDefined();
+  });
+
+  it("renders dialog elements when opened", async () => {
+    wrapper.vm.dialog = true;
+    await flushPromises();
+
+    const dialog = new DOMWrapper(document.body);
+    expect(dialog.find('[data-test="card-dialog"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="icon-chat"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="upgrade-heading"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="upgrade-description"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="upgrade-description2"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="link-anchor"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="card-actions"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="upgrade-btn"]').exists()).toBe(true);
+  });
+
+  it("ensures the upgrade button has correct href", () => {
+    wrapper.vm.dialog = true;
+    const dialog = new DOMWrapper(document.body);
+    expect(dialog.find('[data-test="upgrade-btn"]').attributes("href")).toBe("www.shellhub.io/pricing");
+  });
+});

--- a/ui/tests/components/Users/__snapshots__/PaywallChat.spec.ts.snap
+++ b/ui/tests/components/Users/__snapshots__/PaywallChat.spec.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PaywallChat > renders the component 1`] = `""`;

--- a/ui/tests/layouts/__snapshots__/AppLayout.spec.ts.snap
+++ b/ui/tests/layouts/__snapshots__/AppLayout.spec.ts.snap
@@ -239,7 +239,9 @@ exports[`App Layout Component > Renders the component 1`] = `
       <!---->
     </transition-stub>
     <snackbarcomponent data-v-e7291ef4=""></snackbarcomponent>
-    <header data-v-e7291ef4="" class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--dark v-locale--is-ltr v-app-bar bg-background border-b-thin" style="top: 0px; z-index: 1004; transform: translateY(0px); position: fixed; transition: none; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
+    <!---->
+    <!---->
+    <header class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--dark v-locale--is-ltr v-app-bar bg-background border-b-thin" style="top: 0px; z-index: 1004; transform: translateY(0px); position: fixed; transition: none; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
       <!---->
       <div class="v-toolbar__content" style="height: 64px;">
         <!---->


### PR DESCRIPTION
# Description

This PR introduces a paywall mechanism for chat support access in the AppBar component. Users in a cloud environment with an active subscription can access Chatwoot support, while community users or non-subscribers are redirected to a paywall.
Changes

    UI Updates
        Added PaywallChat component to AppBar.vue.
        Exposed chatSupportPaywall state for conditional rendering.

    Logic & State Management
        Refactored openShellhubHelp to handle different cases (Cloud, Enterprise, Community).
        Introduced chatSupportPaywall state in Vuex support module.
        Updated openChatwoot function for better structure and maintainability.

## Testing
        Modified AppBar.spec.ts to test new paywall logic.
        Added mock data for billing and environment settings.

## How to Test

    Cloud User with Active Billing
        Click on "Support" → Chatwoot should open.
    Cloud User without Active Billing
        Click on "Support" → Paywall should appear.
    Enterprise User
        Click on "Support" → Redirects to GitHub issues page.
    Community User
        Click on "Support" → Paywall should appear.

## Checklist

- [x] Tested in different environments.
- [x] Updated tests to cover new behavior.

## Additional Notes

This update ensures proper handling of support requests based on user type, improving the user experience and maintaining controlled access to support resources.