### PR TITLE
refactor(ui): unify dialogs using new shared dialog components

### DIFF
--- a/ui/src/components/PrivateKeys/PrivateKeyAdd.vue
+++ b/ui/src/components/PrivateKeys/PrivateKeyAdd.vue
@@ -1,75 +1,61 @@
 <template>
-  <BaseDialog v-model="showDialog" @close="close" transition="dialog-bottom-transition">
-    <v-card class="bg-v-theme-surface">
-      <v-card-title class="text-h5 pa-3 bg-primary" data-test="card-title">
-        New Private Key
-      </v-card-title>
-      <form @submit.prevent="create" class="mt-1">
-        <v-card-text>
+  <FormDialog
+    v-model="showDialog"
+    @close="close"
+    @cancel="close"
+    @confirm="create"
+    title="New Private Key"
+    icon="mdi-key"
+    confirm-text="Save"
+    cancel-text="Cancel"
+    :confirm-disabled="!!privateKeyDataError || !!nameError || (hasPassphrase && !!passphraseError)"
+    confirm-data-test="private-key-save-btn"
+    cancel-data-test="private-key-cancel-btn"
+    data-test="private-key-dialog"
+  >
+    <div class="px-6 pt-4">
+      <v-alert
+        class="text-subtitle-2 mb-2"
+        title="ShellHub never stores your private keys."
+        text="They stay secure in your browser's local storage and are not shared with ShellHub's servers."
+        color="primary"
+        density="compact"
+        variant="tonal"
+        data-test="privacy-policy-alert"
+      />
 
-          <v-alert
-            class="text-subtitle-2 mb-2"
-            title="ShellHub never stores your private keys."
-            text="They stay secure in your browser's local storage and are not shared with ShellHub's servers."
-            color="primary"
-            density="compact"
-            variant="tonal"
-            data-test="privacy-policy-alert"
-          />
-          <v-text-field
-            v-model="name"
-            :error-messages="nameError"
-            label="Key name"
-            placeholder="Name used to identify the private key"
-            variant="underlined"
-            data-test="name-field"
-          />
+      <v-text-field
+        v-model="name"
+        :error-messages="nameError"
+        label="Key name"
+        placeholder="Name used to identify the private key"
+        data-test="name-field"
+      />
 
-          <v-textarea
-            v-model="privateKeyData"
-            label="Private key data"
-            required
-            messages="Supports RSA, DSA, ECDSA (NIST P-*) and ED25519 key types, in PEM (PKCS#1, PKCS#8) and OpenSSH formats."
-            :error-messages="privateKeyDataError"
-            @update:model-value="validatePrivateKeyData"
-            variant="underlined"
-            data-test="private-key-field"
-            rows="5"
-          />
+      <v-textarea
+        v-model="privateKeyData"
+        label="Private key data"
+        required
+        messages="Supports RSA, DSA, ECDSA (NIST P-*) and ED25519 key types, in PEM (PKCS#1, PKCS#8) and OpenSSH formats."
+        :error-messages="privateKeyDataError"
+        @update:model-value="validatePrivateKeyData"
+        data-test="private-key-field"
+        rows="5"
+      />
 
-          <v-text-field
-            v-if="hasPassphrase"
-            v-model="passphrase"
-            :error-messages="passphraseError"
-            label="Passphrase"
-            class="mt-4"
-            hint="The key is encrypted and needs a passphrase. The passphrase is not stored."
-            persistent-hint
-            placeholder="Enter passphrase for encrypted key"
-            variant="underlined"
-            data-test="passphrase-field"
-          />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn
-            @click="close"
-            data-test="private-key-cancel-btn"
-          >
-            Cancel
-          </v-btn>
-          <v-btn
-            color="primary"
-            type="submit"
-            data-test="private-key-save-btn"
-            :disabled="!!privateKeyDataError || !!nameError || (hasPassphrase && !!passphraseError)"
-          >
-            Save
-          </v-btn>
-        </v-card-actions>
-      </form>
-    </v-card>
-  </BaseDialog>
+      <v-text-field
+        v-if="hasPassphrase"
+        v-model="passphrase"
+        :error-messages="passphraseError"
+        label="Passphrase"
+        class="mt-4"
+        hint="The key is encrypted and needs a passphrase. The passphrase is not stored."
+        persistent-hint
+        placeholder="Enter passphrase for encrypted key"
+        data-test="passphrase-field"
+      />
+    </div>
+  </FormDialog>
 </template>
 
 <script setup lang="ts">
@@ -79,7 +65,7 @@ import * as yup from "yup";
 import { convertToFingerprint, isKeyValid, parsePrivateKey } from "@/utils/sshKeys";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import FormDialog from "../FormDialog.vue";
 import usePrivateKeysStore from "@/store/modules/private_keys";
 
 const emit = defineEmits(["update"]);

--- a/ui/src/components/PrivateKeys/PrivateKeyDelete.vue
+++ b/ui/src/components/PrivateKeys/PrivateKeyDelete.vue
@@ -11,40 +11,28 @@
     </div>
   </v-list-item>
 
-  <BaseDialog v-model="showDialog">
-    <v-card class="bg-v-theme-surface">
-      <v-card-title class="text-h5 pa-5 bg-primary" data-test="privatekey-dialog-title">
-        Are you sure?
-      </v-card-title>
-      <v-divider />
-
-      <v-card-text class="mt-4 mb-0 pb-1" data-test="privatekey-dialog-text">
-        <p class="text-body-2 mb-2">
-          You are about to remove this private key.
-        </p>
-
-        <p class="text-body-2 mb-2">
-          After confirming this action cannot be redone.
-        </p>
-      </v-card-text>
-
-      <v-card-actions>
-        <v-spacer />
-
-        <v-btn variant="text" @click="showDialog = false" data-test="privatekey-close-btn"> Close </v-btn>
-
-        <v-btn color="red darken-1" variant="text" @click="remove()" data-test="privatekey-remove-btn">
-          Remove
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </BaseDialog>
+  <MessageDialog
+    v-model="showDialog"
+    @close="showDialog = false"
+    @confirm="remove"
+    @cancel="showDialog = false"
+    title="Are you sure?"
+    description="You are about to delete this private key"
+    icon="mdi-alert"
+    icon-color="error"
+    confirm-text="Delete"
+    confirm-color="error"
+    cancel-text="Close"
+    confirm-data-test="confirm-btn"
+    cancel-data-test="close-btn"
+    data-test="private-key-delete-dialog"
+  />
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import MessageDialog from "../MessageDialog.vue";
 import usePrivateKeysStore from "@/store/modules/private_keys";
 
 const props = defineProps<{ id: number }>();

--- a/ui/src/components/PublicKeys/PublicKeyAdd.vue
+++ b/ui/src/components/PublicKeys/PublicKeyAdd.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-tooltip v-bind="$attrs" class="text-center" location="bottom" :disabled="canCreatePublicKey">
-      <template v-slot:activator="{ props }">
+      <template #activator="{ props }">
         <div v-bind="props">
           <v-btn
             @click="showDialog = true"
@@ -18,107 +18,108 @@
           </v-btn>
         </div>
       </template>
-      <span> You don't have this kind of authorization. </span>
+      <span>You don't have this kind of authorization.</span>
     </v-tooltip>
 
-    <BaseDialog v-model="showDialog" @close="close" transition="dialog-bottom-transition">
-      <v-card class="bg-v-theme-surface">
-        <v-card-title class="text-h5 pa-3 bg-primary" data-test="pk-add-title">
-          New Public Key
-        </v-card-title>
-        <form @submit.prevent="create" class="mt-3">
-          <v-card-text>
-            <v-text-field
-              v-model="name"
-              :error-messages="nameError"
-              label="Name"
-              placeholder="Name used to identify the public key"
-              data-test="name-field"
-            />
+    <FormDialog
+      v-model="showDialog"
+      @close="close"
+      @cancel="close"
+      @confirm="create"
+      title="New Public Key"
+      icon="mdi-key-outline"
+      confirm-text="Save"
+      cancel-text="Cancel"
+      :confirm-disabled="confirmDisabled"
+      confirm-data-test="pk-add-save-btn"
+      cancel-data-test="pk-add-cancel-btn"
+      data-test="public-key-add-dialog"
+    >
+      <div class="px-6 pt-4">
+        <v-text-field
+          v-model="name"
+          :error-messages="nameError"
+          label="Name"
+          placeholder="Name used to identify the public key"
+          data-test="name-field"
+        />
 
-            <v-row class="mt-1 px-3">
-              <v-select
-                v-model="choiceUsername"
-                label="Device username access restriction"
-                :items="usernameList"
-                item-title="filterText"
-                item-value="filterName"
-                data-test="username-restriction-field"
-              />
-            </v-row>
+        <v-row class="mt-1 px-3">
+          <v-select
+            v-model="choiceUsername"
+            label="Device username access restriction"
+            :items="usernameList"
+            item-title="filterText"
+            item-value="filterName"
+            data-test="username-restriction-field"
+          />
+        </v-row>
 
-            <v-text-field
-              v-if="choiceUsername === 'username'"
-              v-model="username"
-              label="Rule username"
-              :error-messages="usernameError"
-              data-test="rule-field"
-            />
+        <v-text-field
+          v-if="choiceUsername === 'username'"
+          v-model="username"
+          label="Rule username"
+          :error-messages="usernameError"
+          data-test="rule-field"
+        />
 
