### PR TITLE
fix(ui): ensure name is loaded before MFA recovery and reset

### DIFF
--- a/ui/src/store/modules/auth.ts
+++ b/ui/src/store/modules/auth.ts
@@ -94,6 +94,7 @@ const useAuthStore = defineStore("auth", () => {
   };
 
   const recoverMfa = async (code: string) => {
+    name.value = localStorage.getItem("name") || "";
     const resp = await authApi.recoverMfa({ identifier: name.value, recovery_code: code });
     if (resp.status === 200) {
       persistAuth(resp.data);
@@ -129,7 +130,8 @@ const useAuthStore = defineStore("auth", () => {
   };
 
   const requestMfaReset = async () => {
-    await authApi.requestResetMfa(email.value);
+    name.value = localStorage.getItem("name") || "";
+    await authApi.requestResetMfa(name.value);
   };
 
   const resetMfa = async (data: IMfaReset) => {


### PR DESCRIPTION
# Description

This PR fixes a bug where the name value was not initialized before making MFA-related API calls. As a result, recoverMfa and requestResetMfa could fail due to missing or incorrect identifiers.

## Reasoning

The name value is required for MFA recovery and reset operations. Without explicitly initializing it from localStorage, these functions could behave unexpectedly or fail entirely if name.value is empty or undefined.

## Changes introduced
Load name from localStorage in:
- recoverMfa
- requestMfaReset

## How to test

1. Simulate an MFA recovery or reset flow without prior setting of name.
2. Confirm that the name is correctly loaded from localStorage.
3. Ensure the API calls succeed with the expected parameters.