### PR TITLE
refactor(ui): use `CopyWarning` in new copy components

### DIFF
--- a/ui/src/components/Devices/DeviceAdd.vue
+++ b/ui/src/components/Devices/DeviceAdd.vue
@@ -82,25 +82,29 @@
                 icon="mdi-package-down"
               >
                 Ready to install? Copy the command below and run it on your target device:
-                <v-text-field
-                  :model-value="getCommand(method.value)"
-                  class="code mt-3"
-                  variant="outlined"
-                  readonly
-                  density="compact"
-                  hide-details
-                >
-                  <template #append>
-                    <v-btn
-                      icon="mdi-content-copy"
-                      color="primary"
-                      variant="flat"
-                      rounded
-                      size="small"
-                      @click="copyCommand(method.value)"
-                    />
+                <CopyWarning :copied-item="'Installation command'">
+                  <template #default="{ copyText }">
+                    <v-text-field
+                      :model-value="getCommand(method.value)"
+                      class="code mt-3"
+                      variant="outlined"
+                      readonly
+                      density="compact"
+                      hide-details
+                    >
+                      <template #append>
+                        <v-btn
+                          icon="mdi-content-copy"
+                          color="primary"
+                          variant="flat"
+                          rounded
+                          size="small"
+                          @click="copyText(getCommand(method.value))"
+                        />
+                      </template>
+                    </v-text-field>
                   </template>
-                </v-text-field>
+                </CopyWarning>
 
                 <!-- Advanced Options inside the alert -->
                 <v-expansion-panels
@@ -207,8 +211,8 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import WindowDialog from "../WindowDialog.vue";
+import CopyWarning from "@/components/User/CopyWarning.vue";
 import useAuthStore from "@/store/modules/auth";
-import useSnackbar from "@/helpers/snackbar";
 
 enum InstallMethod {
   AUTO = "auto",
@@ -238,7 +242,6 @@ interface InstallMethodConfig {
 
 const { size } = defineProps<{ size?: string }>();
 const authStore = useAuthStore();
-const snackbar = useSnackbar();
 const showDialog = ref(false);
 const selectedPanel = ref(["auto"]); // Auto panel expanded by default
 const methodAdvancedPanels = ref<Record<string, string[]>>({});
@@ -400,17 +403,6 @@ const getCommand = (method: string) => {
     ...envVars,
     "sh",
   ].join(" ");
-};
-
-const copyCommand = async (methodValue: string) => {
-  try {
-    const command = getCommand(methodValue);
-    await navigator.clipboard.writeText(command);
-    snackbar.showSuccess("Installation command copied to clipboard!");
-  } catch (err) {
-    console.error("Failed to copy: ", err);
-    snackbar.showError("Failed to copy command to clipboard.");
-  }
 };
 </script>
 

--- a/ui/src/components/Team/ApiKeys/ApiKeySuccess.vue
+++ b/ui/src/components/Team/ApiKeys/ApiKeySuccess.vue
@@ -15,43 +15,44 @@
     data-test="api-key-success-dialog"
   >
     <div class="px-4">
-      <v-text-field
-        :value="apiKey"
-        readonly
-        density="compact"
-        class="monospace-field"
-        data-test="generated-key-field"
-      >
-        <template #append-inner>
-          <v-btn
-            icon="mdi-content-copy"
-            color="primary"
-            variant="text"
-            size="small"
-            @click="copyKey"
-            data-test="copy-key-icon-btn"
-          />
+      <CopyWarning ref="copyWarningRef" :copied-item="'API Key'">
+        <template #default="{ copyText }">
+          <v-text-field
+            :value="apiKey"
+            readonly
+            density="compact"
+            class="monospace-field"
+            data-test="generated-key-field"
+          >
+            <template #append-inner>
+              <v-btn
+                icon="mdi-content-copy"
+                color="primary"
+                variant="text"
+                size="small"
+                @click="copyText(apiKey)"
+                data-test="copy-key-icon-btn"
+              />
+            </template>
+          </v-text-field>
         </template>
-      </v-text-field>
+      </CopyWarning>
     </div>
   </MessageDialog>
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import MessageDialog from "@/components/MessageDialog.vue";
-import useSnackbar from "@/helpers/snackbar";
+import CopyWarning from "@/components/User/CopyWarning.vue";
 
 const props = defineProps<{ apiKey: string }>();
-const snackbar = useSnackbar();
 const showDialog = defineModel<boolean>({ required: true });
+const copyWarningRef = ref<InstanceType<typeof CopyWarning>>();
 
 const copyKey = async () => {
-  try {
-    await navigator.clipboard.writeText(props.apiKey || "");
-    snackbar.showSuccess("API Key copied to clipboard!");
-  } catch (err) {
-    console.error("Failed to copy: ", err);
-    snackbar.showError("Failed to copy API key to clipboard.");
+  if (copyWarningRef.value?.copyFn) {
+    await copyWarningRef.value.copyFn(props.apiKey);
   }
 };
 


### PR DESCRIPTION
This pull request refactors `ApiKeySuccess` and `DeviceAdd` to use CopyWarning in their fields, ensuring a more secure use by blocking copying in non-secure contexts.

* Replaces direct clipboard API usage and snackbar calls in `DeviceAdd.vue` and `ApiKeySuccess.vue` with the `CopyWarning` component, which now manages copying and user feedback. 

* Refactors tests in `ApiKeySuccess.spec.ts` to mock the `@vueuse/core` clipboard composable instead of the native clipboard API, ensuring tests align with the new implementation. Updates assertions to expect info-level snackbar messages and to check for the presence of the warning dialog on error. 