### PR TITLE
fix(ui): rollback private keys layout and fix tag spacing

### DIFF
--- a/ui/src/components/PrivateKeys/PrivateKeyList.vue
+++ b/ui/src/components/PrivateKeys/PrivateKeyList.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-table class="bg-background border rounded">
+  <v-table class="bg-background border rounded mx-4">
     <thead
       class="bg-v-theme-background"
       data-test="privateKey-thead"

--- a/ui/src/components/Setting/SettingPrivateKeys.vue
+++ b/ui/src/components/Setting/SettingPrivateKeys.vue
@@ -1,43 +1,43 @@
 <template>
-  <PrivateKeyAdd
-    v-model="privateKeyAdd"
-    @update="getPrivateKeys"
-  />
   <v-container fluid>
+    <PrivateKeyAdd
+      v-model="privateKeyAdd"
+      @update="getPrivateKeys"
+    />
     <v-card
       variant="flat"
       class="bg-transparent"
       data-test="card"
     >
-      <v-row cols="12">
-        <v-col cols="6">
-          <v-card-item class="pa-0 ma-0 mb-2">
-            <v-list-item data-test="card-header">
-              <template #title>
-                <h1 data-test="card-title">Private Keys</h1>
-              </template>
-              <template #subtitle>
-                <span data-test="card-subtitle">
-                  Manage your private keys securely with ShellHub
-                </span>
-              </template>
-            </v-list-item>
-          </v-card-item>
-        </v-col>
-        <v-col
-          cols="6"
-          class="d-flex justify-end"
+      <v-card-item>
+        <v-list-item
+          class="pa-0 ma-0 mb-2"
+          data-test="card-header"
         >
-          <v-btn
-            color="primary"
-            variant="elevated"
-            data-test="card-button"
-            @click="privateKeyAdd = true"
-          >
-            Add Private Key
-          </v-btn>
-        </v-col>
-      </v-row>
+          <template #title>
+            <h1 data-test="card-title">
+              Private Keys
+            </h1>
+          </template>
+          <template #subtitle>
+            <span data-test="card-subtitle">
+              Manage your private keys securely with ShellHub
+            </span>
+          </template>
+          <template #append>
+            <v-btn
+              color="primary"
+              variant="text"
+              class="bg-secondary border"
+              data-test="card-button"
+              @click="privateKeyAdd = true"
+            >
+              Add Private Key
+            </v-btn>
+          </template>
+        </v-list-item>
+      </v-card-item>
+
       <PrivateKeyList data-test="private-key-list" />
     </v-card>
   </v-container>

--- a/ui/src/components/Setting/SettingTags.vue
+++ b/ui/src/components/Setting/SettingTags.vue
@@ -3,7 +3,11 @@
     v-model="createDialog"
     @update="refreshTagList()"
   />
-  <v-container fluid>
+  <v-container
+    fluid
+    class="mx-0 px-0"
+    max-width="60%"
+  >
     <v-card
       variant="flat"
       class="bg-transparent"
@@ -50,7 +54,10 @@
           </v-btn>
         </v-col>
       </v-row>
-      <TagList ref="tagListRef" />
+      <TagList
+        ref="tagListRef"
+        class="mx-4"
+      />
     </v-card>
   </v-container>
 </template>

--- a/ui/tests/components/PrivateKeys/__snapshots__/PrivateKeyList.spec.ts.snap
+++ b/ui/tests/components/PrivateKeys/__snapshots__/PrivateKeyList.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Private Key List > Renders the component 1`] = `
-"<div class="v-table v-theme--light v-table--density-default bg-background border rounded">
+"<div class="v-table v-theme--light v-table--density-default bg-background border rounded mx-4">
   <!---->
   <div class="v-table__wrapper">
     <table>

--- a/ui/tests/components/Setting/__snapshots__/SettingTags.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingTags.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Setting Tags > Renders the component 1`] = `
-"<div class="v-container v-container--fluid v-locale--is-ltr">
+"<div class="v-container v-container--fluid v-locale--is-ltr mx-0 px-0" style="max-width: 60%;">
   <div class="v-card v-theme--light v-card--density-default v-card--variant-flat bg-transparent" data-test="tags-settings-card">
     <!---->
     <div class="v-card__loader">
