### PR TITLE
fix(ssh): avoid panic when end value is returned on web ssh data piping

### DIFF
--- a/ssh/web/conn.go
+++ b/ssh/web/conn.go
@@ -131,7 +131,13 @@ func (c *Conn) WriteMessage(message *Message) (int, error) {
 }
 
 func (c *Conn) WriteBinary(data []byte) (int, error) {
-	socket := c.Socket.(*websocket.Conn)
+	socket, ok := c.Socket.(*websocket.Conn)
+	if !ok {
+		// NOTE: If the underlying connection is not a websocket connection, fallback to a normal write.
+		// This is useful for testing purposes, where we use a mock socket that does not implement
+		// the websocket interface.
+		return c.Socket.Write(data)
+	}
 
 	frame, err := socket.NewFrameWriter(websocket.BinaryFrame)
 	if err != nil {

--- a/ssh/web/session_test.go
+++ b/ssh/web/session_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"io"
 	"testing"
 	"testing/iotest"
 
@@ -12,6 +13,41 @@ type zeroReadNoEOFReader struct{}
 
 func (r *zeroReadNoEOFReader) Read(p []byte) (int, error) {
 	return 0, nil
+}
+
+// singleRead returns the provided bytes on the first Read call, then EOF.
+type singleRead struct {
+	data []byte
+	read bool
+}
+
+func (r *singleRead) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, io.EOF
+	}
+
+	n := copy(p, r.data)
+	r.read = true
+
+	return n, nil
+}
+
+func TestRedirToWs_Regression_EndNegative(t *testing.T) {
+	mock := mocks.NewSocket(t)
+	mock.On("Write", []byte{}).Return(0, nil).Once()
+
+	conn := NewConn(mock)
+
+	// All three bytes are UTF-8 continuation bytes, which will cause the
+	// logic in redirToWs to set end to -1 if not handled properly.
+	// This test ensures that the function does not panic in such a case.
+	//
+	// https://datatracker.ietf.org/doc/html/rfc3629#section-3
+	reader := &singleRead{data: []byte{0x80, 0x81, 0x82}}
+
+	assert.NotPanics(t, func() {
+		_ = redirToWs(reader, conn)
+	}, "expected redirToWs to panic when end is -1 and negative slice is attempted")
 }
 
 func TestRedirToWs_Regression_ZeroReadThenEOF(t *testing.T) {


### PR DESCRIPTION
Previously, when the buffer contained only UTF-8 continuation bytes (0x80–0xBF), the loop responsible for finding a valid rune start could leave the end index as -1. Subsequently, slicing the buffer using this negative value resulted in a runtime panic (slice bounds out of range).

To address this, the code now clamps end to zero when negative, ensuring a safe empty-slice write to the WebSocket. A regression test (TestRedirToWs_Regression_EndNegative) was also added to simulate this scenario, validating that no panic occurs when invalid UTF-8 sequences are encountered.

Additionally, WriteBinary now gracefully handles cases where the underlying connection is not a *websocket.Conn. When such situations occur, during tests, it falls back to a normal write on the socket, improving testability and preventing type assertion failures.