### PR TITLE
fix(ssh): resolve terminal dimension limitations by aligning with RFC 4254

### DIFF
--- a/ssh/web/session.go
+++ b/ssh/web/session.go
@@ -205,7 +205,7 @@ func newSession(ctx context.Context, cache cache.Cache, conn *Conn, creds *Crede
 		return err
 	}
 
-	if err := agent.RequestPty("xterm", dim.Rows, dim.Cols, ssh.TerminalModes{
+	if err := agent.RequestPty("xterm", int(dim.Rows), int(dim.Cols), ssh.TerminalModes{
 		ssh.ECHO:          1,
 		ssh.TTY_OP_ISPEED: 14400,
 		ssh.TTY_OP_OSPEED: 14400,
@@ -249,7 +249,7 @@ func newSession(ctx context.Context, cache cache.Cache, conn *Conn, creds *Crede
 			case messageKindResize:
 				dim := message.Data.(Dimensions)
 
-				if err := agent.WindowChange(dim.Rows, dim.Cols); err != nil {
+				if err := agent.WindowChange(int(dim.Rows), int(dim.Cols)); err != nil {
 					logger.WithError(err).Error("failed to change the size of window for terminal session")
 
 					return

--- a/ssh/web/utils.go
+++ b/ssh/web/utils.go
@@ -65,8 +65,8 @@ func (c *Credentials) isPassword() bool {
 
 // Dimensions represents a web SSH terminal dimensions.
 type Dimensions struct {
-	Cols int `json:"cols"`
-	Rows int `json:"rows"`
+	Cols uint32 `json:"cols"`
+	Rows uint32 `json:"rows"`
 }
 
 type Info struct {

--- a/ssh/web/websocket.go
+++ b/ssh/web/websocket.go
@@ -16,7 +16,7 @@ func getToken(req *http.Request) (string, error) {
 	return token, nil
 }
 
-func getDimensions(req *http.Request) (int, int, error) {
+func getDimensions(req *http.Request) (uint32, uint32, error) {
 	toUint32 := func(text string) (uint64, error) {
 		integer, err := strconv.ParseUint(text, 10, 32)
 		if err != nil {
@@ -36,8 +36,8 @@ func getDimensions(req *http.Request) (int, int, error) {
 		return 0, 0, errors.Join(ErrGetDimensions, err)
 	}
 
-	// nolint: gosec // cols and rows are uint32, so we can safely convert them to int.
-	return int(cols), int(rows), nil
+	//nolint: gosec // cols and rows are uint32, so we can safely convert them.
+	return uint32(cols), uint32(rows), nil
 }
 
 func getIP(req *http.Request) (string, error) {

--- a/ssh/web/websocket.go
+++ b/ssh/web/websocket.go
@@ -17,8 +17,8 @@ func getToken(req *http.Request) (string, error) {
 }
 
 func getDimensions(req *http.Request) (int, int, error) {
-	toUint8 := func(text string) (uint64, error) {
-		integer, err := strconv.ParseUint(text, 10, 8)
+	toUint32 := func(text string) (uint64, error) {
+		integer, err := strconv.ParseUint(text, 10, 32)
 		if err != nil {
 			return 0, err
 		}
@@ -26,17 +26,17 @@ func getDimensions(req *http.Request) (int, int, error) {
 		return integer, nil
 	}
 
-	cols, err := toUint8(req.URL.Query().Get("cols"))
+	cols, err := toUint32(req.URL.Query().Get("cols"))
 	if err != nil {
 		return 0, 0, errors.Join(ErrGetDimensions, err)
 	}
 
-	rows, err := toUint8(req.URL.Query().Get("rows"))
+	rows, err := toUint32(req.URL.Query().Get("rows"))
 	if err != nil {
 		return 0, 0, errors.Join(ErrGetDimensions, err)
 	}
 
-	// nolint: gosec // cols and rows are uint8, so we can safely convert them to int.
+	// nolint: gosec // cols and rows are uint32, so we can safely convert them to int.
 	return int(cols), int(rows), nil
 }
 

--- a/ssh/web/websocket_test.go
+++ b/ssh/web/websocket_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"math"
 	"net/http"
 	"testing"
 
@@ -123,8 +124,8 @@ func TestGetDimensions(t *testing.T) {
 			},
 		},
 		{
-			description: "fail when cols or rows exceed the uint8 limit",
-			uri:         "http://localhost?cols=256&rows=256",
+			description: "fail when cols or rows exceed the uint32 limit",
+			uri:         "http://localhost?cols=4294967296&rows=4294967296",
 			expected: Expected{
 				cols: 0,
 				rows: 0,
@@ -132,11 +133,11 @@ func TestGetDimensions(t *testing.T) {
 			},
 		},
 		{
-			description: "success to get the cols and rows unint8 limit",
-			uri:         "http://localhost?cols=255&rows=255",
+			description: "success to get the cols and rows uint32 limit",
+			uri:         "http://localhost?cols=4294967295&rows=4294967295",
 			expected: Expected{
-				cols: 255,
-				rows: 255,
+				cols: math.MaxUint32,
+				rows: math.MaxUint32,
 				err:  nil,
 			},
 		},

--- a/ssh/web/websocket_test.go
+++ b/ssh/web/websocket_test.go
@@ -59,8 +59,8 @@ func TestGetToken(t *testing.T) {
 
 func TestGetDimensions(t *testing.T) {
 	type Expected struct {
-		cols int
-		rows int
+		cols uint32
+		rows uint32
 		err  error
 	}
 


### PR DESCRIPTION
The previous implementation of the web terminal used `uint8` for the
column and row dimensions. This limited the maximum values to 255, which
could lead to display issues when users attempted to set larger terminal
sizes. Such limitations could hinder user experience, especially in
scenarios where larger terminal dimensions are required for better
visibility and usability.

To address this issue, we have updated the implementation to use
`uint32` for parsing terminal dimensions, in accordance with RFC 4254
specifications. This change allows the web terminal to support a much
larger range of dimensions, up to 4,294,967,295, thus preventing errors
and display issues when users specify larger sizes.