### PR TITLE
fix(ui): fit terminal before opening WebSocket connection

### DIFF
--- a/ui/src/components/Terminal/Terminal.vue
+++ b/ui/src/components/Terminal/Terminal.vue
@@ -174,6 +174,7 @@ const setupWebSocketEvents = () => {
 
 // Initializes the WebSocket session with terminal dimensions.
 const initializeWebSocket = () => {
+  fitAddon.value.fit(); // Ensure terminal is sized correctly before connecting
   const dimensions = getTerminalDimensions();
   ws.value = new WebSocket(getWebSocketUrl(dimensions));
   setupWebSocketEvents();


### PR DESCRIPTION
This pull request fixes a bug in the web terminal where it always initialized with the default 80x24 dimensions, independently of the available space. This PR fixes this by ensuring the `fitAddon` is called before the WebSocket initialization, sending the correct dimension values from the start.