### PR TITLE
fix(ci): use ubuntu 24.04 on commit message action

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -11,7 +11,7 @@ jobs:
   check-commit-message:
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]'  && github.event.pull_request.draft == false }}
     name: Check Commit Message
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check Commit Type
         uses: gsactions/commit-message-checker@v2


### PR DESCRIPTION
The action image Ubuntu 20.04 was deprecated in 2025-04-15, causing failure on any execution of that on GitHub Action. To solve it, we've set it to Ubuntu 24.04.

See: https://github.com/actions/runner-images/issues/11101