### PR TITLE
fix(ui): update AppLayout.spec to use wrapper component and full mount

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-app :theme="getStatusDarkMode">
     <component
       :is="layout"
       :data-test="layout + '-component'"
@@ -21,4 +21,5 @@ const components = {
 };
 const store = useStore();
 const layout = computed(() => components[store.getters["layout/getLayout"]]);
+const getStatusDarkMode = computed(() => store.getters["layout/getStatusDarkMode"]);
 </script>

--- a/ui/src/components/Snackbar/Snackbar.vue
+++ b/ui/src/components/Snackbar/Snackbar.vue
@@ -1,7 +1,7 @@
 <template>
   <v-snackbar
     v-model="show"
-    location="top"
+    location="top center"
     :timeout="4000"
     :color="color"
     transition="slide-x-transition"

--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -1,153 +1,148 @@
 <template>
-  <v-app
-    :theme="getStatusDarkMode"
-    v-bind="$attrs"
+  <v-navigation-drawer
+    theme="dark"
+    v-model="showNavigationDrawer"
+    :permanent="permanent"
+    absolute
+    app
+    class="bg-v-theme-surface"
+    data-test="navigation-drawer"
   >
-    <v-navigation-drawer
-      theme="dark"
-      v-model="showNavigationDrawer"
-      :permanent="permanent"
-      absolute
-      app
-      class="bg-v-theme-surface"
-      data-test="navigation-drawer"
-    >
-      <v-toolbar class="bg-v-theme-surface" data-test="drawer-toolbar">
-        <v-spacer />
-        <router-link
-          to="/"
-          class="text-decoration-none"
-        >
-          <v-img
-            :src="Logo"
-            min-width="140"
-            alt="Shell logo, a cloud with the writing 'ShellHub' on the right side"
-            data-test="logo"
-          />
-        </router-link>
-        <v-spacer />
-      </v-toolbar>
-
-      <div class="pa-2" v-if="hasNamespaces">
-        <Namespace data-test="namespace-component" />
-      </div>
-
-      <div class="d-flex justify-center" v-else>
-        <v-btn
-          color="primary"
-          @click="showNamespaceAdd = true"
-          data-test="save-btn">
-          Add Namespace
-        </v-btn>
-        <NamespaceAdd
-          v-model="showNamespaceAdd"
-          enableSwitchIn
-          data-test="namespaceAdd-component"
+    <v-toolbar class="bg-v-theme-surface" data-test="drawer-toolbar">
+      <v-spacer />
+      <router-link
+        to="/"
+        class="text-decoration-none"
+      >
+        <v-img
+          :src="Logo"
+          min-width="140"
+          alt="Shell logo, a cloud with the writing 'ShellHub' on the right side"
+          data-test="logo"
         />
-      </div>
+      </router-link>
+      <v-spacer />
+    </v-toolbar>
 
-      <v-list density="compact" class="bg-v-theme-surface" data-test="list">
-        <template v-for="item in visibleItems" :key="item.title">
-          <v-list-group
-            v-if="item.children"
-            prepend-icon="mdi-chevron-down"
-            v-model="subMenuState[item.title]"
-            data-test="list-group"
-          >
-            <template v-slot:activator="{ props }">
-              <v-list-item
-                lines="two"
-                v-bind="props"
-                :disabled="disableItem(item.title)">
-                <template #prepend>
-                  <v-icon data-test="icon">
-                    {{ item.icon }}
-                  </v-icon>
-                </template>
-                <v-list-item-title>
-                  {{ item.title }}
-                </v-list-item-title>
-              </v-list-item>
-            </template>
+    <div class="pa-2" v-if="hasNamespaces">
+      <Namespace data-test="namespace-component" />
+    </div>
 
+    <div class="d-flex justify-center" v-else>
+      <v-btn
+        color="primary"
+        @click="showNamespaceAdd = true"
+        data-test="save-btn">
+        Add Namespace
+      </v-btn>
+      <NamespaceAdd
+        v-model="showNamespaceAdd"
+        enableSwitchIn
+        data-test="namespaceAdd-component"
+      />
+    </div>
+
+    <v-list density="compact" class="bg-v-theme-surface" data-test="list">
+      <template v-for="item in visibleItems" :key="item.title">
+        <v-list-group
+          v-if="item.children"
+          prepend-icon="mdi-chevron-down"
+          v-model="subMenuState[item.title]"
+          data-test="list-group"
+        >
+          <template v-slot:activator="{ props }">
             <v-list-item
