### PR TITLE
fix(ui): fix `PrivateKeyEdit` reactivity

### DIFF
--- a/ui/src/components/PrivateKeys/PrivateKeyEdit.vue
+++ b/ui/src/components/PrivateKeys/PrivateKeyEdit.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-list-item @click="showDialog = true" data-test="privatekey-edit-btn">
+    <v-list-item @click="open" data-test="privatekey-edit-btn">
       <div class="d-flex align-center">
         <div data-test="privatekey-icon" class="mr-2">
           <v-icon>mdi-pencil</v-icon>
@@ -76,7 +76,7 @@
 
 <script setup lang="ts">
 import { useField } from "vee-validate";
-import { ref, onMounted } from "vue";
+import { ref } from "vue";
 import * as yup from "yup";
 import { useStore } from "@/store";
 import handleError from "@/utils/handleError";
@@ -132,16 +132,18 @@ const validatePrivateKeyData = () => {
   }
 };
 
-const setPrivateKey = () => {
+const initializeFormData = () => {
+  name.value = privateKey.name ?? "";
   keyLocal.value = privateKey.data ?? "";
+  setKeyLocalError("");
 };
 
-onMounted(() => {
-  setPrivateKey();
-});
+const open = () => {
+  showDialog.value = true;
+  initializeFormData();
+};
 
 const close = () => {
-  setPrivateKey();
   resetPassphrase();
   hasPassphrase.value = privateKey.hasPassphrase;
   showDialog.value = false;
@@ -203,6 +205,5 @@ const edit = async () => {
     handleEditError(error as Error);
   }
 };
-
-defineExpose({ keyLocal, name, hasPassphrase, update, edit, handleError, setPrivateKey });
+defineExpose({ keyLocal, name, hasPassphrase, update, edit, handleError, initializeFormData });
 </script>

--- a/ui/src/components/PrivateKeys/PrivateKeyList.vue
+++ b/ui/src/components/PrivateKeys/PrivateKeyList.vue
@@ -17,7 +17,7 @@
           {{ privateKey.name }}
         </td>
         <td class="text-center" data-test="privateKey-fingerprint">
-          {{ convertToFingerprint(privateKey.data) }}
+          {{ getKeyFingerprint(privateKey) }}
         </td>
         <td class="text-center">
           <v-menu
@@ -60,10 +60,11 @@
 <script setup lang="ts">
 import { computed, onMounted } from "vue";
 import { useStore } from "@/store";
-import { convertToFingerprint } from "@/utils/validate";
 import PrivateKeyDelete from "./PrivateKeyDelete.vue";
 import PrivateKeyEdit from "./PrivateKeyEdit.vue";
 import handleError from "@/utils/handleError";
+import { IPrivateKey } from "@/interfaces/IPrivateKey";
+import { convertToFingerprint } from "@/utils/validate";
 
 const store = useStore();
 const headers = [
@@ -94,6 +95,15 @@ const getPrivateKeys = async () => {
   } catch (error: unknown) {
     handleError(error);
   }
+};
+
+const getKeyFingerprint = (privateKey: IPrivateKey) => {
+  if (privateKey.fingerprint) {
+    return privateKey.fingerprint;
+  }
+
+  const fingerprint = convertToFingerprint(privateKey.data);
+  return fingerprint || "Fingerprint not available";
 };
 
 onMounted(() => {

--- a/ui/src/components/Terminal/Terminal.vue
+++ b/ui/src/components/Terminal/Terminal.vue
@@ -28,15 +28,16 @@ import {
 // SSH signing utilities
 import {
   parsePrivateKeySsh,
-  createSignatureOfPrivateKey,
-  createSignerPrivateKey,
+  generateSignature,
 } from "@/utils/validate";
+
 import handleError from "@/utils/handleError";
 
 // Props passed to the component
-const { token, privateKey } = defineProps<{
+const { token, privateKey, passphrase } = defineProps<{
   token: string;
   privateKey?: string | null;
+  passphrase?: string;
 }>();
 
 // References and reactive state
@@ -112,11 +113,8 @@ const signWebSocketChallenge = async (
   base64Challenge: Base64URLString,
 ): Promise<Base64URLString> => {
   const challengeBuffer = Buffer.from(base64Challenge, "base64");
-  const parsedKey = parsePrivateKeySsh(key);
-
-  return parsedKey.type === "ed25519"
-    ? createSignerPrivateKey(parsedKey, challengeBuffer)
-    : createSignatureOfPrivateKey(key, challengeBuffer);
+  const parsedKey = parsePrivateKeySsh(key, passphrase);
+  return generateSignature(parsedKey, challengeBuffer);
 };
 
 // Parses and handles JSON-structured WebSocket messages (e.g., challenge-response).

--- a/ui/src/components/Terminal/TerminalDialog.vue
+++ b/ui/src/components/Terminal/TerminalDialog.vue
@@ -22,6 +22,7 @@
         :key="terminalKey"
         :token="token"
         :privateKey="privateKey ?? null"
+        :passphrase="passphrase"
       />
 
     </v-card>
@@ -42,10 +43,10 @@ import {
 // Components used in this dialog
 import TerminalLoginForm from "./TerminalLoginForm.vue";
 import Terminal from "./Terminal.vue";
+import BaseDialog from "../BaseDialog.vue";
 
 // Utility to create key fingerprint for private key auth
 import { createKeyFingerprint } from "@/utils/validate";
-import BaseDialog from "../BaseDialog.vue";
 
 // Props: Device UID to connect the terminal session to
 const { deviceUid } = defineProps<{
@@ -60,6 +61,7 @@ const showDialog = defineModel<boolean>({ required: true }); // controls visibil
 // Token and private key values for terminal connection
 const token = ref("");
 const privateKey = ref<LoginFormData["privateKey"]>("");
+const passphrase = ref(); // Passphrase for private key if needed
 
 // Connect to terminal via password or key
 const connect = async (params: IConnectToTerminal) => {
@@ -74,8 +76,8 @@ const connect = async (params: IConnectToTerminal) => {
 
 // Handles private key-based connection
 const connectWithPrivateKey = async (params: IConnectToTerminal) => {
-  const { username, privateKey } = params;
-  const fingerprint = await createKeyFingerprint(privateKey);
+  const { username, privateKey, passphrase } = params;
+  const fingerprint = createKeyFingerprint(privateKey, passphrase);
   await connect({ username, fingerprint });
 };
 
@@ -88,6 +90,7 @@ const handleSubmit = async (params: LoginFormData) => {
 
   await connectWithPrivateKey(params);
   privateKey.value = params.privateKey;
+  passphrase.value = params.passphrase || undefined;
   showLoginForm.value = false;
 };
 

--- a/ui/src/interfaces/IPrivateKey.ts
+++ b/ui/src/interfaces/IPrivateKey.ts
@@ -2,4 +2,6 @@ export interface IPrivateKey {
   id: number,
   name: string;
   data: string;
+  hasPassphrase: boolean;
+  fingerprint: string;
 }

--- a/ui/src/interfaces/ITerminal.ts
+++ b/ui/src/interfaces/ITerminal.ts
@@ -2,6 +2,7 @@ export interface IConnectToTerminal {
   username: string;
   password?: string;
   privateKey?: string;
+  passphrase?: string;
   signature?: string;
   fingerprint?: string;
 }
@@ -16,6 +17,7 @@ export interface LoginFormData {
   password: string;
   authenticationMethod: TerminalAuthMethods;
   privateKey?: string;
+  passphrase?: string;
 }
 
 export interface WebTermDimensions {

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -9,6 +9,7 @@ import { key, store } from "./store";
 import { router } from "./router";
 import App from "./App.vue";
 import "asciinema-player/dist/bundle/asciinema-player.css";
+import "@/nodespecific";
 
 import { loadFonts } from "./plugins/webfontloader";
 

--- a/ui/src/nodespecific.ts
+++ b/ui/src/nodespecific.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "buffer";
 import Process from "process";
 
-globalThis.process = Process;
+const { env } = process;
+globalThis.process = { ...Process, env };
 globalThis.Buffer = Buffer;

--- a/ui/src/utils/validate.ts
+++ b/ui/src/utils/validate.ts
@@ -4,40 +4,36 @@ declare const window: any;
 import handleError from "@/utils/handleError";
 import crypto from "./crypto"
 
-export const validateKey = (typeKey: string, value: string) => {
+export const validateKey = (keyType: string, key: string, passphrase?: string) => {
   try {
-    let x;
-    if (typeKey === "private") {
-      x = crypto.parsePrivateKey(value);
-    } else {
-      x = crypto.parseKey(value);
-    }
+    if (keyType === "private") crypto.parsePrivateKey(key, passphrase);
+    else crypto.parseKey(key);
     return true;
   } catch (err) {
     return false;
   }
 };
 
-export const convertToFingerprint = (privateKey: string) => {
+export const convertToFingerprint = (privateKey: string, passphrase?: string) => {
   try {
-    return crypto.convertKeyToFingerprint(privateKey);
-  } catch (err) {
-    handleError(err);
+    return crypto.convertKeyToFingerprint(privateKey, passphrase);
+  } catch (error) {
+    handleError(error);
     return false;
   }
 };
 
-export const parsePrivateKeySsh = (privateKey: any) => {
-    return crypto.parsePrivateKey(privateKey);
+export const parsePrivateKeySsh = (privateKey, passphrase?) => {
+  return crypto.parsePrivateKey(privateKey, passphrase);
 };
 
 export const parseCertificate = (data: any) => {
   return crypto.parseCertificate(data);
 };
 
-export const createSignerPrivateKey = (privateKey, username) => {
+export const generateSignature = (privateKey, username) => {
   try {
-    return crypto.createSignerAndUpdate(privateKey, username);
+    return crypto.generateSignature(privateKey, username);
   } catch (err) {
     handleError(err);
     return false;
@@ -57,11 +53,11 @@ export const createSignatureOfPrivateKey = (
   privateKeyData: any,
   username: Buffer,
 ) => {
-  const signature = crypto.createSignatureOfPrivateKey(privateKeyData, username);
+  const signature = crypto.generateRsaKeySignature(privateKeyData, username);
   return signature;
 };
 
-export const createKeyFingerprint = async (privateKeyData: any) => {
-  const fingerprint = await crypto.createKeyFingerprint(privateKeyData);
+export const createKeyFingerprint = (privateKeyData, passphrase?) => {
+  const fingerprint = crypto.createKeyFingerprint(privateKeyData, passphrase);
   return fingerprint;
 };

--- a/ui/tests/components/PrivateKeys/PrivateKeyAdd.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyAdd.spec.ts
@@ -96,7 +96,7 @@ describe("Setting Private Keys", () => {
     expect(dialog.find('[data-test="private-key-save-btn"]').exists()).toBe(true);
   });
 
-  it("Sets private key data error message", async () => {
+  it("Sets private key name error message", async () => {
     wrapper.vm.showDialog = true;
     await flushPromises();
 
@@ -106,7 +106,7 @@ describe("Setting Private Keys", () => {
 
     await flushPromises();
 
-    expect(wrapper.vm.nameError).toEqual("this is a required field");
+    expect(wrapper.vm.nameError).toEqual("Name is required");
   });
 
   it("Sets private key data error message", async () => {
@@ -119,6 +119,6 @@ describe("Setting Private Keys", () => {
 
     await flushPromises();
 
-    expect(wrapper.vm.privateKeyDataError).toEqual("this is a required field");
+    expect(wrapper.vm.privateKeyDataError).toEqual("Private key data is required");
   });
 });

--- a/ui/tests/components/PrivateKeys/PrivateKeyEdit.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyEdit.spec.ts
@@ -11,6 +11,11 @@ import { SnackbarInjectionKey } from "@/plugins/snackbar";
 
 type PrivateKeyEditWrapper = VueWrapper<InstanceType<typeof PrivateKeyEdit>>;
 
+vi.mock("@/utils/validate", () => ({
+  createKeyFingerprint: () => "XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX",
+  validateKey: () => true,
+}));
+
 const mockSnackbar = {
   showSuccess: vi.fn(),
   showError: vi.fn(),
@@ -65,6 +70,8 @@ describe("Private Key Edit", () => {
     id: 1,
     name: "test-name",
     data: "test-data",
+    hasPassphrase: false,
+    fingerprint: "XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX",
   };
 
   beforeEach(async () => {
@@ -116,7 +123,6 @@ describe("Private Key Edit", () => {
     wrapper.vm.setPrivateKey();
     const privateKeyData = wrapper.vm.keyLocal;
     expect(privateKeyData).toBeDefined();
-    expect(wrapper.vm.isValid).toBe(true);
   });
 
   it("Checks if the name field is valid", async () => {
@@ -133,9 +139,15 @@ describe("Private Key Edit", () => {
   it("Checks if the edit function updates the store on success", async () => {
     const storeSpy = vi.spyOn(store, "dispatch");
     wrapper.vm.setPrivateKey();
-    const keySend = { name: wrapper.vm.name, data: wrapper.vm.keyLocal };
+    const privateKeyPayload = {
+      name: wrapper.vm.name,
+      data: wrapper.vm.keyLocal,
+      id: 1,
+      fingerprint: "XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX",
+      hasPassphrase: wrapper.vm.hasPassphrase,
+    };
     await wrapper.vm.edit();
-    expect(storeSpy).toHaveBeenCalledWith("privateKey/edit", keySend);
+    expect(storeSpy).toHaveBeenCalledWith("privateKey/edit", privateKeyPayload);
     expect(mockSnackbar.showSuccess).toHaveBeenCalledWith("Private key updated successfully.");
   });
 

--- a/ui/tests/components/PrivateKeys/PrivateKeyEdit.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyEdit.spec.ts
@@ -120,7 +120,7 @@ describe("Private Key Edit", () => {
   });
 
   it("Checks if the private key data is valid", () => {
-    wrapper.vm.setPrivateKey();
+    wrapper.vm.initializeFormData();
     const privateKeyData = wrapper.vm.keyLocal;
     expect(privateKeyData).toBeDefined();
   });
@@ -138,7 +138,7 @@ describe("Private Key Edit", () => {
 
   it("Checks if the edit function updates the store on success", async () => {
     const storeSpy = vi.spyOn(store, "dispatch");
-    wrapper.vm.setPrivateKey();
+    wrapper.vm.initializeFormData();
     const privateKeyPayload = {
       name: wrapper.vm.name,
       data: wrapper.vm.keyLocal,
@@ -152,7 +152,7 @@ describe("Private Key Edit", () => {
   });
 
   it("Checks if the edit function handles error on failure", async () => {
-    wrapper.vm.setPrivateKey();
+    wrapper.vm.initializeFormData();
     await wrapper.vm.edit();
     await flushPromises();
     expect(mockSnackbar.showError).toHaveBeenCalledWith("Failed to update private key.");

--- a/ui/tests/components/Terminal/TerminalLoginForm.spec.ts
+++ b/ui/tests/components/Terminal/TerminalLoginForm.spec.ts
@@ -14,8 +14,8 @@ describe("Terminal Login Form", async () => {
   const vuetify = createVuetify();
 
   const mockPrivateKeys: Array<IPrivateKey> = [
-    { id: 1, name: "test-key-1", data: "private-key-data-1" },
-    { id: 2, name: "test-key-2", data: "private-key-data-2" },
+    { id: 1, name: "test-key-1", data: "private-key-data-1", hasPassphrase: true, fingerprint: "fingerprint-1" },
+    { id: 2, name: "test-key-2", data: "private-key-data-2", hasPassphrase: false, fingerprint: "fingerprint-2" },
   ];
 
   const store = createStore({
@@ -52,10 +52,12 @@ describe("Terminal Login Form", async () => {
     expect(wrapper.find('[data-test="submit-btn"]').exists()).toBe(true);
 
     wrapper.vm.authenticationMethod = TerminalAuthMethods.PrivateKey;
+    wrapper.vm.togglePassphraseField();
     await nextTick();
 
     expect(wrapper.find('[data-test="password-field"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="private-keys-select"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="passphrase-field"]').exists()).toBe(true);
   });
 
   it("toggles password visibility when eye icon is clicked", async () => {
@@ -97,8 +99,10 @@ describe("Terminal Login Form", async () => {
 
     await wrapper.find('[data-test="username-field"] input').setValue(username);
     wrapper.vm.authenticationMethod = TerminalAuthMethods.PrivateKey;
+    wrapper.vm.togglePassphraseField();
     await nextTick();
     await wrapper.find('[data-test="private-keys-select"] input').setValue(privateKey.name);
+    await wrapper.find('[data-test="passphrase-field"] input').setValue("testpassphrase");
     await wrapper.find("form").trigger("submit");
     await nextTick();
 
@@ -107,6 +111,7 @@ describe("Terminal Login Form", async () => {
       password,
       authenticationMethod: TerminalAuthMethods.PrivateKey,
       privateKey: privateKey.data,
+      passphrase: "testpassphrase",
     }]);
   });
 

--- a/ui/tests/components/Terminal/__snapshots__/TerminalDialog.spec.ts.snap
+++ b/ui/tests/components/Terminal/__snapshots__/TerminalDialog.spec.ts.snap
@@ -173,6 +173,7 @@ exports[`Terminal Dialog > Renders the component 1`] = `
                   <!---->
                 </div>
               </div>
+              <!--v-if-->
               <div class="v-card-actions mt-4 d-flex justify-end"><button type="button" class="v-btn v-btn--slim v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text" data-test="cancel-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                   <!----><span class="v-btn__content" data-no-activator=""> Cancel </span>
                   <!---->

--- a/ui/tests/components/Terminal/__snapshots__/TerminalLoginForm.spec.ts.snap
+++ b/ui/tests/components/Terminal/__snapshots__/TerminalLoginForm.spec.ts.snap
@@ -144,6 +144,7 @@ exports[`Terminal Login Form > Renders the component 1`] = `
       <!---->
     </div>
   </div>
+  <!--v-if-->
   <div class="v-card-actions mt-4 d-flex justify-end"><button type="button" class="v-btn v-btn--slim v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-text" data-test="cancel-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
       <!----><span class="v-btn__content" data-no-activator=""> Cancel </span>
       <!---->


### PR DESCRIPTION
This pull request fixes a bug in the `PrivateKeyEdit` component that, when the private key list changed (some key being added or deleted), the values of the edit dialog didn't change, resulting in a mismatch between the item in the list and the data in the dialog.

Depends on #5109 