### PR TITLE
fix(ui): move initial namespace list fetch to `namespaceManager` composable

### DIFF
--- a/ui/src/components/Namespace/composables/useNamespaceManager.ts
+++ b/ui/src/components/Namespace/composables/useNamespaceManager.ts
@@ -27,8 +27,18 @@ export default function useNamespaceManager() {
     }
   };
 
+  const loadNamespaces = async () => {
+    try {
+      await namespacesStore.fetchNamespaceList({ perPage: 30 });
+    } catch (error: unknown) {
+      snackbar.showError("Failed to load namespaces");
+      handleError(error);
+    }
+  };
+
   const loadCurrentNamespace = async () => {
     try {
+      await loadNamespaces();
       await namespacesStore.fetchNamespace(currentTenantId.value);
     } catch (error: unknown) {
       if (!axios.isAxiosError(error)) {

--- a/ui/src/components/User/UserWarning.vue
+++ b/ui/src/components/User/UserWarning.vue
@@ -160,8 +160,6 @@ const showDialogs = async () => {
   try {
     if (!authStore.isLoggedIn) return;
 
-    await namespacesStore.fetchNamespaceList({ perPage: 30 });
-
     if (hasNamespaces.value) {
       await statsStore.fetchStats();
 

--- a/ui/tests/components/AppBar/AppBar.spec.ts
+++ b/ui/tests/components/AppBar/AppBar.spec.ts
@@ -92,7 +92,7 @@ describe("AppBar Component", () => {
     mockSystemApi.onGet("http://localhost:3000/info").reply(200, systemInfo);
     mockDevicesApi.onGet("http://localhost/api/devices?page=1&per_page=10&status=pending").reply(200);
     mockContainersApi.onGet("http://localhost/api/containers?page=1&per_page=10&status=pending").reply(200);
-
+    mockNamespacesApi.onGet("http://localhost:3000/api/namespaces?page=1&per_page=30").reply(200, []);
     authStore.$patch(authStoreData);
     billingStore.billing = billingData;
 

--- a/ui/tests/layouts/AppLayout.spec.ts
+++ b/ui/tests/layouts/AppLayout.spec.ts
@@ -74,8 +74,8 @@ describe("App Layout Component", async () => {
     .onGet("http://localhost:3000/api/containers?page=1&per_page=10&status=pending")
     .reply(200);
   mockNamespacesApi
-    .onGet("http://localhost:3000/api/namespaces")
-    .reply(200);
+    .onGet("http://localhost:3000/api/namespaces?page=1&per_page=30")
+    .reply(200, []);
 
   await router.push("/");
   await router.isReady();


### PR DESCRIPTION
This pull request fixes a bug in the initial namespaces fetch, where the `namespaceManager` composable tried to switch to a namespace before making the fetch list request, consequently, trying to switch to an undefined namespace, and causing a lot of errors. This PR moves the initial `fetchNamespaceList` call from `UserWarning.vue` to `useNamespaceManager.ts`, ensuring the list fetch occurs first and is coordinated with other namespace-related operations.

Tests and mocks were also updated to reflect the changes and prevent warnings in the test console.