### PR TITLE
feat(ui): add session downloading feature to SessionPlay

### DIFF
--- a/ui/src/components/Sessions/Player.vue
+++ b/ui/src/components/Sessions/Player.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="wrapper ma-0 pa-0 w-100 fill-height position-relative bg-v-theme-terminal"
-    v-if="logs"
     ref="containerDiv"
     @keydown.space.prevent="isPlaying = !isPlaying"
     data-test="player-container"

--- a/ui/src/components/Sessions/SessionDownload.vue
+++ b/ui/src/components/Sessions/SessionDownload.vue
@@ -6,11 +6,16 @@
       <v-card-text class="text-justify px-5 py-5">
         This session is very large ({{ getBlobSizeInMB() }} MB), and trying to play it in the browser may not work.<br />
         You can download it to your computer and try to play locally with
-        <a href="https://docs.asciinema.org/manual/cli/quick-start/" target="_blank" rel="noopener noreferrer">Asciinema CLI</a>.
+        <a href="https://docs.asciinema.org/manual/cli/quick-start/" target="_blank" rel="noopener noreferrer">Asciinema CLI</a>.<br />
+
+        <strong>Alternatively</strong>, you can download and re-upload the file here to try playing it in the browser.
       </v-card-text>
-      <v-card-actions class="d-flex justify-end py-4">
+      <v-card-actions class="d-flex justify-space-between px-5 pb-5">
         <v-btn text @click="showDownloadDialog = false">Close</v-btn>
-        <v-btn color="primary" @click="handleDownload()" :loading="downloading">Download</v-btn>
+        <div class="d-flex gap-3">
+          <v-btn color="primary" @click="handleFileUpload">Upload</v-btn>
+          <v-btn color="primary" @click="handleDownload" :loading="downloading">Download</v-btn>
+        </div>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -21,12 +26,14 @@ import { ref } from "vue";
 import useSnackbar from "@/helpers/snackbar";
 import handleError from "@/utils/handleError";
 
+const emit = defineEmits(["play"]);
+
 const { sessionBlob } = defineProps<{
   sessionBlob: Blob | null;
 }>();
 
-const snackbar = useSnackbar();
 const showDownloadDialog = defineModel<boolean>();
+const snackbar = useSnackbar();
 const downloading = ref(false);
 
 const getBlobSizeInMB = () => {
@@ -45,7 +52,6 @@ const downloadSessionFile = async () => {
   const writable = await fileHandler.createWritable();
   await writable.write(sessionBlob);
   snackbar.showInfo("Downloading session...");
-
   await writable.close();
   snackbar.showSuccess("Session downloaded successfully.");
 };
@@ -61,9 +67,35 @@ const handleDownload = async () => {
       handleError(error);
       snackbar.showError("Failed to download the session.");
     }
+  } finally {
+    downloading.value = false;
   }
+};
 
-  downloading.value = false;
-  showDownloadDialog.value = false;
+const handleFileUpload = async () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore: showOpenFilePicker is experimental
+  const [fileHandler] = await window.showOpenFilePicker({
+    types: [{
+      description: "Asciinema Session Files",
+      accept: {
+        "application/octet-stream": [".cast"],
+      },
+    }],
+    startIn: "downloads",
+  });
+
+  const file = await fileHandler.getFile();
+  if (!file) return;
+
+  try {
+    const text = await file.text();
+    emit("play", text);
+    snackbar.showSuccess("Session loaded. Playing...");
+    showDownloadDialog.value = false;
+  } catch (err) {
+    snackbar.showError("Invalid session file or too large.");
+    handleError(err);
+  }
 };
 </script>

--- a/ui/src/components/Sessions/SessionDownload.vue
+++ b/ui/src/components/Sessions/SessionDownload.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-dialog v-model="showDownloadDialog" max-width="500">
+    <v-card>
+      <v-card-title class="text-h5 px-5 py-3 bg-primary">Session Too Large</v-card-title>
+      <v-divider />
+      <v-card-text class="text-justify px-5 py-5">
+        This session is very large ({{ getBlobSizeInMB() }} MB), and trying to play it in the browser may not work.<br />
+        You can download it to your computer and try to play locally with
+        <a href="https://docs.asciinema.org/manual/cli/quick-start/" target="_blank" rel="noopener noreferrer">Asciinema CLI</a>.
+      </v-card-text>
+      <v-card-actions class="d-flex justify-end py-4">
+        <v-btn text @click="showDownloadDialog = false">Close</v-btn>
+        <v-btn color="primary" @click="handleDownload()" :loading="downloading">Download</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import useSnackbar from "@/helpers/snackbar";
+import handleError from "@/utils/handleError";
+
+const { sessionBlob } = defineProps<{
+  sessionBlob: Blob | null;
+}>();
+
+const snackbar = useSnackbar();
+const showDownloadDialog = defineModel<boolean>();
+const downloading = ref(false);
+
+const getBlobSizeInMB = () => {
+  const sizeInMB = (sessionBlob?.size || 0) / (1000 * 1000);
+  return sizeInMB.toFixed(2);
+};
+
+const downloadSessionFile = async () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore: showSaveFilePicker is experimental
+  const fileHandler = await window.showSaveFilePicker({
+    suggestedName: "session.cast",
+    startIn: "downloads",
+  });
+
+  const writable = await fileHandler.createWritable();
+  await writable.write(sessionBlob);
+  snackbar.showInfo("Downloading session...");
+
+  await writable.close();
+  snackbar.showSuccess("Session downloaded successfully.");
+};
+
+const handleDownload = async () => {
+  try {
+    downloading.value = true;
+    await downloadSessionFile();
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      snackbar.showInfo("Download cancelled.");
+    } else {
+      handleError(error);
+      snackbar.showError("Failed to download the session.");
+    }
+  }
+
+  downloading.value = false;
+  showDownloadDialog.value = false;
+};
+</script>

--- a/ui/src/components/Sessions/SessionPlay.vue
+++ b/ui/src/components/Sessions/SessionPlay.vue
@@ -40,6 +40,7 @@
     <SessionDownload
       v-model="showDownloadDialog"
       :sessionBlob
+      @play="handleManualUpload"
     />
   </div>
 </template>
@@ -104,6 +105,11 @@ const displayDialog = async () => {
     snackbar.showError("Failed to play the session.");
     handleError(error);
   }
+};
+
+const handleManualUpload = (text: string) => {
+  logs.value = text;
+  showPlayer.value = true;
 };
 
 const openDialog = () => {

--- a/ui/src/store/api/sessions.ts
+++ b/ui/src/store/api/sessions.ts
@@ -11,4 +11,4 @@ export const closeSession = async (
   session: ISessions,
 ) => sessionsApi.clsoeSession(session.uid, { device: session.device_uid });
 
-export const getLog = async (uid: string) => sessionsApi.getSessionRecord(uid, 0);
+export const getLog = async (uid: string) => sessionsApi.getSessionRecord(uid, 0, { responseType: "blob" });


### PR DESCRIPTION
This PR is a proof of concept for the session downloading feature, used in very large sessions (300 MB+) that break in Chromium-based browsers. Using this, the user can download the session logs to play locally, instead of dealing with a broken player on the web.

After acceptance, the code will be improved, the store will be properly adapted, and tests will be added.