### PR TITLE
fix(ui): replace deprecated `active-color` attribute with `color`

### DIFF
--- a/ui/src/components/Tags/TagSelector.vue
+++ b/ui/src/components/Tags/TagSelector.vue
@@ -31,7 +31,7 @@
               v-else
               :key="`item-${i}`"
               :value="item"
-              active-color="primary"
+              color="primary"
               @click="selectTag(item)"
             >
               <template v-slot:default="{}">


### PR DESCRIPTION
This PR replaces Vuetify's deprecated `active-color` attribute with the new `color` attribute in `TagSelector.vue`, preventing warnings in the console.