### PR TITLE
fix(ui): prevent tooltip click from triggering parent handlers

### DIFF
--- a/ui/src/components/QuickConnection/QuickConnectionList.vue
+++ b/ui/src/components/QuickConnection/QuickConnectionList.vue
@@ -39,12 +39,13 @@
                   <template v-slot:activator="{ props }">
                     <span
                       v-bind="props"
-                      @click="copyText(sshidAddress(item))"
-                      @keypress="copyText(sshidAddress(item))"
+                      @click.stop="copyText(sshidAddress(item))"
+                      @keypress.stop="copyText(sshidAddress(item))"
                       class="hover-text"
                       data-test="copy-id-button">
                       {{ sshidAddress(item) }}
                     </span>
+
                   </template>
                   <span>Copy ID</span>
                 </v-tooltip>


### PR DESCRIPTION
# Description

This PR addresses an issue with event propagation in the `QuickConnectionList.vue` component. Previously, when users clicked or pressed a key on the SSH ID text within the tooltip, the events would bubble up and potentially trigger unintended behavior in parent components.

To resolve this, `.stop` modifiers have been added to the `@click` and `@keypress` events on the span that triggers the copy action. This ensures that the event is handled locally and does not propagate beyond the intended element, improving the reliability and predictability of user interactions with the tooltip.

## Why It Matters

Without stopping event propagation, UI components that rely on scoped interactions may behave unpredictably. For example, a parent component might react to the same click, causing side effects like modal closures or row selections. This change ensures a more intuitive and controlled UX when copying SSH IDs.