### PR TITLE
fix(ssh): prevent panic when agent output is empty in web terminal

### DIFF
--- a/ssh/web/session.go
+++ b/ssh/web/session.go
@@ -278,6 +278,15 @@ func redirToWs(rd io.Reader, ws *Conn) error {
 			return err
 		}
 
+		if nr == 0 {
+			// NOTE: "Callers should treat a return of 0 and nil as indicating that nothing happened; in particular it
+			// does not indicate EOF", in such a case, the caller should not interpret it as EOF, but instead wait for
+			// more data.
+			//
+			// https://pkg.go.dev/io#Reader
+			continue
+		}
+
 		buflen = start + nr
 		for end = buflen - 1; end >= 0; end-- {
 			if utf8.RuneStart(buf[end]) {

--- a/ssh/web/session_test.go
+++ b/ssh/web/session_test.go
@@ -1,0 +1,27 @@
+package web
+
+import (
+	"testing"
+	"testing/iotest"
+
+	"github.com/shellhub-io/shellhub/ssh/web/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+type zeroReadNoEOFReader struct{}
+
+func (r *zeroReadNoEOFReader) Read(p []byte) (int, error) {
+	return 0, nil
+}
+
+func TestRedirToWs_Regression_ZeroReadThenEOF(t *testing.T) {
+	conn := &Conn{
+		Socket: mocks.NewSocket(t),
+	}
+
+	reader := iotest.TimeoutReader(&zeroReadNoEOFReader{})
+
+	assert.NotPanics(t, func() {
+		_ = redirToWs(reader, conn)
+	}, "expected redirToWs to handle zero read without panicking")
+}


### PR DESCRIPTION
The redirToWs function, responsible for piping data from the agent output to the web terminal, previously panicked when it encountered a return value of 0 from io.Reader. This behavior ignored the special case outlined in the io.Reader documentation, which states that a return value of 0 does not indicate EOF but rather signifies that no data was read, and we should expect for more data.

```https://pkg.go.dev/io#Reader```

With this update, the function now correctly handles this scenario by
continuing the reading loop instead of panicking, ensuring more robust
behavior when no data is available. We also added a regression test to
avoid this bahavior in the future.