### PR TITLE
fix(ui): fix player playback time for sessions longer than 24h

### DIFF
--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -92,6 +92,7 @@ import { computed, onMounted, onUnmounted, ref, watchEffect } from "vue";
 import { useEventListener } from "@vueuse/core";
 import { useDisplay } from "vuetify";
 import PlayerShortcutsDialog from "./PlayerShortcutsDialog.vue";
+import formatPlaybackTime from "@/utils/playerPlayback";
 
 const { logs } = defineProps<{
   logs: string | null;
@@ -110,9 +111,8 @@ const isPlaying = ref(true);
 const sessionEnded = ref(false);
 const currentTime = ref(0);
 const duration = ref(0);
-const formatTime = (time: number) => new Date(time * 1000).toISOString().slice(time >= 3600 ? 11 : 14, 19);
-const formattedCurrentTime = computed(() => formatTime(currentTime.value));
-const formattedDuration = computed(() => formatTime(duration.value));
+const formattedCurrentTime = computed(() => formatPlaybackTime(currentTime.value));
+const formattedDuration = computed(() => formatPlaybackTime(duration.value));
 const timeUpdaterId = ref<number>();
 const currentSpeed = ref(1);
 
@@ -211,7 +211,7 @@ onUnmounted(() => {
 
 watchEffect(() => !showDialog.value && changeFocusToPlayer());
 
-defineExpose({ player, currentSpeed, currentTime, isPlaying, showDialog, formatTime, pause });
+defineExpose({ player, currentSpeed, currentTime, isPlaying, showDialog, pause });
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/utils/playerPlayback.ts
+++ b/ui/src/utils/playerPlayback.ts
@@ -1,0 +1,15 @@
+const formatPlaybackTime = (timeInSeconds: number): string => {
+  if (!Number.isFinite(timeInSeconds) || timeInSeconds < 0) return "00:00";
+
+  const hours = Math.floor(timeInSeconds / 3600);
+  const minutes = Math.floor((timeInSeconds % 3600) / 60);
+  const seconds = Math.floor(timeInSeconds % 60);
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(seconds)}`
+    : `${pad(minutes)}:${pad(seconds)}`;
+};
+
+export default formatPlaybackTime;

--- a/ui/tests/components/Sessions/Player.spec.ts
+++ b/ui/tests/components/Sessions/Player.spec.ts
@@ -6,6 +6,7 @@ import { SnackbarPlugin } from "@/plugins/snackbar";
 import { router } from "@/router";
 import { store, key } from "@/store";
 import Player from "@/components/Sessions/Player.vue";
+import formatPlaybackTime from "@/utils/playerPlayback";
 
 vi.mock("asciinema-player", () => ({
   create: vi.fn().mockReturnValue({
@@ -124,10 +125,13 @@ describe("Asciinema Player", () => {
   });
 
   it("Formats time correctly", () => {
-    expect(wrapper.vm.formatTime(3661)).toBe("01:01:01"); // hh:mm:ss if session is longer than 1 hour
-    expect(wrapper.vm.formatTime(61)).toBe("01:01"); // mm:ss otherwise
-    expect(wrapper.vm.formatTime(59)).toBe("00:59"); // Less than 1 minute
-    expect(wrapper.vm.formatTime(0)).toBe("00:00"); // Zero time
+    expect(formatPlaybackTime(3661)).toBe("1:01:01"); // hh:mm:ss if session is longer than 1 hour
+    expect(formatPlaybackTime(61)).toBe("01:01"); // mm:ss otherwise
+    expect(formatPlaybackTime(59)).toBe("00:59"); // Less than 1 minute
+    expect(formatPlaybackTime(0)).toBe("00:00"); // Zero time
+    expect(formatPlaybackTime(90061)).toBe("25:01:01");
+    expect(formatPlaybackTime(172800)).toBe("48:00:00");
+    expect(formatPlaybackTime(363599)).toBe("100:59:59");
   });
 
   it("Updates current time when slider is moved", async () => {


### PR DESCRIPTION
This PR fixes the player's playback time formatting, making it behave properly in sessions longer than 1 day. The formatting logic was rewritten and moved to a separate util file. The tests were also updated to test the new util behavior.