### PR TITLE
refactor(ui): migrate web endpoints to new generic dialog

### DIFF
--- a/ui/src/components/WebEndpoints/WebEndpointCreate.vue
+++ b/ui/src/components/WebEndpoints/WebEndpointCreate.vue
@@ -1,123 +1,112 @@
 <template>
-  <BaseDialog v-model="showDialog" @close="close">
-    <v-card data-test="tunnel-create-dialog" class="bg-v-theme-surface">
-      <v-card-title class="bg-primary" data-test="create-dialog-title">
-        Create Device Web Endpoint
-      </v-card-title>
-      <v-container>
-        <v-alert
-          v-if="alertText"
-          type="error"
-          :text="alertText"
-          data-test="tunnel-create-alert"
-        />
-        <v-card-text>
-          <p class="mb-2" data-test="tunnel-create-text">
-            Configure the host and port to create a tunnel to your device.
-          </p>
-          <v-row>
-            <v-col sm="8" class="pb-0">
-              <v-text-field
-                v-model="host"
-                class="mt-1"
-                label="Host"
-                :error-messages="hostError"
-                variant="underlined"
-                data-test="host-text"
-              />
-            </v-col>
-            <p class="mt-7 pa-0"> : </p>
-            <v-col class="pb-0">
-              <v-text-field
-                v-model.number="port"
-                label="Port"
-                :error-messages="portError"
-                variant="outlined"
-                data-test="port-text"
-              />
-            </v-col>
-          </v-row>
+  <FormDialog
+    v-model="showDialog"
+    @close="close"
+    @cancel="close"
+    @confirm="addWebEndpoint"
+    title="Create Device Web Endpoint"
+    icon="mdi-lan"
+    confirm-text="Create Web Endpoint"
+    cancel-text="Close"
+    :confirm-disabled="hasErrors"
+    :alert-message="alertText"
+    confirm-data-test="create-tunnel-btn"
+    cancel-data-test="close-btn"
+    data-test="tunnel-create-dialog"
+  >
+    <v-container>
+      <v-card-text class="pa-0">
+        <p class="mb-2" data-test="tunnel-create-text">
+          Configure the host and port to create a tunnel to your device.
+        </p>
 
-          <v-row class="mt-1" v-if="props.useDevicesList">
-            <v-col>
-              <v-autocomplete
-                v-model="selectedDevice"
-                :items="deviceOptions"
-                :loading="loadingDevices"
-                item-title="info.pretty_name"
-                item-value="uid"
-                label="Select Device"
-                variant="outlined"
-                return-object
-                hide-details
-                @update:search="fetchDevices"
-                data-test="web-endpoint-autocomplete"
-              >
-                <template #item="{ item, props }">
-                  <v-list-item
-                    v-bind="props"
-                  >
-                    <div>
-                      <DeviceIcon
-                        :icon="item.raw.info.id"
-                        class="mr-2"
-                      />
-                      <span class="text-body-1">{{ item.raw.name }}</span>
-                    </div>
+        <v-row>
+          <v-col sm="8" class="pb-0">
+            <v-text-field
+              v-model="host"
+              class="mt-1"
+              label="Host"
+              :error-messages="hostError"
+              data-test="host-text"
+            />
+          </v-col>
 
-                  </v-list-item>
-                </template>
+          <p class="mt-7 pa-0"> : </p>
 
-                <template #selection="{ item }">
-                  <div class="d-flex align-center">
-                    <DeviceIcon
-                      :icon="item.raw.info.id"
-                      class="mr-2"
-                    />
+          <v-col class="pb-0">
+            <v-text-field
+              v-model.number="port"
+              label="Port"
+              :error-messages="portError"
+              variant="outlined"
+              data-test="port-text"
+            />
+          </v-col>
+        </v-row>
+
+        <v-row class="mt-1" v-if="props.useDevicesList">
+          <v-col>
+            <v-autocomplete
+              v-model="selectedDevice"
+              :items="deviceOptions"
+              :loading="loadingDevices"
+              item-title="info.pretty_name"
+              item-value="uid"
+              label="Select Device"
+              variant="outlined"
+              return-object
+              hide-details
+              @update:search="fetchDevices"
+              data-test="web-endpoint-autocomplete"
+            >
+              <template #item="{ item, props }">
+                <v-list-item v-bind="props">
+                  <div>
+                    <DeviceIcon :icon="item.raw.info.id" class="mr-2" />
                     <span class="text-body-1">{{ item.raw.name }}</span>
                   </div>
