### PR TITLE
fix(ui): separate session state in store

### DIFF
--- a/ui/src/components/Sessions/SessionPlay.vue
+++ b/ui/src/components/Sessions/SessionPlay.vue
@@ -67,16 +67,16 @@ const store = useStore();
 const logs = ref<string | null>(null);
 const isCommunity = computed(() => envVariables.isCommunity);
 
-const getSessions = async () => {
+const getSessionLogs = async () => {
   if (props.recorded) {
-    await store.dispatch("sessions/getLogSession", props.uid);
-    logs.value = store.getters["sessions/get"];
+    await store.dispatch("sessions/getSessionLogs", props.uid);
+    logs.value = store.getters["sessions/getLogs"];
   }
 };
 
 const displayDialog = async () => {
   try {
-    await getSessions();
+    await getSessionLogs();
     showDialog.value = true;
   } catch (error: unknown) {
     store.dispatch(

--- a/ui/src/store/modules/sessions.ts
+++ b/ui/src/store/modules/sessions.ts
@@ -6,6 +6,7 @@ import { State } from "..";
 export interface SessionsState {
   sessions: Array<ISessions>;
   session: ISessions;
+  sessionLogs: string | null;
   numberSessions: number;
   page: number;
   perPage: number;
@@ -16,6 +17,7 @@ export const sessions: Module<SessionsState, State> = {
   state: {
     sessions: [],
     session: {} as ISessions,
+    sessionLogs: null,
     numberSessions: 0,
     page: 1,
     perPage: 10,
@@ -24,6 +26,7 @@ export const sessions: Module<SessionsState, State> = {
   getters: {
     list: (state) => state.sessions,
     get: (state) => state.session,
+    getLogs: (state) => state.sessionLogs,
     getNumberSessions: (state) => state.numberSessions,
     getPage: (state) => state.page,
     getPerPage: (state) => state.perPage,
@@ -37,6 +40,10 @@ export const sessions: Module<SessionsState, State> = {
 
     setSession: (state, res) => {
       state.session = res.data;
+    },
+
+    setSessionLogs: (state, res) => {
+      state.sessionLogs = res.data;
     },
 
     setPagePerpage: (state, data) => {
@@ -54,8 +61,12 @@ export const sessions: Module<SessionsState, State> = {
       state.numberSessions = 0;
     },
 
-    clearObjectSession: (state) => {
+    clearSession: (state) => {
       state.session = {} as ISessions;
+    },
+
+    clearSessionLogs: (state) => {
+      state.sessionLogs = null;
     },
 
     removeRecordedSession: (state) => {
@@ -105,12 +116,12 @@ export const sessions: Module<SessionsState, State> = {
       }
     },
 
-    getLogSession: async (context, uid) => {
+    getSessionLogs: async (context, uid) => {
       try {
         const res = await apiSession.getLog(uid);
-        context.commit("setSession", res);
+        context.commit("setSessionLogs", res);
       } catch (error) {
-        context.commit("clearObjectSession");
+        context.commit("clearSessionLogs");
         throw error;
       }
     },


### PR DESCRIPTION
Previously, the session store used the same variable to store the session details object and the recording logs, alternating between the two, depending on the use case. This PR fixes this, creating a separate variable and methods for the logs, for more clarity. The methods' names in `SessionPlay.vue` were also updated to keep the component and the store aligned.