### PR TITLE
refactor(ui): migrate `ApiKeyDelete` to `MessageDialog`

### DIFF
--- a/ui/src/components/Team/ApiKeys/ApiKeyDelete.vue
+++ b/ui/src/components/Team/ApiKeys/ApiKeyDelete.vue
@@ -1,52 +1,37 @@
 <template>
   <v-list-item @click="showDialog = true" :disabled="!hasAuthorization">
     <div class="d-flex align-center">
-
       <div class="d-flex align-center">
         <div class="mr-2" data-test="delete-icon">
-          <v-icon>mdi-delete</v-icon>
+          <v-icon icon="mdi-delete" />
         </div>
-
         <v-list-item-title data-test="delete-main-btn-title"> Delete </v-list-item-title>
       </div>
     </div>
   </v-list-item>
 
-  <BaseDialog v-model="showDialog">
-    <v-card class="bg-v-theme-surface">
-      <v-card-title class="text-h5 pa-5 bg-primary" data-test="title">
-        Are you sure?
-      </v-card-title>
-      <v-divider />
-
-      <v-card-text class="mt-4 mb-0 pb-1" data-test="text">
-        <p class="text-body-2 mb-2">
-          You are about to remove this Api Key from the namespace.
-        </p>
-
-        <p class="text-body-2 mb-2">
-          After confirming this action cannot be redone.
-        </p>
-      </v-card-text>
-
-      <v-card-actions>
-        <v-spacer />
-
-        <v-btn variant="text" @click="showDialog = false" data-test="close-btn"> Close </v-btn>
-
-        <v-btn color="red darken-1" variant="text" @click="remove()" data-test="delete-btn">
-          Delete Key
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </BaseDialog>
+  <MessageDialog
+    v-model="showDialog"
+    title="Are you sure?"
+    description="You are about to remove this Api Key from the namespace. After confirming this action cannot be undone."
+    icon="mdi-key-remove"
+    icon-color="error"
+    confirm-text="Delete Key"
+    confirm-color="error"
+    cancel-text="Close"
+    confirm-data-test="delete-btn"
+    cancel-data-test="close-btn"
+    @confirm="remove()"
+    @cancel="showDialog = false"
+    @close="showDialog = false"
+  />
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
-import BaseDialog from "@/components/BaseDialog.vue";
+import MessageDialog from "@/components/MessageDialog.vue";
 import useApiKeysStore from "@/store/modules/api_keys";
 
 const props = defineProps<{
@@ -76,4 +61,6 @@ const remove = async () => {
     handleError(error);
   }
 };
+
+defineExpose({ showDialog });
 </script>

--- a/ui/tests/components/Team/ApiKeys/ApiKeyDelete.spec.ts
+++ b/ui/tests/components/Team/ApiKeys/ApiKeyDelete.spec.ts
@@ -39,20 +39,11 @@ describe("Api Key Delete", () => {
     expect(wrapper.vm).toBeTruthy();
   });
 
