### PR TITLE
test(ui): fix inconsistent snapshot behavior in `MfaDisable` tests

### DIFF
--- a/ui/tests/components/AuthMFA/MfaDisable.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaDisable.spec.ts
@@ -1,3 +1,4 @@
+import { nextTick } from "vue";
 import { createPinia, setActivePinia } from "pinia";
 import { createVuetify } from "vuetify";
 import { DOMWrapper, flushPromises, mount, VueWrapper } from "@vue/test-utils";
@@ -19,43 +20,35 @@ describe("MfaDisable", () => {
   const vuetify = createVuetify();
   const mockMfaApi = new MockAdapter(mfaApi.getAxios());
 
-  beforeEach(() => {
+  beforeEach(async () => {
     wrapper = mount(MfaDisable, {
       global: {
         plugins: [vuetify, router, SnackbarPlugin],
-
       },
     });
+    wrapper.vm.showDialog = true;
+    await nextTick();
     dialog = new DOMWrapper(document.body);
-  });
-
-  it("Is a Vue instance", () => {
-    expect(wrapper.vm).toBeTruthy();
+    await flushPromises();
   });
 
   it("Renders the component (Verification Code window)", async () => {
-    wrapper.vm.showDialog = true;
-    await flushPromises();
     expect(dialog.html()).toMatchSnapshot();
   });
 
   it("Renders the component (Recovery Code window)", async () => {
-    wrapper.vm.showDialog = true;
     wrapper.vm.el = 2;
     await flushPromises();
     expect(dialog.html()).toMatchSnapshot();
   });
 
   it("Renders the component (Email Sent window)", async () => {
-    wrapper.vm.showDialog = true;
     wrapper.vm.el = 3;
     await flushPromises();
     expect(dialog.html()).toMatchSnapshot();
   });
 
   it("Disables MFA Authentication using TOTP Code", async () => {
-    wrapper.vm.showDialog = true;
-    await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "disableMfa");
     mockMfaApi.onPut("http://localhost:3000/api/user/mfa/disable").reply(200);
     await wrapper.findComponent('[data-test="verification-code"]').setValue("123456");
@@ -66,8 +59,6 @@ describe("MfaDisable", () => {
   });
 
   it("Disables MFA Authentication using TOTP Code (Fail)", async () => {
-    wrapper.vm.showDialog = true;
-    await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "disableMfa");
     mockMfaApi.onPut("http://localhost:3000/api/user/mfa/disable").reply(403);
     await wrapper.findComponent('[data-test="verification-code"]').setValue("123456");
@@ -78,7 +69,6 @@ describe("MfaDisable", () => {
   });
 
   it("Disables MFA Authentication using Recovery Code", async () => {
-    wrapper.vm.showDialog = true;
     wrapper.vm.el = 2;
     await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "disableMfa");
@@ -90,7 +80,6 @@ describe("MfaDisable", () => {
   });
 
   it("Disables MFA Authentication using Recovery Code (Fail)", async () => {
-    wrapper.vm.showDialog = true;
     wrapper.vm.el = 2;
     await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "disableMfa");
@@ -104,7 +93,6 @@ describe("MfaDisable", () => {
 
   it("Sends the disable codes on the users mail", async () => {
     localStorage.setItem("email", "test@test.com");
-    wrapper.vm.showDialog = true;
     wrapper.vm.el = 2;
     await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "requestMfaReset");
@@ -116,7 +104,6 @@ describe("MfaDisable", () => {
 
   it("Handles error when sending recovery email fails", async () => {
     localStorage.setItem("email", "test@test.com");
-    wrapper.vm.showDialog = true;
     wrapper.vm.el = 2;
     await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "requestMfaReset");

--- a/ui/tests/components/AuthMFA/__snapshots__/MfaDisable.spec.ts.snap
+++ b/ui/tests/components/AuthMFA/__snapshots__/MfaDisable.spec.ts.snap
@@ -360,7 +360,200 @@ exports[`MfaDisable > Renders the component (Email Sent window) 1`] = `
                 </transition-stub>
                 <transition-stub name="v-window-x-transition" appear="false" persisted="false" css="true">
                   <div class="v-window-item" style="display: none;">
-                    <!---->
+                    <div class="v-otp-input mb-4" data-test="verification-code" required="">
+                      <div class="v-otp-input__content">
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="6" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div><input class="v-otp-input-input" type="hidden" required="" value="">
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
+                    </div>
+                    <p class="text-subtitle-2 text-center"> If you lost your MFA TOTP Provider and want to use your recovery code, <span tag="button" class="text-primary cursor-pointer text-decoration-underline" data-test="use-recovery-code-btn"> click here </span></p>
                   </div>
                 </transition-stub>
                 <transition-stub name="v-window-x-transition" appear="false" persisted="false" css="true">
@@ -385,12 +578,12 @@ exports[`MfaDisable > Renders the component (Email Sent window) 1`] = `
                             </div>
                           </div>
                           <!---->
-                          <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" for="input-v-7" aria-hidden="true">
+                          <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" for="input-v-13" aria-hidden="true">
                               <!---->Recovery Code
-                            </label><label class="v-label v-field-label" for="input-v-7">
+                            </label><label class="v-label v-field-label" for="input-v-13">
                               <!---->Recovery Code
                             </label>
-                            <!----><input size="1" type="text" id="input-v-7" aria-describedby="input-v-7-messages" required="" class="v-field__input" value="">
+                            <!----><input size="1" type="text" id="input-v-13" aria-describedby="input-v-13-messages" required="" class="v-field__input" value="">
                             <!---->
                           </div>
                           <!---->
@@ -402,7 +595,7 @@ exports[`MfaDisable > Renders the component (Email Sent window) 1`] = `
                         </div>
                       </div>
                       <!---->
-                      <div id="input-v-7-messages" class="v-input__details" role="alert" aria-live="polite">
+                      <div id="input-v-13-messages" class="v-input__details" role="alert" aria-live="polite">
                         <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
                           <!---->
                         </transition-group-stub>
@@ -506,17 +699,210 @@ exports[`MfaDisable > Renders the component (Email Sent window) 1`] = `
                 <transition-stub name="slide-y-reverse-transition" appear="false" persisted="false" css="true">
                   <!---->
                 </transition-stub>
-                <transition-stub name="" appear="false" persisted="false" css="true">
+                <transition-stub name="v-window-x-reverse-transition" appear="false" persisted="false" css="true">
+                  <div class="v-window-item" style="display: none;">
+                    <div class="v-otp-input mb-4" data-test="verification-code" required="">
+                      <div class="v-otp-input__content">
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="6" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div><input class="v-otp-input-input" type="hidden" required="" value="">
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
+                    </div>
+                    <p class="text-subtitle-2 text-center"> If you lost your MFA TOTP Provider and want to use your recovery code, <span tag="button" class="text-primary cursor-pointer text-decoration-underline" data-test="use-recovery-code-btn"> click here </span></p>
+                  </div>
+                </transition-stub>
+                <transition-stub name="v-window-x-reverse-transition" appear="false" persisted="false" css="true">
                   <div class="v-window-item" style="display: none;">
                     <!---->
                   </div>
                 </transition-stub>
-                <transition-stub name="" appear="false" persisted="false" css="true">
-                  <div class="v-window-item" style="display: none;">
-                    <!---->
-                  </div>
-                </transition-stub>
-                <transition-stub name="" appear="false" persisted="false" css="true">
+                <transition-stub name="v-window-x-reverse-transition" appear="false" persisted="false" css="true">
                   <div class="v-window-item v-window-item--active" style="">
                     <div class="text-center"><i class="mdi-email-check-outline mdi v-icon notranslate v-theme--light text-success mb-4" style="font-size: 80px; height: 80px; width: 80px;" aria-hidden="true"></i></div>
                     <p data-test="sub-title" class="mb-4 text-center text-body-1 font-weight-bold"> An email has been sent to . Please check your inbox and click the link we've provided to disable MFA. </p>
@@ -915,7 +1301,200 @@ exports[`MfaDisable > Renders the component (Recovery Code window) 1`] = `
                 </transition-stub>
                 <transition-stub name="v-window-x-transition" appear="false" persisted="false" css="true">
                   <div class="v-window-item" style="display: none;">
-                    <!---->
+                    <div class="v-otp-input mb-4" data-test="verification-code" required="">
+                      <div class="v-otp-input__content">
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="6" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div>
+                        <!---->
+                        <div class="v-field v-field--center-affix v-field--no-label v-field--variant-outlined v-theme--light v-locale--is-ltr">
+                          <div class="v-field__overlay"></div>
+                          <div class="v-field__loader">
+                            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                              <!---->
+                              <div class="v-progress-linear__background"></div>
+                              <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                                <div class="v-progress-linear__indeterminate">
+                                  <div class="v-progress-linear__indeterminate long"></div>
+                                  <div class="v-progress-linear__indeterminate short"></div>
+                                </div>
+                              </transition-stub>
+                              <!---->
+                            </div>
+                          </div>
+                          <!---->
+                          <div class="v-field__field" data-no-activator="">
+                            <!---->
+                            <!----><input aria-label="Verification Code" autocomplete="one-time-code" class="v-otp-input__field" inputmode="numeric" min="0" maxlength="1" type="text">
+                          </div>
+                          <!---->
+                          <!---->
+                          <div class="v-field__outline">
+                            <div class="v-field__outline__start"></div>
+                            <!---->
+                            <div class="v-field__outline__end"></div>
+                            <!---->
+                          </div>
+                        </div><input class="v-otp-input-input" type="hidden" required="" value="">
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
+                    </div>
+                    <p class="text-subtitle-2 text-center"> If you lost your MFA TOTP Provider and want to use your recovery code, <span tag="button" class="text-primary cursor-pointer text-decoration-underline" data-test="use-recovery-code-btn"> click here </span></p>
                   </div>
                 </transition-stub>
                 <transition-stub name="v-window-x-transition" appear="false" persisted="false" css="true">
@@ -940,12 +1519,12 @@ exports[`MfaDisable > Renders the component (Recovery Code window) 1`] = `
                             </div>
                           </div>
                           <!---->
-                          <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" for="input-v-7" aria-hidden="true">
+                          <div class="v-field__field" data-no-activator=""><label class="v-label v-field-label v-field-label--floating" for="input-v-13" aria-hidden="true">
                               <!---->Recovery Code
-                            </label><label class="v-label v-field-label" for="input-v-7">
+                            </label><label class="v-label v-field-label" for="input-v-13">
                               <!---->Recovery Code
                             </label>
-                            <!----><input size="1" type="text" id="input-v-7" aria-describedby="input-v-7-messages" required="" class="v-field__input" value="">
+                            <!----><input size="1" type="text" id="input-v-13" aria-describedby="input-v-13-messages" required="" class="v-field__input" value="">
                             <!---->
                           </div>
                           <!---->
@@ -957,7 +1536,7 @@ exports[`MfaDisable > Renders the component (Recovery Code window) 1`] = `
                         </div>
                       </div>
                       <!---->
-                      <div id="input-v-7-messages" class="v-input__details" role="alert" aria-live="polite">
+                      <div id="input-v-13-messages" class="v-input__details" role="alert" aria-live="polite">
                         <transition-group-stub name="slide-y-transition" tag="div" appear="false" persisted="false" css="true" class="v-messages">
                           <!---->
                         </transition-group-stub>


### PR DESCRIPTION
This pull request refactors the `MfaDisable` component test setup to streamline dialog initialization and reduce code repetition. The main improvement is moving the `showDialog` and related setup logic into the `beforeEach` block, eliminating the need to manually set `showDialog` in each test. This makes the tests cleaner, easier to maintain, and more predictable.

* Added `nextTick` calls right after opening the dialog, waiting for Vue's reactivity system to be ready before making changes inside the dialog, and preventing unexpected behavior.
* Moved setting `wrapper.vm.showDialog = true` and awaiting `nextTick()` and `flushPromises()` into the `beforeEach` block, so that all tests start with the dialog open and ready for assertions. This removes repetitive setup code from individual tests.
* Removed redundant `showDialog` assignments and related awaits from each test case, as the dialog is now initialized in the shared setup.