### PR TITLE
fix(ui): remove primary color from `TerminalLoginForm` inputs for consistency

### DIFF
--- a/ui/src/components/Terminal/TerminalLoginForm.vue
+++ b/ui/src/components/Terminal/TerminalLoginForm.vue
@@ -50,7 +50,6 @@
       />
 
       <v-text-field
-        color="primary"
         :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
         v-model="password"
         v-else
@@ -67,7 +66,6 @@
       />
 
       <v-text-field
-        color="primary"
         v-if="showPassphraseField"
         :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
         v-model="passphrase"

--- a/ui/tests/components/Terminal/__snapshots__/TerminalDialog.spec.ts.snap
+++ b/ui/tests/components/Terminal/__snapshots__/TerminalDialog.spec.ts.snap
@@ -157,12 +157,12 @@ exports[`Terminal Dialog > Renders the component 1`] = `
                       <div class="v-field__loader">
                         <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
                           <!---->
-                          <div class="v-progress-linear__background bg-primary"></div>
-                          <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
+                          <div class="v-progress-linear__background"></div>
+                          <div class="v-progress-linear__buffer" style="width: 0%;"></div>
                           <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
                             <div class="v-progress-linear__indeterminate">
-                              <div class="v-progress-linear__indeterminate long bg-primary"></div>
-                              <div class="v-progress-linear__indeterminate short bg-primary"></div>
+                              <div class="v-progress-linear__indeterminate long"></div>
+                              <div class="v-progress-linear__indeterminate short"></div>
                             </div>
                           </transition-stub>
                           <!---->

--- a/ui/tests/components/Terminal/__snapshots__/TerminalLoginForm.spec.ts.snap
+++ b/ui/tests/components/Terminal/__snapshots__/TerminalLoginForm.spec.ts.snap
@@ -157,12 +157,12 @@ exports[`Terminal Login Form > Renders the component 1`] = `
                       <div class="v-field__loader">
                         <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
                           <!---->
-                          <div class="v-progress-linear__background bg-primary"></div>
-                          <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
+                          <div class="v-progress-linear__background"></div>
+                          <div class="v-progress-linear__buffer" style="width: 0%;"></div>
                           <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
                             <div class="v-progress-linear__indeterminate">
-                              <div class="v-progress-linear__indeterminate long bg-primary"></div>
-                              <div class="v-progress-linear__indeterminate short bg-primary"></div>
+                              <div class="v-progress-linear__indeterminate long"></div>
+                              <div class="v-progress-linear__indeterminate short"></div>
                             </div>
                           </transition-stub>
                           <!---->
@@ -400,12 +400,12 @@ exports[`Terminal Login Form > Renders the component 1`] = `
                       <div class="v-field__loader">
                         <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
                           <!---->
-                          <div class="v-progress-linear__background bg-primary"></div>
-                          <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
+                          <div class="v-progress-linear__background"></div>
+                          <div class="v-progress-linear__buffer" style="width: 0%;"></div>
                           <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
                             <div class="v-progress-linear__indeterminate">
-                              <div class="v-progress-linear__indeterminate long bg-primary"></div>
-                              <div class="v-progress-linear__indeterminate short bg-primary"></div>
+                              <div class="v-progress-linear__indeterminate long"></div>
+                              <div class="v-progress-linear__indeterminate short"></div>
                             </div>
                           </transition-stub>
                           <!---->


### PR DESCRIPTION
This pull request updates the `TerminalLoginForm` component and its related tests to remove the explicit use of the primary color styling from certain UI elements. The main goal is to ensure that color styling is handled by default or inherited styles rather than being hardcoded, which improves consistency with the rest of the UI.

* Removed the `color="primary"` prop from `v-text-field` components in `TerminalLoginForm.vue`, so they now use default colors
* Updated snapshot tests for both `TerminalDialog` and `TerminalLoginForm` to reflect the changes