### PR TITLE
fix(ui): fix player errors

### DIFF
--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -166,7 +166,7 @@ const openDialog = () => {
 
 const createPlayer = (startAt = 0) => {
   const playerOptions = {
-    fit: "height",
+    fit: "both",
     controls: false,
     ...getSessionDimensions(),
     speed: currentSpeed.value,

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -117,13 +117,6 @@ const currentSpeed = ref(1);
 const formatTime = (time: number) => new Date(time * 1000).toISOString().slice(time >= 3600 ? 11 : 14, 19);
 const changeFocusToPlayer = () => { playerWrapper.value?.focus(); };
 
-const getSessionDimensions = () => {
-  const dimensionsLine = logs?.split("\n")[1] ?? ""; // returns a string in the format of `[0.123, "r", "80x24"]`
-  const dimensions = JSON.parse(dimensionsLine)[2];
-  const [cols, rows] = dimensions.split("x");
-  return { cols, rows };
-};
-
 const getCurrentTime = () => {
   const time = player.value.getCurrentTime();
   currentTime.value = time;
@@ -168,7 +161,6 @@ const createPlayer = (startAt = 0) => {
   const playerOptions = {
     fit: "both",
     controls: false,
-    ...getSessionDimensions(),
     speed: currentSpeed.value,
     startAt,
   };

--- a/ui/tests/components/Sessions/Player.spec.ts
+++ b/ui/tests/components/Sessions/Player.spec.ts
@@ -1,5 +1,6 @@
-import { mount, flushPromises, VueWrapper } from "@vue/test-utils";
+import { mount, VueWrapper } from "@vue/test-utils";
 import { describe, beforeEach, vi, it, expect, afterEach } from "vitest";
+import { nextTick } from "vue";
 import { createVuetify } from "vuetify";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 import { router } from "@/router";
@@ -40,7 +41,6 @@ describe("Asciinema Player", () => {
 
   afterEach(() => {
     wrapper.unmount();
-    vi.clearAllMocks();
   });
 
   it("Is a Vue instance", () => {
@@ -52,7 +52,6 @@ describe("Asciinema Player", () => {
   });
 
   it("Renders components", async () => {
-    await flushPromises();
     expect(wrapper.find('[data-test="player-container"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="player-controls"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="pause-btn"]').exists()).toBe(true);
@@ -64,7 +63,6 @@ describe("Asciinema Player", () => {
   });
 
   it("Creates player on mount", async () => {
-    await flushPromises();
     expect(wrapper.vm.player).toBeDefined();
   });
 
@@ -76,7 +74,7 @@ describe("Asciinema Player", () => {
 
   it("Shows pause button when player is playing", async () => {
     wrapper.vm.isPlaying = true;
-    await wrapper.vm.$nextTick();
+    await nextTick();
 
     const pauseBtn = wrapper.find('[data-test="pause-btn"]');
 
@@ -86,11 +84,11 @@ describe("Asciinema Player", () => {
 
   it("Shows play button when player is paused", async () => {
     wrapper.vm.isPlaying = true;
-    await wrapper.vm.$nextTick();
+    await nextTick();
     const pauseBtn = wrapper.find('[data-test="pause-btn"]');
 
     await pauseBtn.trigger("click");
-    await wrapper.vm.$nextTick();
+    await nextTick();
 
     expect(wrapper.find('[data-test="pause-btn"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="play-btn"]').exists()).toBe(true);


### PR DESCRIPTION
This PR removes the `getSessionDimensions` method, previously used to extract session dimensions as a workaround for buggy recordings. With the underlying recording issue resolved, this method is no longer needed.

The player’s `fit` option is now set to `"both"`, enabling proper resizing in both directions and preventing horizontal text overflow.

The test suite has also been cleaned up—unnecessary `flushPromises` calls were removed, and `wrapper.vm.$nextTick` calls were replaced with Vue's `nextTick`.

Depends on [cloud's #2201](https://github.com/shellhub-io/cloud/pull/2201)