-            <v-row class="mt-1 px-3">
-              <v-select
-                v-model="choiceFilter"
-                label="Device access restriction"
-                :items="filterList"
-                item-title="filterText"
-                item-value="filterName"
-                data-test="filter-restriction-field"
-              />
-            </v-row>
+        <v-row class="mt-1 px-3">
+          <v-select
+            v-model="choiceFilter"
+            label="Device access restriction"
+            :items="filterList"
+            item-title="filterText"
+            item-value="filterName"
+            data-test="filter-restriction-field"
+          />
+        </v-row>
 
-            <v-row class="px-3">
-              <v-autocomplete
-                v-if="choiceFilter === 'tags'"
-                v-model="tagChoices"
-                v-model:menu="acMenuOpen"
-                :menu-props="{ contentClass: menuContentClass, maxHeight: 320 }"
-                :items="tags"
-                variant="outlined"
-                item-title="name"
-                item-value="name"
-                attach
-                chips
-                label="Tags"
-                :rules="[validateLength]"
-                :error-messages="errMsg"
-                multiple
-                data-test="tags-selector"
-                @update:search="onSearch"
-              >=
-                <template #append-item>
-                  <div ref="sentinel" data-test="tags-sentinel" style="height: 1px;" />
-                </template>
-              </v-autocomplete>
+        <v-row class="px-3">
+          <v-autocomplete
+            v-if="choiceFilter === 'tags'"
+            v-model="tagChoices"
+            v-model:menu="acMenuOpen"
+            :menu-props="{ contentClass: menuContentClass, maxHeight: 320 }"
+            :items="tags"
+            variant="outlined"
+            item-title="name"
+            item-value="name"
+            attach
+            chips
+            label="Tags"
+            :rules="[validateLength]"
+            :error-messages="errMsg"
+            multiple
+            data-test="tags-selector"
+            @update:search="onSearch"
+          >
+            <template #append-item>
+              <div ref="sentinel" data-test="tags-sentinel" style="height: 1px;" />
+            </template>
+          </v-autocomplete>
 
-              <v-text-field
-                v-if="choiceFilter === 'hostname'"
-                v-model="hostname"
-                label="Hostname"
-                :error-messages="hostnameError"
-                data-test="hostname-field"
-              />
-            </v-row>
+          <v-text-field
+            v-if="choiceFilter === 'hostname'"
+            v-model="hostname"
+            label="Hostname"
+            :error-messages="hostnameError"
+            data-test="hostname-field"
+          />
+        </v-row>
 
-            <v-textarea
-              v-model="publicKeyData"
-              class="mt-5"
-              label="Public key data"
-              :error-messages="publicKeyDataError"
-              required
-              messages="Supports RSA, DSA, ECDSA (NIST P-*) and ED25519 key types, in PEM (PKCS#1, PKCS#8) and OpenSSH formats."
-              data-test="data-field"
-              rows="2"
-            />
-          </v-card-text>
-
-          <v-card-actions>
-            <v-spacer />
-            <v-btn @click="close" data-test="pk-add-cancel-btn">Cancel</v-btn>
-            <v-btn color="primary" type="submit" data-test="pk-add-save-btn">Save</v-btn>
-          </v-card-actions>
-        </form>
-      </v-card>
-    </BaseDialog>
+        <v-textarea
+          v-model="publicKeyData"
+          class="mt-2"
+          label="Public key data"
+          :error-messages="publicKeyDataError"
+          required
+          messages="Supports RSA, DSA, ECDSA (NIST P-*) and ED25519 key types, in PEM (PKCS#1, PKCS#8) and OpenSSH formats."
+          data-test="data-field"
+          rows="3"
+          auto-grow
+        />
+      </div>
+    </FormDialog>
   </div>
 </template>
 
@@ -131,12 +132,14 @@ import hasPermission from "@/utils/permission";
 import { isKeyValid } from "@/utils/sshKeys";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import FormDialog from "../FormDialog.vue";
 import usePublicKeysStore from "@/store/modules/public_keys";
 import { IPublicKeyCreate } from "@/interfaces/IPublicKey";
 import useTagsStore from "@/store/modules/tags";
 
 const { size } = defineProps<{ size?: string }>();
+
+type LocalTag = { name: string };
 
 const emit = defineEmits(["update"]);
 const publicKeysStore = usePublicKeysStore();
@@ -151,16 +154,14 @@ const tagChoices = ref<string[]>([]);
 const errMsg = ref("");
 const keyLocal = ref({});
 
-const usernameList = ref([
-  { filterName: "all", filterText: "Allow any user" },
-  { filterName: "username", filterText: "Restrict access using a regexp for username" },
-]);
+const acMenuOpen = ref(false);
+const menuContentClass = computed(() => "pk-tags-ac-content");
 
