### PR TITLE
fix(ui): fix user confirmed checkbox tooltip position and message

### DIFF
--- a/ui/admin/src/components/User/UserFormDialog.vue
+++ b/ui/admin/src/components/User/UserFormDialog.vue
@@ -95,7 +95,7 @@
         color="primary"
         variant="outlined"
       />
-      <v-tooltip location="bottom" class="text-center" :disabled="canChangeStatus">
+      <v-tooltip location="bottom start" class="text-center" :disabled="canChangeStatus" :text="statusTooltipMessage">
         <template v-slot:activator="{ props }">
           <div v-bind="props">
             <v-checkbox
@@ -109,7 +109,6 @@
             />
           </div>
         </template>
-        <span>{{ statusTooltipMessage }}</span>
       </v-tooltip>
     </v-card-text>
   </FormDialog>
@@ -140,7 +139,7 @@ const snackbar = useSnackbar();
 const usersStore = useUsersStore();
 const statusTooltipMessage = props.user?.status === "invited"
   ? "You cannot change the status of an invited user."
-  : "You cannot remove confirmation from a user.";
+  : "You cannot remove confirmation from an user.";
 
 const { value: name,
   errorMessage: nameError,

--- a/ui/admin/tests/unit/components/User/UserFormDialog/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/User/UserFormDialog/__snapshots__/index.spec.ts.snap
@@ -418,7 +418,7 @@ exports[`UserFormDialog (Create User) > Renders the component 2`] = `
         <!---->
       </transition-stub>
       <transition-stub name="fade-transition" appear="true" persisted="true" css="true" target="[object HTMLDivElement]">
-        <div class="v-overlay__content" style="min-width: 0px; display: none;"><span>You cannot remove confirmation from a user.</span></div>
+        <div class="v-overlay__content" style="min-width: 0px; display: none;">You cannot remove confirmation from an user.</div>
       </transition-stub>
     </div>
   </div>
@@ -843,7 +843,7 @@ exports[`UserFormDialog (Edit User) > Renders the component 2`] = `
         <!---->
       </transition-stub>
       <transition-stub name="fade-transition" appear="true" persisted="true" css="true" target="[object HTMLDivElement]">
-        <div class="v-overlay__content" style="min-width: 0px; display: none;"><span>You cannot remove confirmation from a user.</span></div>
+        <div class="v-overlay__content" style="min-width: 0px; display: none;">You cannot remove confirmation from an user.</div>
       </transition-stub>
     </div>
   </div>


### PR DESCRIPTION
This pull request makes two small fixes to the admin's `UserFormDialog` "User confirmed" checkbox:
1. Fix the tooltip position, which was appearing in the middle of the dialog, distant from the checkbox itself
2. Fix a typo in the conditional tooltip message