### PR TITLE
feat(api)!: remove unused device methods

### DIFF
--- a/api/store/device.go
+++ b/api/store/device.go
@@ -57,6 +57,4 @@ type DeviceStore interface {
 	DeviceRename(ctx context.Context, uid models.UID, hostname string) error
 	DeviceUpdateStatus(ctx context.Context, uid models.UID, status models.DeviceStatus) error
 	DeviceSetPosition(ctx context.Context, uid models.UID, position models.DevicePosition) error
-	DeviceListByUsage(ctx context.Context, tenantID string) ([]models.UID, error)
-	DeviceChooser(ctx context.Context, tenantID string, chosen []string) error
 }

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -300,24 +300,6 @@ func (_m *Store) DeviceBulkUpdate(ctx context.Context, uids []string, changes *m
 	return r0, r1
 }
 
-// DeviceChooser provides a mock function with given fields: ctx, tenantID, chosen
-func (_m *Store) DeviceChooser(ctx context.Context, tenantID string, chosen []string) error {
-	ret := _m.Called(ctx, tenantID, chosen)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeviceChooser")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, []string) error); ok {
-		r0 = rf(ctx, tenantID, chosen)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // DeviceConflicts provides a mock function with given fields: ctx, target
 func (_m *Store) DeviceConflicts(ctx context.Context, target *models.DeviceConflicts) ([]string, bool, error) {
 	ret := _m.Called(ctx, target)
@@ -473,36 +455,6 @@ func (_m *Store) DeviceList(ctx context.Context, status models.DeviceStatus, pag
 	}
 
 	return r0, r1, r2
-}
-
-// DeviceListByUsage provides a mock function with given fields: ctx, tenantID
-func (_m *Store) DeviceListByUsage(ctx context.Context, tenantID string) ([]models.UID, error) {
-	ret := _m.Called(ctx, tenantID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeviceListByUsage")
-	}
-
-	var r0 []models.UID
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]models.UID, error)); ok {
-		return rf(ctx, tenantID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []models.UID); ok {
-		r0 = rf(ctx, tenantID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]models.UID)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, tenantID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // DevicePullTag provides a mock function with given fields: ctx, uid, tag

--- a/api/store/mongo/device_test.go
+++ b/api/store/mongo/device_test.go
@@ -492,55 +492,6 @@ func TestDeviceList(t *testing.T) {
 	}
 }
 
-func TestDeviceListByUsage(t *testing.T) {
-	type Expected struct {
-		uid []models.UID
-		len int
-		err error
-	}
-	cases := []struct {
-		description string
-		tenant      string
-		fixtures    []string
-		expected    Expected
-	}{
-		{
-			description: "returns an empty list when tenant not exist",
-			tenant:      "nonexistent",
-			fixtures:    []string{fixtureSessions},
-			expected: Expected{
-				uid: []models.UID{},
-				len: 0,
-				err: nil,
-			},
-		},
-		{
-			description: "succeeds when has 1 or more device sessions",
-			tenant:      "00000000-0000-4000-0000-000000000000",
-			fixtures:    []string{fixtureSessions},
-			expected: Expected{
-				uid: []models.UID{"2300230e3ca2f637636b4d025d2235269014865db5204b6d115386cbee89809c"},
-				len: 1,
-				err: nil,
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.description, func(t *testing.T) {
-			ctx := context.Background()
-
-			assert.NoError(t, srv.Apply(tc.fixtures...))
-			t.Cleanup(func() {
-				assert.NoError(t, srv.Reset())
-			})
-
-			uids, err := s.DeviceListByUsage(ctx, tc.tenant)
-			assert.Equal(t, tc.expected, Expected{uid: uids, len: len(uids), err: err})
-		})
-	}
-}
-
 func TestDeviceResolve(t *testing.T) {
 	type Expected struct {
 		dev *models.Device
@@ -817,38 +768,6 @@ func TestDeviceSetPosition(t *testing.T) {
 			})
 
 			err := s.DeviceSetPosition(ctx, tc.uid, tc.position)
-			assert.Equal(t, tc.expected, err)
-		})
-	}
-}
-
-func TestDeviceChooser(t *testing.T) {
-	cases := []struct {
-		description string
-		tenant      string
-		chosen      []string
-		fixtures    []string
-		expected    error
-	}{
-		{
-			description: "",
-			tenant:      "00000000-0000-4000-0000-000000000000",
-			chosen:      []string{""},
-			fixtures:    []string{fixtureDevices},
-			expected:    nil,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.description, func(t *testing.T) {
-			ctx := context.Background()
-
-			assert.NoError(t, srv.Apply(tc.fixtures...))
-			t.Cleanup(func() {
-				assert.NoError(t, srv.Reset())
-			})
-
-			err := s.DeviceChooser(ctx, tc.tenant, tc.chosen)
 			assert.Equal(t, tc.expected, err)
 		})
 	}


### PR DESCRIPTION
BREAKING CHANGE: removes DeviceListByUsage and DeviceChooser methods from DeviceStore interface and all implementations