### PR TITLE
refactor(ui): remove deprecated `createNewClient` method

### DIFF
--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -91,12 +91,6 @@ const announcementApi = new axiosTs.AnnouncementsApi(
 );
 
 /**
- * @deprecated This method is deprecated and no longer performs any action,
- * kept for backward compatibility but it will be removed in the future.
- **/
-export const createNewClient = () => Function;
-
-/**
  * Extends the interface BaseAPI to include a new method `getAxios` allowing
  * access to the protected axios property without the need to access it
  * directly from outside the class and avoiding a linting error caused by

--- a/ui/src/components/AppBar/AppBar.vue
+++ b/ui/src/components/AppBar/AppBar.vue
@@ -102,7 +102,6 @@ import { useRouter, useRoute, RouteLocationRaw, RouteLocation } from "vue-router
 import { useChatWoot } from "@productdevbook/chatwoot/vue";
 import { useEventListener } from "@vueuse/core";
 import { useStore } from "@/store";
-import { createNewClient } from "@/api/http";
 import handleError from "@/utils/handleError";
 import UserIcon from "../User/UserIcon.vue";
 import Notification from "./Notifications/Notification.vue";
@@ -161,7 +160,6 @@ const logout = async () => {
     await store.dispatch("stats/clear");
     await store.dispatch("namespaces/clearNamespaceList");
     await router.push({ name: "Login" });
-    createNewClient();
   } catch (error: unknown) {
     handleError(error);
   }


### PR DESCRIPTION
This PR removes the deprecated `createNewClient` method in `http.ts` and its last reference in `AppBar.vue`.