### PR TITLE
refactor(ui): update SettingTags code

### DIFF
--- a/ui/src/components/Setting/SettingTags.vue
+++ b/ui/src/components/Setting/SettingTags.vue
@@ -1,6 +1,5 @@
 <template>
   <v-container fluid>
-    <PrivateKeyAdd v-model="privateKeyAdd" @update="getPrivateKeys" />
     <v-card
       variant="flat"
       class="bg-transparent"
@@ -25,20 +24,5 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
-import PrivateKeyAdd from "../PrivateKeys/PrivateKeyAdd.vue";
 import TagList from "../Tags/TagList.vue";
-import { useStore } from "@/store";
-import handleError from "@/utils/handleError";
-
-const store = useStore();
-const privateKeyAdd = ref(false);
-
-const getPrivateKeys = async () => {
-  try {
-    await store.dispatch("privateKey/fetch");
-  } catch (error: unknown) {
-    handleError(error);
-  }
-};
 </script>

--- a/ui/src/components/Setting/SettingTags.vue
+++ b/ui/src/components/Setting/SettingTags.vue
@@ -3,18 +3,18 @@
     <v-card
       variant="flat"
       class="bg-transparent"
-      data-test="account-profile-card"
+      data-test="tags-settings-card"
     >
       <v-card-item>
         <v-list-item
           class="pa-0 ma-0 mb-2"
-          data-test="profile-header"
+          data-test="tags-settings-header"
         >
           <template v-slot:title>
             <h1>Tags</h1>
           </template>
           <template v-slot:subtitle>
-            <span data-test="profile-subtitle">Manage your device and connector tags</span>
+            <span data-test="tags-settings-subtitle">Manage your device and connector tags</span>
           </template>
         </v-list-item>
       </v-card-item>

--- a/ui/tests/components/Setting/SettingTags.spec.ts
+++ b/ui/tests/components/Setting/SettingTags.spec.ts
@@ -4,14 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import MockAdapter from "axios-mock-adapter";
 import SettingTags from "@/components/Setting/SettingTags.vue";
 import { namespacesApi, tagsApi, usersApi } from "@/api/http";
-import { store, key } from "@/store";
-import { router } from "@/router";
+import { key, store } from "@/store";
 import { envVariables } from "@/envVariables";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 
 type SettingTagsWrapper = VueWrapper<InstanceType<typeof SettingTags>>;
 
-describe("Setting Owner Info", () => {
+describe("Setting Tags", () => {
   let wrapper: SettingTagsWrapper;
 
   const vuetify = createVuetify();
@@ -77,7 +76,7 @@ describe("Setting Owner Info", () => {
 
     wrapper = mount(SettingTags, {
       global: {
-        plugins: [[store, key], vuetify, router, SnackbarPlugin],
+        plugins: [[store, key], vuetify, SnackbarPlugin],
       },
     });
   });

--- a/ui/tests/components/Setting/__snapshots__/SettingTags.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingTags.spec.ts.snap
@@ -1,10 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Setting Owner Info > Renders the component 1`] = `
+exports[`Setting Tags > Renders the component 1`] = `
 "<div class="v-container v-container--fluid v-locale--is-ltr">
-  <!---->
-  <!---->
-  <div class="v-card v-theme--light v-card--density-default v-card--variant-flat bg-transparent" data-test="account-profile-card">
+  <div class="v-card v-theme--light v-card--density-default v-card--variant-flat bg-transparent" data-test="tags-settings-card">
     <!---->
     <div class="v-card__loader">
       <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -27,14 +25,14 @@ exports[`Setting Owner Info > Renders the component 1`] = `
       <div class="v-card-item__content">
         <!---->
         <!---->
-        <div class="v-list-item v-theme--light v-list-item--density-default rounded-0 v-list-item--variant-text pa-0 ma-0 mb-2" data-test="profile-header">
+        <div class="v-list-item v-theme--light v-list-item--density-default rounded-0 v-list-item--variant-text pa-0 ma-0 mb-2" data-test="tags-settings-header">
           <!----><span class="v-list-item__underlay"></span>
           <!---->
           <div class="v-list-item__content" data-no-activator="">
             <div class="v-list-item-title">
               <h1>Tags</h1>
             </div>
-            <div class="v-list-item-subtitle"><span data-test="profile-subtitle">Manage your device and connector tags</span></div>
+            <div class="v-list-item-subtitle"><span data-test="tags-settings-subtitle">Manage your device and connector tags</span></div>
             <!---->
           </div>
           <!---->


### PR DESCRIPTION
This PR removes code related to the private keys feature of `SettingTags.vue`, since there's no relation between them in that scenario. Also, the component's `data-test` attributes were updated, along with the test suite name, plugins, and snapshot.