### PR TITLE
refactor(ui): fix "perPagae" typo

### DIFF
--- a/ui/admin/src/components/Announcement/AnnouncementList.vue
+++ b/ui/admin/src/components/Announcement/AnnouncementList.vue
@@ -94,12 +94,12 @@ const headers = ref([
 ]);
 
 const getAnnouncements = async (
-  perPagaeValue: number,
+  perPageValue: number,
   pageValue: number,
 ) => {
   try {
     loading.value = true;
-    const hasAnnouncements = await announcementStore.fetchAnnouncements({ perPage: perPagaeValue, page: pageValue, orderBy: "desc" });
+    const hasAnnouncements = await announcementStore.fetchAnnouncements({ perPage: perPageValue, page: pageValue, orderBy: "desc" });
     if (!hasAnnouncements && page.value > 1) {
       page.value--;
     }

--- a/ui/admin/src/components/Device/DeviceList.vue
+++ b/ui/admin/src/components/Device/DeviceList.vue
@@ -172,12 +172,12 @@ onMounted(async () => {
   }
 });
 
-const getDevices = async (perPagaeValue: number, pageValue: number) => {
+const getDevices = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
 
     const hasDevices = await devicesStore.fetch({
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       page: pageValue,
       filter: filter.value,
       sortStatusField: devicesStore.getSortStatusField,

--- a/ui/admin/src/components/FirewallRules/FirewallRulesList.vue
+++ b/ui/admin/src/components/FirewallRules/FirewallRulesList.vue
@@ -143,12 +143,12 @@ onMounted(() => {
 
 const numberFirewalls = computed(() => firewallRulesStore.getNumberFirewalls);
 
-const getFirewallRules = async (perPagaeValue: number, pageValue: number) => {
+const getFirewallRules = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
     const hasFirewallRules = await firewallRulesStore.fetch({
       page: pageValue,
-      perPage: perPagaeValue,
+      perPage: perPageValue,
     });
     if (!hasFirewallRules) page.value--;
   } catch {

--- a/ui/admin/src/components/Namespace/NamespaceList.vue
+++ b/ui/admin/src/components/Namespace/NamespaceList.vue
@@ -122,12 +122,12 @@ const goToNamespace = (namespace: string) => {
   router.push({ name: "namespaceDetails", params: { id: namespace } });
 };
 
-const getNamespaces = async (perPagaeValue: number, pageValue: number) => {
+const getNamespaces = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
     const hasNamespaces = await namespacesStore.fetch({
       page: pageValue,
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       filter: filter.value,
     });
 

--- a/ui/admin/src/components/Sessions/SessionList.vue
+++ b/ui/admin/src/components/Sessions/SessionList.vue
@@ -150,12 +150,12 @@ const itemsPerPage = ref(10);
 const loading = ref(false);
 const page = ref(1);
 
-const getSessions = async (perPagaeValue: number, pageValue: number) => {
+const getSessions = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
 
     const hasSessions = await sessionStore.fetch({
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       page: pageValue,
     });
 

--- a/ui/admin/src/components/User/UserList.vue
+++ b/ui/admin/src/components/User/UserList.vue
@@ -171,11 +171,11 @@ onMounted(async () => {
   }
 });
 
-const getUsers = async (perPagaeValue: number, pageValue: number) => {
+const getUsers = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
     const hasUsers = await userStore.fetch({
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       page: pageValue,
       filter: filter.value,
     });

--- a/ui/admin/tests/unit/views/Announcements/Announcements.spec.ts
+++ b/ui/admin/tests/unit/views/Announcements/Announcements.spec.ts
@@ -1,8 +1,10 @@
+import MockAdapter from "axios-mock-adapter";
 import { createVuetify } from "vuetify";
 import { mount, VueWrapper } from "@vue/test-utils";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import { useAnnouncementStore } from "@admin/store/modules/announcement";
+import { adminApi } from "@admin/api/http";
 import routes from "../../../../src/router";
 import Announcements from "../../../../src/views/Announcements.vue";
 
@@ -21,6 +23,9 @@ const numberAnnouncements = 1;
 
 describe("Announcement Details", () => {
   let wrapper: AnnouncementsWrapper;
+
+  const mockAdminApi = new MockAdapter(adminApi.getAxios());
+  mockAdminApi.onGet("http://localhost:3000/admin/api/announcements?page=1&per_page=10&order_by=desc").reply(200);
 
   beforeEach(() => {
     const pinia = createPinia();

--- a/ui/src/components/Connector/ConnectorList.vue
+++ b/ui/src/components/Connector/ConnectorList.vue
@@ -200,12 +200,12 @@ const hasAuthorizationRemove = () => {
   return false;
 };
 
-const getConnectors = async (perPagaeValue: number, pageValue: number) => {
+const getConnectors = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
     await store.dispatch("connectors/fetch", {
       page: pageValue,
-      perPage: perPagaeValue,
+      perPage: perPageValue,
     });
   } catch (error: unknown) {
     if (axios.isAxiosError(error)) {

--- a/ui/src/components/Devices/DeviceListChooser.vue
+++ b/ui/src/components/Devices/DeviceListChooser.vue
@@ -115,14 +115,14 @@ const selected = computed({
   },
 });
 
-const getDevices = async (perPagaeValue: number, pageValue: number) => {
+const getDevices = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
 
     const hasDevices = await store.dispatch(
       "devices/setDevicesForUserToChoose",
       {
-        perPage: perPagaeValue,
+        perPage: perPageValue,
         page: pageValue,
         filter: filter.value,
         sortStatusField: store.getters["devices/getSortStatusField"],

--- a/ui/src/components/PublicKeys/PublicKeysList.vue
+++ b/ui/src/components/PublicKeys/PublicKeysList.vue
@@ -194,12 +194,12 @@ const hasAuthorizationFormDialogRemove = computed(() => {
 });
 
 const getPublicKeysList = async (
-  perPagaeValue: number,
+  perPageValue: number,
   pageValue: number,
 ) => {
   if (store.getters["box/getStatus"]) {
     const data = {
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       page: pageValue,
     };
     try {

--- a/ui/src/components/QuickConnection/QuickConnectionList.vue
+++ b/ui/src/components/QuickConnection/QuickConnectionList.vue
@@ -151,12 +151,12 @@ onMounted(async () => {
   }
 });
 
-const getDevices = async (perPagaeValue: number, pageValue: number) => {
+const getDevices = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
 
     await store.dispatch("devices/fetchQuickDevices", {
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       page: pageValue,
       status: "accepted",
       filter: filter.value,

--- a/ui/src/components/Sessions/SessionList.vue
+++ b/ui/src/components/Sessions/SessionList.vue
@@ -200,12 +200,12 @@ const numberSessions = computed(
   () => store.getters["sessions/getNumberSessions"],
 );
 
-const getSessions = async (perPagaeValue: number, pageValue: number) => {
+const getSessions = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
     const hasSessions = await store.dispatch("sessions/fetch", {
       page: pageValue,
-      perPage: perPagaeValue,
+      perPage: perPageValue,
     });
 
     if (!hasSessions) {

--- a/ui/src/components/Tables/DeviceTable.vue
+++ b/ui/src/components/Tables/DeviceTable.vue
@@ -361,11 +361,11 @@ onMounted(async () => {
   }
 });
 
-const getDevices = async (perPagaeValue: number, pageValue: number, filter: string) => {
+const getDevices = async (perPageValue: number, pageValue: number, filter: string) => {
   try {
     loading.value = true;
     await fetchDevices({
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       page: pageValue,
       status: props.status,
       filter,

--- a/ui/src/components/Team/ApiKeys/ApiKeyList.vue
+++ b/ui/src/components/Team/ApiKeys/ApiKeyList.vue
@@ -164,12 +164,12 @@ const formatDate = (unixTime: number): string => {
     : `Expires on ${expiryDate.format(format)}.`;
 };
 
-const getKey = async (perPagaeValue: number, pageValue: number) => {
+const getKey = async (perPageValue: number, pageValue: number) => {
   try {
     loading.value = true;
     await store.dispatch("apiKeys/getApiKey", {
       page: pageValue,
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       sortStatusField: store.getters["apiKeys/getSortStatusField"],
       sortStatusString: store.getters["apiKeys/getSortStatusString"],
     });

--- a/ui/src/components/firewall/FirewallRuleList.vue
+++ b/ui/src/components/firewall/FirewallRuleList.vue
@@ -188,10 +188,10 @@ const getNumberFirewallRules = computed(
   () => store.getters["firewallRules/getNumberFirewalls"],
 );
 
-const getFirewalls = async (perPagaeValue: number, pageValue: number) => {
+const getFirewalls = async (perPageValue: number, pageValue: number) => {
   if (!store.getters["boxs/getStatus"]) {
     const data = {
-      perPage: perPagaeValue,
+      perPage: perPageValue,
       page: pageValue,
     };
 


### PR DESCRIPTION
This PR fixes a typo in multiple components, where "perPage" was written as "perPagae". A test mock was also added since some Axios warnings started to be thrown in the tests console.