### PR TITLE
refactor(ui): migrate components to `<script setup>` syntax

### DIFF
--- a/ui/src/components/Announcements/AnnouncementsModal.vue
+++ b/ui/src/components/Announcements/AnnouncementsModal.vue
@@ -42,52 +42,43 @@
   </v-dialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import MarkdownIt from "markdown-it";
 import moment from "moment";
 
-export default defineComponent({
-  props: {
-    show: {
-      type: Boolean,
-      required: true,
-    },
-    announcement: {
-      type: Object,
-      required: true,
-    },
+const props = defineProps({
+  show: {
+    type: Boolean,
+    required: true,
   },
-  emits: ["update"],
-  setup(props, ctx) {
-    const md = new MarkdownIt();
-
-    const date = computed(() => moment(props.announcement.date).format("LL"));
-    const markdownContent = computed(() => md.render(props.announcement.content));
-
-    const showAnnouncements = computed({
-      get() {
-        return props.show;
-      },
-      set(value: boolean) {
-        ctx.emit("update", value);
-      },
-    });
-
-    const close = () => {
-      localStorage.setItem("announcement", btoa(JSON.stringify(props.announcement)));
-      ctx.emit("update", false);
-      showAnnouncements.value = false;
-    };
-
-    return {
-      showAnnouncements,
-      markdownContent,
-      date,
-      close,
-    };
+  announcement: {
+    type: Object,
+    required: true,
   },
 });
+
+const emit = defineEmits(["update"]);
+
+const md = new MarkdownIt();
+
+const date = computed(() => moment(props.announcement.date).format("LL"));
+const markdownContent = computed(() => md.render(props.announcement.content));
+
+const showAnnouncements = computed({
+  get() {
+    return props.show;
+  },
+  set(value: boolean) {
+    emit("update", value);
+  },
+});
+
+const close = () => {
+  localStorage.setItem("announcement", btoa(JSON.stringify(props.announcement)));
+  emit("update", false);
+  showAnnouncements.value = false;
+};
 </script>
 
 <style lang="scss">

--- a/ui/src/components/Billing/BillingIcon.vue
+++ b/ui/src/components/Billing/BillingIcon.vue
@@ -8,53 +8,37 @@
 
   <v-icon
     v-else
-    :icon="['fa:fab', icon()].join(' ')"
+    :icon="['fa:fab', getIcon()].join(' ')"
     :style="{ fontSize: size }"
     data-test="type-icon"
   />
 
 </template>
 
-<script lang="ts">
-/* eslint-disable */
-import { defineComponent, ref } from "vue";
+<script setup lang="ts">
+import { ref } from "vue";
 
-export default defineComponent({
-  props: {
-    iconName: {
-      type: String,
-      required: true,
-    },
-  },
-  setup(props) {
-    const cardIcon = ref({
-      amex: "fa-cc-amex",
-      dinersClub: "fa-cc-diners-club",
-      discover: "fa-cc-discover",
-      jcb: "fa-cc-jcb",
-      mastercard: "fa-cc-mastercard",
-      visa: "fa-cc-visa",
-    });
-
-    const size = ref("1.5rem");
-
-    const isDefaultIcon = () =>
-      cardIcon.value[convertIconName()] === undefined;
-    const icon = () =>
-      cardIcon.value[convertIconName()] || "credit-card";
-    const convertIconName = () => {
-      props.iconName === "diners-club" ? "dinersClub" : props.iconName
-
-      return props.iconName;
-    };
-
-    return {
-      cardIcon,
-      size,
-      isDefaultIcon,
-      icon,
-      convertIconName,
-    };
+const { iconName } = defineProps({
+  iconName: {
+    type: String,
+    required: true,
   },
 });
+
+const cardIcon = ref({
+  amex: "fa-cc-amex",
+  dinersClub: "fa-cc-diners-club",
+  discover: "fa-cc-discover",
+  jcb: "fa-cc-jcb",
+  mastercard: "fa-cc-mastercard",
+  visa: "fa-cc-visa",
+});
+
+const size = ref("1.5rem");
+
+const getFormattedIconName = () => iconName === "diners-club" ? "dinersClub" : iconName;
+
+const isDefaultIcon = () => cardIcon.value[getFormattedIconName()] === undefined;
+
+const getIcon = () => cardIcon.value[getFormattedIconName()] || "credit-card";
 </script>

--- a/ui/src/components/Billing/BillingWarning.vue
+++ b/ui/src/components/Billing/BillingWarning.vue
@@ -40,60 +40,51 @@
   </v-dialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import { actions, authorizer } from "@/authorizer";
 import hasPermission from "@/utils/permission";
 import { useStore } from "@/store";
 
-export default defineComponent({
-  setup() {
-    const store = useStore();
+const store = useStore();
 
-    const hasAuthorization = computed(() => {
-      const role = store.getters["auth/role"];
-      if (role !== "") {
-        return hasPermission(
-          authorizer.role[role],
-          actions.billing.subscribe,
-        );
-      }
+const hasAuthorization = computed(() => {
+  const role = store.getters["auth/role"];
 
-      return false;
-    });
+  if (role !== "") {
+    return hasPermission(
+      authorizer.role[role],
+      actions.billing.subscribe,
+    );
+  }
 
-    const close = () => {
-      if (store.getters["users/statusUpdateAccountDialog"]) {
-        store.dispatch("users/setStatusUpdateAccountDialog", false);
-      } else if (
-        store.getters["users/statusUpdateAccountDialogByDeviceAction"]
-      ) {
-        store.dispatch(
-          "users/setStatusUpdateAccountDialogByDeviceAction",
-          false,
-        );
-      }
-    };
+  return false;
+});
 
-    const showMessage = computed({
-      get() {
-        return (
-          (store.getters["users/statusUpdateAccountDialog"]
+const close = () => {
+  if (store.getters["users/statusUpdateAccountDialog"]) {
+    store.dispatch("users/setStatusUpdateAccountDialog", false);
+  } else if (
+    store.getters["users/statusUpdateAccountDialogByDeviceAction"]
+  ) {
+    store.dispatch(
+      "users/setStatusUpdateAccountDialogByDeviceAction",
+      false,
+    );
+  }
+};
+
+const showMessage = computed({
+  get() {
+    return (
+      (store.getters["users/statusUpdateAccountDialog"]
             && store.getters["stats/stats"].registered_devices === 3
             && !store.getters["billing/active"])
           || store.getters["users/statusUpdateAccountDialogByDeviceAction"]
-        );
-      },
-      set() {
-        close();
-      },
-    });
-
-    return {
-      hasAuthorization,
-      showMessage,
-      close,
-    };
+    );
+  },
+  set() {
+    close();
   },
 });
 </script>

--- a/ui/src/components/Card/Card.vue
+++ b/ui/src/components/Card/Card.vue
@@ -43,50 +43,46 @@
   </v-hover>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
+<script setup lang="ts">
 import DeviceAdd from "../Devices/DeviceAdd.vue";
 
-export default defineComponent({
-  props: {
-    id: {
-      type: Number,
-      default: 0,
-    },
-    title: {
-      type: String,
-      default: "",
-    },
-    fieldObject: {
-      type: String,
-      default: "",
-    },
-    content: {
-      type: String,
-      default: "",
-    },
-    icon: {
-      type: String,
-      default: "",
-    },
-    buttonName: {
-      type: String,
-      default: "",
-    },
-    pathName: {
-      type: String,
-      default: "",
-    },
-    nameUseTest: {
-      type: String,
-      default: "",
-    },
-    stats: {
-      type: Number,
-      default: 0,
-    },
+defineProps({
+  id: {
+    type: Number,
+    default: 0,
   },
-  components: { DeviceAdd },
+  title: {
+    type: String,
+    default: "",
+  },
+  fieldObject: {
+    type: String,
+    default: "",
+  },
+  content: {
+    type: String,
+    default: "",
+  },
+  icon: {
+    type: String,
+    default: "",
+  },
+  buttonName: {
+    type: String,
+    default: "",
+  },
+  pathName: {
+    type: String,
+    default: "",
+  },
+  nameUseTest: {
+    type: String,
+    default: "",
+  },
+  stats: {
+    type: Number,
+    default: 0,
+  },
 });
 </script>
 

--- a/ui/src/components/DataTable.vue
+++ b/ui/src/components/DataTable.vue
@@ -53,8 +53,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType, toRefs, ref } from "vue";
+<script setup lang="ts">
+import { computed, PropType, toRefs, ref } from "vue";
 
 type HeaderItem = {
   text: string;
@@ -70,66 +70,58 @@ type UserTable = {
   namespaces: string;
 };
 
-export default defineComponent({
-  props: {
-    headers: {
-      type: Array as PropType<HeaderItem[]>,
-      default: () => [],
-      required: true,
-    },
-    items: {
-      type: Array,
-      default: () => [] as PropType<UserTable[]>,
-      required: false,
-    },
-    itemsPerPage: {
-      type: Number,
-      required: true,
-    },
-    itemSelectorDisable: {
-      type: Boolean,
-      required: false,
-    },
-    comboboxOptions: {
-      type: Array as PropType<number[]>,
-      required: false,
-      default: () => [10, 20, 50, 100],
-    },
-    loading: {
-      type: Boolean,
-      default: false,
-      required: false,
-    },
-    actualPage: {
-      type: Number,
-      default: 1,
-    },
-    totalCount: {
-      type: Number,
-      required: true,
-    },
-    nextPage: {
-      type: Function as PropType<() => void>,
-      default: Function as PropType<() => {}>,
-    },
-    previousPage: {
-      type: Function as PropType<() => void>,
-      default: Function as PropType<() => {}>,
-    },
+const props = defineProps({
+  headers: {
+    type: Array as PropType<HeaderItem[]>,
+    default: () => [],
+    required: true,
   },
-  emits: ["changeItemsPerPage", "clickNextPage", "clickPreviousPage", "clickSortableIcon"],
-  setup(props) {
-    const { itemsPerPage, totalCount } = toRefs(props);
-
-    const itemsPerPageRef = ref(itemsPerPage.value);
-    const pageQuantity = computed(() => Math.ceil(totalCount.value / itemsPerPageRef.value));
-
-    return {
-      itemsPerPageRef,
-      pageQuantity,
-    };
+  items: {
+    type: Array,
+    default: () => [] as PropType<UserTable[]>,
+    required: false,
+  },
+  itemsPerPage: {
+    type: Number,
+    required: true,
+  },
+  itemSelectorDisable: {
+    type: Boolean,
+    required: false,
+  },
+  comboboxOptions: {
+    type: Array as PropType<number[]>,
+    required: false,
+    default: () => [10, 20, 50, 100],
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+    required: false,
+  },
+  actualPage: {
+    type: Number,
+    default: 1,
+  },
+  totalCount: {
+    type: Number,
+    required: true,
+  },
+  nextPage: {
+    type: Function as PropType<() => void>,
+    default: Function as PropType<() => {}>,
+  },
+  previousPage: {
+    type: Function as PropType<() => void>,
+    default: Function as PropType<() => {}>,
   },
 });
+
+defineEmits(["changeItemsPerPage", "clickNextPage", "clickPreviousPage", "clickSortableIcon"]);
+
+const { itemsPerPage, totalCount } = toRefs(props);
+const itemsPerPageRef = ref(itemsPerPage.value);
+const pageQuantity = computed(() => Math.ceil(totalCount.value / itemsPerPageRef.value));
 </script>
 
 <style scoped>

--- a/ui/src/components/Namespace/NamespaceList.vue
+++ b/ui/src/components/Namespace/NamespaceList.vue
@@ -13,44 +13,38 @@
   </v-list-item>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import { useStore } from "@/store";
 import { INotificationsError } from "@/interfaces/INotifications";
 import handleError from "@/utils/handleError";
 import { INamespace } from "@/interfaces/INamespace";
 
-export default defineComponent({
+defineOptions({
   inheritAttrs: false,
-  setup() {
-    const store = useStore();
-
-    const namespace = computed(() => store.getters["namespaces/get"]);
-
-    const namespaces = computed(() => store.getters["namespaces/list"].filter(
-      (el: INamespace) => el.name !== namespace.value.name,
-    ));
-
-    const switchIn = async (tenant: string) => {
-      try {
-        await store.dispatch("namespaces/switchNamespace", {
-          tenant_id: tenant,
-        });
-
-        window.location.reload();
-      } catch (error: unknown) {
-        store.dispatch(
-          "snackbar/showSnackbarErrorLoading",
-          INotificationsError.namespaceSwitch,
-        );
-        handleError(error);
-      }
-    };
-    return {
-      namespace,
-      namespaces,
-      switchIn,
-    };
-  },
 });
+
+const store = useStore();
+
+const namespace = computed(() => store.getters["namespaces/get"]);
+
+const namespaces = computed(() => store.getters["namespaces/list"].filter(
+  (el: INamespace) => el.name !== namespace.value.name,
+));
+
+const switchIn = async (tenant: string) => {
+  try {
+    await store.dispatch("namespaces/switchNamespace", {
+      tenant_id: tenant,
+    });
+
+    window.location.reload();
+  } catch (error: unknown) {
+    store.dispatch(
+      "snackbar/showSnackbarErrorLoading",
+      INotificationsError.namespaceSwitch,
+    );
+    handleError(error);
+  }
+};
 </script>

--- a/ui/src/components/Sessions/SessionClose.vue
+++ b/ui/src/components/Sessions/SessionClose.vue
@@ -47,8 +47,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType, ref } from "vue";
+<script setup lang="ts">
+import { PropType, ref } from "vue";
 import {
   INotificationsError,
   INotificationsSuccess,
@@ -57,55 +57,47 @@ import { IDevice } from "@/interfaces/IDevice";
 import { useStore } from "@/store";
 import handleError from "@/utils/handleError";
 
-export default defineComponent({
-  props: {
-    uid: {
-      type: String,
-      required: true,
-    },
-    device: {
-      type: Object as PropType<IDevice>,
-      required: true,
-    },
-    notHasAuthorization: {
-      type: Boolean,
-      default: false,
-    },
-    style: {
-      type: [String, Object],
-      default: undefined,
-    },
+const props = defineProps({
+  uid: {
+    type: String,
+    required: true,
   },
-  emits: ["update"],
-  setup(props, ctx) {
-    const showDialog = ref(false);
-    const store = useStore();
-
-    const closeSession = async () => {
-      try {
-        await store.dispatch("sessions/close", {
-          uid: props.uid,
-          device_uid: props.device.uid,
-        });
-        showDialog.value = false;
-        store.dispatch(
-          "snackbar/showSnackbarSuccessAction",
-          INotificationsSuccess.sessionClose,
-        );
-        ctx.emit("update");
-      } catch (error: unknown) {
-        store.dispatch(
-          "snackbar/showSnackbarErrorAction",
-          INotificationsError.sessionClose,
-        );
-        handleError(error);
-      }
-    };
-
-    return {
-      showDialog,
-      closeSession,
-    };
+  device: {
+    type: Object as PropType<IDevice>,
+    required: true,
+  },
+  notHasAuthorization: {
+    type: Boolean,
+    default: false,
+  },
+  style: {
+    type: [String, Object],
+    default: undefined,
   },
 });
+
+const emit = defineEmits(["update"]);
+const showDialog = ref(false);
+const store = useStore();
+
+const closeSession = async () => {
+  try {
+    await store.dispatch("sessions/close", {
+      uid: props.uid,
+      device_uid: props.device.uid,
+    });
+    showDialog.value = false;
+    store.dispatch(
+      "snackbar/showSnackbarSuccessAction",
+      INotificationsSuccess.sessionClose,
+    );
+    emit("update");
+  } catch (error: unknown) {
+    store.dispatch(
+      "snackbar/showSnackbarErrorAction",
+      INotificationsError.sessionClose,
+    );
+    handleError(error);
+  }
+};
 </script>

--- a/ui/src/components/Sessions/SessionDelete.vue
+++ b/ui/src/components/Sessions/SessionDelete.vue
@@ -46,8 +46,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref } from "vue";
+<script setup lang="ts">
+import { ref } from "vue";
 import {
   INotificationsError,
   INotificationsSuccess,
@@ -55,48 +55,41 @@ import {
 import { useStore } from "@/store";
 import handleError from "@/utils/handleError";
 
-export default defineComponent({
-  props: {
-    uid: {
-      type: String,
-      required: true,
-    },
-    notHasAuthorization: {
-      type: Boolean,
-      default: false,
-    },
-    style: {
-      type: [String, Object],
-      default: undefined,
-    },
+const props = defineProps({
+  uid: {
+    type: String,
+    required: true,
   },
-  emits: ["update"],
-  setup(props, ctx) {
-    const showDialog = ref(false);
-    const store = useStore();
-
-    const deleteRecord = async () => {
-      try {
-        await store.dispatch("sessions/deleteSessionLogs", props.uid);
-        showDialog.value = false;
-        store.dispatch(
-          "snackbar/showSnackbarSuccessAction",
-          INotificationsSuccess.sessionRemoveRecord,
-        );
-        ctx.emit("update");
-      } catch (error: unknown) {
-        store.dispatch(
-          "snackbar/showSnackbarErrorAction",
-          INotificationsError.sessionRemoveRecord,
-        );
-        handleError(error);
-      }
-    };
-
-    return {
-      showDialog,
-      deleteRecord,
-    };
+  notHasAuthorization: {
+    type: Boolean,
+    default: false,
+  },
+  style: {
+    type: [String, Object],
+    default: undefined,
   },
 });
+
+const emit = defineEmits(["update"]);
+
+const showDialog = ref(false);
+const store = useStore();
+
+const deleteRecord = async () => {
+  try {
+    await store.dispatch("sessions/deleteSessionLogs", props.uid);
+    showDialog.value = false;
+    store.dispatch(
+      "snackbar/showSnackbarSuccessAction",
+      INotificationsSuccess.sessionRemoveRecord,
+    );
+    emit("update");
+  } catch (error: unknown) {
+    store.dispatch(
+      "snackbar/showSnackbarErrorAction",
+      INotificationsError.sessionRemoveRecord,
+    );
+    handleError(error);
+  }
+};
 </script>

--- a/ui/src/components/Snackbar/Snackbar.vue
+++ b/ui/src/components/Snackbar/Snackbar.vue
@@ -1,28 +1,18 @@
 <template>
-  <snackbar-sucess :type-message="message.typeMessage" :main-content="message.typeContent" />
+  <snackbar-success :type-message="message.typeMessage" :main-content="message.typeContent" />
 
   <snackbar-error :type-message="message.typeMessage" :main-content="message.typeContent" />
 
   <snackbar-copy :main-content="message.typeContent" />
 </template>
 
-<script lang="ts">
-import { defineComponent, computed } from "vue";
-import SnackbarSucess from "./SnackbarSucess.vue";
+<script setup lang="ts">
+import { computed } from "vue";
+import SnackbarSuccess from "./SnackbarSuccess.vue";
 import SnackbarError from "./SnackbarError.vue";
 import SnackbarCopy from "./SnackbarCopy.vue";
 import { useStore } from "@/store";
 
-export default defineComponent({
-  setup() {
-    const store = useStore();
-
-    const message = computed(() => store.getters["snackbar/snackbarMessageAndContentType"]);
-
-    return {
-      message,
-    };
-  },
-  components: { SnackbarSucess, SnackbarError, SnackbarCopy },
-});
+const store = useStore();
+const message = computed(() => store.getters["snackbar/snackbarMessageAndContentType"]);
 </script>

--- a/ui/src/components/Snackbar/SnackbarCopy.vue
+++ b/ui/src/components/Snackbar/SnackbarCopy.vue
@@ -10,39 +10,30 @@
   </v-snackbar>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import { useStore } from "@/store";
 
-export default defineComponent({
-  props: {
-    mainContent: {
-      type: String,
-      default: "",
-      required: true,
-    },
-  },
-  setup(props) {
-    const store = useStore();
-
-    const color = computed(() => store.getters["layout/getStatusDarkMode"] === "dark" ? "#F9F3EE" : "#1E1E1E");
-
-    const snackbar = computed({
-      get() {
-        return store.getters["snackbar/snackbarCopy"];
-      },
-      set() {
-        store.dispatch("snackbar/unsetShowStatusSnackbarCopy");
-      },
-    });
-
-    const message = computed(() => `${props.mainContent} copied to clipboard.`);
-
-    return {
-      color,
-      snackbar,
-      message,
-    };
+const { mainContent } = defineProps({
+  mainContent: {
+    type: String,
+    default: "",
+    required: true,
   },
 });
+
+const store = useStore();
+
+const color = computed(() => store.getters["layout/getStatusDarkMode"] === "dark" ? "#F9F3EE" : "#1E1E1E");
+
+const snackbar = computed({
+  get() {
+    return store.getters["snackbar/snackbarCopy"];
+  },
+  set() {
+    store.dispatch("snackbar/unsetShowStatusSnackbarCopy");
+  },
+});
+
+const message = computed(() => `${mainContent} copied to clipboard.`);
 </script>

--- a/ui/src/components/Snackbar/SnackbarError.vue
+++ b/ui/src/components/Snackbar/SnackbarError.vue
@@ -1,61 +1,39 @@
 <template>
   <v-snackbar
     v-model="snackbar"
-    :timeout="4000"
-    color="#bd4147"
+    :timeout="2000"
     location="top"
+    :color="color"
     transition="slide-x-transition"
   >
     {{ message }}
   </v-snackbar>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
 import { useStore } from "@/store";
 
-export default defineComponent({
-  props: {
-    typeMessage: {
-      type: String,
-      required: true,
-    },
-
-    mainContent: {
-      type: String,
-      default: "",
-      required: false,
-    },
-  },
-  setup(props) {
-    const store = useStore();
-
-    const snackbar = computed({
-      get() {
-        return store.getters["snackbar/snackbarError"];
-      },
-      set() {
-        store.dispatch("snackbar/unsetShowStatusSnackbarError");
-      },
-    });
-
-    const message = computed(() => {
-      switch (props.typeMessage) {
-        case "loading":
-          return `Loading the ${props.mainContent} has failed, please try again.`;
-        case "action":
-          return `The ${props.mainContent} request has failed, please try again.`;
-        case "licenseRequired":
-          return `The ${props.mainContent} request has failed, license required.`;
-        default:
-          return "The request has failed, please try again.";
-      }
-    });
-
-    return {
-      snackbar,
-      message,
-    };
+const { mainContent } = defineProps({
+  mainContent: {
+    type: String,
+    default: "",
+    required: true,
   },
 });
+
+const store = useStore();
+
+const color = computed(() => store.getters["layout/getStatusDarkMode"] === "dark" ? "#F9F3EE" : "#1E1E1E");
+
+const snackbar = computed({
+  get() {
+    return store.getters["snackbar/snackbarCopy"];
+  },
+  set() {
+    store.dispatch("snackbar/unsetShowStatusSnackbarCopy");
+  },
+});
+
+const message = computed(() => `${mainContent} copied to clipboard.`);
 </script>

--- a/ui/src/components/Snackbar/SnackbarSucess.vue
+++ b/ui/src/components/Snackbar/SnackbarSucess.vue
@@ -10,50 +10,42 @@
   </v-snackbar>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent } from "vue";
-import { useStore } from "@/store";
+<script setup lang="ts">
+import { computed } from "vue";
+import { useStore } from "../../store";
 
-export default defineComponent({
-  props: {
-    typeMessage: {
-      type: String,
-      required: true,
-    },
-
-    mainContent: {
-      type: String,
-      default: "",
-      required: false,
-    },
+const { mainContent, typeMessage } = defineProps({
+  typeMessage: {
+    type: String,
+    required: true,
   },
-  setup(props) {
-    const store = useStore();
 
-    const snackbar = computed({
-      get() {
-        return store.getters["snackbar/snackbarSuccess"];
-      },
-      set() {
-        store.dispatch("snackbar/unsetShowStatusSnackbarSuccess");
-      },
-    });
-
-    const message = computed(() => {
-      switch (props.typeMessage) {
-        case "action":
-          return `The ${props.mainContent} has succeeded.`;
-        case "no-content":
-          return "There is no content to export";
-        default:
-          return "The request has succeeded.";
-      }
-    });
-
-    return {
-      snackbar,
-      message,
-    };
+  mainContent: {
+    type: String,
+    default: "",
+    required: false,
   },
+});
+
+const store = useStore();
+
+const snackbar = computed({
+  get() {
+    return store.getters["snackbar/snackbarSuccess"];
+  },
+  set() {
+    store.dispatch("snackbar/unsetShowStatusSnackbarSuccess");
+  },
+});
+
+const message = computed(() => {
+  switch (typeMessage) {
+    case "action":
+      return `The ${mainContent} has succeeded.`;
+    case "no-content":
+      return "There is no content to export";
+    default:
+      return "The request has succeeded.";
+  }
 });
 </script>

--- a/ui/src/components/Tags/TagRemove.vue
+++ b/ui/src/components/Tags/TagRemove.vue
@@ -39,8 +39,8 @@
   </v-dialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref } from "vue";
+<script setup lang="ts">
+import { ref } from "vue";
 import {
   INotificationsError,
   INotificationsSuccess,
@@ -48,47 +48,42 @@ import {
 import { useStore } from "@/store";
 import handleError from "@/utils/handleError";
 
-export default defineComponent({
-  props: {
-    tag: {
-      type: String,
-      required: true,
-    },
-    notHasAuthorization: {
-      type: Boolean,
-      required: true,
-    },
+defineOptions({
+  inheritAttrs: false,
+});
+
+const props = defineProps({
+  tag: {
+    type: String,
+    required: true,
   },
-  emits: ["update"],
-  inheritAttrs: true,
-  setup(props, ctx) {
-    const showDialog = ref(false);
-    const store = useStore();
-
-    const remove = async () => {
-      try {
-        await store.dispatch("tags/remove", props.tag);
-
-        store.dispatch(
-          "snackbar/showSnackbarSuccessAction",
-          INotificationsSuccess.deviceTagDelete,
-        );
-        ctx.emit("update");
-      } catch (error: unknown) {
-        store.dispatch(
-          "snackbar/showSnackbarErrorAction",
-          INotificationsError.deviceTagDelete,
-        );
-        handleError(error);
-      } finally {
-        showDialog.value = false;
-      }
-    };
-
-    return {
-      showDialog,
-      remove,
-    };
+  notHasAuthorization: {
+    type: Boolean,
+    required: true,
   },
 });
+
+const emit = defineEmits(["update"]);
+const showDialog = ref(false);
+const store = useStore();
+
+const remove = async () => {
+  try {
+    await store.dispatch("tags/remove", props.tag);
+
+    store.dispatch(
+      "snackbar/showSnackbarSuccessAction",
+      INotificationsSuccess.deviceTagDelete,
+    );
+    emit("update");
+  } catch (error: unknown) {
+    store.dispatch(
+      "snackbar/showSnackbarErrorAction",
+      INotificationsError.deviceTagDelete,
+    );
+    handleError(error);
+  } finally {
+    showDialog.value = false;
+  }
+};
 </script>


### PR DESCRIPTION
This PR migrates 13 components to the new <script setup> syntax, the recommended syntax for SFCs and Composition API. It provides cleaner and more succinct code, with less boilerplate.

Closed the previous PR to solve some conflicts.