-              v-for="child in getFilteredChildren(item.children)"
-              :key="child.title"
-              :to="child.path"
-              :disabled="disableItem(item.title)"
-              data-test="list-item"
-            >
-              <v-list-item-title :data-test="child.title + '-listItem'">
-                {{ child.title }}
+              lines="two"
+              v-bind="props"
+              :disabled="disableItem(item.title)">
+              <template #prepend>
+                <v-icon data-test="icon">
+                  {{ item.icon }}
+                </v-icon>
+              </template>
+              <v-list-item-title>
+                {{ item.title }}
               </v-list-item-title>
             </v-list-item>
-          </v-list-group>
+          </template>
 
           <v-list-item
-            v-else
-            :to="item.path"
-            lines="two"
-            class="mb-2"
+            v-for="child in getFilteredChildren(item.children)"
+            :key="child.title"
+            :to="child.path"
             :disabled="disableItem(item.title)"
             data-test="list-item"
           >
-            <template #prepend>
-              <v-icon data-test="icon">
-                {{ item.icon }}
-              </v-icon>
-            </template>
-            <template #append>
-              <v-icon
-                v-if="item.isPremium && envVariables.isCommunity && envVariables.premiumPaywall"
-                color="yellow"
-                size="x-small"
-                icon="mdi-crown"
-                data-test="icon"
-              />
-            </template>
-            <v-list-item-title :data-test="item.icon + '-listItem'">
-              {{ item.title }}
+            <v-list-item-title :data-test="child.title + '-listItem'">
+              {{ child.title }}
             </v-list-item-title>
           </v-list-item>
-        </template>
+        </v-list-group>
 
-        <v-col class="d-flex align-end justify-center">
-          <QuickConnection />
-        </v-col>
-      </v-list>
-    </v-navigation-drawer>
-
-    <Snackbar />
-
-    <AppBar v-model="showNavigationDrawer" data-test="app-bar" />
-
-    <v-main data-test="main">
-      <slot>
-        <v-container
-          :class="{ 'pa-8': true, 'container-light-bg': getStatusDarkMode == 'light' }"
-          fluid
-          data-test="container"
+        <v-list-item
+          v-else
+          :to="item.path"
+          lines="two"
+          class="mb-2"
+          :disabled="disableItem(item.title)"
+          data-test="list-item"
         >
-          <router-view :key="currentRoute.value.path" />
-        </v-container>
-      </slot>
-    </v-main>
+          <template #prepend>
+            <v-icon data-test="icon">
+              {{ item.icon }}
+            </v-icon>
+          </template>
+          <template #append>
+            <v-icon
+              v-if="item.isPremium && envVariables.isCommunity && envVariables.premiumPaywall"
+              color="yellow"
+              size="x-small"
+              icon="mdi-crown"
+              data-test="icon"
+            />
+          </template>
+          <v-list-item-title :data-test="item.icon + '-listItem'">
+            {{ item.title }}
+          </v-list-item-title>
+        </v-list-item>
+      </template>
 
-    <v-overlay
-      :model-value="hasSpinner"
-      :scrim="false"
-      contained
-      class="align-center justify-center w-100 h-100"
-      data-test="overlay"
-    >
-      <v-progress-circular
-        indeterminate
-        size="64"
-        alt="Request loading"
-        data-test="progress-circular"
-      />
-    </v-overlay>
-  </v-app>
+      <v-col class="d-flex align-end justify-center">
+        <QuickConnection />
+      </v-col>
+    </v-list>
+  </v-navigation-drawer>
+
+  <Snackbar />
+
+  <AppBar v-model="showNavigationDrawer" data-test="app-bar" />
+
+  <v-main data-test="main">
+    <slot>
+      <v-container
+        :class="{ 'pa-8': true, 'container-light-bg': getStatusDarkMode == 'light' }"
+        fluid
+        data-test="container"
+      >
+        <router-view :key="currentRoute.value.path" />
+      </v-container>
+    </slot>
+  </v-main>
+
+  <v-overlay
+    :model-value="hasSpinner"
+    :scrim="false"
+    contained
+    class="align-center justify-center w-100 h-100"
+    data-test="overlay"
+  >
+    <v-progress-circular
+      indeterminate
+      size="64"
+      alt="Request loading"
+      data-test="progress-circular"
+    />
+  </v-overlay>
 
   <UserWarning data-test="userWarning-component" />
 </template>