-  it("Renders the component", () => {
-    expect(wrapper.html()).toMatchSnapshot();
-  });
-
-  it("Renders components", async () => {
-    expect(wrapper.find('[data-test="delete-icon"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="delete-main-btn-title"]').exists()).toBe(true);
-    await wrapper.findComponent('[data-test="delete-main-btn-title"]').trigger("click");
-    const dialog = new DOMWrapper(document.body);
+  it("Renders the component", async () => {
+    wrapper.vm.showDialog = true;
     await flushPromises();
-    expect(dialog.find('[data-test="title"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="text"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);
-    expect(dialog.find('[data-test="delete-btn"]').exists()).toBe(true);
+    const dialog = new DOMWrapper(document.body);
+    expect(dialog.html()).toMatchSnapshot();
   });
 
   it("Successfully Delete Api Key", async () => {

--- a/ui/tests/components/Team/ApiKeys/__snapshots__/ApiKeyDelete.spec.ts.snap
+++ b/ui/tests/components/Team/ApiKeys/__snapshots__/ApiKeyDelete.spec.ts.snap
@@ -1,18 +1,70 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Api Key Delete > Renders the component 1`] = `
-"<div class="v-list-item v-list-item--link v-theme--light v-list-item--density-default rounded-0 v-list-item--variant-text" tabindex="0"><span class="v-list-item__overlay"></span><span class="v-list-item__underlay"></span>
-  <!---->
-  <div class="v-list-item__content" data-no-activator="">
-    <!---->
-    <!---->
-    <div class="d-flex align-center">
-      <div class="d-flex align-center">
-        <div class="mr-2" data-test="delete-icon"><i class="mdi-delete mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-        <div class="v-list-item-title" data-test="delete-main-btn-title"> Delete </div>
-      </div>
+"<body>
+  <div class="v-overlay-container">
+    <div class="v-overlay v-overlay--active v-theme--light v-locale--is-ltr v-dialog v-dialog--scrollable" style="z-index: 2400;" aria-modal="true" role="dialog" data-v-51513c71="">
+      <transition-stub name="fade-transition" appear="true" persisted="false" css="true">
+        <div class="v-overlay__scrim"></div>
+      </transition-stub>
+      <transition-stub name="dialog-transition" appear="true" persisted="true" css="true">
+        <div class="v-overlay__content" style="max-width: 600px;" tabindex="-1">
+          <div data-v-51513c71="" class="v-card v-theme--light v-card--density-default v-card--variant-elevated bg-v-theme-surface border">
+            <!---->
+            <div class="v-card__loader">
+              <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                <!---->
+                <div class="v-progress-linear__background"></div>
+                <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                  <div class="v-progress-linear__indeterminate">
+                    <div class="v-progress-linear__indeterminate long"></div>
+                    <div class="v-progress-linear__indeterminate short"></div>
+                  </div>
+                </transition-stub>
+                <!---->
+              </div>
+            </div>
+            <!---->
+            <!---->
+            <!-- Content -->
+            <!-- Titlebar -->
+            <!--v-if-->
+            <!-- Content -->
+            <div class="v-card-text text-center py-8"><i class="mdi-key-remove mdi v-icon notranslate v-theme--light text-error mb-4" style="font-size: 48px; height: 48px; width: 48px;" aria-hidden="true"></i>
+              <div class="text-h5 mb-4">Are you sure?</div>
+              <div class="text-body-2 text-medium-emphasis mb-6">You are about to remove this Api Key from the namespace. After confirming this action cannot be undone.</div>
+            </div><!-- Footer -->
+            <header class="v-toolbar v-toolbar--density-default bg-primary v-theme--light v-locale--is-ltr bg-v-theme-surface border-t px-6 py-2">
+              <!---->
+              <div class="v-toolbar__content" style="height: 64px;">
+                <!---->
+                <!---->
+                <!-- Block Layout: Full width buttons -->
+                <div class="v-row ma-0 ga-3">
+                  <div class="v-col pa-0"><button type="button" class="v-btn v-btn--block v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-tonal" data-test="close-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                      <!----><span class="v-btn__content" data-no-activator="">Close</span>
+                      <!---->
+                      <!---->
+                    </button></div>
+                  <div class="v-col pa-0"><button type="button" class="v-btn v-btn--block v-theme--light bg-error v-btn--density-default v-btn--size-default v-btn--variant-flat" data-test="delete-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                      <!----><span class="v-btn__content" data-no-activator="">Delete Key</span>
+                      <!---->
+                      <!---->
+                    </button></div>
+                </div>
+                <!---->
+              </div>
+              <transition-stub name="expand-transition" appear="false" persisted="false" css="true">
+                <!---->
+              </transition-stub>
+            </header>
+            <!---->
+            <!----><span class="v-card__underlay"></span>
+          </div>
+        </div>
+      </transition-stub>
     </div>
   </div>
-  <!---->
-</div>"
+</body>"
 `;


### PR DESCRIPTION
This pull request migrates the `ApiKeyDelete` dialog to the new `MessageDialog` component and updates its corresponding tests.