### PR TITLE
fix(api,ssh): update script that generate private keys in pkcs8 format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ export COMPOSE_TEMPLATE
 
 # Generate required private key for api service
 api_private_key:
-	@$(KEYGEN) genrsa -out api_private_key 2048
+	@$(KEYGEN) genpkey -algorithm RSA -out api_private_key -pkeyopt rsa_keygen_bits:2048
 
 # Generate required public key for api service
 api_public_key:
@@ -26,7 +26,7 @@ api_public_key:
 
 # Generate required private key for ssh service
 ssh_private_key:
-	@$(KEYGEN) genrsa -out ssh_private_key 2048
+	@$(KEYGEN) genpkey -algorithm RSA -out ssh_private_key -pkeyopt rsa_keygen_bits:2048
 
 .PHONY: keygen
 # Generate required keys

--- a/api/entrypoint-dev.sh
+++ b/api/entrypoint-dev.sh
@@ -6,7 +6,7 @@ mkdir -p /var/run/secrets
 
 if [ ! -f /var/run/secrets/api_private_key ]; then
     echo "Generating private key"
-    openssl genrsa -out /var/run/secrets/api_private_key 2048
+    openssl genpkey -algorithm RSA -out /var/run/secrets/api_private_key -pkeyopt rsa_keygen_bits:2048
     openssl rsa -in /var/run/secrets/api_private_key -pubout -out /var/run/secrets/api_public_key
 fi
 

--- a/devscripts/add-device
+++ b/devscripts/add-device
@@ -10,7 +10,7 @@ MACADDR=$(echo -n 02; dd bs=1 count=5 if=/dev/random 2>/dev/null | hexdump -v -e
 PRIVATE_KEY_FILE=$(mktemp -u)
 PUBLIC_KEY_FILE=$(mktemp -u)
 
-openssl genrsa -out $PRIVATE_KEY_FILE 2048 2> /dev/null
+openssl genpkey -algorithm RSA -out $PRIVATE_KEY_FILE -pkeyopt rsa_keygen_bits:2048 2> /dev/null
 openssl rsa -in $PRIVATE_KEY_FILE -out $PUBLIC_KEY_FILE -pubout 2> /dev/null
 
 PUBLIC_KEY=$(cat $PUBLIC_KEY_FILE)

--- a/ssh/entrypoint-dev.sh
+++ b/ssh/entrypoint-dev.sh
@@ -6,7 +6,7 @@ mkdir -p /var/run/secrets
 
 if [ ! -f /var/run/secrets/ssh_private_key ]; then
     echo "Generating private key"
-    openssl genrsa -out /var/run/secrets/ssh_private_key 2048
+    openssl genpkey -algorithm RSA -out /var/run/secrets/ssh_private_key -pkeyopt rsa_keygen_bits:2048
 fi
 
 air


### PR DESCRIPTION
Replace old openssl genrsa command with openssl genpkey to generate RSA private keys in PKCS#8 format by default. This modernizes key generation across all services and scripts.

Closes #5219