### PR TITLE
fix(ui): fix support button behavior

### DIFF
--- a/ui/src/components/User/PaywallChat.vue
+++ b/ui/src/components/User/PaywallChat.vue
@@ -47,7 +47,7 @@
           <v-btn
             color="primary"
             variant="flat"
-            href="www.shellhub.io/pricing"
+            href="https://www.shellhub.io/pricing"
             target="_blank"
             rel="noreferrer noopener"
             data-test="upgrade-btn">

--- a/ui/tests/components/Users/PaywallChat.spec.ts
+++ b/ui/tests/components/Users/PaywallChat.spec.ts
@@ -95,6 +95,6 @@ describe("PaywallChat", () => {
   it("ensures the upgrade button has correct href", () => {
     wrapper.vm.dialog = true;
     const dialog = new DOMWrapper(document.body);
-    expect(dialog.find('[data-test="upgrade-btn"]').attributes("href")).toBe("www.shellhub.io/pricing");
+    expect(dialog.find('[data-test="upgrade-btn"]').attributes("href")).toBe("https://www.shellhub.io/pricing");
   });
 });


### PR DESCRIPTION
This PR makes two fixes in the support button of the AppBar:
1. Updates the "Upgrade" button's URL, now pointing correctly to [ShellHub's pricing page](https://www.shellhub.io/pricing);
2. Adds proper error handling for cases where the Chatwoot support chat fails to open, now displaying a snackbar error to inform the user.