--- a/ui/src/layouts/LoginLayout.vue
+++ b/ui/src/layouts/LoginLayout.vue
@@ -1,45 +1,43 @@
 <template>
-  <v-app>
-    <Snackbar />
-    <v-main class="d-flex justify-center align-center">
-      <v-container
-        class="full-height d-flex justify-center align-center"
-        fluid
+  <Snackbar />
+  <v-main class="d-flex justify-center align-center">
+    <v-container
+      class="full-height d-flex justify-center align-center"
+      fluid
+    >
+      <v-row
+        align="center"
+        justify="center"
       >
-        <v-row
-          align="center"
-          justify="center"
+        <v-col
+          cols="12"
+          sm="8"
+          md="4"
+          xl="3"
         >
-          <v-col
-            cols="12"
-            sm="8"
-            md="4"
-            xl="3"
+          <v-card
+            theme="dark"
+            class="pa-6 bg-v-theme-surface"
+            rounded="lg"
           >
-            <v-card
-              theme="dark"
-              class="pa-6 bg-v-theme-surface"
-              rounded="lg"
-            >
-              <v-card-title class="d-flex justify-center align-center mt-4">
-                <v-img
-                  :src="Logo"
-                  max-width="220"
-                  alt="ShellHub logo, a cloud with a shell in your base write ShellHub in the right side"
-                />
-              </v-card-title>
-              <p
-                v-if="!envVariables.isEnterprise && !envVariables.isCloud"
-                class="text-caption text-center text-md font-weight-bolad"
-              >Community Edition
-              </p>
-              <router-view :key="currentRoute.value.path" />
-            </v-card>
-          </v-col>
-        </v-row>
-      </v-container>
-    </v-main>
-  </v-app>
+            <v-card-title class="d-flex justify-center align-center mt-4">
+              <v-img
+                :src="Logo"
+                max-width="220"
+                alt="ShellHub logo, a cloud with a shell in your base write ShellHub in the right side"
+              />
+            </v-card-title>
+            <p
+              v-if="!envVariables.isEnterprise && !envVariables.isCloud"
+              class="text-caption text-center text-md font-weight-bolad"
+            >Community Edition
+            </p>
+            <router-view :key="currentRoute.value.path" />
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-main>
 </template>
 
 <script setup lang="ts">

--- a/ui/src/layouts/SimpleLayout.vue
+++ b/ui/src/layouts/SimpleLayout.vue
@@ -1,40 +1,38 @@
 <template>
-  <v-app>
-    <Snackbar />
-    <v-main class="d-flex justify-center align-center">
-      <v-container
-        class="full-height d-flex justify-center align-center"
-        fluid
+  <Snackbar />
+  <v-main class="d-flex justify-center align-center">
+    <v-container
+      class="full-height d-flex justify-center align-center"
+      fluid
+    >
+      <v-row
+        align="center"
+        justify="center"
       >
-        <v-row
-          align="center"
-          justify="center"
+        <v-col
+          cols="12"
+          sm="8"
+          md="4"
+          xl="3"
         >
-          <v-col
-            cols="12"
-            sm="8"
-            md="4"
-            xl="3"
+          <v-card
+            theme="dark"
+            class="pa-6 bg-v-theme-surface"
+            rounded="lg"
           >
-            <v-card
-              theme="dark"
-              class="pa-6 bg-v-theme-surface"
-              rounded="lg"
-            >
-              <v-card-title class="d-flex justify-center align-center mt-4">
-                <v-img
-                  :src="Logo"
-                  max-width="220"
-                  alt="ShellHub logo, a cloud with a shell in your base write ShellHub in the right side"
-                />
-              </v-card-title>
-              <router-view :key="currentRoute.value.path" />
-            </v-card>
-          </v-col>
-        </v-row>
-      </v-container>
-    </v-main>
-  </v-app>
+            <v-card-title class="d-flex justify-center align-center mt-4">
+              <v-img
+                :src="Logo"
+                max-width="220"
+                alt="ShellHub logo, a cloud with a shell in your base write ShellHub in the right side"
+              />
+            </v-card-title>
+            <router-view :key="currentRoute.value.path" />
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-main>
 </template>
 
 <script setup lang="ts">

