### PR TITLE
feat(ui): add Asciinema player

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -67,6 +67,7 @@
         "@vitest/coverage-v8": "^2.1.8",
         "@vitest/ui": "^2.1.8",
         "@vue/test-utils": "^2.4.6",
+        "asciinema-player": "^3.9.0",
         "axios-mock-adapter": "^1.21.4",
         "buffer": "^6.0.3",
         "eslint": "^8.57.1",
@@ -3435,6 +3436,16 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "node_modules/asciinema-player": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/asciinema-player/-/asciinema-player-3.9.0.tgz",
+      "integrity": "sha512-SXVFImVzeNr8ZUdNIHABGuzlbnGWTKy245AquAjODsAnv+Lp6vxjYGN0LfA8ns30tnx/ag/bMrTbLq13TpHE6w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "solid-js": "^1.3.0"
+      }
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -9353,6 +9364,27 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/seroval": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.2.1.tgz",
+      "integrity": "sha512-yBxFFs3zmkvKNmR0pFSU//rIsYjuX418TnlDmc2weaq5XFDqDIV/NOMPBoLrbxjLH42p4UzRuXHryXh9dYcKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.2.1.tgz",
+      "integrity": "sha512-H5vs53+39+x4Udwp4J5rNZfgFuA+Lt+uU+09w1gYBVWomtAl98B+E9w7yC05Xc81/HgLvJdlyqJbU0fJCKCmdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -9505,6 +9537,17 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/solid-js": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.5.tgz",
+      "integrity": "sha512-ogI3DaFcyn6UhYhrgcyRAMbu/buBJitYQASZz5WzfQVPP10RD2AbCoRZ517psnezrasyCbWzIxZ6kVqet768xw==",
+      "dev": true,
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "^1.1.0",
+        "seroval-plugins": "^1.1.0"
       }
     },
     "node_modules/source-map": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -75,6 +75,7 @@
     "@vitest/coverage-v8": "^2.1.8",
     "@vitest/ui": "^2.1.8",
     "@vue/test-utils": "^2.4.6",
