### PR TITLE
fix(ui): fix extraneous non-props warning in `TunnelDelete`

### DIFF
--- a/ui/src/components/Tunnels/TunnelDelete.vue
+++ b/ui/src/components/Tunnels/TunnelDelete.vue
@@ -42,6 +42,10 @@ import { actions, authorizer } from "@/authorizer";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
 
+defineOptions({
+  inheritAttrs: false,
+});
+
 const props = defineProps({
   uid: {
     type: String,


### PR DESCRIPTION
This PR disables the attribute inheritance in `TunnelDelete.vue`, since this behavior caused warnings due to the lack of a single root element in the component's template.