### PR TITLE
fix(ui): align Device & FirewallRules tests with tag objects

### DIFF
--- a/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
@@ -86,22 +86,22 @@ exports[`Device > Renders the component 1`] = `
             </thead>
             <tbody>
               <tr data-v-aca44803="">
-                <td data-v-aca44803=""><i data-v-aca44803="" class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" data-test="success-icon"></i></td>
-                <td data-v-aca44803="">08-97-98-68-7a-97</td>
-                <td data-v-aca44803=""><span data-v-aca44803="" class="d-inline-flex align-center ga-2"><i data-v-aca44803="" class="fl-ubuntu" style="font-size: 20px;"></i> Ubuntu 20.04.4 LTS</span></td>
-                <td data-v-aca44803=""><span data-v-aca44803="" tabindex="0" class="hover">dev</span></td>
+                <td data-v-aca44803=""><i data-v-aca44803="" class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default" style="color: rgb(229, 57, 53); caret-color: #E53935;" aria-hidden="true" data-test="error-icon"></i></td>
+                <td data-v-aca44803="">39-5e-2a</td>
+                <td data-v-aca44803=""><span data-v-aca44803="" class="d-inline-flex align-center ga-2"><i data-v-aca44803="" class="fl-linuxmint" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
+                <td data-v-aca44803=""><span data-v-aca44803="" tabindex="0" class="hover">user</span></td>
                 <td data-v-aca44803="">
                   <div data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-15"><!----><span class="v-chip__underlay"></span>
                     <!---->
                     <!---->
-                    <div class="v-chip__content" data-no-activator="">tag1</div>
+                    <div class="v-chip__content" data-no-activator="">test-tag</div>
                     <!---->
                     <!----></span>
                     <!--teleport start-->
                     <!--teleport end-->
                   </div>
                 </td>
-                <td data-v-aca44803="">Monday, June 6th 2022, 6:51:53 pm</td>
+                <td data-v-aca44803="">Wednesday, May 20th 2020, 6:58:53 pm</td>
                 <td data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false"><!----><span class="v-chip__underlay"></span>
                   <!---->
                   <!---->
@@ -110,6 +110,35 @@ exports[`Device > Renders the component 1`] = `
                   <!----></span>
                 </td>
                 <td data-v-aca44803=""><a data-v-aca44803="" class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-18"></a>
+                  <!--teleport start-->
+                  <!--teleport end-->
+                </td>
+              </tr>
+              <tr data-v-aca44803="">
+                <td data-v-aca44803=""><i data-v-aca44803="" class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" data-test="success-icon"></i></td>
+                <td data-v-aca44803="">39-5e-2b</td>
+                <td data-v-aca44803=""><span data-v-aca44803="" class="d-inline-flex align-center ga-2"><i data-v-aca44803="" class="fl-linuxmint" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
+                <td data-v-aca44803=""><span data-v-aca44803="" tabindex="0" class="hover">user</span></td>
+                <td data-v-aca44803="">
+                  <div data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-19"><!----><span class="v-chip__underlay"></span>
+                    <!---->
+                    <!---->
+                    <div class="v-chip__content" data-no-activator="">test-tag</div>
+                    <!---->
+                    <!----></span>
+                    <!--teleport start-->
+                    <!--teleport end-->
+                  </div>
+                </td>
+                <td data-v-aca44803="">Wednesday, May 20th 2020, 7:58:53 pm</td>
+                <td data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false"><!----><span class="v-chip__underlay"></span>
+                  <!---->
+                  <!---->
+                  <div class="v-chip__content" data-no-activator="">accepted</div>
+                  <!---->
+                  <!----></span>
+                </td>
+                <td data-v-aca44803=""><a data-v-aca44803="" class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-22"></a>
                   <!--teleport start-->
                   <!--teleport end-->
                 </td>

--- a/ui/admin/tests/unit/views/Device/index.spec.ts
+++ b/ui/admin/tests/unit/views/Device/index.spec.ts
@@ -9,28 +9,68 @@ import { SnackbarPlugin } from "@/plugins/snackbar";
 
 type DeviceWrapper = VueWrapper<InstanceType<typeof Device>>;
 
