### PR TITLE
fix(ui): fix member's role case when inviting with link

### DIFF
--- a/ui/src/components/Team/Member/MemberInvite.vue
+++ b/ui/src/components/Team/Member/MemberInvite.vue
@@ -280,16 +280,16 @@ const handleInviteError = (error: unknown) => {
   }
 };
 
+const getInvitePayload = () => ({
+  email: email.value,
+  tenant_id: store.getters["auth/tenant"],
+  role: selectedRole.value.toLocaleLowerCase(),
+});
+
 const generateLinkInvite = async () => {
   try {
-    await store.dispatch("namespaces/generateInvitationLink", {
-      email: email.value,
-      tenant_id: store.getters["auth/tenant"],
-      role: selectedRole.value,
-    });
-
+    await store.dispatch("namespaces/generateInvitationLink", getInvitePayload());
     snackbar.showSuccess("Invitation link generated successfully.");
-
     formWindow.value = "form-2";
   } catch (error) {
     handleInviteError(error);
@@ -298,14 +298,8 @@ const generateLinkInvite = async () => {
 
 const sendEmailInvite = async () => {
   try {
-    await store.dispatch("namespaces/sendEmailInvitation", {
-      email: email.value,
-      tenant_id: store.getters["auth/tenant"],
-      role: selectedRole.value.toLocaleLowerCase(),
-    });
-
+    await store.dispatch("namespaces/sendEmailInvitation", getInvitePayload());
     snackbar.showSuccess("Invitation email sent successfully.");
-
     update();
     resetFields();
   } catch (error) {


### PR DESCRIPTION
This pull request fixes the invitation with link functionality in the `MemberInvite.vue` component. The payload was being sent with the `role` in uppercase, causing problems with authorization. Now it sends the correct role in lowercase. A method to generate the payload was also added, reducing code duplication, since both link and email invitations use the same payload structure.