### PR TITLE
fix(gateway): fix healthcheck failure when PROXY protocol is enabled

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,14 @@ services:
     networks:
       - shellhub
     healthcheck:
-      test: "curl -f -k -L http://gateway/healthcheck || exit 1"
+      test: >
+        sh -c '
+        if [ "$SHELLHUB_PROXY" = "true" ]; then
+          curl -f -k -L --haproxy-protocol http://gateway/healthcheck || exit 1
+        else
+          curl -f -k -L http://gateway/healthcheck || exit 1
+        fi
+        '
       interval: 30s
       start_period: 10s
   cli:

--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -692,7 +692,7 @@ server {
 
 {{ if and ($cfg.EnableAutoSSL) (ne $cfg.Env "development") }}
 server {
-    listen 80 default_server;
+    listen 80 default_server{{ if $cfg.EnableProxyProtocol }} proxy_protocol{{ end }};
 
     return 308 https://$host$request_uri;
 }


### PR DESCRIPTION
When `SHELLHUB_PROXY=true` is set, the gateway health check fails because
NGINX expects PROXY protocol headers, but `curl` does not send them in
the redirected HTTPS request.

This commit fixes the issue by:
- Adding the `--haproxy-protocol` flag to the `curl` command in the
  healthcheck script when the proxy is enabled.
- Enabling `proxy_protocol` on the plain HTTP server block in the NGINX
  configuration.
