### PR TITLE
fix(ui): check `hasNamespaces` in `AppBar` instead of `DevicesDropdown`

### DIFF
--- a/ui/src/components/AppBar/AppBar.vue
+++ b/ui/src/components/AppBar/AppBar.vue
@@ -59,7 +59,7 @@
         <span>Need assistance? Click here for support.</span>
       </v-tooltip>
 
-      <DevicesDropdown />
+      <DevicesDropdown v-if="hasNamespaces" />
 
       <v-menu
         scrim
@@ -215,6 +215,7 @@ const userId = computed(() => authStore.id);
 const currentUser = computed(() => authStore.username);
 const isBillingActive = computed(() => billingStore.isActive);
 const theme = computed(() => layoutStore.theme);
+const hasNamespaces = computed(() => namespacesStore.namespaceList.length > 0);
 const isChatCreated = computed(() => supportStore.isChatCreated);
 const identifier = computed(() => supportStore.identifier);
 const isDarkMode = ref(theme.value === "dark");

--- a/ui/src/components/AppBar/DevicesDropdown.vue
+++ b/ui/src/components/AppBar/DevicesDropdown.vue
@@ -1,6 +1,5 @@
 <template>
   <v-badge
-    v-if="hasNamespaces"
     :model-value="pendingDevicesCount > 0"
     :content="pendingDevicesCount"
     offset-y="-5"
@@ -330,12 +329,10 @@ import useSnackbar from "@/helpers/snackbar";
 import moment from "moment";
 import { IDevice } from "@/interfaces/IDevice";
 import DeviceActionButton from "@/components/Devices/DeviceActionButton.vue";
-import useNamespacesStore from "@/store/modules/namespaces";
 
 const { smAndUp, thresholds } = useDisplay();
 const statsStore = useStatsStore();
 const devicesStore = useDevicesStore();
-const namespacesStore = useNamespacesStore();
 const snackbar = useSnackbar();
 
 const isDrawerOpen = ref(false);
@@ -347,7 +344,6 @@ const stats = computed(() => statsStore.stats);
 const offlineDevices = computed(
   () => stats.value.registered_devices - stats.value.online_devices,
 );
-const hasNamespaces = computed(() => namespacesStore.namespaceList.length > 0);
 const toggleDrawer = () => {
   isDrawerOpen.value = !isDrawerOpen.value;
 };
