### PR TITLE
fix(ui): fix No tags chip alignment in `QuickConnectionList`

### DIFF
--- a/ui/src/components/QuickConnection/QuickConnectionList.vue
+++ b/ui/src/components/QuickConnection/QuickConnectionList.vue
@@ -52,8 +52,8 @@
             </v-tooltip>
           </v-chip>
         </v-col>
-        <v-col md="3" data-test="device-tags">
-          <div v-if="item.tags[0]" class="text-center">
+        <v-col md="3" data-test="device-tags" class="text-center">
+          <div v-if="item.tags[0]">
             <v-tooltip v-for="(tag, index) in item.tags" :key="index" location="bottom" :disabled="!showTag(tag.name)">
               <template #activator="{ props }">
                 <v-chip size="small" v-bind="props" data-test="tag-chip">

--- a/ui/tests/components/QuickConnection/__snapshots__/QuickConnectionList.spec.ts.snap
+++ b/ui/tests/components/QuickConnection/__snapshots__/QuickConnectionList.spec.ts.snap
@@ -24,8 +24,8 @@ exports[`Quick Connection List > Renders the component 1`] = `
           <!---->
           <!----></span>
         </div>
-        <div data-v-7c65953f="" class="v-col-md-3 v-col" data-test="device-tags">
-          <div data-v-7c65953f="" class="text-center"><span data-v-7c65953f="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-3" data-test="tag-chip"><!----><span class="v-chip__underlay"></span>
+        <div data-v-7c65953f="" class="v-col-md-3 v-col text-center" data-test="device-tags">
+          <div data-v-7c65953f=""><span data-v-7c65953f="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-3" data-test="tag-chip"><!----><span class="v-chip__underlay"></span>
             <!---->
             <!---->
             <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -61,7 +61,7 @@ exports[`Quick Connection List > Renders the component 1`] = `
           <!---->
           <!----></span>
         </div>
-        <div data-v-7c65953f="" class="v-col-md-3 v-col" data-test="device-tags">
+        <div data-v-7c65953f="" class="v-col-md-3 v-col text-center" data-test="device-tags">
           <div data-v-7c65953f=""><span data-v-7c65953f="" class="v-chip v-theme--light text-grey-darken-2 v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" data-test="no-tags-chip"><!----><span class="v-chip__underlay"></span>
             <!---->
             <!---->


### PR DESCRIPTION
This pull request makes a small UI improvement to the `QuickConnectionList` component by centering the "No tags" chip when there are no tags to display. The associated test snapshot has also been updated to reflect this change. 