### PR TITLE
fix(ui): fix active and action selects in `FirewallRuleAdd`

### DIFF
--- a/ui/src/components/firewall/FirewallRuleAdd.vue
+++ b/ui/src/components/firewall/FirewallRuleAdd.vue
@@ -29,7 +29,7 @@
             <v-row>
               <v-col>
                 <v-select
-                  :model-value="active"
+                  v-model="active"
                   :items="activeSelectOptions"
                   label="Rule status"
                   variant="underlined"
@@ -50,7 +50,7 @@
 
               <v-col>
                 <v-select
-                  :model-value="action"
+                  v-model="action"
                   :items="actionSelectOptions"
                   label="Rule policy"
                   variant="underlined"
@@ -293,6 +293,8 @@ const hasErrors = computed(() => (
 ));
 
 const resetForm = () => {
+  active.value = true;
+  action.value = "allow";
   selectedFilterOption.value = FormFilterOptions.All;
   selectedIPOption.value = "all";
   selectedUsernameOption.value = "all";


### PR DESCRIPTION
This pull request fixes the Active and Action selects in `FirewallRuleAdd`. The component was refactored, and erroneously these selects have been left with `:model-value` instead of `v-model`, breaking its reactivity and sending the wrong data to the back-end. That PR fixes that and, additionally, ensures that those selects are reset when the dialog is closed.