-                </template>
-              </v-autocomplete>
+                </v-list-item>
+              </template>
 
-            </v-col>
-          </v-row>
+              <template #selection="{ item }">
+                <div class="d-flex align-center">
+                  <DeviceIcon :icon="item.raw.info.id" class="mr-2" />
+                  <span class="text-body-1">{{ item.raw.name }}</span>
+                </div>
+              </template>
+            </v-autocomplete>
+          </v-col>
+        </v-row>
 
-          <v-row>
-            <v-col>
-              <v-select
-                v-model="selectedTimeout"
-                :items="predefinedTimeouts"
-                item-title="text"
-                item-value="value"
-                label="Timeout (in seconds)"
-                variant="outlined"
-                data-test="timeout-combobox"
-              />
-            </v-col>
-          </v-row>
-          <v-row v-if="selectedTimeout === 'custom'">
-            <v-col>
-              <v-text-field
-                v-model.number="customTimeout"
-                :error-messages="customTimeoutError"
-                label="Custom Timeout (in seconds)"
-                type="number"
-                variant="outlined"
-                data-test="custom-timeout"
-              />
-            </v-col>
-          </v-row>
-        </v-card-text>
-      </v-container>
-      <v-card-actions>
-        <v-spacer />
-        <v-btn data-test="close-btn" @click="close"> Close </v-btn>
-        <v-btn :disabled="hasErrors" color="primary" data-test="create-tunnel-btn" @click="addWebEndpoint()">
-          Create Web Endpoint
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </BaseDialog>
+        <v-row>
+          <v-col>
+            <v-select
+              v-model="selectedTimeout"
+              :items="predefinedTimeouts"
+              item-title="text"
+              item-value="value"
+              label="Timeout (in seconds)"
+              variant="outlined"
+              data-test="timeout-combobox"
+            />
+          </v-col>
+        </v-row>
+
+        <v-row v-if="selectedTimeout === 'custom'">
+          <v-col>
+            <v-text-field
+              v-model.number="customTimeout"
+              :error-messages="customTimeoutError"
+              label="Custom Timeout (in seconds)"
+              type="number"
+              variant="outlined"
+              data-test="custom-timeout"
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-container>
+  </FormDialog>
 </template>
 
 <script setup lang="ts">
@@ -128,7 +117,7 @@ import axios, { AxiosError } from "axios";
 import DeviceIcon from "@/components/Devices/DeviceIcon.vue";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import FormDialog from "../FormDialog.vue";
 import useDevicesStore from "@/store/modules/devices";
 import useWebEndpointsStore from "@/store/modules/web_endpoints";
 import { IDevice } from "@/interfaces/IDevice";
@@ -143,7 +132,7 @@ const devicesStore = useDevicesStore();
 const webEndpointsStore = useWebEndpointsStore();
 const snackbar = useSnackbar();
 const showDialog = defineModel({ default: false });
-const alertText = ref();
+const alertText = ref("");
 
 const selectedDevice = ref<IDevice | null>(null);
 const deviceOptions = ref<IDevice[]>([]);
