### PR TITLE
refactor(api): remove unused opts parameter from NamespaceGetPreferred

### DIFF
--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -799,16 +799,9 @@ func (_m *Store) NamespaceEdit(ctx context.Context, tenant string, changes *mode
 	return r0
 }
 
-// NamespaceGetPreferred provides a mock function with given fields: ctx, userID, opts
-func (_m *Store) NamespaceGetPreferred(ctx context.Context, userID string, opts ...store.NamespaceQueryOption) (*models.Namespace, error) {
-	_va := make([]interface{}, len(opts))
-	for _i := range opts {
-		_va[_i] = opts[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx, userID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// NamespaceGetPreferred provides a mock function with given fields: ctx, userID
+func (_m *Store) NamespaceGetPreferred(ctx context.Context, userID string) (*models.Namespace, error) {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for NamespaceGetPreferred")
@@ -816,19 +809,19 @@ func (_m *Store) NamespaceGetPreferred(ctx context.Context, userID string, opts 
 
 	var r0 *models.Namespace
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, ...store.NamespaceQueryOption) (*models.Namespace, error)); ok {
-		return rf(ctx, userID, opts...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*models.Namespace, error)); ok {
+		return rf(ctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, ...store.NamespaceQueryOption) *models.Namespace); ok {
-		r0 = rf(ctx, userID, opts...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *models.Namespace); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Namespace)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, ...store.NamespaceQueryOption) error); ok {
-		r1 = rf(ctx, userID, opts...)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/api/store/mongo/namespace.go
+++ b/api/store/mongo/namespace.go
@@ -255,7 +255,7 @@ func (s *Store) NamespaceResolve(ctx context.Context, resolver store.NamespaceRe
 	return namespace, nil
 }
 
-func (s *Store) NamespaceGetPreferred(ctx context.Context, userID string, opts ...store.NamespaceQueryOption) (*models.Namespace, error) {
+func (s *Store) NamespaceGetPreferred(ctx context.Context, userID string) (*models.Namespace, error) {
 	filter := bson.M{"members.id": userID}
 
 	if user, _ := s.UserResolve(ctx, store.UserIDResolver, userID); user != nil {
@@ -267,12 +267,6 @@ func (s *Store) NamespaceGetPreferred(ctx context.Context, userID string, opts .
 	ns := new(models.Namespace)
 	if err := s.db.Collection("namespaces").FindOne(ctx, filter).Decode(ns); err != nil {
 		return nil, FromMongoError(err)
-	}
-
-	for _, opt := range opts {
-		if err := opt(context.WithValue(ctx, "db", s.db), ns); err != nil { //nolint:revive
-			return nil, err
-		}
 	}
 
 	return ns, nil

--- a/api/store/namespace.go
+++ b/api/store/namespace.go
@@ -34,7 +34,7 @@ type NamespaceStore interface {
 	// can be passed via `opts` to inject additional data into the namespace.
 	//
 	// It returns the namespace or an error if any.
-	NamespaceGetPreferred(ctx context.Context, userID string, opts ...NamespaceQueryOption) (*models.Namespace, error)
+	NamespaceGetPreferred(ctx context.Context, userID string) (*models.Namespace, error)
 
 	NamespaceCreate(ctx context.Context, namespace *models.Namespace) (*models.Namespace, error)
 


### PR DESCRIPTION
- Remove NamespaceQueryOption variadic parameter from NamespaceGetPreferred
- Simplify method signature since namespace lookup is always by user membership
- Remove unnecessary option processing logic in MongoDB implementation
- Update mock generation to reflect simplified interface

The opts parameter was unused as the method always matches by user membership without additional filters or model modifications.