### PR TITLE
fix(api): restore default sorting for session list

### DIFF
--- a/api/services/session.go
+++ b/api/services/session.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/shellhub-io/shellhub/api/store"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
@@ -20,18 +21,15 @@ type SessionService interface {
 }
 
 func (s *service) ListSessions(ctx context.Context, req *requests.ListSessions) ([]models.Session, int, error) {
-	opts := []store.QueryOption{
-		s.store.Options().Paginate(&req.Paginator),
-	}
-
+	opts := make([]store.QueryOption, 0)
 	if req.TenantID != "" {
 		opts = append(opts, s.store.Options().InNamespace(req.TenantID))
 	}
 
-	return s.store.SessionList(
-		ctx,
-		opts...,
-	)
+	opts = append(opts, s.store.Options().Sort(&query.Sorter{By: "started_at", Order: query.OrderDesc}))
+	opts = append(opts, s.store.Options().Paginate(&req.Paginator))
+
+	return s.store.SessionList(ctx, opts...)
 }
 
 func (s *service) GetSession(ctx context.Context, uid models.UID) (*models.Session, error) {

--- a/api/services/session_test.go
+++ b/api/services/session_test.go
@@ -50,10 +50,14 @@ func TestListSessions(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
+					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc}).
+					Return(nil).
+					Once()
+				queryOptionsMock.
 					On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
 					Return(nil).
 					Once()
-				storeMock.On("SessionList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
+				storeMock.On("SessionList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
 					Return(nil, 0, goerrors.New("error")).Once()
 			},
 			expected: Expected{
@@ -79,10 +83,14 @@ func TestListSessions(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
+					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc}).
+					Return(nil).
+					Once()
+				queryOptionsMock.
 					On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
 					Return(nil).
 					Once()
-				storeMock.On("SessionList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
+				storeMock.On("SessionList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
 					Return(sessions, len(sessions), nil).Once()
 			},
 			expected: Expected{


### PR DESCRIPTION
Re-add missing default sorting by started_at in descending order for session listing. This sorting was previously present but was lost in a regression, causing sessions to be returned in an unpredictable order.

Sessions are now consistently ordered by most recent first.