### PR TITLE
fix(ssh,api): return from device's lookup only accepted ones

### DIFF
--- a/api/services/device.go
+++ b/api/services/device.go
@@ -208,7 +208,12 @@ func (s *service) LookupDevice(ctx context.Context, namespace, name string) (*mo
 		return nil, NewErrNamespaceNotFound(namespace, err)
 	}
 
-	device, err := s.store.DeviceResolve(ctx, store.DeviceHostnameResolver, name, s.store.Options().InNamespace(n.TenantID))
+	opts := []store.QueryOption{
+		s.store.Options().InNamespace(n.TenantID),
+		s.store.Options().WithDeviceStatus(models.DeviceStatusAccepted),
+	}
+
+	device, err := s.store.DeviceResolve(ctx, store.DeviceHostnameResolver, name, opts...)
 	if err != nil || device == nil {
 		return nil, NewErrDeviceNotFound(models.UID(name), err)
 	}

--- a/api/services/device_test.go
+++ b/api/services/device_test.go
@@ -1272,7 +1272,7 @@ func TestLookupDevice(t *testing.T) {
 			},
 		},
 		{
-			description: "fails when namespace does not exists",
+			description: "fails when device is not found",
 			namespace:   "namespace",
 			device:      &models.Device{UID: "uid", Name: "name", TenantID: "tenant", Identity: &models.DeviceIdentity{MAC: "00:00:00:00:00:00"}, Status: "accepted"},
 			requiredMocks: func(device *models.Device, namespace string) {
@@ -1284,8 +1284,19 @@ func TestLookupDevice(t *testing.T) {
 					On("InNamespace", "00000000-0000-0000-0000-000000000000").
 					Return(nil).
 					Once()
+				queryOptionsMock.
+					On("WithDeviceStatus", models.DeviceStatusAccepted).
+					Return(nil).
+					Once()
 				storeMock.
-					On("DeviceResolve", ctx, store.DeviceHostnameResolver, "name", mock.AnythingOfType("store.QueryOption")).
+					On(
+						"DeviceResolve",
+						ctx,
+						store.DeviceHostnameResolver,
+						"name",
+						mock.AnythingOfType("store.QueryOption"),
+						mock.AnythingOfType("store.QueryOption"),
+					).
 					Return(nil, errors.New("error", "", 0)).
 					Once()
 			},
@@ -1295,7 +1306,7 @@ func TestLookupDevice(t *testing.T) {
 			},
 		},
 		{
-			description: "succeeds",
+			description: "succeeds to lookup for device",
 			namespace:   "namespace",
 			device:      &models.Device{UID: "uid", Name: "name", TenantID: "tenant", Identity: &models.DeviceIdentity{MAC: "00:00:00:00:00:00"}, Status: "accepted"},
 			requiredMocks: func(device *models.Device, namespace string) {
@@ -1307,8 +1318,19 @@ func TestLookupDevice(t *testing.T) {
 					On("InNamespace", "00000000-0000-0000-0000-000000000000").
 					Return(nil).
 					Once()
+				queryOptionsMock.
+					On("WithDeviceStatus", models.DeviceStatusAccepted).
+					Return(nil).
+					Once()
 				storeMock.
-					On("DeviceResolve", ctx, store.DeviceHostnameResolver, "name", mock.AnythingOfType("store.QueryOption")).
+					On(
+						"DeviceResolve",
+						ctx,
+						store.DeviceHostnameResolver,
+						"name",
+						mock.AnythingOfType("store.QueryOption"),
+						mock.AnythingOfType("store.QueryOption"),
+					).
 					Return(device, nil).
 					Once()
 			},

--- a/api/services/device_test.go
+++ b/api/services/device_test.go
@@ -1056,7 +1056,7 @@ func TestDeleteDevice(t *testing.T) {
 					).
 					Once()
 				storeMock.
-					On("NamespaceGet", ctx, "tenant").
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "tenant").
 					Return(
 						&models.Namespace{
 							Name:     "group1",


### PR DESCRIPTION
When two devices with same hostname or identity are registered, device's lookup API method called be SSH service could return the wrong device when SSH connection is requested. Since only “accepted” devices should be reachable, we now constrain the lookup to devices in the accepted state. This ensures SSH connections always target the correct, approved device.