### PR TITLE
fix(ui): fix Vue's attribute inheritance warnings

### DIFF
--- a/ui/src/components/AppBar/AppBar.vue
+++ b/ui/src/components/AppBar/AppBar.vue
@@ -121,6 +121,11 @@ type BreadcrumbItem = {
   title: string;
   href: string;
 };
+
+defineOptions({
+  inheritAttrs: false,
+});
+
 const store = useStore();
 const router = useRouter();
 const route = useRoute();

--- a/ui/src/components/Namespace/Namespace.vue
+++ b/ui/src/components/Namespace/Namespace.vue
@@ -57,6 +57,10 @@ interface NamespaceItem {
   name: string;
 }
 
+defineOptions({
+  inheritAttrs: false,
+});
+
 const store = useStore();
 const namespaceList = computed(() => store.getters["namespaces/list"]);
 const selectedNamespace = computed(() => store.getters["namespaces/get"]);

--- a/ui/src/components/User/UserWarning.vue
+++ b/ui/src/components/User/UserWarning.vue
@@ -68,6 +68,10 @@ import RecoveryHelper from "../AuthMFA/RecoveryHelper.vue";
 import MfaForceRecoveryMail from "../AuthMFA/MfaForceRecoveryMail.vue";
 import PaywallDialog from "./PaywallDialog.vue";
 
+defineOptions({
+  inheritAttrs: false,
+});
+
 const store = useStore();
 const router = useRouter();
 const showInstructions = ref(false);


### PR DESCRIPTION
The following warning was displayed:
```
► [Vue warn]: Extraneous non-props attributes (data-test) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes.
```

That happened because some components (specifically `Namespace.vue`, `UserWarning.vue`, and `AppBar.vue`) have more than one element as the root of the template, and Vue was trying to inherit the `data-test` attribute determined in the parent component to the children components. Since there's more than one root element, the inheritance failed and the warning was shown.

This PR adds the following snippet to the specified components:
```javascript
defineOptions({
  inheritAttrs: false,
});
```

This is a [Vue's macro](https://vuejs.org/api/sfc-script-setup#defineoptions) used to prevent the default attribute inheritance for the specific components, since `data-test` will not be used inside of it.