### PR TITLE
refactor(ui): remove `console.error` calls

### DIFF
--- a/ui/admin/src/components/Announcement/AnnouncementDelete.vue
+++ b/ui/admin/src/components/Announcement/AnnouncementDelete.vue
@@ -40,6 +40,7 @@
 import { ref } from "vue";
 import useAnnouncementStore from "@admin/store/modules/announcement";
 import useSnackbar from "@/helpers/snackbar";
+import handleError from "@/utils/handleError";
 
 const props = defineProps({
   uuid: {
@@ -59,7 +60,8 @@ const remove = async () => {
     await announcement.deleteAnnouncement(props.uuid);
     emit("update");
     snackbar.showSuccess("Announcement deleted successfully.");
-  } catch {
+  } catch (error) {
+    handleError(error);
     snackbar.showError("Failed to delete announcement.");
   }
 };

--- a/ui/admin/src/components/Announcement/AnnouncementEdit.vue
+++ b/ui/admin/src/components/Announcement/AnnouncementEdit.vue
@@ -108,6 +108,7 @@ import * as yup from "yup";
 import useAnnouncementStore from "@admin/store/modules/announcement";
 import useSnackbar from "@/helpers/snackbar";
 import { envVariables } from "../../envVariables";
+import handleError from "@/utils/handleError";
 
 const props = defineProps({
   announcementItem: {
@@ -166,6 +167,7 @@ const onSubmit = async () => {
     dialog.value = false;
     emit("update");
   } catch (error) {
+    handleError(error);
     snackbar.showError("Failed to update announcement.");
   }
 };

--- a/ui/admin/src/components/Announcement/AnnouncementList.vue
+++ b/ui/admin/src/components/Announcement/AnnouncementList.vue
@@ -62,6 +62,7 @@ import DataTable from "../DataTable.vue";
 import AnnouncementDelete from "./AnnouncementDelete.vue";
 import AnnouncementEdit from "./AnnouncementEdit.vue";
 import { IAnnouncements } from "../../interfaces/IAnnouncements";
+import handleError from "@/utils/handleError";
 
 const router = useRouter();
 const announcementStore = useAnnouncementStore();
@@ -104,6 +105,7 @@ const getAnnouncements = async (
     }
     loading.value = false;
   } catch (error) {
+    handleError(error);
     snackbar.showError("Failed to fetch announcements.");
   }
 };

--- a/ui/admin/src/components/Settings/SettingsAuthentication.vue
+++ b/ui/admin/src/components/Settings/SettingsAuthentication.vue
@@ -257,7 +257,7 @@ const changeSamlAuthStatus = async () => {
 
 const downloadSSOCertificates = () => {
   if (!certificate.value) {
-    console.error("No certificates available to download.");
+    snackbar.showError("No certificates available to download.");
     return;
   }
 

--- a/ui/admin/src/components/Settings/SettingsLicense.vue
+++ b/ui/admin/src/components/Settings/SettingsLicense.vue
@@ -210,6 +210,7 @@ import moment from "moment";
 import useLicenseStore from "@admin/store/modules/license";
 import useSnackbar from "@/helpers/snackbar";
 import { Features } from "../../interfaces/ILicense";
+import handleError from "@/utils/handleError";
 
 const currentFile = ref<File | null>(null);
 const licenseUploadStatus = ref(false);
@@ -275,7 +276,7 @@ const uploadLicense = async () => {
       snackbar.showSuccess("License uploaded successfully.");
       licenseUploadStatus.value = false;
     } catch (error) {
-      console.error("License upload error:", error);
+      handleError(error);
       snackbar.showError("Failed to upload the license.");
     }
   }

--- a/ui/admin/src/store/modules/announcement.ts
+++ b/ui/admin/src/store/modules/announcement.ts
@@ -39,58 +39,33 @@ export const useAnnouncementStore = defineStore("announcement", {
 
   actions: {
     async postAnnouncement(announcement: Announcement) {
-      try {
-        const { data } = await postAnnouncement(announcement as Required<Announcement>);
-        this.announcement = data;
-      } catch (error) {
-        console.error(error);
-        throw error;
-      }
+      const { data } = await postAnnouncement(announcement as Required<Announcement>);
+      this.announcement = data;
     },
 
     async updateAnnouncement(uuid: string, announcement: Announcement) {
-      try {
-        const { data } = await updateAnnouncement(uuid, announcement as Required<Announcement>);
-        this.announcement = data;
-      } catch (error) {
-        console.error(error);
-        throw error;
-      }
+      const { data } = await updateAnnouncement(uuid, announcement as Required<Announcement>);
+      this.announcement = data;
     },
 
     async fetchAnnouncement(uuid: string) {
-      try {
-        const { data } = await getAnnouncement(uuid);
-        this.announcement = data;
-      } catch (error) {
-        console.error(error);
-        throw error;
-      }
+      const { data } = await getAnnouncement(uuid);
+      this.announcement = data;
     },
 
     async fetchAnnouncements({ page, perPage, orderBy }: { page: number; perPage: number; orderBy: "asc" | "desc" }) {
-      try {
-        const res = await getListAnnouncements(page, perPage, orderBy);
-        if (res.data && res.data.length) {
-          this.announcements = res.data;
-          this.numberAnnouncements = parseInt(res.headers["x-total-count"], 10);
-          return res;
-        }
-        return false;
-      } catch (error) {
-        console.error(error);
-        throw error;
+      const res = await getListAnnouncements(page, perPage, orderBy);
+      if (res.data && res.data.length) {
+        this.announcements = res.data;
+        this.numberAnnouncements = parseInt(res.headers["x-total-count"], 10);
+        return res;
       }
+      return false;
     },
 
     async deleteAnnouncement(uuid: string) {
-      try {
-        const { data } = await deleteAnnouncement(uuid);
-        this.announcement = data;
-      } catch (error) {
-        console.error(error);
-        throw error;
-      }
+      const { data } = await deleteAnnouncement(uuid);
+      this.announcement = data;
     },
 
     setPageAndPerPage({ page, perPage }: { page: number; perPage: number }) {

--- a/ui/admin/src/views/NewAnnouncement.vue
+++ b/ui/admin/src/views/NewAnnouncement.vue
@@ -74,6 +74,7 @@ import { useRouter } from "vue-router";
 import useAnnouncementStore from "@admin/store/modules/announcement";
 import useSnackbar from "@/helpers/snackbar";
 import { envVariables } from "../envVariables";
+import handleError from "@/utils/handleError";
 
 const router = useRouter();
 const snackbar = useSnackbar();
@@ -114,6 +115,7 @@ const postAnnouncement = () => {
     snackbar.showSuccess("Successfully created announcement.");
     router.push({ name: "announcements" });
   } catch (error) {
+    handleError(error);
     snackbar.showError("Failed to create announcement.");
   }
 };


### PR DESCRIPTION
This pull request keeps consistent error handling across multiple components in the admin UI by removing `console.error` calls. Some unnecessary try/catch blocks were removed, and error handling is now done with the util `handleError` where needed.