-const mockDevices = [
+const devices = [
   {
-    uid: "cb1533e2e683aec21aee89b24ac4604b1a1955930362d33fb22e4e03fac52c75",
-    name: "08-97-98-68-7a-97",
-    identity: { mac: "08:97:98:68:7a:97" },
-    info: {
-      id: "ubuntu",
-      pretty_name: "Ubuntu 20.04.4 LTS",
-      version: "latest",
-      arch: "amd64",
-      platform: "docker",
+    uid: "a582b47a42d",
+    name: "39-5e-2a",
+    identity: {
+      mac: "00:00:00:00:00:00",
     },
-    public_key: "---BEGIN RSA KEY---",
-    tenant_id: "00000000-0000-4000-0000-000000000000",
-    last_seen: "2022-06-06T18:51:53.813Z",
-    online: true,
-    namespace: "dev",
+    info: {
+      id: "linuxmint",
+      pretty_name: "Linux Mint 19.3",
+      version: "",
+      arch: "x86_64",
+      platform: "linux",
+    },
+    public_key: "----- PUBLIC KEY -----",
+    tenant_id: "fake-tenant-data",
+    last_seen: "2020-05-20T18:58:53.276Z",
+    created_at: "2020-05-20T18:00:00.000Z",
+    online: false,
+    namespace: "user",
     status: "accepted",
-    created_at: "2022-04-13T11:43:25.218Z",
-    remote_addr: "172.22.0.1",
+    remoteAddr: "127.0.0.1",
     position: { latitude: 0, longitude: 0 },
-    tags: ["tag1"],
+    tags: [
+      {
+        tenant_id: "fake-tenant-data",
+        name: "test-tag",
+        created_at: "",
+        updated_at: "",
+      },
+    ],
+  },
+  {
+    uid: "a582b47a42e",
+    name: "39-5e-2b",
+    identity: {
+      mac: "00:00:00:00:00:00",
+    },
+    info: {
+      id: "linuxmint",
+      pretty_name: "Linux Mint 19.3",
+      version: "",
+      arch: "x86_64",
+      platform: "linux",
+    },
+    public_key: "----- PUBLIC KEY -----",
+    tenant_id: "fake-tenant-data",
+    last_seen: "2020-05-20T19:58:53.276Z",
+    created_at: "2020-05-20T18:00:00.000Z",
+    online: true,
+    namespace: "user",
+    status: "accepted",
+    remoteAddr: "127.0.0.1",
+    position: { latitude: 0, longitude: 0 },
+    tags: [
+      {
+        tenant_id: "fake-tenant-data",
+        name: "test-tag",
+        created_at: "",
+        updated_at: "",
+      },
+    ],
   },
 ];
 
@@ -44,7 +84,7 @@ describe("Device", () => {
     const devicesStore = useDevicesStore();
 
     devicesStore.fetchDeviceList = vi.fn().mockImplementation(() => {
-      devicesStore.devices = mockDevices;
+      devicesStore.devices = devices;
       devicesStore.deviceCount = 1;
     });
 

--- a/ui/admin/tests/unit/views/FirewallRules/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/FirewallRules/__snapshots__/index.spec.ts.snap
@@ -49,21 +49,14 @@ exports[`Firewall Rules > Renders the component 1`] = `
                 <div><span class="v-chip v-theme--light v-chip--density-compact v-chip--size-default v-chip--variant-tonal mr-1" draggable="false" outlined="" aria-describedby="v-tooltip-v-6"><!----><span class="v-chip__underlay"></span>
                   <!---->
                   <!---->
-                  <div class="v-chip__content" data-no-activator="">xxxx</div>
-                  <!---->
-                  <!----></span>
-                  <!--teleport start-->
-                  <!--teleport end--><span class="v-chip v-theme--light v-chip--density-compact v-chip--size-default v-chip--variant-tonal mr-1" draggable="false" outlined="" aria-describedby="v-tooltip-v-8"><!----><span class="v-chip__underlay"></span>
-                  <!---->
-                  <!---->
-                  <div class="v-chip__content" data-no-activator="">yyyy</div>
+                  <div class="v-chip__content" data-no-activator="">test-tag</div>
                   <!---->
                   <!----></span>
                   <!--teleport start-->
                   <!--teleport end-->
                 </div>
               </td>
-              <td><a class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-10"></a>
+              <td><a class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-8"></a>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/admin/tests/unit/views/FirewallRules/index.spec.ts
+++ b/ui/admin/tests/unit/views/FirewallRules/index.spec.ts
@@ -9,12 +9,19 @@ import { SnackbarPlugin } from "@/plugins/snackbar";
 
 type FirewallRulesWrapper = VueWrapper<InstanceType<typeof FirewallRules>>;
 
-const mockFirewallRules = [
+const firewallRules = [
   {
     action: "allow" as const,
     active: true,
     filter: {
-      tags: ["xxxx", "yyyy"],
+      tags: [
+        {
+          tenant_id: "fake-tenant-data",
+          name: "test-tag",
+          created_at: "",
+          updated_at: "",
+        },
+      ],
     },
     id: "5f1996c84d2190a22d5857bb",
     tenant_id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -33,7 +40,7 @@ describe("Firewall Rules", () => {
 
     const firewallStore = useFirewallRulesStore();
     firewallStore.fetchFirewallRulesList = vi.fn().mockImplementation(() => {
-      firewallStore.firewallRules = mockFirewallRules;
+      firewallStore.firewallRules = firewallRules;
       firewallStore.firewallRulesCount = 1;
     });
 


### PR DESCRIPTION
# Summary

This PR updates the admin UI unit tests and snapshots for Device and FirewallRules to align with the updated backend model where tags are now represented as objects instead of simple strings.

It also refreshes mock data to reflect the new schema and updates related snapshots accordingly.

## Changes

### Tags

Converted tags from strings to objects ({ tenant_id, name, created_at, updated_at }).

Updated snapshots to display test-tag instead of old string values (tag1, xxxx, yyyy).

### Device tests

- Renamed mockDevices → devices.
- Added a second mock device with corresponding snapshot row.

### Updated fields

- remote_addr → remoteAddr
- OS info changed from Ubuntu → Linux Mint
- Updated timestamps (last_seen, created_at) and namespaces.
- Adjusted status icons (success → error for offline, etc.).

### FirewallRules tests

- Renamed mockFirewallRules → firewallRules.
- Updated filter tags to use object schema.
- Adjusted tooltip IDs and chip content in snapshots.
