### PR TITLE
refactor(api): simplify device authentication flow

### DIFF
--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -105,8 +105,7 @@ func (h *Handler) AuthDevice(c gateway.Context) error {
 		return err
 	}
 
-	ip := c.Request().Header.Get("X-Real-IP")
-	res, err := h.service.AuthDevice(c.Ctx(), req, ip)
+	res, err := h.service.AuthDevice(c.Ctx(), req)
 	if err != nil {
 		return err
 	}

--- a/api/routes/auth_test.go
+++ b/api/routes/auth_test.go
@@ -49,7 +49,7 @@ func TestAuthDevice(t *testing.T) {
 				TenantID:  "your_tenant_id",
 			},
 			requiredMocks: func() {
-				mock.On("AuthDevice", gomock.Anything, gomock.AnythingOfType("requests.DeviceAuth"), "").Return(&models.DeviceAuthResponse{}, nil).Once()
+				mock.On("AuthDevice", gomock.Anything, gomock.AnythingOfType("requests.DeviceAuth")).Return(&models.DeviceAuthResponse{}, nil).Once()
 			},
 			expected: Expected{
 				expectedResponse: &models.DeviceAuthResponse{},
@@ -71,7 +71,7 @@ func TestAuthDevice(t *testing.T) {
 				TenantID:  "your_tenant_id",
 			},
 			requiredMocks: func() {
-				mock.On("AuthDevice", gomock.Anything, gomock.AnythingOfType("requests.DeviceAuth"), "").Return(&models.DeviceAuthResponse{}, nil).Once()
+				mock.On("AuthDevice", gomock.Anything, gomock.AnythingOfType("requests.DeviceAuth")).Return(&models.DeviceAuthResponse{}, nil).Once()
 			},
 			expected: Expected{
 				expectedResponse: &models.DeviceAuthResponse{},
@@ -95,7 +95,7 @@ func TestAuthDevice(t *testing.T) {
 				TenantID:  "your_tenant_id",
 			},
 			requiredMocks: func() {
-				mock.On("AuthDevice", gomock.Anything, gomock.AnythingOfType("requests.DeviceAuth"), "").Return(&models.DeviceAuthResponse{}, nil).Once()
+				mock.On("AuthDevice", gomock.Anything, gomock.AnythingOfType("requests.DeviceAuth")).Return(&models.DeviceAuthResponse{}, nil).Once()
 				mock.On("SetDevicePosition", gomock.Anything, models.UID(""), "").Return(nil).Once()
 			},
 			expected: Expected{

--- a/api/services/mocks/services.go
+++ b/api/services/mocks/services.go
@@ -122,9 +122,9 @@ func (_m *Service) AuthCacheToken(ctx context.Context, tenant string, id string,
 	return r0
 }
 
-// AuthDevice provides a mock function with given fields: ctx, req, remoteAddr
-func (_m *Service) AuthDevice(ctx context.Context, req requests.DeviceAuth, remoteAddr string) (*models.DeviceAuthResponse, error) {
-	ret := _m.Called(ctx, req, remoteAddr)
+// AuthDevice provides a mock function with given fields: ctx, req
+func (_m *Service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*models.DeviceAuthResponse, error) {
+	ret := _m.Called(ctx, req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AuthDevice")
@@ -132,19 +132,19 @@ func (_m *Service) AuthDevice(ctx context.Context, req requests.DeviceAuth, remo
 
 	var r0 *models.DeviceAuthResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, requests.DeviceAuth, string) (*models.DeviceAuthResponse, error)); ok {
-		return rf(ctx, req, remoteAddr)
+	if rf, ok := ret.Get(0).(func(context.Context, requests.DeviceAuth) (*models.DeviceAuthResponse, error)); ok {
+		return rf(ctx, req)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, requests.DeviceAuth, string) *models.DeviceAuthResponse); ok {
-		r0 = rf(ctx, req, remoteAddr)
+	if rf, ok := ret.Get(0).(func(context.Context, requests.DeviceAuth) *models.DeviceAuthResponse); ok {
+		r0 = rf(ctx, req)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.DeviceAuthResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, requests.DeviceAuth, string) error); ok {
-		r1 = rf(ctx, req, remoteAddr)
+	if rf, ok := ret.Get(1).(func(context.Context, requests.DeviceAuth) error); ok {
+		r1 = rf(ctx, req)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/api/store/device.go
+++ b/api/store/device.go
@@ -28,6 +28,9 @@ const (
 )
 
 type DeviceStore interface {
+	// DeviceCreate creates a new device. It returns the inserted UID and an error, if any.
+	DeviceCreate(ctx context.Context, device *models.Device) (insertedUID string, err error)
+
 	DeviceList(ctx context.Context, status models.DeviceStatus, pagination query.Paginator, filters query.Filters, sorter query.Sorter, acceptable DeviceAcceptable) ([]models.Device, int, error)
 
 	// DeviceResolve fetches a device using a specific resolver within a given tenant ID.
@@ -51,7 +54,6 @@ type DeviceStore interface {
 	DeviceBulkUpdate(ctx context.Context, uids []string, changes *models.DeviceChanges) (modifiedCount int64, err error)
 
 	DeviceDelete(ctx context.Context, uid models.UID) error
-	DeviceCreate(ctx context.Context, d models.Device, hostname string) (bool, error)
 	DeviceRename(ctx context.Context, uid models.UID, hostname string) error
 	DeviceUpdateStatus(ctx context.Context, uid models.UID, status models.DeviceStatus) error
 	DeviceSetPosition(ctx context.Context, uid models.UID, position models.DevicePosition) error

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -355,27 +355,27 @@ func (_m *Store) DeviceConflicts(ctx context.Context, target *models.DeviceConfl
 	return r0, r1, r2
 }
 
-// DeviceCreate provides a mock function with given fields: ctx, d, hostname
-func (_m *Store) DeviceCreate(ctx context.Context, d models.Device, hostname string) (bool, error) {
-	ret := _m.Called(ctx, d, hostname)
+// DeviceCreate provides a mock function with given fields: ctx, device
+func (_m *Store) DeviceCreate(ctx context.Context, device *models.Device) (string, error) {
+	ret := _m.Called(ctx, device)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeviceCreate")
 	}
 
-	var r0 bool
+	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, models.Device, string) (bool, error)); ok {
-		return rf(ctx, d, hostname)
+	if rf, ok := ret.Get(0).(func(context.Context, *models.Device) (string, error)); ok {
+		return rf(ctx, device)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, models.Device, string) bool); ok {
-		r0 = rf(ctx, d, hostname)
+	if rf, ok := ret.Get(0).(func(context.Context, *models.Device) string); ok {
+		r0 = rf(ctx, device)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, models.Device, string) error); ok {
-		r1 = rf(ctx, d, hostname)
+	if rf, ok := ret.Get(1).(func(context.Context, *models.Device) error); ok {
+		r1 = rf(ctx, device)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/api/requests/device.go
+++ b/pkg/api/requests/device.go
@@ -103,4 +103,5 @@ type DeviceAuth struct {
 	Identity  *DeviceIdentity `json:"identity,omitempty" validate:"required_without=Hostname,omitempty"`
 	PublicKey string          `json:"public_key" validate:"required"`
 	TenantID  string          `json:"tenant_id" validate:"required"`
+	RealIP    string          `header:"X-Real-IP"`
 }


### PR DESCRIPTION
Refactor AuthDevice method to separate device creation from updates and remove struct intermediaries in cache operations. This improves code clarity and maintainability while preserving all existing functionality.

- Replace upsert-based DeviceCreate with explicit create/update flow
- Remove intermediate Device struct from cache operations using map[string]string
- Move hostname derivation logic to service layer for better separation
- Add explicit device status updates for existing devices going online
- Improve error handling and add proper logging for cache operations
- Update documentation to be concise and focused on core functionality

DeviceCreate no longer returns insertion boolean, now focuses solely on creation with separate DeviceUpdate for modifications.