### PR TITLE
feat(ui): improve profile settings UI

### DIFF
--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -249,7 +249,7 @@ const editPasswordStatus = ref(false);
 const mfaEnabled = computed(() => store.getters["auth/isMfa"]);
 const isEnterprise = computed(() => envVariables.isEnterprise);
 const isCloud = computed(() => envVariables.isCloud);
-const isCommunity = computed(() => !(isCloud.value || isEnterprise.value));
+const isCommunity = computed(() => envVariables.isCommunity);
 const dialogMfaSettings = ref(false);
 const dialogMfaDisable = ref(false);
 const showChangePassword = ref(false);

--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -165,10 +165,12 @@
               </template>
             </v-card-item>
             <v-divider />
-            <div class="d-flex mr-4" v-if="isCloud || isEnterprise">
+            <div class="d-flex align-center justify-space-between pr-4">
               <v-card
+                :disabled="isCommunity"
                 flat
                 class="bg-background"
+                :class="lgAndUp ? 'w-100' : 'w-75'"
                 prepend-icon="mdi-fingerprint"
                 data-test="mfa-card"
               >
@@ -177,25 +179,30 @@
                 </template>
                 <div class="d-flex flex-no-wrap justify-space-between">
                   <div>
-                    <v-card-text class="pt-0" data-test="mfa-text">
+                    <v-card-text class="pt-0 text-justify" data-test="mfa-text">
                       Enable multi-factor authentication (MFA) to add an extra layer of security to your account.
                       You'll need to enter a one-time verification code from your preferred TOTP provider to log in.
                     </v-card-text>
                   </div>
                 </div>
               </v-card>
-              <div class="d-flex align-center bg-background pr-4">
-                <v-switch
-                  hide-details
-                  inset
-                  color="primary"
-                  v-model="mfaEnabled"
-                  @click="toggleMfa()"
-                  data-test="switch-mfa"
-                />
-                <MfaSettings v-model="dialogMfaSettings" />
-                <MfaDisable v-model="dialogMfaDisable" />
-              </div>
+              <v-tooltip location="top" text="Only available for Cloud or Enterprise accounts!" :disabled="!isCommunity">
+                <template v-slot:activator="{ props }">
+                  <div v-bind="props" class="d-flex align-center bg-background" style="height: fit-content;">
+                    <v-switch
+                      hide-details
+                      inset
+                      color="primary"
+                      v-model="mfaEnabled"
+                      @click="toggleMfa()"
+                      :disabled="isCommunity"
+                      data-test="switch-mfa"
+                    />
+                    <MfaSettings v-model="dialogMfaSettings" />
+                    <MfaDisable v-model="dialogMfaDisable" />
+                  </div>
+                </template>
+              </v-tooltip>
             </div>
 
           </div>
@@ -220,6 +227,7 @@
 <script setup lang="ts">
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { ref, computed, onMounted } from "vue";
+import { useDisplay } from "vuetify";
 import { useField } from "vee-validate";
 import axios, { AxiosError } from "axios";
 import * as yup from "yup";
@@ -241,12 +249,14 @@ const editPasswordStatus = ref(false);
 const mfaEnabled = computed(() => store.getters["auth/isMfa"]);
 const isEnterprise = computed(() => envVariables.isEnterprise);
 const isCloud = computed(() => envVariables.isCloud);
+const isCommunity = computed(() => !(isCloud.value || isEnterprise.value));
 const dialogMfaSettings = ref(false);
 const dialogMfaDisable = ref(false);
 const showChangePassword = ref(false);
 const showDeleteAccountDialog = ref(false);
 const getAuthMethods = computed(() => store.getters["auth/getAuthMethods"]);
 const isLocalAuth = computed(() => getAuthMethods.value.includes("local"));
