### PR TITLE
refactor: replace specific user getter methods with unified UserResolve

### DIFF
--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -858,7 +858,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 					).
 					Once()
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(nil, store.ErrNoDocuments).
 					Once()
 			},
@@ -891,7 +891,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 					).
 					Once()
 				mock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(nil, store.ErrNoDocuments).
 					Once()
 			},
@@ -944,7 +944,10 @@ func TestService_AuthLocalUser(t *testing.T) {
 					},
 				}
 
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
+					Return(user, nil).
+					Once()
 			},
 			expected: Expected{
 				res:      nil,
@@ -995,7 +998,10 @@ func TestService_AuthLocalUser(t *testing.T) {
 					},
 				}
 
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
+					Return(user, nil).
+					Once()
 			},
 			expected: Expected{
 				res:      nil,
@@ -1026,7 +1032,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 					).
 					Once()
 				mock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(
 						&models.User{
 							ID:        "65fdd16b5f62f93184ec8a39",
@@ -1102,7 +1108,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1160,7 +1166,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1226,7 +1232,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1301,7 +1307,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1405,7 +1411,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1500,7 +1506,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1607,7 +1613,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1715,7 +1721,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1822,7 +1828,7 @@ func TestService_AuthLocalUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByUsername", ctx, "john_doe").
+					On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
 					Return(user, nil).
 					Once()
 				cacheMock.
@@ -1927,8 +1933,8 @@ func TestCreateUserToken(t *testing.T) {
 			req:         &requests.CreateUserToken{UserID: "000000000000000000000000", TenantID: "00000000-0000-4000-0000-000000000000"},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(nil, 0, store.ErrNoDocuments).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nil, store.ErrNoDocuments).
 					Once()
 			},
 			expected: Expected{
@@ -1941,7 +1947,7 @@ func TestCreateUserToken(t *testing.T) {
 			req:         &requests.CreateUserToken{UserID: "000000000000000000000000", TenantID: "00000000-0000-4000-0000-000000000000"},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID:        "000000000000000000000000",
@@ -1962,7 +1968,6 @@ func TestCreateUserToken(t *testing.T) {
 								PreferredNamespace: "",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -1981,7 +1986,7 @@ func TestCreateUserToken(t *testing.T) {
 			req:         &requests.CreateUserToken{UserID: "000000000000000000000000", TenantID: "00000000-0000-4000-0000-000000000000"},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID:        "000000000000000000000000",
@@ -2002,7 +2007,6 @@ func TestCreateUserToken(t *testing.T) {
 								PreferredNamespace: "",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -2027,7 +2031,7 @@ func TestCreateUserToken(t *testing.T) {
 			req:         &requests.CreateUserToken{UserID: "000000000000000000000000", TenantID: "00000000-0000-4000-0000-000000000000"},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID:        "000000000000000000000000",
@@ -2048,7 +2052,6 @@ func TestCreateUserToken(t *testing.T) {
 								PreferredNamespace: "",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -2079,7 +2082,7 @@ func TestCreateUserToken(t *testing.T) {
 			req:         &requests.CreateUserToken{UserID: "000000000000000000000000", TenantID: "00000000-0000-4000-0000-000000000000"},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID:        "000000000000000000000000",
@@ -2100,7 +2103,6 @@ func TestCreateUserToken(t *testing.T) {
 								PreferredNamespace: "",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -2151,7 +2153,7 @@ func TestCreateUserToken(t *testing.T) {
 			req:         &requests.CreateUserToken{UserID: "000000000000000000000000", TenantID: ""},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID:        "000000000000000000000000",
@@ -2172,7 +2174,6 @@ func TestCreateUserToken(t *testing.T) {
 								PreferredNamespace: "00000000-0000-4000-0000-000000000000",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -2218,7 +2219,7 @@ func TestCreateUserToken(t *testing.T) {
 			req:         &requests.CreateUserToken{UserID: "000000000000000000000000", TenantID: ""},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID:        "000000000000000000000000",
@@ -2239,7 +2240,6 @@ func TestCreateUserToken(t *testing.T) {
 								PreferredNamespace: "",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()

--- a/api/services/member.go
+++ b/api/services/member.go
@@ -54,7 +54,7 @@ func (s *service) AddNamespaceMember(ctx context.Context, req *requests.Namespac
 		return nil, NewErrNamespaceNotFound(req.TenantID, err)
 	}
 
-	user, _, err := s.store.UserGetByID(ctx, req.UserID, false)
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
 	if err != nil || user == nil {
 		return nil, NewErrUserNotFound(req.UserID, err)
 	}
@@ -72,7 +72,7 @@ func (s *service) AddNamespaceMember(ctx context.Context, req *requests.Namespac
 	// In cloud instances, if the target user does not exist, we need to create a new user
 	// with the specified email. We use the inserted ID to identify the user once they complete
 	// the registration and accepts the invitation.
-	passiveUser, err := s.store.UserGetByEmail(ctx, strings.ToLower(req.MemberEmail))
+	passiveUser, err := s.store.UserResolve(ctx, store.UserEmailResolver, strings.ToLower(req.MemberEmail))
 	if err != nil {
 		if !envs.IsCloud() || !errors.Is(err, store.ErrNoDocuments) {
 			return nil, NewErrUserNotFound(req.MemberEmail, err)
@@ -162,7 +162,7 @@ func (s *service) UpdateNamespaceMember(ctx context.Context, req *requests.Names
 		return NewErrNamespaceNotFound(req.TenantID, err)
 	}
 
-	user, _, err := s.store.UserGetByID(ctx, req.UserID, false)
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
 	if err != nil {
 		return NewErrUserNotFound(req.UserID, err)
 	}
@@ -199,7 +199,7 @@ func (s *service) RemoveNamespaceMember(ctx context.Context, req *requests.Names
 		return nil, NewErrNamespaceNotFound(req.TenantID, err)
 	}
 
-	user, _, err := s.store.UserGetByID(ctx, req.UserID, false)
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
 	if err != nil {
 		return nil, NewErrUserNotFound(req.UserID, err)
 	}

--- a/api/services/member_test.go
+++ b/api/services/member_test.go
@@ -83,8 +83,8 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(nil, 0, ErrUserNotFound).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nil, ErrUserNotFound).
 					Once()
 			},
 			expected: Expected{
@@ -112,11 +112,11 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: Expected{
@@ -150,11 +150,11 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: Expected{
@@ -188,11 +188,11 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: Expected{
@@ -226,14 +226,14 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(nil, errors.New("error")).
 					Once()
 				envMock.
@@ -277,14 +277,14 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(&models.User{
 						ID:       "000000000000000000000001",
 						UserData: models.UserData{Username: "john_doe"},
@@ -331,14 +331,14 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(&models.User{
 						ID:       "000000000000000000000001",
 						UserData: models.UserData{Username: "john_doe"},
@@ -386,14 +386,14 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(&models.User{
 						ID:       "000000000000000000000001",
 						UserData: models.UserData{Username: "john_doe"},
@@ -441,14 +441,14 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(&models.User{
 						ID:       "000000000000000000000001",
 						UserData: models.UserData{Username: "john_doe"},
@@ -534,14 +534,14 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(nil, store.ErrNoDocuments).
 					Once()
 				envMock.
@@ -628,14 +628,14 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(&models.User{
 						ID:       "000000000000000000000001",
 						UserData: models.UserData{Username: "john_doe"},
@@ -681,14 +681,14 @@ func TestAddNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByEmail", ctx, "john.doe@test.com").
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(&models.User{
 						ID:       "000000000000000000000001",
 						UserData: models.UserData{Username: "john_doe"},
@@ -1067,8 +1067,8 @@ func TestUpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(nil, 0, ErrUserNotFound).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nil, ErrUserNotFound).
 					Once()
 			},
 			expected: NewErrUserNotFound("000000000000000000000000", ErrUserNotFound),
@@ -1092,11 +1092,11 @@ func TestUpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: NewErrNamespaceMemberNotFound("000000000000000000000000", nil),
@@ -1125,11 +1125,11 @@ func TestUpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: NewErrNamespaceMemberNotFound("000000000000000000000001", nil),
@@ -1162,11 +1162,11 @@ func TestUpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: NewErrRoleInvalid(),
@@ -1199,11 +1199,11 @@ func TestUpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: NewErrRoleInvalid(),
@@ -1236,11 +1236,11 @@ func TestUpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceUpdateMember", ctx, "00000000-0000-4000-0000-000000000000", "000000000000000000000001", &models.MemberChanges{Role: authorizer.RoleAdministrator}).
@@ -1316,8 +1316,8 @@ func TestRemoveNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(nil, 0, ErrUserNotFound).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nil, ErrUserNotFound).
 					Once()
 			},
 			expected: Expected{
@@ -1343,11 +1343,11 @@ func TestRemoveNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: Expected{
@@ -1378,11 +1378,11 @@ func TestRemoveNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: Expected{
@@ -1417,11 +1417,11 @@ func TestRemoveNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: Expected{
@@ -1456,11 +1456,11 @@ func TestRemoveNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceRemoveMember", ctx, "00000000-0000-4000-0000-000000000000", "000000000000000000000001").
@@ -1499,11 +1499,11 @@ func TestRemoveNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:       "000000000000000000000000",
 						UserData: models.UserData{Username: "jane_doe"},
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceRemoveMember", ctx, "00000000-0000-4000-0000-000000000000", "000000000000000000000001").
@@ -1744,7 +1744,7 @@ func TestService_LeaveNamespace(t *testing.T) {
 				// internally calls it to create another token. Since this functionality is already tested,
 				// we are duplicating the test here to prevent failures. The important tests are all in the lines above.
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID:        "000000000000000000000000",
@@ -1767,7 +1767,6 @@ func TestService_LeaveNamespace(t *testing.T) {
 								AuthMethods:        []models.UserAuthMethod{models.UserAuthMethodLocal},
 							},
 						},
-						0,
 						nil,
 					).
 					Once()

--- a/api/services/namespace.go
+++ b/api/services/namespace.go
@@ -25,7 +25,7 @@ type NamespaceService interface {
 
 // CreateNamespace creates a new namespace.
 func (s *service) CreateNamespace(ctx context.Context, req *requests.NamespaceCreate) (*models.Namespace, error) {
-	user, _, err := s.store.UserGetByID(ctx, req.UserID, false)
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
 	if err != nil || user == nil {
 		return nil, NewErrUserNotFound(req.UserID, err)
 	}

--- a/api/services/namespace_test.go
+++ b/api/services/namespace_test.go
@@ -367,8 +367,8 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(nil, 0, store.ErrNoDocuments).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nil, store.ErrNoDocuments).
 					Once()
 			},
 			expected: Expected{
@@ -385,11 +385,11 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 0,
-					}, 0, nil).
+					}, nil).
 					Once()
 			},
 			expected: Expected{
@@ -406,11 +406,11 @@ func TestCreateNamespace(t *testing.T) {
 			},
 			requiredMocks: func() {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 1,
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("UserGetInfo", ctx, "000000000000000000000000").
@@ -447,11 +447,11 @@ func TestCreateNamespace(t *testing.T) {
 					).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 3,
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -482,11 +482,11 @@ func TestCreateNamespace(t *testing.T) {
 					).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 3,
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -517,11 +517,11 @@ func TestCreateNamespace(t *testing.T) {
 					).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 3,
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -594,11 +594,11 @@ func TestCreateNamespace(t *testing.T) {
 					).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 3,
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -710,11 +710,11 @@ func TestCreateNamespace(t *testing.T) {
 					).
 					Once()
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 3,
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -832,11 +832,11 @@ func TestCreateNamespace(t *testing.T) {
 					Once()
 				// envs.IsCommunity = false
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 3,
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").
@@ -949,11 +949,11 @@ func TestCreateNamespace(t *testing.T) {
 					Once()
 				// envs.IsCommunity = false
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(&models.User{
 						ID:            "000000000000000000000000",
 						MaxNamespaces: 3,
-					}, 0, nil).
+					}, nil).
 					Once()
 				storeMock.
 					On("NamespaceGetByName", ctx, "namespace").

--- a/api/services/user.go
+++ b/api/services/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
@@ -22,7 +23,7 @@ type UserService interface {
 }
 
 func (s *service) UpdateUser(ctx context.Context, req *requests.UpdateUser) ([]string, error) {
-	user, _, err := s.store.UserGetByID(ctx, req.UserID, false)
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
 	if err != nil {
 		return []string{}, NewErrUserNotFound(req.UserID, nil)
 	}
@@ -65,7 +66,7 @@ func (s *service) UpdateUser(ctx context.Context, req *requests.UpdateUser) ([]s
 //
 // Deprecated, use [Service.UpdateUser] instead.
 func (s *service) UpdatePasswordUser(ctx context.Context, id, currentPassword, newPassword string) error {
-	user, _, err := s.store.UserGetByID(ctx, id, false)
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, id)
 	if user == nil {
 		return NewErrUserNotFound(id, err)
 	}

--- a/api/services/user_test.go
+++ b/api/services/user_test.go
@@ -38,8 +38,8 @@ func TestUpdateUser(t *testing.T) {
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
-					Return(nil, 0, NewErrUserNotFound("000000000000000000000000", nil)).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nil, NewErrUserNotFound("000000000000000000000000", nil)).
 					Once()
 			},
 			expected: Expected{
@@ -58,7 +58,7 @@ func TestUpdateUser(t *testing.T) {
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID: "000000000000000000000000",
@@ -69,7 +69,6 @@ func TestUpdateUser(t *testing.T) {
 								RecoveryEmail: "recover@test.com",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -90,7 +89,7 @@ func TestUpdateUser(t *testing.T) {
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID: "000000000000000000000000",
@@ -101,7 +100,6 @@ func TestUpdateUser(t *testing.T) {
 								RecoveryEmail: "recover@test.com",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -122,7 +120,7 @@ func TestUpdateUser(t *testing.T) {
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID: "000000000000000000000000",
@@ -133,7 +131,6 @@ func TestUpdateUser(t *testing.T) {
 								RecoveryEmail: "recover@test.com",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -160,7 +157,7 @@ func TestUpdateUser(t *testing.T) {
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID: "000000000000000000000000",
@@ -174,7 +171,6 @@ func TestUpdateUser(t *testing.T) {
 								Hash: "$2a$10$V/6N1wsjheBVvWosVVVV2uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -203,7 +199,7 @@ func TestUpdateUser(t *testing.T) {
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID: "000000000000000000000000",
@@ -214,7 +210,6 @@ func TestUpdateUser(t *testing.T) {
 								RecoveryEmail: "recover@test.com",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -259,7 +254,7 @@ func TestUpdateUser(t *testing.T) {
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
-					On("UserGetByID", ctx, "000000000000000000000000", false).
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(
 						&models.User{
 							ID: "000000000000000000000000",
@@ -270,7 +265,6 @@ func TestUpdateUser(t *testing.T) {
 								RecoveryEmail: "recover@test.com",
 							},
 						},
-						0,
 						nil,
 					).
 					Once()
@@ -328,8 +322,8 @@ func TestUpdatePasswordUser(t *testing.T) {
 			id:          "65fde3a72c4c7507c7f53c43",
 			requiredMocks: func() {
 				mock.
-					On("UserGetByID", ctx, "65fde3a72c4c7507c7f53c43", false).
-					Return(nil, 0, errors.New("error", "", 0)).
+					On("UserResolve", ctx, store.UserIDResolver, "65fde3a72c4c7507c7f53c43").
+					Return(nil, errors.New("error", "", 0)).
 					Once()
 			},
 			expected: NewErrUserNotFound("65fde3a72c4c7507c7f53c43", errors.New("error", "", 0)),
@@ -347,8 +341,8 @@ func TestUpdatePasswordUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByID", ctx, "1", false).
-					Return(user, 1, nil).
+					On("UserResolve", ctx, store.UserIDResolver, "1").
+					Return(user, nil).
 					Once()
 				hashMock.
 					On("CompareWith", "wrong_password", "$2a$10$V/6N1wsjheBVvWosVVVV2uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi").
@@ -371,8 +365,8 @@ func TestUpdatePasswordUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByID", ctx, "65fde3a72c4c7507c7f53c43", false).
-					Return(user, 1, nil).
+					On("UserResolve", ctx, store.UserIDResolver, "65fde3a72c4c7507c7f53c43").
+					Return(user, nil).
 					Once()
 				hashMock.
 					On("CompareWith", "secret", "$2a$10$V/6N1wsjheBVvWosVVVV2uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi").
@@ -399,8 +393,8 @@ func TestUpdatePasswordUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByID", ctx, "65fde3a72c4c7507c7f53c43", false).
-					Return(user, 1, nil).
+					On("UserResolve", ctx, store.UserIDResolver, "65fde3a72c4c7507c7f53c43").
+					Return(user, nil).
 					Once()
 				hashMock.
 					On("CompareWith", "secret", "$2a$10$V/6N1wsjheBVvWosVVVV2uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi").
@@ -439,8 +433,8 @@ func TestUpdatePasswordUser(t *testing.T) {
 				}
 
 				mock.
-					On("UserGetByID", ctx, "65fde3a72c4c7507c7f53c43", false).
-					Return(user, 1, nil).
+					On("UserResolve", ctx, store.UserIDResolver, "65fde3a72c4c7507c7f53c43").
+					Return(user, nil).
 					Once()
 				hashMock.
 					On("CompareWith", "secret", "$2a$10$V/6N1wsjheBVvWosVVVV2uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi").

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -2116,103 +2116,6 @@ func (_m *Store) UserDelete(ctx context.Context, id string) error {
 	return r0
 }
 
-// UserGetByEmail provides a mock function with given fields: ctx, email
-func (_m *Store) UserGetByEmail(ctx context.Context, email string) (*models.User, error) {
-	ret := _m.Called(ctx, email)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UserGetByEmail")
-	}
-
-	var r0 *models.User
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*models.User, error)); ok {
-		return rf(ctx, email)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *models.User); ok {
-		r0 = rf(ctx, email)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.User)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, email)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// UserGetByID provides a mock function with given fields: ctx, id, ns
-func (_m *Store) UserGetByID(ctx context.Context, id string, ns bool) (*models.User, int, error) {
-	ret := _m.Called(ctx, id, ns)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UserGetByID")
-	}
-
-	var r0 *models.User
-	var r1 int
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) (*models.User, int, error)); ok {
-		return rf(ctx, id, ns)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) *models.User); ok {
-		r0 = rf(ctx, id, ns)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.User)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, bool) int); ok {
-		r1 = rf(ctx, id, ns)
-	} else {
-		r1 = ret.Get(1).(int)
-	}
-
-	if rf, ok := ret.Get(2).(func(context.Context, string, bool) error); ok {
-		r2 = rf(ctx, id, ns)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
-// UserGetByUsername provides a mock function with given fields: ctx, username
-func (_m *Store) UserGetByUsername(ctx context.Context, username string) (*models.User, error) {
-	ret := _m.Called(ctx, username)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UserGetByUsername")
-	}
-
-	var r0 *models.User
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*models.User, error)); ok {
-		return rf(ctx, username)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *models.User); ok {
-		r0 = rf(ctx, username)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.User)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, username)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // UserGetInfo provides a mock function with given fields: ctx, id
 func (_m *Store) UserGetInfo(ctx context.Context, id string) (*models.UserInfo, error) {
 	ret := _m.Called(ctx, id)
@@ -2278,6 +2181,43 @@ func (_m *Store) UserList(ctx context.Context, paginator query.Paginator, filter
 	}
 
 	return r0, r1, r2
+}
+
+// UserResolve provides a mock function with given fields: ctx, resolver, value, opts
+func (_m *Store) UserResolve(ctx context.Context, resolver store.UserResolver, value string, opts ...store.QueryOption) (*models.User, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, resolver, value)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UserResolve")
+	}
+
+	var r0 *models.User
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, store.UserResolver, string, ...store.QueryOption) (*models.User, error)); ok {
+		return rf(ctx, resolver, value, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, store.UserResolver, string, ...store.QueryOption) *models.User); ok {
+		r0 = rf(ctx, resolver, value, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, store.UserResolver, string, ...store.QueryOption) error); ok {
+		r1 = rf(ctx, resolver, value, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UserUpdate provides a mock function with given fields: ctx, id, changes

--- a/api/store/mongo/namespace.go
+++ b/api/store/mongo/namespace.go
@@ -29,7 +29,7 @@ func (s *Store) NamespaceList(ctx context.Context, paginator query.Paginator, fi
 
 	// Only match for the respective tenant if requested
 	if id := gateway.IDFromContext(ctx); id != nil {
-		user, _, err := s.UserGetByID(ctx, id.ID, false)
+		user, err := s.UserResolve(ctx, store.UserIDResolver, id.ID)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -135,7 +135,7 @@ Opts:
 func (s *Store) NamespaceGetPreferred(ctx context.Context, userID string, opts ...store.NamespaceQueryOption) (*models.Namespace, error) {
 	filter := bson.M{"members.id": userID}
 
-	if user, _, _ := s.UserGetByID(ctx, userID, false); user != nil {
+	if user, _ := s.UserResolve(ctx, store.UserIDResolver, userID); user != nil {
 		if user.Preferences.PreferredNamespace != "" {
 			filter["tenant_id"] = user.Preferences.PreferredNamespace
 		}

--- a/api/store/user.go
+++ b/api/store/user.go
@@ -7,6 +7,14 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
 
+type UserResolver uint
+
+const (
+	UserIDResolver UserResolver = iota + 1
+	UserEmailResolver
+	UserUsernameResolver
+)
+
 type UserStore interface {
 	UserList(ctx context.Context, paginator query.Paginator, filters query.Filters) ([]models.User, int, error)
 
@@ -21,9 +29,10 @@ type UserStore interface {
 	// It returns the inserted ID or an error, if any.
 	UserCreateInvited(ctx context.Context, email string) (insertedID string, err error)
 
-	UserGetByUsername(ctx context.Context, username string) (*models.User, error)
-	UserGetByEmail(ctx context.Context, email string) (*models.User, error)
-	UserGetByID(ctx context.Context, id string, ns bool) (*models.User, int, error)
+	// UserResolve fetches a device using a specific resolver within a given tenant ID.
+	//
+	// It returns the resolved user if found and an error, if any.
+	UserResolve(ctx context.Context, resolver UserResolver, value string, opts ...QueryOption) (*models.User, error)
 
 	// UserConflicts reports whether the target contains conflicting attributes with the database. Pass zero values for
 	// attributes you do not wish to match on. For example, the following call checks for conflicts based on email only:

--- a/cli/services/namespaces.go
+++ b/cli/services/namespaces.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"strings"
 
+	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/cli/pkg/inputs"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/clock"
@@ -23,7 +25,7 @@ func (s *service) NamespaceCreate(ctx context.Context, input *inputs.NamespaceCr
 		return nil, ErrNamespaceInvalid
 	}
 
-	user, err := s.store.UserGetByUsername(ctx, input.Owner)
+	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Owner))
 	if err != nil {
 		return nil, ErrUserNotFound
 	}
@@ -72,7 +74,7 @@ func (s *service) NamespaceAddMember(ctx context.Context, input *inputs.MemberAd
 		return nil, ErrInvalidFormat
 	}
 
-	user, err := s.store.UserGetByUsername(ctx, input.Username)
+	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Username))
 	if err != nil {
 		return nil, ErrUserNotFound
 	}
@@ -95,7 +97,7 @@ func (s *service) NamespaceRemoveMember(ctx context.Context, input *inputs.Membe
 		return nil, ErrInvalidFormat
 	}
 
-	user, err := s.store.UserGetByUsername(ctx, input.Username)
+	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Username))
 	if err != nil {
 		return nil, ErrUserNotFound
 	}

--- a/cli/services/namespaces_test.go
+++ b/cli/services/namespaces_test.go
@@ -74,7 +74,7 @@ func TestNamespaceCreate(t *testing.T) {
 			requiredMocks: func() {
 				envMock := &env_mocks.Backend{}
 				envs.DefaultBackend = envMock
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(nil, errors.New("error")).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(nil, errors.New("error")).Once()
 			},
 			expected: Expected{nil, ErrUserNotFound},
 		},
@@ -97,7 +97,7 @@ func TestNamespaceCreate(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",
@@ -141,7 +141,7 @@ func TestNamespaceCreate(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",
@@ -204,7 +204,7 @@ func TestNamespaceCreate(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",
@@ -267,7 +267,7 @@ func TestNamespaceCreate(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",
@@ -330,7 +330,7 @@ func TestNamespaceCreate(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",
@@ -393,7 +393,7 @@ func TestNamespaceCreate(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",
@@ -477,7 +477,7 @@ func TestNamespaceAddMember(t *testing.T) {
 			namespace:   "namespace",
 			role:        authorizer.RoleObserver,
 			requiredMocks: func() {
-				mock.On("UserGetByUsername", ctx, "john").Return(nil, errors.New("error")).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john").Return(nil, errors.New("error")).Once()
 			},
 			expected: Expected{nil, ErrUserNotFound},
 		},
@@ -495,7 +495,7 @@ func TestNamespaceAddMember(t *testing.T) {
 						Username: "john",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john").Return(user, nil).Once()
 				mock.On("NamespaceGetByName", ctx, "invalid_namespace").Return(nil, errors.New("error")).Once()
 			},
 			expected: Expected{nil, ErrNamespaceNotFound},
@@ -514,7 +514,7 @@ func TestNamespaceAddMember(t *testing.T) {
 						Username: "john",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",
@@ -577,7 +577,7 @@ func TestNamespaceRemoveMember(t *testing.T) {
 			username:    "john_doe",
 			namespace:   "namespace",
 			requiredMocks: func() {
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(nil, errors.New("error")).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(nil, errors.New("error")).Once()
 			},
 			expected: Expected{nil, ErrUserNotFound},
 		},
@@ -594,7 +594,7 @@ func TestNamespaceRemoveMember(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				mock.On("NamespaceGetByName", ctx, "namespace").Return(nil, errors.New("error")).Once()
 			},
 			expected: Expected{nil, ErrNamespaceNotFound},
@@ -612,7 +612,7 @@ func TestNamespaceRemoveMember(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",
@@ -641,7 +641,7 @@ func TestNamespaceRemoveMember(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				namespace := &models.Namespace{
 					Name:     "namespace",
 					Owner:    "507f191e810c19729de860ea",

--- a/cli/services/users.go
+++ b/cli/services/users.go
@@ -3,7 +3,9 @@ package services
 import (
 	"context"
 	"slices"
+	"strings"
 
+	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/cli/pkg/inputs"
 	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
@@ -77,7 +79,7 @@ func (s *service) UserDelete(ctx context.Context, input *inputs.UserDelete) erro
 		return ErrUserDataInvalid
 	}
 
-	user, err := s.store.UserGetByUsername(ctx, input.Username)
+	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Username))
 	if err != nil {
 		return ErrUserNotFound
 	}
@@ -112,7 +114,7 @@ func (s *service) UserUpdate(ctx context.Context, input *inputs.UserUpdate) erro
 		return ErrUserDataInvalid
 	}
 
-	user, err := s.store.UserGetByUsername(ctx, input.Username)
+	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Username))
 	if err != nil {
 		return ErrUserNotFound
 	}

--- a/cli/services/users_test.go
+++ b/cli/services/users_test.go
@@ -237,7 +237,7 @@ func TestUserDelete(t *testing.T) {
 			description: "fails when could not find a user",
 			username:    "john_doe",
 			requiredMocks: func() {
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(nil, errors.New("error")).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(nil, errors.New("error")).Once()
 			},
 			expected: ErrUserNotFound,
 		},
@@ -253,7 +253,7 @@ func TestUserDelete(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 				mock.On("UserGetInfo", ctx, "507f191e810c19729de860ea").Return(nil, errors.New("error")).Once()
 			},
 			expected: ErrNamespaceNotFound,
@@ -270,7 +270,7 @@ func TestUserDelete(t *testing.T) {
 						Username: "john_doe",
 					},
 				}
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 
 				namespaceOwned := []models.Namespace{
 					{
@@ -373,7 +373,7 @@ func TestUserResetPassword(t *testing.T) {
 			username:    "john_doe",
 			password:    "password",
 			requiredMocks: func() {
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(nil, errors.New("error")).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(nil, errors.New("error")).Once()
 			},
 			expected: ErrUserNotFound,
 		},
@@ -384,7 +384,7 @@ func TestUserResetPassword(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{ID: "507f191e810c19729de860ea"}
 
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 
 				hashMock.
 					On("Do", "secret").
@@ -405,7 +405,7 @@ func TestUserResetPassword(t *testing.T) {
 			requiredMocks: func() {
 				user := &models.User{ID: "507f191e810c19729de860ea"}
 
-				mock.On("UserGetByUsername", ctx, "john_doe").Return(user, nil).Once()
+				mock.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").Return(user, nil).Once()
 
 				hashMock.
 					On("Do", "secret").


### PR DESCRIPTION
Replace `UserGetByID`, `UserGetByEmail`, and `UserGetByUsername` with a single `UserResolve` method that uses resolver patterns for better consistency and maintainability.

- Add `UserResolver` enum with ID, Email, and Username resolvers
- Implement `UserResolve` method in store with resolver-based querying
- Update all service layers to use `UserResolve` instead of specific getters
- Remove deprecated `UserGetByID`, `UserGetByEmail`, `UserGetByUsername` methods
- Update all tests to use new `UserResolve` method calls
- Fix test mocks to return correct number of values (remove extra int parameter)
- Add comprehensive test coverage for UserResolve functionality