### PR TITLE
refactor(ui): replace BaseDialog with FormDialog/MessageDialog in tags

### DIFF
--- a/ui/src/components/Tags/TagRemove.vue
+++ b/ui/src/components/Tags/TagRemove.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-list-item v-bind="$attrs" @click="showDialog = true" :disabled="!hasAuthorization" data-test="open-tag-remove">
+  <v-list-item
+    v-bind="$attrs"
+    @click="showDialog = true"
+    :disabled="!hasAuthorization"
+    data-test="open-tag-remove"
+  >
     <div class="d-flex align-center">
       <div class="mr-2">
         <v-icon> mdi-delete </v-icon>
@@ -11,44 +16,32 @@
     </div>
   </v-list-item>
 
-  <BaseDialog v-model="showDialog">
-    <v-card class="bg-v-theme-surface" data-test="dialog-card">
-      <v-card-title class="text-h5 pa-5 bg-primary" data-test="dialog-title">
-        Are you sure?
-      </v-card-title>
-      <v-divider />
-
-      <v-card-text class="mt-4 mb-0 pb-1" data-test="dialog-subtitle">
-        <p class="text-body-2 mb-2">You are about to remove this tag.</p>
-
-        <p class="text-body-2 mb-2">
-          After confirming this action cannot be redone.
-        </p>
-      </v-card-text>
-
-      <v-card-actions>
-        <v-spacer />
-
-        <v-btn variant="text" @click="close()" data-test="close-btn"> Close </v-btn>
-
-        <v-btn color="red darken-1" variant="text" @click="remove()" data-test="remove-btn">
-          Remove
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </BaseDialog>
+  <MessageDialog
+    v-model="showDialog"
+    @close="showDialog = false"
+    @cancel="showDialog = false"
+    @confirm="remove"
+    title="Are you sure?"
+    description="You are about to remove this tag. After confirming this action cannot be redone."
+    icon="mdi-alert"
+    icon-color="error"
+    confirm-text="Remove"
+    confirm-color="error"
+    cancel-text="Close"
+    confirm-data-test="confirm-btn"
+    cancel-data-test="close-btn"
+    data-test="delete-tag-dialog"
+  />
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import MessageDialog from "../MessageDialog.vue";
 import useTagsStore from "@/store/modules/tags";
 
