### PR TITLE
fix(ui): fix admin's favicon path

### DIFF
--- a/ui/admin/index.html
+++ b/ui/admin/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="public/favicon.ico" />
+    <link rel="icon" href="../public/favicon.ico" />
     <link href="//cdn.jsdelivr.net/npm/font-logos@0.18/assets/font-logos.css" rel="stylesheet">
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/@mdi/font@6.5.95/css/materialdesignicons.min.css">
     <meta name="viewport" content="width=device-width">


### PR DESCRIPTION
This pull request fixes the path of the admin's `index.html` favicon, which was not appearing because the incorrect path was being called.