### PR TITLE
fix(ui): fix navigation in Devices view

### DIFF
--- a/ui/src/components/Terminal/TerminalDialog.vue
+++ b/ui/src/components/Terminal/TerminalDialog.vue
@@ -120,8 +120,12 @@ useEventListener("keyup", handleEscKey);
 
 // Close terminal and log out when navigating away
 onBeforeRouteLeave(() => {
-  close();
-  return false;
+  if (showDialog.value) {
+    close();
+    return false; // Prevent navigation if dialog is open
+  }
+
+  return true;
 });
 
 // Auto-open terminal when navigating to specific device route


### PR DESCRIPTION
This pull request fixes a bug in the Devices view caused by the `onBeforeRouteLeave` in the terminal dialog component. Now it blocks navigation only when the terminal dialog is open, keeping the common behavior when the terminal is not open.