### PR TITLE
fix(ui): start layout state in store as an empty value

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -19,6 +19,6 @@ const components = {
   LoginLayout,
 };
 const layoutStore = useLayoutStore();
-const layout = computed(() => components[layoutStore.layout]);
+const layout = computed(() => components[layoutStore.layout || ""]);
 const theme = computed(() => layoutStore.theme);
 </script>

--- a/ui/src/store/modules/layout.ts
+++ b/ui/src/store/modules/layout.ts
@@ -5,7 +5,7 @@ export type Layout = "AppLayout" | "LoginLayout";
 type Theme = "dark" | "light";
 
 const useLayoutStore = defineStore("layout", () => {
-  const layout = ref<Layout>("AppLayout");
+  const layout = ref<Layout>();
   const theme = ref<Theme>(localStorage.getItem("theme") as Theme || "dark");
 
   const setTheme = (newTheme: Theme) => {

--- a/ui/tests/store/modules/layout.spec.ts
+++ b/ui/tests/store/modules/layout.spec.ts
@@ -11,7 +11,7 @@ describe("Layout Store", () => {
   });
 
   it("should have initial state values", () => {
-    expect(layoutStore.layout).toEqual("AppLayout");
+    expect(layoutStore.layout).toEqual(undefined);
     expect(layoutStore.theme).toEqual("dark");
   });
 


### PR DESCRIPTION
This pull request changes the Layout store in the main UI to initialize the `layout` state as an empty value. This prevents a bug where the initial value `AppLayout` was used before the layout was properly set by the router's `beforeEach` guard, causing problems like unnecessary API calls related to the AppLayout in places that didn't use it (e.g. Login page).