### PR TITLE
refactor(ui): use injected `isAdmin` in `DataTable`

### DIFF
--- a/ui/src/components/DataTable.vue
+++ b/ui/src/components/DataTable.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, inject } from "vue";
 
 type Header = {
   text: string;
@@ -79,7 +79,7 @@ defineEmits(["update:sort"]);
 const page = defineModel<number>("page", { required: true, type: Number });
 const itemsPerPage = defineModel("itemsPerPage", { required: true, type: Number });
 const pageQuantity = computed(() => Math.ceil(props.totalCount / itemsPerPage.value) || 1);
-const isAdmin = window.location.pathname.startsWith("/admin");
+const isAdmin: boolean = inject("isAdmin", false);
 
 const goToFirstPage = () => { page.value = 1; };
 </script>


### PR DESCRIPTION
This pull request modifies the DataTable component to use the injected `isAdmin` ref to define the style when the user is in the admin UI. This change removes the dependency on the location path or in the router, using a more predictable source. 