### PR TITLE
fix(api,gateway): allow admins to access resources without tenant scope

### DIFF
--- a/api/routes/middleware/authorize.go
+++ b/api/routes/middleware/authorize.go
@@ -15,7 +15,10 @@ func Authorize(next echo.HandlerFunc) echo.HandlerFunc {
 
 		id := gateway.IDFromContext(ctx)
 		tenant := gateway.TenantFromContext(ctx)
-		if id != nil && tenant == nil {
+		gCtx := c.(*gateway.Context)
+
+		// Allow admins to access resources without tenant scope (e.g., from /admin/api endpoints)
+		if id != nil && tenant == nil && !gCtx.IsAdmin() {
 			return c.NoContent(http.StatusForbidden)
 		}
 

--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -336,10 +336,8 @@ server {
         proxy_set_header X-Forwarded-Port $x_forwarded_port;
         proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
         proxy_set_header X-Api-Key $api_key;
-        proxy_set_header X-ID $id;
         proxy_set_header X-Request-ID $request_id;
         proxy_set_header X-Role $role;
-        proxy_set_header X-Tenant-ID $tenant_id;
         proxy_set_header X-Username $username;
         proxy_set_header X-Admin $admin;
 


### PR DESCRIPTION
Remove tenant and user ID headers from admin API requests to enable
admins to view and manage resources across all namespaces from the
admin dashboard. Update authorization middleware to permit admin
access without tenant context.
