### PR TITLE
refactor(ui): remove unnecessary "Data is defined" tests

### DIFF
--- a/ui/tests/components/AppBar/AppBar.spec.ts
+++ b/ui/tests/components/AppBar/AppBar.spec.ts
@@ -76,10 +76,10 @@ const authData = {
 const systemInfo = {
   version: "v0.18.0",
   endpoints:
-{
-  ssh: "localhost:2222",
-  api: "localhost:8080",
-},
+  {
+    ssh: "localhost:2222",
+    api: "localhost:8080",
+  },
   setup: true,
   authentication:
   {
@@ -142,10 +142,6 @@ describe("AppBar Component", () => {
 
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
   });
 
   it("Renders internal components", async () => {

--- a/ui/tests/components/AuthMFA/MfaDisable.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaDisable.spec.ts
@@ -95,11 +95,6 @@ describe("MfaDisable", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    // Test if component data is defined
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Dialog opens", async () => {
     // Test if the dialog opens when the button is clicked
     wrapper.vm.showDialog = true;

--- a/ui/tests/components/AuthMFA/MfaForceRecoveryMail.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaForceRecoveryMail.spec.ts
@@ -95,11 +95,6 @@ describe("Force Adding a Recovery Mail", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    // Test if component data is defined
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the components", async () => {
     const dialog = new DOMWrapper(document.body);
     wrapper.vm.dialog = true;

--- a/ui/tests/components/AuthMFA/MfaMailRecover.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaMailRecover.spec.ts
@@ -91,11 +91,6 @@ describe("Mfa Mail Recover ", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    // Test if component data is defined
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the components", async () => {
     expect(wrapper.find('[data-test="title"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="sub-title"]').exists()).toBe(true);

--- a/ui/tests/components/AuthMFA/MfaSettings.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaSettings.spec.ts
@@ -106,11 +106,6 @@ describe("MfaSettings", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    // Test if the component's data is defined
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Dialog opens", async () => {
     // Test if the dialog opens when a button is clicked
     wrapper.vm.showDialog = true;

--- a/ui/tests/components/Billing/BillingDialog.spec.ts
+++ b/ui/tests/components/Billing/BillingDialog.spec.ts
@@ -119,10 +119,6 @@ describe("Billing Dialog", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders dialog text", async () => {
     wrapper.vm.dialogCheckout = true;
     await flushPromises();

--- a/ui/tests/components/Billing/BillingPayment.spec.ts
+++ b/ui/tests/components/Billing/BillingPayment.spec.ts
@@ -114,10 +114,6 @@ describe("Billing Payment", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the correct html", async () => {
     await flushPromises();
     expect(wrapper.findComponent('[data-test="customer-name"]').exists()).toBe(true);

--- a/ui/tests/components/Billing/BillingWarning.spec.ts
+++ b/ui/tests/components/Billing/BillingWarning.spec.ts
@@ -158,12 +158,6 @@ describe("BillingWarning", () => {
         expect(wrapper.html()).toMatchSnapshot();
       });
 
-      ///////
-      // Data checking
-      //////
-      it("Data is defined", () => {
-        expect(wrapper.vm.$data).toBeDefined();
-      });
       it("Process data in the computed", () => {
         Reflect.ownKeys(test.computed).forEach((c) => {
           expect(wrapper.vm[c]).toEqual(test.computed[c]);

--- a/ui/tests/components/Connectors/ConnectorAdd.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorAdd.spec.ts
@@ -100,10 +100,6 @@ describe("Connector Add", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     await wrapper.findComponent('[data-test="connector-add-btn"]').trigger("click");
     const dialog = new DOMWrapper(document.body);

--- a/ui/tests/components/Connectors/ConnectorDelete.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorDelete.spec.ts
@@ -104,10 +104,6 @@ describe("Connector Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="connector-remove-btn"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="remove-icon"]').exists()).toBe(true);

--- a/ui/tests/components/Connectors/ConnectorEdit.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorEdit.spec.ts
@@ -106,10 +106,6 @@ describe("Connector Edit", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="connector-edit-btn"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="connector-edit-icon"]').exists()).toBe(true);

--- a/ui/tests/components/Connectors/ConnectorForm.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorForm.spec.ts
@@ -107,10 +107,6 @@ describe("Connector Form", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("renders the component", async () => {
     wrapper.vm.localDialog = true;
     await flushPromises();

--- a/ui/tests/components/Connectors/ConnectorList.spec.ts
+++ b/ui/tests/components/Connectors/ConnectorList.spec.ts
@@ -71,28 +71,29 @@ describe("Connector List", () => {
     },
   ];
 
-  const connectors = { data: [
-    {
-
-      uid: "3dd0d1f8-8246-4519-b11a-a3dd33717f65",
-      tenant_id: "3dd0d1f8-8246-4519-b11a-a3dd33717f65",
-      enable: true,
-      address: "127.0.0.1",
-      port: 2375,
-      secure: false,
-      status:
-
+  const connectors = {
+    data: [
       {
-        State: "connected",
-        Message: "",
-      },
-      tls: null,
 
+        uid: "3dd0d1f8-8246-4519-b11a-a3dd33717f65",
+        tenant_id: "3dd0d1f8-8246-4519-b11a-a3dd33717f65",
+        enable: true,
+        address: "127.0.0.1",
+        port: 2375,
+        secure: false,
+        status:
+
+        {
+          State: "connected",
+          Message: "",
+        },
+        tls: null,
+
+      },
+    ],
+    headers: {
+      "x-total-count": 1,
     },
-  ],
-  headers: {
-    "x-total-count": 1,
-  },
   };
 
   const billingData = {
@@ -200,10 +201,6 @@ describe("Connector List", () => {
 
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
   });
 
   it("Renders the component HTML", async () => {

--- a/ui/tests/components/Containers/Container.spec.ts
+++ b/ui/tests/components/Containers/Container.spec.ts
@@ -161,10 +161,6 @@ describe("Device", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders correctly", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });

--- a/ui/tests/components/Containers/ContainerAdd.spec.ts
+++ b/ui/tests/components/Containers/ContainerAdd.spec.ts
@@ -167,10 +167,6 @@ describe("ContainerAdd", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component data table", async () => {
     expect(wrapper.find('[data-test="device-add-btn"]').exists()).toBe(true);
     await wrapper.findComponent('[data-test="device-add-btn"]').trigger("click");

--- a/ui/tests/components/Containers/ContainerList.spec.ts
+++ b/ui/tests/components/Containers/ContainerList.spec.ts
@@ -169,10 +169,6 @@ describe("Container List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component HTML", async () => {
     expect(wrapper.findComponent('[data-test="container-table"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Containers/ContainerPendingList.spec.ts
+++ b/ui/tests/components/Containers/ContainerPendingList.spec.ts
@@ -169,10 +169,6 @@ describe("Container Pending List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component HTML", async () => {
     expect(wrapper.findComponent('[data-test="container-table"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Containers/ContainerRejectList.spec.ts
+++ b/ui/tests/components/Containers/ContainerRejectList.spec.ts
@@ -169,10 +169,6 @@ describe("Container Rejected List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component HTML", async () => {
     expect(wrapper.findComponent('[data-test="container-table"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Devices/Device.spec.ts
+++ b/ui/tests/components/Devices/Device.spec.ts
@@ -160,10 +160,6 @@ describe("Device", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders correctly", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });

--- a/ui/tests/components/Devices/DeviceAcceptWarning.spec.ts
+++ b/ui/tests/components/Devices/DeviceAcceptWarning.spec.ts
@@ -169,10 +169,6 @@ describe("Device Accept Warning", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component", async () => {
     const dialog = new DOMWrapper(document.body);
     expect(dialog.find('[data-test="device-accept-warning-dialog"]').exists()).toBe(true);

--- a/ui/tests/components/Devices/DeviceActionButton.spec.ts
+++ b/ui/tests/components/Devices/DeviceActionButton.spec.ts
@@ -173,10 +173,6 @@ describe("Device Action Button", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component data table", async () => {
     await wrapper.setProps({ name: "test-device", uid: "test-uid", notificationStatus: true, show: true });
     expect(wrapper.find('[data-test="notification-item"]').exists()).toBe(true);

--- a/ui/tests/components/Devices/DeviceAdd.spec.ts
+++ b/ui/tests/components/Devices/DeviceAdd.spec.ts
@@ -167,10 +167,6 @@ describe("Device Add", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component data table", async () => {
     expect(wrapper.find('[data-test="device-add-btn"]').exists()).toBe(true);
     await wrapper.findComponent('[data-test="device-add-btn"]').trigger("click");

--- a/ui/tests/components/Devices/DeviceChooser.spec.ts
+++ b/ui/tests/components/Devices/DeviceChooser.spec.ts
@@ -168,10 +168,6 @@ describe("Device Chooser", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component data table", async () => {
     const wrapper = new DOMWrapper(document.body);
     expect(wrapper.find('[data-test="dialog"]').exists()).toBe(true);

--- a/ui/tests/components/Devices/DeviceDelete.spec.ts
+++ b/ui/tests/components/Devices/DeviceDelete.spec.ts
@@ -177,10 +177,6 @@ describe("Device Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component data table", async () => {
     expect(wrapper.find('[data-test="device-delete-item"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="remove-icon"]').exists()).toBe(true);

--- a/ui/tests/components/Devices/DeviceIcon.spec.ts
+++ b/ui/tests/components/Devices/DeviceIcon.spec.ts
@@ -162,10 +162,6 @@ describe("Device Icon", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component", () => {
     expect(wrapper.find('[data-test="type-icon"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Devices/DeviceList.spec.ts
+++ b/ui/tests/components/Devices/DeviceList.spec.ts
@@ -166,10 +166,6 @@ describe("Device List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component HTML", async () => {
     expect(wrapper.findComponent('[data-test="device-table"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Devices/DeviceListChooser.spec.ts
+++ b/ui/tests/components/Devices/DeviceListChooser.spec.ts
@@ -152,10 +152,6 @@ describe("Device Chooser List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("renders the component data table", async () => {
     expect(wrapper.findComponent('[data-test="devices-dataTable"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Devices/DevicePendingList.spec.ts
+++ b/ui/tests/components/Devices/DevicePendingList.spec.ts
@@ -160,10 +160,6 @@ describe("Device Pending List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component data table", async () => {
     expect(wrapper.findComponent('[data-test="device-table"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Devices/DeviceRejectedList.spec.ts
+++ b/ui/tests/components/Devices/DeviceRejectedList.spec.ts
@@ -160,10 +160,6 @@ describe("Device Rejected List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component data table", async () => {
     expect(wrapper.findComponent('[data-test="device-table"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Devices/DeviceRename.spec.ts
+++ b/ui/tests/components/Devices/DeviceRename.spec.ts
@@ -108,10 +108,6 @@ describe("Device Rename", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("renders the component items", async () => {
     expect(wrapper.findComponent('[data-test="rename-icon"]').exists()).toBe(true);
     expect(wrapper.findComponent('[data-test="rename-title"]').exists()).toBe(true);

--- a/ui/tests/components/Namespace/NamespaceEdit.spec.ts
+++ b/ui/tests/components/Namespace/NamespaceEdit.spec.ts
@@ -101,10 +101,6 @@ describe("Namespace Edit", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     const dialog = new DOMWrapper(document.body);
     wrapper.vm.show = true;

--- a/ui/tests/components/Namespace/NamespaceLeave.spec.ts
+++ b/ui/tests/components/Namespace/NamespaceLeave.spec.ts
@@ -101,10 +101,6 @@ describe("Namespace Leave", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     const dialog = new DOMWrapper(document.body);
     wrapper.vm.dialog = true;

--- a/ui/tests/components/PrivateKeys/PrivateKeyAdd.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyAdd.spec.ts
@@ -96,10 +96,6 @@ describe("Setting Private Keys", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     wrapper.vm.dialog = true;
     await flushPromises();

--- a/ui/tests/components/PrivateKeys/PrivateKeyDelete.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyDelete.spec.ts
@@ -102,10 +102,6 @@ describe("Private Key Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="privatekey-delete-btn"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="privatekey-delete-btn-title"]').exists()).toBe(true);

--- a/ui/tests/components/PrivateKeys/PrivateKeyEdit.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyEdit.spec.ts
@@ -107,10 +107,6 @@ describe("Private Key Edit", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="privatekey-title"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="privatekey-icon"]').exists()).toBe(true);

--- a/ui/tests/components/PrivateKeys/PrivateKeyList.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyList.spec.ts
@@ -115,10 +115,6 @@ describe("Private Key List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="no-private-key-warning"]').exists()).toBe(true);
     store.commit("privateKey/fetchPrivateKey", privateKeys);

--- a/ui/tests/components/PublicKeys/PublicKeyAdd.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyAdd.spec.ts
@@ -104,10 +104,6 @@ describe("Public Key Add", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="public-key-add-btn"]').exists()).toBe(true);
     await wrapper.findComponent('[data-test="public-key-add-btn"]').trigger("click");

--- a/ui/tests/components/PublicKeys/PublicKeyDelete.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyDelete.spec.ts
@@ -107,10 +107,6 @@ describe("Public Key Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="public-key-remove-btn"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="remove-icon"]').exists()).toBe(true);

--- a/ui/tests/components/PublicKeys/PublicKeyEdit.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyEdit.spec.ts
@@ -112,10 +112,6 @@ describe("Public Key Edit", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="public-key-edit-title-btn"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="public-key-edit-icon"]').exists()).toBe(true);
@@ -140,15 +136,17 @@ describe("Public Key Edit", () => {
   });
 
   it("Allows editing a public key with username restriction", async () => {
-    await wrapper.setProps({ keyObject: {
-      data: "fake key",
-      filter: {
-        hostname: ".*",
+    await wrapper.setProps({
+      keyObject: {
+        data: "fake key",
+        filter: {
+          hostname: ".*",
+        },
+        name: "my edited public key",
+        username: ".*",
+        fingerprint: "fingerprint123",
       },
-      name: "my edited public key",
-      username: ".*",
-      fingerprint: "fingerprint123",
-    } });
+    });
     mockSsh.onPut("http://localhost:3000/api/sshkeys/public-keys/fingerprint123").reply(200);
     const pkEdit = vi.spyOn(store, "dispatch");
     await wrapper.findComponent('[data-test="public-key-edit-title-btn"]').trigger("click");

--- a/ui/tests/components/PublicKeys/PublicKeyList.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyList.spec.ts
@@ -118,10 +118,6 @@ describe("Public Key List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="publicKeys-list"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="public-key-item"]').exists()).toBe(true);

--- a/ui/tests/components/QuickConnection/QuickConnection.spec.ts
+++ b/ui/tests/components/QuickConnection/QuickConnection.spec.ts
@@ -122,10 +122,6 @@ describe("Quick Connection", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the dialog open button and other key elements", async () => {
     const dialog = new DOMWrapper(document.body);
 
@@ -158,7 +154,7 @@ describe("Quick Connection", () => {
     mockDevices.reset();
 
     mockDevices
-    // eslint-disable-next-line vue/max-len
+      // eslint-disable-next-line vue/max-len
       .onGet("http://localhost:3000/api/devices?filter=W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJvbmxpbmUiLCJvcGVyYXRvciI6ImVxIiwidmFsdWUiOnRydWV9fV0%3D&per_page=10&status=accepted")
       .reply(403);
 

--- a/ui/tests/components/QuickConnection/QuickConnectionList.spec.ts
+++ b/ui/tests/components/QuickConnection/QuickConnectionList.spec.ts
@@ -150,10 +150,6 @@ describe("Quick Connection List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the devices list", () => {
     expect(wrapper.find('[data-test="devices-list"]').exists()).toBe(true);
   });
@@ -185,7 +181,7 @@ describe("Quick Connection List", () => {
     mockDevices.reset();
     // Test with an empty online filtered request
     mockDevices
-    // eslint-disable-next-line vue/max-len
+      // eslint-disable-next-line vue/max-len
       .onGet("http://localhost:3000/api/devices?filter=W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJvbmxpbmUiLCJvcGVyYXRvciI6ImVxIiwidmFsdWUiOnRydWV9fV0%3D&per_page=10&status=accepted")
       .reply(200, []);
     await flushPromises();

--- a/ui/tests/components/Setting/SettingBilling.spec.ts
+++ b/ui/tests/components/Setting/SettingBilling.spec.ts
@@ -115,10 +115,6 @@ describe("Billing Settings Free Mode", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the free plan section", () => {
     expect(wrapper.find('[data-test="billing-card"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="billing-header"]').exists()).toBe(true);

--- a/ui/tests/components/Setting/SettingNamespace.spec.ts
+++ b/ui/tests/components/Setting/SettingNamespace.spec.ts
@@ -30,19 +30,20 @@ describe("Setting Namespace", () => {
     },
   ];
 
-  const namespaceData = { data: {
-    name: "test",
-    owner: "test",
-    tenant_id: "fake-tenant",
-    members,
-    settings: {
-      session_record: true,
-      connection_announcement: "",
+  const namespaceData = {
+    data: {
+      name: "test",
+      owner: "test",
+      tenant_id: "fake-tenant",
+      members,
+      settings: {
+        session_record: true,
+        connection_announcement: "",
+      },
+      max_devices: 3,
+      devices_count: 3,
+      created_at: "",
     },
-    max_devices: 3,
-    devices_count: 3,
-    created_at: "",
-  },
   };
 
   const authData = {
@@ -127,14 +128,6 @@ describe("Setting Namespace", () => {
 
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
   });
 
   const dataTests = [

--- a/ui/tests/components/Setting/SettingOwnerInfo.spec.ts
+++ b/ui/tests/components/Setting/SettingOwnerInfo.spec.ts
@@ -97,10 +97,6 @@ describe("Setting Owner Info", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Displays message when user is not the owner", async () => {
     expect(wrapper.find('[data-test="message-div"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="contactUser-p"]').text()).toContain("Contact  user for more information.");

--- a/ui/tests/components/Setting/SettingProfile.spec.ts
+++ b/ui/tests/components/Setting/SettingProfile.spec.ts
@@ -108,10 +108,6 @@ describe("Settings Namespace", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders all data-test elements", () => {
     const dataTests = [
       "account-profile-container",

--- a/ui/tests/components/Setting/SettingSecurity.spec.ts
+++ b/ui/tests/components/Setting/SettingSecurity.spec.ts
@@ -100,10 +100,6 @@ describe("Setting Security", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="security-switch"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Setting/SettingTags.spec.ts
+++ b/ui/tests/components/Setting/SettingTags.spec.ts
@@ -94,10 +94,6 @@ describe("Setting Owner Info", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="tagList-component"]').exists());
   });

--- a/ui/tests/components/Setting/SettingsPrivateKeys.spec.ts
+++ b/ui/tests/components/Setting/SettingsPrivateKeys.spec.ts
@@ -90,10 +90,6 @@ describe("Setting Private Keys", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="card"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="card-header"]').exists()).toBe(true);

--- a/ui/tests/components/Tables/DeviceTable.spec.ts
+++ b/ui/tests/components/Tables/DeviceTable.spec.ts
@@ -195,10 +195,6 @@ describe("Device Table", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component HTML", async () => {
     expect(wrapper.findComponent('[data-test="items-list"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Tags/TagEdit.spec.ts
+++ b/ui/tests/components/Tags/TagEdit.spec.ts
@@ -141,10 +141,6 @@ describe("Tag Form Edit", async () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component table", async () => {
     const dialog = new DOMWrapper(document.body);
     await flushPromises();

--- a/ui/tests/components/Tags/TagFormUpdate.spec.ts
+++ b/ui/tests/components/Tags/TagFormUpdate.spec.ts
@@ -168,10 +168,6 @@ describe("Tag Form Update", async () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component data table", async () => {
     const dialog = new DOMWrapper(document.body);
     await wrapper.setProps({ deviceUid: devices[0].uid, tagsList: devices[0].tags });

--- a/ui/tests/components/Team/ApiKeys/ApiKeyDelete.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyDelete.spec.ts
@@ -128,10 +128,6 @@ describe("Api Key Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="delete-icon"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="delete-main-btn-title"]').exists()).toBe(true);

--- a/ui/tests/components/Team/ApiKeys/ApiKeyEdit.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyEdit.spec.ts
@@ -130,10 +130,6 @@ describe("Api Key Edit", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="edit-icon"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="edit-main-btn-title"]').exists()).toBe(true);

--- a/ui/tests/components/Team/ApiKeys/ApiKeyGenerate.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyGenerate.spec.ts
@@ -128,10 +128,6 @@ describe("Api Key Generate", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="namespace-generate-main-btn"]').exists()).toBe(true);
     await wrapper.findComponent('[data-test="namespace-generate-main-btn"]').trigger("click");

--- a/ui/tests/components/Team/ApiKeys/ApiKeyList.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyList.spec.ts
@@ -122,10 +122,6 @@ describe("Api Key List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="api-key-list"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Team/Member/MemberDelete.spec.ts
+++ b/ui/tests/components/Team/Member/MemberDelete.spec.ts
@@ -105,10 +105,6 @@ describe("Member Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     const dialog = new DOMWrapper(document.body);
 

--- a/ui/tests/components/Team/Member/MemberEdit.spec.ts
+++ b/ui/tests/components/Team/Member/MemberEdit.spec.ts
@@ -102,10 +102,6 @@ describe("Member Edit", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     const dialog = new DOMWrapper(document.body);
 

--- a/ui/tests/components/Team/Member/MemberInvite.spec.ts
+++ b/ui/tests/components/Team/Member/MemberInvite.spec.ts
@@ -98,10 +98,6 @@ describe("Member Invite", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     const dialog = new DOMWrapper(document.body);
 

--- a/ui/tests/components/Team/Member/MemberList.spec.ts
+++ b/ui/tests/components/Team/Member/MemberList.spec.ts
@@ -118,10 +118,6 @@ describe("Member List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component HTML", async () => {
     expect(wrapper.findComponent('[data-test="member-table"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Tunnels/TunnelCreate.spec.ts
+++ b/ui/tests/components/Tunnels/TunnelCreate.spec.ts
@@ -146,10 +146,6 @@ describe("Tunnel Create", async () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component table", async () => {
     const dialog = new DOMWrapper(document.body);
 

--- a/ui/tests/components/Tunnels/TunnelDelete.spec.ts
+++ b/ui/tests/components/Tunnels/TunnelDelete.spec.ts
@@ -143,10 +143,6 @@ describe("Tunnel Delete", async () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component table", async () => {
     const dialog = new DOMWrapper(document.body);
 

--- a/ui/tests/components/Users/ChangePassword.spec.ts
+++ b/ui/tests/components/Users/ChangePassword.spec.ts
@@ -74,10 +74,6 @@ describe("Change Password", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     wrapper.vm.show = true;
     const dialog = new DOMWrapper(document.body);

--- a/ui/tests/components/Users/PaywallDialog.spec.ts
+++ b/ui/tests/components/Users/PaywallDialog.spec.ts
@@ -121,10 +121,6 @@ describe("PaywallDialog", async () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the component table", async () => {
     wrapper.vm.dialog = true;
     const dialog = new DOMWrapper(document.body);

--- a/ui/tests/components/Users/UserDelete.spec.ts
+++ b/ui/tests/components/Users/UserDelete.spec.ts
@@ -75,10 +75,6 @@ describe("User Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders components", async () => {
     wrapper.vm.show = true;
     const dialog = new DOMWrapper(document.body);

--- a/ui/tests/components/Welcome/Welcome.spec.ts
+++ b/ui/tests/components/Welcome/Welcome.spec.ts
@@ -88,10 +88,6 @@ describe("Welcome", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the dialog open button and other key elements", async () => {
     const dialog = new DOMWrapper(document.body);
     wrapper.vm.el = 1;

--- a/ui/tests/components/Welcome/WelcomeFirstScreen.spec.ts
+++ b/ui/tests/components/Welcome/WelcomeFirstScreen.spec.ts
@@ -74,10 +74,6 @@ describe("Welcome First Screen", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the components", async () => {
     expect(wrapper.find('[data-test="welcome-first-screen-name"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="welcome-first-screen-text"]').exists()).toBe(true);

--- a/ui/tests/components/Welcome/WelcomeFourthScreen.spec.ts
+++ b/ui/tests/components/Welcome/WelcomeFourthScreen.spec.ts
@@ -78,10 +78,6 @@ describe("Welcome Fourth Screen", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the components", async () => {
     expect(wrapper.find('[data-test="welcome-fourth-succesfully"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="welcome-fourth-links"]').exists()).toBe(true);

--- a/ui/tests/components/Welcome/WelcomeSecondScreen.spec.ts
+++ b/ui/tests/components/Welcome/WelcomeSecondScreen.spec.ts
@@ -84,10 +84,6 @@ describe("Welcome Second Screen", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the components", async () => {
     expect(wrapper.find('[data-test="welcome-second-title"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="welcome-second-text"]').exists()).toBe(true);

--- a/ui/tests/components/Welcome/WelcomeThirdScreen.spec.ts
+++ b/ui/tests/components/Welcome/WelcomeThirdScreen.spec.ts
@@ -18,7 +18,7 @@ describe("Welcome Third Screen", () => {
 
   let mockNamespace: MockAdapter;
 
-  let mockDevices : MockAdapter;
+  let mockDevices: MockAdapter;
 
   const members = [
     {
@@ -107,10 +107,6 @@ describe("Welcome Third Screen", () => {
 
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
   });
 
   it("Renders the components", async () => {

--- a/ui/tests/components/firewall/FirewallRuleAdd.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleAdd.spec.ts
@@ -89,10 +89,6 @@ describe("Firewall Rule Add", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the dialog open button and other key elements", async () => {
     const dialog = new DOMWrapper(document.body);
 

--- a/ui/tests/components/firewall/FirewallRuleDelete.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleDelete.spec.ts
@@ -91,10 +91,6 @@ describe("Firewall Rule Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the dialog open button and other key elements", async () => {
     const dialog = new DOMWrapper(document.body);
 

--- a/ui/tests/components/firewall/FirewallRuleEdit.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleEdit.spec.ts
@@ -103,10 +103,6 @@ describe("Firewall Rule Edit", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the dialog open button and other key elements", async () => {
     const dialog = new DOMWrapper(document.body);
 

--- a/ui/tests/components/firewall/FirewallRuleList.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleList.spec.ts
@@ -117,10 +117,6 @@ describe("Firewall Rule List", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the Firewall List", async () => {
     expect(wrapper.find('[data-test="firewallRules-list"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="firewall-rules-active"]').exists()).toBe(true);

--- a/ui/tests/layouts/AppLayout.spec.ts
+++ b/ui/tests/layouts/AppLayout.spec.ts
@@ -40,11 +40,6 @@ describe("App Layout Component", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    // Test if the component's data is defined
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders internal components", () => {
     expect(wrapper.find('[data-test="navigation-drawer"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="drawer-toolbar"]').exists()).toBe(true);

--- a/ui/tests/views/DetailsDevice.spec.ts
+++ b/ui/tests/views/DetailsDevice.spec.ts
@@ -158,10 +158,6 @@ describe("Details Device", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the template with data", () => {
     expect(wrapper.find('[data-test="deviceUid-field"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="deviceMac-field"]').exists()).toBe(true);

--- a/ui/tests/views/DetailsSessions.spec.ts
+++ b/ui/tests/views/DetailsSessions.spec.ts
@@ -109,7 +109,8 @@ describe("Details Sessions", () => {
     recorded: true,
     type: "none",
     term: "none",
-    position: { longitude: 0, latitude: 0 } };
+    position: { longitude: 0, latitude: 0 },
+  };
 
   let router;
 
@@ -165,10 +166,6 @@ describe("Details Sessions", () => {
 
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
   });
 
   it("Renders the template with data", () => {

--- a/ui/tests/views/Devices.spec.ts
+++ b/ui/tests/views/Devices.spec.ts
@@ -121,10 +121,6 @@ describe("Devices View", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the template with data", async () => {
     expect(wrapper.find('[data-test="search-text"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="device-title"]').exists()).toBe(true);

--- a/ui/tests/views/FirewallRules.spec.ts
+++ b/ui/tests/views/FirewallRules.spec.ts
@@ -129,10 +129,6 @@ describe("Firewall Rules", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the template with data", () => {
     expect(wrapper.find('[data-test="firewall-rules"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="help-icon"]').exists()).toBe(true);

--- a/ui/tests/views/Home.spec.ts
+++ b/ui/tests/views/Home.spec.ts
@@ -119,10 +119,6 @@ describe("Home", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the template with data", async () => {
     expect(wrapper.find('[data-test="home-card"]').exists()).toBe(true);
     wrapper.vm.hasStatus = true; // Set the conditional validation to true so it can show the error card.

--- a/ui/tests/views/MfaResetValidation.spec.ts
+++ b/ui/tests/views/MfaResetValidation.spec.ts
@@ -91,11 +91,6 @@ describe("Validate Recovery Mail", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    // Test if component data is defined
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the components", async () => {
     await flushPromises();
 

--- a/ui/tests/views/NamespaceInviteCard.spec.ts
+++ b/ui/tests/views/NamespaceInviteCard.spec.ts
@@ -140,10 +140,6 @@ describe("Namespace Invite Dialog", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders dialog elements with correct data-test attributes", async () => {
     expect(wrapper.find('[data-test="title"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="message"]').exists()).toBe(true);

--- a/ui/tests/views/PublicKeys.spec.ts
+++ b/ui/tests/views/PublicKeys.spec.ts
@@ -130,10 +130,6 @@ describe("Public Keys", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the template with data", () => {
     expect(wrapper.find('[data-test="public-keys-title"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="public-keys-components"]').exists()).toBe(true);

--- a/ui/tests/views/Sessions.spec.ts
+++ b/ui/tests/views/Sessions.spec.ts
@@ -67,52 +67,54 @@ describe("Sessions View", () => {
     },
   };
 
-  const sessionObj = { data: [{
-    uid: "1",
-    device_uid: "1",
-    device: {
+  const sessionObj = {
+    data: [{
       uid: "1",
-      name: "00-00-00-00-00-01",
-      identity: {
-        mac: "00-00-00-00-00-01",
+      device_uid: "1",
+      device: {
+        uid: "1",
+        name: "00-00-00-00-00-01",
+        identity: {
+          mac: "00-00-00-00-00-01",
+        },
+        info: {
+          id: "manjaro",
+          pretty_name: "Manjaro Linux",
+          version: "latest",
+          arch: "amd64",
+          platform: "docker",
+        },
+        public_key: "",
+        tenant_id: "fake-tenant-data",
+        last_seen: "0",
+        online: true,
+        namespace: "dev",
+        status: "accepted",
+        status_updated_at: "0",
+        created_at: "0",
+        remote_addr: "192.168.0.1",
+        position: { latitude: 0, longitude: 0 },
+        tags: [],
+        public_url: false,
+        public_url_address: "",
+        acceptable: false,
       },
-      info: {
-        id: "manjaro",
-        pretty_name: "Manjaro Linux",
-        version: "latest",
-        arch: "amd64",
-        platform: "docker",
-      },
-      public_key: "",
       tenant_id: "fake-tenant-data",
-      last_seen: "0",
-      online: true,
-      namespace: "dev",
-      status: "accepted",
-      status_updated_at: "0",
-      created_at: "0",
-      remote_addr: "192.168.0.1",
-      position: { latitude: 0, longitude: 0 },
-      tags: [],
-      public_url: false,
-      public_url_address: "",
-      acceptable: false,
+      username: "test",
+      ip_address: "192.168.0.1",
+      started_at: "",
+      last_seen: "",
+      active: false,
+      authenticated: true,
+      recorded: true,
+      type: "none",
+      term: "none",
+      position: { longitude: 0, latitude: 0 },
+    }],
+    headers: {
+      "x-total-count": 1,
     },
-    tenant_id: "fake-tenant-data",
-    username: "test",
-    ip_address: "192.168.0.1",
-    started_at: "",
-    last_seen: "",
-    active: false,
-    authenticated: true,
-    recorded: true,
-    type: "none",
-    term: "none",
-    position: { longitude: 0, latitude: 0 },
-  }],
-  headers: {
-    "x-total-count": 1,
-  } };
+  };
 
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -157,10 +159,6 @@ describe("Sessions View", () => {
 
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
   });
 
   it("Renders the template with data", () => {

--- a/ui/tests/views/Settings.spec.ts
+++ b/ui/tests/views/Settings.spec.ts
@@ -34,8 +34,4 @@ describe("Settings View", () => {
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
 });

--- a/ui/tests/views/TeamApiKeys.spec.ts
+++ b/ui/tests/views/TeamApiKeys.spec.ts
@@ -137,10 +137,6 @@ describe("Team Api Keys", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the template with data", async () => {
     expect(wrapper.find('[data-test="title"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="api-key-generate"]').exists()).toBe(true);

--- a/ui/tests/views/TeamMembers.spec.ts
+++ b/ui/tests/views/TeamMembers.spec.ts
@@ -30,19 +30,20 @@ describe("Team Members", () => {
     },
   ];
 
-  const namespaceData = { data: {
-    name: "test",
-    owner: "test",
-    tenant_id: "fake-tenant",
-    members,
-    settings: {
-      session_record: true,
-      connection_announcement: "",
+  const namespaceData = {
+    data: {
+      name: "test",
+      owner: "test",
+      tenant_id: "fake-tenant",
+      members,
+      settings: {
+        session_record: true,
+        connection_announcement: "",
+      },
+      max_devices: 3,
+      devices_count: 3,
+      created_at: "",
     },
-    max_devices: 3,
-    devices_count: 3,
-    created_at: "",
-  },
   };
 
   const authData = {
@@ -122,10 +123,6 @@ describe("Team Members", () => {
 
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
   });
 
   it("Renders the template with data", async () => {

--- a/ui/tests/views/ValidationAccount.spec.ts
+++ b/ui/tests/views/ValidationAccount.spec.ts
@@ -106,10 +106,6 @@ describe("Validation Account", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Data is defined", async () => {
-    expect(wrapper.vm.$data).toBeDefined();
-  });
-
   it("Renders the template with data", async () => {
     expect(wrapper.find('[data-test="verification-title"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="processing-cardText"]').exists()).toBe(true);


### PR DESCRIPTION
This PR removes tests that check for the existence of the `data` property.
```javascript
it("Data is defined", () => {
  expect(wrapper.vm.$data).toBeDefined();
});
```
These tests are no longer relevant since our components have been refactored to use Vue's Composition API instead of the Options API.

With Composition API components, `wrapper.vm.$data` always returns an empty object, making these assertions meaningless. Removing these tests improves the test suite clarity without reducing coverage.