### PR TITLE
fix(ui): fix Terminal input message data's max size

### DIFF
--- a/ui/src/components/Terminal/Terminal.vue
+++ b/ui/src/components/Terminal/Terminal.vue
@@ -87,10 +87,11 @@ const setupTerminalEvents = () => {
   // Send user input over WebSocket
   xterm.value.onData((data) => {
     if (!isWebSocketOpen()) return;
+    const encodedData = textEncoder.encode(data).slice(0, 1023); // Limited to 1024 bytes
 
     const message: InputMessage = {
       kind: MessageKind.Input,
-      data: [...textEncoder.encode(data)],
+      data: [...encodedData],
     };
     ws.value.send(JSON.stringify(message));
   });


### PR DESCRIPTION
This pull request introduces a small but important change to the `setupTerminalEvents` function in `Terminal.vue`. The goal is to limit user input sent over the WebSocket to 1024 bytes per message, increasing robustness and preventing connection drops caused by oversized payloads.

Currently, when the terminal captures input, it sends a message like:
```javascript
{"kind":1,"data":[97]}
```
Here, `data` is a `Uint8Array` representing the input encoded with ASCII decimal codes. In this example, the user typed `a`, which corresponds to the decimal code 97. When pasting longer commands, the data array grows rapidly: the encoded array length can be up to 4x larger than the original character count, since each byte is represented by numbers of one to three digits, separated by commas.

The backend enforces a strict 4096-byte limit on incoming WebSocket messages (plus 20 bytes of JSON overhead). By limiting the raw encoded input to 1024 bytes, we ensure that even after JSON serialization, the message remains comfortably under the backend's limit, avoiding disconnections caused by buffer overflow.