+    "asciinema-player": "^3.9.0",
     "axios-mock-adapter": "^1.21.4",
     "buffer": "^6.0.3",
     "eslint": "^8.57.1",

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -94,6 +94,7 @@ const { logs } = defineProps<{
 
 const isPlaying = ref(true);
 const showDialog = ref(false);
+const sessionEnded = ref(false);
 const containerDiv = ref<HTMLDivElement | null>(null);
 const player = ref<AsciinemaPlayer.AsciinemaPlayer | null>(null);
 const playerWrapper = ref<HTMLDivElement | null>(null);
@@ -162,6 +163,7 @@ const openDialog = () => {
 
 const setPlayerEventListeners = () => {
   player.value.addEventListener("playing", () => {
+    sessionEnded.value = false;
     getCurrentTime();
     // clear to prevent multiple intervals when replaying
     clearInterval(timeUpdaterId.value);
@@ -171,18 +173,20 @@ const setPlayerEventListeners = () => {
   });
 
   player.value.addEventListener("ended", () => {
+    sessionEnded.value = true;
     isPlaying.value = false;
     clearCurrentTimeUpdater();
   });
 };
 
 const changePlaybackSpeed = () => {
+  const newPlayerOptions = {
+    ...playerOptions,
+    speed: currentSpeed.value,
+    startAt: sessionEnded.value ? 0 : currentTime.value,
+  };
   player.value.dispose();
-  player.value = AsciinemaPlayer.create(
-    { data: logs },
-    containerDiv.value,
-    { ...playerOptions, speed: currentSpeed.value, startAt: currentTime.value },
-  );
+  player.value = AsciinemaPlayer.create({ data: logs }, containerDiv.value, newPlayerOptions);
   play();
   setPlayerEventListeners();
 };

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -142,7 +142,6 @@ const getSessionRows = () => {
 const playerOptions = {
   fit: "height",
   controls: false,
-  autoplay: true,
   rows: getSessionRows(),
 };
 
@@ -184,6 +183,7 @@ const changePlaybackSpeed = () => {
     containerDiv.value,
     { ...playerOptions, speed: currentSpeed.value, startAt: currentTime.value },
   );
+  play();
   setPlayerEventListeners();
 };
 
@@ -194,6 +194,8 @@ onMounted(() => {
 
   playerWrapper.value = containerDiv.value?.querySelector(".ap-wrapper") as HTMLDivElement;
   changeFocusToPlayer();
+
+  play();
 
   setPlayerEventListeners();
 });

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -54,6 +54,7 @@
       flat
       prepend-inner-icon="mdi-speedometer"
       data-test="speed-select"
+      @click.stop
       @update:model-value="changePlaybackSpeed()"
     />
     <v-btn

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -37,8 +37,34 @@
       @update:model-value="(value) => changePlaybackTime(value)"
       @mousedown="pause"
       @mouseup="play"
+      @touchstart="pause"
+      @touchend="play"
+    />
+    <v-btn
+      role="button"
+      variant="text"
+      icon="mdi-keyboard"
+      rounded
+      size="x-large"
+      data-test="keyboard-icon"
+      @click="openDialog"
     />
   </v-card-actions>
+  <v-dialog
+    :fullscreen="false"
+    v-model="showDialog"
+  >
+    <v-card title="Keyboard Shortcuts">
+      <v-card-text>
+        <div class="shortcut"><v-kbd>space</v-kbd>: pause / resume</div>
+        <div class="shortcut"><v-kbd>f</v-kbd>: toggle fullscreen mode</div>
+        <div class="shortcut"><v-kbd>←</v-kbd> / <v-kbd>→</v-kbd>: rewind / fast-forward by 5 seconds</div>
+        <div class="shortcut"><v-kbd>Shift</v-kbd> + <v-kbd>←</v-kbd> / <v-kbd>→</v-kbd>: rewind / fast-forward by 10%</div>
+        <div class="shortcut"><v-kbd>0</v-kbd>, <v-kbd>1</v-kbd>, <v-kbd>2</v-kbd> ... <v-kbd>9</v-kbd>: jump to 0%, 10%, 20% ... 90%</div>
+        <div class="shortcut"><v-kbd>,</v-kbd>/<v-kbd>.</v-kbd>: step back / forward, a frame at a time (only when paused)</div>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script setup lang="ts">
@@ -50,6 +76,7 @@ const { logs } = defineProps<{
 }>();
 
 const isPlaying = ref(true);
+const showDialog = ref(false);
 const wrapper = ref<HTMLDivElement | null>(null);
 const player = ref<AsciinemaPlayer.AsciinemaPlayer | null>(null);
 const currentTime = ref(0);
@@ -121,11 +148,28 @@ const pause = () => {
   player.value.pause();
   isPlaying.value = false;
 };
+
+const openDialog = () => {
+  pause();
+  showDialog.value = true;
+};
 </script>
 
 <style lang="scss" scoped>
 :deep(.ap-wrapper) {
   background-color: #121314;
   justify-content: start;
+}
+
+.shortcut {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+
+  .v-kbd {
+    padding: .2rem .5rem;
+    font-weight: 700;
+  }
 }
 </style>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -97,7 +97,7 @@ onMounted(() => {
   });
 });
 
-watchEffect(() => isPlaying.value ? player.value.play() : player.value.pause());
+watchEffect(() => isPlaying.value ? player.value?.play() : player.value?.pause());
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -1,27 +1,96 @@
 <template>
-  <div class="wrapper" v-if="logs" ref="wrapper" />
+  <div class="wrapper ma-0 pa-0 w-100 fill-height position-relative bg-v-theme-terminal" v-if="logs" ref="wrapper" />
+
+  <v-card-actions
+    class="text-h5 pa-3 d-flex justify-start ga-4 align-center"
+  >
+    <v-icon
+      v-if="isPlaying"
+      variant="text"
+      icon="mdi-pause-circle"
+      color="primary"
+      rounded
+      size="x-large"
+      data-test="pause-icon"
+      @click="isPlaying = false"
+    />
+    <v-icon
+      v-else
+      variant="text"
+      icon="mdi-play-circle"
+      color="primary"
+      rounded
+      size="x-large"
+      data-test="play-icon"
+      @click="isPlaying = true"
+    />
+    <v-slider
+      v-model="currentTime"
+      class="ml-0 flex-grow-1 flex-shrink-0"
+      min="0"
+      :max="duration"
+      :label="`${formattedCurrentTime} - ${formattedDuration}`"
+      hide-details
+      color="white"
+      data-test="time-slider"
+
+    />
+  </v-card-actions>
 </template>
 
 <script setup lang="ts">
 import * as AsciinemaPlayer from "asciinema-player";
-import { onMounted, ref } from "vue";
+import { onMounted, ref, watchEffect } from "vue";
 
 const { logs } = defineProps<{
   logs: string | null;
 }>();
 
+const isPlaying = ref(true);
+
 const wrapper = ref<HTMLDivElement | null>(null);
 const player = ref<AsciinemaPlayer.AsciinemaPlayer | null>(null);
+const currentTime = ref(0);
+const duration = ref(0);
+const formattedCurrentTime = ref("00:00:00");
+const formattedDuration = ref("00:00:00");
+
+const formatTime = (time: number) => new Date(time * 1000).toISOString().slice(11, 19);
 
 onMounted(() => {
-  console.log(logs);
-  player.value = AsciinemaPlayer.create({ data: logs }, wrapper.value, { fit: "height" });
+  const playerOptions = {
+    fit: "height",
+    terminalFontSize: "1rem",
+    controls: false,
+    autoplay: true,
+  };
+  const timeIntervalId = ref<NodeJS.Timeout>();
+
+  player.value = AsciinemaPlayer.create({ data: logs }, wrapper.value, playerOptions);
+
+  player.value.addEventListener("playing", () => {
+    console.log("playing");
+    timeIntervalId.value = setInterval(() => {
+      console.log("currentTime", player.value.getCurrentTime());
+      currentTime.value = player.value.getCurrentTime();
+      formattedCurrentTime.value = formatTime(currentTime.value);
+    }, 100);
+    duration.value = player.value.getDuration();
+    formattedDuration.value = formatTime(duration.value);
+  });
+
+  player.value.addEventListener("ended", () => {
+    isPlaying.value = false;
+    clearInterval(timeIntervalId.value);
+  });
 });
+
+watchEffect(() => isPlaying.value ? player.value?.play() : player.value?.pause());
 </script>
 
 <style lang="scss" scoped>
-.wrapper {
-  height: 100%;
-  overflow: scroll-y;
+:deep(.ap-wrapper) {
+  background-color: #121314;
+  justify-content: start;
 }
 </style>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -12,7 +12,7 @@
       rounded
       size="x-large"
       data-test="pause-icon"
-      @click="isPlaying = false"
+      @click="pause"
     />
     <v-icon
       v-else
@@ -22,7 +22,7 @@
       rounded
       size="x-large"
       data-test="play-icon"
-      @click="isPlaying = true"
+      @click="play"
     />
     <v-slider
       v-model="currentTime"
@@ -40,14 +40,13 @@
 
 <script setup lang="ts">
 import * as AsciinemaPlayer from "asciinema-player";
-import { onMounted, ref, watchEffect } from "vue";
+import { onMounted, ref } from "vue";
 
 const { logs } = defineProps<{
   logs: string | null;
 }>();
 
 const isPlaying = ref(true);
-
 const wrapper = ref<HTMLDivElement | null>(null);
 const player = ref<AsciinemaPlayer.AsciinemaPlayer | null>(null);
 const currentTime = ref(0);
@@ -84,7 +83,7 @@ onMounted(() => {
   player.value = AsciinemaPlayer.create({ data: logs }, wrapper.value, playerOptions);
 
   player.value.addEventListener("playing", () => {
-    // reset to prevent multiple intervals when replaying
+    // clear to prevent multiple intervals when replaying
     clearInterval(timeUpdaterId.value);
     startCurrentTimeUpdater();
     duration.value = player.value.getDuration();
@@ -97,7 +96,15 @@ onMounted(() => {
   });
 });
 
-watchEffect(() => isPlaying.value ? player.value?.play() : player.value?.pause());
+const play = () => {
+  player.value.play();
+  isPlaying.value = true;
+};
+
+const pause = () => {
+  player.value.pause();
+  isPlaying.value = false;
+};
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -132,17 +132,17 @@ const changePlaybackTime = (value: number) => {
   formattedCurrentTime.value = formatTime(value);
 };
 
-const getSessionRows = () => {
+const getSessionDimensions = () => {
   const dimensionsLine = logs?.split("\n")[1] ?? ""; // returns a string in the format of `[0.123, "r", "80x24"]`
   const dimensions = JSON.parse(dimensionsLine)[2];
-  const rows = dimensions.split("x")[1];
-  return rows;
+  const [cols, rows] = dimensions.split("x");
+  return { cols, rows };
 };
 
 const playerOptions = {
   fit: "height",
   controls: false,
-  rows: getSessionRows(),
+  ...getSessionDimensions(),
 };
 
 const play = () => {

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="wrapper" v-if="logs" ref="wrapper" />
+</template>
+
+<script setup lang="ts">
+import * as AsciinemaPlayer from "asciinema-player";
+import { onMounted, ref } from "vue";
+
+const { logs } = defineProps<{
+  logs: string | null;
+}>();
+
+const wrapper = ref<HTMLDivElement | null>(null);
+const player = ref<AsciinemaPlayer.AsciinemaPlayer | null>(null);
+
+onMounted(() => {
+  console.log(logs);
+  player.value = AsciinemaPlayer.create({ data: logs }, wrapper.value, { fit: "height" });
+});
+</script>
+
+<style lang="scss" scoped>
+.wrapper {
+  height: 100%;
+  overflow: scroll-y;
+}
+</style>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -185,6 +185,8 @@ const setPlayerEventListeners = () => {
   });
 };
 
+const changeFocusToPlayer = () => { playerWrapper.value?.focus(); };
+
 const changePlaybackSpeed = () => {
   const newPlayerOptions = {
     ...playerOptions,
@@ -195,9 +197,8 @@ const changePlaybackSpeed = () => {
   player.value = AsciinemaPlayer.create({ data: logs }, containerDiv.value, newPlayerOptions);
   play();
   setPlayerEventListeners();
+  playerWrapper.value = containerDiv.value?.querySelector(".ap-wrapper") as HTMLDivElement;
 };
-
-const changeFocusToPlayer = () => { playerWrapper.value?.focus(); };
 
 onMounted(() => {
   player.value = AsciinemaPlayer.create({ data: logs }, containerDiv.value, playerOptions);

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -71,27 +71,17 @@
       @click="openDialog"
     />
   </v-card-actions>
-  <v-dialog
-    :fullscreen="false"
-    v-model="showDialog"
-  >
-    <v-card title="Keyboard Shortcuts">
-      <v-card-text>
-        <div class="shortcut"><v-kbd>space</v-kbd>: pause / resume</div>
-        <div class="shortcut"><v-kbd>f</v-kbd>: toggle fullscreen mode</div>
-        <div class="shortcut"><v-kbd>←</v-kbd> / <v-kbd>→</v-kbd>: rewind / fast-forward by 5 seconds</div>
-        <div class="shortcut"><v-kbd>Shift</v-kbd> + <v-kbd>←</v-kbd> / <v-kbd>→</v-kbd>: rewind / fast-forward by 10%</div>
-        <div class="shortcut"><v-kbd>0</v-kbd>, <v-kbd>1</v-kbd>, <v-kbd>2</v-kbd> ... <v-kbd>9</v-kbd>: jump to 0%, 10%, 20% ... 90%</div>
-        <div class="shortcut"><v-kbd>,</v-kbd>/<v-kbd>.</v-kbd>: step back / forward, a frame at a time (only when paused)</div>
-      </v-card-text>
-    </v-card>
-  </v-dialog>
+
+  <PlayerShortcutsDialog
+    v-model:showDialog="showDialog"
+  />
 </template>
 
 <script setup lang="ts">
 import * as AsciinemaPlayer from "asciinema-player";
 import { onMounted, ref, watchEffect } from "vue";
-import { useDisplay } from "vuetify/lib/framework.mjs";
+import { useDisplay } from "vuetify";
+import PlayerShortcutsDialog from "./PlayerShortcutsDialog.vue";
 
 const { logs } = defineProps<{
   logs: string | null;
@@ -227,17 +217,5 @@ watchEffect(() => !showDialog.value && changeFocusToPlayer());
   background-color: #121314;
   justify-content: start;
   max-height: calc(100vh - 4rem) !important;
-}
-
-.shortcut {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-bottom: 1rem;
-
-  .v-kbd {
-    padding: .2rem .5rem;
-    font-weight: 700;
-  }
 }
 </style>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -2,28 +2,29 @@
   <div class="wrapper ma-0 pa-0 w-100 fill-height position-relative bg-v-theme-terminal" v-if="logs" ref="wrapper" />
 
   <v-card-actions
-    class="text-h5 pa-3 d-flex justify-start ga-4 align-center"
+    class="text-h5 pa-3 d-flex ga-4 align-center"
   >
-    <v-icon
+    <v-btn
       v-if="isPlaying"
-      variant="text"
-      icon="mdi-pause-circle"
-      color="primary"
-      rounded
-      size="x-large"
+      class="bg-primary"
+      rounded="circle"
+      size="48"
+      :ripple="false"
+      icon="mdi-pause"
       data-test="pause-icon"
       @click="pause"
     />
-    <v-icon
+    <v-btn
       v-else
-      variant="text"
-      icon="mdi-play-circle"
-      color="primary"
-      rounded
-      size="x-large"
-      data-test="play-icon"
+      class="bg-primary"
+      rounded="circle"
+      size="48"
+      :ripple="false"
+      icon="mdi-play"
+      data-test="play-btn"
       @click="play"
     />
+
     <v-slider
       v-model="currentTime"
       class="ml-0 flex-grow-1 flex-shrink-0"

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -80,12 +80,19 @@ const changePlaybackTime = (value: number) => {
   formattedCurrentTime.value = formatTime(value);
 };
 
+const getSessionRows = () => {
+  const dimensionsLine = logs?.split("\n")[1] ?? ""; // returns a string in the format of `[0.123, "r", "80x24"]`
+  const dimensions = JSON.parse(dimensionsLine)[2];
+  const rows = dimensions.split("x")[1];
+  return rows;
+};
+
 onMounted(() => {
   const playerOptions = {
     fit: "height",
-    terminalFontSize: "1rem",
     controls: false,
     autoplay: true,
+    rows: getSessionRows(),
   };
 
   player.value = AsciinemaPlayer.create({ data: logs }, wrapper.value, playerOptions);

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -218,6 +218,7 @@ watchEffect(() => !showDialog.value && changeFocusToPlayer());
 :deep(.ap-wrapper) {
   background-color: #121314;
   justify-content: start;
+  max-height: calc(100vh - 4rem) !important;
 }
 
 .shortcut {

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -8,6 +8,7 @@
 
   <v-card-actions
     class="text-h5 pa-3 d-flex ga-4 align-center"
+    @click="changeFocusToPlayer()"
   >
     <v-btn
       v-if="isPlaying"
@@ -74,7 +75,7 @@
 
 <script setup lang="ts">
 import * as AsciinemaPlayer from "asciinema-player";
-import { onMounted, ref } from "vue";
+import { onMounted, ref, watchEffect } from "vue";
 
 const { logs } = defineProps<{
   logs: string | null;
@@ -84,6 +85,7 @@ const isPlaying = ref(true);
 const showDialog = ref(false);
 const containerDiv = ref<HTMLDivElement | null>(null);
 const player = ref<AsciinemaPlayer.AsciinemaPlayer | null>(null);
+const playerWrapper = ref<HTMLDivElement | null>(null);
 const currentTime = ref(0);
 const duration = ref(0);
 const formattedCurrentTime = ref("00:00:00");
@@ -140,6 +142,8 @@ const openDialog = () => {
   showDialog.value = true;
 };
 
+const changeFocusToPlayer = () => { playerWrapper.value?.focus(); };
+
 onMounted(() => {
   const playerOptions = {
     fit: "height",
@@ -150,7 +154,8 @@ onMounted(() => {
 
   player.value = AsciinemaPlayer.create({ data: logs }, containerDiv.value, playerOptions);
 
-  (containerDiv.value?.querySelector(".ap-wrapper") as HTMLElement).focus();
+  playerWrapper.value = containerDiv.value?.querySelector(".ap-wrapper") as HTMLDivElement;
+  changeFocusToPlayer();
 
   player.value.addEventListener("playing", () => {
     getCurrentTime();
@@ -166,6 +171,8 @@ onMounted(() => {
     clearCurrentTimeUpdater();
   });
 });
+
+watchEffect(() => !showDialog.value && changeFocusToPlayer());
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -4,11 +4,13 @@
     v-if="logs"
     ref="containerDiv"
     @keydown.space.prevent="isPlaying = !isPlaying"
+    data-test="player-container"
   />
 
   <v-card-actions
     class="text-h5 px-3 py-2 d-flex ga-4 align-center"
-    @click="changeFocusToPlayer()"
+    @click="changeFocusToPlayer"
+    data-test="player-controls"
   >
     <v-btn
       v-if="isPlaying"
@@ -17,7 +19,7 @@
       size="48"
       :ripple="false"
       icon="mdi-pause"
-      data-test="pause-icon"
+      data-test="pause-btn"
       @click="pause"
     />
     <v-btn
@@ -31,7 +33,14 @@
       @click="play"
     />
 
-    <span v-if="smAndUp" id="playback-time" class="text-medium-emphasis text-body-1">{{formattedCurrentTime}} / {{formattedDuration}}</span>
+    <span
+      v-if="smAndUp"
+      id="playback-time"
+      class="text-medium-emphasis text-body-1"
+      data-test="playback-time"
+    >
+      {{formattedCurrentTime}} / {{formattedDuration}}
+    </span>
 
     <v-slider
       v-model="currentTime"
@@ -57,7 +66,7 @@
       prepend-inner-icon="mdi-speedometer"
       data-test="speed-select"
       @click.stop
-      @update:model-value="changePlaybackSpeed()"
+      @update:model-value="changePlaybackSpeed"
     />
     <v-btn
       v-if="mdAndUp"
@@ -67,7 +76,7 @@
       rounded
       density="compact"
       size="x-large"
-      data-test="keyboard-icon"
+      data-test="shortcuts-btn"
       @click="openDialog"
     />
   </v-card-actions>
@@ -207,6 +216,8 @@ onMounted(() => {
 });
 
 watchEffect(() => !showDialog.value && changeFocusToPlayer());
+
+defineExpose({ player });
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -33,7 +33,9 @@
       hide-details
       color="white"
       data-test="time-slider"
-
+      @update:model-value="(value) => changePlaybackTime(value)"
+      @mousedown="pause"
+      @mouseup="play"
     />
   </v-card-actions>
 </template>
@@ -70,6 +72,12 @@ const startCurrentTimeUpdater = () => {
       formattedCurrentTime.value = formatTime(time);
     }
   }, 100);
+};
+
+const changePlaybackTime = (value: number) => {
+  player.value.seek(value);
+  currentTime.value = value;
+  formattedCurrentTime.value = formatTime(value);
 };
 
 onMounted(() => {

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -7,7 +7,7 @@
   />
 
   <v-card-actions
-    class="text-h5 pa-3 d-flex ga-4 align-center"
+    class="text-h5 px-3 py-2 d-flex ga-4 align-center"
     @click="changeFocusToPlayer()"
   >
     <v-btn
@@ -31,12 +31,14 @@
       @click="play"
     />
 
+    <span v-if="smAndUp" id="playback-time" class="text-medium-emphasis text-body-1">{{formattedCurrentTime}} / {{formattedDuration}}</span>
+
     <v-slider
       v-model="currentTime"
       class="ml-0 flex-grow-1 flex-shrink-0"
       min="0"
       :max="duration"
-      :label="`${formattedCurrentTime} - ${formattedDuration}`"
+      aria-labelledby="playback-time"
       hide-details
       color="white"
       data-test="time-slider"
@@ -58,10 +60,12 @@
       @update:model-value="changePlaybackSpeed()"
     />
     <v-btn
+      v-if="mdAndUp"
       role="button"
       variant="text"
       icon="mdi-keyboard"
       rounded
+      density="compact"
       size="x-large"
       data-test="keyboard-icon"
       @click="openDialog"
@@ -87,6 +91,7 @@
 <script setup lang="ts">
 import * as AsciinemaPlayer from "asciinema-player";
 import { onMounted, ref, watchEffect } from "vue";
+import { useDisplay } from "vuetify/lib/framework.mjs";
 
 const { logs } = defineProps<{
   logs: string | null;
@@ -104,8 +109,9 @@ const formattedCurrentTime = ref("00:00:00");
 const formattedDuration = ref("00:00:00");
 const timeUpdaterId = ref<number>();
 const currentSpeed = ref(1);
+const { smAndUp, mdAndUp } = useDisplay();
 
-const formatTime = (time: number) => new Date(time * 1000).toISOString().slice(11, 19);
+const formatTime = (time: number) => new Date(time * 1000).toISOString().slice(time >= 3600 ? 11 : 14, 19);
 
 const getCurrentTime = () => {
   const time = player.value.getCurrentTime();

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -97,6 +97,8 @@ const { logs } = defineProps<{
   logs: string | null;
 }>();
 
+const emit = defineEmits(["close"]);
+
 const isPlaying = ref(true);
 const showDialog = ref(false);
 const sessionEnded = ref(false);
@@ -182,6 +184,12 @@ const setPlayerEventListeners = () => {
     sessionEnded.value = true;
     isPlaying.value = false;
     clearCurrentTimeUpdater();
+  });
+
+  containerDiv.value?.addEventListener("keydown", (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      emit("close");
+    }
   });
 };
 

--- a/ui/src/components/Sessions/PlayerShortcutsDialog.vue
+++ b/ui/src/components/Sessions/PlayerShortcutsDialog.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-dialog
+    :fullscreen="false"
+    v-model="showDialog"
+  >
+    <v-card title="Keyboard Shortcuts">
+      <v-card-text>
+        <div class="shortcut"><v-kbd>space</v-kbd>: pause / resume</div>
+        <div class="shortcut"><v-kbd>f</v-kbd>: toggle fullscreen mode</div>
+        <div class="shortcut"><v-kbd>←</v-kbd> / <v-kbd>→</v-kbd>: rewind / fast-forward by 5 seconds</div>
+        <div class="shortcut"><v-kbd>Shift</v-kbd> + <v-kbd>←</v-kbd> / <v-kbd>→</v-kbd>: rewind / fast-forward by 10%</div>
+        <div class="shortcut"><v-kbd>0</v-kbd>, <v-kbd>1</v-kbd>, <v-kbd>2</v-kbd> ... <v-kbd>9</v-kbd>: jump to 0%, 10%, 20% ... 90%</div>
+        <div class="shortcut"><v-kbd>,</v-kbd>/<v-kbd>.</v-kbd>: step back / forward, a frame at a time (only when paused)</div>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+const showDialog = defineModel<boolean>("showDialog");
+</script>
+
+<style lang="scss" scoped>
+.shortcut {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+
+  .v-kbd {
+    padding: .2rem .5rem;
+    font-weight: 700;
+  }
+}
+</style>

--- a/ui/src/components/Sessions/SessionPlay.vue
+++ b/ui/src/components/Sessions/SessionPlay.vue
@@ -17,20 +17,16 @@
       :fullscreen="true"
       v-model="showDialog"
     >
-      <v-card class="bg-v-theme-surface">
-        <v-card-title
-          class="text-h5 pa-3 bg-primary d-flex justify-space-between ga-4 align-center"
-        >
-          <v-btn
-            variant="text"
-            data-test="close-btn"
-            icon="mdi-close"
-            @click="showDialog = false"
-          />
-        </v-card-title>
-        <div class="ma-0 pa-0 w-100 fill-height position-relative bg-v-theme-terminal">
-          <Player :logs />
-        </div>
+      <v-card class="bg-v-theme-surface position-relative">
+        <v-btn
+          class="position-absolute top-0 right-0 ma-2 close-btn"
+          variant="text"
+          data-test="close-btn"
+          icon="mdi-close"
+          @click="closeDialog"
+        />
+
+        <Player :logs />
       </v-card>
     </v-dialog>
   </div>
@@ -71,7 +67,7 @@ const store = useStore();
 const logs = ref<string | null>(null);
 const isCommunity = computed(() => envVariables.isCommunity);
 
-const openPlay = async () => {
+const getSessions = async () => {
   if (props.recorded) {
     await store.dispatch("sessions/getLogSession", props.uid);
     logs.value = store.getters["sessions/get"];
@@ -80,7 +76,7 @@ const openPlay = async () => {
 
 const displayDialog = async () => {
   try {
-    await openPlay();
+    await getSessions();
     showDialog.value = true;
   } catch (error: unknown) {
     store.dispatch(
@@ -98,15 +94,14 @@ const openDialog = () => {
   }
   displayDialog();
 };
+
+const closeDialog = () => {
+  showDialog.value = false;
+};
 </script>
 
 <style lang="scss" scoped>
-.terminal {
-  position: absolute;
-  top: 0px;
-  bottom: 0px;
-  left: 0;
-  right:0;
-  margin-right: 0px;
+.close-btn {
+  z-index: 999;
 }
 </style>

--- a/ui/src/components/Sessions/SessionPlay.vue
+++ b/ui/src/components/Sessions/SessionPlay.vue
@@ -18,70 +18,19 @@
       v-model="showDialog"
     >
       <v-card class="bg-v-theme-surface">
-        <div class="ma-0 pa-0 w-100 fill-height position-relative">
-          <div ref="terminal" class="terminal" />
-        </div>
         <v-card-title
           class="text-h5 pa-3 bg-primary d-flex justify-space-between ga-4 align-center"
         >
-
-          <v-icon
-            v-if="!paused"
-            variant="text"
-            icon="mdi-pause-circle"
-            class="maa-2"
-            color="primaary"
-            rounded
-            size="x-large"
-            data-test="pause-icon"
-            @click="pauseHandler"
-          />
-          <v-icon
-            v-else
-            variant="text"
-            icon="mdi-play-circle"
-            class="pl-0"
-            color="primaary"
-            rounded
-            size="x-large"
-            data-test="play-icon"
-            @click="pauseHandler"
-          />
-          <v-slider
-            v-model="currentTime"
-            class="ml-0 flex-grow-1 flex-shrink-0"
-            min="0"
-            :max="totalLength"
-            :label="`${nowTimerDisplay} - ${endTimerDisplay}`"
-            hide-details
-            color="white"
-            data-test="time-slider"
-            @update:model-value="changeSliderTime()"
-            @mousedown="(previousPause = paused), (paused = true)"
-            @mouseup="paused = previousPause"
-            @click="setSliderDiplayTime(currentTime)"
-          />
-          <div class="d-flex flex-column">
-            <v-select
-              :items="speedList"
-              v-model="defaultSpeed"
-              hide-details
-              flat
-              prepend-inner-icon="mdi-speedometer"
-              data-test="speed-select"
-              @change="speedChange(defaultSpeed)"
-            />
-          </div>
-
           <v-btn
             variant="text"
             data-test="close-btn"
             icon="mdi-close"
             @click="showDialog = false"
           />
-
         </v-card-title>
-
+        <div class="ma-0 pa-0 w-100 fill-height position-relative bg-v-theme-terminal">
+          <Player :logs />
+        </div>
       </v-card>
     </v-dialog>
   </div>
@@ -90,22 +39,13 @@
 <script setup lang="ts">
 import {
   computed,
-  nextTick,
-  onUpdated,
   ref,
-  watch,
 } from "vue";
-import { Terminal } from "xterm";
-import "xterm/css/xterm.css";
-import { FitAddon } from "xterm-addon-fit";
-import moment from "moment";
 import { envVariables } from "@/envVariables";
 import { useStore } from "@/store";
 import { INotificationsError } from "@/interfaces/INotifications";
 import handleError from "@/utils/handleError";
-import { ITerminalFrames, ITerminalLog } from "@/interfaces/ITerminal";
-
-type Timer = ReturnType<typeof setTimeout>;
+import Player from "./Player.vue";
 
 const props = defineProps({
   uid: {
@@ -125,243 +65,23 @@ const props = defineProps({
     default: false,
   },
 });
-const emit = defineEmits(["update"]);
+
 const showDialog = ref(false);
-const terminal = ref<HTMLElement>({} as HTMLElement);
-const currentTime = ref(0);
-const totalLength = ref(0);
-const endTimerDisplay = ref<string | number>(0);
-const getTimerNow = ref<string | number>(0);
-const paused = ref(false);
-const previousPause = ref(false);
-const sliderChange = ref(false);
-const speedList = ref([0.5, 1, 1.5, 2, 4]);
-const logs = ref<Array<ITerminalLog>>([]);
-const frames = ref<Array<ITerminalFrames>>([]);
-const defaultSpeed = ref(1);
-const transition = ref(false);
-const xterm = ref<Terminal>({} as Terminal);
-const fitAddon = ref<FitAddon>({} as FitAddon);
-const iterativeTimer = ref<Timer>();
-const iterativePrinting = ref<Timer>();
-const isCommunity = computed(() => envVariables.isCommunity);
 const store = useStore();
-const length = computed(() => logs.value.length);
-const nowTimerDisplay = computed(() => getTimerNow.value);
-
-const openDialog = () => {
-  if (envVariables.isCommunity) {
-    store.commit("users/setShowPaywall", true);
-    return;
-  }
-  showDialog.value = true;
-};
-const getSliderIntervalLength = (timeMs: number | null) => {
-  let interval: number;
-  if (!timeMs && logs.value.length > 0) {
-    // not params, will return metrics to max timelength
-    const max = new Date(logs.value[length.value - 1].time);
-    const min = new Date(logs.value[0].time);
-    interval = +max - +min;
-  } else {
-    // it will format to the time argument passed
-    interval = timeMs || 0;
-  }
-
-  return interval;
-};
-
-const setSliderDiplayTime = async (timeMs: number | null) => {
-  const interval = getSliderIntervalLength(timeMs);
-  const duration = moment.duration(interval, "milliseconds");
-
-  // format according to how long
-  let hoursFormat;
-  if (duration.asHours() > 1) hoursFormat = "h";
-  else hoursFormat = "";
-
-  const displayTime = moment
-    .utc(duration.asMilliseconds())
-    .format(`${hoursFormat ? `${hoursFormat}:` : ""}mm:ss`);
-  if (timeMs) {
-    endTimerDisplay.value = displayTime;
-  } else {
-    getTimerNow.value = displayTime;
-  }
-};
-
-const createFrames = () => {
-  // create cumulative frames for the exibition in slider
-  let time = 0;
-  let message = "";
-  const arrFrames = [
-    {
-      incMessage: (message += logs.value[0].message),
-      incTime: time,
-    },
-  ];
-
-  for (let i = 1; i < logs.value.length; i += 1) {
-    const future = new Date(logs.value[i].time);
-    const now = new Date(logs.value[i - 1].time);
-    const interval = moment
-      .duration(+future - +now, "milliseconds")
-      .asMilliseconds();
-    time += interval;
-    message += logs.value[i].message;
-    arrFrames.push({
-      incMessage: message,
-      incTime: time,
-    });
-  }
-  return arrFrames;
-};
-
-const timer = () => {
-  // Increments the slider
-  if (!paused.value) {
-    if (currentTime.value >= totalLength.value) {
-      paused.value = true;
-      return;
-    }
-    currentTime.value += 100;
-    setSliderDiplayTime(currentTime.value);
-  }
-  iterativeTimer.value = setTimeout(
-    timer.bind(null),
-    100 * (1 / defaultSpeed.value),
-  );
-};
-
-const searchClosestFrame = (givenTime: number, frames: Array<ITerminalFrames>) => {
-  // applies a binary search to find nearest frame
-  let between: number;
-  let lowerBound = 0;
-  let higherBound = frames.length - 1;
-  let nextTimeSetPrint;
-
-  for (; higherBound - lowerBound > 1;) {
-    // progressive increment search
-    between = Math.floor((lowerBound + higherBound) / 2);
-    if (frames[between].incTime < givenTime) {
-      lowerBound = between;
-      nextTimeSetPrint = givenTime - frames[between].incTime;
-    } else {
-      higherBound = between;
-      nextTimeSetPrint = frames[between].incTime - givenTime;
-    }
-  }
-  return {
-    message: frames[lowerBound].incMessage,
-    index: lowerBound,
-    waitForPrint: nextTimeSetPrint,
-  };
-};
-
-const print = (i: number, logsArray: Array<ITerminalLog>) => {
-  // Writes iteratevely on xterm as time progresses
-  sliderChange.value = false;
-  if (!paused.value) {
-    xterm.value.write(`${logsArray[i].message}`);
-    if (i === logsArray.length - 1) return;
-    const nowTimerDisplay = new Date(logsArray[i].time);
-    const future = new Date(logsArray[i + 1].time);
-    const interval = +future - +nowTimerDisplay;
-    iterativePrinting.value = setTimeout(
-      print.bind(null, i + 1, logsArray),
-      interval * (1 / defaultSpeed.value),
-    );
-  }
-};
-
-const clear = () => {
-  // Ensure to clear functions for syncronism
-  clearInterval(iterativePrinting.value);
-  clearInterval(iterativeTimer.value);
-};
-
-const xtermSyncFrame = (givenTime: number) => {
-  if (xterm.value) {
-    xterm.value.write("\u001Bc"); // clean screen
-    const frame = searchClosestFrame(givenTime, frames.value);
-    clear();
-    xterm.value.write(frame.message); // write frame on xterm
-    iterativeTimer.value = setTimeout(timer.bind(null), 1);
-    iterativePrinting.value = setTimeout(
-      print.bind(null, frame.index + 1, logs.value),
-      frame.waitForPrint * (1 / defaultSpeed.value),
-    );
-  }
-};
-
-const speedChange = (speed: number) => {
-  defaultSpeed.value = speed;
-  xtermSyncFrame(currentTime.value);
-};
-
-const changeSliderTime = () => {
-  sliderChange.value = true;
-  xtermSyncFrame(currentTime.value);
-};
-
-const pauseHandler = () => {
-  paused.value = !paused.value;
-  xtermSyncFrame(currentTime.value);
-};
-
-onUpdated(() => {
-  if (showDialog.value) {
-    setSliderDiplayTime(currentTime.value);
-  }
-});
+const logs = ref<string | null>(null);
+const isCommunity = computed(() => envVariables.isCommunity);
 
 const openPlay = async () => {
   if (props.recorded) {
     await store.dispatch("sessions/getLogSession", props.uid);
     logs.value = store.getters["sessions/get"];
-    totalLength.value = getSliderIntervalLength(null);
-    setSliderDiplayTime(null);
-    setSliderDiplayTime(currentTime.value);
-
-    frames.value = createFrames();
-
-    xterm.value = new Terminal({
-      cursorBlink: true,
-      fontFamily: "monospace",
-      theme: {
-        background: "#0f1526",
-      },
-    });
-
-    fitAddon.value = new FitAddon();
-    xterm.value.loadAddon(fitAddon.value); // adjust screen in container
-
-    fitAddon.value.fit();
-
-    if (xterm.value.element) {
-      xterm.value.reset();
-    }
-  }
-};
-
-const connect = async () => {
-  if (!xterm.value.element) {
-    xterm.value.open(terminal.value);
-    fitAddon.value.fit();
-    xterm.value.focus();
-    print(0, logs.value);
-    timer();
   }
 };
 
 const displayDialog = async () => {
-  // await to change dialog for the connection
   try {
     await openPlay();
-
-    await nextTick().then(() => {
-      connect();
-    });
+    showDialog.value = true;
   } catch (error: unknown) {
     store.dispatch(
       "snackbar/showSnackbarErrorLoading",
@@ -371,28 +91,13 @@ const displayDialog = async () => {
   }
 };
 
-const close = async () => {
-  transition.value = true;
-  if (xterm.value) {
-    xterm.value.reset();
-    xterm.value.element?.remove();
+const openDialog = () => {
+  if (envVariables.isCommunity) {
+    store.commit("users/setShowPaywall", true);
+    return;
   }
-  clear();
-  currentTime.value = 0;
-  paused.value = false;
-  defaultSpeed.value = 1;
-
-  emit("update");
+  displayDialog();
 };
-
-watch(showDialog, (value) => {
-  if (!value) {
-    close();
-    showDialog.value = false;
-  } else {
-    displayDialog();
-  }
-});
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Sessions/SessionPlay.vue
+++ b/ui/src/components/Sessions/SessionPlay.vue
@@ -26,7 +26,7 @@
           @click="closeDialog"
         />
 
-        <Player :logs />
+        <Player :logs @close="closeDialog" />
       </v-card>
     </v-dialog>
   </div>

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -8,6 +8,7 @@ import vuetify from "./plugins/vuetify";
 import { key, store } from "./store";
 import { router } from "./router";
 import App from "./App.vue";
+import "asciinema-player/dist/bundle/asciinema-player.css";
 
 import { loadFonts } from "./plugins/webfontloader";
 

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -2,6 +2,7 @@
 $font-size-root: 36px;
 $v-theme-surface: #667acc;
 $v-theme-background: #1E2127;
+$v-theme-terminal: #0f1526;
 
 // $material-dark: map-merge(
 //   $material-dark,

--- a/ui/tests/components/Sessions/Player.spec.ts
+++ b/ui/tests/components/Sessions/Player.spec.ts
@@ -1,0 +1,112 @@
+import { mount, flushPromises, VueWrapper } from "@vue/test-utils";
+import { describe, beforeEach, vi, it, expect } from "vitest";
+import { createVuetify } from "vuetify";
+import { SnackbarPlugin } from "@/plugins/snackbar";
+import { router } from "@/router";
+import { store, key } from "@/store";
+import Player from "@/components/Sessions/Player.vue";
+
+type PlayerWrapper = VueWrapper<InstanceType<typeof Player>>;
+
+describe("Asciinema Player", () => {
+  let wrapper: PlayerWrapper;
+
+  const vuetify = createVuetify();
+
+  // eslint-disable-next-line vue/max-len
+  const logsMock = "{\"version\": 2, \"width\": 80, \"height\": 24}\n[0.123, \"r\", \"80x24\"]\n[1.0, \"o\", \"Asciinema player test\"]\n[2.0, \"o\", \"logout\"]";
+
+  const authData = {
+    status: "success",
+    token: "",
+    user: "test",
+    name: "test",
+    tenant: "fake-tenant",
+    email: "test@test.com",
+    id: "507f1f77bcf86cd799439011",
+    role: "owner",
+    mfa: {
+      enable: false,
+      validate: false,
+    },
+  };
+
+  const session = true;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("tenant", "fake-tenant");
+
+    store.commit("auth/authSuccess", authData);
+    store.commit("auth/changeData", authData);
+    store.commit("security/setSecurity", session);
+
+    wrapper = mount(Player, {
+      global: {
+        plugins: [[store, key], vuetify, router, SnackbarPlugin],
+        config: {
+          errorHandler: () => { /* ignore global error handler */ },
+        },
+      },
+      props: {
+        logs: logsMock,
+      },
+    });
+  });
+
+  it("Is a Vue instance", () => {
+    expect(wrapper.vm).toBeTruthy();
+  });
+
+  it("Renders the component", () => {
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("Data is defined", () => {
+    expect(wrapper.vm.$data).toBeDefined();
+  });
+
+  it("Renders components", async () => {
+    await flushPromises();
+    expect(wrapper.find('[data-test="player-container"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="player-controls"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="pause-btn"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="play-btn"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="playback-time"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="time-slider"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="speed-select"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="shortcuts-btn"]').exists()).toBe(true);
+  });
+
+  it("Creates player on mount", async () => {
+    await flushPromises();
+    expect(wrapper.vm.player).toBeDefined();
+  });
+
+  // it("Fails to Change Password", async () => {
+  //   mockUser.onPatch("http://localhost:3000/api/users").reply(403);
+
+  //   const StoreSpy = vi.spyOn(store, "dispatch");
+
+  //   wrapper.vm.show = true;
+  //   await flushPromises();
+
+  //   await wrapper.findComponent('[data-test="password-input"]').setValue("xxxxxx");
+  //   await wrapper.findComponent('[data-test="new-password-input"]').setValue("x1x2x3");
+  //   await wrapper.findComponent('[data-test="confirm-new-password-input"]').setValue("x1x2x3");
+
+  //   await wrapper.findComponent('[data-test="change-password-btn"]').trigger("click");
+  //   await flushPromises();
+
+  //   expect(StoreSpy).toHaveBeenCalledWith("users/patchPassword", {
+  //     name: "test",
+  //     username: undefined,
+  //     email: "test@test.com",
+  //     recovery_email: undefined,
+  //     currentPassword: "xxxxxx",
+  //     newPassword: "x1x2x3",
+  //   });
+
+  //   expect(StoreSpy).toHaveBeenCalledWith("snackbar/showSnackbarErrorDefault");
+  // });
+});

--- a/ui/tests/components/Sessions/__snapshots__/Player.spec.ts.snap
+++ b/ui/tests/components/Sessions/__snapshots__/Player.spec.ts.snap
@@ -1,0 +1,92 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Asciinema Player > Renders the component 1`] = `
+"<div data-v-f3a0259a="" class="wrapper ma-0 pa-0 w-100 fill-height position-relative bg-v-theme-terminal" data-test="player-container">
+  <div class="ap-wrapper" tabindex="-1">
+    <div class="ap-player asciinema-player-theme-asciinema" style="height: 0px;"><pre class="ap-terminal ap-cursor-on ap-blink" aria-live="polite" tabindex="0" style="width: 80ch; height: 31.9999999992em; font-size: 100%; --term-line-height: 1.3333333333em; --term-cols: 80;"></pre>
+    </div>
+  </div>
+</div>
+<div data-v-f3a0259a="" class="v-card-actions text-h5 px-3 py-2 d-flex ga-4 align-center" data-test="player-controls"><button data-v-f3a0259a="" type="button" class="v-btn v-btn--icon v-btn--slim v-theme--light v-btn--density-default rounded-circle v-btn--variant-text bg-primary" style="width: 48px; height: 48px;" data-test="pause-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+    <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-pause mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+    <!---->
+    <!---->
+  </button><span data-v-f3a0259a="" id="playback-time" class="text-medium-emphasis text-body-1" data-test="playback-time">00:00:00 / 00:00:00</span>
+  <div data-v-f3a0259a="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-slider v-locale--is-ltr ml-0 flex-grow-1 flex-shrink-0" aria-labelledby="playback-time" data-test="time-slider">
+    <!---->
+    <div class="v-input__control">
+      <div class="v-slider__container"><input id="input-v-1" name="input-v-1" tabindex="-1" value="0">
+        <div class="v-slider-track" style="--v-slider-track-size: 4px; --v-slider-tick-size: 2px;">
+          <div class="v-slider-track__background bg-white v-slider-track__background--opacity" style="inset-inline-start: 0%; width: 100%;"></div>
+          <div class="v-slider-track__fill bg-white" style="inset-inline-start: 0%; width: 0%;"></div>
+          <!---->
+        </div>
+        <div class="v-slider-thumb v-locale--is-ltr" style="--v-slider-thumb-position: 0%; --v-slider-thumb-size: 20px;" role="slider" tabindex="0" aria-valuemin="0" aria-valuemax="0" aria-valuenow="0" aria-readonly="false" aria-orientation="horizontal" aria-describedby="input-v-1-messages" elevation="2">
+          <div class="v-slider-thumb__surface text-white elevation-2"></div>
+          <div class="v-slider-thumb__ripple text-white"></div>
+          <transition-stub name="scale-transition" appear="false" persisted="false" css="true">
+            <div class="v-slider-thumb__label-container" style="display: none;">
+              <div class="v-slider-thumb__label">
+                <div>0.0</div>
+              </div>
+            </div>
+          </transition-stub>
+        </div>
+      </div>
+    </div>
+    <!---->
+    <!---->
+  </div>
+  <div data-v-f3a0259a="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-select v-select--single v-select--selected flex-grow-0 flex-shrink-0" data-test="speed-select">
+    <!---->
+    <div class="v-input__control">
+      <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--flat v-field--prepended v-field--no-label v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-controls="v-menu-v-4">
+        <div class="v-field__overlay"></div>
+        <div class="v-field__loader">
+          <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+            <!---->
+            <div class="v-progress-linear__background"></div>
+            <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+            <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+              <div class="v-progress-linear__indeterminate">
+                <div class="v-progress-linear__indeterminate long"></div>
+                <div class="v-progress-linear__indeterminate short"></div>
+              </div>
+            </transition-stub>
+            <!---->
+          </div>
+        </div>
+        <div class="v-field__prepend-inner"><i class="mdi-speedometer mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i>
+          <!---->
+        </div>
+        <div class="v-field__field" data-no-activator="">
+          <!---->
+          <!---->
+          <!---->
+          <div class="v-field__input" data-no-activator="">
+            <!---->
+            <!---->
+            <div class="v-select__selection"><span class="v-select__selection-text">1<!----></span></div><input size="1" type="text" id="input-v-2" aria-describedby="input-v-2-messages" inputmode="none" aria-label="Open" title="Open" value="1">
+          </div>
+          <!---->
+        </div>
+        <!---->
+        <div class="v-field__append-inner">
+          <!----><i class="mdi-menu-down mdi v-icon notranslate v-theme--light v-icon--size-default v-select__menu-icon" aria-hidden="true"></i>
+          <!---->
+        </div>
+        <div class="v-field__outline">
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </div>
+    <!---->
+    <!---->
+  </div><button data-v-f3a0259a="" type="button" class="v-btn v-btn--icon v-btn--slim v-theme--light v-btn--density-compact v-btn--rounded v-btn--size-x-large v-btn--variant-text" role="button" data-test="shortcuts-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+    <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-keyboard mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+    <!---->
+    <!---->
+  </button>
+</div>"
+`;


### PR DESCRIPTION
This PR adds the Asciinema Player to stream the new recorded sessions, now recorded as Asciinema `.cast` files. 

Now, the old player code in `SessionPlay.vue` was replaced by the new `Player.vue` component, based in the Asciinema Player. The new player also has some unit tests, that was lacking in the previous implementation.