### PR TITLE
fix(ui): fix items' alignment in `PaywallDialog` features

### DIFF
--- a/ui/src/components/User/PaywallDialog.vue
+++ b/ui/src/components/User/PaywallDialog.vue
@@ -50,7 +50,7 @@
             >
               <v-col class="d-flex align-center pb-2">
                 <v-icon>mdi-check-circle</v-icon>
-                <p class="ml-2">{{ feature }}</p>
+                <p class="ml-2 text-left">{{ feature }}</p>
               </v-col>
             </v-row>
           </v-card-text>


### PR DESCRIPTION
This pull request makes a minor change in the paywall dialog, changing the items' alignment to the left and preventing an unexpected behavior in smaller screens.

Before:
<img width="300" height="288" alt="" src="https://github.com/user-attachments/assets/b0906c74-cf89-4096-8f6b-973e31fd49c8" />

After:
<img width="300" height="288" alt="" src="https://github.com/user-attachments/assets/2cf8f56e-2181-4818-b249-b007cc1139c1" />

