### PR TITLE
fix(ui): fix MemberInvite errors

### DIFF
--- a/ui/src/components/Team/Member/MemberInvite.vue
+++ b/ui/src/components/Team/Member/MemberInvite.vue
@@ -82,6 +82,7 @@
 
               <v-text-field
                 v-model="email"
+                class="mb-4"
                 label="Email"
                 :error-messages="emailError"
                 required

--- a/ui/src/components/Team/Member/MemberInvite.vue
+++ b/ui/src/components/Team/Member/MemberInvite.vue
@@ -30,7 +30,7 @@
         class="bg-v-theme-surface"
       >
         <div class="mt-4 mb-4">
-          <div class="d-flex justify-center align-center bg-whitea">
+          <div class="d-flex justify-center align-center">
             <v-avatar
               class="-right-32 z-0"
               size="46"
@@ -251,8 +251,9 @@ const handleInviteError = (error: unknown) => {
         setEmailError("This user does not exist.");
         break;
       default:
-        handleError(error);
+        setEmailError("An error occurred while sending the invitation.");
     }
+    handleError(error);
   }
 };
 

--- a/ui/src/store/modules/namespaces.ts
+++ b/ui/src/store/modules/namespaces.ts
@@ -135,22 +135,12 @@ export const namespaces: Module<NamespacesState, State> = {
     },
 
     sendEmailInvitation: async (context, data) => {
-      try {
-        await apiNamespace.sendNamespaceLink(data);
-      } catch (error) {
-        console.error(error);
-        throw error;
-      }
+      await apiNamespace.sendNamespaceLink(data);
     },
 
     generateInvitationLink: async (context, data) => {
-      try {
-        const res = await apiNamespace.generateNamespaceLink(data);
-        context.commit("setInvitationLink", res.data.link);
-      } catch (error) {
-        console.error(error);
-        throw error;
-      }
+      const res = await apiNamespace.generateNamespaceLink(data);
+      context.commit("setInvitationLink", res.data.link);
     },
 
     editUser: async (context, data) => {


### PR DESCRIPTION
This PR removes `console.error` statements in the store, that caused Axios errors in the MemberInvite component tests. Additionally, it removes a misspelled "bg-whitea" Vuetify class that had no visual effect, and adds proper margin to the email input to separate its error messages from the role input, improving readability.