### PR TITLE
fix(ui): fix `PublicKeyAdd` reset data field behavior

### DIFF
--- a/ui/src/components/PublicKeys/PublicKeyAdd.vue
+++ b/ui/src/components/PublicKeys/PublicKeyAdd.vue
@@ -248,6 +248,7 @@ watch([tagChoices, choiceFilter], ([list, currentFilter]) => {
 });
 
 watch(publicKeyData, () => {
+  if (!showDialog.value) return;
   if (!publicKeyData.value) {
     publicKeyDataError.value = "Field is required";
     return;


### PR DESCRIPTION
This pull request introduces a minor improvement to the validation logic in the public key addition dialog. The change ensures that the data field validation only runs when the dialog is visible, preventing unnecessary error messages when the dialog is opened and closed.