### PR TITLE
fix(ui): properly update namespace selector list when namespace is edited

### DIFF
--- a/ui/admin/src/components/Namespace/NamespaceEdit.vue
+++ b/ui/admin/src/components/Namespace/NamespaceEdit.vue
@@ -45,7 +45,8 @@
 import { useField } from "vee-validate";
 import { computed, defineModel } from "vue";
 import * as yup from "yup";
-import useNamespacesStore from "@admin/store/modules/namespaces";
+import useAdminNamespacesStore from "@admin/store/modules/namespaces";
+import useNamespacesStore from "@/store/modules/namespaces";
 import useSnackbar from "@/helpers/snackbar";
 import { IAdminNamespace } from "@admin/interfaces/INamespace";
 import FormDialog from "@/components/Dialogs/FormDialog.vue";
@@ -55,6 +56,7 @@ const emit = defineEmits(["update"]);
 
 const snackbar = useSnackbar();
 const namespacesStore = useNamespacesStore();
+const adminNamespacesStore = useAdminNamespacesStore();
 const showDialog = defineModel<boolean>({ default: false });
 
 const {
@@ -104,7 +106,7 @@ const submitForm = async () => {
   if (hasErrors.value) return;
 
   try {
-    await namespacesStore.updateNamespace({
+    await adminNamespacesStore.updateNamespace({
       ...props.namespace,
       name: name.value,
       max_devices: Number(maxDevices.value),
@@ -113,6 +115,7 @@ const submitForm = async () => {
         session_record: sessionRecord.value,
       },
     });
+    await namespacesStore.fetchNamespaceList({ perPage: 30 });
     snackbar.showSuccess("Namespace updated successfully.");
     showDialog.value = false;
     emit("update");

--- a/ui/admin/tests/unit/components/Namespaces/NamespaceEdit/index.spec.ts
+++ b/ui/admin/tests/unit/components/Namespaces/NamespaceEdit/index.spec.ts
@@ -1,3 +1,4 @@
+import MockAdapter from "axios-mock-adapter";
 import { createVuetify } from "vuetify";
 import { DOMWrapper, flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -7,6 +8,7 @@ import useNamespacesStore from "@admin/store/modules/namespaces";
 import NamespaceEdit from "@admin/components/Namespace/NamespaceEdit.vue";
 import { IAdminNamespace } from "@admin/interfaces/INamespace";
 import { SnackbarInjectionKey } from "@/plugins/snackbar";
+import { namespacesApi } from "@/api/http";
 
 const namespace: IAdminNamespace = {
   billing: {
@@ -47,6 +49,7 @@ const mockSnackbar = {
 describe("Namespace Edit", () => {
   let wrapper: VueWrapper<InstanceType<typeof NamespaceEdit>>;
   let namespacesStore: ReturnType<typeof useNamespacesStore>;
+  const mockNamespacesApi = new MockAdapter(namespacesApi.getAxios());
 
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -92,6 +95,7 @@ describe("Namespace Edit", () => {
   });
 
   it("Calls namespace store and snackbar on form submission with updated values", async () => {
+    mockNamespacesApi.onGet("http://localhost:3000/api/namespaces?page=1&per_page=30").reply(200, []);
     wrapper.vm.name = "updated-namespace";
     wrapper.vm.maxDevices = 42;
     wrapper.vm.sessionRecord = false;

--- a/ui/src/components/Namespace/Namespace.vue
+++ b/ui/src/components/Namespace/Namespace.vue
@@ -147,9 +147,8 @@ const showAdminButton = computed(() => {
 });
 
 const availableNamespaces = computed(() => {
-  const namespaces = namespaceList.value.filter((ns) => ns.tenant_id !== currentNamespace.value.tenant_id);
-  if (props.isAdminContext && currentNamespace.value.tenant_id) namespaces.push(currentNamespace.value);
-  return namespaces;
+  if (props.isAdminContext) return namespaceList.value;
+  return namespaceList.value.filter((ns) => ns.tenant_id !== currentNamespace.value.tenant_id);
 });
 
 const navigateToAdminPanel = () => { window.location.href = "/admin"; };


### PR DESCRIPTION
This pull request fixes the admin's `NamespaceEdit.vue` and the `Namespace.vue` components to properly update the namespace list after a namespace is edited in the Admin Console.

Depends on #5550 