### PR TITLE
fix(ui): fix admin's user list

### DIFF
--- a/ui/admin/src/components/User/UserFormDialog.vue
+++ b/ui/admin/src/components/User/UserFormDialog.vue
@@ -272,6 +272,16 @@ const submitUser = async (isCreating: boolean, userData: Record<string, unknown>
   }
 };
 
+const getStatus = () => {
+  if (props.createUser) return undefined;
+
+  if (canChangeStatus) {
+    return isConfirmed.value ? "confirmed" : "not-confirmed";
+  }
+
+  return props.user?.status;
+};
+
 const prepareUserData = (): Record<string, unknown> => ({
   name: name.value,
   email: email.value,
@@ -279,6 +289,7 @@ const prepareUserData = (): Record<string, unknown> => ({
   password: password.value || "",
   max_namespaces: changeNamespaceLimit.value ? maxNamespaces.value : undefined,
   confirmed: !props.createUser ? isConfirmed.value : undefined,
+  status: getStatus(),
   id: !props.createUser ? props.user?.id : undefined,
 });
 

--- a/ui/admin/src/components/User/UserList.vue
+++ b/ui/admin/src/components/User/UserList.vue
@@ -57,9 +57,9 @@
                   tag="a"
                   dark
                   v-bind="props"
-                  @click="loginToken(item)"
+                  @click="loginToken(item.id)"
                   tabindex="0"
-                  @keyup.enter="loginToken(item)"
+                  @keyup.enter="loginToken(item.id)"
                 >mdi-login
                 </v-icon>
               </template>
@@ -186,9 +186,9 @@ watch(itemsPerPage, () => {
   getUsers(itemsPerPage.value, page.value);
 });
 
-const loginToken = async (user) => {
+const loginToken = async (userId: string) => {
   try {
-    const token = await authStore.loginToken(user);
+    const token = await authStore.loginToken(userId);
 
     const url = `/login?token=${token}`;
     window.open(url, "_target");

--- a/ui/admin/src/components/User/UserList.vue
+++ b/ui/admin/src/components/User/UserList.vue
@@ -30,14 +30,7 @@
             {{ item.namespaces }}
           </td>
           <td class="pl-0">
-            <v-chip
-              class="ma-2"
-              :color="statusChip[item.status].color"
-              variant="text"
-              :prepend-icon="statusChip[item.status].icon"
-            >
-              {{ statusChip[item.status].label }}
-            </v-chip>
+            <UserStatusChip :status="item.status" />
           </td>
 
           <td>
@@ -95,6 +88,7 @@ import { IUser, UserAuthMethods } from "@admin/interfaces/IUser";
 import useAuthStore from "@admin/store/modules/auth";
 import useSnackbar from "@/helpers/snackbar";
 import DataTable from "../DataTable.vue";
+import UserStatusChip from "./UserStatusChip.vue";
 import UserFormDialog from "./UserFormDialog.vue";
 import UserDelete from "./UserDelete.vue";
 import UserResetPassword from "./UserResetPassword.vue";
@@ -110,11 +104,6 @@ const page = ref(1);
 const filter = ref("");
 const users = computed(() => userStore.getUsers as unknown as IUser[]);
 const totalUsers = computed(() => userStore.numberUsers);
-const statusChip: Record<IUser["status"], { color: string; icon: string; label: string }> = {
-  confirmed: { color: "success", icon: "mdi-checkbox-marked-circle", label: "Confirmed" },
-  invited: { color: "warning", icon: "mdi-email-alert", label: "Invited" },
-  "not-confirmed": { color: "error", icon: "mdi-alert-circle", label: "Not Confirmed" },
-};
 
 const header = [
   {

--- a/ui/admin/src/components/User/UserList.vue
+++ b/ui/admin/src/components/User/UserList.vue
@@ -29,14 +29,14 @@
           <td :namespaces-test="item.namespaces">
             {{ item.namespaces }}
           </td>
-          <td v-if="item.confirmed" class="pl-0">
-            <v-chip class="ma-2" color="success" variant="text" prepend-icon="mdi-checkbox-marked-circle">
-              Confirmed
-            </v-chip>
-          </td>
-          <td v-else class="pl-0">
-            <v-chip class="ma-2" color="warning" variant="text" prepend-icon="mdi-alert-circle">
-              Not confirmed
+          <td class="pl-0">
+            <v-chip
+              class="ma-2"
+              :color="statusChip[item.status].color"
+              variant="text"
+              :prepend-icon="statusChip[item.status].icon"
+            >
+              {{ statusChip[item.status].label }}
             </v-chip>
           </td>
 
@@ -91,26 +91,13 @@
 import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import useUsersStore from "@admin/store/modules/users";
-import { UserAdminResponse } from "@admin/api/client/api";
+import { IUser } from "@admin/interfaces/IUser";
 import useAuthStore from "@admin/store/modules/auth";
 import useSnackbar from "@/helpers/snackbar";
 import DataTable from "../DataTable.vue";
 import UserFormDialog from "./UserFormDialog.vue";
 import UserDelete from "./UserDelete.vue";
 import UserResetPassword from "./UserResetPassword.vue";
-
-export interface IUser {
-  id: string;
-  auth_methods: Array<string>;
-  namespaces: number;
-  confirmed: boolean;
-  created_at: string;
-  last_login: string;
-  name: string;
-  email: string;
-  username: string;
-  password: string;
-}
 
 const router = useRouter();
 const snackbar = useSnackbar();
@@ -123,6 +110,11 @@ const page = ref(1);
 const filter = ref("");
 const users = computed(() => userStore.getUsers as unknown as IUser[]);
 const totalUsers = computed(() => userStore.numberUsers);
+const statusChip: Record<IUser["status"], { color: string; icon: string; label: string }> = {
+  confirmed: { color: "success", icon: "mdi-checkbox-marked-circle", label: "Confirmed" },
+  invited: { color: "warning", icon: "mdi-email-alert", label: "Invited" },
+  "not-confirmed": { color: "error", icon: "mdi-alert-circle", label: "Not Confirmed" },
+};
 
 const header = [
   {
@@ -220,7 +212,7 @@ const refreshUsers = async () => {
   await userStore.refresh();
 };
 
-const redirectToUser = async (user: UserAdminResponse) => {
+const redirectToUser = async (user: IUser) => {
   router.push({ name: "userDetails", params: { id: user.id } });
 };
 

--- a/ui/admin/src/components/User/UserList.vue
+++ b/ui/admin/src/components/User/UserList.vue
@@ -74,7 +74,7 @@
             </v-tooltip>
 
             <UserResetPassword
-              v-if="checkAuthMethods(item as IUser)"
+              v-if="userPrefersSAMLAuthentication(item.preferences.auth_methods)"
               :userId="item.id"
               @update="refreshUsers"
             />
@@ -91,7 +91,7 @@
 import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import useUsersStore from "@admin/store/modules/users";
-import { IUser } from "@admin/interfaces/IUser";
+import { IUser, UserAuthMethods } from "@admin/interfaces/IUser";
 import useAuthStore from "@admin/store/modules/auth";
 import useSnackbar from "@/helpers/snackbar";
 import DataTable from "../DataTable.vue";
@@ -143,9 +143,9 @@ const header = [
   },
 ];
 
-const checkAuthMethods = (user: IUser | undefined) => user?.auth_methods
-  && user.auth_methods.length === 1
-  && user.auth_methods[0] === "saml";
+const userPrefersSAMLAuthentication = (authMethods: UserAuthMethods) => (
+  authMethods && authMethods.length === 1 && authMethods[0] === "saml"
+);
 
 onMounted(async () => {
   try {

--- a/ui/admin/src/components/User/UserStatusChip.vue
+++ b/ui/admin/src/components/User/UserStatusChip.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-chip
+    class="ma-2"
+    :color="statusChipAttributes.color"
+    variant="text"
+    :prepend-icon="statusChipAttributes.icon"
+  >
+    {{ statusChipAttributes.label }}
+  </v-chip>
+</template>
+
+<script setup lang="ts">
+import { UserStatus } from "@admin/interfaces/IUser";
+import { computed } from "vue";
+
+const { status } = defineProps<{
+  status: UserStatus;
+}>();
+
+const validStatuses = ["confirmed", "invited", "not-confirmed"];
+
+const safeStatus = computed(() => validStatuses.includes(status) ? status : "not-confirmed");
+
+const statusChipAttributes = computed(() => ({
+  confirmed: { color: "success", icon: "mdi-checkbox-marked-circle", label: "Confirmed" },
+  invited: { color: "warning", icon: "mdi-email-alert", label: "Invited" },
+  "not-confirmed": { color: "error", icon: "mdi-alert-circle", label: "Not Confirmed" },
+}[safeStatus.value]));
+</script>

--- a/ui/admin/src/interfaces/IUser.ts
+++ b/ui/admin/src/interfaces/IUser.ts
@@ -5,6 +5,7 @@ export type UserAuthMethods = Array<"saml" | "local">;
 export interface IUser {
   id: string;
   namespaces: number;
+  max_namespaces: number;
   status: "confirmed" | "invited" | "not-confirmed";
   created_at: string;
   last_login: string;

--- a/ui/admin/src/interfaces/IUser.ts
+++ b/ui/admin/src/interfaces/IUser.ts
@@ -6,7 +6,7 @@ export interface IUser {
   id: string;
   namespaces: number;
   max_namespaces: number;
-  status: "confirmed" | "invited" | "not-confirmed";
+  status: UserStatus;
   created_at: string;
   last_login: string;
   name: string;

--- a/ui/admin/src/interfaces/IUser.ts
+++ b/ui/admin/src/interfaces/IUser.ts
@@ -1,7 +1,7 @@
 export interface IUser {
   id: string;
   namespaces: number;
-  confirmed: boolean;
+  status: "confirmed" | "invited" | "not-confirmed";
   created_at: string;
   last_login: string;
   name: string;

--- a/ui/admin/src/interfaces/IUser.ts
+++ b/ui/admin/src/interfaces/IUser.ts
@@ -1,3 +1,7 @@
+export type UserStatus = "confirmed" | "invited" | "not-confirmed";
+
+export type UserAuthMethods = Array<"saml" | "local">;
+
 export interface IUser {
   id: string;
   namespaces: number;
@@ -8,4 +12,7 @@ export interface IUser {
   email: string;
   username: string;
   password: string;
+  preferences: {
+    auth_methods: UserAuthMethods;
+  }
 }

--- a/ui/admin/src/store/api/users.ts
+++ b/ui/admin/src/store/api/users.ts
@@ -1,13 +1,6 @@
-import { adminApi } from "./../../api/http";
-
-type userDataType = {
-  name: string;
-  email: string;
-  username: string;
-  password: string;
-  confirmed?: boolean;
-  max_namespaces?: number;
-};
+import { IUser } from "@admin/interfaces/IUser";
+import { UserAdminRequest } from "@admin/api/client";
+import { adminApi } from "@admin/api/http";
 
 const fetchUsers = async (
   perPage: number,
@@ -19,7 +12,7 @@ const getUser = (id: string) => adminApi.getUser(id);
 
 const exportUsers = async (filter: string) => adminApi.exportUsers(filter);
 
-const addUser = (userData: userDataType) => adminApi.createUserAdmin({
+const addUser = (userData: IUser) => adminApi.createUserAdmin({
   name: userData.name,
   email: userData.email,
   username: userData.username,
@@ -27,14 +20,14 @@ const addUser = (userData: userDataType) => adminApi.createUserAdmin({
   max_namespaces: userData.max_namespaces,
 });
 
-const putUser = async (id: string, userData: userDataType) => adminApi.adminUpdateUser(id, {
+const putUser = async (id: string, userData: IUser) => adminApi.adminUpdateUser(id, {
   name: userData.name,
   email: userData.email,
   username: userData.username,
   password: userData.password,
-  confirmed: userData.confirmed,
+  status: userData.status,
   max_namespaces: userData.max_namespaces,
-});
+} as UserAdminRequest);
 
 const resetUserPassword = async (id: string) => adminApi.adminResetUserPassword(id);
 

--- a/ui/admin/src/store/modules/auth.ts
+++ b/ui/admin/src/store/modules/auth.ts
@@ -39,9 +39,9 @@ export const useAuthStore = defineStore("auth", {
       }
     },
 
-    async loginToken(user: { id: string }) {
+    async loginToken(userId: string) {
       try {
-        const resp = await getToken(user.id);
+        const resp = await getToken(userId);
         return resp.data.token;
       } catch (error) {
         this.status = "error";

--- a/ui/admin/src/views/UserDetails.vue
+++ b/ui/admin/src/views/UserDetails.vue
@@ -16,26 +16,9 @@
 
   <v-card v-if="currentUser" class="mt-2 pa-4">
     <v-card-text>
-      <div class="text-overline mt-3">
+      <div class="text-overline mt-3" v-if="currentUser.status">
         <h3>Status:</h3>
-        <v-chip
-          v-if="currentUser.confirmed === true"
-          class="ma-2"
-          color="success"
-          variant="text"
-          prepend-icon="mdi-checkbox-marked-circle"
-        >
-          Confirmed
-        </v-chip>
-        <v-chip
-          v-else
-          class="ma-2"
-          color="warning"
-          variant="text"
-          prepend-icon="mdi-alert-circle"
-        >
-          Not confirmed
-        </v-chip>
+        <UserStatusChip :status="currentUser.status" />
       </div>
       <div>
         <div class="text-overline mt-3">
@@ -85,6 +68,7 @@ import { useRoute } from "vue-router";
 import useUsersStore from "@admin/store/modules/users";
 import { IUser } from "@admin/interfaces/IUser";
 import useAuthStore from "@admin/store/modules/auth";
+import UserStatusChip from "@admin/components/User/UserStatusChip.vue";
 import useSnackbar from "@/helpers/snackbar";
 import UserDelete from "../components/User/UserDelete.vue";
 
@@ -92,17 +76,7 @@ const route = useRoute();
 const snackbar = useSnackbar();
 const userStore = useUsersStore();
 const authStore = useAuthStore();
-
 const userId = computed(() => route.params.id as string);
-
-onBeforeMount(async () => {
-  try {
-    await userStore.get(userId.value);
-  } catch {
-    snackbar.showError("Failed to get user details.");
-  }
-});
-
 const currentUser = computed(() => userStore.getUser as IUser);
 
 const loginToken = async () => {
@@ -115,6 +89,14 @@ const loginToken = async () => {
     snackbar.showError("Failed to get the login token.");
   }
 };
+
+onBeforeMount(async () => {
+  try {
+    await userStore.get(userId.value);
+  } catch {
+    snackbar.showError("Failed to get user details.");
+  }
+});
 
 defineExpose({ currentUser });
 </script>

--- a/ui/admin/src/views/UserDetails.vue
+++ b/ui/admin/src/views/UserDetails.vue
@@ -81,7 +81,7 @@ const currentUser = computed(() => userStore.getUser as IUser);
 
 const loginToken = async () => {
   try {
-    const token = await authStore.loginToken(currentUser.value);
+    const token = await authStore.loginToken(userId.value);
 
     const url = `/login?token=${token}`;
     window.open(url, "_target");

--- a/ui/admin/tests/unit/components/User/UserFormDialog/index.spec.ts
+++ b/ui/admin/tests/unit/components/User/UserFormDialog/index.spec.ts
@@ -4,17 +4,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import useUsersStore from "@admin/store/modules/users";
 import UserFormDialog from "@admin/components/User/UserFormDialog.vue";
+import { IUser } from "@admin/interfaces/IUser";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 
 type UserFormDialogWrapper = VueWrapper<InstanceType<typeof UserFormDialog>>;
 
-const user = {
+const user: IUser = {
   id: "5f1996c84d2190a22d5857bb",
   name: "Antony",
   email: "antony@gmail.com",
   username: "antony",
   password: "123456789",
-  confirmed: true,
+  status: "confirmed",
+  namespaces: 1,
+  max_namespaces: 10,
+  created_at: "2023-10-01T12:00:00Z",
+  last_login: "2023-10-01T12:00:00Z",
+  preferences: {
+    auth_methods: ["saml", "local"],
+  },
 };
 
 describe("UserFormDialog With prop 'createUser' equals false", () => {
@@ -55,7 +63,7 @@ describe("UserFormDialog With prop 'createUser' equals false", () => {
     expect(wrapper.vm.titleCard).toEqual("Edit User");
     expect(wrapper.vm.createUser).toEqual(false);
     expect(wrapper.vm.user).toEqual(user);
-    expect(wrapper.vm.emailIsConfirmed).toEqual(user.confirmed);
+    expect(wrapper.vm.isConfirmed).toEqual(user.status === "confirmed");
   });
 
   it("Compare user data with prop value", () => {
@@ -63,7 +71,6 @@ describe("UserFormDialog With prop 'createUser' equals false", () => {
     expect(wrapper.vm.email).toEqual(user.email);
     expect(wrapper.vm.username).toEqual(user.username);
     expect(wrapper.vm.password).toBeUndefined();
-    expect(wrapper.vm.userConfirmed).toEqual(user.confirmed);
   });
 });
 
@@ -96,6 +103,6 @@ describe("UserFormDialog With prop 'createUser' equals true", () => {
   it("Compare data with default value", () => {
     expect(wrapper.vm.titleCard).toEqual("Add User");
     expect(wrapper.vm.createUser).toEqual(true);
-    expect(wrapper.vm.emailIsConfirmed).toBeUndefined();
+    expect(wrapper.vm.isConfirmed).toBeUndefined();
   });
 });

--- a/ui/admin/tests/unit/components/User/UserList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/User/UserList/__snapshots__/index.spec.ts.snap
@@ -28,7 +28,7 @@ exports[`UserList > Renders the component 1`] = `
                 <div class="v-chip__prepend"><i class="mdi-checkbox-marked-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--start" aria-hidden="true"></i>
                   <!---->
                 </div>
-                <div class="v-chip__content" data-no-activator=""> Confirmed </div>
+                <div class="v-chip__content" data-no-activator="">Confirmed</div>
                 <!---->
                 <!----></span>
               </td>

--- a/ui/admin/tests/unit/components/User/UserList/index.spec.ts
+++ b/ui/admin/tests/unit/components/User/UserList/index.spec.ts
@@ -11,7 +11,7 @@ type UserListWrapper = VueWrapper<InstanceType<typeof UserList>>;
 
 const mockUsers = [
   {
-    confirmed: true,
+    status: "confirmed",
     created_at: "2022-04-13T11:42:49.578Z",
     email: "depaulacostaantony@gmail.com",
     id: "6256b739302b50b6cc5eafcc",
@@ -20,7 +20,9 @@ const mockUsers = [
     namespaces: 2,
     password: "dummy",
     username: "antony",
-    auth_methods: ["saml"],
+    preferences: {
+      auth_methods: ["saml"],
+    },
   },
 ];
 

--- a/ui/admin/tests/unit/components/User/UserStatusChip/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/User/UserStatusChip/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`User Status Chip > Renders the component 1`] = `
+"<span class="v-chip v-theme--light text-success v-chip--density-default v-chip--size-default v-chip--variant-text ma-2" draggable="false"><!----><span class="v-chip__underlay"></span>
+<!---->
+<div class="v-chip__prepend"><i class="mdi-checkbox-marked-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--start" aria-hidden="true"></i>
+  <!---->
+</div>
+<div class="v-chip__content" data-no-activator="">Confirmed</div>
+<!---->
+<!----></span>"
+`;

--- a/ui/admin/tests/unit/components/User/UserStatusChip/index.spec.ts
+++ b/ui/admin/tests/unit/components/User/UserStatusChip/index.spec.ts
@@ -1,0 +1,70 @@
+import { createVuetify } from "vuetify";
+import { mount, VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import UserStatusChip from "@admin/components/User/UserStatusChip.vue";
+import { UserStatus } from "@admin/interfaces/IUser";
+import { SnackbarPlugin } from "@/plugins/snackbar";
+
+describe("User Status Chip", () => {
+  let wrapper: VueWrapper<InstanceType<typeof UserStatusChip>>;
+  const vuetify = createVuetify();
+
+  const createWrapper = (status: UserStatus) => mount(UserStatusChip, {
+    global: {
+      plugins: [vuetify, SnackbarPlugin],
+    },
+    props: { status },
+  });
+
+  beforeEach(async () => {
+    wrapper = createWrapper("confirmed");
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it("Is a Vue instance", () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it("Renders the component", () => {
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("renders confirmed status correctly", () => {
+    wrapper = createWrapper("confirmed");
+    const chip = wrapper.findComponent({ name: "VChip" });
+
+    expect(chip.props("color")).toBe("success");
+    expect(chip.props("prependIcon")).toBe("mdi-checkbox-marked-circle");
+    expect(chip.text()).toBe("Confirmed");
+  });
+
+  it("renders invited status correctly", () => {
+    wrapper = createWrapper("invited");
+    const chip = wrapper.findComponent({ name: "VChip" });
+
+    expect(chip.props("color")).toBe("warning");
+    expect(chip.props("prependIcon")).toBe("mdi-email-alert");
+    expect(chip.text()).toBe("Invited");
+  });
+
+  it("renders not-confirmed status correctly", () => {
+    wrapper = createWrapper("not-confirmed");
+    const chip = wrapper.findComponent({ name: "VChip" });
+
+    expect(chip.props("color")).toBe("error");
+    expect(chip.props("prependIcon")).toBe("mdi-alert-circle");
+    expect(chip.text()).toBe("Not Confirmed");
+  });
+
+  it("handles invalid status by falling back to not-confirmed", () => {
+    const wrapper = createWrapper("fake-status" as UserStatus);
+    const chip = wrapper.findComponent({ name: "VChip" });
+
+    expect(chip.props("color")).toBe("error");
+    expect(chip.props("prependIcon")).toBe("mdi-alert-circle");
+    expect(chip.text()).toBe("Not Confirmed");
+  });
+});

--- a/ui/admin/tests/unit/views/UserDetails/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/UserDetails/__snapshots__/index.spec.ts.snap
@@ -37,7 +37,7 @@ exports[`User Details > Renders the component 1`] = `
       <div class="v-chip__prepend"><i class="mdi-checkbox-marked-circle mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--start" aria-hidden="true"></i>
         <!---->
       </div>
-      <div class="v-chip__content" data-no-activator=""> Confirmed </div>
+      <div class="v-chip__content" data-no-activator="">Confirmed</div>
       <!---->
       <!----></span>
     </div>

--- a/ui/admin/tests/unit/views/UserDetails/index.spec.ts
+++ b/ui/admin/tests/unit/views/UserDetails/index.spec.ts
@@ -11,7 +11,7 @@ import UserDetails from "../../../../src/views/UserDetails.vue";
 type UserDetailsWrapper = VueWrapper<InstanceType<typeof UserDetails>>;
 
 const user = {
-  confirmed: true,
+  status: "confirmed",
   created_at: "2022-04-13T11:42:49.578Z",
   email: "antony@gmail.com",
   id: "6256b739302b50b6cc5eafcc",


### PR DESCRIPTION
This pull request fixes some bugs in the admin's users panel, focusing on replacing the old `confirmed` boolean with a new `status` field for user confirmation states. It also includes updates to improve code clarity and consistency, such as the introduction of the `UserStatusChip` component for displaying user statuses and refactoring related logic.

* Replaced the outdated and buggy `confirmed` boolean with a `status` field. Updated all related logic and UI components to use `status` instead of `confirmed`, fixing a related bug due to changes in the API.
* Added `UserStatusChip` component to display user statuses in a standardized format across the UI. 
* Refactored the `loginToken` function to accept `userId` directly instead of a user object. Updated all references accordingly.
* Improved type definitions by introducing `UserAuthMethods` and `UserStatus` types, and updated related logic for authentication methods and user preferences. 
* Updated unit tests to reflect the changes in user properties and added snapshot/tests for the new `UserStatusChip` component