### PR TITLE
feat(api): restructure SAML signon_url to support multiple URL types

### DIFF
--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -116,6 +116,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration104,
 		migration105,
 		migration106,
+		migration107,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_107.go
+++ b/api/store/mongo/migrations/migration_107.go
@@ -1,0 +1,78 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	log "github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration107 = migrate.Migration{
+	Version:     107,
+	Description: "Restructure SAML signon_url to signon_urls object with post and redirect fields",
+	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{"component": "migration", "version": 107, "action": "Up"}).Info("Applying migration")
+
+		system := &models.System{}
+		if err := db.Collection("system").FindOne(ctx, bson.M{}).Decode(system); err != nil {
+			return err
+		}
+
+		preferred := ""
+		if system.Authentication.SAML.Enabled {
+			preferred = "post"
+		}
+
+		pipeline := []bson.M{
+			{
+				"$set": bson.M{
+					"authentication.saml.idp.binding": bson.M{
+						"post":      bson.M{"$ifNull": []any{"$authentication.saml.idp.signon_url", ""}},
+						"redirect":  "",
+						"preferred": preferred,
+					},
+				},
+			},
+			{
+				"$unset": "authentication.saml.idp.signon_url",
+			},
+		}
+
+		if _, err := db.Collection("system").UpdateOne(ctx, bson.M{}, pipeline); err != nil {
+			log.WithError(err).Error("Failed to update system document")
+
+			return err
+		}
+
+		log.Info("Successfully restructured SAML signon_url to signon_urls")
+
+		return nil
+	}),
+	Down: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{"component": "migration", "version": 107, "action": "Down"}).Info("Reverting migration")
+
+		pipeline := []bson.M{
+			{
+				"$set": bson.M{
+					"authentication.saml.idp.signon_url": "$authentication.saml.idp.binding.post",
+				},
+			},
+			{
+				"$unset": "authentication.saml.idp.binding",
+			},
+		}
+
+		if _, err := db.Collection("system").UpdateOne(ctx, bson.M{}, pipeline); err != nil {
+			log.WithError(err).Error("Failed to revert system document")
+
+			return err
+		}
+
+		log.Info("Successfully reverted SAML signon_urls to signon_url")
+
+		return nil
+	}),
+}

--- a/api/store/mongo/migrations/migration_107_test.go
+++ b/api/store/mongo/migrations/migration_107_test.go
@@ -1,0 +1,109 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMigration107Up(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		description string
+		setup       func() error
+		verify      func(tt *testing.T)
+	}{
+		{
+			description: "succeeds restructuring signon_url to binding when SAML has signon_url",
+			setup: func() error {
+				system := bson.M{
+					"authentication": bson.M{
+						"saml": bson.M{
+							"enabled": true,
+							"idp": bson.M{
+								"signon_url": "https://example.com/saml/login",
+							},
+						},
+					},
+				}
+
+				_, err := c.Database("test").Collection("system").InsertOne(ctx, system)
+
+				return err
+			},
+			verify: func(tt *testing.T) {
+				system := make(map[string]any)
+				require.NoError(tt, c.Database("test").Collection("system").FindOne(ctx, bson.M{}).Decode(&system))
+
+				auth := system["authentication"].(map[string]any)
+				saml := auth["saml"].(map[string]any)
+				idp := saml["idp"].(map[string]any)
+
+				_, hasOldURL := idp["signon_url"]
+				assert.False(tt, hasOldURL)
+
+				binding, hasBinding := idp["binding"]
+				require.True(tt, hasBinding)
+
+				signonURLsMap := binding.(map[string]any)
+				assert.Equal(tt, "https://example.com/saml/login", signonURLsMap["post"])
+				assert.Equal(tt, "", signonURLsMap["redirect"])
+				assert.Equal(tt, "post", signonURLsMap["preferred"])
+			},
+		},
+		{
+			description: "creates binding even when SAML config doesn't exist",
+			setup: func() error {
+				system := bson.M{
+					"authentication": bson.M{
+						"local": bson.M{
+							"enabled": true,
+						},
+						"saml": bson.M{
+							"enabled": false,
+							"idp": bson.M{
+								"signon_url": "",
+							},
+						},
+					},
+				}
+
+				_, err := c.Database("test").Collection("system").InsertOne(ctx, system)
+
+				return err
+			},
+			verify: func(tt *testing.T) {
+				system := make(map[string]any)
+				require.NoError(tt, c.Database("test").Collection("system").FindOne(ctx, bson.M{}).Decode(&system))
+
+				auth := system["authentication"].(map[string]any)
+				saml, hasSAML := auth["saml"]
+				require.True(tt, hasSAML)
+
+				samlMap := saml.(map[string]any)
+				idp := samlMap["idp"].(map[string]any)
+
+				binding := idp["binding"].(map[string]any)
+				assert.Equal(tt, "", binding["post"])
+				assert.Equal(tt, "", binding["redirect"])
+				assert.Equal(tt, "", binding["preferred"])
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(tt *testing.T) {
+			tt.Cleanup(func() { assert.NoError(tt, srv.Reset()) })
+
+			require.NoError(tt, tc.setup())
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[106])
+			require.NoError(tt, migrates.Up(ctx, migrate.AllAvailable))
+			tc.verify(tt)
+		})
+	}
+}


### PR DESCRIPTION
- Add migration 107 to transform signon_url into bidingf object
- Update SystemIdpSAML model to use binding with post/redirect fields
- Maintain backward compatibility through migration down function
- Add comprehensive tests migrations

BREAKING CHANGE: SAML configuration now uses binding object instead of signon_url string