### PR TITLE
fix(ui): fix extraneous non-props attribute warning in layouts

### DIFF
--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -162,6 +162,10 @@ import QuickConnection from "../components/QuickConnection/QuickConnection.vue";
 import NamespaceAdd from "@/components/Namespace/NamespaceAdd.vue";
 import Snackbar from "@/components/Snackbar/Snackbar.vue";
 
+defineOptions({
+  inheritAttrs: false,
+});
+
 const router = useRouter();
 const store = useStore();
 const currentRoute = computed(() => router.currentRoute);

--- a/ui/src/layouts/LoginLayout.vue
+++ b/ui/src/layouts/LoginLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <Snackbar />
-  <v-main class="d-flex justify-center align-center">
+  <v-main class="d-flex justify-center align-center" v-bind="$attrs">
     <v-container
       class="full-height d-flex justify-center align-center"
       fluid


### PR DESCRIPTION
This pull request fixes several warnings that were being thrown in the console due to attributes being passed to `AppLayout` and `LoginLayout`.