### PR TITLE
fix(ui): add nextTick to stabilize Vue DOM updates in MFA snapshot tests

### DIFF
--- a/ui/tests/components/AuthMFA/MfaDisable.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaDisable.spec.ts
@@ -39,12 +39,14 @@ describe("MfaDisable", () => {
 
   it("Renders the component (Recovery Code window)", async () => {
     wrapper.vm.el = 2;
+    await nextTick();
     await flushPromises();
     expect(dialog.html()).toMatchSnapshot();
   });
 
   it("Renders the component (Email Sent window)", async () => {
     wrapper.vm.el = 3;
+    await nextTick();
     await flushPromises();
     expect(dialog.html()).toMatchSnapshot();
   });
@@ -71,6 +73,7 @@ describe("MfaDisable", () => {
 
   it("Disables MFA Authentication using Recovery Code", async () => {
     wrapper.vm.el = 2;
+    await nextTick();
     await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "disableMfa");
     mockMfaApi.onPut("http://localhost:3000/api/user/mfa/disable").reply(200);
@@ -82,6 +85,7 @@ describe("MfaDisable", () => {
 
   it("Disables MFA Authentication using Recovery Code (Fail)", async () => {
     wrapper.vm.el = 2;
+    await nextTick();
     await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "disableMfa");
     mockMfaApi.onPut("http://localhost:3000/api/user/mfa/disable").reply(403);
@@ -95,6 +99,7 @@ describe("MfaDisable", () => {
   it("Sends the disable codes on the users mail", async () => {
     localStorage.setItem("email", "test@test.com");
     wrapper.vm.el = 2;
+    await nextTick();
     await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "requestMfaReset");
     mockMfaApi.onPost("http://localhost:3000/api/user/mfa/reset").reply(200);
@@ -106,6 +111,7 @@ describe("MfaDisable", () => {
   it("Handles error when sending recovery email fails", async () => {
     localStorage.setItem("email", "test@test.com");
     wrapper.vm.el = 2;
+    await nextTick();
     await flushPromises();
     const mfaSpy = vi.spyOn(authStore, "requestMfaReset");
     mockMfaApi.onPost("http://localhost:3000/api/user/mfa/reset").reply(403);


### PR DESCRIPTION
# Description

This PR improves the reliability of the snapshot tests for the `MfaDisable` component by adding a call to `nextTick()` after updating `wrapper.vm.el`. Previously, the tests were intermittently failing on CI due to` x-window-transition` classes appearing in the DOM during snapshot capture.

## Background

The MfaDisable component uses Vuetify’s `v-window` for rendering different views, which introduces transition classes such as x-window-transition. During asynchronous DOM updates, especially under slower CI environments, the test could capture the DOM while it's still in a transitional state — leading to inconsistent snapshots.

## Fix

This PR introduces `await nextTick()` calls immediately after setting `wrapper.vm.el`. This ensures Vue’s reactive DOM updates are completed prior to calling `flushPromises()`, achieving a stable render before taking the snapshot.

```diff
wrapper.vm.el = 2;
+ await nextTick();
await flushPromises();
expect(dialog.html()).toMatchSnapshot();
```

## Benefits

- Prevents intermittent snapshot failures caused by transition class artifacts.
- Ensures a more deterministic and stable test environment.
- Improves confidence in CI results without modifying component behavior.