### PR TITLE
refactor(ui): profile settings component

### DIFF
--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -82,7 +82,7 @@
             </template>
           </v-card-item>
           <v-divider />
-          <div v-if="isLocalAuth || envVariables.isCloud">
+          <div v-if="isLocalAuth || isCloud">
             <v-card-item style="grid-template-columns: max-content 1.5fr 2fr">
               <template #prepend>
                 <v-icon>mdi-account</v-icon>
@@ -129,7 +129,7 @@
           </v-card-item>
           <v-divider />
 
-          <div v-if="isLocalAuth || envVariables.isCloud">
+          <div v-if="isLocalAuth || isCloud">
             <v-card-item style="grid-template-columns: max-content 1.5fr 2fr">
               <template #prepend>
                 <v-icon>mdi-email-lock</v-icon>
@@ -152,7 +152,7 @@
               </template>
             </v-card-item>
             <v-divider />
-            <v-card-item style="grid-template-columns: max-content 1.5fr 2fr" v-if="isLocalAuth || envVariables.isCloud">
+            <v-card-item style="grid-template-columns: max-content 1.5fr 2fr" v-if="isLocalAuth || isCloud">
               <template #prepend>
                 <v-icon>mdi-key</v-icon>
               </template>

--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -247,15 +247,13 @@ const store = useStore();
 const editDataStatus = ref(false);
 const editPasswordStatus = ref(false);
 const mfaEnabled = computed(() => store.getters["auth/isMfa"]);
-const isEnterprise = computed(() => envVariables.isEnterprise);
-const isCloud = computed(() => envVariables.isCloud);
-const isCommunity = computed(() => envVariables.isCommunity);
 const dialogMfaSettings = ref(false);
 const dialogMfaDisable = ref(false);
 const showChangePassword = ref(false);
 const showDeleteAccountDialog = ref(false);
 const getAuthMethods = computed(() => store.getters["auth/getAuthMethods"]);
 const isLocalAuth = computed(() => getAuthMethods.value.includes("local"));
+const { isCloud, isCommunity } = envVariables;
 const { lgAndUp } = useDisplay();
 
 const {

--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -225,7 +225,6 @@
 </template>
 
 <script setup lang="ts">
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { ref, computed, onMounted } from "vue";
 import { useDisplay } from "vuetify";
 import { useField } from "vee-validate";


### PR DESCRIPTION
This PR makes some refactorings in the `SettingProfile.vue` code.

I replaced some useless `computed`s with an object destructuring since these properties weren't reactive. I also removed some `envVariables` from the template, using the destructured values directly. An useless `eslint-disable` comment was removed too.