### PR TITLE
refactor(ui): use computed and remove duplicated method in Player

### DIFF
--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -132,7 +132,7 @@ const clearCurrentTimeUpdater = () => {
 };
 
 const startCurrentTimeUpdater = () => {
-  clearCurrentTimeUpdater();
+  clearCurrentTimeUpdater(); // clear to prevent multiple intervals when replaying
   timeUpdaterId.value = window.setInterval(getCurrentTime, 100);
 };
 
@@ -166,8 +166,6 @@ const setPlayerEventListeners = () => {
   player.value.addEventListener("playing", () => {
     sessionEnded.value = false;
     getCurrentTime();
-    // clear to prevent multiple intervals when replaying
-    clearCurrentTimeUpdater();
     startCurrentTimeUpdater();
     getDuration();
   });

--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -88,7 +88,7 @@
 
 <script setup lang="ts">
 import * as AsciinemaPlayer from "asciinema-player";
-import { onMounted, onUnmounted, ref, watchEffect } from "vue";
+import { computed, onMounted, onUnmounted, ref, watchEffect } from "vue";
 import { useEventListener } from "@vueuse/core";
 import { useDisplay } from "vuetify";
 import PlayerShortcutsDialog from "./PlayerShortcutsDialog.vue";
@@ -110,24 +110,17 @@ const isPlaying = ref(true);
 const sessionEnded = ref(false);
 const currentTime = ref(0);
 const duration = ref(0);
-const formattedCurrentTime = ref("00:00:00");
-const formattedDuration = ref("00:00:00");
+const formatTime = (time: number) => new Date(time * 1000).toISOString().slice(time >= 3600 ? 11 : 14, 19);
+const formattedCurrentTime = computed(() => formatTime(currentTime.value));
+const formattedDuration = computed(() => formatTime(duration.value));
 const timeUpdaterId = ref<number>();
 const currentSpeed = ref(1);
 
-const formatTime = (time: number) => new Date(time * 1000).toISOString().slice(time >= 3600 ? 11 : 14, 19);
 const changeFocusToPlayer = () => { playerWrapper.value?.focus(); };
 
-const getCurrentTime = () => {
-  const time = player.value.getCurrentTime();
-  currentTime.value = time;
-  formattedCurrentTime.value = formatTime(time);
-};
+const getCurrentTime = () => { currentTime.value = player.value.getCurrentTime(); };
 
-const getDuration = () => {
-  duration.value = player.value.getDuration();
-  formattedDuration.value = formatTime(duration.value);
-};
+const getDuration = () => { duration.value = player.value.getDuration(); };
 
 const changePlaybackTime = (value: number) => {
   player.value.seek(value);

--- a/ui/tests/components/Sessions/__snapshots__/Player.spec.ts.snap
+++ b/ui/tests/components/Sessions/__snapshots__/Player.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`Asciinema Player > Renders the component 1`] = `
     <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-pause mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
     <!---->
     <!---->
-  </button><span data-v-f3a0259a="" id="playback-time" class="text-medium-emphasis text-body-1" data-test="playback-time">00:00:00 / 00:00:00</span>
+  </button><span data-v-f3a0259a="" id="playback-time" class="text-medium-emphasis text-body-1" data-test="playback-time">00:00 / 00:00</span>
   <div data-v-f3a0259a="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-slider v-locale--is-ltr ml-0 flex-grow-1 flex-shrink-0" aria-labelledby="playback-time" data-test="time-slider">
     <!---->
     <div class="v-input__control">


### PR DESCRIPTION
This PR refactors the player's script by replacing manual updates to the formatted time and duration with computed properties, improving reactivity and code clarity. It also removes a duplicated and unnecessary call to `clearCurrentTimeUpdater`.