### PR TITLE
refactor(api): replace APIKeyGet methods with unified APIKeyResolve

### DIFF
--- a/api/services/api-key.go
+++ b/api/services/api-key.go
@@ -87,7 +87,7 @@ func (s *service) CreateAPIKey(ctx context.Context, req *requests.CreateAPIKey) 
 
 	// As we need to return the plain key in the create service, we temporarily set
 	// the apiKey.ID to the plain key here.
-	apiKey, _ := s.store.APIKeyGet(ctx, hashedKey)
+	apiKey, _ := s.store.APIKeyResolve(ctx, store.APIKeyIDResolver, hashedKey)
 	apiKey.ID = req.Key
 
 	return responses.CreateAPIKeyFromModel(apiKey), nil

--- a/api/services/api-key_test.go
+++ b/api/services/api-key_test.go
@@ -275,7 +275,7 @@ func TestCreateAPIKey(t *testing.T) {
 					Return(hashedKey, nil).
 					Once()
 				storeMock.
-					On("APIKeyGet", ctx, hashedKey).
+					On("APIKeyResolve", ctx, store.APIKeyIDResolver, hashedKey).
 					Return(&models.APIKey{
 						ID:        hashedKey,
 						Name:      "dev",
@@ -353,7 +353,7 @@ func TestCreateAPIKey(t *testing.T) {
 					Return(hashedKey, nil).
 					Once()
 				storeMock.
-					On("APIKeyGet", ctx, hashedKey).
+					On("APIKeyResolve", ctx, store.APIKeyIDResolver, hashedKey).
 					Return(&models.APIKey{
 						ID:        hashedKey,
 						Name:      "dev",

--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -431,7 +431,7 @@ func (s *service) AuthAPIKey(ctx context.Context, key string) (*models.APIKey, e
 		hashedKey := hex.EncodeToString(keySum[:])
 
 		var err error
-		if apiKey, err = s.store.APIKeyGet(ctx, hashedKey); err != nil {
+		if apiKey, err = s.store.APIKeyResolve(ctx, store.APIKeyIDResolver, hashedKey); err != nil {
 			return nil, NewErrAPIKeyNotFound("", err)
 		}
 	}

--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -2424,7 +2424,7 @@ func TestAuthAPIKey(t *testing.T) {
 				keySum := sha256.Sum256([]byte("00000000-0000-4000-0000-000000000000"))
 				hashedKey := hex.EncodeToString(keySum[:])
 				storeMock.
-					On("APIKeyGet", ctx, hashedKey).
+					On("APIKeyResolve", ctx, store.APIKeyIDResolver, hashedKey).
 					Return(nil, errors.New("error", "", 0)).
 					Once()
 			},
@@ -2444,7 +2444,7 @@ func TestAuthAPIKey(t *testing.T) {
 				keySum := sha256.Sum256([]byte("00000000-0000-4000-0000-000000000000"))
 				hashedKey := hex.EncodeToString(keySum[:])
 				storeMock.
-					On("APIKeyGet", ctx, hashedKey).
+					On("APIKeyResolve", ctx, store.APIKeyIDResolver, hashedKey).
 					Return(
 						&models.APIKey{
 							Name:      "dev",
@@ -2470,7 +2470,7 @@ func TestAuthAPIKey(t *testing.T) {
 				keySum := sha256.Sum256([]byte("00000000-0000-4000-0000-000000000000"))
 				hashedKey := hex.EncodeToString(keySum[:])
 				storeMock.
-					On("APIKeyGet", ctx, hashedKey).
+					On("APIKeyResolve", ctx, store.APIKeyIDResolver, hashedKey).
 					Return(
 						&models.APIKey{
 							Name:      "dev",

--- a/api/store/api_key.go
+++ b/api/store/api_key.go
@@ -7,15 +7,21 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
 
+type APIKeyResolver uint
+
+const (
+	APIKeyIDResolver APIKeyResolver = iota + 1
+	APIKeyNameResolver
+)
+
 type APIKeyStore interface {
 	// APIKeyCreate creates an API key with the provided data. Returns the inserted ID and an error if any.
 	APIKeyCreate(ctx context.Context, APIKey *models.APIKey) (insertedID string, err error)
 
-	// APIKeyGet retrieves an API key based on its ID. Returns the API key and an error if any.
-	APIKeyGet(ctx context.Context, id string) (apiKey *models.APIKey, err error)
-
-	// APIKeyGetByName retrieves an API key based on its name and tenant ID. Returns the API key and an error if any.
-	APIKeyGetByName(ctx context.Context, tenantID string, name string) (apiKey *models.APIKey, err error)
+	// APIKeyResolve fetches an API key using a specific resolver within a given tenant ID.
+	//
+	// It returns the resolved API key if found and an error, if any.
+	APIKeyResolve(ctx context.Context, resolver APIKeyResolver, value string, opts ...QueryOption) (*models.APIKey, error)
 
 	// APIKeyConflicts reports whether the target contains conflicting attributes with the database. Pass zero values for
 	// attributes you do not wish to match on.  It returns an array of conflicting attribute fields and an error, if any.

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -101,66 +101,6 @@ func (_m *Store) APIKeyDelete(ctx context.Context, tenantID string, name string)
 	return r0
 }
 
-// APIKeyGet provides a mock function with given fields: ctx, id
-func (_m *Store) APIKeyGet(ctx context.Context, id string) (*models.APIKey, error) {
-	ret := _m.Called(ctx, id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for APIKeyGet")
-	}
-
-	var r0 *models.APIKey
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*models.APIKey, error)); ok {
-		return rf(ctx, id)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *models.APIKey); ok {
-		r0 = rf(ctx, id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.APIKey)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// APIKeyGetByName provides a mock function with given fields: ctx, tenantID, name
-func (_m *Store) APIKeyGetByName(ctx context.Context, tenantID string, name string) (*models.APIKey, error) {
-	ret := _m.Called(ctx, tenantID, name)
-
-	if len(ret) == 0 {
-		panic("no return value specified for APIKeyGetByName")
-	}
-
-	var r0 *models.APIKey
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*models.APIKey, error)); ok {
-		return rf(ctx, tenantID, name)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *models.APIKey); ok {
-		r0 = rf(ctx, tenantID, name)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.APIKey)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, tenantID, name)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // APIKeyList provides a mock function with given fields: ctx, tenantID, paginator, sorter
 func (_m *Store) APIKeyList(ctx context.Context, tenantID string, paginator query.Paginator, sorter query.Sorter) ([]models.APIKey, int, error) {
 	ret := _m.Called(ctx, tenantID, paginator, sorter)
@@ -196,6 +136,43 @@ func (_m *Store) APIKeyList(ctx context.Context, tenantID string, paginator quer
 	}
 
 	return r0, r1, r2
+}
+
+// APIKeyResolve provides a mock function with given fields: ctx, resolver, value, opts
+func (_m *Store) APIKeyResolve(ctx context.Context, resolver store.APIKeyResolver, value string, opts ...store.QueryOption) (*models.APIKey, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, resolver, value)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for APIKeyResolve")
+	}
+
+	var r0 *models.APIKey
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, store.APIKeyResolver, string, ...store.QueryOption) (*models.APIKey, error)); ok {
+		return rf(ctx, resolver, value, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, store.APIKeyResolver, string, ...store.QueryOption) *models.APIKey); ok {
+		r0 = rf(ctx, resolver, value, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.APIKey)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, store.APIKeyResolver, string, ...store.QueryOption) error); ok {
+		r1 = rf(ctx, resolver, value, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // APIKeyUpdate provides a mock function with given fields: ctx, tenantID, name, changes


### PR DESCRIPTION
- Replace APIKeyGet and APIKeyGetByName with APIKeyResolve method
- Add APIKeyResolver enum with IDResolver and NameResolver options
- Update all service calls to use new resolver pattern
- Consolidate API key lookup logic into single method with resolver strategy
- Fix syntax error in CreateAPIKey method

BREAKING CHANGE: removes APIKeyGet and APIKeyGetByName methods from APIKeyStore interface