### PR TITLE
fix(ui): don't show `NamespaceInstructions` in Admin Console

### DIFF
--- a/ui/src/components/Namespace/Namespace.vue
+++ b/ui/src/components/Namespace/Namespace.vue
@@ -139,7 +139,7 @@ const {
 const { mdAndDown, thresholds } = useDisplay();
 
 const showAddDialog = ref(false);
-const showAddNamespaceInstructions = computed(() => namespacesLoaded.value && !hasNamespaces.value);
+const showAddNamespaceInstructions = computed(() => namespacesLoaded.value && !hasNamespaces.value && !props.isAdminContext);
 const userId = computed(() => authStore.id || localStorage.getItem("id") || "");
 
 const showAdminButton = computed(() => {


### PR DESCRIPTION
This pull request fixes a bug where the `NamespaceInstructions` component appeared for users without namespaces in the Admin Console, a behavior that's incorrect since an admin, even without namespaces, should be able to operate the Admin Console.