### PR TITLE
feat(ui): update SAML configuration to support POST and Redirect URLs

### DIFF
--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -116,6 +116,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration104,
 		migration105,
 		migration106,
+		migration107,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_107.go
+++ b/api/store/mongo/migrations/migration_107.go
@@ -1,0 +1,78 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	log "github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration107 = migrate.Migration{
+	Version:     107,
+	Description: "Restructure SAML signon_url to signon_urls object with post and redirect fields",
+	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{"component": "migration", "version": 107, "action": "Up"}).Info("Applying migration")
+
+		system := &models.System{}
+		if err := db.Collection("system").FindOne(ctx, bson.M{}).Decode(system); err != nil {
+			return err
+		}
+
+		preferred := ""
+		if system.Authentication.SAML.Enabled {
+			preferred = "post"
+		}
+
+		pipeline := []bson.M{
+			{
+				"$set": bson.M{
+					"authentication.saml.idp.binding": bson.M{
+						"post":      bson.M{"$ifNull": []any{"$authentication.saml.idp.signon_url", ""}},
+						"redirect":  "",
+						"preferred": preferred,
+					},
+				},
+			},
+			{
+				"$unset": "authentication.saml.idp.signon_url",
+			},
+		}
+
+		if _, err := db.Collection("system").UpdateOne(ctx, bson.M{}, pipeline); err != nil {
+			log.WithError(err).Error("Failed to update system document")
+
+			return err
+		}
+
+		log.Info("Successfully restructured SAML signon_url to signon_urls")
+
+		return nil
+	}),
+	Down: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{"component": "migration", "version": 107, "action": "Down"}).Info("Reverting migration")
+
+		pipeline := []bson.M{
+			{
+				"$set": bson.M{
+					"authentication.saml.idp.signon_url": "$authentication.saml.idp.binding.post",
+				},
+			},
+			{
+				"$unset": "authentication.saml.idp.binding",
+			},
+		}
+
+		if _, err := db.Collection("system").UpdateOne(ctx, bson.M{}, pipeline); err != nil {
+			log.WithError(err).Error("Failed to revert system document")
+
+			return err
+		}
+
+		log.Info("Successfully reverted SAML signon_urls to signon_url")
+
+		return nil
+	}),
+}

--- a/api/store/mongo/migrations/migration_107_test.go
+++ b/api/store/mongo/migrations/migration_107_test.go
@@ -1,0 +1,109 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMigration107Up(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		description string
+		setup       func() error
+		verify      func(tt *testing.T)
+	}{
+		{
+			description: "succeeds restructuring signon_url to binding when SAML has signon_url",
+			setup: func() error {
+				system := bson.M{
+					"authentication": bson.M{
+						"saml": bson.M{
+							"enabled": true,
+							"idp": bson.M{
+								"signon_url": "https://example.com/saml/login",
+							},
+						},
+					},
+				}
+
+				_, err := c.Database("test").Collection("system").InsertOne(ctx, system)
+
+				return err
+			},
+			verify: func(tt *testing.T) {
+				system := make(map[string]any)
+				require.NoError(tt, c.Database("test").Collection("system").FindOne(ctx, bson.M{}).Decode(&system))
+
+				auth := system["authentication"].(map[string]any)
+				saml := auth["saml"].(map[string]any)
+				idp := saml["idp"].(map[string]any)
+
+				_, hasOldURL := idp["signon_url"]
+				assert.False(tt, hasOldURL)
+
+				binding, hasBinding := idp["binding"]
+				require.True(tt, hasBinding)
+
+				signonURLsMap := binding.(map[string]any)
+				assert.Equal(tt, "https://example.com/saml/login", signonURLsMap["post"])
+				assert.Equal(tt, "", signonURLsMap["redirect"])
+				assert.Equal(tt, "post", signonURLsMap["preferred"])
+			},
+		},
+		{
+			description: "creates binding even when SAML config doesn't exist",
+			setup: func() error {
+				system := bson.M{
+					"authentication": bson.M{
+						"local": bson.M{
+							"enabled": true,
+						},
+						"saml": bson.M{
+							"enabled": false,
+							"idp": bson.M{
+								"signon_url": "",
+							},
+						},
+					},
+				}
+
+				_, err := c.Database("test").Collection("system").InsertOne(ctx, system)
+
+				return err
+			},
+			verify: func(tt *testing.T) {
+				system := make(map[string]any)
+				require.NoError(tt, c.Database("test").Collection("system").FindOne(ctx, bson.M{}).Decode(&system))
+
+				auth := system["authentication"].(map[string]any)
+				saml, hasSAML := auth["saml"]
+				require.True(tt, hasSAML)
+
+				samlMap := saml.(map[string]any)
+				idp := samlMap["idp"].(map[string]any)
+
+				binding := idp["binding"].(map[string]any)
+				assert.Equal(tt, "", binding["post"])
+				assert.Equal(tt, "", binding["redirect"])
+				assert.Equal(tt, "", binding["preferred"])
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(tt *testing.T) {
+			tt.Cleanup(func() { assert.NoError(tt, srv.Reset()) })
+
+			require.NoError(tt, tc.setup())
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[106])
+			require.NoError(tt, migrates.Up(ctx, migrate.AllAvailable))
+			tc.verify(tt)
+		})
+	}
+}

