### PR TITLE
fix(api): correct pagination index in device cleanup task

### DIFF
--- a/api/services/task.go
+++ b/api/services/task.go
@@ -109,7 +109,7 @@ func (s *service) deviceCleanup() store.TransactionCb {
 			opts := []store.QueryOption{
 				s.store.Options().Match(filter),
 				s.store.Options().Sort(sorter),
-				s.store.Options().Paginate(&query.Paginator{Page: page, PerPage: pageSize}),
+				s.store.Options().Paginate(&query.Paginator{Page: page + 1, PerPage: pageSize}),
 			}
 
 			devices, _, err := s.store.DeviceList(ctx, store.DeviceAcceptableAsFalse, opts...)

--- a/api/services/task_test.go
+++ b/api/services/task_test.go
@@ -201,7 +201,7 @@ func TestService_DeviceCleanup(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Paginate", &query.Paginator{Page: 0, PerPage: 1000}).
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 1000}).
 					Return(nil).
 					Once()
 				storeMock.
@@ -231,7 +231,7 @@ func TestService_DeviceCleanup(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Paginate", &query.Paginator{Page: 0, PerPage: 1000}).
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 1000}).
 					Return(nil).
 					Once()
 				storeMock.
@@ -276,7 +276,7 @@ func TestService_DeviceCleanup(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Paginate", &query.Paginator{Page: 0, PerPage: 1000}).
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 1000}).
 					Return(nil).
 					Once()
 				storeMock.
@@ -334,7 +334,7 @@ func TestService_DeviceCleanup(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Paginate", &query.Paginator{Page: 0, PerPage: 1000}).
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 1000}).
 					Return(nil).
 					Once()
 				storeMock.
@@ -392,7 +392,7 @@ func TestService_DeviceCleanup(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Paginate", &query.Paginator{Page: 0, PerPage: 1000}).
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 1000}).
 					Return(nil).
 					Once()
 				storeMock.
@@ -418,7 +418,7 @@ func TestService_DeviceCleanup(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Paginate", &query.Paginator{Page: 1, PerPage: 1000}).
+					On("Paginate", &query.Paginator{Page: 2, PerPage: 1000}).
 					Return(nil).
 					Once()
 				storeMock.
@@ -444,7 +444,7 @@ func TestService_DeviceCleanup(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Paginate", &query.Paginator{Page: 2, PerPage: 1000}).
+					On("Paginate", &query.Paginator{Page: 3, PerPage: 1000}).
 					Return(nil).
 					Once()
 				storeMock.


### PR DESCRIPTION
The Paginator expects 1-based page numbers, but the loop was passing 0-based indices. This caused MongoDB to receive negative values for $skip when page was 0, resulting in query failures.

Changed pagination to use page+1 to align with the 1-indexed expectation of the Paginator struct.