### PR TITLE
refactor(ui): replace native DOM event listeners with useEventListener

### DIFF
--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -89,6 +89,7 @@
 <script setup lang="ts">
 import * as AsciinemaPlayer from "asciinema-player";
 import { onMounted, onUnmounted, ref, watchEffect } from "vue";
+import { useEventListener } from "@vueuse/core";
 import { useDisplay } from "vuetify";
 import PlayerShortcutsDialog from "./PlayerShortcutsDialog.vue";
 
@@ -184,12 +185,12 @@ const setPlayerEventListeners = () => {
     clearCurrentTimeUpdater();
   });
 
-  containerDiv.value?.addEventListener("keydown", (event: KeyboardEvent) => {
+  useEventListener(containerDiv.value, "keydown", (event: KeyboardEvent) => {
     getCurrentTime();
     if (event.key === "Escape") emit("close");
   });
 
-  containerDiv.value?.addEventListener("keyup", () => {
+  useEventListener(containerDiv.value, "keyup", () => {
     getCurrentTime();
   });
 };

--- a/ui/src/components/Setting/SettingBilling.vue
+++ b/ui/src/components/Setting/SettingBilling.vue
@@ -154,6 +154,7 @@ import {
   onMounted,
   reactive,
 } from "vue";
+import { useEventListener } from "@vueuse/core";
 import axios from "axios";
 import { useStore } from "@/store";
 import hasPermission from "@/utils/permission";
@@ -188,7 +189,7 @@ const hasAuthorization = computed(() => {
   return false;
 });
 
-window.addEventListener("pageshow", (event) => {
+useEventListener("pageshow", (event) => {
   const historyPage = event.persisted
   || (typeof window.performance !== "undefined"
   && (window.performance.getEntries()[0] as PerformanceNavigationTiming).type === "back_forward");


### PR DESCRIPTION
This PR replaces native `addEventListener` calls with VueUse’s `useEventListener` composable in the player and billing settings components for consistency with the rest of the codebase.

Note: the remaining `addEventListener` calls in the player component are part of the Asciinema API implementation, not native DOM listeners, and therefore cannot be replaced with useEventListener.