### PR TITLE
fix(ui): fix SnackbarError component

### DIFF
--- a/ui/src/components/Snackbar/SnackbarError.vue
+++ b/ui/src/components/Snackbar/SnackbarError.vue
@@ -1,9 +1,9 @@
 <template>
   <v-snackbar
     v-model="snackbar"
-    :timeout="2000"
+    :timeout="4000"
+    color="#bd4147"
     location="top"
-    :color="color"
     transition="slide-x-transition"
   >
     {{ message }}
@@ -12,28 +12,43 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useStore } from "@/store";
+import { useStore } from "../../store";
 
-const { mainContent } = defineProps({
+const { mainContent, typeMessage } = defineProps({
+  typeMessage: {
+    type: String,
+    required: true,
+  },
+
   mainContent: {
     type: String,
     default: "",
-    required: true,
+    required: false,
   },
 });
-
 const store = useStore();
-
-const color = computed(() => store.getters["layout/getStatusDarkMode"] === "dark" ? "#F9F3EE" : "#1E1E1E");
 
 const snackbar = computed({
   get() {
-    return store.getters["snackbar/snackbarCopy"];
+    return store.getters["snackbar/snackbarError"];
   },
   set() {
-    store.dispatch("snackbar/unsetShowStatusSnackbarCopy");
+    store.dispatch("snackbar/unsetShowStatusSnackbarError");
   },
 });
 
-const message = computed(() => `${mainContent} copied to clipboard.`);
+const message = computed(() => {
+  switch (typeMessage) {
+    case "custom":
+      return mainContent;
+    case "loading":
+      return `Loading the ${mainContent} has failed, please try again.`;
+    case "action":
+      return `The ${mainContent} request has failed, please try again.`;
+    case "licenseRequired":
+      return `The ${mainContent} request has failed, license required.`;
+    default:
+      return "The request has failed, please try again.";
+  }
+});
 </script>


### PR DESCRIPTION
This PR fixes the `SnackbarError` component, which was non-functional in the Community edition due to what appears to be a mistaken copy-paste from `SnackbarCopy`. As a result, users received no visual feedback when errors occurred.

The component now properly reads from the store's error section and displays the snackbar when an error is triggered, restoring expected error visibility.