### PR TITLE
fix(ui): add snackbar error for support unsupported env case

### DIFF
--- a/ui/src/components/AppBar/AppBar.vue
+++ b/ui/src/components/AppBar/AppBar.vue
@@ -223,6 +223,7 @@ const openShellhubHelp = async (): Promise<void> => {
       break;
 
     default:
+      snackbar.showError("Your environment configuration is not supported.");
       throw new Error("Unsupported environment configuration.");
   }
 };


### PR DESCRIPTION
This PR adds an error snackbar to the support button when the environment is not supported, an edge case that didn't give any visual feedback to the user (except by a console error).