### PR TITLE
fix(ui): show beta chip for cloud-only beta nav items

### DIFF
--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -102,7 +102,7 @@
               data-test="icon"
             />
             <v-chip
-              v-if="item.isBeta"
+              v-if="item.isBeta && envVariables.isCloud"
               label
               color="yellow"
               size="x-small"

--- a/ui/tests/layouts/AppLayout.spec.ts
+++ b/ui/tests/layouts/AppLayout.spec.ts
@@ -37,6 +37,7 @@ describe("App Layout Component", () => {
     vi.useFakeTimers();
 
     envVariables.hasWebEndpoints = true;
+    envVariables.isCloud = true;
     store.dispatch("spinner/setStatus", true);
 
     mockDevices = new MockAdapter(devicesApi.getAxios());


### PR DESCRIPTION
# Summary

This PR introduces a visual "BETA" label to navigation items that are both marked as beta and only available in cloud environments. This helps users identify experimental or in-development features more clearly when using the cloud version of the application.

## Changes

Added a v-chip with the label "BETA" to applicable nav items in AppLayout.vue

The chip is conditionally rendered when:

- item.isBeta is true
- envVariables.isCloud is true
- Updated snapshot tests to reflect the new UI rendering logic

## Rationale

Providing a clear visual indicator for beta features improves transparency and sets appropriate expectations for users. Limiting this to cloud deployments ensures that only relevant users see the label.

## Testing

- Manually verified that the BETA chip appears only for items meeting the conditions
- Snapshot tests updated and passing