### PR TITLE
test(ui): mock `fetchDeviceList` in web endpoints test

### DIFF
--- a/ui/tests/views/WebEndpoints.spec.ts
+++ b/ui/tests/views/WebEndpoints.spec.ts
@@ -11,6 +11,7 @@ import { router } from "@/router";
 import useWebEndpointsStore from "@/store/modules/web_endpoints";
 import { IWebEndpoint } from "@/interfaces/IWebEndpoints";
 import useAuthStore from "@/store/modules/auth";
+import useDevicesStore from "@/store/modules/devices";
 
 type WebEndpointsWrapper = VueWrapper<InstanceType<typeof WebEndpoints>>;
 
@@ -38,8 +39,11 @@ describe("WebEndpoints.vue", () => {
   const mockWebEndpointsApi = new MockAdapter(webEndpointsApi.getAxios());
   setActivePinia(createPinia());
   const authStore = useAuthStore();
+  const devicesStore = useDevicesStore();
   const webEndpointsStore = useWebEndpointsStore();
   const vuetify = createVuetify();
+
+  devicesStore.fetchDeviceList = vi.fn().mockResolvedValue([]);
 
   beforeEach(async () => {
     mockWebEndpointsApi


### PR DESCRIPTION
This pull request adds a mock to `fetchDeviceList` in `WebEndpoints.spec.ts` to prevent errors in the test console.