### PR TITLE
chore(api): moving routes to package representing api version

### DIFF
--- a/api/routes/v0/api-key.go
+++ b/api/routes/v0/api-key.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/api-key_test.go
+++ b/api/routes/v0/api-key_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"encoding/json"

--- a/api/routes/v0/auth.go
+++ b/api/routes/v0/auth.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"errors"

--- a/api/routes/v0/auth_test.go
+++ b/api/routes/v0/auth_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"crypto/rand"

--- a/api/routes/v0/device.go
+++ b/api/routes/v0/device.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/device_test.go
+++ b/api/routes/v0/device_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"encoding/json"

--- a/api/routes/v0/handler.go
+++ b/api/routes/v0/handler.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	svc "github.com/shellhub-io/shellhub/api/services"

--- a/api/routes/v0/healthcheck.go
+++ b/api/routes/v0/healthcheck.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/healthcheck_test.go
+++ b/api/routes/v0/healthcheck_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/nsadm.go
+++ b/api/routes/v0/nsadm.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/nsadm_test.go
+++ b/api/routes/v0/nsadm_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"encoding/json"

--- a/api/routes/v0/routes.go
+++ b/api/routes/v0/routes.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"
@@ -164,8 +164,11 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 		publicAPI.POST(SetupEndpoint, gateway.Handler(handler.Setup))
 	}
 
-	// NOTE: Rewrite requests to containers to devices, as they are the same thing under the hood, using it as an alias.
 	router.Pre(echoMiddleware.Rewrite(map[string]string{
+		// NOTE: Rewrites request to /api/v0 and /internal/v0 to uri without version.
+		"/api/v0/*":      "/api/$1",
+		"/internal/v0/*": "/internal/$1",
+		// NOTE: Rewrite requests to containers to devices, as they are the same thing under the hood, using it as an alias.
 		"/api/containers":   "/api/devices?connector=true",
 		"/api/containers?*": "/api/devices?$1&connector=true",
 		"/api/containers/*": "/api/devices/$1",

--- a/api/routes/v0/session.go
+++ b/api/routes/v0/session.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/session_test.go
+++ b/api/routes/v0/session_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"encoding/json"

--- a/api/routes/v0/setup.go
+++ b/api/routes/v0/setup.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/setup_test.go
+++ b/api/routes/v0/setup_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"errors"

--- a/api/routes/v0/sshkeys.go
+++ b/api/routes/v0/sshkeys.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/sshkeys_test.go
+++ b/api/routes/v0/sshkeys_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"encoding/json"

--- a/api/routes/v0/stats.go
+++ b/api/routes/v0/stats.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/stats_test.go
+++ b/api/routes/v0/stats_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"encoding/json"

--- a/api/routes/v0/tags.go
+++ b/api/routes/v0/tags.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/tags_test.go
+++ b/api/routes/v0/tags_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"encoding/json"

--- a/api/routes/v0/user.go
+++ b/api/routes/v0/user.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"net/http"

--- a/api/routes/v0/user_test.go
+++ b/api/routes/v0/user_test.go
@@ -1,4 +1,4 @@
-package routes
+package v0
 
 import (
 	"encoding/json"

--- a/api/server.go
+++ b/api/server.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/labstack/echo/v4"
-	"github.com/shellhub-io/shellhub/api/routes"
+	"github.com/shellhub-io/shellhub/api/routes/v0"
 	"github.com/shellhub-io/shellhub/api/services"
 	"github.com/shellhub-io/shellhub/api/store/mongo"
 	"github.com/shellhub-io/shellhub/api/store/mongo/options"
@@ -97,7 +97,7 @@ func (s *Server) Setup(ctx context.Context) error {
 	}
 
 	service := services.NewService(store, nil, nil, cache, apiClient, servicesOptions...)
-	s.router = routes.NewRouter(service, routerOptions...)
+	s.router = v0.NewRouter(service, routerOptions...)
 
 	s.worker = asynq.NewServer(
 		s.env.RedisURI,
@@ -167,8 +167,8 @@ func (s *Server) serviceOptions(ctx context.Context) ([]services.Option, error) 
 }
 
 // routerOptions returns configuration options for the HTTP router.
-func (s *Server) routerOptions() ([]routes.Option, error) {
-	opts := []routes.Option{}
+func (s *Server) routerOptions() ([]v0.Option, error) {
+	opts := []v0.Option{}
 
 	if s.env.SentryDSN != "" {
 		log.Info("Initializing Sentry error reporting")
@@ -187,7 +187,7 @@ func (s *Server) routerOptions() ([]routes.Option, error) {
 
 		log.Info("Sentry error reporting initialized successfully")
 
-		opts = append(opts, routes.WithReporter(reporter))
+		opts = append(opts, v0.WithReporter(reporter))
 	}
 
 	return opts, nil


### PR DESCRIPTION
Configure both `/api` and `/api/v0` to be handled by the same
proxy/router, and apply the same behavior for `/internal` and
`/internal/v0`. This ensures that all incoming requests to either the
unversioned or v0 path are routed to the identical backend handler,
simplifying maintenance and avoiding duplicate logic.