### PR TITLE
fix(ui): update SessionPlay props in DetailsSessions

### DIFF
--- a/ui/src/views/DetailsSessions.vue
+++ b/ui/src/views/DetailsSessions.vue
@@ -40,12 +40,10 @@
                 <div v-bind="props">
                   <SessionPlay
                     v-if="session.authenticated && session.recorded"
+                    :authenticated="session.authenticated"
                     :uid="session.uid"
-                    :device="session.device"
-                    :notHasAuthorization="!hasAuthorizationPlay()"
-                    :recorded="session.authenticated && session.recorded"
-                    @update="refreshSessions"
-                    data-test="sessionPlay-component"
+                    :recorded="session.recorded"
+                    data-test="session-play-component"
                   />
                 </div>
               </template>


### PR DESCRIPTION
This PR updates the props passed to the `SessionPlay` component in `DetailsSession.vue`, aligning with the updates made in PR #4888, fixing the component's behavior, and preventing the UI's build from failing.