### PR TITLE
refactor(api): use clock abstraction for JWT issue time

### DIFF
--- a/pkg/api/jwttoken/claims.go
+++ b/pkg/api/jwttoken/claims.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/uuid"
 )
 
@@ -85,7 +86,7 @@ func EncodeUserClaims(claims authorizer.UserClaims, privateKey *rsa.PrivateKey) 
 // EncodeDeviceClaims encodes the provided device claims into a signed JWT token. It returns
 // the encoded token and an error, if any.
 func EncodeDeviceClaims(claims authorizer.DeviceClaims, privateKey *rsa.PrivateKey) (string, error) {
-	now := time.Now()
+	now := clock.Now()
 	jwtClaims := deviceClaims{
 		Kind:         kindDeviceClaims,
 		DeviceClaims: claims,


### PR DESCRIPTION
We are using the clock abstraction to manage the issue time of JSON Web Tokens (JWTs) within the API. This change is motivated by the need to improve stability in our test suite. By decoupling the JWT issuance from the system clock, we can create more reliable tests.