### PR TITLE
fix(ui): fix `getSessionRecord` error

### DIFF
--- a/ui/src/store/api/users.ts
+++ b/ui/src/store/api/users.ts
@@ -18,7 +18,7 @@ export const postValidationAccount = async (data : IUser) => usersApi.getValidat
 
 export const putSecurity = async (data : IUserPutSecurity) => usersApi.setSessionRecord(data.id, { session_record: data.status });
 
-export const getSecurity = async () => usersApi.getSessionRecord();
+export const getSecurity = async () => usersApi.checkSessionRecord();
 
 export const postUpdatePassword = async (data : IUserUpdatePassword) => usersApi.updateRecoverPassword(data.id, {
   token: data.token,


### PR DESCRIPTION
This PR fixes the error caused in the users API store by the `getSessionRecord`, that does not exist in the API anymore ─ it was replaced by `checkSessionRecord`, but this change wasn't made in the store. This pull request fixes this.

Closes #4605 