### PR TITLE
fix(api): remove redundant CreateCollection method

### DIFF
--- a/api/store/mongo/migrations/migration_91.go
+++ b/api/store/mongo/migrations/migration_91.go
@@ -20,10 +20,6 @@ var migration91 = migrate.Migration{
 			"action":    "Up",
 		}).Info("Applying migration")
 
-		if err := db.CreateCollection(ctx, "sessions_events"); err != nil {
-			return err
-		}
-
 		sessionIndex := mongo.IndexModel{
 			Keys: bson.M{
 				"session": 1,


### PR DESCRIPTION
MongoDB automatically creates collections when inserting documents into non-existent collections, making the explicit CreateCollection call unnecessary. Removing this method eliminates potential errors from multiple executions.