### PR TITLE
feat(ui): add TLS config support to Web Endpoints

### DIFF
--- a/ui/src/components/WebEndpoints/WebEndpointList.vue
+++ b/ui/src/components/WebEndpoints/WebEndpointList.vue
@@ -50,6 +50,27 @@
         <td class="text-center">
           {{ endpoint.port }}
         </td>
+
+        <td
+          class="text-center"
+          data-test="web-endpoint-tls"
+        >
+          <v-chip
+            v-if="endpoint.tls?.enabled"
+            size="small"
+          >
+            {{ endpoint.tls?.domain }}
+          </v-chip>
+
+          <v-chip
+            v-else
+            size="small"
+            color="error"
+          >
+            Disabled
+          </v-chip>
+        </td>
+
         <td class="text-center">
           {{ formatDate(endpoint.expires_in) }}
         </td>
@@ -96,6 +117,7 @@ const headers = [
   { text: "Address", value: "address", sortable: true },
   { text: "Host", value: "host", sortable: true },
   { text: "Port", value: "port", sortable: true },
+  { text: "Domain", value: "tls", sortable: false },
   { text: "Expiration Date", value: "expires_in", sortable: true },
   { text: "Actions", value: "actions", sortable: false },
 ];

--- a/ui/src/interfaces/IWebEndpoints.ts
+++ b/ui/src/interfaces/IWebEndpoints.ts
@@ -1,20 +1,28 @@
 import { IDevice } from "./IDevice";
 
