### PR TITLE
fix(ui): fix `PaywallChat` text style and Close button behavior

### DIFF
--- a/ui/src/components/User/PaywallChat.vue
+++ b/ui/src/components/User/PaywallChat.vue
@@ -2,8 +2,6 @@
   <MessageDialog
     v-model="showDialog"
     title="Upgrade to have access to chat support!"
-    description="Get real-time assistance from our team with priority responses.
-     Skip the hassle of documentation — upgrade now and unlock direct chat support."
     icon="mdi-chat-question"
     icon-color="success"
     cancel-text="Close"
@@ -11,9 +9,14 @@
     confirm-text="Upgrade"
     confirm-data-test="upgrade-btn"
     @confirm="redirectToPricing"
+    @cancel="showDialog = false"
     data-test="paywall-chat-dialog"
   >
-    <p class="align-center text-grey text-center" data-test="upgrade-description2">
+    <p class="text-center mb-4" data-test="upgrade-description-1">
+      Get real-time assistance from our team with priority responses.
+      Skip the hassle of documentation — upgrade now and unlock direct chat support.
+    </p>
+    <p class="text-center text-grey" data-test="upgrade-description-2">
       However, you can still use
       <a
         href="https://docs.shellhub.io/"

--- a/ui/tests/components/Users/PaywallChat.spec.ts
+++ b/ui/tests/components/Users/PaywallChat.spec.ts
@@ -34,11 +34,8 @@ describe("PaywallChat", () => {
     const dialog = new DOMWrapper(document.body);
 
     expect(dialog.text()).toContain("Upgrade to have access to chat support!");
-    expect(dialog.text()).toContain(
-      "Get real-time assistance from our team with priority responses.",
-    );
-
-    expect(dialog.find('[data-test="upgrade-description2"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="upgrade-description-1"]').exists()).toBe(true);
+    expect(dialog.find('[data-test="upgrade-description-2"]').exists()).toBe(true);
     expect(dialog.find('[data-test="link-anchor"]').exists()).toBe(true);
 
     expect(dialog.find('[data-test="close-btn"]').exists()).toBe(true);


### PR DESCRIPTION
This pull request makes two small fixes in the `PaywallChat` component, making a minor change in the text's styles and fixing the Close button behavior, which wasn't closing the dialog.