--- a/ui/admin/src/api/client/api.ts
+++ b/ui/admin/src/api/client/api.ts
@@ -450,12 +450,6 @@ export interface ConfigureSAMLAuthenticationRequestIdp {
      */
     'entity_id'?: string;
     /**
-     * The Sign-On URL of the IdP.
-     * @type {string}
-     * @memberof ConfigureSAMLAuthenticationRequestIdp
-     */
-    'signon_url'?: string;
-    /**
      * The public X509 certificate of the IdP. It can be provided with or without  the PEM delimiters (`-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`). 
      * @type {string}
      * @memberof ConfigureSAMLAuthenticationRequestIdp
@@ -463,11 +457,50 @@ export interface ConfigureSAMLAuthenticationRequestIdp {
     'certificate'?: string;
     /**
      * 
+     * @type {ConfigureSAMLAuthenticationRequestIdpBinding}
+     * @memberof ConfigureSAMLAuthenticationRequestIdp
+     */
+    'binding'?: ConfigureSAMLAuthenticationRequestIdpBinding;
+    /**
+     * 
      * @type {ConfigureSAMLAuthenticationRequestIdpMappings}
      * @memberof ConfigureSAMLAuthenticationRequestIdp
      */
     'mappings'?: ConfigureSAMLAuthenticationRequestIdpMappings;
 }
+/**
+ * Configuration for SAML binding methods that define how authentication requests  and responses are transmitted between ShellHub and the IdP. SAML supports  different binding protocols for flexibility in deployment scenarios. 
+ * @export
+ * @interface ConfigureSAMLAuthenticationRequestIdpBinding
+ */
+export interface ConfigureSAMLAuthenticationRequestIdpBinding {
+    /**
+     * The Single Sign-On URL for HTTP-POST binding. This URL is where ShellHub  will redirect users for authentication using the HTTP-POST method, which  sends SAML data in the body of an HTTP POST request. This binding is more  secure as it doesn\'t expose SAML data in URL parameters. 
+     * @type {string}
+     * @memberof ConfigureSAMLAuthenticationRequestIdpBinding
+     */
+    'post'?: string;
+    /**
+     * The Single Sign-On URL for HTTP-Redirect binding. This URL is where ShellHub  will redirect users for authentication using the HTTP-Redirect method, which  sends SAML data as URL parameters. This binding is simpler but has URL length  limitations and exposes SAML data in browser history and server logs. 
+     * @type {string}
+     * @memberof ConfigureSAMLAuthenticationRequestIdpBinding
+     */
+    'redirect'?: string;
+    /**
+     * Specifies which binding method ShellHub should prefer when both POST and  Redirect bindings are available. If only one binding URL is provided,  that binding will be used regardless of this preference setting. If left blank or empty, POST binding is preferred by default. 
+     * @type {string}
+     * @memberof ConfigureSAMLAuthenticationRequestIdpBinding
+     */
+    'preferred'?: ConfigureSAMLAuthenticationRequestIdpBindingPreferredEnum;
+}
+
+export const ConfigureSAMLAuthenticationRequestIdpBindingPreferredEnum = {
+    Post: 'post',
+    Redirect: 'redirect'
+} as const;
+
+export type ConfigureSAMLAuthenticationRequestIdpBindingPreferredEnum = typeof ConfigureSAMLAuthenticationRequestIdpBindingPreferredEnum[keyof typeof ConfigureSAMLAuthenticationRequestIdpBindingPreferredEnum];
+
 /**
  * Defines how SAML attributes from the IdP should be mapped to ShellHub user attributes. 
  * @export
@@ -1039,12 +1072,6 @@ export interface GetAuthenticationSettings200ResponseSamlIdp {
      */
     'entity_id'?: string;
     /**
-     * The Sign-On URL of the IdP.
-     * @type {string}
-     * @memberof GetAuthenticationSettings200ResponseSamlIdp
-     */
-    'signon_url'?: string;
-    /**
      * The list of public X509 certificates of the IdP.
      * @type {Array<string>}
      * @memberof GetAuthenticationSettings200ResponseSamlIdp
@@ -1052,11 +1079,50 @@ export interface GetAuthenticationSettings200ResponseSamlIdp {
     'certificates'?: Array<string>;
     /**
      * 
+     * @type {GetAuthenticationSettings200ResponseSamlIdpBinding}
+     * @memberof GetAuthenticationSettings200ResponseSamlIdp
+     */
+    'binding'?: GetAuthenticationSettings200ResponseSamlIdpBinding;
+    /**
+     * 
      * @type {GetAuthenticationSettings200ResponseSamlIdpMappings}
      * @memberof GetAuthenticationSettings200ResponseSamlIdp
      */
     'mappings'?: GetAuthenticationSettings200ResponseSamlIdpMappings;
 }
