### PR TITLE
refactor(ui): create standard `@close` event for `BaseDialog`

### DIFF
--- a/ui/src/components/Announcements/AnnouncementsModal.vue
+++ b/ui/src/components/Announcements/AnnouncementsModal.vue
@@ -1,6 +1,7 @@
 <template>
   <BaseDialog
     v-model="showDialog"
+    @close="close"
     scrollable
     persistent
   >

--- a/ui/src/components/AuthMFA/MfaDisable.vue
+++ b/ui/src/components/AuthMFA/MfaDisable.vue
@@ -2,7 +2,7 @@
   <BaseDialog
     v-model="showDialog"
     scrollable
-    @click:outside="close"
+    @close="close"
     data-test="dialog"
   >
     <v-card class="bg-grey-darken-4 bg-v-theme-surface pa-3">

--- a/ui/src/components/AuthMFA/MfaSettings.vue
+++ b/ui/src/components/AuthMFA/MfaSettings.vue
@@ -1,10 +1,10 @@
 <template>
   <BaseDialog
     v-model="showDialog"
+    @close="close"
     scrollable
     transition="dialog-bottom-transition"
     data-test="dialog"
-    @click:outside="close()"
   >
     <v-card class="bg-v-theme-surface content" data-test="card-first-page">
       <v-container>

--- a/ui/src/components/AuthMFA/RecoveryHelper.vue
+++ b/ui/src/components/AuthMFA/RecoveryHelper.vue
@@ -1,6 +1,7 @@
 <template>
   <BaseDialog
     v-model="showDialog"
+    @close="close"
     transition="dialog-bottom-transition"
     persistent
   >

--- a/ui/src/components/BaseDialog.vue
+++ b/ui/src/components/BaseDialog.vue
@@ -1,6 +1,7 @@
 <template>
   <v-dialog
     v-model="showDialog"
+    @update:model-value="handleModelValueChange"
     :fullscreen
     :max-width
   >
@@ -24,10 +25,13 @@ const props = defineProps<{
   forceFullscreen?: boolean
 }>();
 
+const emit = defineEmits(["close"]);
 const showDialog = defineModel<boolean>({ required: true });
 const { smAndDown, thresholds } = useDisplay();
 const fullscreen = computed(() => props.forceFullscreen || smAndDown.value);
 const maxWidth = computed(() => fullscreen.value ? undefined : thresholds.value[props.threshold || "sm"]);
+
+const handleModelValueChange = (value: boolean) => { if (!value) emit("close"); };
 
 defineExpose({ fullscreen, maxWidth });
 </script>

--- a/ui/src/components/Billing/BillingDialog.vue
+++ b/ui/src/components/Billing/BillingDialog.vue
@@ -1,8 +1,8 @@
 <template>
   <BaseDialog
     v-model="showCheckoutDialog"
+    @close="resetDialog"
     transition="dialog-bottom-transition"
-    @click:outside="resetDialog"
     data-test="checkout-dialog"
   >
     <v-window v-model="el">


### PR DESCRIPTION
This pull request creates a default `close` event for the generic `BaseDialog` component, facilitating the close handling in components that need to perform some action when closing the dialog, such as resetting refs, form fields, etc.

## Components to be adapted (by directory)
- [ ] Announcement (Admin)
- [ ] Instance (Admin)
- [ ] Namespace (Admin)
- [ ] User (Admin)
- [x] Announcements
- [x] AuthMFA
- [x] Billing
- [ ] Containers
- [ ] Devices
- [ ] firewall
- [ ] Namespace
- [ ] PrivateKeys
- [ ] PublicKeys
- [ ] QuickConnection
- [ ] Sessions
- [ ] Tags
- [ ] Team
- [ ] Terminal
- [ ] User
- [ ] WebEndpoints