### PR TITLE
fix(ui): fix Admin Console button behavior

### DIFF
--- a/ui/src/components/Namespace/Namespace.vue
+++ b/ui/src/components/Namespace/Namespace.vue
@@ -144,7 +144,7 @@ const {
 const showAddDialog = ref(false);
 const userId = computed(() => authStore.id);
 
-const showAdminPanel = computed(() => envVariables.isEnterprise);
+const showAdminPanel = computed(() => envVariables.isEnterprise && !envVariables.isCloud);
 
 const otherNamespaces = computed(() => namespaceList.value.filter((ns) => ns.tenant_id !== currentNamespace.value.tenant_id));
 


### PR DESCRIPTION
This pull request makes minor adjustments to the `Namespace.vue` component to improve admin panel visibility logic and fix navigation. 
* The `showAdminPanel` computed property now only shows the admin panel button in Enterprise-only environments
* The `navigateToAdminPanel` function now uses `window.location.href` instead of Vue Router, since the router needs to be properly configured to navigate to the admin instance. This change is a quick fix until that question is fully addressed.