+/**
+ * Configuration for SAML binding methods that define how authentication requests  and responses are transmitted between ShellHub and the IdP. 
+ * @export
+ * @interface GetAuthenticationSettings200ResponseSamlIdpBinding
+ */
+export interface GetAuthenticationSettings200ResponseSamlIdpBinding {
+    /**
+     * The Single Sign-On URL for HTTP-POST binding. This URL is where ShellHub  will redirect users for authentication using the HTTP-POST method. 
+     * @type {string}
+     * @memberof GetAuthenticationSettings200ResponseSamlIdpBinding
+     */
+    'post'?: string;
+    /**
+     * The Single Sign-On URL for HTTP-Redirect binding. This URL is where ShellHub  will redirect users for authentication using the HTTP-Redirect method. 
+     * @type {string}
+     * @memberof GetAuthenticationSettings200ResponseSamlIdpBinding
+     */
+    'redirect'?: string;
+    /**
+     * Specifies which binding method ShellHub prefers when both POST and  Redirect bindings are available. If left blank or empty, POST binding is preferred. 
+     * @type {string}
+     * @memberof GetAuthenticationSettings200ResponseSamlIdpBinding
+     */
+    'preferred'?: GetAuthenticationSettings200ResponseSamlIdpBindingPreferredEnum;
+}
+
+export const GetAuthenticationSettings200ResponseSamlIdpBindingPreferredEnum = {
+    Post: 'post',
+    Redirect: 'redirect'
+} as const;
+
+export type GetAuthenticationSettings200ResponseSamlIdpBindingPreferredEnum = typeof GetAuthenticationSettings200ResponseSamlIdpBindingPreferredEnum[keyof typeof GetAuthenticationSettings200ResponseSamlIdpBindingPreferredEnum];
+
 /**
  * 
  * @export

--- a/ui/admin/src/components/Settings/SettingsAuthentication.vue
+++ b/ui/admin/src/components/Settings/SettingsAuthentication.vue
@@ -82,14 +82,26 @@
           </v-col>
         </v-row>
 
-        <v-row>
+        <v-row v-if="ssoSettings.saml?.idp.binding.post">
           <v-col md="auto" sm="auto">
-            <v-card tile :elevation="0" data-test="idp-signon-label">IdP SignOn URL</v-card>
+            <v-card tile :elevation="0" data-test="idp-signon-post-label">IdP SignOn POST URL</v-card>
           </v-col>
           <v-spacer />
           <v-col md="auto" sm="auto" class="ml-auto">
-            <v-card tile :elevation="0" data-test="idp-signon-value">
-              {{ ssoSettings.saml?.idp.signon_url }}
+            <v-card tile :elevation="0" data-test="idp-signon-post-value">
+              {{ ssoSettings.saml?.idp.binding.post }}
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <v-row v-if="ssoSettings.saml?.idp.binding.redirect">
+          <v-col md="auto" sm="auto">
+            <v-card tile :elevation="0" data-test="idp-signon-redirect-label">IdP SignOn Redirect URL</v-card>
+          </v-col>
+          <v-spacer />
+          <v-col md="auto" sm="auto" class="ml-auto">
+            <v-card tile :elevation="0" data-test="idp-signon-redirect-value">
+              {{ ssoSettings.saml?.idp.binding.redirect }}
             </v-card>
           </v-col>
         </v-row>

--- a/ui/admin/src/interfaces/IInstance.ts
+++ b/ui/admin/src/interfaces/IInstance.ts
@@ -1,9 +1,21 @@
+// Binding needs to receive either post or redirect URL, or both.
+type SAMLBinding = ({
+  post: string,
+} | {
+  redirect: string,
+} | {
+  post: string,
+  redirect: string,
+}) & {
+  preferred?: "post" | "redirect",
+}
+
 export interface IAdminSAMLConfig {
   enable: boolean,
   idp: {
     metadata_url?: string,
     entity_id?: string,
-    signon_url?: string,
+    binding?: SAMLBinding,
     certificate?: string
     mappings?: {
       email: string,

--- a/ui/admin/src/store/api/instance.ts
+++ b/ui/admin/src/store/api/instance.ts
@@ -1,5 +1,5 @@
-import { adminApi } from "./../../api/http";
-import { IAdminSAMLConfig } from "../../interfaces/IInstance";
+import { adminApi } from "@admin/api/http";
+import { IAdminSAMLConfig } from "@admin/interfaces/IInstance";
 
 const getAuthenticationSettings = async () => adminApi.getAuthenticationSettings();
 

--- a/ui/admin/src/store/modules/instance.ts
+++ b/ui/admin/src/store/modules/instance.ts
@@ -14,7 +14,10 @@ export interface InstanceState {
       assertion_url: string;
       idp: {
         entity_id: string;
-        signon_url: string;
+        binding: {
+          post?: string;
+          redirect?: string;
+        };
         certificates: string[];
       };
       sp: {
@@ -37,7 +40,10 @@ export const useInstanceStore = defineStore("instance", {
         assertion_url: "",
         idp: {
           entity_id: "",
-          signon_url: "",
+          binding: {
+            post: "",
+            redirect: "",
+          },
           certificates: [],
         },
         sp: {

--- a/ui/admin/tests/unit/components/Instance/SSO/index.spec.ts
+++ b/ui/admin/tests/unit/components/Instance/SSO/index.spec.ts
@@ -38,17 +38,17 @@ describe("Configure SSO", () => {
   });
 
   it("resets fields when 'close' is clicked", async () => {
-    wrapper.vm.checkbox = true;
+    wrapper.vm.useMetadataUrl = true;
     wrapper.vm.IdPMetadataURL = "https://example.com/metadata";
 
     await wrapper.findComponent("[data-test='close-btn']").trigger("click");
 
     expect(wrapper.vm.IdPMetadataURL).toBe("");
-    expect(wrapper.vm.checkbox).toBe(false);
+    expect(wrapper.vm.useMetadataUrl).toBe(false);
   });
 
   it("disables save button if required fields are empty", () => {
-    wrapper.vm.checkbox = true;
+    wrapper.vm.useMetadataUrl = true;
     wrapper.vm.IdPMetadataURL = "";
 
     expect(wrapper.findComponent("[data-test='save-btn']").attributes("disabled")).toBeDefined();

--- a/ui/admin/tests/unit/components/Settings/SettingsAuthentication/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Settings/SettingsAuthentication/__snapshots__/index.spec.ts.snap
@@ -174,7 +174,7 @@ exports[`Authentication > renders correctly 1`] = `
       </div>
       <div class="v-row">
         <div class="v-col-sm-auto v-col-md-auto v-col">
-          <div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated" data-test="idp-signon-label">
+          <div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated" data-test="idp-signon-post-label">
             <!---->
             <div class="v-card__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -191,14 +191,14 @@ exports[`Authentication > renders correctly 1`] = `
               </div>
             </div>
             <!---->
-            <!---->IdP SignOn URL
+            <!---->IdP SignOn POST URL
             <!---->
             <!----><span class="v-card__underlay"></span>
           </div>
         </div>
         <div class="v-spacer"></div>
         <div class="v-col-sm-auto v-col-md-auto v-col ml-auto">
-          <div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated" data-test="idp-signon-value">
+          <div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated" data-test="idp-signon-post-value">
             <!---->
             <div class="v-card__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -215,7 +215,56 @@ exports[`Authentication > renders correctly 1`] = `
               </div>
             </div>
             <!---->
-            <!---->https://signon.example.com
+            <!---->https://example.com/signon-post
+            <!---->
+            <!----><span class="v-card__underlay"></span>
+          </div>
+        </div>
+      </div>
+      <div class="v-row">
+        <div class="v-col-sm-auto v-col-md-auto v-col">
+          <div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated" data-test="idp-signon-redirect-label">
+            <!---->
+            <div class="v-card__loader">
+              <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                <!---->
+                <div class="v-progress-linear__background"></div>
+                <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                  <div class="v-progress-linear__indeterminate">
+                    <div class="v-progress-linear__indeterminate long"></div>
+                    <div class="v-progress-linear__indeterminate short"></div>
+                  </div>
+                </transition-stub>
+                <!---->
+              </div>
+            </div>
+            <!---->
+            <!---->IdP SignOn Redirect URL
+            <!---->
+            <!----><span class="v-card__underlay"></span>
+          </div>
+        </div>
+        <div class="v-spacer"></div>
+        <div class="v-col-sm-auto v-col-md-auto v-col ml-auto">
+          <div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated" data-test="idp-signon-redirect-value">
+            <!---->
+            <div class="v-card__loader">
+              <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                <!---->
+                <div class="v-progress-linear__background"></div>
+                <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                  <div class="v-progress-linear__indeterminate">
+                    <div class="v-progress-linear__indeterminate long"></div>
+                    <div class="v-progress-linear__indeterminate short"></div>
+                  </div>
+                </transition-stub>
+                <!---->
+              </div>
+            </div>
+            <!---->
+            <!---->https://example.com/signon-redirect
             <!---->
             <!----><span class="v-card__underlay"></span>
           </div>

--- a/ui/admin/tests/unit/components/Settings/SettingsAuthentication/index.spec.ts
+++ b/ui/admin/tests/unit/components/Settings/SettingsAuthentication/index.spec.ts
@@ -4,10 +4,10 @@ import { createVuetify } from "vuetify";
 import { createPinia, setActivePinia } from "pinia";
 import MockAdapter from "axios-mock-adapter";
 import useInstanceStore from "@admin/store/modules/instance";
+import SettingsAuthentication from "@admin/components/Settings/SettingsAuthentication.vue";
+import { adminApi } from "@admin/api/http";
+import routes from "@admin/router";
 import { SnackbarPlugin } from "@/plugins/snackbar";
-import { adminApi } from "../../../../../src/api/http";
-import SettingsAuthentication from "../../../../../src/components/Settings/SettingsAuthentication.vue";
-import routes from "../../../../../src/router";
 
 Object.assign(navigator, {
   clipboard: {
@@ -38,7 +38,10 @@ const authData = {
     assertion_url: "http://example/api/user/saml/auth",
     idp: {
       entity_id: "entity-id-example",
-      signon_url: "https://signon.example.com",
+      binding: {
+        post: "https://example.com/signon-post",
+        redirect: "https://example.com/signon-redirect",
+      },
       certificates: ["certificate-string"],
       mappings: {
         email: "emailAddress",
@@ -104,7 +107,8 @@ describe("Authentication", () => {
   });
 
   it("renders SAML settings when enabled", () => {
-    expect(wrapper.find("[data-test='idp-signon-value']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='idp-signon-post-value']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='idp-signon-redirect-value']").exists()).toBe(true);
     expect(wrapper.find("[data-test='idp-entity-value']").exists()).toBe(true);
   });
 

--- a/ui/admin/tests/unit/store/modules/instance.spec.ts
+++ b/ui/admin/tests/unit/store/modules/instance.spec.ts
@@ -15,7 +15,10 @@ describe("Instance Pinia Store", () => {
       assertion_url: "https://example.com/assertion",
       idp: {
         entity_id: "entity123",
-        signon_url: "https://example.com/signon",
+        binding: {
+          post: "https://example.com/signon-post",
+          redirect: "https://example.com/signon-redirect",
+        },
         certificates: ["cert123"],
       },
       sp: {
@@ -40,7 +43,10 @@ describe("Instance Pinia Store", () => {
           assertion_url: "",
           idp: {
             entity_id: "",
-            signon_url: "",
+            binding: {
+              post: "",
+              redirect: "",
+            },
             certificates: [],
           },
           sp: {


### PR DESCRIPTION
This pull request updates the admin's UI to support both POST and Redirect URLs for SAML configuration instead of a single signon URL.