### PR TITLE
fix(ui): normalize certificate formatting before saving

### DIFF
--- a/ui/admin/src/components/Instance/SSO/ConfigureSSO.vue
+++ b/ui/admin/src/components/Instance/SSO/ConfigureSSO.vue
@@ -283,7 +283,7 @@ const isAtLeastOneUrlValid = (): boolean => {
 };
 
 const hasErrors = computed((): boolean => {
-  // ✅ If using metadata URL, validate only it and stop.
+  // If using metadata URL, validate only it and stop.
   if (useMetadataUrl.value) {
     return IdPMetadataURL.value.trim() === "" || !!IdPMetadataURLError.value;
   }
@@ -311,6 +311,12 @@ const hasErrors = computed((): boolean => {
   return false;
 });
 
+// Trim linebreaks on the certificate
+const normalizeCertificate = (c: string) => c.replace(
+  /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/,
+  (m) => m.replace(/\s+/g, "\n").replace(/\n+/g, "\n").trim(),
+);
+
 const updateSAMLConfiguration = async (): Promise<void> => {
   const idpConfig: IAdminSAMLConfig["idp"] = useMetadataUrl.value
     ? { metadata_url: IdPMetadataURL.value }
@@ -320,7 +326,7 @@ const updateSAMLConfiguration = async (): Promise<void> => {
         post: postUrl.value,
         redirect: redirectUrl.value,
       },
-      certificate: x509Certificate.value,
+      certificate: normalizeCertificate(x509Certificate.value),
     };
 
   const validMappings = mappings.value.filter(


### PR DESCRIPTION
# Description:

This PR updates the SSO configuration process to ensure SAML x509 certificates are properly normalized before being saved. The normalizeCertificate function trims whitespace, enforces consistent newline characters, and removes unnecessary spaces within the certificate block.

## Changes:

-  Added normalizeCertificate utility to clean certificate input
-  Applied normalization before sending the certificate in updateSAMLConfiguration
-  Removed unnecessary checkmark emoji from comment for clarity

## Why:

Some certificates entered manually contained extra spaces or inconsistent line breaks, causing validation or authentication issues. Normalizing the format ensures compatibility and reduces user input errors.

## Impact:

- Prevents malformed certificate uploads
- Improves reliability of SAML configuration
- No breaking changes to existing configurations