### PR TITLE
fix(ui): listen to submit event in FormDialog's v-form

### DIFF
--- a/ui/src/components/Dialogs/FormDialog.vue
+++ b/ui/src/components/Dialogs/FormDialog.vue
@@ -12,7 +12,7 @@
     :show-footer="showFooter"
   >
     <!-- Content -->
-    <v-form>
+    <v-form @submit.prevent="handleConfirm">
       <slot />
     </v-form>
 


### PR DESCRIPTION
This pull request updates the form handling in the `FormDialog.vue` component to improve how form submissions are managed.

* Added a `@submit.prevent="handleConfirm"` event listener to the `v-form` element to ensure that form submissions trigger the `handleConfirm` method and prevent the default browser behavior.