### PR TITLE
fix(ui): mock `onBeforeRouteLeave` in tests

### DIFF
--- a/ui/vitest/beforeAll.ts
+++ b/ui/vitest/beforeAll.ts
@@ -19,6 +19,14 @@ const mockedSystemInfo = {
 const systemApiMock = new MockAdapter(systemApi.getAxios());
 systemApiMock.onGet("http://localhost:3000/info").reply(200, mockedSystemInfo);
 
+vi.mock("vue-router", async (importOriginal) => {
+  const original = await importOriginal<typeof import("vue-router")>();
+  return {
+    ...original,
+    onBeforeRouteLeave: vi.fn(),
+  };
+});
+
 vi.stubGlobal("visualViewport", new EventTarget());
 
 global.CSS = { supports: () => false } as never;


### PR DESCRIPTION
This pull request adds a mock for `onBeforeRouteLeave` in tests to prevent warnings that were being thrown in the console.