### PR TITLE
refactor(ui): change Connector Add to Container Modal in empty Containers view

### DIFF
--- a/ui/src/views/Containers.vue
+++ b/ui/src/views/Containers.vue
@@ -37,8 +37,8 @@
     type-message="container"
     data-test="boxMessageDevice-component"
   >
-    <template v-slot:container v-if="envVariables.hasConnector">
-      <ConnectorAdd @update="refresh" />
+    <template v-slot:container>
+      <ContainerAdd />
     </template>
   </BoxMessage>
 </template>
@@ -48,11 +48,9 @@ import { computed, ref, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
 import { useStore } from "../store";
 import { envVariables } from "../envVariables";
-import ConnectorAdd from "../components/Connector/ConnectorAdd.vue";
 import Containers from "../components/Containers/Container.vue";
 import TagSelector from "../components/Tags/TagSelector.vue";
 import BoxMessage from "../components/Box/BoxMessage.vue";
-import handleError from "@/utils/handleError";
 import ContainerAdd from "../components/Containers/ContainerAdd.vue";
 import useSnackbar from "@/helpers/snackbar";
 
@@ -89,24 +87,6 @@ const searchDevices = () => {
 };
 
 const isContainerList = computed(() => router.currentRoute.value.name === "ContainerList");
-
-const refresh = async () => {
-  loading.value = true;
-  setTimeout(() => {
-    try {
-      store.dispatch("container/fetch", {
-        page: store.getters["container/getPage"],
-        perPage: store.getters["container/getPerPage"],
-        filter: store.getters["container/getFilter"],
-        status: "",
-        committable: false,
-      });
-    } catch (error) {
-      handleError(error);
-    }
-    loading.value = false;
-  }, 10000);
-};
 
 onUnmounted(async () => {
   await store.dispatch("container/setFilter", "");


### PR DESCRIPTION
# Description
This PR simplifies the logic for displaying the container addition component in the Containers.vue view. Key changes include:

    Replaced the conditional ConnectorAdd slot with a direct ContainerAdd component.

    Removed the now-unnecessary refresh method and its 10-second delay logic.

    Cleaned up unused imports: ConnectorAdd and handleError.

This refactor removes legacy connector logic, improves clarity, and reduces unused code.

## Why:
The conditional rendering based on envVariables.hasConnector is no longer needed, and maintaining legacy ConnectorAdd logic created unnecessary complexity.

## Impact:
Only affects the UI logic related to adding containers. No backend or data-fetching logic is impacted.