### PR TITLE
fix(agent): remove agent updater container instead of stopping it

### DIFF
--- a/pkg/agent/pkg/selfupdater/updater_docker.go
+++ b/pkg/agent/pkg/selfupdater/updater_docker.go
@@ -81,6 +81,10 @@ func (d *dockerUpdater) CompleteUpdate() error {
 		return err
 	}
 
+	if err := d.removeContainer(parent); err != nil {
+		return err
+	}
+
 	_, pv := parent.splitImageVersion()
 	v, _ := semver.NewVersion(pv)
 	v0_4_0, _ := semver.NewVersion("v0.4.0")
@@ -135,7 +139,7 @@ func (d *dockerUpdater) CompleteUpdate() error {
 		return err
 	}
 
-	if err := d.stopContainer(container); err != nil {
+	if err := d.removeContainer(container); err != nil {
 		return err
 	}
 
@@ -179,10 +183,14 @@ func (d *dockerUpdater) stopContainer(container *dockerContainer) error {
 		return err
 	}
 
-	opts := containertypes.RemoveOptions{Force: true, RemoveVolumes: true}
-	err := d.api.ContainerRemove(ctx, container.info.ID, opts)
+	return nil
+}
 
-	return err
+func (d *dockerUpdater) removeContainer(container *dockerContainer) error {
+	ctx := context.Background()
+
+	opts := containertypes.RemoveOptions{Force: true, RemoveVolumes: true}
+	return d.api.ContainerRemove(ctx, container.info.ID, opts)
 }
 
 func (d *dockerUpdater) updateContainer(container *dockerContainer, image, name string, parent bool) (*dockerContainer, error) { //nolint:unparam


### PR DESCRIPTION
This commit resolves an issue where the updater container was stopping itself, preventing its removal after the update process. The previous implementation of the `CompleteUpdate` method would stop the updater container, resulting in it remaining in a stopped state rather than being properly removed.

This behavior led to wasted system resources, as accumulated stopped containers could complicate the environment. By directly removing the updater container, we enhance resource management and streamline the update process.