### PR TITLE
fix(ui): validation for X.509 certificate in SAML config

### DIFF
--- a/ui/admin/tests/unit/components/Instance/SSO/index.spec.ts
+++ b/ui/admin/tests/unit/components/Instance/SSO/index.spec.ts
@@ -57,7 +57,7 @@ describe("Configure SSO", () => {
   it("adds a mapping when 'Add Mapping' is clicked", async () => {
     await wrapper.findComponent("[data-test='advanced-settings-title']").trigger("click");
     await wrapper.findComponent("[data-test='add-mapping-btn']").trigger("click");
-    expect(wrapper.vm.mappings.length).toBe(2);
+    expect(wrapper.vm.mappings.length).toBe(1);
   });
 
   it("removes a mapping when 'Remove Mapping' button is clicked", async () => {
@@ -86,10 +86,6 @@ describe("Configure SSO", () => {
       enable: true,
       idp: {
         metadata_url: "https://example.co/metadata",
-        mappings: {
-          email: "",
-          name: "",
-        },
       },
       sp: {
         sign_requests: false,

--- a/ui/src/utils/crypto.ts
+++ b/ui/src/utils/crypto.ts
@@ -33,6 +33,15 @@ const parseCertificate = (data) => {
   return cert;
 };
 
+const validateCertificate = (certificate: string): boolean => {
+  try {
+    sshpk.parseCertificate(certificate, "pem");
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const convertKeyToFingerprint = (privateKey) => {
   const fingerprint = sshpk.parsePrivateKey(privateKey).fingerprint("md5");
   return fingerprint;
@@ -50,6 +59,7 @@ export default {
   parsePrivateKey,
   parseKey,
   parseCertificate,
+  validateCertificate,
   convertKeyToFingerprint,
   createSignerAndUpdate,
 };

--- a/ui/src/utils/validate.ts
+++ b/ui/src/utils/validate.ts
@@ -44,6 +44,15 @@ export const createSignerPrivateKey = (privateKey, username) => {
   }
 };
 
+export const validateX509Certificate = (value: string): boolean => {
+  try {
+    return crypto.validateCertificate(value);
+  } catch (err) {
+    handleError(err);
+    return false;
+  }
+};
+
 export const createSignatureOfPrivateKey = (
   privateKeyData: any,
   username: Buffer,


### PR DESCRIPTION
# Description

This PR fixes and enhances the SAML SSO configuration flow by introducing validation for the X.509 certificate field. It ensures that users provide a valid certificate in PEM format before submitting the configuration form.

## Changes

- Added validateX509Certificate utility to verify X.509 certificates using sshpk.
- Display inline error messages for invalid or empty certificate fields.
- Improved the hasError computed logic to account for certificate validity.
- Refactored how SAML mapping data is constructed and validated.
- Ensured only non-empty mappings are submitted.

## Benefits

- Prevents invalid X.509 certificates from being submitted.
- Improves user feedback with clear validation errors.
- Reduces chances of SAML misconfiguration due to bad input.

## Testing

- Attempted to submit form with empty and malformed certificates.
- Verified correct error messages display.
- Confirmed form submission only succeeds with a valid certificate.