### PR TITLE
refactor(ui): add reusable `RoleSelect` component

### DIFF
--- a/ui/src/components/Team/ApiKeys/ApiKeyEdit.vue
+++ b/ui/src/components/Team/ApiKeys/ApiKeyEdit.vue
@@ -39,14 +39,9 @@
         </v-row>
         <v-row>
           <v-col>
-            <v-select
+            <RoleSelect
               v-if="hasAuthorization"
               v-model="selectedRole"
-              label="Key Role"
-              :items="itemsRoles"
-              :item-props="true"
-              variant="outlined"
-              return-object
               data-test="namespace-generate-role"
             />
           </v-col>
@@ -73,6 +68,8 @@ import { useStore } from "@/store";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
 import BaseDialog from "@/components/BaseDialog.vue";
+import RoleSelect from "@/components/Team/RoleSelect.vue";
+import { BasicRole } from "@/interfaces/INamespace";
 
 defineOptions({
   inheritAttrs: false,
@@ -89,7 +86,6 @@ const showDialog = ref(false);
 const store = useStore();
 const snackbar = useSnackbar();
 const keyGetter = computed(() => props.keyName);
-const isOwner = computed(() => store.getters["auth/role"] === "owner");
 const {
   value: keyInput,
   errorMessage: keyInputError,
@@ -117,34 +113,18 @@ const update = () => {
   showDialog.value = false;
 };
 
-const itemsRoles = [
-  {
-    title: "observer",
-    value: "observer",
-  },
-  {
-    title: "operator",
-    value: "operator",
-  },
-  {
-    title: "administrator",
-    value: "administrator",
-    disabled: !props.hasAuthorization || !isOwner.value,
-  },
-];
-
-const selectedRole = ref(itemsRoles.find((role) => role.value === props.keyRole) || itemsRoles[0]);
+const selectedRole = ref<BasicRole>(props.keyRole as BasicRole);
 
 const edit = async () => {
   const equalName = props.keyName === keyInput.value;
-  const equalRole = props.keyRole === selectedRole.value.value;
+  const equalRole = props.keyRole === selectedRole.value;
   const payload: { key: string; name?: string; role?: string } = { key: props.keyName };
 
   if (!equalName) {
     payload.name = keyInput.value;
   }
   if (!equalRole) {
-    payload.role = selectedRole.value.value;
+    payload.role = selectedRole.value;
   }
 
   try {

--- a/ui/src/components/Team/ApiKeys/ApiKeyGenerate.vue
+++ b/ui/src/components/Team/ApiKeys/ApiKeyGenerate.vue
@@ -56,13 +56,9 @@
               />
             </v-col>
             <v-col>
-              <v-select
+              <RoleSelect
                 v-if="hasAuthorization"
                 v-model="selectedRole"
-                label="Key Role"
-                :items="itemsRoles"
-                :item-props="true"
-                return-object
                 data-test="api-key-generate-role"
               />
             </v-col>
@@ -118,6 +114,8 @@ import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
 import CopyWarning from "@/components/User/CopyWarning.vue";
 import BaseDialog from "@/components/BaseDialog.vue";
+import RoleSelect from "@/components/Team/RoleSelect.vue";
+import { BasicRole } from "@/interfaces/INamespace";
 
 const emit = defineEmits(["update"]);
 const snackbar = useSnackbar();
@@ -127,7 +125,6 @@ const successKey = ref(false);
 const failKey = ref(false);
 const errorMessage = ref("");
 const keyResponse = computed(() => store.getters["apiKeys/apiKey"]);
-const isAdmin = computed(() => ["administrator", "owner"].includes(store.getters["auth/role"]));
 const hasAuthorization = computed(() => {
   const role = store.getters["auth/role"];
   return !!role && hasPermission(authorizer.role[role], actions.apiKey.create);
@@ -166,22 +163,6 @@ const getExpiryDate = (item) => {
   };
 };
 
-const itemsRoles = [
-  {
-    title: "observer",
-    value: "observer",
-  },
-  {
-    title: "operator",
-    value: "operator",
-  },
-  {
-    title: "administrator",
-    value: "administrator",
-    disabled: !hasAuthorization.value || !isAdmin.value,
-  },
-];
-
 const itemsDate = [
   {
     title: "30 days",
@@ -211,7 +192,7 @@ const itemsDate = [
 ];
 
 const selectedDate = ref(itemsDate[0]);
-const selectedRole = ref(itemsRoles[0]);
+const selectedRole = ref<BasicRole>("administrator");
 const expirationHint = ref(getExpiryDate(selectedDate.value.title).expirationDate);
 const tenant = computed(() => localStorage.getItem("tenant"));
 
@@ -251,7 +232,7 @@ const generateKey = async () => {
       tenant: tenant.value,
       name: keyName.value,
       expires_at: selectedDate.value.time,
-      role: selectedRole.value.title,
+      role: selectedRole.value,
     });
     successKey.value = true;
     failKey.value = false;
@@ -267,7 +248,7 @@ const close = () => {
   successKey.value = false;
   keyName.value = "";
   [selectedDate.value] = itemsDate;
-  [selectedRole.value] = itemsRoles;
+  selectedRole.value = "administrator";
 };
 defineExpose({ errorMessage });
 </script>

--- a/ui/src/components/Team/ApiKeys/ApiKeyList.vue
+++ b/ui/src/components/Team/ApiKeys/ApiKeyList.vue
@@ -17,7 +17,7 @@
             <v-icon class="mr-1" :icon="formatKey(item.expires_in) ? 'mdi-clock-alert-outline' : 'mdi-key-outline'" />
             {{ item.name }}
           </td>
-          <td :class="formatKey(item.expires_in) ? 'text-warning text-center' : 'text-center'" data-test="key-name">
+          <td :class="formatKey(item.expires_in) ? 'text-warning text-center' : 'text-center'" class="text-capitalize" data-test="key-name">
             {{ item.role }}
           </td>
           <td :class="formatKey(item.expires_in) ? 'text-warning text-center' : 'text-center'" data-test="key-name">

--- a/ui/src/components/Team/Member/MemberEdit.vue
+++ b/ui/src/components/Team/Member/MemberEdit.vue
@@ -24,18 +24,10 @@
         <v-divider />
 
         <v-card-text class="mt-4 mb-0 pb-1">
-          <v-row align="center">
-            <v-col cols="12">
-              <v-select
-                v-model="newRole"
-                :items="items"
-                label="Role"
-                :error-messages="errorMessage"
-                require
-                data-test="role-select"
-              />
-            </v-col>
-          </v-row>
+          <RoleSelect
+            v-model="newRole"
+            data-test="role-select"
+          />
         </v-card-text>
 
         <v-card-actions>
@@ -61,11 +53,12 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import axios from "axios";
-import { INamespaceMember } from "@/interfaces/INamespace";
+import { BasicRole, INamespaceMember } from "@/interfaces/INamespace";
 import { useStore } from "@/store";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
 import BaseDialog from "@/components/BaseDialog.vue";
+import RoleSelect from "@/components/Team/RoleSelect.vue";
 
 const { member, hasAuthorization } = defineProps<{
   member: INamespaceMember;
@@ -76,9 +69,7 @@ const emit = defineEmits(["update"]);
 const store = useStore();
 const snackbar = useSnackbar();
 const showDialog = ref(false);
-const newRole = ref(member.role);
-const errorMessage = ref("");
-const items = ["administrator", "operator", "observer"];
+const newRole = ref(member.role as BasicRole);
 
 const close = () => {
   showDialog.value = false;
@@ -94,23 +85,20 @@ const handleEditMemberError = (error: unknown) => {
     const status = error.response?.status;
     switch (status) {
       case 400:
-        errorMessage.value = "The user isn't linked to the namespace.";
+        snackbar.showError("The user isn't linked to the namespace.");
         break;
       case 403:
-        errorMessage.value = "You don't have permission to assign a role to the user.";
+        snackbar.showError("You don't have permission to assign a role to the user.");
         break;
       case 404:
-        errorMessage.value = "The username doesn't exist.";
+        snackbar.showError("The username doesn't exist.");
         break;
       default:
-        handleError(error);
+        snackbar.showError("Failed to update user role.");
     }
+  } else snackbar.showError("Failed to update user role.");
 
-    snackbar.showError("Failed to update user role.");
-  } else {
-    snackbar.showError("Failed to update user role.");
-    handleError(error);
-  }
+  handleError(error);
 };
 
 const editMember = async () => {

--- a/ui/src/components/Team/Member/MemberInvite.vue
+++ b/ui/src/components/Team/Member/MemberInvite.vue
@@ -90,29 +90,10 @@
             </v-card-text>
 
             <v-card-text class="mt-n10">
-              <v-select
+              <RoleSelect
                 v-model="selectedRole"
-                :items="items"
-                item-title="value"
-                item-value="value"
-                label="Role"
-                :error-messages="selectedRoleError"
-                required
                 data-test="role-select"
-              >
-                <template v-slot:item="{ props, item }">
-                  <v-list-item v-bind="props">
-                    <v-list-item-subtitle class="description-text">
-                      {{ item.raw.description }}
-                    </v-list-item-subtitle>
-                  </v-list-item>
-                </template>
-
-                <template v-slot:selection="{ item }">
-                  <span>{{ item.value }}</span>
-                </template>
-              </v-select>
-
+              />
               <v-checkbox
                 v-if="envVariables.isCloud"
                 v-model="getInvitationCheckbox"
@@ -188,23 +169,8 @@ import { envVariables } from "@/envVariables";
 import useSnackbar from "@/helpers/snackbar";
 import CopyWarning from "@/components/User/CopyWarning.vue";
 import BaseDialog from "@/components/BaseDialog.vue";
-
-const items = [
-  {
-    value: "Administrator",
-    // eslint-disable-next-line vue/max-len
-    description: "Full access to the namespace, can perform all actions except managing billing.\nThis includes user and device management, but excludes billing-related operations.",
-  },
-  {
-    value: "Operator",
-    // eslint-disable-next-line vue/max-len
-    description: "Can manage and operate devices, but has limited administrative privileges.\nOperators cannot change billing or ownership settings.",
-  },
-  {
-    value: "Observer",
-    description: "Can view device details and sessions but cannot make any changes.\nObservers have read-only access to monitor activity.",
-  },
-];
+import RoleSelect from "../RoleSelect.vue";
+import { BasicRole } from "@/interfaces/INamespace";
 
 const emit = defineEmits(["update"]);
 const store = useStore();
@@ -213,6 +179,7 @@ const showDialog = ref(false);
 const getInvitationCheckbox = ref(false);
 const invitationLink = computed(() => store.getters["namespaces/getInvitationLink"]);
 const formWindow = ref("form-1");
+const selectedRole = ref<BasicRole>("administrator");
 
 const {
   value: email,
@@ -221,14 +188,6 @@ const {
   resetField: resetIdentifier,
 } = useField<string>("identifier", yup.string().email().required(), {
   initialValue: "",
-});
-
-const {
-  value: selectedRole,
-  errorMessage: selectedRoleError,
-  resetField: resetSelectedRole,
-} = useField<string>("selectedRole", yup.string().required(), {
-  initialValue: undefined,
 });
 
 const hasAuthorization = () => {
@@ -240,12 +199,12 @@ const getAvatar = (index: number) => multiavatar(`${Math.floor(Math.random() * (
 
 const resetFields = () => {
   resetIdentifier();
-  resetSelectedRole();
+  selectedRole.value = "administrator";
 };
 
 const close = () => {
-  resetFields();
   showDialog.value = false;
+  resetFields();
   formWindow.value = "form-1";
 };
 
@@ -276,7 +235,7 @@ const handleInviteError = (error: unknown) => {
 const getInvitePayload = () => ({
   email: email.value,
   tenant_id: store.getters["auth/tenant"],
-  role: selectedRole.value.toLocaleLowerCase(),
+  role: selectedRole.value,
 });
 
 const generateLinkInvite = async () => {
@@ -319,12 +278,4 @@ defineExpose({ emailError, formWindow, invitationLink });
     z-index: #{$i};
   }
 }
-
-.description-text {
-  white-space: normal;
-  word-break: break-word;
-  max-width: 400px;
-  display: block;
-}
-
 </style>

--- a/ui/src/components/Team/Member/MemberList.vue
+++ b/ui/src/components/Team/Member/MemberList.vue
@@ -34,7 +34,7 @@
             {{ member.email }}
           </td>
 
-          <td class="text-center">
+          <td class="text-center text-capitalize">
             {{ member.role }}
           </td>
 

--- a/ui/src/components/Team/RoleSelect.vue
+++ b/ui/src/components/Team/RoleSelect.vue
@@ -1,0 +1,52 @@
+<template>
+  <v-select
+    v-model="selectedRole"
+    :items="roles"
+    label="Role"
+    required
+    data-test="role-select"
+  >
+    <template v-slot:item="{ props, item }">
+      <v-list-item v-bind="props">
+        <v-list-item-subtitle class="description-text">
+          {{ item.raw.description }}
+        </v-list-item-subtitle>
+      </v-list-item>
+    </template>
+  </v-select>
+</template>
+
+<script setup lang="ts">
+import { BasicRole } from "@/interfaces/INamespace";
+
+const roles = [
+  {
+    title: "Administrator",
+    value: "administrator",
+    // eslint-disable-next-line vue/max-len
+    description: "Full access to the namespace, can perform all actions except managing billing.\nThis includes user and device management, but excludes billing-related operations.",
+  },
+  {
+    title: "Operator",
+    value: "operator",
+    // eslint-disable-next-line vue/max-len
+    description: "Can manage and operate devices, but has limited administrative privileges.\nOperators cannot change billing or ownership settings.",
+  },
+  {
+    title: "Observer",
+    value: "observer",
+    description: "Can view device details and sessions but cannot make any changes.\nObservers have read-only access to monitor activity.",
+  },
+];
+
+const selectedRole = defineModel<BasicRole>({ required: true });
+</script>
+
+<style scoped lang="scss">
+.description-text {
+  white-space: normal;
+  word-break: break-word;
+  max-width: 600px;
+  display: block;
+}
+</style>

--- a/ui/src/interfaces/INamespace.ts
+++ b/ui/src/interfaces/INamespace.ts
@@ -1,6 +1,7 @@
 import { IBilling } from "./IBilling";
 
-export type Role = "administrator" | "operator" | "observer" | "owner";
+export type BasicRole = "administrator" | "operator" | "observer";
+export type Role = BasicRole | "owner";
 
 export interface INamespaceMember {
   id: string;

--- a/ui/tests/components/Team/ApiKeys/ApiKeyGenerate.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyGenerate.spec.ts
@@ -147,7 +147,7 @@ describe("Api Key Generate", () => {
     await flushPromises();
     expect(storeSpy).toHaveBeenCalledWith("apiKeys/generateApiKey", {
       name: "my api key",
-      role: "observer",
+      role: "administrator",
       expires_at: 30,
       tenant: "fake-tenant",
     });

--- a/ui/tests/components/Team/ApiKeys/__snapshots__/ApiKeyList.spec.ts.snap
+++ b/ui/tests/components/Team/ApiKeys/__snapshots__/ApiKeyList.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`Api Key List > Renders the component 1`] = `
           <tbody>
             <tr>
               <td class="text-warning text-center"><i class="mdi-clock-alert-outline mdi v-icon notranslate v-theme--light v-icon--size-default mr-1" aria-hidden="true"></i> aaaa2</td>
-              <td class="text-warning text-center" data-test="key-name">administrator</td>
+              <td class="text-warning text-center text-capitalize" data-test="key-name">administrator</td>
               <td class="text-warning text-center" data-test="key-name">Expired on Jul 7 2024.</td>
               <td class="text-center" data-test="menu-key-component"><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                   <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
@@ -31,7 +31,7 @@ exports[`Api Key List > Renders the component 1`] = `
             </tr>
             <tr>
               <td class="text-warning text-center"><i class="mdi-clock-alert-outline mdi v-icon notranslate v-theme--light v-icon--size-default mr-1" aria-hidden="true"></i> aaaa2</td>
-              <td class="text-warning text-center" data-test="key-name">administrator</td>
+              <td class="text-warning text-center text-capitalize" data-test="key-name">administrator</td>
               <td class="text-warning text-center" data-test="key-name">Expired on Jul 7 2024.</td>
               <td class="text-center" data-test="menu-key-component"><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-6"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                   <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>

--- a/ui/tests/components/Team/Member/MemberEdit.spec.ts
+++ b/ui/tests/components/Team/Member/MemberEdit.spec.ts
@@ -110,7 +110,7 @@ describe("Member Edit", () => {
   });
 
   it("Edit Member Error Validation", async () => {
-    mockNamespace.onPatch("http://localhost:3000/api/namespaces/fake-tenant-data/members").reply(409);
+    mockNamespace.onPatch("http://localhost:3000/api/namespaces/fake-tenant-data/members/xxxxxxxx").reply(409);
 
     const storeSpy = vi.spyOn(store, "dispatch");
 
@@ -132,7 +132,7 @@ describe("Member Edit", () => {
   });
 
   it("Edit Member Success Validation", async () => {
-    mockNamespace.onPatch("http://localhost:3000/api/namespaces/fake-tenant-data/members").reply(200);
+    mockNamespace.onPatch("http://localhost:3000/api/namespaces/fake-tenant-data/members/xxxxxxxx").reply(200);
 
     const storeSpy = vi.spyOn(store, "dispatch");
 

--- a/ui/tests/components/Team/RoleSelect/RoleSelect.spec.ts
+++ b/ui/tests/components/Team/RoleSelect/RoleSelect.spec.ts
@@ -1,0 +1,61 @@
+import { mount, VueWrapper } from "@vue/test-utils";
+import { createVuetify } from "vuetify";
+import { expect, describe, it, beforeEach } from "vitest";
+import RoleSelect from "@/components/Team/RoleSelect.vue";
+import { BasicRole } from "@/interfaces/INamespace";
+
+describe("RoleSelect", () => {
+  let wrapper: VueWrapper<InstanceType<typeof RoleSelect>>;
+  const vuetify = createVuetify();
+
+  beforeEach(async () => {
+    wrapper = mount(RoleSelect, {
+      global: {
+        plugins: [vuetify],
+      },
+      props: {
+        modelValue: "administrator" as BasicRole,
+      },
+    });
+  });
+
+  it("Is a Vue instance", () => {
+    expect(wrapper.vm).toBeTruthy();
+  });
+
+  it("Renders the component", () => {
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  it("renders the role select component", () => {
+    expect(wrapper.find('[data-test="role-select"]').exists()).toBe(true);
+  });
+
+  it("displays the initial model value", async () => {
+    const selectComponent = wrapper.findComponent({ name: "VSelect" });
+    expect(selectComponent.props("modelValue")).toBe("administrator");
+  });
+
+  it("has correct values for each role", () => {
+    const select = wrapper.findComponent({ name: "VSelect" });
+    const items = select.props("items");
+
+    expect(items[0]).toEqual({
+      title: "Administrator",
+      value: "administrator",
+      description: expect.stringContaining("Full access to the namespace"),
+    });
+
+    expect(items[1]).toEqual({
+      title: "Operator",
+      value: "operator",
+      description: expect.stringContaining("Can manage and operate devices"),
+    });
+
+    expect(items[2]).toEqual({
+      title: "Observer",
+      value: "observer",
+      description: expect.stringContaining("Can view device details"),
+    });
+  });
+});

--- a/ui/tests/components/Team/RoleSelect/__snapshots__/RoleSelect.spec.ts.snap
+++ b/ui/tests/components/Team/RoleSelect/__snapshots__/RoleSelect.spec.ts.snap
@@ -1,0 +1,56 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RoleSelect > Renders the component 1`] = `
+"<div data-v-444f7389="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-select v-select--single v-select--selected" data-test="role-select">
+  <!---->
+  <div class="v-input__control">
+    <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-controls="v-menu-v-2">
+      <div class="v-field__overlay"></div>
+      <div class="v-field__loader">
+        <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+          <!---->
+          <div class="v-progress-linear__background"></div>
+          <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+          <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+            <div class="v-progress-linear__indeterminate">
+              <div class="v-progress-linear__indeterminate long"></div>
+              <div class="v-progress-linear__indeterminate short"></div>
+            </div>
+          </transition-stub>
+          <!---->
+        </div>
+      </div>
+      <!---->
+      <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" for="input-v-0" aria-hidden="false">
+          <!---->Role
+        </label><label class="v-label v-field-label" for="input-v-0">
+          <!---->Role
+        </label>
+        <!---->
+        <div class="v-field__input" data-no-activator="">
+          <!---->
+          <!---->
+          <div class="v-select__selection"><span class="v-select__selection-text">Administrator<!----></span></div><input size="1" type="text" id="input-v-0" aria-describedby="input-v-0-messages" inputmode="none" aria-label="Open" title="Open" required="" value="administrator">
+        </div>
+        <!---->
+      </div>
+      <!---->
+      <div class="v-field__append-inner">
+        <!----><i class="mdi-menu-down mdi v-icon notranslate v-theme--light v-icon--size-default v-select__menu-icon" aria-hidden="true"></i>
+        <!---->
+      </div>
+      <div class="v-field__outline">
+        <!---->
+        <!---->
+      </div>
+    </div>
+  </div>
+  <!---->
+  <div id="input-v-0-messages" class="v-input__details" role="alert" aria-live="polite">
+    <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
+      <!---->
+    </transition-group-stub>
+    <!---->
+  </div>
+</div>"
+`;

--- a/ui/tests/views/__snapshots__/TeamApiKeys.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/TeamApiKeys.spec.ts.snap
@@ -36,7 +36,7 @@ exports[`Team Api Keys > Renders the component 1`] = `
             <tbody>
               <tr>
                 <td class="text-warning text-center"><i class="mdi-clock-alert-outline mdi v-icon notranslate v-theme--light v-icon--size-default mr-1" aria-hidden="true"></i> fake-api-key</td>
-                <td class="text-warning text-center" data-test="key-name">owner</td>
+                <td class="text-warning text-center text-capitalize" data-test="key-name">owner</td>
                 <td class="text-warning text-center" data-test="key-name">Expired on Jan 1 1970.</td>
                 <td class="text-center" data-test="menu-key-component"><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-4"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                     <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>

--- a/ui/tests/views/__snapshots__/TeamMembers.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/TeamMembers.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`Team Members > Renders the component 1`] = `
         <tbody data-test="member-table-rows">
           <tr class="text-center">
             <td><i class="mdi-account mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i> </td>
-            <td class="text-center">owner</td>
+            <td class="text-center text-capitalize">owner</td>
             <td class="text-center" aria-describedby="v-tooltip-v-2">
               <!---->
               <!--teleport start-->


### PR DESCRIPTION
This pull request refactors role selection across multiple components by introducing a reusable `RoleSelect` component and simplifying role-related logic. Additionally, it removes redundant code and ensures consistent capitalization for role display. 

Affected components:
- `MemberInvite.vue`
- `MemberEdit.vue`
- `ApiKeyGenerate.vue`
- `ApiKeyEdit.vue`

Tests and snapshots were also added/updated.