### PR TITLE
fix(ui): fix player error when playing session recorded on local terminal

### DIFF
--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -230,7 +230,7 @@ onUnmounted(() => {
 
 watchEffect(() => !showDialog.value && changeFocusToPlayer());
 
-defineExpose({ player, currentSpeed, currentTime, isPlaying, showDialog, formatTime, pause });
+defineExpose({ player, currentSpeed, currentTime, isPlaying, showDialog, formatTime, defaultDimensions, getSessionDimensions, pause });
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -119,6 +119,8 @@ const changeFocusToPlayer = () => { playerWrapper.value?.focus(); };
 
 const getSessionDimensions = () => {
   const dimensionsLine = logs?.split("\n")[1] ?? ""; // returns a string in the format of `[0.123, "r", "80x24"]`
+  if (!dimensionsLine.includes("\"r\"")) return { cols: 80, rows: 24 };
+
   const dimensions = JSON.parse(dimensionsLine)[2];
   const [cols, rows] = dimensions.split("x");
   return { cols, rows };

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -90,6 +90,7 @@
 import * as AsciinemaPlayer from "asciinema-player";
 import { onMounted, onUnmounted, ref, watchEffect } from "vue";
 import { useDisplay } from "vuetify";
+import { isNumber } from "@vueuse/core";
 import PlayerShortcutsDialog from "./PlayerShortcutsDialog.vue";
 
 const { logs } = defineProps<{
@@ -114,16 +115,16 @@ const formattedDuration = ref("00:00:00");
 const timeUpdaterId = ref<number>();
 const currentSpeed = ref(1);
 
+const defaultDimensions = { cols: 80, rows: 24 };
+
 const formatTime = (time: number) => new Date(time * 1000).toISOString().slice(time >= 3600 ? 11 : 14, 19);
 const changeFocusToPlayer = () => { playerWrapper.value?.focus(); };
 
 const getSessionDimensions = () => {
-  const dimensionsLine = logs?.split("\n")[1] ?? ""; // returns a string in the format of `[0.123, "r", "80x24"]`
-  if (!dimensionsLine.includes("\"r\"")) return { cols: 80, rows: 24 };
-
-  const dimensions = JSON.parse(dimensionsLine)[2];
-  const [cols, rows] = dimensions.split("x");
-  return { cols, rows };
+  const line = logs?.split("\n")[1] || "";
+  const dimensions = JSON.parse(line)[2];
+  const [cols, rows] = dimensions.split("x").map(Number);
+  return isNumber(cols) && isNumber(rows) ? { cols, rows } : defaultDimensions;
 };
 
 const getCurrentTime = () => {

--- a/ui/tests/components/Sessions/Player.spec.ts
+++ b/ui/tests/components/Sessions/Player.spec.ts
@@ -1,5 +1,6 @@
-import { mount, flushPromises, VueWrapper } from "@vue/test-utils";
+import { mount, VueWrapper } from "@vue/test-utils";
 import { describe, beforeEach, vi, it, expect, afterEach } from "vitest";
+import { nextTick } from "vue";
 import { createVuetify } from "vuetify";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 import { router } from "@/router";
@@ -43,7 +44,6 @@ describe("Asciinema Player", () => {
 
   afterEach(() => {
     wrapper.unmount();
-    vi.clearAllMocks();
   });
 
   it("Is a Vue instance", () => {
@@ -55,7 +55,6 @@ describe("Asciinema Player", () => {
   });
 
   it("Renders components", async () => {
-    await flushPromises();
     expect(wrapper.find('[data-test="player-container"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="player-controls"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="pause-btn"]').exists()).toBe(true);
@@ -67,7 +66,6 @@ describe("Asciinema Player", () => {
   });
 
   it("Creates player on mount", async () => {
-    await flushPromises();
     expect(wrapper.vm.player).toBeDefined();
   });
 
@@ -79,7 +77,7 @@ describe("Asciinema Player", () => {
 
   it("Shows pause button when player is playing", async () => {
     wrapper.vm.isPlaying = true;
-    await wrapper.vm.$nextTick();
+    await nextTick();
 
     const pauseBtn = wrapper.find('[data-test="pause-btn"]');
 
@@ -89,11 +87,11 @@ describe("Asciinema Player", () => {
 
   it("Shows play button when player is paused", async () => {
     wrapper.vm.isPlaying = true;
-    await wrapper.vm.$nextTick();
+    await nextTick();
     const pauseBtn = wrapper.find('[data-test="pause-btn"]');
 
     await pauseBtn.trigger("click");
-    await wrapper.vm.$nextTick();
+    await nextTick();
 
     expect(wrapper.find('[data-test="pause-btn"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="play-btn"]').exists()).toBe(true);

--- a/ui/tests/components/Sessions/Player.spec.ts
+++ b/ui/tests/components/Sessions/Player.spec.ts
@@ -24,8 +24,11 @@ describe("Asciinema Player", () => {
   let wrapper: PlayerWrapper;
   const vuetify = createVuetify();
 
-  // eslint-disable-next-line vue/max-len
-  const logsMock = "{\"version\": 2, \"width\": 80, \"height\": 24}\n[0.123, \"r\", \"80x24\"]\n[1.0, \"o\", \"Asciinema player test\"]\n[2.0, \"o\", \"logout\"]";
+  const logsMock = [
+    // eslint-disable-next-line vue/max-len
+    "{\"version\": 2, \"width\": 80, \"height\": 24}\n[0.123, \"r\", \"147x50\"]\n[1.0, \"o\", \"Asciinema player test\"]\n[2.0, \"o\", \"logout\"]",
+    "{\"version\": 2, \"width\": 80, \"height\": 24}\n[1.0, \"o\", \"Asciinema player test\"]\n[2.0, \"o\", \"logout\"]",
+  ];
 
   beforeEach(async () => {
     wrapper = mount(Player, {
@@ -33,7 +36,7 @@ describe("Asciinema Player", () => {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
       },
       props: {
-        logs: logsMock,
+        logs: logsMock[0],
       },
     });
   });
@@ -153,6 +156,23 @@ describe("Asciinema Player", () => {
     await slider.trigger("mouseup");
 
     expect(wrapper.vm.player.play).toHaveBeenCalled();
+  });
+
+  it("Gets session dimensions from logs", () => {
+    const sessionDimensions = wrapper.vm.getSessionDimensions();
+    expect(sessionDimensions).toEqual({
+      cols: 147,
+      rows: 50,
+    });
+  });
+
+  it("Gets default dimensions when logs don't have resize event at the start", async () => {
+    await wrapper.setProps({ logs: logsMock[1] });
+    const { defaultDimensions, getSessionDimensions } = wrapper.vm;
+
+    const sessionDimensions = getSessionDimensions();
+
+    expect(sessionDimensions).toEqual(defaultDimensions);
   });
 
   it("Disposes player when component is unmounted", async () => {


### PR DESCRIPTION
This PR fixes the `getSessionDimensions` method in the player, which previously relied on an initial resize event—behavior specific to web terminal sessions. For sessions recorded via local terminals (e.g., using [ssh](https://docs.shellhub.io/user-guides/devices/connecting#command-line-ssh-client)), the absence of this event caused WASM errors and broke player initialization.

The method now gracefully handles missing resize events by falling back to default dimensions (80x24), ensuring proper playback in these scenarios.