### PR TITLE
fix(ui): fix firewall rules docs URL

### DIFF
--- a/ui/src/views/FirewallRules.vue
+++ b/ui/src/views/FirewallRules.vue
@@ -21,7 +21,7 @@
     Firewall rules gives a fine-grained control over which SSH connections reach
     the devices.
     <a
-      href="https://docs.shellhub.io/user-guides/security/managing-firewall-rules"
+      href="https://docs.shellhub.io/user-guides/firewall/"
       target="_blank"
       rel="noopener noreferrer"
     >See More</a


### PR DESCRIPTION
This PR fixes the `href` attribute that redirects the user to the firewall rules section in ShellHub Docs.