### PR TITLE
refactor(ui): add `DeviceStatus` type to `IDevice`

### DIFF
--- a/ui/admin/tests/unit/components/Device/DeviceList/index.spec.ts
+++ b/ui/admin/tests/unit/components/Device/DeviceList/index.spec.ts
@@ -40,7 +40,7 @@ const devices = [
     created_at: "2020-05-20T18:00:00.000Z",
     online: false,
     namespace: "user",
-    status: "accepted",
+    status: "accepted" as const,
     remote_addr: "127.0.0.1",
     position: { latitude: 0, longitude: 0 },
     tags: [
@@ -71,7 +71,7 @@ const devices = [
     created_at: "2020-05-20T18:00:00.000Z",
     online: true,
     namespace: "user",
-    status: "accepted",
+    status: "accepted" as const,
     remote_addr: "127.0.0.1",
     position: { latitude: 0, longitude: 0 },
     tags: [

--- a/ui/admin/tests/unit/views/Device/index.spec.ts
+++ b/ui/admin/tests/unit/views/Device/index.spec.ts
@@ -29,7 +29,7 @@ const devices = [
     created_at: "2020-05-20T18:00:00.000Z",
     online: false,
     namespace: "user",
-    status: "accepted",
+    status: "accepted" as const,
     remote_addr: "127.0.0.1",
     position: { latitude: 0, longitude: 0 },
     tags: [
@@ -60,7 +60,7 @@ const devices = [
     created_at: "2020-05-20T18:00:00.000Z",
     online: true,
     namespace: "user",
-    status: "accepted",
+    status: "accepted" as const,
     remote_addr: "127.0.0.1",
     position: { latitude: 0, longitude: 0 },
     tags: [

--- a/ui/src/components/Tables/DeviceTable.vue
+++ b/ui/src/components/Tables/DeviceTable.vue
@@ -265,7 +265,7 @@ import TagFormUpdate from "../Tags/TagFormUpdate.vue";
 import TerminalConnectButton from "../Terminal/TerminalConnectButton.vue";
 import CopyWarning from "@/components/User/CopyWarning.vue";
 import TerminalHelper from "../Terminal/TerminalHelper.vue";
-import { IDevice, IDeviceMethods } from "@/interfaces/IDevice";
+import { IDevice, IDeviceMethods, DeviceStatus } from "@/interfaces/IDevice";
 import hasPermission from "@/utils/permission";
 import showTag from "@/utils/tag";
 import { displayOnlyTenCharacters } from "@/utils/string";
@@ -276,7 +276,7 @@ import useAuthStore from "@/store/modules/auth";
 
 const props = defineProps<{
   storeMethods: IDeviceMethods | IContainerMethods;
-  status: "accepted" | "pending" | "rejected";
+  status: DeviceStatus;
   header: "primary" | "secondary";
   variant: "device" | "container";
 }>();

--- a/ui/src/interfaces/IContainer.ts
+++ b/ui/src/interfaces/IContainer.ts
@@ -3,6 +3,7 @@ import {
   IDeviceRename,
   FetchDevicesParams,
   IDeviceMethods,
+  DeviceStatus,
 } from "./IDevice";
 
 // Container is essentially the same as Device
@@ -11,6 +12,8 @@ export type IContainer = IDevice;
 export type IContainerRename = IDeviceRename;
 
 export type FetchContainerParams = FetchDevicesParams;
+
+export type ContainerStatus = DeviceStatus;
 
 export interface IContainerMethods extends IDeviceMethods {
   fetchDevices: (params: FetchContainerParams) => Promise<void>; // Keep original method name for compatibility with DeviceTable component

--- a/ui/src/interfaces/IDevice.ts
+++ b/ui/src/interfaces/IDevice.ts
@@ -18,6 +18,8 @@ type Position = {
   longitude: number;
 }
 
+export type DeviceStatus = "accepted" | "pending" | "rejected";
+
 export interface IDevice {
   uid: string;
   name: string;
@@ -28,7 +30,7 @@ export interface IDevice {
   last_seen: string;
   online: boolean;
   namespace: string;
-  status: string;
+  status: DeviceStatus;
   created_at: string;
   remote_addr: string;
   position: Position;
@@ -44,7 +46,7 @@ export interface FetchDevicesParams {
   perPage?: number;
   page?: number;
   filter?: string;
-  status?: "accepted" | "pending" | "rejected";
+  status?: DeviceStatus;
   sortField?: string;
   sortOrder?: "asc" | "desc";
 }

--- a/ui/src/store/api/containers.ts
+++ b/ui/src/store/api/containers.ts
@@ -1,10 +1,10 @@
-import { IContainerRename } from "@/interfaces/IContainer";
+import { ContainerStatus, IContainerRename } from "@/interfaces/IContainer";
 import { containersApi } from "@/api/http";
 
 export const fetchContainers = async (
   page: number,
   perPage: number,
-  status?: "accepted" | "rejected" | "pending",
+  status?: ContainerStatus,
   filter?: string,
   sortField?: string,
   sortOrder?: "asc" | "desc",

--- a/ui/src/store/api/devices.ts
+++ b/ui/src/store/api/devices.ts
@@ -1,4 +1,4 @@
-import { IDeviceRename } from "@/interfaces/IDevice";
+import { DeviceStatus, IDeviceRename } from "@/interfaces/IDevice";
 import { devicesApi, tagsApi } from "@/api/http";
 
 export const postTag = async (data) => tagsApi.createTag(data.uid, data.name);
@@ -6,17 +6,17 @@ export const postTag = async (data) => tagsApi.createTag(data.uid, data.name);
 export const fetchDevices = async (
   page: number,
   perPage: number,
-  status?: "accepted" | "rejected" | "pending",
+  status?: DeviceStatus,
   filter?: string,
-  sortStatusField?: string,
-  sortStatusString?: "asc" | "desc",
+  sortField?: string,
+  sortOrder?: "asc" | "desc",
 ) => devicesApi.getDevices(
   filter,
   page,
   perPage,
   status,
-  sortStatusField,
-  sortStatusString,
+  sortField,
+  sortOrder,
 );
 
 export const resolveDevice = async (hostname?: string, uid?: string) => devicesApi.resolveDevice(hostname, uid);

--- a/ui/src/views/Devices.vue
+++ b/ui/src/views/Devices.vue
@@ -62,6 +62,7 @@ import TagSelector from "../components/Tags/TagSelector.vue";
 import NoItemsMessage from "../components/NoItemsMessage.vue";
 import useSnackbar from "@/helpers/snackbar";
 import useDevicesStore from "@/store/modules/devices";
+import { DeviceStatus } from "@/interfaces/IDevice";
 
 const devicesStore = useDevicesStore();
 const route = useRoute();
@@ -70,7 +71,7 @@ const filter = ref("");
 const showDevices = computed(() => devicesStore.showDevices);
 const isDeviceList = computed(() => route.name === "DeviceList");
 
-const statusMap: Record<string, "accepted" | "pending" | "rejected"> = {
+const statusMap: Record<string, DeviceStatus> = {
   "/devices": "accepted",
   "/devices/pending": "pending",
   "/devices/rejected": "rejected",

--- a/ui/tests/views/DetailsDevice.spec.ts
+++ b/ui/tests/views/DetailsDevice.spec.ts
@@ -41,7 +41,7 @@ describe("Details Device", () => {
     created_at: "2020-05-20T18:00:00.000Z",
     online: false,
     namespace: "user",
-    status: "accepted",
+    status: "accepted" as const,
     remote_addr: "127.0.0.1",
     position: { latitude: 0, longitude: 0 },
     tags: [


### PR DESCRIPTION
This pull request refactors how device and container status types are handled throughout the codebase, introducing a `DeviceStatus` type in `IDevice.ts` to reduce code repetition and improve typing. Logic and tests that used the old approach were updated.

Depends on #5331 