### PR TITLE
feat: podman support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ podman_install() {
     echo "📥 Downloading ShellHub container image..."
 
     {
-        $SUDO podman pull -q shellhubio/agent:$AGENT_VERSION
+        $SUDO podman pull -q docker.io/shellhubio/agent:$AGENT_VERSION
     } || { echo "❌ Failed to download shellhub container image."; exit 1; }
 
     MODE=""


### PR DESCRIPTION
This PR adds podman support to install.sh
It looks for podman before docker as aliasing docker with podman with `alias docker=podman` is a common scenario and attempting to use the docker params would cause issues.

It also installs the container as `root` but further PRs are being investigated to look at rootless options

**Test Environment**
```
$ cat /etc/os-release 
NAME="Fedora Linux"
VERSION="40 (Xfce)"

$ podman --version 
podman version 5.4.2
``` 
**Tested as root and user with the following output**
```
TENANT_ID=<TENENT-ID> SERVER_ADDRESS=https://cloud.shellhub.io sh ./install.sh 
🛠️ Welcome to the ShellHub Agent Installer Script

📝 Summary of chosen options:
- Server address: https://cloud.shellhub.io
- Tenant ID: <TENENT-ID>
- Install method: podman
- Agent version: v0.18.2

🐳 Installing ShellHub using podman method...
📥 Downloading ShellHub container image...
70cb3f21e378e59bd9650fdac1de5c856b063dceda300c79e69826d2128b0598
🚀 Starting ShellHub container in Agent mode...
5fcd62c0dc48f847421f86b33c272cef81f462240e7f907aa6064ca1917ddf24
```

