### PR TITLE
fix(ui): declare useChatwoot on auth store only when it will be used

### DIFF
--- a/ui/src/store/modules/auth.ts
+++ b/ui/src/store/modules/auth.ts
@@ -10,7 +10,6 @@ import {
   reloadConfiguration as reloadApiConfiguration,
 } from "@/api/http";
 
-const { reset, toggle } = useChatWoot();
 export interface AuthState {
   status: string;
   token: string;
@@ -363,6 +362,7 @@ export const auth: Module<AuthState, State> = {
       localStorage.removeItem("recovery_email");
       const chatIsCreated = context.rootGetters["support/getCreatedStatus"];
       if (chatIsCreated) {
+        const { reset, toggle } = useChatWoot();
         toggle("close");
         reset();
       }


### PR DESCRIPTION
This pull request fixes an issue that the chatwoot module would warn an onMounted
and onBeforeUnmounted because the chatwoot module was called before it's
usage.