+export interface IWebEndpointTLS {
+  enabled: boolean;
+  verify: boolean;
+  domain: string;
+}
+
 export interface IWebEndpoint {
-  address: string,
-  full_address: string,
-  device: IDevice
-  expires_in: string,
-  device_uid: string,
-  host: string,
-  port: number
+  address: string;
+  full_address: string;
+  device: IDevice;
+  expires_in: string;
+  device_uid: string;
+  host: string;
+  port: number;
+  tls?: IWebEndpointTLS;
 }
 
 export interface IWebEndpointsCreate {
-  uid: string,
-  host: string,
-  port: number,
-  ttl: number
+  uid: string;
+  host: string;
+  port: number;
+  ttl: number;
+  tls?: IWebEndpointTLS;
 }
 
 export interface FetchWebEndpointsParams {

--- a/ui/src/store/api/web_endpoints.ts
+++ b/ui/src/store/api/web_endpoints.ts
@@ -1,4 +1,5 @@
 import { webEndpointsApi } from "@/api/http";
+import { IWebEndpointsCreate } from "@/interfaces/IWebEndpoints";
 
 export const getWebEndpoints = (
   page: number,
@@ -14,13 +15,7 @@ export const getWebEndpoints = (
   sortOrder,
 );
 
-export const createWebEndpoint = (uid: string, host: string, port: number, ttl: number) => webEndpointsApi.createWebEndpoint(
-  {
-    uid,
-    host,
-    port,
-    ttl,
-  },
-);
+export const createWebEndpoint = (payload: IWebEndpointsCreate) =>
+  webEndpointsApi.createWebEndpoint(payload);
 
 export const deleteWebEndpoint = (address: string) => webEndpointsApi.deleteWebEndpoint(address);

--- a/ui/src/store/modules/web_endpoints.ts
+++ b/ui/src/store/modules/web_endpoints.ts
@@ -31,8 +31,7 @@ const useWebEndpointsStore = defineStore("webEndpoints", () => {
   };
 
   const createWebEndpoint = async (data: IWebEndpointsCreate) => {
-    const { uid, host, port, ttl } = data;
-    const res = await webEndpointsApi.createWebEndpoint(uid, host, port, ttl);
+    const res = await webEndpointsApi.createWebEndpoint(data);
     return res;
   };
 

--- a/ui/tests/components/WebEndpoints/WebEndpointCreate.spec.ts
+++ b/ui/tests/components/WebEndpoints/WebEndpointCreate.spec.ts
@@ -40,18 +40,16 @@ describe("WebEndpointCreate.vue", () => {
     const dialog = new DOMWrapper(document.body);
     await flushPromises();
 
-    // Title now comes from FormDialog — assert by text
     expect(dialog.text()).toContain("Create Device Web Endpoint");
-
-    // Keep the field checks
     expect(dialog.find('[data-test="host-text"]').exists()).toBe(true);
     expect(dialog.find('[data-test="port-text"]').exists()).toBe(true);
     expect(dialog.find('[data-test="timeout-combobox"]').exists()).toBe(true);
     expect(dialog.find('[data-test="custom-timeout"]').exists()).toBe(false);
+    expect(dialog.find('[data-test="tls-enabled-checkbox"]').exists()).toBe(true);
     expect(dialog.find('[data-test="create-tunnel-btn"]').exists()).toBe(true);
   });
 
-  it("successfully creates a Web Endpoint", async () => {
+  it("successfully creates a Web Endpoint without TLS", async () => {
     mockWebEndpointsApi.onPost("http://localhost:3000/api/web-endpoints").reply(200);
 
     const storeSpy = vi.spyOn(webEndpointsStore, "createWebEndpoint");
@@ -77,10 +75,9 @@ describe("WebEndpointCreate.vue", () => {
 
     await wrapper.findComponent('[data-test="host-text"]').setValue("127.0.0.1");
     await wrapper.findComponent('[data-test="port-text"]').setValue("8080");
-
     await wrapper.findComponent('[data-test="timeout-combobox"]').setValue(600);
-
     await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
+
     await flushPromises();
 
     expect(storeSpy).toHaveBeenCalledWith({
@@ -89,6 +86,116 @@ describe("WebEndpointCreate.vue", () => {
       port: 8080,
       ttl: 600,
     });
+  });
+
+  it("successfully creates a Web Endpoint with TLS enabled", async () => {
+    mockWebEndpointsApi.onPost("http://localhost:3000/api/web-endpoints").reply(200);
+
+    const storeSpy = vi.spyOn(webEndpointsStore, "createWebEndpoint");
+
+    await wrapper.findComponent('[data-test="host-text"]').setValue("192.168.1.1");
+    await wrapper.findComponent('[data-test="port-text"]').setValue("443");
+
+    const tlsCheckbox = wrapper.findComponent('[data-test="tls-enabled-checkbox"]');
+    await tlsCheckbox.setValue(true);
+    await flushPromises();
+
+    await wrapper.findComponent('[data-test="tls-domain-text"]').setValue("example.com");
+    await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
+
+    await flushPromises();
+
+    expect(storeSpy).toHaveBeenCalledWith({
+      uid: "fake-uid",
+      host: "192.168.1.1",
+      port: 443,
+      ttl: -1,
+      tls: {
+        enabled: true,
+        verify: false,
+        domain: "example.com",
+      },
+    });
+  });
+
+  it("successfully creates a Web Endpoint with TLS and certificate verification", async () => {
+    mockWebEndpointsApi.onPost("http://localhost:3000/api/web-endpoints").reply(200);
+
+    const storeSpy = vi.spyOn(webEndpointsStore, "createWebEndpoint");
+
+    await wrapper.findComponent('[data-test="host-text"]').setValue("10.0.0.5");
+    await wrapper.findComponent('[data-test="port-text"]').setValue("8443");
+
+    const tlsCheckbox = wrapper.findComponent('[data-test="tls-enabled-checkbox"]');
+    await tlsCheckbox.setValue(true);
+    await flushPromises();
+
+    const tlsVerifyCheckbox = wrapper.findComponent('[data-test="tls-verify-checkbox"]');
+    await tlsVerifyCheckbox.setValue(true);
+    await flushPromises();
+
+    await wrapper.findComponent('[data-test="tls-domain-text"]').setValue("secure.local");
+    await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
+
+    await flushPromises();
+
+    expect(storeSpy).toHaveBeenCalledWith({
+      uid: "fake-uid",
+      host: "10.0.0.5",
+      port: 8443,
+      ttl: -1,
+      tls: {
+        enabled: true,
+        verify: true,
+        domain: "secure.local",
+      },
+    });
+  });
+
+  it("shows TLS domain field when TLS is enabled", async () => {
+    const tlsCheckbox = wrapper.findComponent('[data-test="tls-enabled-checkbox"]');
+    await tlsCheckbox.setValue(true);
+    await flushPromises();
+
+    expect(wrapper.findComponent('[data-test="tls-domain-text"]').exists()).toBe(true);
+    expect(wrapper.findComponent('[data-test="tls-verify-checkbox"]').exists()).toBe(true);
+  });
+
+  it("validates TLS domain is required when TLS is enabled", async () => {
+    const dialog = new DOMWrapper(document.body);
+
+    await wrapper.findComponent('[data-test="host-text"]').setValue("127.0.0.1");
+    await wrapper.findComponent('[data-test="port-text"]').setValue("8080");
+
+    const tlsCheckbox = wrapper.findComponent('[data-test="tls-enabled-checkbox"]');
+    await tlsCheckbox.setValue(true);
+    await flushPromises();
+
+    const createButton = dialog.find('[data-test="create-tunnel-btn"]');
+    expect(createButton.attributes("disabled")).toBeDefined();
+  });
+
+  it("accepts valid domain formats for TLS", async () => {
+    mockWebEndpointsApi.onPost("http://localhost:3000/api/web-endpoints").reply(200);
+
+    const storeSpy = vi.spyOn(webEndpointsStore, "createWebEndpoint");
+
+    await wrapper.findComponent('[data-test="host-text"]').setValue("127.0.0.1");
+    await wrapper.findComponent('[data-test="port-text"]').setValue("443");
+
+    const tlsCheckbox = wrapper.findComponent('[data-test="tls-enabled-checkbox"]');
+    await tlsCheckbox.setValue(true);
+    await flushPromises();
+
+    await wrapper.findComponent('[data-test="tls-domain-text"]').setValue("192.168.1.1");
+    await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
+    await flushPromises();
+
+    expect(storeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tls: expect.objectContaining({ domain: "192.168.1.1" }),
+      }),
+    );
   });
 
   it("shows alert on 403 error", async () => {
@@ -100,7 +207,7 @@ describe("WebEndpointCreate.vue", () => {
     await flushPromises();
 
     const dialog = new DOMWrapper(document.body);
-    const alert = dialog.find('[data-test="form-dialog-alert"]'); // <-- updated selector
+    const alert = dialog.find('[data-test="form-dialog-alert"]');
     expect(alert.exists()).toBe(true);
     expect(alert.text()).toContain("This device has reached the maximum allowed number of Web Endpoints");
   });
@@ -135,8 +242,8 @@ describe("WebEndpointCreate.vue", () => {
 
     await wrapper.findComponent('[data-test="host-text"]').setValue("127.0.0.1");
     await wrapper.findComponent('[data-test="port-text"]').setValue(8080);
-
     await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
+
     await flushPromises();
 
     expect(storeSpy).toHaveBeenCalledWith({
@@ -144,6 +251,59 @@ describe("WebEndpointCreate.vue", () => {
       host: "127.0.0.1",
       port: 8080,
       ttl: -1,
+    });
+  });
+
+  it("successfully creates a Web Endpoint using device selector with TLS", async () => {
+    mockWebEndpointsApi.onPost("http://localhost:3000/api/web-endpoints").reply(200);
+
+    const storeSpy = vi.spyOn(webEndpointsStore, "createWebEndpoint");
+
+    wrapper.unmount();
+    wrapper = mount(WebEndpointCreate, {
+      attachTo: document.body,
+      global: {
+        plugins: [vuetify, SnackbarPlugin],
+      },
+      props: {
+        useDevicesList: true,
+        modelValue: true,
+      },
+    });
+
+    await flushPromises();
+
+    await wrapper.findComponent('[data-test="web-endpoint-autocomplete"]').setValue({
+      uid: "device-xyz",
+      name: "device-xyz-name",
+      info: {
+        id: "ubuntu",
+        pretty_name: "Ubuntu",
+      },
+    });
+
+    await wrapper.findComponent('[data-test="host-text"]').setValue("10.10.10.10");
+    await wrapper.findComponent('[data-test="port-text"]').setValue(443);
+
+    const tlsCheckbox = wrapper.findComponent('[data-test="tls-enabled-checkbox"]');
+    await tlsCheckbox.setValue(true);
+    await flushPromises();
+
+    await wrapper.findComponent('[data-test="tls-domain-text"]').setValue("device.local");
+    await wrapper.findComponent('[data-test="create-tunnel-btn"]').trigger("click");
+
+    await flushPromises();
+
+    expect(storeSpy).toHaveBeenCalledWith({
+      uid: "device-xyz",
+      host: "10.10.10.10",
+      port: 443,
+      ttl: -1,
+      tls: {
+        enabled: true,
+        verify: false,
+        domain: "device.local",
+      },
     });
   });
 });

--- a/ui/tests/components/WebEndpoints/WebEndpointList.spec.ts
+++ b/ui/tests/components/WebEndpoints/WebEndpointList.spec.ts
@@ -63,13 +63,14 @@ describe("WebEndpointList.vue", () => {
 
   it("renders table headers correctly", () => {
     const headers = wrapper.findAll('[data-test="web-endpoints-table"] thead th');
-    expect(headers.length).toBe(6);
+    expect(headers.length).toBe(7);
     expect(headers[0].text()).toContain("Device");
     expect(headers[1].text()).toContain("Address");
     expect(headers[2].text()).toContain("Host");
     expect(headers[3].text()).toContain("Port");
-    expect(headers[4].text()).toContain("Expiration Date");
-    expect(headers[5].text()).toContain("Actions");
+    expect(headers[4].text()).toContain("Domain");
+    expect(headers[5].text()).toContain("Expiration Date");
+    expect(headers[6].text()).toContain("Actions");
   });
 
   it("renders table rows with web endpoints", () => {


### PR DESCRIPTION
# Description

This PR updates the generated Cloud/OpenAPI client to match the current backend responses, adds TLS support to Web Endpoints end-to-end (API types, store, UI, and tests).

## Changes

### OpenAPI Client Updates

- User details shape (`GetUser200Response`)
- Replace the old user?: `UserAdminResponse` wrapper with a flat user response:

#### Web Endpoint TLS types:

Add TLS configuration to Web Endpoint types:

- `CreateWebEndpointRequest` now includes optional:
- tls?: `WebendpointTLS`
- Webendpoint now includes optional:
- tls?: `WebendpointTLS`

#### New models:

WebendpointTLS with:

- enabled: boolean
- verify: boolean
- domain: string
- Add corresponding documentation pages:
- `WebendpointTLS.md`
- Update `CreateWebEndpointRequest.md` and `Webendpoint.md` to include tls.

MFA:
- MFA reset API parameter
- Make userId a required parameter on MFA reset endpoints in all generated clients:
- CloudApi.resetMFA
- MfaApi.resetMFA
- UsersApi.resetMFA
- Add assertParamExists for userId in the axios parameter creators.
- Update docs to remove “(optional)” from userId and reflect it as a required argument in examples and parameter tables.

#### Web Endpoint Creation (TLS support)

Component: `WebEndpointCreate.vue`

#### Add a TLS section to the dialog:

- Checkbox to enable TLS (tlsEnabled) and optional certificate verification (tlsVerify).
- TLS domain text field (tlsDomain) shown only when TLS is enabled.

#### Validation:

- Domain is required when TLS is enabled.
- Accepts hostnames, IPv4, IPv6, and localhost (with helpers using hostnameRegex, ipv4Regex, ipv6Regex).

#### Payload:

`addWebEndpoint` now builds a payload with optional tls:

```
{
  uid: string;
  host: string;
  port: number;
  ttl: number;
  tls?: {
    enabled: boolean;
    verify: boolean;
    domain: string;
  };
}
```