### PR TITLE
fix(api): return correct `admin` value in user info GET request

### DIFF
--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -455,6 +455,7 @@ func (s *service) CreateUserToken(ctx context.Context, req *requests.CreateUserT
 		Role:          role,
 		Token:         token,
 		MaxNamespaces: user.MaxNamespaces,
+		Admin:         user.Admin,
 	}, nil
 }
 


### PR DESCRIPTION
This pull request adds the `admin` field to the get user info response, now returning the correct value instead of always returning false.