### PR TITLE
fix(ui): change admin's stores IDs to prevent conflict with main UI's stores

### DIFF
--- a/ui/admin/src/store/modules/announcement.ts
+++ b/ui/admin/src/store/modules/announcement.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { IAdminAnnouncement, IAdminAnnouncementRequestBody, IAdminAnnouncementShort } from "@admin/interfaces/IAnnouncement";
 import * as announcementApi from "../api/announcement";
 
-const useAnnouncementStore = defineStore("announcement", () => {
+const useAnnouncementStore = defineStore("adminAnnouncement", () => {
   const announcements = ref<Array<IAdminAnnouncementShort>>([]);
   const announcement = ref<IAdminAnnouncement>({} as IAdminAnnouncement);
   const announcementCount = ref<number>(0);

--- a/ui/admin/src/store/modules/auth.ts
+++ b/ui/admin/src/store/modules/auth.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { ref, computed } from "vue";
 import * as authApi from "../api/auth";
 
-const useAuthStore = defineStore("auth", () => {
+const useAuthStore = defineStore("adminAuth", () => {
   const status = ref<string>("");
   const token = ref<string>(localStorage.getItem("token") || "");
   const currentUser = ref<string>(localStorage.getItem("user") || "");

--- a/ui/admin/src/store/modules/devices.ts
+++ b/ui/admin/src/store/modules/devices.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { IAdminDevice } from "@admin/interfaces/IDevice";
 import * as devicesApi from "../api/devices";
 
-const useDevicesStore = defineStore("devices", () => {
+const useDevicesStore = defineStore("adminDevices", () => {
   const devices = ref<IAdminDevice[]>([]);
   const deviceCount = ref(0);
 

--- a/ui/admin/src/store/modules/firewall_rules.ts
+++ b/ui/admin/src/store/modules/firewall_rules.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { IAdminFirewallRule } from "@admin/interfaces/IFirewallRule";
 import * as firewallRulesApi from "../api/firewall_rules";
 
-const useFirewallRulesStore = defineStore("firewallRules", () => {
+const useFirewallRulesStore = defineStore("adminFirewallRules", () => {
   const firewallRules = ref<Array<IAdminFirewallRule>>([]);
   const firewallRulesCount = ref(0);
 

--- a/ui/admin/src/store/modules/instance.ts
+++ b/ui/admin/src/store/modules/instance.ts
@@ -3,7 +3,7 @@ import { ref, computed } from "vue";
 import { IAdminAuth, IAdminUpdateSAML } from "@admin/interfaces/IInstance";
 import * as instanceApi from "../api/instance";
 
-const useInstanceStore = defineStore("instance", () => {
+const useInstanceStore = defineStore("adminInstance", () => {
   const authenticationSettings = ref<IAdminAuth>({
     local: {
       enabled: false,

--- a/ui/admin/src/store/modules/license.ts
+++ b/ui/admin/src/store/modules/license.ts
@@ -3,7 +3,7 @@ import { ref, computed } from "vue";
 import { IAdminLicense } from "@admin/interfaces/ILicense";
 import * as apiLicense from "../api/license";
 
-const useLicenseStore = defineStore("license", () => {
+const useLicenseStore = defineStore("adminLicense", () => {
   const license = ref({} as IAdminLicense);
   const isExpired = computed(() => (license.value && license.value.expired)
     || (license.value && license.value.expired === undefined));

--- a/ui/admin/src/store/modules/namespaces.ts
+++ b/ui/admin/src/store/modules/namespaces.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { IAdminNamespace } from "@admin/interfaces/INamespace";
 import * as namespacesApi from "../api/namespaces";
 
-const useNamespacesStore = defineStore("namespaces", () => {
+const useNamespacesStore = defineStore("adminNamespaces", () => {
   const namespaces = ref<IAdminNamespace[]>([]);
   const namespaceCount = ref(0);
 
@@ -17,7 +17,6 @@ const useNamespacesStore = defineStore("namespaces", () => {
     const page = data?.page || 1;
     const perPage = data?.perPage || 10;
     const filter = data?.filter ?? currentFilter.value ?? "";
-
     const res = await namespacesApi.fetchNamespaces(page, perPage, filter);
     namespaces.value = res.data as IAdminNamespace[];
     namespaceCount.value = parseInt(res.headers["x-total-count"] as string, 10);

--- a/ui/admin/src/store/modules/sessions.ts
+++ b/ui/admin/src/store/modules/sessions.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { IAdminSession } from "@admin/interfaces/ISession";
 import * as sessionsApi from "../api/sessions";
 
-const useSessionsStore = defineStore("sessions", () => {
+const useSessionsStore = defineStore("adminSessions", () => {
   const sessions = ref<Array<IAdminSession>>([]);
   const sessionCount = ref<number>(0);
 

--- a/ui/admin/src/store/modules/stats.ts
+++ b/ui/admin/src/store/modules/stats.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { IAdminStats } from "@admin/interfaces/IStats";
 import getAdminStats from "../api/stats";
 
-const useStatsStore = defineStore("stats", () => {
+const useStatsStore = defineStore("adminStats", () => {
   const getStats = async () => {
     const { data } = await getAdminStats();
     return data as IAdminStats;

--- a/ui/admin/src/store/modules/users.ts
+++ b/ui/admin/src/store/modules/users.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 import { IAdminUser, IAdminUserFormData } from "@admin/interfaces/IUser";
 import * as usersApi from "../api/users";
 
-const useUsersStore = defineStore("users", () => {
+const useUsersStore = defineStore("adminUsers", () => {
   const users = ref<IAdminUser[]>([]);
   const usersCount = ref<number>(0);
 


### PR DESCRIPTION
This pull request standardizes the naming convention for Pinia store modules in the admin UI by prefixing all store names with "admin". This change improves clarity and reduces the risk of naming collisions with non-admin stores.