### PR TITLE
fix(ui): fix quick connection card min-height

### DIFF
--- a/ui/src/components/QuickConnection/QuickConnection.vue
+++ b/ui/src/components/QuickConnection/QuickConnection.vue
@@ -20,7 +20,7 @@
     </div>
 
     <v-dialog v-model="dialog" width="1000" transition="dialog-bottom-transition">
-      <v-card class="bg-v-theme-surface content" min-height="700" max-height="700">
+      <v-card class="bg-v-theme-surface content" max-height="700">
         <div class="pa-5">
           <v-row>
             <v-col>


### PR DESCRIPTION
This pull request includes a minor change to the `QuickConnection.vue` file. The change removes the `min-height` property from the `<v-card>` element, leaving only the `max-height` property. This change improves the element's responsiveness, since the `min-height` set to 700px was leading to problems in screens with less than 700px of height available.