@@ -93,7 +93,7 @@ exports[`Setting Tags > Renders the component 1`] = `
           <!---->
         </button></div>
     </div>
-    <div data-test="tag-list">
+    <div data-test="tag-list" class="mx-4">
       <div class="v-table v-theme--light v-table--density-default bg-background border rounded text-center" data-test="datatable">
         <!---->
         <div class="v-table__wrapper">

--- a/ui/tests/components/Setting/__snapshots__/SettingsPrivateKeys.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingsPrivateKeys.spec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`Setting Private Keys > Renders the component 1`] = `
 "<div class="v-container v-container--fluid v-locale--is-ltr">
+  <!---->
+  <!---->
   <div class="v-card v-theme--light v-card--density-default v-card--variant-flat bg-transparent" data-test="card">
     <!---->
     <div class="v-card__loader">
@@ -20,36 +22,33 @@ exports[`Setting Private Keys > Renders the component 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="v-row" cols="12">
-      <div class="v-col v-col-6">
-        <div class="v-card-item pa-0 ma-0 mb-2">
+    <div class="v-card-item">
+      <!---->
+      <div class="v-card-item__content">
+        <!---->
+        <!---->
+        <div class="v-list-item v-theme--light v-list-item--density-default rounded-0 v-list-item--variant-text pa-0 ma-0 mb-2" data-test="card-header">
+          <!----><span class="v-list-item__underlay"></span>
           <!---->
-          <div class="v-card-item__content">
-            <!---->
-            <!---->
-            <div class="v-list-item v-theme--light v-list-item--density-default rounded-0 v-list-item--variant-text" data-test="card-header">
-              <!----><span class="v-list-item__underlay"></span>
-              <!---->
-              <div class="v-list-item__content" data-no-activator="">
-                <div class="v-list-item-title">
-                  <h1 data-test="card-title">Private Keys</h1>
-                </div>
-                <div class="v-list-item-subtitle"><span data-test="card-subtitle"> Manage your private keys securely with ShellHub </span></div>
-                <!---->
-              </div>
-              <!---->
+          <div class="v-list-item__content" data-no-activator="">
+            <div class="v-list-item-title">
+              <h1 data-test="card-title"> Private Keys </h1>
             </div>
+            <div class="v-list-item-subtitle"><span data-test="card-subtitle"> Manage your private keys securely with ShellHub </span></div>
+            <!---->
           </div>
-          <!---->
+          <div class="v-list-item__append"><button type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-text bg-secondary border" data-test="card-button"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""> Add Private Key </span>
+              <!---->
+              <!---->
+            </button>
+            <div class="v-list-item__spacer"></div>
+          </div>
         </div>
       </div>
-      <div class="v-col v-col-6 d-flex justify-end"><button type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated" data-test="card-button"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""> Add Private Key </span>
-          <!---->
-          <!---->
-        </button></div>
+      <!---->
     </div>
-    <div class="v-table v-theme--light v-table--density-default bg-background border rounded" data-test="private-key-list">
+    <div class="v-table v-theme--light v-table--density-default bg-background border rounded mx-4" data-test="private-key-list">
       <!---->
       <div class="v-table__wrapper">
         <table>


### PR DESCRIPTION
# Description:

This PR includes two related UI updates aimed at restoring proper layout and spacing across the Private Keys and Tags settings pages:

## Rollback: Private Keys Layout

- Restores the previous layout structure for `PrivateKeyList` and `SettingPrivateKeys`.
- Reverts recent changes to the `v-list-item` structure and table margins to match the prior, more stable design.

## Fix: Tags Layout Spacing

- Corrects spacing issues in the `SettingTags` component.
- Applies `mx-0 px-0` and sets a `max-width` on the container for improved alignment.
- Adds horizontal margin to the `TagList` for better visual consistency.
- These changes improve UI alignment, undo unwanted layout shifts, and ensure consistent padding/margin across views.

## Reasoning:

- The Private Keys layout changes introduced regressions in structure and spacing.
- Tags view required adjustments for consistent container width and visual clarity.

## Testing:

- [x] Verified layout renders as expected across breakpoints.
- [x] Confirmed visual alignment of components after changes.
- [x] No changes to business logic or functionality.