### PR TITLE
fix(ui): fix Authenticated icon in SessionList

### DIFF
--- a/ui/admin/src/components/Sessions/SessionList.vue
+++ b/ui/admin/src/components/Sessions/SessionList.vue
@@ -49,7 +49,7 @@
           <td>
             {{ session.username }}
           </td>
-          <td class="d-flex justify-center align-center">
+          <td class="text-center">
             <v-tooltip anchor="bottom" v-if="session.authenticated">
               <template v-slot:activator="{ props }">
                 <v-icon v-bind="props">mdi-shield-check </v-icon>

--- a/ui/admin/tests/unit/components/Session/SessionList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Session/SessionList/__snapshots__/index.spec.ts.snap
@@ -39,7 +39,7 @@ exports[`Sessions List > Renders the component 1`] = `
               </td>
               <td data-v-d900b695=""><span data-v-d900b695="" tabindex="0" class="hover">39-5e-2a</span></td>
               <td data-v-d900b695="">user</td>
-              <td data-v-d900b695="" class="d-flex justify-center align-center"><i data-v-d900b695="" class="mdi-shield-alert mdi v-icon notranslate v-theme--light v-icon--size-default text-error" aria-hidden="true" aria-describedby="v-tooltip-v-3"></i>
+              <td data-v-d900b695="" class="text-center"><i data-v-d900b695="" class="mdi-shield-alert mdi v-icon notranslate v-theme--light v-icon--size-default text-error" aria-hidden="true" aria-describedby="v-tooltip-v-3"></i>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
@@ -75,7 +75,7 @@ exports[`Sessions List > Renders the component 1`] = `
               </td>
               <td data-v-d900b695=""><span data-v-d900b695="" tabindex="0" class="hover">b4-2e-99</span></td>
               <td data-v-d900b695="">user</td>
-              <td data-v-d900b695="" class="d-flex justify-center align-center"><i data-v-d900b695="" class="mdi-shield-alert mdi v-icon notranslate v-theme--light v-icon--size-default text-error" aria-hidden="true" aria-describedby="v-tooltip-v-9"></i>
+              <td data-v-d900b695="" class="text-center"><i data-v-d900b695="" class="mdi-shield-alert mdi v-icon notranslate v-theme--light v-icon--size-default text-error" aria-hidden="true" aria-describedby="v-tooltip-v-9"></i>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>


### PR DESCRIPTION
This PR fixes a buggy behavior from the Authenticated icon in the sessions list, which caused the table layout to break on smaller screens:
![image](https://github.com/user-attachments/assets/7609a40f-6e2f-4e0e-8872-31df1223149a)

Changed the styling classes and updated the test snapshot accordingly.
