### PR TITLE
fix(ui): fix filter and pagination in device/container list

### DIFF
--- a/ui/src/components/Tables/DeviceTable.vue
+++ b/ui/src/components/Tables/DeviceTable.vue
@@ -139,7 +139,7 @@
                         :device-uid="item.uid"
                         :tags-list="item.tags"
                         :has-authorization="canUpdateDeviceTag"
-                        @update="refreshDevices"
+                        @update="getDevices"
                       />
                     </div>
                   </template>
@@ -157,7 +157,7 @@
                         :variant
                         :uid="item.uid"
                         :hasAuthorization="canRemoveDevice"
-                        @update="refreshDevices"
+                        @update="getDevices"
                       />
                     </div>
                   </template>
@@ -225,7 +225,7 @@
                   :isInNotification="false"
                   action="accept"
                   :show="showDeviceAcceptButton"
-                  @update="refreshDevices()"
+                  @update="getDevices"
                   data-test="DeviceActionButtonAccept-component"
                 />
                 <DeviceActionButton
@@ -234,7 +234,7 @@
                   :action="status === 'pending' ? 'reject' : 'remove'"
                   :isInNotification="false"
                   :show="showDeviceRejectButton"
-                  @update="refreshDevices()"
+                  @update="getDevices"
                   data-test="deviceActionButtonReject-component"
                 />
               </v-list>
@@ -281,7 +281,7 @@ const props = defineProps<{
   variant: "device" | "container";
 }>();
 
-const { fetchDevices, getList, getCount } = props.storeMethods;
+const { fetchDevices, getList, getCount, getFilter } = props.storeMethods;
 const authStore = useAuthStore();
 const router = useRouter();
 const loading = ref(false);
@@ -291,7 +291,7 @@ const showDeviceAcceptButton = ref(false);
 const showDeviceRejectButton = ref(false);
 const itemsPerPage = ref(10);
 const page = ref(1);
-const status = computed(() => props.status);
+const filter = computed(() => getFilter());
 const sortField = ref();
 const sortOrder = ref();
 const showTerminalHelper = ref(false);
@@ -409,17 +409,14 @@ const sortByItem = async (field: string) => {
   await getDevices();
 };
 
