### PR TITLE
fix(ui): accept empty filter (`""`) in devices and containers list filtering

### DIFF
--- a/ui/src/components/Tags/TagSelector.vue
+++ b/ui/src/components/Tags/TagSelector.vue
@@ -132,7 +132,7 @@ const loadInitialTags = async (): Promise<void> => {
   await loadTags();
 };
 
-const fetchDevices = async (filter?: string): Promise<void> => {
+const fetchDevices = async (filter = ""): Promise<void> => {
   const fetch = {
     device: () => devicesStore.fetchDeviceList({ filter }),
     container: () => containersStore.fetchContainerList({ filter }),

--- a/ui/src/store/modules/containers.ts
+++ b/ui/src/store/modules/containers.ts
@@ -11,7 +11,7 @@ const useContainersStore = defineStore("containers", () => {
   const containerListFilter = ref<string>();
 
   const fetchContainerList = async (data?: FetchContainerParams) => {
-    const filter = data?.filter || containerListFilter.value;
+    const filter = data?.filter === undefined ? containerListFilter.value : data.filter;
     containerListFilter.value = filter;
     try {
       const res = await containerApi.fetchContainers(

--- a/ui/src/store/modules/devices.ts
+++ b/ui/src/store/modules/devices.ts
@@ -19,7 +19,7 @@ const useDevicesStore = defineStore("devices", () => {
   const selectedDevices = ref<Array<IDevice>>([]);
 
   const fetchDeviceList = async (data?: FetchDevicesParams) => {
-    const filter = data?.filter || deviceListFilter.value;
+    const filter = data?.filter === undefined ? deviceListFilter.value : data.filter;
     deviceListFilter.value = filter;
     try {
       const res = await devicesApi.fetchDevices(


### PR DESCRIPTION
This pull request improves the handling of filter parameters in device and container list fetching logic, ensuring that empty strings and undefined values are treated consistently. The changes help prevent unintended behavior when no filter is provided.

Improvements to filter handling:
* Updated `fetchDevices` in `TagSelector.vue` to default the `filter` parameter to an empty string, ensuring predictable behavior when no filter is passed.
* Modified `fetchContainerList` in `containers.ts` to explicitly check for `undefined` before falling back to the stored filter value, preventing unexpected behavior when using empty strings.
* Modified `fetchDeviceList` in `devices.ts` to use the same explicit `undefined` check for the filter parameter, aligning the logic with containers and improving consistency.