--- a/ui/tests/layouts/AppLayout.spec.ts
+++ b/ui/tests/layouts/AppLayout.spec.ts
@@ -1,90 +1,116 @@
-import MockAdapter from "axios-mock-adapter";
+// AppLayout.spec.ts
+import { defineComponent, nextTick } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
 import { createVuetify } from "vuetify";
-import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import { nextTick } from "vue";
+import MockAdapter from "axios-mock-adapter";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
 import AppLayout from "@/layouts/AppLayout.vue";
 import { store, key } from "@/store";
 import { router } from "@/router";
 import { SnackbarPlugin } from "@/plugins/snackbar";
-import { containersApi, devicesApi } from "@/api/http";
-
-type AppLayoutWrapper = VueWrapper<InstanceType<typeof AppLayout>>;
+import { devicesApi, containersApi } from "@/api/http";
 
 let mockDevices: MockAdapter;
 let mockContainers: MockAdapter;
 
 describe("App Layout Component", () => {
-  let wrapper: AppLayoutWrapper;
-  const vuetify = createVuetify();
+  let wrapper;
+
+  const vuetify = createVuetify({
+    components,
+    directives,
+  });
+
+  const AppWrapperComponent = defineComponent({
+    components: { AppLayout },
+    template: `
+      <v-app>
+        <AppLayout />
+      </v-app>
+    `,
+  });
 
   beforeEach(() => {
     vi.useFakeTimers();
+
     store.dispatch("spinner/setStatus", true);
 
     mockDevices = new MockAdapter(devicesApi.getAxios());
     mockContainers = new MockAdapter(containersApi.getAxios());
 
-    mockDevices.onGet("http://localhost/api/devices?filter=&page=1&per_page=10&status=pending").reply(200);
-    mockContainers.onGet("http://localhost/api/containers?filter=&page=1&per_page=10&status=pending").reply(200);
+    mockDevices
+      .onGet("http://localhost/api/devices?filter=&page=1&per_page=10&status=pending")
+      .reply(200);
+    mockContainers
+      .onGet("http://localhost/api/containers?filter=&page=1&per_page=10&status=pending")
+      .reply(200);
 
-    wrapper = mount(AppLayout, {
+    wrapper = mount(AppWrapperComponent, {
       global: {
         plugins: [[store, key], vuetify, router, SnackbarPlugin],
+        stubs: {
+          "router-link": {
+            template: "<a><slot /></a>",
+          },
+          "router-view": true,
+        },
+
       },
+      attachTo: document.body,
     });
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
-    wrapper.unmount();
+    if (wrapper) wrapper.unmount();
   });
 
   it("Is a Vue instance", () => {
-    // Test if the wrapper represents a Vue instance
     expect(wrapper.vm).toBeTruthy();
   });
 
   it("Renders the component", () => {
-    // Test if the component renders as expected
     expect(wrapper.html()).toMatchSnapshot();
   });
 
   it("Renders internal components", () => {
-    expect(wrapper.find('[data-test="navigation-drawer"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="drawer-toolbar"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="logo"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="list"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="list-item"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="icon"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="app-bar"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="main"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="container"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="overlay"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="progress-circular"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="userWarning-component"]').exists()).toBe(false);
+    const layoutWrapper = wrapper.findComponent(AppLayout);
+    expect(layoutWrapper.find('[data-test="navigation-drawer"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="drawer-toolbar"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="logo"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="list"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="list-item"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="icon"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="app-bar"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="main"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="container"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="overlay"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="progress-circular"]').exists()).toBe(true);
+    expect(layoutWrapper.find('[data-test="userWarning-component"]').exists()).toBe(false);
   });
 
   it("Renders loading screen", async () => {
     await store.dispatch("spinner/setStatus", true);
-
     await flushPromises();
 
-    expect(wrapper.find('[data-test="progress-circular"]').exists()).toBeTruthy();
+    const layoutWrapper = wrapper.findComponent(AppLayout);
+    expect(layoutWrapper.find('[data-test="progress-circular"]').exists()).toBeTruthy();
   });
 
   it("Renders navigation drawer correctly", async () => {
-    // Simulate a state change and check if the navigation drawer visibility changes accordingly
-    wrapper.vm.lgAndUp = !wrapper.vm.lgAndUp;
+    const layoutWrapper = wrapper.findComponent(AppLayout);
+    layoutWrapper.vm.lgAndUp = !layoutWrapper.vm.lgAndUp;
     await nextTick();
-    expect(wrapper.find('[data-test="navigation-drawer"]').isVisible()).toBe(wrapper.vm.lgAndUp);
+    expect(layoutWrapper.find('[data-test="navigation-drawer"]').isVisible()).toBe(layoutWrapper.vm.lgAndUp);
   });
 
   it("Navigates correctly on item click", async () => {
-    // Test if clicking on a navigation item navigates to the correct path
-    const item = wrapper.vm.items[0];
-    await wrapper.find(`[data-test="${item.icon}-listItem"]`).trigger("click");
+    const layoutWrapper = wrapper.findComponent(AppLayout);
+    const item = layoutWrapper.vm.items[0];
+    await layoutWrapper.find(`[data-test="${item.icon}-listItem"]`).trigger("click");
     expect(router.currentRoute.value.path).toBe(item.path);
   });
 });

--- a/ui/tests/layouts/__snapshots__/AppLayout.spec.ts.snap
+++ b/ui/tests/layouts/__snapshots__/AppLayout.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`App Layout Component > Renders the component 1`] = `
-"<div data-v-e7291ef4="" class="v-application v-theme--dark v-layout v-layout--full-height v-locale--is-ltr">
+"<div class="v-application v-theme--light v-layout v-layout--full-height v-locale--is-ltr">
   <div class="v-application__wrap">
     <nav class="v-navigation-drawer v-navigation-drawer--left v-navigation-drawer--temporary v-theme--dark v-navigation-drawer--mobile bg-v-theme-surface" style="left: 0px; z-index: 1006; transform: translateX(-256px); position: absolute; transition: none; height: calc(100% - 0px - 0px); top: 0px; bottom: 0px; width: 256px;" data-v-e7291ef4="" app="" data-test="navigation-drawer">
       <!---->
@@ -12,7 +12,7 @@ exports[`App Layout Component > Renders the component 1`] = `
           <div class="v-toolbar__content" style="height: 64px;">
             <!---->
             <!---->
-            <div data-v-e7291ef4="" class="v-spacer"></div><a data-v-e7291ef4="" href="/" class="text-decoration-none">
+            <div data-v-e7291ef4="" class="v-spacer"></div><a data-v-e7291ef4="" to="/" class="text-decoration-none">
               <div data-v-e7291ef4="" class="v-responsive v-img v-img--booting" style="min-width: 140px;" aria-label="Shell logo, a cloud with the writing 'ShellHub' on the right side" role="img" data-test="logo">
                 <div class="v-responsive__sizer"></div>
                 <transition-stub name="fade-transition" appear="true" persisted="false" css="true"><img class="v-img__img v-img__img--contain" src="/src/assets/logo-inverted.png" alt="Shell logo, a cloud with the writing 'ShellHub' on the right side" style="display: none;"></transition-stub>
@@ -242,34 +242,34 @@ exports[`App Layout Component > Renders the component 1`] = `
     <!---->
     <!---->
     <!---->
-    <header class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--dark v-locale--is-ltr v-app-bar bg-background border-b-thin" style="top: 0px; z-index: 1004; transform: translateY(0px); position: fixed; transition: none; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
+    <header class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar bg-background border-b-thin" style="top: 0px; z-index: 1004; transform: translateY(0px); position: fixed; transition: none; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
       <!---->
       <div class="v-toolbar__content" style="height: 64px;">
         <!---->
-        <!----><button type="button" class="v-btn v-btn--icon v-theme--dark v-btn--density-default v-btn--size-default v-btn--variant-text hidden-lg-and-up v-app-bar-nav-icon" aria-label="Toggle Menu" data-test="menu-toggle"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-menu mdi v-icon notranslate v-theme--dark v-icon--size-default" aria-hidden="true"></i></span>
+        <!----><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text hidden-lg-and-up v-app-bar-nav-icon" aria-label="Toggle Menu" data-test="menu-toggle"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-menu mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
           <!---->
           <!---->
-        </button><i class="mdi-server-network mdi v-icon notranslate v-theme--dark v-icon--size-default ml-4 hidden-md-and-down" aria-hidden="true"></i>
+        </button><i class="mdi-server-network mdi v-icon notranslate v-theme--light v-icon--size-default ml-4 hidden-md-and-down" aria-hidden="true"></i>
         <ul class="v-breadcrumbs v-breadcrumbs--density-default hidden-md-and-down" data-test="breadcrumbs">
           <!---->
           <!---->
         </ul>
-        <div class="v-spacer"></div><button type="button" class="v-btn v-btn--icon v-theme--dark text-primary v-btn--density-default v-btn--variant-text" aria-describedby="v-tooltip-v-6" aria-label="community-help-icon" data-test="support-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-help-circle mdi v-icon notranslate v-theme--dark v-icon--size-default" aria-hidden="true"></i></span>
+        <div class="v-spacer"></div><button type="button" class="v-btn v-btn--icon v-theme--light text-primary v-btn--density-default v-btn--variant-text" aria-describedby="v-tooltip-v-6" aria-label="community-help-icon" data-test="support-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-help-circle mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
           <!---->
           <!---->
         </button>
         <!--teleport start-->
         <!--teleport end-->
         <div class="v-badge ml-3 mr-2" size="x-small" data-test="notifications-badge">
-          <div class="v-badge__wrapper"><i class="mdi-bell mdi v-icon notranslate v-theme--dark v-icon--size-default text-primary v-icon--clickable" role="button" aria-hidden="false" tabindex="0" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-8" aria-label="Open notifications menu"></i>
-            <transition-stub name="scale-rotate-transition" appear="false" persisted="false" css="true"><span class="v-badge__badge v-theme--dark bg-success" style="bottom: calc(100% - 7px); left: calc(100% - 12px); display: none;" aria-atomic="true" aria-label="Badge" aria-live="polite" role="status">0</span></transition-stub>
+          <div class="v-badge__wrapper"><i class="mdi-bell mdi v-icon notranslate v-theme--light v-icon--size-default text-primary v-icon--clickable" role="button" aria-hidden="false" tabindex="0" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-8" aria-label="Open notifications menu"></i>
+            <transition-stub name="scale-rotate-transition" appear="false" persisted="false" css="true"><span class="v-badge__badge v-theme--light bg-success" style="bottom: calc(100% - 7px); left: calc(100% - 12px); display: none;" aria-atomic="true" aria-label="Badge" aria-live="polite" role="status">0</span></transition-stub>
           </div>
         </div>
-        <!----><button type="button" class="v-btn v-theme--dark text-primary v-btn--density-default v-btn--size-default v-btn--variant-text pl-2 pr-2 mr-4" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-9" data-test="user-menu-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><div data-v-09753bb1="" class="v-avatar v-theme--dark bg-primary v-avatar--density-default v-avatar--variant-flat border" style="width: 1.5rem; height: 1.5rem;" email="" data-test="user-icon"><div data-v-09753bb1="" class="v-responsive v-img v-img--booting" data-test="gravatar-image"><div class="v-responsive__sizer"></div><!----><transition-stub name="fade-transition" appear="false" persisted="false" css="true"><!----></transition-stub><!----><!----><!----><!----></div><!----><span class="v-avatar__underlay"></span>
-      </div></span><span class="v-btn__append"><i class="mdi-menu-down mdi v-icon notranslate v-theme--dark v-icon--size-default" aria-hidden="true"></i></span>
+        <!----><button type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-text pl-2 pr-2 mr-4" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-9" data-test="user-menu-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><div data-v-09753bb1="" class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat border" style="width: 1.5rem; height: 1.5rem;" email="" data-test="user-icon"><div data-v-09753bb1="" class="v-responsive v-img v-img--booting" data-test="gravatar-image"><div class="v-responsive__sizer"></div><!----><transition-stub name="fade-transition" appear="false" persisted="false" css="true"><!----></transition-stub><!----><!----><!----><!----></div><!----><span class="v-avatar__underlay"></span>
+      </div></span><span class="v-btn__append"><i class="mdi-menu-down mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       <!----></button>
       <!---->
       <!---->
@@ -280,18 +280,18 @@ exports[`App Layout Component > Renders the component 1`] = `
   </header>
   <main data-v-e7291ef4="" class="v-main" style="--v-layout-left: 0px; --v-layout-right: 0px; --v-layout-top: 64px; --v-layout-bottom: 0px; transition: none;" data-test="main">
     <div data-v-e7291ef4="" class="v-container v-container--fluid v-locale--is-ltr pa-8" data-test="container">
-      <!---->
+      <router-view-stub data-v-e7291ef4=""></router-view-stub>
     </div>
   </main>
   <!---->
   <!--teleport start-->
-  <div class="v-overlay v-overlay--absolute v-overlay--active v-overlay--contained v-theme--dark v-locale--is-ltr align-center justify-center w-100 h-100" style="z-index: 2000;" data-v-e7291ef4="" data-test="overlay">
+  <div class="v-overlay v-overlay--absolute v-overlay--active v-overlay--contained v-theme--light v-locale--is-ltr align-center justify-center w-100 h-100" style="z-index: 2000;" data-v-e7291ef4="" data-test="overlay">
     <transition-stub name="fade-transition" appear="true" persisted="false" css="true">
       <!---->
     </transition-stub>
     <transition-stub name="fade-transition" appear="true" persisted="true" css="true">
       <div class="v-overlay__content">
-        <div data-v-e7291ef4="" class="v-progress-circular v-progress-circular--indeterminate v-theme--dark" style="width: 64px; height: 64px;" role="progressbar" aria-valuemin="0" aria-valuemax="100" alt="Request loading" data-test="progress-circular"><svg style="transform: rotate(calc(-90deg + 0deg));" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42.666666666666664 42.666666666666664">
+        <div data-v-e7291ef4="" class="v-progress-circular v-progress-circular--indeterminate v-theme--light" style="width: 64px; height: 64px;" role="progressbar" aria-valuemin="0" aria-valuemax="100" alt="Request loading" data-test="progress-circular"><svg style="transform: rotate(calc(-90deg + 0deg));" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42.666666666666664 42.666666666666664">
             <circle class="v-progress-circular__underlay" fill="transparent" cx="50%" cy="50%" r="20" stroke-width="2.6666666666666665" stroke-dasharray="125.66370614359172" stroke-dashoffset="0"></circle>
             <circle class="v-progress-circular__overlay" fill="transparent" cx="50%" cy="50%" r="20" stroke-width="2.6666666666666665" stroke-dasharray="125.66370614359172" stroke-dashoffset="125.66370614359172px"></circle>
           </svg>
@@ -301,10 +301,20 @@ exports[`App Layout Component > Renders the component 1`] = `
     </transition-stub>
   </div>
   <!--teleport end-->
+  <!--v-if-->
+  <!---->
+  <!---->
+  <!--v-if-->
+  <!--v-if-->
+  <!---->
+  <!---->
+  <!--v-if-->
+  <!---->
+  <!---->
+  <!---->
+  <!---->
+  <!---->
+  <!---->
 </div>
-</div>
-<!--v-if-->
-<!--v-if-->
-<!--v-if-->
-<!--v-if-->"
+</div>"
 `;


### PR DESCRIPTION
# Description:

This PR introduces dynamic theme support across the UI and removes redundant <v-app> wrappers from layout components, centralizing it in App.vue.

## Changes

### App.vue

Sets :theme="getStatusDarkMode" on the root <v-app> using the store.

### AppLayout.vue

Removed inner <v-app> wrapper to prevent nesting.

Minor reindentation for improved readability.

### LoginLayout.vue and SimpleLayout.vue

Removed <v-app> wrapper (already handled by App.vue).

### Snackbar.vue

Aligned the snackbar to top center for better visual positioning.

### AppLayout.spec.ts

Wrapped AppLayout with <v-app> in tests to reflect updated layout structure.

Added stubs and proper mounting for compatibility with Vuetify.

### Snapshot Update

Reflects light theme and new structure in updated snapshot.

## Why?

- Avoids multiple conflicting Vuetify themes by consolidating the root <v-app>.
- Enables light/dark mode switching via the store dynamically.
- Cleans up redundant layout nesting for simplicity and maintainability.

## Testing

1. Updated unit tests for AppLayout now mount under a <v-app>.
2. Snapshot reflects theme changes and layout structure adjustments.