### PR TITLE
fix(ui): add await to `getConnectors` call

### DIFF
--- a/ui/src/components/Connector/ConnectorList.vue
+++ b/ui/src/components/Connector/ConnectorList.vue
@@ -219,15 +219,15 @@ const getConnectors = async (perPageValue: number, pageValue: number) => {
   }
 };
 
-onMounted(() => {
+onMounted(async () => {
   if (envVariables.isCommunity) {
     return;
   }
-  getConnectors(itemsPerPage.value, page.value);
+  await getConnectors(itemsPerPage.value, page.value);
 });
 
-const refresh = () => {
-  getConnectors(itemsPerPage.value, page.value);
+const refresh = async () => {
+  await getConnectors(itemsPerPage.value, page.value);
 };
 
 const next = async () => {


### PR DESCRIPTION
This PR fixes some asynchronous calls in `ConnectorList.vue` that lacked the `await` keyword before it. This could lead to some errors when calling the API. 