### PR TITLE
fix(ui): make namespace settings properties optional

### DIFF
--- a/ui/src/interfaces/INamespace.ts
+++ b/ui/src/interfaces/INamespace.ts
@@ -29,11 +29,11 @@ export interface INamespaceInvite {
 }
 
 export interface INamespaceSettings {
-  connection_announcement: string;
-  session_record: boolean;
+  connection_announcement?: string;
+  session_record?: boolean;
 }
 export interface INamespaceResponse {
-  settings: INamespaceSettings;
+  settings?: INamespaceSettings;
   id: string;
   tenant_id: string;
   name: string;

--- a/ui/src/store/api/namespaces.ts
+++ b/ui/src/store/api/namespaces.ts
@@ -18,8 +18,8 @@ export const leaveNamespace = async (tenant: string) => namespacesApi.leaveNames
 export const putNamespace = async (data: INamespaceResponse) => namespacesApi.editNamespace(data.id, {
   name: data.name,
   settings: {
-    connection_announcement: data.settings.connection_announcement,
-    session_record: data.settings.session_record,
+    connection_announcement: data.settings?.connection_announcement,
+    session_record: data.settings?.session_record,
   },
 });
 


### PR DESCRIPTION
# Description:

This PR updates the INamespaceSettings interface by making its properties optional. This prevents potential undefined property access issues and improves flexibility when handling namespace settings.

## Changes:

    Updated INamespaceSettings to mark connection_announcement and session_record as optional (? modifier).
    Made settings in INamespaceResponse optional to allow for cases where settings might be omitted.
    Modified the putNamespace function to handle optional settings safely using optional chaining (?.).

## Why This Change?

    Prevents runtime errors when settings or its properties are missing.
    Enhances API flexibility by allowing partial updates without requiring all settings fields.

## Testing & Impact:

    This change ensures existing functionality remains intact while preventing crashes due to missing properties.
    API calls that previously relied on these fields will now gracefully handle undefined values.
    
## Related Issues:

This PR fixes #4602 