### PR TITLE
fix(ui): correct copy icon behavior in command field

### DIFF
--- a/ui/src/components/Terminal/TerminalHelper.vue
+++ b/ui/src/components/Terminal/TerminalHelper.vue
@@ -27,8 +27,8 @@
               <template #default="{ copyText }">
                 <v-text-field
                   :model-value="commandLine"
-                  @click:append="copyText(commandLine)"
-                  append-icon="mdi-content-copy"
+                  @click:append-inner="copyText(commandLine)"
+                  append-inner-icon="mdi-content-copy"
                   hint="Run this command on your Terminal"
                   class="code"
                   variant="outlined"


### PR DESCRIPTION
# Description

This PR updates the v-text-field inside the TerminalHelper.vue component to:    

- Replace append-icon with append-inner-icon
- Update @click:append to @click:append-inner

These changes ensure the copy icon correctly appears inside the input field and functions when clicked.