### PR TITLE
fix(ui): ensure stats are fetched when namespace becomes available

### DIFF
--- a/ui/src/views/Home.vue
+++ b/ui/src/views/Home.vue
@@ -23,10 +23,11 @@
               <v-card class="pa-4" variant="tonal">
                 <div class="text-overline text-medium-emphasis mb-2">TENANT ID</div>
                 <div class="d-flex align-center justify-space-between">
-                  <code class="text-primary">{{ namespace.tenant_id }}</code>
+                  <code class="text-primary" data-test="tenant-info-text">{{ namespace.tenant_id }}</code>
                   <CopyWarning :copied-item="'Tenant ID'">
                     <template #default="{ copyText }">
                       <v-btn
+                        data-test="copy-tenant-btn"
                         @click="copyText(namespace.tenant_id)"
                         color="primary"
                         variant="elevated"
@@ -108,7 +109,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import axios, { AxiosError } from "axios";
 import handleError from "@/utils/handleError";
 import useSnackbar from "@/helpers/snackbar";
@@ -126,7 +127,7 @@ const stats = computed(() => statsStore.stats);
 const namespace = computed(() => namespacesStore.currentNamespace);
 const hasNamespace = computed(() => namespacesStore.namespaceList.length !== 0);
 
-onMounted(async () => {
+const fetchStats = async () => {
   if (!hasNamespace.value) return;
 
   try {
@@ -147,6 +148,16 @@ onMounted(async () => {
       }
     }
     handleError(error);
+  }
+};
+
+onMounted(async () => {
+  await fetchStats();
+});
+
+watch(hasNamespace, (newValue) => {
+  if (newValue) {
+    fetchStats();
   }
 });
 

--- a/ui/tests/views/Home.spec.ts
+++ b/ui/tests/views/Home.spec.ts
@@ -9,25 +9,30 @@ import { devicesApi } from "@/api/http";
 import { router } from "@/router";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 import useNamespacesStore from "@/store/modules/namespaces";
+import useStatsStore from "@/store/modules/stats";
 import { INamespace } from "@/interfaces/INamespace";
 
 type HomeWrapper = VueWrapper<InstanceType<typeof Home>>;
 
 describe("Home", () => {
   let wrapper: HomeWrapper;
-  setActivePinia(createPinia());
-  const namespacesStore = useNamespacesStore();
+  let namespacesStore: ReturnType<typeof useNamespacesStore>;
+  let statsStore: ReturnType<typeof useStatsStore>;
+  let mockDevicesApi: MockAdapter;
   const vuetify = createVuetify();
-  const mockDevicesApi = new MockAdapter(devicesApi.getAxios());
 
   const members = [
     {
       id: "xxxxxxxx",
       role: "owner" as const,
+      email: "test@example.com",
+      status: "accepted" as const,
+      added_at: "2024-01-01T00:00:00Z",
+      expires_at: "2025-01-01T00:00:00Z",
     },
   ];
 
-  const namespaceData = {
+  const namespaceData: INamespace = {
     billing: null,
     name: "test",
     owner: "test",
@@ -42,53 +47,208 @@ describe("Home", () => {
     devices_rejected_count: 0,
     devices_pending_count: 0,
     created_at: "",
+    type: "personal",
   };
 
   const statsMock = {
-    registered_devices: 0,
-    online_devices: 0,
-    active_sessions: 0,
-    pending_devices: 0,
+    registered_devices: 5,
+    online_devices: 3,
+    active_sessions: 2,
+    pending_devices: 1,
     rejected_devices: 0,
   };
 
   beforeEach(async () => {
+    setActivePinia(createPinia());
+    namespacesStore = useNamespacesStore();
+    statsStore = useStatsStore();
+
+    mockDevicesApi = new MockAdapter(devicesApi.getAxios());
     mockDevicesApi.onGet("http://localhost:3000/api/stats").reply(200, statsMock);
 
-    namespacesStore.namespaceList = [namespaceData] as INamespace[];
+    namespacesStore.$patch({
+      namespaceList: [namespaceData],
+      currentNamespace: namespaceData,
+    });
 
     wrapper = mount(Home, {
       global: {
         plugins: [vuetify, router, SnackbarPlugin],
       },
     });
+
+    await flushPromises();
   });
 
   afterEach(() => {
     wrapper.unmount();
+    mockDevicesApi.reset();
+    mockDevicesApi.restore();
   });
 
-  it("Renders the component", () => {
-    expect(wrapper.html()).toMatchSnapshot();
+  describe("Component Rendering", () => {
+    it("renders the component successfully", () => {
+      expect(wrapper.exists()).toBe(true);
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    it("displays namespace information", async () => {
+      await flushPromises();
+
+      expect(wrapper.text()).toContain("TENANT ID");
+      expect(wrapper.text()).toContain(namespaceData.tenant_id);
+      expect(wrapper.text()).toContain("This is your active namespace");
+    });
+
+    it("displays all device stat cards", () => {
+      expect(wrapper.text()).toContain("Accepted Devices");
+      expect(wrapper.text()).toContain("Online Devices");
+      expect(wrapper.text()).toContain("Pending Devices");
+    });
+
+    it("displays the add device card", () => {
+      expect(wrapper.text()).toContain("Add a new device");
+      expect(wrapper.text()).toContain("Register new devices to this namespace");
+    });
   });
 
-  it("Renders the template with data", async () => {
-    expect(wrapper.text()).toContain("Accepted Devices");
-    expect(wrapper.text()).toContain("Online Devices");
-    expect(wrapper.text()).toContain("Pending Devices");
-    wrapper.vm.hasStatus = true; // Set the conditional validation to true so it can show the error card.
-    await nextTick();
-    expect(wrapper.find('[data-test="home-failed"]').exists()).toBe(true);
+  describe("Stats Loading", () => {
+    it("fetches and displays stats on mount", async () => {
+      await flushPromises();
+
+      expect(statsStore.stats.registered_devices).toBe(statsMock.registered_devices);
+      expect(statsStore.stats.online_devices).toBe(statsMock.online_devices);
+      expect(statsStore.stats.pending_devices).toBe(statsMock.pending_devices);
+    });
+
+    it("displays correct stat values in the UI", async () => {
+      await flushPromises();
+
+      const text = wrapper.text();
+      expect(text).toContain("Accepted Devices");
+      expect(text).toContain("Online Devices");
+      expect(text).toContain("Pending Devices");
+    });
+
+    it("handles missing namespace gracefully", async () => {
+      wrapper.unmount();
+      namespacesStore.namespaceList = [];
+
+      wrapper = mount(Home, {
+        global: {
+          plugins: [vuetify, router, SnackbarPlugin],
+        },
+      });
+
+      await flushPromises();
+
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    it("fetches stats when namespace becomes available", async () => {
+      wrapper.unmount();
+      namespacesStore.namespaceList = [];
+
+      wrapper = mount(Home, {
+        global: {
+          plugins: [vuetify, router, SnackbarPlugin],
+        },
+      });
+
+      await flushPromises();
+
+      namespacesStore.namespaceList = [namespaceData];
+      await nextTick();
+      await flushPromises();
+
+      expect(statsStore.stats.registered_devices).toBe(statsMock.registered_devices);
+    });
   });
 
-  it("Displays error message if API call fails with 403 status code", async () => {
-    mockDevicesApi.onGet("http://localhost:3000/api/stats").reply(403);
+  describe("Error Handling", () => {
+    it("displays error message when API call fails with 403 status", async () => {
+      wrapper.unmount();
+      mockDevicesApi.reset();
+      mockDevicesApi.onGet("http://localhost:3000/api/stats").reply(403);
 
-    await flushPromises();
+      wrapper = mount(Home, {
+        global: {
+          plugins: [vuetify, router, SnackbarPlugin],
+        },
+      });
 
-    expect(wrapper.find('[data-test="home-failed"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="home-failed"]').text()).toContain(
-      "Something is wrong, try again!",
-    );
+      await flushPromises();
+
+      expect(wrapper.vm.hasStatus).toBe(true);
+      expect(wrapper.find('[data-test="home-failed"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="home-failed"]').text()).toContain(
+        "Something is wrong, try again!",
+      );
+    });
+
+    it("displays error message when API call fails with other errors", async () => {
+      wrapper.unmount();
+      mockDevicesApi.reset();
+      mockDevicesApi.onGet("http://localhost:3000/api/stats").reply(500);
+
+      wrapper = mount(Home, {
+        global: {
+          plugins: [vuetify, router, SnackbarPlugin],
+        },
+      });
+
+      await flushPromises();
+
+      expect(wrapper.vm.hasStatus).toBe(true);
+      expect(wrapper.find('[data-test="home-failed"]').exists()).toBe(true);
+    });
+
+    it("displays error message when API call times out", async () => {
+      wrapper.unmount();
+      mockDevicesApi.reset();
+      mockDevicesApi.onGet("http://localhost:3000/api/stats").timeout();
+
+      wrapper = mount(Home, {
+        global: {
+          plugins: [vuetify, router, SnackbarPlugin],
+        },
+      });
+
+      await flushPromises();
+
+      expect(wrapper.vm.hasStatus).toBe(true);
+      expect(wrapper.find('[data-test="home-failed"]').exists()).toBe(true);
+    });
+
+    it("can manually toggle error state", async () => {
+      expect(wrapper.find('[data-test="home-failed"]').exists()).toBe(false);
+
+      wrapper.vm.hasStatus = true;
+      await nextTick();
+
+      expect(wrapper.find('[data-test="home-failed"]').exists()).toBe(true);
+    });
+  });
+
+  describe("User Interactions", () => {
+    it("allows copying tenant ID", async () => {
+      const copyButton = wrapper.find('[data-test="copy-tenant-btn"]');
+      expect(copyButton.exists()).toBe(true);
+    });
+
+    it("displays tenant ID in code format", () => {
+      const codeElement = wrapper.find('[data-test="tenant-info-text"]');
+      expect(codeElement.exists()).toBe(true);
+      expect(codeElement.text()).toBe(namespaceData.tenant_id);
+    });
+  });
+
+  describe("Navigation", () => {
+    it("has navigation buttons for device pages", () => {
+      const text = wrapper.text();
+      expect(text).toContain("View all devices");
+      expect(text).toContain("View Online Devices");
+      expect(text).toContain("Approve Devices");
+    });
   });
 });

--- a/ui/tests/views/__snapshots__/Home.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/Home.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Home > Renders the component 1`] = `
+exports[`Home > Component Rendering > renders the component successfully 1`] = `
 "<div>
   <!-- Namespace Info Card -->
   <div class="v-row">
@@ -31,7 +31,7 @@ exports[`Home > Renders the component 1`] = `
               </div>
               <div>
                 <div class="text-overline text-medium-emphasis mb-1">Home</div>
-                <div class="text-h5 font-weight-bold mb-2"></div>
+                <div class="text-h5 font-weight-bold mb-2">test</div>
                 <div class="text-body-2 text-medium-emphasis"> This is your active namespace. All devices, sessions and configurations are isolated within this namespace. </div>
               </div>
             </div>
@@ -56,8 +56,8 @@ exports[`Home > Renders the component 1`] = `
               <!---->
               <!---->
               <div class="text-overline text-medium-emphasis mb-2">TENANT ID</div>
-              <div class="d-flex align-center justify-space-between"><code class="text-primary"></code>
-                <div><button type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-small v-btn--variant-elevated"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span><span class="v-btn__prepend"><i class="mdi-content-copy mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span><span class="v-btn__content" data-no-activator=""> Copy </span>
+              <div class="d-flex align-center justify-space-between"><code class="text-primary" data-test="tenant-info-text">fake-tenant-data</code>
+                <div><button type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-small v-btn--variant-elevated" data-test="copy-tenant-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span><span class="v-btn__prepend"><i class="mdi-content-copy mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span><span class="v-btn__content" data-no-activator=""> Copy </span>
                     <!---->
                     <!---->
                   </button>
@@ -105,7 +105,7 @@ exports[`Home > Renders the component 1`] = `
           <!----><span class="v-avatar__underlay"></span>
         </div>
         <div class="v-card-title text-overline text-medium-emphasis mb-2">Accepted Devices</div>
-        <div class="v-card-subtitle text-h2 font-weight-bold mb-4">0</div><a href="/devices" class="v-btn v-btn--block v-theme--light text-primary v-btn--density-default v-btn--size-small v-btn--variant-text"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+        <div class="v-card-subtitle text-h2 font-weight-bold mb-4">5</div><a href="/devices" class="v-btn v-btn--block v-theme--light text-primary v-btn--density-default v-btn--size-small v-btn--variant-text"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator="">View all devices</span>
           <!---->
           <!---->
@@ -137,7 +137,7 @@ exports[`Home > Renders the component 1`] = `
           <!----><span class="v-avatar__underlay"></span>
         </div>
         <div class="v-card-title text-overline text-medium-emphasis mb-2">Online Devices</div>
-        <div class="v-card-subtitle text-h2 font-weight-bold mb-4">0</div><a href="/devices" class="v-btn v-btn--block v-theme--light text-primary v-btn--density-default v-btn--size-small v-btn--variant-text"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+        <div class="v-card-subtitle text-h2 font-weight-bold mb-4">3</div><a href="/devices" class="v-btn v-btn--block v-theme--light text-primary v-btn--density-default v-btn--size-small v-btn--variant-text"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator="">View Online Devices</span>
           <!---->
           <!---->
@@ -169,7 +169,7 @@ exports[`Home > Renders the component 1`] = `
           <!----><span class="v-avatar__underlay"></span>
         </div>
         <div class="v-card-title text-overline text-medium-emphasis mb-2">Pending Devices</div>
-        <div class="v-card-subtitle text-h2 font-weight-bold mb-4">0</div><a href="/devices/pending" class="v-btn v-btn--block v-theme--light text-primary v-btn--density-default v-btn--size-small v-btn--variant-text"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+        <div class="v-card-subtitle text-h2 font-weight-bold mb-4">1</div><a href="/devices/pending" class="v-btn v-btn--block v-theme--light text-primary v-btn--density-default v-btn--size-small v-btn--variant-text"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator="">Approve Devices</span>
           <!---->
           <!---->


### PR DESCRIPTION
# Description

This PR addresses a bug in the Home view where the namespace might not be immediately available on component mount, causing the initial stats request to fail silently. The fix ensures that stats are fetched as soon as the namespace becomes available.

## What’s Changed

Refactored the `onMounted` hook to delegate fetching to a new `fetchStats` function.

Added a watch on `hasNamespace` to trigger `fetchStats()` when the namespace becomes available.

### Introduced data-test attributes:

`data-test="tenant-info-text"` for tenant ID display
`data-test="copy-tenant-btn" `for the copy-to-clipboard button

### Improved unit tests:

- Added test cases for delayed namespace availability
- Verified stat display updates correctly
- Expanded error handling scenarios
- Updated snapshot to reflect new UI state and identifiers

## How to Test

1. Load the Home view with a delayed or async namespace population.
2. Ensure stats are displayed once the namespace is set.
3. Run `npm run test` to confirm all tests pass.
4. Confirm data-test attributes are present in the DOM.
