### PR TITLE
fix(ui): delete problematic global components declarations

### DIFF
--- a/ui/admin/src/global-components.d.ts
+++ b/ui/admin/src/global-components.d.ts
@@ -1,6 +1,0 @@
-declare module "@vue/runtime-core" {
-  export interface GlobalComponents {
-    RouterLink: typeof import("vue-router")["RouterLink"];
-    RouterView: typeof import("vue-router")["RouterView"];
-  }
-}

--- a/ui/src/global-components.d.ts
+++ b/ui/src/global-components.d.ts
@@ -1,6 +1,0 @@
-declare module "@vue/runtime-core" {
-  export interface GlobalComponents {
-    RouterLink: typeof import("vue-router")["RouterLink"];
-    RouterView: typeof import("vue-router")["RouterView"];
-  }
-}


### PR DESCRIPTION
This PR removes the `global-components.d.ts` files, which caused problems with TypeScript and the `vue` package.