### PR TITLE
fix(ui): use address instead of full_address when filtering web endpoints

### DIFF
--- a/ui/src/views/WebEndpoints.vue
+++ b/ui/src/views/WebEndpoints.vue
@@ -92,7 +92,7 @@ const searchWebEndpoints = () => {
     const filterToEncodeBase64 = [
       {
         type: "property",
-        params: { name: "full_address", operator: "contains", value: filter.value },
+        params: { name: "address", operator: "contains", value: filter.value },
       },
     ];
     encodedFilter = btoa(JSON.stringify(filterToEncodeBase64));

--- a/ui/tests/views/WebEndpoints.spec.ts
+++ b/ui/tests/views/WebEndpoints.spec.ts
@@ -97,7 +97,7 @@ describe("WebEndpoints.vue", () => {
       page: 1,
       perPage: 10,
       // eslint-disable-next-line vue/max-len
-      filter: "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJmdWxsX2FkZHJlc3MiLCJvcGVyYXRvciI6ImNvbnRhaW5zIiwidmFsdWUiOiJsb2NhbGhvc3QifX1d",
+      filter: "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJhZGRyZXNzIiwib3BlcmF0b3IiOiJjb250YWlucyIsInZhbHVlIjoibG9jYWxob3N0In19XQ==",
     }));
   });
 


### PR DESCRIPTION
Filtering by `full_address` isn't effective since it's generated by the backend as an alias. To ensure accurate filtering of the web endpoints, the `address` field should be used, as it contains the actual data stored in the database.