### PR TITLE
fix(ui): fix `NamespaceEdit` max devices number input behavior

### DIFF
--- a/ui/admin/src/components/Namespace/NamespaceEdit.vue
+++ b/ui/admin/src/components/Namespace/NamespaceEdit.vue
@@ -35,12 +35,14 @@
         :error-messages="nameError"
         data-test="name-text"
       />
-      <v-text-field
+      <v-number-input
         v-model="maxDevices"
         label="Maximum Devices"
         required
-        type="number"
-        :min="-1"
+        variant="outlined"
+        density="comfortable"
+        inset
+        controlVariant="hidden"
         :error-messages="maxDevicesError"
         data-test="maxDevices-text"
       />
@@ -78,7 +80,7 @@ const { value: name, errorMessage: nameError, resetField: resetName } = useField
 
 const { value: maxDevices, errorMessage: maxDevicesError, resetField: resetMaxDevices } = useField<number | undefined>(
   "maxDevices",
-  yup.number().required(),
+  yup.number().integer().required().min(-1, "Maximum devices must be -1 (unlimited) or greater"),
   { initialValue: props.namespace.max_devices },
 );
 


### PR DESCRIPTION
This pull request makes minor fixes in the admin's `NamespaceEdit` component, specifically in the maximum devices input. Now, instead of being a regular text field, it uses the proper `VNumberInput` component, designed to deal with numbers. Additionally, validation for integer and negative values was added.