-watch([page, itemsPerPage], async () => {
+watch(filter, async () => {
+  page.value = 1;
   await getDevices();
 });
 
-const refreshDevices = async () => {
-  await getDevices();
-};
+watch([page, itemsPerPage], async () => { await getDevices(); });
 
-onMounted(async () => {
-  await getDevices();
-});
+onMounted(async () => { await getDevices(); });
 
 defineExpose({ page, showTerminalHelper, openTerminalHelper });
 </script>

--- a/ui/src/interfaces/IDevice.ts
+++ b/ui/src/interfaces/IDevice.ts
@@ -55,4 +55,5 @@ export interface IDeviceMethods {
   fetchDevices: (params: FetchDevicesParams) => Promise<void>;
   getList: () => IDevice[];
   getCount: () => number;
+  getFilter: () => string | undefined;
 }

--- a/ui/src/store/modules/containers.ts
+++ b/ui/src/store/modules/containers.ts
@@ -8,14 +8,17 @@ const useContainersStore = defineStore("containers", () => {
   const container = ref<IContainer>({} as IContainer);
   const containerCount = ref(0);
   const showContainers = ref(false);
+  const containerListFilter = ref<string>();
 
   const fetchContainerList = async (data?: FetchContainerParams) => {
+    const filter = data?.filter || containerListFilter.value;
+    containerListFilter.value = filter;
     try {
       const res = await containerApi.fetchContainers(
         data?.page || 1,
         data?.perPage || 10,
         data?.status || "accepted",
-        data?.filter,
+        filter,
         data?.sortField,
         data?.sortOrder,
       );
@@ -66,6 +69,7 @@ const useContainersStore = defineStore("containers", () => {
     container,
     containerCount,
     showContainers,
+    containerListFilter,
     fetchContainerList,
     setContainerListVisibility,
     removeContainer,

--- a/ui/src/store/modules/devices.ts
+++ b/ui/src/store/modules/devices.ts
@@ -10,6 +10,7 @@ const useDevicesStore = defineStore("devices", () => {
   const showDevices = ref<boolean>(false);
   const deviceCount = ref<number>(0);
   const duplicatedDeviceName = ref<string>("");
+  const deviceListFilter = ref<string>();
 
   const onlineDevices = ref<Array<IDevice>>([]);
 
@@ -18,12 +19,14 @@ const useDevicesStore = defineStore("devices", () => {
   const selectedDevices = ref<Array<IDevice>>([]);
 
   const fetchDeviceList = async (data?: FetchDevicesParams) => {
+    const filter = data?.filter || deviceListFilter.value;
+    deviceListFilter.value = filter;
     try {
       const res = await devicesApi.fetchDevices(
         data?.page || 1,
         data?.perPage || 10,
         data?.status || "accepted",
-        data?.filter,
+        filter,
         data?.sortField,
         data?.sortOrder,
       );
@@ -119,6 +122,7 @@ const useDevicesStore = defineStore("devices", () => {
     suggestedDevices,
     selectedDevices,
     duplicatedDeviceName,
+    deviceListFilter,
 
     fetchDeviceList,
     setDeviceListVisibility,

--- a/ui/src/utils/storeMethods.ts
+++ b/ui/src/utils/storeMethods.ts
@@ -19,11 +19,13 @@ export function getContainerStoreMethods(): IContainerMethods {
 
   const getList = () => containersStore.containers;
   const getCount = () => containersStore.containerCount;
+  const getFilter = () => containersStore.containerListFilter;
 
   return {
     fetchDevices,
     getList,
     getCount,
+    getFilter,
   };
 }
 
@@ -43,10 +45,12 @@ export function getDeviceStoreMethods(): IDeviceMethods {
 
   const getList = () => devicesStore.devices;
   const getCount = () => devicesStore.deviceCount;
+  const getFilter = () => devicesStore.deviceListFilter;
 
   return {
     fetchDevices,
     getList,
     getCount,
+    getFilter,
   };
 }

--- a/ui/src/views/Devices.vue
+++ b/ui/src/views/Devices.vue
@@ -13,7 +13,7 @@
         single-line
         hide-details
         v-model.trim="filter"
-        @update:model-value="searchDevices"
+        @update:model-value="updateDeviceListFilter"
         prepend-inner-icon="mdi-magnify"
         density="compact"
         data-test="search-text"
@@ -60,37 +60,22 @@ import Device from "../components/Devices/Device.vue";
 import DeviceAdd from "../components/Devices/DeviceAdd.vue";
 import TagSelector from "../components/Tags/TagSelector.vue";
 import NoItemsMessage from "../components/NoItemsMessage.vue";
-import useSnackbar from "@/helpers/snackbar";
 import useDevicesStore from "@/store/modules/devices";
-import { DeviceStatus } from "@/interfaces/IDevice";
 
 const devicesStore = useDevicesStore();
 const route = useRoute();
-const snackbar = useSnackbar();
 const filter = ref("");
 const showDevices = computed(() => devicesStore.showDevices);
 const isDeviceList = computed(() => route.name === "DeviceList");
 
-const statusMap: Record<string, DeviceStatus> = {
-  "/devices": "accepted",
-  "/devices/pending": "pending",
-  "/devices/rejected": "rejected",
-};
-
-const searchDevices = async () => {
-  const filterToEncodeBase64 = [{
+const updateDeviceListFilter = async () => {
+  const base64DeviceFilter = [{
     type: "property",
     params: { name: "name", operator: "contains", value: filter.value },
   }];
 
-  const encodedFilter = filter.value ? btoa(JSON.stringify(filterToEncodeBase64)) : undefined;
+  const encodedFilter = filter.value ? btoa(JSON.stringify(base64DeviceFilter)) : undefined;
 
-  const status = statusMap[route.path] || "accepted";
-
-  try {
-    await devicesStore.fetchDeviceList({ filter: encodedFilter, status });
-  } catch {
-    snackbar.showError("Failed to load devices.");
-  }
+  devicesStore.deviceListFilter = encodedFilter;
 };
 </script>

--- a/ui/tests/components/Tables/DeviceTable.spec.ts
+++ b/ui/tests/components/Tables/DeviceTable.spec.ts
@@ -63,6 +63,7 @@ describe("Device Table", () => {
     fetchDevices: vi.fn(),
     getList: () => devices as IDevice[],
     getCount: () => devices.length,
+    getFilter: () => undefined,
   };
 
   beforeEach(async () => {


### PR DESCRIPTION
This pull request enhances device and container filtering in the UI by introducing a persistent filter state in the stores and updating the process of applying and refreshing filters. The main focus is on making the filter state reactive, ensuring that updates to the search/filter input are reflected across the UI without redundant fetches or prop drilling, and also work well with pagination, without one overlapping the other.

**State Management and Filtering Improvements:**

* Added a persistent `deviceListFilter` to the devices store and `containerListFilter` to the containers store, ensuring that the current filter is always available and used in fetch operations
* Updated the store methods interfaces and utility functions to include a `getFilter` method, allowing components to access the current filter state easily
* Made the device table reactively watch the filter state so that changes to the filter reset the page and trigger a refresh
* Refactored the device search/filter logic in the `Devices.vue` view to update the store’s filter state directly, encoding the filter as base64 and removing redundant API calls and error handling. 
* Updated the device table tests to provide a `getFilter` method in the mock store methods, ensuring compatibility with the new interface.