+const { lgAndUp } = useDisplay();
 
 const {
   value: name,

--- a/ui/tests/components/Setting/SettingProfile.spec.ts
+++ b/ui/tests/components/Setting/SettingProfile.spec.ts
@@ -76,6 +76,7 @@ describe("Settings Namespace", () => {
     vi.useFakeTimers();
     localStorage.setItem("tenant", "fake-tenant-data");
     envVariables.isCloud = true;
+    envVariables.isCommunity = true; // used in the MFA switch test only
 
     mockNamespace = new MockAdapter(namespacesApi.getAxios());
     mockUser = new MockAdapter(usersApi.getAxios());
@@ -140,6 +141,11 @@ describe("Settings Namespace", () => {
       const element = wrapper.find(`[data-test="${dataTest}"]`);
       expect(element.exists()).toBe(true);
     });
+  });
+
+  it("Disables the MFA switch for Community accounts", async () => {
+    const switchMfa = wrapper.find('[data-test="switch-mfa"] input');
+    expect(switchMfa.attributes().disabled).toBeDefined();
   });
 
   it("Successfully changes user data", async () => {

--- a/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
@@ -310,7 +310,7 @@ exports[`Settings Namespace > Renders the component 1`] = `
               <!---->
               <div data-v-b3fa301d="" class="d-flex flex-no-wrap justify-space-between">
                 <div data-v-b3fa301d="">
-                  <div data-v-b3fa301d="" class="v-card-text pt-0" data-test="mfa-text"> Enable multi-factor authentication (MFA) to add an extra layer of security to your account. You'll need to enter a one-time verification code from your preferred TOTP provider to log in. </div>
+                  <div data-v-b3fa301d="" class="v-card-text pt-0 text-justify" data-test="mfa-text"> Enable multi-factor authentication (MFA) to add an extra layer of security to your account. You'll need to enter a one-time verification code from your preferred TOTP provider to log in. </div>
                 </div>
               </div>
               <!---->
@@ -345,6 +345,8 @@ exports[`Settings Namespace > Renders the component 1`] = `
               <!---->
               <!---->
             </div>
+            <!--teleport start-->
+            <!--teleport end-->
           </div>
         </div>
         <hr data-v-b3fa301d="" class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">

--- a/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
@@ -279,8 +279,8 @@ exports[`Settings Namespace > Renders the component 1`] = `
             </div>
           </div>
           <hr data-v-b3fa301d="" class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
-          <div data-v-b3fa301d="" class="d-flex mr-4">
-            <div data-v-b3fa301d="" class="v-card v-card--flat v-theme--light v-card--density-default v-card--variant-elevated bg-background" data-test="mfa-card">
+          <div data-v-b3fa301d="" class="d-flex align-center justify-space-between pr-4">
+            <div data-v-b3fa301d="" class="v-card v-card--disabled v-card--flat v-theme--light v-card--density-default v-card--variant-elevated bg-background w-75" tabindex="-1" data-test="mfa-card">
               <!---->
               <div class="v-card__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -316,17 +316,17 @@ exports[`Settings Namespace > Renders the component 1`] = `
               <!---->
               <!----><span class="v-card__underlay"></span>
             </div>
-            <div data-v-b3fa301d="" class="d-flex align-center bg-background pr-4">
-              <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-switch v-switch--inset" data-test="switch-mfa">
+            <div data-v-b3fa301d="" aria-describedby="v-tooltip-11" class="d-flex align-center bg-background">
+              <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-switch v-switch--inset" data-test="switch-mfa">
                 <!---->
                 <div class="v-input__control">
-                  <div class="v-selection-control v-selection-control--density-default">
+                  <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default">
                     <div class="v-selection-control__wrapper">
                       <div class="v-switch__track">
                         <!---->
                         <!---->
                       </div>
-                      <div class="v-selection-control__input"><input id="switch-11" aria-disabled="false" type="checkbox" aria-describedby="switch-11-messages" value="true">
+                      <div class="v-selection-control__input"><input disabled="" id="switch-12" aria-disabled="true" type="checkbox" aria-describedby="switch-12-messages" value="true">
                         <div class="v-switch__thumb">
                           <transition-stub name="scale-transition" appear="false" persisted="false" css="true">
                             <!---->


### PR DESCRIPTION
This PR adds a disabled MFA switch with an explanatory tooltip for Community accounts. Previously, the MFA option on the profile settings page wasn't visible for Community. Now, it appears as a disabled switch with a tooltip stating "Only available for Cloud or Enterprise accounts!" to improve user understanding. The responsiveness of the MFA card was improved too, limiting the width of the text in smaller screens, preventing it from "hiding" the switch button. I've added a basic unit test for this switch and updated the snapshot.
![422923147-53a94275-0277-470a-8cd5-eadc63cdaae1](https://github.com/user-attachments/assets/28f87a9d-3cd8-477c-a746-5242ac5272af)
