### PR TITLE
test(ui): add stubs to `NotificationsList` test

### DIFF
--- a/ui/tests/components/AppBar/Notifications/NotificationsList.spec.ts
+++ b/ui/tests/components/AppBar/Notifications/NotificationsList.spec.ts
@@ -27,25 +27,27 @@ const mockNotifications = [
 ];
 
 describe("Notifications List", () => {
-  let wrapper: VueWrapper<InstanceType<typeof NotificationsList>>;
   const vuetify = createVuetify();
   setActivePinia(createPinia());
 
-  beforeEach(() => {
-    wrapper = mount(NotificationsList, {
-      global: {
-        plugins: [router, vuetify, SnackbarPlugin],
+  const wrapper = mount(NotificationsList, {
+    global: {
+      plugins: [router, vuetify, SnackbarPlugin],
+      stubs: {
+        DeviceActionButton: {
+          name: 'DeviceActionButton',
+          template: '<div data-test="device-action-button-stub"></div>',
+          props: ['uid', 'name', 'variant', 'isInNotification', 'show', 'action']
+        },
+        RouterLink: {
+          template: '<a :href="`/devices/${to.params.identifier}`"><slot /></a>',
+          props: ['to']
+        }
       },
-      props: {
-        notifications: mockNotifications as INotification[],
-      },
-    });
-  });
-
-  afterEach(() => { wrapper.unmount(); });
-
-  it("Is a Vue instance", () => {
-    expect(wrapper.vm).toBeTruthy();
+    },
+    props: {
+      notifications: mockNotifications as INotification[],
+    },
   });
 
   it("Renders the correct number of list items", () => {


### PR DESCRIPTION
This pull request refactors the test setup in `NotificationsList.spec.ts`, removing the remount/unmount calls and adding stubs for `DeviceActionButton` and `RouterLink`. The goal is to prevent errors related to Vuetify's internals, specifically timeouts, that occasionally throw errors in the test console.