### PR TITLE
fix(agent): fix import path

### DIFF
--- a/agent/server/modes/host/utils_freebsd.go
+++ b/agent/server/modes/host/utils_freebsd.go
@@ -8,7 +8,7 @@ import (
 
 	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/agent/pkg/osauth"
-	"github.com/shellhub-io/shellhub/agent/pkg/server/modes/host/command"
+	"github.com/shellhub-io/shellhub/agent/server/modes/host/command"
 )
 
 func generateShellCmd(deviceName string, session gliderssh.Session, term string) *exec.Cmd {


### PR DESCRIPTION
To reproduce the error you can run `go mod tidy`:
```shell
λ go mod tidy
go: finding module for package github.com/shellhub-io/shellhub/agent/pkg/server/modes/host/command
go: github.com/shellhub-io/shellhub/agent/server/modes/host imports
	 github.com/shellhub-io/shellhub/agent/pkg/server/modes/host/command: module github.com/shellhub-io/shellhub@latest found (v0.20.1, replaced by ../), but does not contain package github.com/shellhub-io/shellhub/agent/pkg/server/modes/host/command
```