@@ -394,7 +390,6 @@ const fetchRecentDevices = async () => {
 };
 
 onBeforeMount(async () => {
-  if (!hasNamespaces.value) return;
   await fetchStats();
   await fetchPendingDevices();
   await fetchRecentDevices();

--- a/ui/tests/components/AppBar/__snapshots__/AppBar.spec.ts.snap
+++ b/ui/tests/components/AppBar/__snapshots__/AppBar.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`AppBar Component > Renders the component 1`] = `
 "<div class="v-layout">
   <!---->
   <!---->
-  <header class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar bg-v-theme-surface border-b-thin" style="top: 0px; z-index: 1006; transform: translateY(0px); position: fixed; transition: none; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
+  <header class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar bg-v-theme-surface border-b-thin" style="top: 0px; z-index: 1004; transform: translateY(0px); position: fixed; transition: none; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
     <!---->
     <div class="v-toolbar__content" style="height: 64px;">
       <!---->
@@ -43,9 +43,7 @@ exports[`AppBar Component > Renders the component 1`] = `
       </button>
       <!--teleport start-->
       <!--teleport end-->
-      <!--v-if-->
-      <!--teleport start-->
-      <!--teleport end--><button type="button" class="v-btn v-btn--icon v-theme--light text-primary v-btn--density-default v-btn--variant-text" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-14" aria-owns="v-menu-v-14" data-test="user-menu-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <!--v-if--><button type="button" class="v-btn v-btn--icon v-theme--light text-primary v-btn--density-default v-btn--variant-text" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-8" aria-owns="v-menu-v-8" data-test="user-menu-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
         <!----><span class="v-btn__content" data-no-activator=""><div data-v-09753bb1="" class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat border" style="width: 1.5rem; height: 1.5rem;" email="test@example.com" data-test="user-icon"><div data-v-09753bb1="" class="v-responsive v-img v-img--booting" data-test="gravatar-image"><div class="v-responsive__sizer"></div><!----><transition-stub name="fade-transition" appear="false" persisted="false" css="true"><!----></transition-stub><!----><!----><!----><!----></div><!----><span class="v-avatar__underlay"></span>
     </div></span>
     <!---->

--- a/ui/tests/layouts/__snapshots__/AppLayout.spec.ts.snap
+++ b/ui/tests/layouts/__snapshots__/AppLayout.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`App Layout Component > Renders the component 1`] = `
 "<div class="v-application v-theme--light v-layout v-layout--full-height v-locale--is-ltr">
   <div class="v-application__wrap">
-    <nav class="v-navigation-drawer v-navigation-drawer--left v-navigation-drawer--temporary v-theme--dark v-navigation-drawer--mobile bg-v-theme-surface" style="left: 0px; z-index: 1008; transform: translateX(-256px); position: absolute; height: calc(100% - 0px - 0px); top: 0px; bottom: 0px; width: 256px;" data-v-e7291ef4="" app="" data-test="navigation-drawer">
+    <nav class="v-navigation-drawer v-navigation-drawer--left v-navigation-drawer--temporary v-theme--dark v-navigation-drawer--mobile bg-v-theme-surface" style="left: 0px; z-index: 1006; transform: translateX(-256px); position: absolute; height: calc(100% - 0px - 0px); top: 0px; bottom: 0px; width: 256px;" data-v-e7291ef4="" app="" data-test="navigation-drawer">
       <!---->
       <!---->
       <div class="v-navigation-drawer__content">
@@ -258,7 +258,7 @@ exports[`App Layout Component > Renders the component 1`] = `
     <!---->
     <!---->
     <!---->
-    <header class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar bg-v-theme-surface border-b-thin" style="top: 0px; z-index: 1006; transform: translateY(0px); position: fixed; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
+    <header class="v-toolbar v-toolbar--flat v-toolbar--floating v-toolbar--density-default v-theme--light v-locale--is-ltr v-app-bar bg-v-theme-surface border-b-thin" style="top: 0px; z-index: 1004; transform: translateY(0px); position: fixed; left: 0px; width: calc(100% - 0px - 0px);" data-test="app-bar">
       <!---->
       <div class="v-toolbar__content" style="height: 64px;">
         <!---->
@@ -300,9 +300,7 @@ exports[`App Layout Component > Renders the component 1`] = `
         </button>
         <!--teleport start-->
         <!--teleport end-->
-        <!--v-if-->
-        <!--teleport start-->
-        <!--teleport end--><button type="button" class="v-btn v-btn--icon v-theme--light text-primary v-btn--density-default v-btn--variant-text" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-18" aria-owns="v-menu-v-18" data-test="user-menu-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+        <!--v-if--><button type="button" class="v-btn v-btn--icon v-theme--light text-primary v-btn--density-default v-btn--variant-text" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-12" aria-owns="v-menu-v-12" data-test="user-menu-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator=""><div data-v-09753bb1="" class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat border" style="width: 1.5rem; height: 1.5rem;" email="" data-test="user-icon"><i data-v-09753bb1="" class="mdi-account mdi v-icon notranslate v-theme--light v-icon--size-default text-surface" aria-hidden="true" data-test="gravatar-placeholder"></i><!----><span class="v-avatar__underlay"></span>
       </div></span>
       <!---->


### PR DESCRIPTION
This pull request updates the `AppBar.vue` component to conditionally render the `DevicesDropdown` only when there are available namespaces. This computed property was previously inside the dropdown component; however, its behavior conflicted with Vue's lifecycle, always returning false on the before mount hook and never loading the devices or stats.