### PR TITLE
fix(ui): fix warnings and errors in tag-related tests

### DIFF
--- a/ui/src/store/modules/tags.ts
+++ b/ui/src/store/modules/tags.ts
@@ -133,12 +133,7 @@ const useTagsStore = defineStore("tags", () => {
     tenant: string;
     name: string;
   }) => {
-    try {
-      await apiTags.createTag(tenant, name);
-    } catch (error) {
-      console.error(error);
-      throw error;
-    }
+    await apiTags.createTag(tenant, name);
   };
 
   const editTag = async ({
@@ -150,12 +145,7 @@ const useTagsStore = defineStore("tags", () => {
     currentName: string;
     newName: UpdateTagRequest;
   }) => {
-    try {
-      await apiTags.updateTag(tenant, currentName, newName);
-    } catch (error) {
-      console.error(error);
-      throw error;
-    }
+    await apiTags.updateTag(tenant, currentName, newName);
   };
 
   const removeTag = async ({
@@ -165,12 +155,7 @@ const useTagsStore = defineStore("tags", () => {
     tenant: string;
     currentName: string;
   }) => {
-    try {
-      await apiTags.removeTag(tenant, currentName);
-    } catch (error) {
-      console.error(error);
-      throw error;
-    }
+    await apiTags.removeTag(tenant, currentName);
   };
 
   const pushTagToDevice = async ({

--- a/ui/tests/components/Containers/ContainerList.spec.ts
+++ b/ui/tests/components/Containers/ContainerList.spec.ts
@@ -5,73 +5,77 @@ import MockAdapter from "axios-mock-adapter";
 import { expect, describe, it, beforeEach } from "vitest";
 import ContainerList from "@/components/Containers/ContainerList.vue";
 import { router } from "@/router";
-import { containersApi } from "@/api/http";
+import { containersApi, tagsApi } from "@/api/http";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 
 type ContainerListWrapper = VueWrapper<InstanceType<typeof ContainerList>>;
+
+const containers = [
+  {
+    uid: "a582b47a42d",
+    name: "39-5e-2a",
+    identity: {
+      mac: "00:00:00:00:00:00",
+    },
+    info: {
+      id: "linuxmint",
+      pretty_name: "Linux Mint 19.3",
+      version: "",
+    },
+    public_key: "----- PUBLIC KEY -----",
+    tenant_id: "fake-tenant-data",
+    last_seen: "2020-05-20T18:58:53.276Z",
+    online: false,
+    namespace: "user",
+    status: "accepted",
+    tags: [{
+      tenant_id: "fake-tenant-data",
+      name: "test-tag",
+      created_at: "",
+      updated_at: "",
+    }],
+  },
+  {
+    uid: "a582b47a42e",
+    name: "39-5e-2b",
+    identity: {
+      mac: "00:00:00:00:00:00",
+    },
+    info: {
+      id: "linuxmint",
+      pretty_name: "Linux Mint 19.3",
+      version: "",
+    },
+    public_key: "----- PUBLIC KEY -----",
+    tenant_id: "fake-tenant-data",
+    last_seen: "2020-05-20T19:58:53.276Z",
+    online: true,
+    namespace: "user",
+    status: "accepted",
+    tags: [
+      {
+        tenant_id: "fake-tenant-data",
+        name: "test-tag",
+        created_at: "",
+        updated_at: "",
+      },
+    ],
+  },
+];
 
 describe("Container List", () => {
   let wrapper: ContainerListWrapper;
   setActivePinia(createPinia());
   const vuetify = createVuetify();
   const mockContainersApi = new MockAdapter(containersApi.getAxios());
+  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
+  localStorage.setItem("tenant", "fake-tenant-data");
+  mockContainersApi.onGet("http://localhost:3000/api/containers?page=1&per_page=10&status=accepted").reply(200, containers);
+  mockTagsApi
+    .onGet("http://localhost:3000/api/namespaces/fake-tenant-data/tags?filter=&page=1&per_page=10")
+    .reply(200, []);
 
-  const containers = [
-    {
-      uid: "a582b47a42d",
-      name: "39-5e-2a",
-      identity: {
-        mac: "00:00:00:00:00:00",
-      },
-      info: {
-        id: "linuxmint",
-        pretty_name: "Linux Mint 19.3",
-        version: "",
-      },
-      public_key: "----- PUBLIC KEY -----",
-      tenant_id: "fake-tenant-data",
-      last_seen: "2020-05-20T18:58:53.276Z",
-      online: false,
-      namespace: "user",
-      status: "accepted",
-      tags: [{
-        tenant_id: "fake-tenant-data",
-        name: "test-tag",
-        created_at: "",
-        updated_at: "",
-      }],
-    },
-    {
-      uid: "a582b47a42e",
-      name: "39-5e-2b",
-      identity: {
-        mac: "00:00:00:00:00:00",
-      },
-      info: {
-        id: "linuxmint",
-        pretty_name: "Linux Mint 19.3",
-        version: "",
-      },
-      public_key: "----- PUBLIC KEY -----",
-      tenant_id: "fake-tenant-data",
-      last_seen: "2020-05-20T19:58:53.276Z",
-      online: true,
-      namespace: "user",
-      status: "accepted",
-      tags: [
-        {
-          tenant_id: "fake-tenant-data",
-          name: "test-tag",
-          created_at: "",
-          updated_at: "",
-        },
-      ],
-    },
-  ];
-
-  beforeEach(async () => {
-    mockContainersApi.onGet("http://localhost:3000/api/containers?page=1&per_page=10&status=accepted").reply(200, containers);
-
+  beforeEach(() => {
     wrapper = mount(ContainerList, {
       global: {
         plugins: [vuetify, router, SnackbarPlugin],

--- a/ui/tests/components/Devices/DeviceList.spec.ts
+++ b/ui/tests/components/Devices/DeviceList.spec.ts
@@ -5,73 +5,78 @@ import MockAdapter from "axios-mock-adapter";
 import { expect, describe, it, beforeEach } from "vitest";
 import DeviceList from "@/components/Devices/DeviceList.vue";
 import { router } from "@/router";
-import { devicesApi } from "@/api/http";
+import { devicesApi, tagsApi } from "@/api/http";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 
 type DeviceListWrapper = VueWrapper<InstanceType<typeof DeviceList>>;
+
+const devices = [
+  {
+    uid: "a582b47a42d",
+    name: "39-5e-2a",
+    identity: {
+      mac: "00:00:00:00:00:00",
+    },
+    info: {
+      id: "linuxmint",
+      pretty_name: "Linux Mint 19.3",
+      version: "",
+    },
+    public_key: "----- PUBLIC KEY -----",
+    tenant_id: "fake-tenant-data",
+    last_seen: "2020-05-20T18:58:53.276Z",
+    online: false,
+    namespace: "user",
+    status: "accepted",
+    tags: [{
+      tenant_id: "fake-tenant-data",
+      name: "test-tag",
+      created_at: "",
+      updated_at: "",
+    }],
+  },
+  {
+    uid: "a582b47a42e",
+    name: "39-5e-2b",
+    identity: {
+      mac: "00:00:00:00:00:00",
+    },
+    info: {
+      id: "linuxmint",
+      pretty_name: "Linux Mint 19.3",
+      version: "",
+    },
+    public_key: "----- PUBLIC KEY -----",
+    tenant_id: "fake-tenant-data",
+    last_seen: "2020-05-20T19:58:53.276Z",
+    online: true,
+    namespace: "user",
+    status: "accepted",
+    tags: [
+      {
+        tenant_id: "fake-tenant-data",
+        name: "test-tag",
+        created_at: "",
+        updated_at: "",
+      },
+    ],
+  },
+];
 
 describe("Device List", () => {
   let wrapper: DeviceListWrapper;
   setActivePinia(createPinia());
   const vuetify = createVuetify();
   const mockDevicesApi = new MockAdapter(devicesApi.getAxios());
+  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
 
-  const devices = [
-    {
-      uid: "a582b47a42d",
-      name: "39-5e-2a",
-      identity: {
-        mac: "00:00:00:00:00:00",
-      },
-      info: {
-        id: "linuxmint",
-        pretty_name: "Linux Mint 19.3",
-        version: "",
-      },
-      public_key: "----- PUBLIC KEY -----",
-      tenant_id: "fake-tenant-data",
-      last_seen: "2020-05-20T18:58:53.276Z",
-      online: false,
-      namespace: "user",
-      status: "accepted",
-      tags: [{
-        tenant_id: "fake-tenant-data",
-        name: "test-tag",
-        created_at: "",
-        updated_at: "",
-      }],
-    },
-    {
-      uid: "a582b47a42e",
-      name: "39-5e-2b",
-      identity: {
-        mac: "00:00:00:00:00:00",
-      },
-      info: {
-        id: "linuxmint",
-        pretty_name: "Linux Mint 19.3",
-        version: "",
-      },
-      public_key: "----- PUBLIC KEY -----",
-      tenant_id: "fake-tenant-data",
-      last_seen: "2020-05-20T19:58:53.276Z",
-      online: true,
-      namespace: "user",
-      status: "accepted",
-      tags: [
-        {
-          tenant_id: "fake-tenant-data",
-          name: "test-tag",
-          created_at: "",
-          updated_at: "",
-        },
-      ],
-    },
-  ];
+  localStorage.setItem("tenant", "fake-tenant-data");
+  mockDevicesApi.onGet("http://localhost:3000/api/devices?page=1&per_page=10&status=accepted").reply(200, devices);
+  mockTagsApi
+    .onGet("http://localhost:3000/api/namespaces/fake-tenant-data/tags?filter=&page=1&per_page=10")
+    .reply(200, []);
 
   beforeEach(async () => {
-    mockDevicesApi.onGet("http://localhost:3000/api/devices?page=1&per_page=10&status=accepted").reply(200, devices);
-
     wrapper = mount(DeviceList, {
       global: {
         plugins: [vuetify, router, SnackbarPlugin],

--- a/ui/tests/components/Tags/TagCreate.spec.ts
+++ b/ui/tests/components/Tags/TagCreate.spec.ts
@@ -9,51 +9,6 @@ import { tagsApi } from "@/api/http";
 import { SnackbarInjectionKey } from "@/plugins/snackbar";
 import useTagsStore from "@/store/modules/tags";
 
-const node = document.createElement("div");
-node.setAttribute("id", "app");
-document.body.appendChild(node);
-
-const devices = [
-  {
-    uid: "a582b47a42d",
-    name: "39-5e-2a",
-    identity: {
-      mac: "00:00:00:00:00:00",
-    },
-    info: {
-      id: "linuxmint",
-      pretty_name: "Linux Mint 19.3",
-      version: "",
-    },
-    public_key: "----- PUBLIC KEY -----",
-    tenant_id: "fake-tenant-data",
-    last_seen: "2020-05-20T18:58:53.276Z",
-    online: false,
-    namespace: "user",
-    status: "accepted",
-    tags: ["test"],
-  },
-  {
-    uid: "a582b47a42e",
-    name: "39-5e-2b",
-    identity: {
-      mac: "00:00:00:00:00:00",
-    },
-    info: {
-      id: "linuxmint",
-      pretty_name: "Linux Mint 19.3",
-      version: "",
-    },
-    public_key: "----- PUBLIC KEY -----",
-    tenant_id: "fake-tenant-data",
-    last_seen: "2020-05-20T19:58:53.276Z",
-    online: true,
-    namespace: "user",
-    status: "accepted",
-    tags: ["test2"],
-  },
-];
-
 const mockSnackbar = {
   showSuccess: vi.fn(),
   showError: vi.fn(),
@@ -62,29 +17,16 @@ const mockSnackbar = {
 describe("Tag Form Create", async () => {
   let wrapper: VueWrapper<InstanceType<typeof TagCreate>>;
   setActivePinia(createPinia());
-
   const tagsStore = useTagsStore();
   const vuetify = createVuetify();
-
-  let mockTags: MockAdapter;
+  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
+  localStorage.setItem("tenant", "fake-tenant-data");
 
   beforeEach(async () => {
-    const el = document.createElement("div");
-    document.body.appendChild(el);
-
-    localStorage.setItem("tenant", "fake-tenant-data");
-
-    mockTags = new MockAdapter(tagsApi.getAxios());
-
-    mockTags.onGet("http://localhost:3000/api/devices?filter=&page=1&per_page=10&status=accepted").reply(200, devices);
-
     wrapper = mount(TagCreate, {
       global: {
         plugins: [vuetify, router],
         provide: { [SnackbarInjectionKey]: mockSnackbar },
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
       },
     });
   });
@@ -114,7 +56,7 @@ describe("Tag Form Create", async () => {
     wrapper.vm.showDialog = true;
     await flushPromises();
 
-    mockTags.onPost("http://localhost:3000/api/namespaces/fake-tenant-data/tags").reply(200);
+    mockTagsApi.onPost("http://localhost:3000/api/namespaces/fake-tenant-data/tags").reply(200);
 
     const tagsSpy = vi.spyOn(tagsStore, "createTag");
 
@@ -135,7 +77,7 @@ describe("Tag Form Create", async () => {
 
     await flushPromises();
 
-    mockTags.onPost("http://localhost:3000/api/namespaces/fake-tenant-data/tags").reply(409);
+    mockTagsApi.onPost("http://localhost:3000/api/namespaces/fake-tenant-data/tags").reply(409);
 
     await wrapper.findComponent('[data-test="tag-field"]').setValue("");
 

--- a/ui/tests/components/Tags/TagEdit.spec.ts
+++ b/ui/tests/components/Tags/TagEdit.spec.ts
@@ -19,10 +19,8 @@ describe("Tag Form Edit", async () => {
   setActivePinia(createPinia());
   const tagsStore = useTagsStore();
   const vuetify = createVuetify();
-
+  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
   localStorage.setItem("tenant", "fake-tenant-data");
-
-  const mockTags = new MockAdapter(tagsApi.getAxios());
 
   beforeEach(async () => {
     wrapper = mount(TagEdit, {
@@ -57,7 +55,7 @@ describe("Tag Form Edit", async () => {
   });
 
   it("Successfully edit tag", async () => {
-    mockTags.onPatch("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(200);
+    mockTagsApi.onPatch("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(200);
 
     const tagsSpy = vi.spyOn(tagsStore, "editTag");
 
@@ -79,7 +77,7 @@ describe("Tag Form Edit", async () => {
   });
 
   it("Failed to add tags", async () => {
-    mockTags.onPatch("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(409);
+    mockTagsApi.onPatch("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(409);
 
     await wrapper.findComponent('[data-test="open-tag-edit"]').trigger("click");
 

--- a/ui/tests/components/Tags/TagList.spec.ts
+++ b/ui/tests/components/Tags/TagList.spec.ts
@@ -1,77 +1,26 @@
-import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { createVuetify } from "vuetify";
 import MockAdapter from "axios-mock-adapter";
-import { expect, describe, it, beforeEach } from "vitest";
+import { expect, describe, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import TagList from "@/components/Tags/TagList.vue";
 import { router } from "@/router";
-import { namespacesApi, devicesApi, tagsApi } from "@/api/http";
+import { tagsApi } from "@/api/http";
 import { SnackbarPlugin } from "@/plugins/snackbar";
-
-const members = [
-  {
-    id: "xxxxxxxx",
-    username: "test",
-    role: "owner",
-  },
-];
-
-const namespaceData = {
-  name: "test",
-  owner: "xxxxxxxx",
-  tenant_id: "fake-tenant-data",
-  members,
-  max_devices: 3,
-  devices_count: 3,
-  devices: 2,
-  created_at: "",
-};
-
-const stats = {
-  registered_devices: 3,
-  online_devices: 1,
-  active_sessions: 0,
-  pending_devices: 0,
-  rejected_devices: 0,
-};
 
 const tags = [{ name: "123x" }, { name: "newtag" }];
 
 describe("Tag List", async () => {
-  let wrapper: VueWrapper<InstanceType<typeof TagList>>;
-
   const vuetify = createVuetify();
+  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
+  setActivePinia(createPinia());
+  localStorage.setItem("tenant", "fake-tenant-data");
 
-  let mockNamespace: MockAdapter;
-  let mockDevices: MockAdapter;
-  let mockTags: MockAdapter;
+  mockTagsApi
+    .onGet("http://localhost:3000/api/namespaces/fake-tenant-data/tags?filter=&page=1&per_page=10")
+    .reply(200, tags);
 
-  beforeEach(async () => {
-    const el = document.createElement("div");
-    document.body.appendChild(el);
-    setActivePinia(createPinia());
-
-    localStorage.setItem("tenant", "fake-tenant-data");
-
-    mockNamespace = new MockAdapter(namespacesApi.getAxios());
-    mockDevices = new MockAdapter(devicesApi.getAxios());
-    mockTags = new MockAdapter(tagsApi.getAxios());
-
-    mockNamespace.onGet("http://localhost:3000/api/namespaces/fake-tenant-data").reply(200, namespaceData);
-    mockTags
-      .onGet("http://localhost:3000/api/namespaces/fake-tenant-data/tags?filter=&page=1&per_page=10")
-      .reply(200, tags);
-    mockDevices.onGet("http://localhost:3000/api/stats").reply(200, stats);
-
-    wrapper = mount(TagList, {
-      global: {
-        plugins: [vuetify, router, SnackbarPlugin],
-        config: {
-          errorHandler: () => { /* ignore global error handler */ },
-        },
-      },
-    });
-  });
+  const wrapper = mount(TagList, { global: { plugins: [vuetify, router, SnackbarPlugin] } });
 
   it("Is a Vue instance", () => {
     expect(wrapper.vm).toBeTruthy();
@@ -79,10 +28,6 @@ describe("Tag List", async () => {
 
   it("Renders the component", () => {
     expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Data is defined", () => {
-    expect(wrapper.vm.$data).toBeDefined();
   });
 
   it("Renders the component table", async () => {

--- a/ui/tests/components/Tags/TagRemove.spec.ts
+++ b/ui/tests/components/Tags/TagRemove.spec.ts
@@ -1,84 +1,12 @@
-import { flushPromises, DOMWrapper, mount, VueWrapper } from "@vue/test-utils";
+import { flushPromises, DOMWrapper, mount } from "@vue/test-utils";
 import { createVuetify } from "vuetify";
 import MockAdapter from "axios-mock-adapter";
-import { expect, describe, it, beforeEach, vi } from "vitest";
+import { expect, describe, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import TagRemove from "@/components/Tags/TagRemove.vue";
 import { router } from "@/router";
-import { namespacesApi, devicesApi, tagsApi } from "@/api/http";
+import { tagsApi } from "@/api/http";
 import { SnackbarInjectionKey } from "@/plugins/snackbar";
-
-const node = document.createElement("div");
-node.setAttribute("id", "app");
-document.body.appendChild(node);
-
-const devices = [
-  {
-    uid: "a582b47a42d",
-    name: "39-5e-2a",
-    identity: {
-      mac: "00:00:00:00:00:00",
-    },
-    info: {
-      id: "linuxmint",
-      pretty_name: "Linux Mint 19.3",
-      version: "",
-    },
-    public_key: "----- PUBLIC KEY -----",
-    tenant_id: "fake-tenant-data",
-    last_seen: "2020-05-20T18:58:53.276Z",
-    online: false,
-    namespace: "user",
-    status: "accepted",
-    tags: ["test"],
-  },
-  {
-    uid: "a582b47a42e",
-    name: "39-5e-2b",
-    identity: {
-      mac: "00:00:00:00:00:00",
-    },
-    info: {
-      id: "linuxmint",
-      pretty_name: "Linux Mint 19.3",
-      version: "",
-    },
-    public_key: "----- PUBLIC KEY -----",
-    tenant_id: "fake-tenant-data",
-    last_seen: "2020-05-20T19:58:53.276Z",
-    online: true,
-    namespace: "user",
-    status: "accepted",
-    tags: ["test2"],
-  },
-];
-
-const members = [
-  {
-    id: "xxxxxxxx",
-    username: "test",
-    role: "owner",
-  },
-];
-
-const namespaceData = {
-  name: "test",
-  owner: "xxxxxxxx",
-  tenant_id: "fake-tenant-data",
-  members,
-  max_devices: 3,
-  devices_count: 3,
-  devices: 2,
-  created_at: "",
-};
-
-const stats = {
-  registered_devices: 3,
-  online_devices: 1,
-  active_sessions: 0,
-  pending_devices: 0,
-  rejected_devices: 0,
-};
 
 const mockSnackbar = {
   showSuccess: vi.fn(),
@@ -86,39 +14,20 @@ const mockSnackbar = {
 };
 
 describe("Tag Remove", async () => {
-  let wrapper: VueWrapper<InstanceType<typeof TagRemove>>;
-
+  setActivePinia(createPinia());
+  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
   const vuetify = createVuetify();
+  localStorage.setItem("tenant", "fake-tenant-data");
 
-  let mockNamespace: MockAdapter;
-  let mockDevices: MockAdapter;
-  let mockTags: MockAdapter;
-
-  beforeEach(async () => {
-    const el = document.createElement("div");
-    document.body.appendChild(el);
-    setActivePinia(createPinia());
-
-    localStorage.setItem("tenant", "fake-tenant-data");
-
-    mockNamespace = new MockAdapter(namespacesApi.getAxios());
-    mockDevices = new MockAdapter(devicesApi.getAxios());
-    mockTags = new MockAdapter(tagsApi.getAxios());
-
-    mockNamespace.onGet("http://localhost:3000/api/namespaces/fake-tenant-data").reply(200, namespaceData);
-    mockDevices.onGet("http://localhost:3000/api/devices?filter=&page=1&per_page=10&status=accepted").reply(200, devices);
-    mockDevices.onGet("http://localhost:3000/api/stats").reply(200, stats);
-
-    wrapper = mount(TagRemove, {
-      global: {
-        plugins: [vuetify, router],
-        provide: { [SnackbarInjectionKey]: mockSnackbar },
-      },
-      props: {
-        tagName: "tag-test",
-        hasAuthorization: true,
-      },
-    });
+  const wrapper = mount(TagRemove, {
+    global: {
+      plugins: [vuetify, router],
+      provide: { [SnackbarInjectionKey]: mockSnackbar },
+    },
+    props: {
+      tagName: "tag-test",
+      hasAuthorization: true,
+    },
   });
 
   it("Is a Vue instance", () => {
@@ -149,7 +58,7 @@ describe("Tag Remove", async () => {
   it("Successfully remove tag", async () => {
     await flushPromises();
 
-    mockTags.onDelete("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(200);
+    mockTagsApi.onDelete("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(200);
 
     const tagsSpy = vi.spyOn(tagsApi, "deleteTag");
 
@@ -163,7 +72,7 @@ describe("Tag Remove", async () => {
   });
 
   it("Failed to remove tags", async () => {
-    mockTags.onDelete("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(409);
+    mockTagsApi.onDelete("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(409);
 
     await wrapper.findComponent('[data-test="open-tag-remove"]').trigger("click");
 

--- a/ui/tests/components/Tags/__snapshots__/TagList.spec.ts.snap
+++ b/ui/tests/components/Tags/__snapshots__/TagList.spec.ts.snap
@@ -12,9 +12,28 @@ exports[`Tag List > Renders the component 1`] = `
             <th class="text-center"><span>Actions</span></th>
           </tr>
         </thead>
-        <tbody class="pa-4 text-subtitle-2">
+        <tbody>
           <tr>
-            <td colspan="2" class="pa-4 text-subtitle-2 text-center"> No data available </td>
+            <td class="text-center" data-test="tag-name">123x</td>
+            <td class="text-center"><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-6" data-test="tag-list-actions"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+                <!---->
+                <!---->
+              </button>
+              <!--teleport start-->
+              <!--teleport end-->
+            </td>
+          </tr>
+          <tr>
+            <td class="text-center" data-test="tag-name">newtag</td>
+            <td class="text-center"><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-10" data-test="tag-list-actions"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+                <!---->
+                <!---->
+              </button>
+              <!--teleport start-->
+              <!--teleport end-->
+            </td>
           </tr>
         </tbody>
       </table>
@@ -22,18 +41,7 @@ exports[`Tag List > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 4px; --v-progress-linear-height: 4px;" role="progressbar" aria-hidden="false" aria-valuemin="0" aria-valuemax="100" alt="Data table loading">
-    <!---->
-    <div class="v-progress-linear__background"></div>
-    <div class="v-progress-linear__buffer" style="width: 0%;"></div>
-    <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-      <div class="v-progress-linear__indeterminate">
-        <div class="v-progress-linear__indeterminate long"></div>
-        <div class="v-progress-linear__indeterminate short"></div>
-      </div>
-    </transition-stub>
-    <!---->
-  </div>
+  <!--v-if-->
   <div class="d-flex w-100 justify-end align-center"><span class="text-subtitle-2 mr-4">Items per page:</span>
     <div>
       <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4">

--- a/ui/tests/views/DetailsDevice.spec.ts
+++ b/ui/tests/views/DetailsDevice.spec.ts
@@ -6,7 +6,7 @@ import MockAdapter from "axios-mock-adapter";
 import { nextTick } from "vue";
 import { createRouter, createWebHistory } from "vue-router";
 import DetailsDevice from "@/views/DetailsDevice.vue";
-import { devicesApi } from "@/api/http";
+import { devicesApi, tagsApi } from "@/api/http";
 import { routes } from "@/router";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 import useDevicesStore from "@/store/modules/devices";
@@ -19,7 +19,7 @@ describe("Details Device", () => {
   setActivePinia(createPinia());
   const devicesStore = useDevicesStore();
   const vuetify = createVuetify();
-
+  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
   const mockDevicesApi = new MockAdapter(devicesApi.getAxios());
 
   const device = {
@@ -54,6 +54,8 @@ describe("Details Device", () => {
     ],
   };
 
+  localStorage.setItem("tenant", "fake-tenant-data");
+
   beforeEach(async () => {
     const router = createRouter({
       history: createWebHistory(),
@@ -66,6 +68,9 @@ describe("Details Device", () => {
       .reply(200, device);
     mockDevicesApi.onGet("http://localhost:3000/api/devices?page=1&per_page=10&status=accepted")
       .reply(200, [device]);
+    mockTagsApi
+      .onGet("http://localhost:3000/api/namespaces/fake-tenant-data/tags?filter=&page=1&per_page=10")
+      .reply(200, []);
 
     devicesStore.device = device;
 

--- a/ui/tests/views/PublicKeys.spec.ts
+++ b/ui/tests/views/PublicKeys.spec.ts
@@ -4,36 +4,39 @@ import { mount, VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import MockAdapter from "axios-mock-adapter";
 import PublicKeys from "@/views/PublicKeys.vue";
-import { sshApi } from "@/api/http";
+import { sshApi, tagsApi } from "@/api/http";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 import usePublicKeysStore from "@/store/modules/public_keys";
 
 type PublicKeysWrapper = VueWrapper<InstanceType<typeof PublicKeys>>;
+
+const mockPublicKeys = [{
+  data: "",
+  fingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01",
+  created_at: "2025-01-01T00:00:00.000Z",
+  tenant_id: "00000000-0000-4000-0000-000000000000",
+  name: "public-key-test",
+  username: ".*",
+  filter: {
+    hostname: ".*",
+  },
+}];
 
 describe("Public Keys", () => {
   let wrapper: PublicKeysWrapper;
   setActivePinia(createPinia());
   const publicKeysStore = usePublicKeysStore();
   const vuetify = createVuetify();
-
+  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
   const mockSshApi = new MockAdapter(sshApi.getAxios());
-
-  const mockPublicKeys = [{
-    data: "",
-    fingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01",
-    created_at: "2025-01-01T00:00:00.000Z",
-    tenant_id: "00000000-0000-4000-0000-000000000000",
-    name: "public-key-test",
-    username: ".*",
-    filter: {
-      hostname: ".*",
-    },
-  }];
+  localStorage.setItem("tenant", "fake-tenant-data");
+  mockSshApi.onGet("http://localhost:3000/api/sshkeys/public-keys?page=1&per_page=10").reply(200, mockPublicKeys, { "x-total-count": 1 });
+  mockTagsApi
+    .onGet("http://localhost:3000/api/namespaces/fake-tenant-data/tags?filter=&page=1&per_page=10")
+    .reply(200, []);
+  publicKeysStore.publicKeys = mockPublicKeys;
 
   beforeEach(async () => {
-    mockSshApi.onGet("http://localhost:3000/api/sshkeys/public-keys?page=1&per_page=10").reply(200, mockPublicKeys, { "x-total-count": 1 });
-    publicKeysStore.publicKeys = mockPublicKeys;
-
     wrapper = mount(PublicKeys, {
       global: {
         plugins: [vuetify, SnackbarPlugin],


### PR DESCRIPTION
This pull request cleans up tests related to the new tags' refactor and fixes warnings and errors caused by missing mocks to the new API routes. It also removes unnecessary `console.error` calls in the Tags store.