### PR TITLE
refactor(ui): centralize layout handling and simplify auth check

### DIFF
--- a/ui/admin/src/App.vue
+++ b/ui/admin/src/App.vue
@@ -1,58 +1,23 @@
 <template>
   <v-app>
-    <component :is="layout" :data-test="`${layout}-component`" />
+    <component
+      :is="layout"
+      :data-test="`${layout}-component`" />
   </v-app>
 </template>
 
-<script lang="ts">
-import { defineComponent, onMounted, computed } from "vue";
-import { useRouter } from "vue-router";
+<script setup lang="ts">
+import { computed } from "vue";
 import SimpleLayout from "./layouts/SimpleLayout.vue";
 import AppLayout from "./layouts/AppLayout.vue";
 import { useStore } from "./store";
-import { INotificationsError } from "./interfaces/INotifications";
 
-export default defineComponent({
-  name: "App",
-  components: {
-    appLayout: AppLayout,
-    simpleLayout: SimpleLayout,
-  },
-  setup() {
-    const store = useStore();
-    const router = useRouter();
+const components = {
+  SimpleLayout,
+  AppLayout,
+};
 
-    const layout = computed(() => store.getters["layout/getLayout"]);
+const store = useStore();
 
-    const isLoggedIn = computed(() => store.getters["auth/isLoggedIn"]);
-
-    const currentRoute = computed(() => router.currentRoute.value.path);
-
-    onMounted(async () => {
-      if (!isLoggedIn.value) {
-        try {
-          await store.dispatch("auth/logout");
-          store.dispatch("layout/setLayout", "simpleLayout");
-          router.push("/login");
-        } catch {
-          store.dispatch("snackbar/showSnackbarErrorAction", INotificationsError.namespaceLoad);
-        }
-      }
-
-      if (isLoggedIn.value && currentRoute.value !== "/login") {
-        const license = await store.dispatch("license/get");
-        if (!license || license.expired) {
-          store.dispatch("snackbar/showSnackbarErrorAction", INotificationsError.license);
-          store.dispatch("layout/setLayout", "appLayout");
-          router.push("/license");
-        }
-        store.dispatch("layout/setLayout", "appLayout");
-      }
-    });
-
-    return {
-      layout,
-    };
-  },
-});
+const layout = computed(() => components[store.getters["layout/getLayout"]]);
 </script>

--- a/ui/admin/src/layouts/AppLayout.vue
+++ b/ui/admin/src/layouts/AppLayout.vue
@@ -188,8 +188,9 @@ const logout = async () => {
   await store.dispatch("auth/logout");
   await router.push("/login");
   createNewClient();
-  store.dispatch("layout/setLayout", "simpleLayout");
+  store.dispatch("layout/setLayout", "SimpleLayout");
 };
+
 const triggerClick = (item: MenuItem): void => {
   switch (item.type) {
     case "path":
@@ -293,10 +294,14 @@ const getFilteredChildren = (children: DrawerItem[]) => expiredLicense.value
 
 const visibleItems = computed(() => {
   if (expiredLicense.value) {
-    return items.filter(
-      (item) => item.title === "Settings" && item.children?.some((child) => child.title === "License"),
-    );
+    return items
+      .filter((item) => item.title === "Settings")
+      .map((item) => ({
+        ...item,
+        children: item.children?.filter((child) => child.title === "License"),
+      }));
   }
+
   return items.filter((item) => !item.hidden);
 });
 

--- a/ui/admin/src/layouts/SimpleLayout.vue
+++ b/ui/admin/src/layouts/SimpleLayout.vue
@@ -2,20 +2,11 @@
   <router-view :key="currentRoute.value.path" />
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { computed } from "vue";
 import { useRouter } from "vue-router";
 
-export default {
-  name: "SimpleLayout",
-  setup() {
-    const router = useRouter();
+const router = useRouter();
 
-    const currentRoute = computed(() => router.currentRoute);
-
-    return {
-      currentRoute,
-    };
-  },
-};
+const currentRoute = computed(() => router.currentRoute);
 </script>

--- a/ui/admin/src/store/modules/auth.ts
+++ b/ui/admin/src/store/modules/auth.ts
@@ -20,7 +20,7 @@ export const auth: Module<AuthState, State> = {
     tenant: localStorage.getItem("tenant") || "",
   },
   getters: {
-    isLoggedIn: (state) => state.token,
+    isLoggedIn: (state) => !!state.token,
     currentUser: (state) => state.user,
     authStatus: (state) => state.status,
     tenant: (state) => state.tenant,

--- a/ui/admin/src/store/modules/license.ts
+++ b/ui/admin/src/store/modules/license.ts
@@ -9,6 +9,9 @@ export interface LicenseState {
 
 export const license: Module<LicenseState, State> = {
   namespaced: true,
+  state: {
+    license: {} as ILicense,
+  },
 
   getters: {
     isExpired: (state) => (state.license && state.license.expired)

--- a/ui/admin/tests/unit/store/modules/Auth.spec.ts
+++ b/ui/admin/tests/unit/store/modules/Auth.spec.ts
@@ -38,13 +38,13 @@ describe("Auth", () => {
 
     store.commit("auth/authSuccess", { token, user, tenant });
     expect(store.getters["auth/authStatus"]).toEqual(statusSuccess);
-    expect(store.getters["auth/isLoggedIn"]).toEqual(token);
+    expect(store.getters["auth/isLoggedIn"]).toEqual(true);
     expect(store.getters["auth/currentUser"]).toEqual(user);
     expect(store.getters["auth/tenant"]).toEqual(tenant);
 
     store.commit("auth/logout");
     expect(store.getters["auth/authStatus"]).toEqual("");
-    expect(store.getters["auth/isLoggedIn"]).toEqual("");
+    expect(store.getters["auth/isLoggedIn"]).toEqual(false);
     expect(store.getters["auth/currentUser"]).toEqual("");
     expect(store.getters["auth/tenant"]).toEqual("");
   });


### PR DESCRIPTION
# Summary

This PR refactors layout handling and authentication flow in the admin UI to be more maintainable and consistent. It shifts from component-level logic to a router-driven approach using route metadata and Vue's <script setup> syntax.

## Changes

- Migrated App.vue, SimpleLayout.vue, and AppLayout.vue to <script setup> for cleaner syntax.
- Replaced onMounted logic in App.vue with centralized auth/layout handling in router.beforeEach.
- Added meta.layout and meta.requiresAuth fields to route definitions.
Updated router guard to:
```
1. Apply the correct layout via layout/setLayout.
2. Redirect unauthenticated users when required.
```

- Normalized layout naming (SimpleLayout, AppLayout) for consistency.
-Fixed isLoggedIn getter to return a boolean instead of the token itself.

## Why refactoring the layouts?

Separation of concerns: Moves layout logic out of components and into routing, where it belongs.

Cleaner component code: Reduces lifecycle boilerplate in App.vue.

Improved maintainability: Adding new routes with different layouts is now trivial via metadata.

## Testing

1. Navigated between protected and public routes (e.g., /login, /dashboard)
2. Verified layout switching works correctly on login/logout
3. Confirmed proper redirects for unauthenticated access