### PR TITLE
fix(ui): fix `AppLayout` use in auth-required views

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -19,6 +19,6 @@ const components = {
   LoginLayout,
 };
 const layoutStore = useLayoutStore();
-const layout = computed(() => components[layoutStore.layout as keyof typeof components] || AppLayout);
+const layout = computed(() => components[layoutStore.layout as keyof typeof components]);
 const theme = computed(() => layoutStore.theme);
 </script>

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -557,18 +557,13 @@ router.beforeEach(
     const { isLoggedIn } = useAuthStore();
     const requiresAuth = to.meta.requiresAuth ?? true;
 
+    if (!isLoggedIn && requiresAuth) return next({
+      name: "Login",
+      query: { redirect: to.fullPath },
+    });
+
     const layout = to.meta.layout || "AppLayout";
     useLayoutStore().layout = layout as Layout;
-
-    if (!isLoggedIn) {
-      if (requiresAuth) {
-        return next({
-          name: "Login",
-          query: { redirect: to.fullPath },
-        });
-      }
-    }
-
     return next();
   },
 );


### PR DESCRIPTION
This pull request makes minor fixes in the UI, addressing a bug where the `AppLayout` was quickly rendering and unmounting in views that use the `LoginLayout`, calling some API routes that need authentication, which failed with status 401 and showed up unrelated snackbar errors in the page.