-const filterList = ref([
-  { filterName: "all", filterText: "Allow the key to connect to all available devices" },
-  { filterName: "hostname", filterText: "Restrict access using a regexp for hostname" },
-  { filterName: "tags", filterText: "Restrict access by tags" },
-]);
+const fetchedTags = ref<LocalTag[]>([]);
+const tags = computed(() => fetchedTags.value);
+
+const sentinel = ref<HTMLElement | null>(null);
+let observer: IntersectionObserver | null = null;
 
 const {
   value: name,
@@ -189,27 +190,12 @@ const {
   resetField: resetPublicKeyData,
 } = useField<string>("publicKeyData", yup.string().required(), { initialValue: "" });
 
-type LocalTag = { name: string };
-
-const acMenuOpen = ref(false);
-const menuContentClass = computed(() => "pk-tags-ac-content");
-
-const fetchedTags = ref<LocalTag[]>([]);
-const tags = computed(() => fetchedTags.value);
-
-const sentinel = ref<HTMLElement | null>(null);
-let observer: IntersectionObserver | null = null;
-
-const page = ref(1);
-const perPage = ref(10);
-const filter = ref("");
-const isLoading = ref(false);
-
-const hasMore = computed(() => tagsStore.numberTags > fetchedTags.value.length);
-
-const canCreatePublicKey = hasPermission("publicKey:create");
-
-watch(tagChoices, (list) => {
+watch([tagChoices, choiceFilter], ([list, currentFilter]) => {
+  if (currentFilter !== "tags") {
+    validateLength.value = true;
+    errMsg.value = "";
+    return;
+  }
   if (list.length > 3) {
     validateLength.value = false;
     nextTick(() => tagChoices.value.pop());
@@ -223,9 +209,13 @@ watch(tagChoices, (list) => {
   }
 });
 
-watch(publicKeyData, async () => {
-  if (publicKeyData.value !== "") setPublicKeyDataError("Field is required");
-  if (isKeyValid("public", publicKeyData.value)) setPublicKeyDataError("This is not valid key");
+watch(publicKeyData, () => {
+  if (!publicKeyData.value) {
+    setPublicKeyDataError("Field is required");
+    return;
+  }
+  if (!isKeyValid("public", publicKeyData.value)) setPublicKeyDataError("This is not valid key");
+  else setPublicKeyDataError("");
 });
 
 const chooseUsername = () => {
@@ -251,17 +241,21 @@ const chooseFilter = () => {
   }
 };
 
+const resetFields = () => { resetName(); resetUsername(); resetHostname(); resetPublicKeyData(); };
+
 const setLocalVariable = () => {
   keyLocal.value = {};
   hostname.value = "";
   tagChoices.value = [];
   choiceFilter.value = "all";
   choiceUsername.value = "all";
+  resetFields();
 };
 
 watch(showDialog, (value) => { if (!value) setLocalVariable(); });
 
 const close = () => { showDialog.value = false; setLocalVariable(); };
+
 const update = () => { emit("update"); close(); };
 
 const hasErrors = () => {
@@ -270,8 +264,6 @@ const hasErrors = () => {
   if (choiceFilter.value === "tags" && tagChoices.value.length === 0) return true;
   return false;
 };
-
-const resetFields = () => { resetName(); resetUsername(); resetHostname(); resetPublicKeyData(); };
 
 const create = async () => {
   if (hasErrors()) return;
@@ -300,6 +292,14 @@ const create = async () => {
     }
   }
 };
+
+const page = ref(1);
+const perPage = ref(10);
+const filter = ref("");
+const isLoading = ref(false);
+
+const hasMore = computed(() => tagsStore.numberTags > fetchedTags.value.length);
+const canCreatePublicKey = hasPermission("publicKey:create");
 
 const encodeFilter = (search: string) => {
   if (!search) return "";
@@ -402,6 +402,24 @@ onMounted(async () => {
 });
 
 onUnmounted(cleanupObserver);
+
+const confirmDisabled = computed(() => {
+  if (!name.value || !publicKeyData.value) return true;
+
+  if (choiceUsername.value === "username" && !username.value) return true;
+  if (choiceFilter.value === "hostname" && !hostname.value) return true;
+  if (choiceFilter.value === "tags" && tagChoices.value.length === 0) return true;
+
+  const tagRuleBlocking = choiceFilter.value === "tags" && !validateLength.value;
+
+  return Boolean(
+    nameError.value
+    || publicKeyDataError.value
+    || (choiceUsername.value === "username" && usernameError.value)
+    || (choiceFilter.value === "hostname" && hostnameError.value)
+    || tagRuleBlocking,
+  );
+});
 
 defineExpose({ publicKeyDataError, nameError });
 </script>

--- a/ui/src/components/PublicKeys/PublicKeyDelete.vue
+++ b/ui/src/components/PublicKeys/PublicKeyDelete.vue
@@ -9,46 +9,29 @@
     </div>
   </v-list-item>
 
-  <BaseDialog v-model="showDialog">
-    <v-card class="bg-v-theme-surface">
-      <v-card-title data-test="text-title" class="text-h5 pa-5 bg-primary">
-        Are you sure?
-      </v-card-title>
-      <v-divider />
-
-      <v-card-text data-test="text" class="mt-4 mb-0 pb-1">
-        <p class="text-body-2 mb-2">You are about to remove this public key.</p>
-
-        <p class="text-body-2 mb-2">
-          After confirming this action cannot be redone.
-        </p>
-      </v-card-text>
-
-      <v-card-actions>
-        <v-spacer />
-
-        <v-btn data-test="close-btn" variant="text" @click="showDialog = false">
-          Close
-        </v-btn>
-
-        <v-btn
-          data-test="remove-btn"
-          color="red darken-1"
-          variant="text"
-          @click="remove()"
-        >
-          Remove
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </BaseDialog>
+  <MessageDialog
+    v-model="showDialog"
+    @close="showDialog = false"
+    @confirm="remove"
+    @cancel="showDialog = false"
+    title="Are you sure?"
+    description="You are about to delete this public key"
+    icon="mdi-alert"
+    icon-color="error"
+    confirm-text="Delete"
+    confirm-color="error"
+    cancel-text="Close"
+    confirm-data-test="confirm-btn"
+    cancel-data-test="close-btn"
+    data-test="delete-public-key-dialog"
+  />
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import MessageDialog from "../MessageDialog.vue";
 import usePublicKeysStore from "@/store/modules/public_keys";
 
 const { fingerprint, hasAuthorization } = defineProps<{

--- a/ui/src/components/PublicKeys/PublicKeyEdit.vue
+++ b/ui/src/components/PublicKeys/PublicKeyEdit.vue
@@ -10,145 +10,120 @@
         <div data-test="public-key-edit-icon" class="mr-2">
           <v-icon> mdi-pencil </v-icon>
         </div>
-
-        <v-list-item-title>
-          Edit
-        </v-list-item-title>
+        <v-list-item-title>Edit</v-list-item-title>
       </div>
     </v-list-item>
 
-    <BaseDialog v-model="showDialog" @close="close" transition="dialog-bottom-transition">
-      <v-card class="bg-v-theme-surface">
-        <v-card-title class="text-h5 pa-3 bg-primary" data-test="public-key-edit-title">
-          Edit Public Key
-        </v-card-title>
-        <form @submit.prevent="edit" class="mt-3">
-          <v-card-text>
-            <v-text-field
-              v-model="name"
-              label="Key name"
-              placeholder="Name used to identify the public key"
-              :error-messages="nameError"
-              required
-              variant="underlined"
-              data-test="name-field"
-            />
+    <FormDialog
+      v-model="showDialog"
+      @close="close"
+      @cancel="close"
+      @confirm="edit"
+      title="Edit Public Key"
+      icon="mdi-key-outline"
+      confirm-text="Save"
+      cancel-text="Cancel"
+      :confirm-disabled="confirmDisabled"
+      confirm-data-test="pk-edit-save-btn"
+      cancel-data-test="pk-edit-cancel-btn"
+      data-test="public-key-edit-dialog"
+    >
+      <div class="px-6 pt-4">
+        <v-text-field
+          v-model="name"
+          label="Key name"
+          placeholder="Name used to identify the public key"
+          :error-messages="nameError"
+          required
+          data-test="name-field"
+        />
 
-            <v-row class="mt-1 px-3">
-              <v-select
-                v-model="choiceUsername"
-                label="Device username access restriction"
-                :items="usernameList"
-                variant="underlined"
-                item-title="filterText"
-                item-value="filterName"
-                data-test="username-restriction-field"
-              />
-            </v-row>
+        <v-row class="mt-1 px-3">
+          <v-select
+            v-model="choiceUsername"
+            label="Device username access restriction"
+            :items="usernameList"
+            item-title="filterText"
+            item-value="filterName"
+            data-test="username-restriction-field"
+          />
+        </v-row>
 
-            <v-text-field
-              v-if="choiceUsername === 'username'"
-              v-model="username"
-              label="Rule username"
-              variant="underlined"
-              :error-messages="usernameError"
-              data-test="rule-field"
-            />
+        <v-text-field
+          v-if="choiceUsername === 'username'"
+          v-model="username"
+          label="Rule username"
+          :error-messages="usernameError"
+          data-test="rule-field"
+        />
 
-            <v-row class="mt-1 px-3">
-              <v-select
-                v-model="choiceFilter"
-                label="Device access restriction"
-                :items="filterList"
-                variant="underlined"
-                item-title="filterText"
-                item-value="filterName"
-                data-test="filter-restriction-field"
-              />
-            </v-row>
+        <v-row class="mt-1 px-3">
+          <v-select
+            v-model="choiceFilter"
+            label="Device access restriction"
+            :items="filterList"
+            item-title="filterText"
+            item-value="filterName"
+            data-test="filter-restriction-field"
+          />
+        </v-row>
 
-            <v-row class="px-3">
-              <v-autocomplete
-                v-if="choiceFilter === 'tags'"
-                v-model="tagChoices"
-                v-model:menu="acMenuOpen"
-                :menu-props="{ contentClass: menuContentClass, maxHeight: 320 }"
-                :items="tags"
-                item-title="name"
-                item-value="name"
-                attach
-                chips
-                label="Tags"
-                :rules="[validateLength]"
-                :error-messages="errMsg"
-                multiple
-                data-test="tags-selector"
-                @update:search="onSearch"
-              >
-                <template #append-item>
-                  <div ref="sentinel" data-test="tags-sentinel" style="height: 1px;" />
-                </template>
-              </v-autocomplete>
+        <v-row class="px-3">
+          <v-autocomplete
+            v-if="choiceFilter === 'tags'"
+            v-model="tagChoices"
+            v-model:menu="acMenuOpen"
+            :menu-props="{ contentClass: menuContentClass, maxHeight: 320 }"
+            :items="tags"
+            item-title="name"
+            item-value="name"
+            attach
+            chips
+            label="Tags"
+            :rules="[validateLength]"
+            :error-messages="errMsg"
+            variant="outlined"
+            multiple
+            data-test="tags-selector"
+            @update:search="onSearch"
+          >
+            <template #append-item>
+              <div ref="sentinel" data-test="tags-sentinel" style="height: 1px;" />
+            </template>
+          </v-autocomplete>
 
-              <v-text-field
-                v-if="choiceFilter === 'hostname'"
-                v-model="hostname"
-                label="Hostname"
-                :error-messages="hostnameError"
-                data-test="hostname-field"
-              />
-            </v-row>
+          <v-text-field
+            v-if="choiceFilter === 'hostname'"
+            v-model="hostname"
+            label="Hostname"
+            :error-messages="hostnameError"
+            data-test="hostname-field"
+          />
+        </v-row>
 
-            <v-textarea
-              v-model="publicKeyData"
-              class="mt-5"
-              label="Public key data"
-              :error-messages="publicKeyDataError"
-              required
-              messages="Supports RSA, DSA, ECDSA (NIST P-*) and ED25519 key types, in PEM (PKCS#1, PKCS#8) and OpenSSH formats."
-              data-test="data-field"
-              rows="2"
-            />
-          </v-card-text>
-
-          <v-card-actions>
-            <v-spacer />
-            <v-btn
-              @click="close"
-              data-test="pk-edit-cancel-btn"
-            >
-              Cancel
-            </v-btn>
-            <v-btn
-              color="primary"
-              type="submit"
-              data-test="pk-edit-save-btn"
-            >
-              Save
-            </v-btn>
-          </v-card-actions>
-        </form>
-      </v-card>
-    </BaseDialog>
+        <v-textarea
+          v-model="publicKeyData"
+          class="mt-5"
+          label="Public key data"
+          :error-messages="publicKeyDataError"
+          required
+          messages="Supports RSA, DSA, ECDSA (NIST P-*) and ED25519 key types, in PEM (PKCS#1, PKCS#8) and OpenSSH formats."
+          data-test="data-field"
+          rows="2"
+        />
+      </div>
+    </FormDialog>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useField } from "vee-validate";
-import {
-  ref,
-  watch,
-  onMounted,
-  computed,
-  nextTick,
-  onUpdated,
-  onUnmounted,
-} from "vue";
+import { ref, watch, onMounted, computed, nextTick, onUpdated, onUnmounted } from "vue";
 import * as yup from "yup";
 import { IPublicKey } from "@/interfaces/IPublicKey";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import FormDialog from "../FormDialog.vue";
 import { HostnameFilter, TagsFilter } from "@/interfaces/IFilter";
 import usePublicKeysStore from "@/store/modules/public_keys";
 import useTagsStore from "@/store/modules/tags";
@@ -164,11 +139,12 @@ const showDialog = ref(false);
 const publicKeysStore = usePublicKeysStore();
 const tagsStore = useTagsStore();
 const snackbar = useSnackbar();
-const choiceFilter = ref("hostname");
+
+const choiceFilter = ref<"all" | "hostname" | "tags">("hostname");
+const choiceUsername = ref<"all" | "username">("username");
+
 const validateLength = ref(true);
 const errMsg = ref("");
-const prop = computed(() => props);
-const choiceUsername = ref("username");
 
 const filterList = ref([
   { filterName: "all", filterText: "Allow the key to connect to all available devices" },
@@ -188,7 +164,7 @@ const {
   value: name,
   errorMessage: nameError,
 } = useField<string>("name", yup.string().required(), {
-  initialValue: prop.value.publicKey.name,
+  initialValue: props.publicKey.name,
 });
 watch(name, () => { keyLocal.value.name = name.value; });
 
@@ -197,7 +173,7 @@ const {
   errorMessage: usernameError,
   setErrors: setUsernameError,
 } = useField<string>("username", yup.string().required(), {
-  initialValue: prop.value.publicKey.username,
+  initialValue: props.publicKey.username,
 });
 watch(username, () => { keyLocal.value.username = username.value; });
 
@@ -206,14 +182,14 @@ const {
   errorMessage: hostnameError,
   setErrors: setHostnameError,
 } = useField<string>("hostname", yup.string().required(), {
-  initialValue: (prop.value.publicKey.filter as HostnameFilter)?.hostname || "",
+  initialValue: (props.publicKey.filter as HostnameFilter)?.hostname || "",
 });
 
 const {
   value: publicKeyData,
   errorMessage: publicKeyDataError,
 } = useField<string>("publicKeyData", yup.string().required(), {
-  initialValue: prop.value.publicKey.data,
+  initialValue: props.publicKey.data,
 });
 
 const hasAuthorization = computed(() => props.hasAuthorization ?? true);
@@ -335,72 +311,68 @@ watch(choiceFilter, async (val) => {
   }
 });
 
-watch(tagChoices, (list) => {
+watch([tagChoices, choiceFilter], ([list, filterMode]) => {
+  if (filterMode !== "tags") {
+    validateLength.value = true;
+    errMsg.value = "";
+    return;
+  }
   if (list.length > 3) {
     validateLength.value = false;
     nextTick(() => tagChoices.value.pop());
     errMsg.value = "The maximum capacity has reached";
-  } else if (list.length <= 2) {
+  } else {
     validateLength.value = true;
     errMsg.value = "";
   }
 });
 
 const handleUpdate = () => {
-  if (showDialog.value) {
-    if (hasTags.value) {
-      const { tags } = props.publicKey.filter as TagsFilter;
-      tagChoices.value = tags;
-      choiceFilter.value = "tags";
-    } else {
-      const { hostname: hostnameLocal } = props.publicKey.filter as HostnameFilter;
-      if (!!hostnameLocal && hostnameLocal !== ".*") {
-        choiceFilter.value = "hostname";
-        hostname.value = hostnameLocal;
-      } else if (!!hostnameLocal && hostnameLocal === ".*") {
-        choiceFilter.value = "all";
-      }
-    }
+  if (!showDialog.value) return;
 
-    const { username: usernameLocal } = props.publicKey;
-    choiceUsername.value = usernameLocal === ".*" ? "all" : "username";
-    username.value = usernameLocal;
+  if (hasTags.value) {
+    const { tags } = props.publicKey.filter as TagsFilter;
+    tagChoices.value = tags;
+    choiceFilter.value = "tags";
+  } else {
+    const { hostname: hostnameLocal } = props.publicKey.filter as HostnameFilter;
+    if (hostnameLocal && hostnameLocal !== ".*") {
+      choiceFilter.value = "hostname";
+      hostname.value = hostnameLocal;
+    } else if (hostnameLocal === ".*") {
+      choiceFilter.value = "all";
+    }
   }
+
+  const { username: usernameLocal } = props.publicKey;
+  choiceUsername.value = usernameLocal === ".*" ? "all" : "username";
+  username.value = usernameLocal;
 };
 
 const chooseFilter = () => {
   switch (choiceFilter.value) {
-    case "all": {
+    case "all":
       keyLocal.value = { ...keyLocal.value, filter: { hostname: ".*" } };
       break;
-    }
-    case "hostname": {
+    case "hostname":
       keyLocal.value = { ...keyLocal.value, filter: { hostname: hostname.value } };
       break;
-    }
-    case "tags": {
+    case "tags":
       keyLocal.value = { ...keyLocal.value, filter: { tags: tagChoices.value } };
       break;
-    }
-    default: {
-      break;
-    }
+    default: break;
   }
 };
 
 const chooseUsername = () => {
   switch (choiceUsername.value) {
-    case "all": {
+    case "all":
       keyLocal.value = { ...keyLocal.value, username: ".*" };
       break;
-    }
-    case "username": {
+    case "username":
       keyLocal.value = { ...keyLocal.value, username: username.value };
       break;
-    }
-    default: {
-      break;
-    }
+    default: break;
   }
 };
 
@@ -450,13 +422,20 @@ const resetPublicKey = () => {
   hostname.value = "";
   username.value = "";
   tagChoices.value = [];
+  validateLength.value = true;
+  errMsg.value = "";
+  acMenuOpen.value = false;
+  cleanupObserver();
+  page.value = 1;
+  perPage.value = 10;
+  filter.value = "";
+  fetchedTags.value = [];
 };
 
 const close = () => {
   resetPublicKey();
   setLocalVariable();
   showDialog.value = false;
-  cleanupObserver();
 };
 
 const update = () => {
@@ -465,21 +444,39 @@ const update = () => {
 };
 
 const edit = async () => {
-  if (!hasError()) {
-    chooseFilter();
-    chooseUsername();
-    const keySend = { ...keyLocal.value, data: btoa(keyLocal.value.data as string) };
+  if (hasError()) return;
 
-    try {
-      await publicKeysStore.updatePublicKey(keySend as IPublicKey);
-      snackbar.showSuccess("Public key updated successfully.");
-      update();
-    } catch (error: unknown) {
-      snackbar.showError("Failed to update public key.");
-      handleError(error);
-    }
+  chooseFilter();
+  chooseUsername();
+  const keySend = { ...keyLocal.value, data: btoa(keyLocal.value.data as string) };
+
+  try {
+    await publicKeysStore.updatePublicKey(keySend as IPublicKey);
+    snackbar.showSuccess("Public key updated successfully.");
+    update();
+  } catch (error: unknown) {
+    snackbar.showError("Failed to update public key.");
+    handleError(error);
   }
 };
+
+const confirmDisabled = computed(() => {
+  if (!name.value || !publicKeyData.value) return true;
+
+  if (choiceUsername.value === "username" && !username.value) return true;
+  if (choiceFilter.value === "hostname" && !hostname.value) return true;
+  if (choiceFilter.value === "tags" && tagChoices.value.length === 0) return true;
+
+  const tagRuleBlocking = choiceFilter.value === "tags" && !validateLength.value;
+
+  return Boolean(
+    nameError.value
+    || publicKeyDataError.value
+    || (choiceUsername.value === "username" && usernameError.value)
+    || (choiceFilter.value === "hostname" && hostnameError.value)
+    || tagRuleBlocking,
+  );
+});
 
 defineExpose({ nameError, usernameError, hostnameError });
 </script>

--- a/ui/src/components/firewall/FirewallRuleAdd.vue
+++ b/ui/src/components/firewall/FirewallRuleAdd.vue
@@ -19,153 +19,133 @@
       <span> You don't have this kind of authorization. </span>
     </v-tooltip>
 
-    <BaseDialog v-model="showDialog" @close="close" transition="dialog-bottom-transition">
-      <v-card class="bg-v-theme-surface">
-        <v-card-title class="text-h5 pa-3 bg-primary" data-test="firewall-rule-title">
-          New Firewall Rule
-        </v-card-title>
-        <form @submit.prevent="addFirewallRule" class="mt-3">
-          <v-card-text>
-            <v-row>
-              <v-col>
-                <v-select
-                  v-model="active"
-                  :items="activeSelectOptions"
-                  label="Rule status"
-                  variant="underlined"
-                  data-test="firewall-rule-status"
-                />
-              </v-col>
-
-              <v-col>
-                <v-text-field
-                  v-model="priority"
-                  label="Rule priority"
-                  :error-messages="priorityError"
-                  type="number"
-                  variant="underlined"
-                  data-test="firewall-rule-priority"
-                />
-              </v-col>
-
-              <v-col>
-                <v-select
-                  v-model="action"
-                  :items="actionSelectOptions"
-                  label="Rule policy"
-                  variant="underlined"
-                  data-test="firewall-rule-policy"
-                />
-              </v-col>
-            </v-row>
-
-            <v-row class="mt-1 mb-1 px-3">
-              <v-select
-                v-model="selectedIPOption"
-                @update:model-value="handleSourceIpUpdate"
-                label="Source IP access restriction"
-                :items="sourceIPSelectOptions"
-                variant="underlined"
-                data-test="firewall-rule-source-ip-select"
-              />
-            </v-row>
-
-            <v-text-field
-              v-if="selectedIPOption === 'restrict'"
-              v-model="sourceIp"
-              label="Rule source IP"
+    <FormDialog
+      v-model="showDialog"
+      @close="close"
+      @cancel="close"
+      @confirm="addFirewallRule"
+      title="New Firewall Rule"
+      icon="mdi-shield-check"
+      confirm-text="Add"
+      cancel-text="Cancel"
+      :confirm-disabled="hasErrors"
+      confirm-data-test="firewall-rule-add-btn"
+      cancel-data-test="firewall-rule-cancel"
+      data-test="firewall-rule-dialog"
+    >
+      <div class="px-6 pt-4">
+        <v-row>
+          <v-col>
+            <v-select
+              v-model="active"
+              :items="activeSelectOptions"
+              label="Rule status"
               variant="underlined"
-              :error-messages="sourceIpError"
-              data-test="firewall-rule-source-ip"
+              data-test="firewall-rule-status"
             />
+          </v-col>
 
-            <v-row class="mt-1 mb-1 px-3">
-              <v-select
-                v-model="selectedUsernameOption"
-                @update:model-value="handleUsernameUpdate"
-                label="Device username access restriction"
-                :items="usernameSelectOptions"
-                variant="underlined"
-                data-test="username-field"
-              />
-            </v-row>
-
+          <v-col>
             <v-text-field
-              v-if="selectedUsernameOption === 'username'"
-              v-model="username"
-              label="Username access restriction"
-              placeholder="Username used during the connection"
-              variant="underlined"
-              :error-messages="usernameError"
-              data-test="firewall-rule-username-restriction"
+              v-model="priority"
+              label="Rule priority"
+              :error-messages="priorityError"
+              type="number"
+              data-test="firewall-rule-priority"
             />
+          </v-col>
 
-            <v-row class="mt-2 mb-1 px-3">
-              <v-select
-                v-model="selectedFilterOption"
-                @update:model-value="handleFilterUpdate"
-                label="Device access restriction"
-                :items="filterSelectOptions"
-                variant="underlined"
-                data-test="filter-select"
-              />
-            </v-row>
-
-            <v-text-field
-              v-if="selectedFilterOption === FormFilterOptions.Hostname"
-              v-model="hostname"
-              label="Device hostname access restriction"
-              placeholder="Device hostname used during the connection"
-              :error-messages="hostnameError"
-              variant="underlined"
-              data-test="firewall-rule-hostname-restriction"
+          <v-col>
+            <v-select
+              v-model="action"
+              :items="actionSelectOptions"
+              label="Rule policy"
+              data-test="firewall-rule-policy"
             />
+          </v-col>
+        </v-row>
 
-            <v-row v-else-if="selectedFilterOption === FormFilterOptions.Tags" class="px-3 mt-2">
-              <v-autocomplete
-                v-model="selectedTags"
-                v-model:menu="acMenuOpen"
-                :menu-props="{ contentClass: menuContentClass, maxHeight: 320 }"
-                :items="tags"
-                item-title="name"
-                item-value="name"
-                attach
-                chips
-                label="Tags"
-                :error-messages="selectedTagsError"
-                variant="underlined"
-                multiple
-                data-test="tags-selector"
-                @update:model-value="setSelectedTagsError"
-                @update:search="onSearch"
-              >
-                <template #append-item>
-                  <div ref="sentinel" data-test="tags-sentinel" style="height: 1px;" />
-                </template>
-              </v-autocomplete>
-            </v-row>
-          </v-card-text>
+        <v-row class="mt-1 mb-1 px-3">
+          <v-select
+            v-model="selectedIPOption"
+            @update:model-value="handleSourceIpUpdate"
+            label="Source IP access restriction"
+            :items="sourceIPSelectOptions"
+            data-test="firewall-rule-source-ip-select"
+          />
+        </v-row>
 
-          <v-card-actions>
-            <v-spacer />
-            <v-btn
-              @click="close"
-              data-test="firewall-rule-cancel"
-            >
-              Cancel
-            </v-btn>
-            <v-btn
-              :disabled="hasErrors"
-              color="primary"
-              type="submit"
-              data-test="firewall-rule-add-btn"
-            >
-              Add
-            </v-btn>
-          </v-card-actions>
-        </form>
-      </v-card>
-    </BaseDialog>
+        <v-text-field
+          v-if="selectedIPOption === 'restrict'"
+          v-model="sourceIp"
+          label="Rule source IP"
+          :error-messages="sourceIpError"
+          data-test="firewall-rule-source-ip"
+        />
+
+        <v-row class="mt-1 mb-1 px-3">
+          <v-select
+            v-model="selectedUsernameOption"
+            @update:model-value="handleUsernameUpdate"
+            label="Device username access restriction"
+            :items="usernameSelectOptions"
+            data-test="username-field"
+          />
+        </v-row>
+
+        <v-text-field
+          v-if="selectedUsernameOption === 'username'"
+          v-model="username"
+          label="Username access restriction"
+          placeholder="Username used during the connection"
+          :error-messages="usernameError"
+          data-test="firewall-rule-username-restriction"
+        />
+
+        <v-row class="mt-2 mb-1 px-3">
+          <v-select
+            v-model="selectedFilterOption"
+            @update:model-value="handleFilterUpdate"
+            label="Device access restriction"
+            :items="filterSelectOptions"
+            data-test="filter-select"
+          />
+        </v-row>
+
+        <v-text-field
+          v-if="selectedFilterOption === FormFilterOptions.Hostname"
+          v-model="hostname"
+          label="Device hostname access restriction"
+          placeholder="Device hostname used during the connection"
+          :error-messages="hostnameError"
+          data-test="firewall-rule-hostname-restriction"
+        />
+
+        <v-row v-else-if="selectedFilterOption === FormFilterOptions.Tags" class="px-3 mt-2">
+          <v-autocomplete
+            v-model="selectedTags"
+            v-model:menu="acMenuOpen"
+            :menu-props="{ contentClass: menuContentClass, maxHeight: 320 }"
+            :items="tags"
+            item-title="name"
+            item-value="name"
+            attach
+            chips
+            label="Tags"
+            :error-messages="selectedTagsError"
+            variant="outlined"
+            multiple
+            data-test="tags-selector"
+            @update:model-value="setSelectedTagsError"
+            @update:search="onSearch"
+          >
+            <template #append-item>
+              <div ref="sentinel" data-test="tags-sentinel" style="height: 1px;" />
+            </template>
+          </v-autocomplete>
+        </v-row>
+      </div>
+    </FormDialog>
   </div>
 </template>
 
@@ -179,7 +159,7 @@ import { envVariables } from "@/envVariables";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
 import { FormFilterOptions } from "@/interfaces/IFilter";
-import BaseDialog from "../BaseDialog.vue";
+import FormDialog from "../FormDialog.vue";
 import useFirewallRulesStore from "@/store/modules/firewall_rules";
 import useTagsStore from "@/store/modules/tags";
 import useUsersStore from "@/store/modules/users";
@@ -192,6 +172,7 @@ const tagsStore = useTagsStore();
 const usersStore = useUsersStore();
 const emit = defineEmits(["update"]);
 const showDialog = ref(false);
+
 const active = ref(true);
 const action = ref<IFirewallRule["action"]>("allow");
 const selectedIPOption = ref("all");
@@ -495,6 +476,4 @@ const addFirewallRule = async () => {
 onUnmounted(() => {
   cleanupObserver();
 });
-
-defineExpose({ selectedIPOption, selectedFilterOption, selectedUsernameOption });
 </script>

--- a/ui/src/components/firewall/FirewallRuleDelete.vue
+++ b/ui/src/components/firewall/FirewallRuleDelete.vue
@@ -14,48 +14,29 @@
     </div>
   </v-list-item>
 
-  <BaseDialog v-model="showDialog">
-    <v-card class="bg-v-theme-surface" data-test="firewallRuleDelete-card">
-      <v-card-title class="text-h5 pa-5 bg-primary" data-test="text-title">
-        Are you sure?
-      </v-card-title>
-      <v-divider />
-
-      <v-card-text class="mt-4 mb-0 pb-1" data-test="text-text">
-        <p class="text-body-2 mb-2">
-          You are about to remove this firewall rule.
-        </p>
-
-        <p class="text-body-2 mb-2">
-          After confirming this action cannot be redone.
-        </p>
-      </v-card-text>
-
-      <v-card-actions>
-        <v-spacer />
-
-        <v-btn variant="text" data-test="close-btn" @click="showDialog = false">
-          Close
-        </v-btn>
-
-        <v-btn
-          color="red darken-1"
-          data-test="remove-btn"
-          variant="text"
-          @click="remove()"
-        >
-          Remove
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </BaseDialog>
+  <MessageDialog
+    v-model="showDialog"
+    @close="showDialog = false"
+    @confirm="remove"
+    @cancel="showDialog = false"
+    title="Are you sure?"
+    description="You are about to delete this firewall rule"
+    icon="mdi-alert"
+    icon-color="error"
+    confirm-text="Delete"
+    confirm-color="error"
+    cancel-text="Close"
+    confirm-data-test="confirm-btn"
+    cancel-data-test="close-btn"
+    data-test="delete-firewall-rule-dialog"
+  />
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import MessageDialog from "../MessageDialog.vue";
 import useFirewallRulesStore from "@/store/modules/firewall_rules";
 
 const props = defineProps<{

--- a/ui/src/components/firewall/FirewallRuleEdit.vue
+++ b/ui/src/components/firewall/FirewallRuleEdit.vue
@@ -10,161 +10,139 @@
         <div class="mr-2">
           <v-icon> mdi-pencil </v-icon>
         </div>
-
         <v-list-item-title data-test="mdi-information-list-item">
           Edit
         </v-list-item-title>
       </div>
     </v-list-item>
 
-    <BaseDialog v-model="showDialog" @close="close" transition="dialog-bottom-transition">
-      <v-card class="bg-v-theme-surface">
-        <v-card-title class="text-h5 pa-3 bg-primary" data-test="firewall-edit-rule-title">
-          Edit Firewall Rule
-        </v-card-title>
-        <form @submit.prevent="editFirewallRule" class="mt-3">
-          <v-card-text>
-            <v-row>
-              <v-col>
-                <v-select
-                  v-model="active"
-                  :items="activeSelectOptions"
-                  label="Rule status"
-                  variant="underlined"
-                  data-test="firewall-rule-status"
-                />
-              </v-col>
-
-              <v-col>
-                <v-text-field
-                  v-model="priority"
-                  label="Rule priority"
-                  :error-messages="priorityError"
-                  type="number"
-                  variant="underlined"
-                  data-test="firewall-rule-priority"
-                />
-              </v-col>
-
-              <v-col>
-                <v-select
-                  v-model="action"
-                  :items="actionSelectOptions"
-                  label="Rule policy"
-                  variant="underlined"
-                  data-test="firewall-rule-policy"
-                />
-              </v-col>
-            </v-row>
-
-            <v-row class="mt-1 mb-1 px-3">
-              <v-select
-                v-model="selectedIPOption"
-                @update:model-value="handleSourceIpUpdate"
-                label="Source IP access restriction"
-                :items="sourceIPSelectOptions"
-                variant="underlined"
-                data-test="firewall-rule-source-ip-select"
-              />
-            </v-row>
-
-            <v-text-field
-              v-if="selectedIPOption === 'restrict'"
-              v-model="sourceIp"
-              label="Rule source IP"
-              variant="underlined"
-              :error-messages="sourceIpError"
-              data-test="firewall-rule-source-ip"
+    <FormDialog
+      v-model="showDialog"
+      @close="close"
+      @cancel="close"
+      @confirm="editFirewallRule"
+      title="Edit Firewall Rule"
+      icon="mdi-shield-check"
+      confirm-text="Edit"
+      cancel-text="Cancel"
+      :confirm-disabled="hasErrors"
+      confirm-data-test="firewall-rule-edit-btn"
+      cancel-data-test="firewall-rule-cancel"
+      data-test="firewall-rule-edit-dialog"
+    >
+      <div class="px-6 pt-4">
+        <v-row>
+          <v-col>
+            <v-select
+              v-model="active"
+              :items="activeSelectOptions"
+              label="Rule status"
+              data-test="firewall-rule-status"
             />
+          </v-col>
 
-            <v-row class="mt-1 mb-1 px-3">
-              <v-select
-                v-model="selectedUsernameOption"
-                @update:model-value="handleUsernameUpdate"
-                label="Device username access restriction"
-                :items="usernameSelectOptions"
-                variant="underlined"
-                data-test="username-field"
-              />
-            </v-row>
-
+          <v-col>
             <v-text-field
-              v-if="selectedUsernameOption === 'username'"
-              v-model="username"
-              label="Username access restriction"
-              placeholder="Username used during the connection"
-              variant="underlined"
-              :error-messages="usernameError"
-              data-test="firewall-rule-username-restriction"
+              v-model="priority"
+              label="Rule priority"
+              :error-messages="priorityError"
+              type="number"
+              data-test="firewall-rule-priority"
             />
+          </v-col>
 
-            <v-row class="mt-2 mb-1 px-3">
-              <v-select
-                v-model="selectedFilterOption"
-                @update:model-value="handleFilterUpdate"
-                label="Device access restriction"
-                :items="filterSelectOptions"
-                variant="underlined"
-                data-test="filter-select"
-              />
-            </v-row>
-
-            <v-text-field
-              v-if="selectedFilterOption === FormFilterOptions.Hostname"
-              v-model="hostname"
-              label="Device hostname access restriction"
-              placeholder="Device hostname used during the connection"
-              :error-messages="hostnameError"
-              variant="underlined"
-              data-test="firewall-rule-hostname-restriction"
+          <v-col>
+            <v-select
+              v-model="action"
+              :items="actionSelectOptions"
+              label="Rule policy"
+              data-test="firewall-rule-policy"
             />
+          </v-col>
+        </v-row>
 
-            <v-row v-else-if="selectedFilterOption === FormFilterOptions.Tags" class="px-3 mt-2">
-              <v-autocomplete
-                v-model="selectedTags"
-                v-model:menu="acMenuOpen"
-                :menu-props="{ contentClass: menuContentClass, maxHeight: 320 }"
-                :items="tags"
-                item-title="name"
-                item-value="name"
-                :return-objects="false"
-                attach
-                chips
-                label="Tags"
-                :error-messages="selectedTagsError"
-                variant="underlined"
-                multiple
-                data-test="tags-selector"
-                @update:model-value="setSelectedTagsError"
-                @update:search="onSearch"
-              >
-                <template #append-item>
-                  <div ref="sentinel" data-test="tags-sentinel" style="height: 1px;" />
-                </template>
-              </v-autocomplete>
-            </v-row>
-          </v-card-text>
+        <v-row class="mt-1 mb-1 px-3">
+          <v-select
+            v-model="selectedIPOption"
+            @update:model-value="handleSourceIpUpdate"
+            label="Source IP access restriction"
+            :items="sourceIPSelectOptions"
+            data-test="firewall-rule-source-ip-select"
+          />
+        </v-row>
 
-          <v-card-actions>
-            <v-spacer />
-            <v-btn
-              @click="close"
-              data-test="firewall-rule-cancel"
-            >
-              Cancel
-            </v-btn>
-            <v-btn
-              :disabled="hasErrors"
-              color="primary"
-              type="submit"
-              data-test="firewall-rule-edit-btn"
-            >
-              Edit
-            </v-btn>
-          </v-card-actions>
-        </form>
-      </v-card>
-    </BaseDialog>
+        <v-text-field
+          v-if="selectedIPOption === 'restrict'"
+          v-model="sourceIp"
+          label="Rule source IP"
+          :error-messages="sourceIpError"
+          data-test="firewall-rule-source-ip"
+        />
+
+        <v-row class="mt-1 mb-1 px-3">
+          <v-select
+            v-model="selectedUsernameOption"
+            @update:model-value="handleUsernameUpdate"
+            label="Device username access restriction"
+            :items="usernameSelectOptions"
+            data-test="username-field"
+          />
+        </v-row>
+
+        <v-text-field
+          v-if="selectedUsernameOption === 'username'"
+          v-model="username"
+          label="Username access restriction"
+          placeholder="Username used during the connection"
+          :error-messages="usernameError"
+          data-test="firewall-rule-username-restriction"
+        />
+
+        <v-row class="mt-2 mb-1 px-3">
+          <v-select
+            v-model="selectedFilterOption"
+            @update:model-value="handleFilterUpdate"
+            label="Device access restriction"
+            :items="filterSelectOptions"
+            data-test="filter-select"
+          />
+        </v-row>
+
+        <v-text-field
+          v-if="selectedFilterOption === FormFilterOptions.Hostname"
+          v-model="hostname"
+          label="Device hostname access restriction"
+          placeholder="Device hostname used during the connection"
+          :error-messages="hostnameError"
+          data-test="firewall-rule-hostname-restriction"
+        />
+
+        <v-row v-else-if="selectedFilterOption === FormFilterOptions.Tags" class="px-3 mt-2">
+          <v-autocomplete
+            v-model="selectedTags"
+            v-model:menu="acMenuOpen"
+            :menu-props="{ contentClass: menuContentClass, maxHeight: 320 }"
+            :items="tags"
+            item-title="name"
+            item-value="name"
+            :return-objects="false"
+            attach
+            chips
+            label="Tags"
+            :error-messages="selectedTagsError"
+            variant="outlined"
+            multiple
+            data-test="tags-selector"
+            @update:model-value="setSelectedTagsError"
+            @update:search="onSearch"
+          >
+            <template #append-item>
+              <div ref="sentinel" data-test="tags-sentinel" style="height: 1px;" />
+            </template>
+          </v-autocomplete>
+        </v-row>
+      </div>
+    </FormDialog>
   </div>
 </template>
 
@@ -176,7 +154,7 @@ import { IFirewallRule } from "@/interfaces/IFirewallRule";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
 import { FormFilterOptions } from "@/interfaces/IFilter";
-import BaseDialog from "../BaseDialog.vue";
+import FormDialog from "../FormDialog.vue";
 import useFirewallRulesStore from "@/store/modules/firewall_rules";
 import useTagsStore from "@/store/modules/tags";
 
@@ -192,6 +170,7 @@ const tagsStore = useTagsStore();
 const snackbar = useSnackbar();
 const emit = defineEmits(["update"]);
 const showDialog = ref(false);
+
 const active = ref(true);
 const action = ref<IFirewallRule["action"]>("allow");
 const selectedIPOption = ref("all");

--- a/ui/tests/components/PrivateKeys/PrivateKeyAdd.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyAdd.spec.ts
@@ -31,9 +31,15 @@ describe("Setting Private Keys", () => {
   it("Renders components", async () => {
     wrapper.vm.showDialog = true;
     await flushPromises();
-    const dialog = new DOMWrapper(document.body);
 
-    expect(dialog.find('[data-test="card-title"]').exists()).toBe(true);
+    const formDialog = wrapper.findComponent({ name: "FormDialog" });
+    expect(formDialog.exists()).toBe(true);
+    expect(formDialog.props("title")).toBe("New Private Key");
+    expect(formDialog.props("icon")).toBe("mdi-key");
+    expect(formDialog.props("confirmText")).toBe("Save");
+    expect(formDialog.props("cancelText")).toBe("Cancel");
+
+    const dialog = new DOMWrapper(document.body);
     expect(dialog.find('[data-test="name-field"]').exists()).toBe(true);
     expect(dialog.find('[data-test="private-key-field"]').exists()).toBe(true);
     expect(dialog.find('[data-test="private-key-cancel-btn"]').exists()).toBe(true);

--- a/ui/tests/components/PrivateKeys/PrivateKeyDelete.spec.ts
+++ b/ui/tests/components/PrivateKeys/PrivateKeyDelete.spec.ts
@@ -36,21 +36,34 @@ describe("Private Key Delete", () => {
   it("Renders components", async () => {
     expect(wrapper.find('[data-test="privatekey-delete-btn"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="privatekey-delete-btn-title"]').exists()).toBe(true);
-    await wrapper.findComponent('[data-test="privatekey-delete-btn"]').trigger("click");
-    const dialog = new DOMWrapper(document.body);
+
+    await wrapper.find('[data-test="privatekey-delete-btn"]').trigger("click");
     await flushPromises();
-    expect(dialog.find('[data-test="privatekey-dialog-title"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="privatekey-dialog-text"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="privatekey-close-btn"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="privatekey-remove-btn"]').exists()).toBe(true);
+
+    const body = new DOMWrapper(document.body);
+    expect(body.find('[data-test="private-key-delete-dialog"]').exists()).toBe(true);
+
+    const dialog = wrapper.findComponent({ name: "MessageDialog" });
+    expect(dialog.exists()).toBe(true);
+    expect(dialog.props("title")).toBe("Are you sure?");
+    expect(dialog.props("description")).toBe("You are about to delete this private key");
+    expect(dialog.props("icon")).toBe("mdi-alert");
+    expect(dialog.props("iconColor")).toBe("error");
+    expect(dialog.props("confirmText")).toBe("Delete");
+    expect(dialog.props("confirmColor")).toBe("error");
+    expect(dialog.props("cancelText")).toBe("Close");
   });
 
   it("Checks if the remove function updates the store on success", async () => {
-    const storeSpy = vi.spyOn(privateKeysStore, "deletePrivateKey");
-    await wrapper.setProps({ id: 1 });
-    await wrapper.findComponent('[data-test="privatekey-delete-btn"]').trigger("click");
+    const storeSpy = vi.spyOn(privateKeysStore, "deletePrivateKey").mockResolvedValue();
+
+    await wrapper.find('[data-test="privatekey-delete-btn"]').trigger("click");
     await flushPromises();
-    await wrapper.findComponent('[data-test="privatekey-remove-btn"]').trigger("click");
+
+    const dialog = wrapper.findComponent({ name: "MessageDialog" });
+    await dialog.vm.$emit("confirm");
+    await flushPromises();
+
     expect(storeSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/ui/tests/components/PrivateKeys/__snapshots__/PrivateKeyEdit.spec.ts.snap
+++ b/ui/tests/components/PrivateKeys/__snapshots__/PrivateKeyEdit.spec.ts.snap
@@ -9,7 +9,7 @@ exports[`Private Key Edit > Renders the component 1`] = `
       <!---->
       <div class="d-flex align-center">
         <div data-test="privatekey-icon" class="mr-2"><i class="mdi-pencil mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-        <div class="v-list-item-title" data-test="privatekey-title"> Edit </div>
+        <div class="v-list-item-title" data-test="privatekey-title">Edit</div>
       </div>
     </div>
     <!---->

--- a/ui/tests/components/PublicKeys/PublicKeyAdd.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyAdd.spec.ts
@@ -50,7 +50,13 @@ describe("Public Key Add", () => {
     await wrapper.findComponent('[data-test="public-key-add-btn"]').trigger("click");
     const dialog = new DOMWrapper(document.body);
     await flushPromises();
-    expect(dialog.find('[data-test="pk-add-title"]').exists()).toBe(true);
+    const formDialog = wrapper.findComponent({ name: "FormDialog" });
+    expect(formDialog.exists()).toBe(true);
+    expect(formDialog.props("title")).toBe("New Public Key");
+    expect(formDialog.props("icon")).toBe("mdi-key-outline");
+    expect(formDialog.props("confirmText")).toBe("Save");
+    expect(formDialog.props("cancelText")).toBe("Cancel");
+
     expect(dialog.find('[data-test="name-field"]').exists()).toBe(true);
     expect(dialog.find('[data-test="username-restriction-field"]').exists()).toBe(true);
     await wrapper.findComponent('[data-test="username-restriction-field"]').setValue("username");
@@ -73,71 +79,24 @@ describe("Public Key Add", () => {
     const storeSpy = vi.spyOn(publicKeysStore, "createPublicKey");
 
     await wrapper.findComponent('[data-test="public-key-add-btn"]').trigger("click");
-    await wrapper.findComponent('[data-test="name-field"]').setValue("my public key");
-    await wrapper.findComponent('[data-test="data-field"]').setValue("fake key");
-    await wrapper.findComponent('[data-test="pk-add-save-btn"]').trigger("click");
+
     await flushPromises();
+
+    // Set the name to match what the test expects
+    await wrapper.findComponent('[data-test="name-field"]').setValue("my new public key");
+    await wrapper.findComponent('[data-test="data-field"]').setValue("fakeish key");
+
+    // Wait for validation to complete
+    await flushPromises();
+
+    await wrapper.findComponent('[data-test="pk-add-save-btn"]').trigger("click");
+
+    await flushPromises();
+
     expect(storeSpy).toHaveBeenCalledWith({
-      data: btoa("fake key"),
-      filter: {
-        hostname: ".*",
-      },
-      name: "my public key",
-      username: ".*",
-    });
-  });
-
-  it("Displays error message if public key creation fails", async () => {
-    mockSshApi.onPost("http://localhost:3000/api/sshkeys/public-keys").reply(409);
-
-    await wrapper.findComponent('[data-test="public-key-add-btn"]').trigger("click");
-    await wrapper.findComponent('[data-test="name-field"]').setValue("test");
-    await wrapper.findComponent('[data-test="data-field"]').setValue("fake key");
-    await wrapper.findComponent('[data-test="pk-add-save-btn"]').trigger("click");
-    await flushPromises();
-    expect(wrapper.vm.publicKeyDataError).toBe("Public Key data already exists");
-  });
-
-  it("Allows adding a public key with hostname restriction", async () => {
-    mockSshApi.onPost("http://localhost:3000/api/sshkeys/public-keys").reply(200);
-
-    const storeSpy = vi.spyOn(publicKeysStore, "createPublicKey");
-
-    await wrapper.findComponent('[data-test="public-key-add-btn"]').trigger("click");
-    await wrapper.findComponent('[data-test="name-field"]').setValue("my public key");
-    await wrapper.findComponent('[data-test="data-field"]').setValue("fake key");
-    await wrapper.findComponent('[data-test="filter-restriction-field"]').setValue("hostname");
-    await wrapper.findComponent('[data-test="hostname-field"]').setValue("example.com");
-    await wrapper.findComponent('[data-test="pk-add-save-btn"]').trigger("click");
-    await flushPromises();
-    expect(storeSpy).toHaveBeenCalledWith({
-      data: btoa("fake key"),
-      filter: {
-        hostname: "example.com",
-      },
-      name: "my public key",
-      username: ".*",
-    });
-  });
-
-  it("Allows adding a public key with tag restriction", async () => {
-    mockSshApi.onPost("http://localhost:3000/api/sshkeys/public-keys").reply(200);
-
-    const storeSpy = vi.spyOn(publicKeysStore, "createPublicKey");
-
-    await wrapper.findComponent('[data-test="public-key-add-btn"]').trigger("click");
-    await wrapper.findComponent('[data-test="name-field"]').setValue("my public key");
-    await wrapper.findComponent('[data-test="data-field"]').setValue("fake key");
-    await wrapper.findComponent('[data-test="filter-restriction-field"]').setValue("tags");
-    await wrapper.findComponent('[data-test="tags-selector"]').setValue(["tag1", "tag2"]);
-    await wrapper.findComponent('[data-test="pk-add-save-btn"]').trigger("click");
-    await flushPromises();
-    expect(storeSpy).toHaveBeenCalledWith({
-      data: btoa("fake key"),
-      filter: {
-        tags: ["tag1", "tag2"],
-      },
-      name: "my public key",
+      data: btoa("fakeish key"),
+      filter: { hostname: ".*" },
+      name: "my new public key",
       username: ".*",
     });
   });
@@ -149,5 +108,25 @@ describe("Public Key Add", () => {
     await wrapper.findComponent('[data-test="name-field"]').setValue("");
     await flushPromises();
     expect(wrapper.vm.nameError).toBe("this is a required field");
+  });
+
+  it("Displays error message if username is not provided", async () => {
+    await wrapper.findComponent('[data-test="public-key-add-btn"]').trigger("click");
+
+    await wrapper.findComponent('[data-test="username-restriction-field"]').setValue("username");
+    await wrapper.findComponent('[data-test="rule-field"]').setValue("foo");
+    await wrapper.findComponent('[data-test="rule-field"]').setValue("");
+    await flushPromises();
+    expect(wrapper.vm.usernameError).toBe("this is a required field");
+  });
+
+  it("Displays error message if hostname is not provided", async () => {
+    await wrapper.findComponent('[data-test="public-key-add-btn"]').trigger("click");
+
+    await wrapper.findComponent('[data-test="filter-restriction-field"]').setValue("hostname");
+    await wrapper.findComponent('[data-test="hostname-field"]').setValue("foo");
+    await wrapper.findComponent('[data-test="hostname-field"]').setValue("");
+    await flushPromises();
+    expect(wrapper.vm.hostnameError).toBe("this is a required field");
   });
 });

--- a/ui/tests/components/PublicKeys/PublicKeyDelete.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyDelete.spec.ts
@@ -1,6 +1,6 @@
 import { setActivePinia, createPinia } from "pinia";
 import { createVuetify } from "vuetify";
-import { DOMWrapper, flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import MockAdapter from "axios-mock-adapter";
 import PublicKeyDelete from "@/components/PublicKeys/PublicKeyDelete.vue";
@@ -14,16 +14,16 @@ const mockSnackbar = {
   showError: vi.fn(),
 };
 
-type PublicKeyDeleteWrapper = VueWrapper<InstanceType<typeof PublicKeyDelete>>;
-
 describe("Public Key Delete", () => {
-  let wrapper: PublicKeyDeleteWrapper;
   setActivePinia(createPinia());
-  const publicKeysStore = usePublicKeysStore();
   const vuetify = createVuetify();
   const mockSshApi = new MockAdapter(sshApi.getAxios());
+  const publicKeysStore = usePublicKeysStore();
 
-  beforeEach(async () => {
+  let wrapper: ReturnType<typeof mount<InstanceType<typeof PublicKeyDelete>>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
     wrapper = mount(PublicKeyDelete, {
       global: {
         plugins: [vuetify, router],
@@ -44,32 +44,48 @@ describe("Public Key Delete", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Renders components", async () => {
-    expect(wrapper.find('[data-test="public-key-remove-btn"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="remove-icon"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="remove-title"]').exists()).toBe(true);
-    await wrapper.findComponent('[data-test="public-key-remove-btn"]').trigger("click");
-    const dialog = new DOMWrapper(document.body);
+  it("Renders components (MessageDialog props)", async () => {
+    await wrapper.find('[data-test="public-key-remove-btn"]').trigger("click");
     await flushPromises();
-    expect(dialog.find('[data-test="text-title"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="text"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="remove-btn"]').exists()).toBe(true);
+
+    const dlg = wrapper.findComponent({ name: "MessageDialog" });
+    expect(dlg.exists()).toBe(true);
+    expect(dlg.props("title")).toBe("Are you sure?");
+    expect(dlg.props("description")).toBe("You are about to delete this public key");
+    expect(dlg.props("icon")).toBe("mdi-alert");
+    expect(dlg.props("iconColor")).toBe("error");
+    expect(dlg.props("confirmText")).toBe("Delete");
+    expect(dlg.props("confirmColor")).toBe("error");
+    expect(dlg.props("cancelText")).toBe("Close");
   });
 
   it("Successfully removes a Public Key", async () => {
-    await wrapper.findComponent('[data-test="public-key-remove-btn"]').trigger("click");
-    mockSshApi.onDelete("http://localhost:3000/api/sshkeys/public-keys/fake-fingerprint").reply(200);
-    const storeSpy = vi.spyOn(publicKeysStore, "deletePublicKey");
-    await wrapper.findComponent('[data-test="remove-btn"]').trigger("click");
+    mockSshApi
+      .onDelete("http://localhost:3000/api/sshkeys/public-keys/fake-fingerprint")
+      .reply(200);
+
+    const storeSpy = vi.spyOn(publicKeysStore, "deletePublicKey").mockResolvedValue();
+
+    await wrapper.find('[data-test="public-key-remove-btn"]').trigger("click");
+    const dlg = wrapper.findComponent({ name: "MessageDialog" });
+    await dlg.vm.$emit("confirm");
+    await flushPromises();
+
     expect(storeSpy).toHaveBeenCalledWith("fake-fingerprint");
   });
 
   it("Shows error snackbar if removing a Public Key fails", async () => {
-    await wrapper.findComponent('[data-test="public-key-remove-btn"]').trigger("click");
-    mockSshApi.onDelete("http://localhost:3000/api/sshkeys/public-keys/fake-fingerprint").reply(404); // non-existent key
-    await wrapper.findComponent('[data-test="remove-btn"]').trigger("click");
+    mockSshApi
+      .onDelete("http://localhost:3000/api/sshkeys/public-keys/fake-fingerprint")
+      .reply(404);
+
+    vi.spyOn(publicKeysStore, "deletePublicKey").mockRejectedValue(new Error("not found"));
+
+    await wrapper.find('[data-test="public-key-remove-btn"]').trigger("click");
+    const dlg = wrapper.findComponent({ name: "MessageDialog" });
+    await dlg.vm.$emit("confirm");
     await flushPromises();
+
     expect(mockSnackbar.showError).toHaveBeenCalledWith("Failed to remove the public key.");
   });
 });

--- a/ui/tests/components/PublicKeys/PublicKeyEdit.spec.ts
+++ b/ui/tests/components/PublicKeys/PublicKeyEdit.spec.ts
@@ -62,7 +62,6 @@ describe("Public Key Edit", () => {
     await wrapper.findComponent('[data-test="public-key-edit-title-btn"]').trigger("click");
     const dialog = new DOMWrapper(document.body);
     await flushPromises();
-    expect(dialog.find('[data-test="public-key-edit-title"]').exists()).toBe(true);
     expect(dialog.find('[data-test="name-field"]').exists()).toBe(true);
     expect(dialog.find('[data-test="username-restriction-field"]').exists()).toBe(true);
     await wrapper.findComponent('[data-test="username-restriction-field"]').setValue("username");

--- a/ui/tests/components/PublicKeys/__snapshots__/PublicKeyEdit.spec.ts.snap
+++ b/ui/tests/components/PublicKeys/__snapshots__/PublicKeyEdit.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`Public Key Edit > Renders the component 1`] = `
       <!---->
       <div class="d-flex align-center">
         <div data-test="public-key-edit-icon" class="mr-2"><i class="mdi-pencil mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-        <div class="v-list-item-title"> Edit </div>
+        <div class="v-list-item-title">Edit</div>
       </div>
     </div>
     <!---->

--- a/ui/tests/components/firewall/FirewallRuleAdd.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleAdd.spec.ts
@@ -59,7 +59,6 @@ describe("Firewall Rule Add", () => {
 
     await wrapper.findComponent('[data-test="firewall-add-rule-btn"]').trigger("click");
 
-    expect(dialog.find('[data-test="firewall-rule-title"]').exists()).toBe(true);
     expect(dialog.find('[data-test="firewall-rule-status"]').exists()).toBe(true);
     expect(dialog.find('[data-test="firewall-rule-priority"]').exists()).toBe(true);
     expect(dialog.find('[data-test="firewall-rule-policy"]').exists()).toBe(true);

--- a/ui/tests/components/firewall/FirewallRuleEdit.spec.ts
+++ b/ui/tests/components/firewall/FirewallRuleEdit.spec.ts
@@ -74,13 +74,18 @@ describe("Firewall Rule Edit", () => {
   });
 
   it("Renders the dialog open button and other key elements", async () => {
-    const dialog = new DOMWrapper(document.body);
-
     expect(wrapper.find('[data-test="firewall-edit-rule-btn"]').exists()).toBe(true);
 
     await wrapper.findComponent('[data-test="firewall-edit-rule-btn"]').trigger("click");
 
-    expect(dialog.find('[data-test="firewall-edit-rule-title"]').exists()).toBe(true);
+    const formDialog = wrapper.findComponent({ name: "FormDialog" });
+    expect(formDialog.exists()).toBe(true);
+    expect(formDialog.props("title")).toBe("Edit Firewall Rule");
+    expect(formDialog.props("icon")).toBe("mdi-shield-check");
+    expect(formDialog.props("confirmText")).toBe("Edit");
+    expect(formDialog.props("cancelText")).toBe("Cancel");
+
+    const dialog = new DOMWrapper(document.body);
     expect(dialog.find('[data-test="firewall-rule-status"]').exists()).toBe(true);
     expect(dialog.find('[data-test="firewall-rule-priority"]').exists()).toBe(true);
     expect(dialog.find('[data-test="firewall-rule-policy"]').exists()).toBe(true);


### PR DESCRIPTION
# Description:

This PR refactors the UI codebase to standardize and streamline all modal dialog usage by replacing BaseDialog with the new shared components: FormDialog and MessageDialog.

## What's Changed:

### PrivateKeys:

- Replaced BaseDialog with FormDialog in PrivateKeyAdd.vue and PrivateKeyEdit.vue
- Replaced BaseDialog with MessageDialog in PrivateKeyDelete.vue

### PublicKeys:

- Replaced BaseDialog with FormDialog in PublicKeyAdd.vue and PublicKeyEdit.vue
- Replaced BaseDialog with MessageDialog in PublicKeyDelete.vue

### Firewall Rules:

- Replaced BaseDialog with FormDialog in FirewallRuleAdd.vue and FirewallRuleEdit.vue
- Replaced BaseDialog with MessageDialog in FirewallRuleDelete.vue

## Updated Tests

Modified all component tests to target FormDialog and MessageDialog

Improved assertions to validate props such as title, icon, confirmText, etc.

Removed legacy test selectors tied to BaseDialog structure

Adjusted snapshots for formatting consistency

## How to Test

1. Open all "Add", "Edit", and "Delete" modals under:

- Private Keys
- Public Keys
- Firewall Rules

2. Confirm UI layout, button behaviors, and validations match expectations