### PR TITLE
fix(ui): restore resize handling during incomplete signature

### DIFF
--- a/ui/src/components/Terminal/Terminal.vue
+++ b/ui/src/components/Terminal/Terminal.vue
@@ -63,6 +63,11 @@ const getTerminalDimensions = (): WebTermDimensions => ({
   rows: xterm.value.rows,
 });
 
+// Resize terminal on window resize events
+const registerResizeHandler = () => {
+  useEventListener(window, "resize", () => fitAddon.value.fit());
+};
+
 // Encodes a params object as URL query string.
 const encodeURLParams = (params: IParams): string => new URLSearchParams(params as Record<string, string>).toString();
 
@@ -136,6 +141,10 @@ const handleJsonMessage = async (message: string): Promise<void> => {
         ws.value.send(
           JSON.stringify({ kind: MessageKind.Signature, data: signature }),
         );
+
+        // Register resize handler
+        registerResizeHandler();
+
         break;
       }
 
@@ -152,6 +161,7 @@ const handleWebSocketMessage = async (rawData: Blob | string): Promise<void> => 
   if (rawData instanceof Blob) {
     // For password-based logins, always just write messages to the terminal
     xterm.value.write(await rawData.text());
+    registerResizeHandler();
   } else {
     await handleJsonMessage(rawData);
   }
@@ -189,9 +199,6 @@ onMounted(() => {
   initializeWebSocket();
   xterm.value.focus();
 });
-
-// Resize terminal on window resize events
-useEventListener(window, "resize", () => fitAddon.value.fit());
 
 // Cleanup lifecycle: close WebSocket if active on unMount
 onUnmounted(() => {


### PR DESCRIPTION
# Description

This PR fixes a bug where the terminal would not resize correctly if the signature process had not completed. Previously, the resize event listener was registered unconditionally on mount, which caused issues when the terminal was not fully initialized.

## Changes

### Moved the window resize event listener registration (`useEventListener`) from onMounted() into:

`handleJsonMessage()` after the signature process completes.

`handleWebSocketMessage()` when a text blob is received (password-based logins).

Ensured the resize handler only attaches when the terminal is ready.
Removed the unconditional resize registration in `onMounted()`.

## How to Reproduce the Original Issue

1. Start the signature process but do not complete it.
2. Resize the browser window.
3. The terminal does not resize properly.

## How to Test

1. Verify the terminal resizes correctly during and after the signature process.
2. Test both signature-based and password-based logins.
3. Confirm no errors occur when resizing the window in any state.