@@ -163,29 +152,19 @@ const predefinedTimeouts = ref([
 
 const { value: host, errorMessage: hostError, resetField: resetHost } = useField<string>(
   "host",
-  yup
-    .string()
-    .required(),
+  yup.string().required(),
   { initialValue: "127.0.0.1" },
 );
 
 const { value: port, errorMessage: portError, resetField: resetPort } = useField<number>(
   "port",
-  yup
-    .number()
-    .integer()
-    .max(65535)
-    .required(),
+  yup.number().integer().max(65535).required(),
   { initialValue: undefined },
 );
 
 const { value: customTimeout, errorMessage: customTimeoutError, resetField: resetCustomTimeout } = useField<number>(
   "customTimeout",
-  yup
-    .number()
-    .integer()
-    .min(1)
-    .max(9223372036)
+  yup.number().integer().min(1).max(9223372036)
     .required(),
   { initialValue: 60 },
 );
@@ -201,16 +180,28 @@ const hasErrors = computed(() => {
     || !host.value
     || !timeout.value;
 
-  if (props.useDevicesList) {
-    return formInvalid || !selectedDevice.value;
-  }
-
+  if (props.useDevicesList) return formInvalid || !selectedDevice.value;
   return formInvalid;
 });
 
-const resetFields = () => { resetPort(); resetHost(); selectedTimeout.value = -1; resetCustomTimeout(); };
-const close = () => { resetFields(); showDialog.value = false; };
-const update = () => { emit("update"); close(); };
+const resetFields = () => {
+  resetPort();
+  resetHost();
+  selectedTimeout.value = -1;
+  resetCustomTimeout();
+  alertText.value = "";
+  selectedDevice.value = null;
+};
+
+const close = () => {
+  resetFields();
+  showDialog.value = false;
+};
+
+const update = () => {
+  emit("update");
+  close();
+};
 
 const fetchDevices = async (searchQuery?: string) => {
   loadingDevices.value = true;
@@ -220,23 +211,22 @@ const fetchDevices = async (searchQuery?: string) => {
       { type: "property", params: { name: "name", operator: "contains", value: searchQuery } },
     ]))
     : undefined;
+
   try {
     await devicesStore.fetchDeviceList({ filter });
     deviceOptions.value = devicesStore.devices;
   } catch (error) {
     snackbar.showError("Failed to load devices.");
     handleError(error);
+  } finally {
+    loadingDevices.value = false;
   }
-
-  loadingDevices.value = false;
 };
 
 const addWebEndpoint = async () => {
   if (hasErrors.value) return;
 
-  const deviceUid = props.useDevicesList
-    ? selectedDevice.value?.uid
-    : props.uid;
+  const deviceUid = props.useDevicesList ? selectedDevice.value?.uid : props.uid;
 
   try {
     await webEndpointsStore.createWebEndpoint({
@@ -252,13 +242,15 @@ const addWebEndpoint = async () => {
     if (axios.isAxiosError(error)) {
       if ((error as AxiosError).response?.status === 403) {
         alertText.value = "This device has reached the maximum allowed number of Web Endpoints";
-      } else {
-        snackbar.showError("Failed to create Web Endpoint.");
-        handleError(error);
+        return;
       }
     }
+    snackbar.showError("Failed to create Web Endpoint.");
+    handleError(error);
   }
 };
 
-onMounted(async () => { if (props.useDevicesList) await fetchDevices(); });
+onMounted(async () => {
+  if (props.useDevicesList) await fetchDevices();
+});
 </script>

--- a/ui/src/components/WebEndpoints/WebEndpointDelete.vue
+++ b/ui/src/components/WebEndpoints/WebEndpointDelete.vue
@@ -9,62 +9,53 @@
     :disabled="!canDeleteWebEndpoint"
     data-test="web-endpoint-delete-dialog-btn"
   />
-  <BaseDialog v-model="showDialog">
-    <v-card class="bg-v-theme-surface">
-      <v-card-title class="text-h5 pa-5 bg-primary" data-test="title">
-        Are you sure?
-      </v-card-title>
-      <v-divider />
 
-      <v-card-text class="mt-4 mb-0 pb-1" data-test="text">
-        <p class="text-body-2 mb-2">
-          You are about to remove this Web Endpoint.
-        </p>
-      </v-card-text>
-
-      <v-card-actions>
-        <v-spacer />
-
-        <v-btn variant="text" @click="showDialog = false" data-test="close-btn"> Close </v-btn>
-
-        <v-btn color="red darken-1" variant="text" @click="remove()" data-test="delete-btn">
-          Delete Web Endpoint
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </BaseDialog>
+  <MessageDialog
+    v-model="showDialog"
+    @close="showDialog = false"
+    @cancel="showDialog = false"
+    @confirm="remove"
+    title="Are you sure?"
+    description="You are about to remove this Web Endpoint."
+    icon="mdi-alert"
+    icon-color="error"
+    confirm-text="Delete Web Endpoint"
+    confirm-color="error"
+    cancel-text="Close"
+    confirm-data-test="delete-btn"
+    cancel-data-test="close-btn"
+    data-test="web-endpoint-delete-dialog"
+  />
 </template>
 
 <script setup lang="ts">
 import hasPermission from "@/utils/permission";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "../BaseDialog.vue";
+import MessageDialog from "../MessageDialog.vue";
 import useWebEndpointsStore from "@/store/modules/web_endpoints";
 
-defineOptions({
-  inheritAttrs: false,
-});
+defineOptions({ inheritAttrs: false });
 
 const props = defineProps<{ address: string }>();
-
 const emit = defineEmits(["update"]);
 const showDialog = defineModel({ default: false });
+
 const webEndpointsStore = useWebEndpointsStore();
 const snackbar = useSnackbar();
+
+const canDeleteWebEndpoint = hasPermission("webEndpoint:delete");
 
 const update = () => {
   emit("update");
   showDialog.value = false;
 };
 
-const canDeleteWebEndpoint = hasPermission("webEndpoint:delete");
-
 const remove = async () => {
   try {
     await webEndpointsStore.deleteWebEndpoint(props.address);
-    update();
     snackbar.showSuccess("Web Endpoint deleted successfully.");
+    update();
   } catch (error: unknown) {
     snackbar.showError("Failed to delete Web Endpoint.");
     handleError(error);

--- a/ui/tests/components/WebEndpoints/WebEndpointDelete.spec.ts
+++ b/ui/tests/components/WebEndpoints/WebEndpointDelete.spec.ts
@@ -40,13 +40,16 @@ describe("WebEndpointDelete.vue", () => {
   });
 
   it("opens and renders the dialog with correct elements", async () => {
-    const dialog = new DOMWrapper(document.body);
-
     await wrapper.find('[data-test="web-endpoint-delete-dialog-btn"]').trigger("click");
     await flushPromises();
 
-    expect(dialog.find('[data-test="title"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="text"]').exists()).toBe(true);
+    const dialog = new DOMWrapper(document.body);
+
+    expect(dialog.find('[data-test="web-endpoint-delete-dialog"]').exists()).toBe(true);
+
+    expect(dialog.text()).toContain("Are you sure?");
+    expect(dialog.text()).toContain("You are about to remove this Web Endpoint.");
+
     expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);
     expect(dialog.find('[data-test="delete-btn"]').exists()).toBe(true);
   });


### PR DESCRIPTION
# Description

This PR modernizes the dialogs in the Web Endpoints feature by replacing the legacy BaseDialog component with the shared FormDialog and MessageDialog components. This brings consistency to the UI and simplifies dialog logic.

## Changes

### WebEndpointCreate.vue

- Migrated to FormDialog
- Hooked up confirm, cancel, and close actions
- Disabled confirm when validation errors are present
- Initialized alertText as an empty string and reset on close
- Reset fields (including device selection) when closing
- Simplified validation rules and error handling
- Improved axios error path and snackbar usage

### WebEndpointDelete.vue

- Migrated to MessageDialog
- Added confirm/cancel/close bindings
- Moved permission check (canDeleteWebEndpoint) alongside dialog usage
- Simplified update flow after deletion

## Tests

- Updated selectors to match FormDialog and MessageDialog
- Added checks for title and description text
- Adjusted test setup to flush promises where needed
- Simplified Vuetify plugin initialization

## How to Test

1. Open the Create Web Endpoint dialog
2. Verify form fields render correctly
3. Confirm/close buttons behave as expected
4. Errors disable the confirm button
5. Alerts display correctly on validation/API errors
6. Open the Delete Web Endpoint dialog
7. Verify title and description text appear
8. Confirm and cancel buttons close the dialog
9. Deleting shows a success snackbar and triggers an update event
10. Run the updated tests:

`npm test -- -u`