### PR TITLE
feat(ui): display device header in web endpoints list

### DIFF
--- a/ui/src/interfaces/IWebEndpoints.ts
+++ b/ui/src/interfaces/IWebEndpoints.ts
@@ -1,8 +1,11 @@
+import { IDevice } from "./IDevice";
+
 export interface IWebEndpoints {
   address: string,
   full_address: string,
+  device: IDevice
   expires_in: string,
-  device: string,
+  device_uid: string,
   host: string,
   port: number
 }

--- a/ui/tests/components/WebEndpoints/WebEndpointList.spec.ts
+++ b/ui/tests/components/WebEndpoints/WebEndpointList.spec.ts
@@ -15,7 +15,24 @@ const mockEndpoints = [
   {
     address: "abc123",
     namespace: "namespace",
-    device: "device-1",
+    device: {
+      uid: "a582b47a42d",
+      name: "39-5e-2a",
+      identity: {
+        mac: "00:00:00:00:00:00",
+      },
+      info: {
+        id: "linuxmint",
+        pretty_name: "Linux Mint 19.3",
+        version: "",
+      },
+      public_key: "----- PUBLIC KEY -----",
+      tenant_id: "fake-tenant-data",
+      last_seen: "2020-05-20T18:58:53.276Z",
+      online: false,
+      namespace: "user",
+      status: "accepted",
+    },
     host: "192.168.0.1",
     port: 8080,
     full_address: "192.168.0.1:8080",
@@ -66,12 +83,13 @@ describe("WebEndpointList.vue", () => {
 
   it("renders table headers correctly", () => {
     const headers = wrapper.findAll('[data-test="web-endpoints-table"] thead th');
-    expect(headers.length).toBe(5);
-    expect(headers[0].text()).toContain("Address");
-    expect(headers[1].text()).toContain("Host");
-    expect(headers[2].text()).toContain("Port");
-    expect(headers[3].text()).toContain("Expiration Date");
-    expect(headers[4].text()).toContain("Actions");
+    expect(headers.length).toBe(6);
+    expect(headers[0].text()).toContain("Device");
+    expect(headers[1].text()).toContain("Address");
+    expect(headers[2].text()).toContain("Host");
+    expect(headers[3].text()).toContain("Port");
+    expect(headers[4].text()).toContain("Expiration Date");
+    expect(headers[5].text()).toContain("Actions");
   });
 
   it("renders table rows with web endpoints", () => {


### PR DESCRIPTION
# Description:
This PR enhances the Web Endpoints list by displaying associated device information directly in the table. A new Device column is added at the start of the table, showing:

- Device icon (based on device.info.id)
- Device name (clickable link to device details page)
- Device pretty name (as a subtitle)

## Key changes:

- Updated WebEndpointList.vue to render device icon and names in a new column.
- Added redirectDevice method to navigate to the device details view.
- Updated IWebEndpoints interface to use a full IDevice object instead of a device string.
- Adjusted tests to validate the updated table structure and data.

## Why:

This change improves usability by allowing users to quickly identify and navigate to the related device from the Web Endpoints list, without needing to search for it separately.

## Testing:

- Updated and ran unit tests to reflect the new column and device data structure.
- Verified that clicking a device name routes to the device details page.