-defineOptions({
-  inheritAttrs: false,
-});
+defineOptions({ inheritAttrs: false });
 
 const props = defineProps<{
   tagName: string;
@@ -56,31 +49,30 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits(["update"]);
+
 const tagsStore = useTagsStore();
 const snackbar = useSnackbar();
-const tenant = computed(() => localStorage.getItem("tenant"));
+const tenant = computed(() => localStorage.getItem("tenant") || "");
 const showDialog = ref(false);
-
-const close = () => {
-  showDialog.value = false;
-};
 
 const update = () => {
   emit("update");
-  close();
+  showDialog.value = false;
 };
 
 const remove = async () => {
   try {
     await tagsStore.removeTag({
-      tenant: tenant.value || "",
+      tenant: tenant.value,
       currentName: props.tagName,
     });
-    update();
     snackbar.showSuccess(`${props.tagName} was removed successfully.`);
+    update();
   } catch (error: unknown) {
     snackbar.showError("Failed to remove tag.");
     handleError(error);
+  } finally {
+    showDialog.value = false;
   }
 };
 </script>

--- a/ui/tests/components/Tags/TagCreate.spec.ts
+++ b/ui/tests/components/Tags/TagCreate.spec.ts
@@ -74,15 +74,15 @@ describe("Tag Form Create", async () => {
 
   it("Fails to create tag", async () => {
     wrapper.vm.showDialog = true;
-
     await flushPromises();
 
-    mockTagsApi.onPost("http://localhost:3000/api/namespaces/fake-tenant-data/tags").reply(409);
+    mockTagsApi
+      .onPost("http://localhost:3000/api/namespaces/fake-tenant-data/tags")
+      .reply(409);
 
-    await wrapper.findComponent('[data-test="tag-field"]').setValue("");
+    await wrapper.findComponent('[data-test="tag-field"]').setValue("duplicate-tag");
 
     await wrapper.findComponent('[data-test="create-btn"]').trigger("click");
-
     await flushPromises();
 
     expect(mockSnackbar.showError).toHaveBeenCalledWith("Failed to create tag.");

--- a/ui/tests/components/Tags/TagFormUpdate.spec.ts
+++ b/ui/tests/components/Tags/TagFormUpdate.spec.ts
@@ -99,8 +99,18 @@ describe("Tag Form Update", async () => {
     await flushPromises();
     await wrapper.findComponent('[data-test="open-tags-btn"]').trigger("click");
     await wrapper.findComponent('[data-test="deviceTag-autocomplete"]').trigger("click");
+
     expect(wrapper.find('[data-test="has-tags-verification"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="title"]').exists()).toBe(true);
+
+    const formDialog = wrapper.findComponent({ name: "FormDialog" });
+    expect(formDialog.exists()).toBe(true);
+    expect(formDialog.props("title")).toBe("Edit tags");
+    expect(formDialog.props("icon")).toBe("mdi-tag");
+    expect(formDialog.props("confirmText")).toBe("");
+    expect(formDialog.props("cancelText")).toBe("Close");
+    expect(formDialog.props("confirmDisabled")).toBe(true);
+
+    // Content inside the dialog
     expect(dialog.find('[data-test="deviceTag-autocomplete"]').exists()).toBe(true);
     expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);
   });

--- a/ui/tests/components/Tags/TagRemove.spec.ts
+++ b/ui/tests/components/Tags/TagRemove.spec.ts
@@ -1,33 +1,38 @@
 import { flushPromises, DOMWrapper, mount } from "@vue/test-utils";
 import { createVuetify } from "vuetify";
 import MockAdapter from "axios-mock-adapter";
-import { expect, describe, it, vi } from "vitest";
+import { expect, describe, it, vi, beforeEach } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import TagRemove from "@/components/Tags/TagRemove.vue";
 import { router } from "@/router";
 import { tagsApi } from "@/api/http";
 import { SnackbarInjectionKey } from "@/plugins/snackbar";
+import useTagsStore from "@/store/modules/tags";
 
 const mockSnackbar = {
   showSuccess: vi.fn(),
   showError: vi.fn(),
 };
 
-describe("Tag Remove", async () => {
-  setActivePinia(createPinia());
-  const mockTagsApi = new MockAdapter(tagsApi.getAxios());
-  const vuetify = createVuetify();
-  localStorage.setItem("tenant", "fake-tenant-data");
+describe("Tag Remove", () => {
+  let wrapper: ReturnType<typeof mount>;
+  let mockTagsApi: MockAdapter;
 
-  const wrapper = mount(TagRemove, {
-    global: {
-      plugins: [vuetify, router],
-      provide: { [SnackbarInjectionKey]: mockSnackbar },
-    },
-    props: {
-      tagName: "tag-test",
-      hasAuthorization: true,
-    },
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockTagsApi = new MockAdapter(tagsApi.getAxios());
+    localStorage.setItem("tenant", "fake-tenant-data");
+
+    wrapper = mount(TagRemove, {
+      global: {
+        plugins: [createVuetify(), router],
+        provide: { [SnackbarInjectionKey]: mockSnackbar },
+      },
+      props: {
+        tagName: "tag-test",
+        hasAuthorization: true,
+      },
+    });
   });
 
   it("Is a Vue instance", () => {
@@ -42,42 +47,54 @@ describe("Tag Remove", async () => {
     expect(wrapper.vm.$data).toBeDefined();
   });
 
-  it("Renders the component table", async () => {
-    const dialog = new DOMWrapper(document.body);
+  it("Renders dialog and controls", async () => {
+    const body = new DOMWrapper(document.body);
     await flushPromises();
-    await wrapper.findComponent('[data-test="open-tag-remove"]').trigger("click");
+
+    await wrapper.find('[data-test="open-tag-remove"]').trigger("click");
+    await flushPromises();
 
     expect(wrapper.find('[data-test="mdi-information-list-item"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="dialog-card"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="dialog-title"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="dialog-subtitle"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="remove-btn"]').exists()).toBe(true);
+    // New MessageDialog selectors
+    expect(body.find('[data-test="delete-tag-dialog"]').exists()).toBe(true);
+    expect(body.find('[data-test="close-btn"]').exists()).toBe(true);
+    expect(body.find('[data-test="confirm-btn"]').exists()).toBe(true);
   });
 
-  it("Successfully remove tag", async () => {
+  it("Successfully removes tag", async () => {
+    mockTagsApi
+      .onDelete("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test")
+      .reply(200);
+
+    const tagsStore = useTagsStore();
+    const storeSpy = vi.spyOn(tagsStore, "removeTag");
+
+    await wrapper.find('[data-test="open-tag-remove"]').trigger("click");
     await flushPromises();
 
-    mockTagsApi.onDelete("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(200);
-
-    const tagsSpy = vi.spyOn(tagsApi, "deleteTag");
-
-    await wrapper.findComponent('[data-test="open-tag-remove"]').trigger("click");
-
-    await wrapper.findComponent('[data-test="remove-btn"]').trigger("click");
-
+    const messageDialogStub = wrapper.findComponent({ name: "MessageDialog" });
+    await messageDialogStub.vm.$emit("confirm");
     await flushPromises();
 
-    expect(tagsSpy).toHaveBeenCalledWith("fake-tenant-data", "tag-test");
+    expect(storeSpy).toHaveBeenCalledWith({
+      tenant: "fake-tenant-data",
+      currentName: "tag-test",
+    });
+
+    expect(mockSnackbar.showSuccess).toHaveBeenCalled();
   });
 
-  it("Failed to remove tags", async () => {
-    mockTagsApi.onDelete("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test").reply(409);
+  it("Shows error snackbar on failure", async () => {
+    mockTagsApi
+      .onDelete("http://localhost:3000/api/namespaces/fake-tenant-data/tags/tag-test")
+      .reply(409);
 
-    await wrapper.findComponent('[data-test="open-tag-remove"]').trigger("click");
-
-    await wrapper.findComponent('[data-test="remove-btn"]').trigger("click");
+    await wrapper.find('[data-test="open-tag-remove"]').trigger("click");
     await flushPromises();
+
+    await new DOMWrapper(document.body).find('[data-test="confirm-btn"]').trigger("click");
+    await flushPromises();
+
     expect(mockSnackbar.showError).toHaveBeenCalledWith("Failed to remove tag.");
   });
 });


### PR DESCRIPTION
# Description

This PR refactors all tag-related components to replace the use of the legacy BaseDialog component with the newer, more flexible FormDialog and MessageDialog components.

## Changes Made

**TagCreate.vue**
Replaced BaseDialog with FormDialog, added confirmDisabled logic, and updated structure/styling.

**TagEdit.vue**
Switched to FormDialog, improved validation handling, and aligned logic with TagCreate.

**TagFormUpdate.vue**
Integrated FormDialog for improved UX and consistent layout. Dialog is now confirm-disabled with inline tag creation.

**TagRemove.vue**
Migrated from BaseDialog to MessageDialog, streamlined dialog confirmation flow, and removed unused methods.

### Test files updated:

- TagCreate.spec.ts
- TagFormUpdate.spec.ts
- TagRemove.spec.ts

All tests now validate dialog rendering, event emissions, and UI changes according to the new components.

## Why This Change?

- Promotes component reuse and design consistency
- Reduces boilerplate code
- Aligns with current UI component architecture
- Improves testability and separation of concerns

## Test Coverage

- All modified components have updated unit tests that validate:
- Dialog rendering
- User interaction
- Success/failure states
- Emission of update events