### PR TITLE
chore(ui): relocate .v-container styles to Settings view

### DIFF
--- a/ui/src/components/Setting/SettingBilling.vue
+++ b/ui/src/components/Setting/SettingBilling.vue
@@ -289,10 +289,4 @@ p {
 .hover-text:hover {
   text-decoration: underline;
 }
-
-.v-container {
-  max-width: 960px;
-  margin-left: 0;
-  padding: 0;
-}
 </style>

--- a/ui/src/components/Setting/SettingNamespace.vue
+++ b/ui/src/components/Setting/SettingNamespace.vue
@@ -325,12 +325,6 @@ const hasTenant = () => tenant.value !== "";
   text-decoration: underline;
 }
 
-.v-container {
-  max-width: 960px;
-  margin-left: 0;
-  padding: 0;
-}
-
 :deep(.v-field--variant-plain) {
   --v-field-padding-start: 16px;
   --v-field-padding-end: 16px;

--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -420,12 +420,6 @@ onMounted(() => {
 </script>
 
 <style lang="scss" scoped>
-.v-container {
-  max-width: 960px;
-  margin-left: 0;
-  padding: 0;
-}
-
 :deep(.v-field--variant-plain) {
   --v-field-padding-start: 16px;
   --v-field-padding-end: 16px;

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -6,3 +6,11 @@
 
 <script setup lang="ts">
 </script>
+
+<style scoped>
+.v-container {
+  max-width: 960px;
+  margin-left: 0;
+  padding: 0;
+}
+</style>

--- a/ui/tests/views/__snapshots__/Settings.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/Settings.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Settings View > Renders the component 1`] = `
-"<div>
+"<div data-v-817427b0="">
   <!---->
 </div>"
 `;


### PR DESCRIPTION
# Description

This PR relocates the shared .v-container styles from individual Setting components (SettingBilling.vue, SettingNamespace.vue, and SettingProfile.vue) to the parent Settings.vue file. This change consolidates redundant style definitions into a single location, improving maintainability and ensuring consistent styling across all settings-related views.

## Changes

Removed .v-container styles from:
- SettingBilling.vue
- SettingNamespace.vue
- SettingProfile.vue

Added .v-container styles to:
- Settings.vue

## Motivation

By centralizing the .v-container styles, we reduce duplication and make future adjustments simpler and less error-prone. This promotes better adherence to DRY (Don't Repeat Yourself) principles and improves code readability.
Impact

    No functional changes to the application.

    Improved maintainability and consistency in style management.

    Scoped styles ensure that only relevant components are affected.