### PR TITLE
fix(ui): fix variant prop passing in DeviceTable

### DIFF
--- a/ui/src/components/Tables/DeviceTable.vue
+++ b/ui/src/components/Tables/DeviceTable.vue
@@ -148,7 +148,7 @@
                 <template v-slot:activator="{ props }">
                   <div v-bind="props">
                     <DeviceDelete
-                      :variant="props.variant === 'device' ? 'device' : 'container' "
+                      :variant
                       :uid="item.uid"
                       :notHasAuthorization="!hasAuthorizationRemove()"
                       @update="refreshDevices"
@@ -215,7 +215,7 @@
               <DeviceActionButton
                 :uid="item.uid"
                 :name="item.name"
-                :variant="props.variant === 'device' ? 'device' : 'container' "
+                :variant
                 :isInNotification="false"
                 action="accept"
                 :show="showDeviceAcceptButton"
@@ -224,7 +224,7 @@
               />
               <DeviceActionButton
                 :uid="item.uid"
-                :variant="props.variant === 'device' ? 'device' : 'container' "
+                :variant
                 :action="status === 'pending' ? 'reject' : 'remove'"
                 :isInNotification="false"
                 :show="showDeviceRejectButton"


### PR DESCRIPTION
This pull request fixes a bug in the `variant` prop passing in `DeviceTable.vue`. Due to the use of the tooltip component, which has a `props` attribute, the `props.variant` call was conflicting, passing the wrong value to the children components and causing visual mismatch. This PR fixes this and simplifies the props passing, using Vue's same name prop shorthand.