### PR TITLE
refactor(ui): enhance items-per-page input handling in DataTable

### DIFF
--- a/ui/admin/tests/unit/components/Announcement/AnnouncementList/__snapshots__/AnnouncementList.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Announcement/AnnouncementList/__snapshots__/AnnouncementList.spec.ts.snap
@@ -67,12 +67,13 @@ exports[`Announcement List > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -96,7 +97,7 @@ exports[`Announcement List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -115,15 +116,17 @@ exports[`Announcement List > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/admin/tests/unit/components/Device/DeviceList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Device/DeviceList/__snapshots__/index.spec.ts.snap
@@ -84,12 +84,13 @@ exports[`Device List > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-18" aria-owns="menu-v-18">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-18" aria-owns="menu-v-18">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -113,7 +114,7 @@ exports[`Device List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-20" aria-expanded="false" aria-controls="menu-v-18" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-20" aria-expanded="false" aria-controls="menu-v-18" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -132,15 +133,17 @@ exports[`Device List > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
 </div>"

--- a/ui/admin/tests/unit/components/FirewallRules/FirewallRulesList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/FirewallRules/FirewallRulesList/__snapshots__/index.spec.ts.snap
@@ -46,12 +46,13 @@ exports[`Firewall Rules List > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -75,7 +76,7 @@ exports[`Firewall Rules List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -94,15 +95,17 @@ exports[`Firewall Rules List > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/admin/tests/unit/components/Namespaces/NamespaceList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Namespaces/NamespaceList/__snapshots__/index.spec.ts.snap
@@ -51,12 +51,13 @@ exports[`Namespace List > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -80,7 +81,7 @@ exports[`Namespace List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -99,15 +100,17 @@ exports[`Namespace List > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
   <!--v-if-->

--- a/ui/admin/tests/unit/components/Session/SessionList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Session/SessionList/__snapshots__/index.spec.ts.snap
@@ -99,12 +99,13 @@ exports[`Sessions List > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-16" aria-owns="menu-v-16">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-16" aria-owns="menu-v-16">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -128,7 +129,7 @@ exports[`Sessions List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-18" aria-expanded="false" aria-controls="menu-v-16" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-18" aria-expanded="false" aria-controls="menu-v-16" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -147,15 +148,17 @@ exports[`Sessions List > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
 </div>"

--- a/ui/admin/tests/unit/components/User/UserList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/User/UserList/__snapshots__/index.spec.ts.snap
@@ -54,12 +54,13 @@ exports[`UserList > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-7" aria-owns="menu-v-7">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-7" aria-owns="menu-v-7">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -83,7 +84,7 @@ exports[`UserList > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-9" aria-expanded="false" aria-controls="menu-v-7" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-9" aria-expanded="false" aria-controls="menu-v-7" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -102,15 +103,17 @@ exports[`UserList > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/admin/tests/unit/views/Announcements/__snapshots__/Announcements.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Announcements/__snapshots__/Announcements.spec.ts.snap
@@ -51,12 +51,13 @@ exports[`Announcement Details > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -80,7 +81,7 @@ exports[`Announcement Details > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -99,15 +100,17 @@ exports[`Announcement Details > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
@@ -129,12 +129,13 @@ exports[`Device > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -158,7 +159,7 @@ exports[`Device > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -177,15 +178,17 @@ exports[`Device > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
 </div>"

--- a/ui/admin/tests/unit/views/FirewallRules/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/FirewallRules/__snapshots__/index.spec.ts.snap
@@ -47,12 +47,13 @@ exports[`Firewall Rules > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -76,7 +77,7 @@ exports[`Firewall Rules > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -95,15 +96,17 @@ exports[`Firewall Rules > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/admin/tests/unit/views/Namespaces/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Namespaces/__snapshots__/index.spec.ts.snap
@@ -77,12 +77,13 @@ exports[`Namespaces > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -106,7 +107,7 @@ exports[`Namespaces > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -125,15 +126,17 @@ exports[`Namespaces > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
   <!--v-if-->

--- a/ui/admin/tests/unit/views/Sessions/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Sessions/__snapshots__/index.spec.ts.snap
@@ -31,12 +31,13 @@ exports[`Sessions > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -60,7 +61,7 @@ exports[`Sessions > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -79,15 +80,17 @@ exports[`Sessions > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
 </div>"

--- a/ui/admin/tests/unit/views/Users/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Users/__snapshots__/index.spec.ts.snap
@@ -84,12 +84,13 @@ exports[`Users > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-5" aria-owns="menu-v-5">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-5" aria-owns="menu-v-5">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -113,7 +114,7 @@ exports[`Users > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-7" aria-expanded="false" aria-controls="menu-v-5" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-7" aria-expanded="false" aria-controls="menu-v-5" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -132,15 +133,17 @@ exports[`Users > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/tests/components/Connectors/__snapshots__/ConnectorList.spec.ts.snap
+++ b/ui/tests/components/Connectors/__snapshots__/ConnectorList.spec.ts.snap
@@ -88,12 +88,13 @@ exports[`Connector List > Renders the component 1`] = `
     </transition-stub>
     <!---->
   </div>
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -117,7 +118,7 @@ exports[`Connector List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -136,15 +137,17 @@ exports[`Connector List > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/tests/components/Containers/__snapshots__/ContainerList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerList.spec.ts.snap
@@ -148,12 +148,13 @@ exports[`Container List > Renders the component 1`] = `
         </transition-stub>
         <!---->
       </div>
-      <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-        <div>
-          <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+      <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+        <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-28" aria-owns="menu-v-28">
+              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-28" aria-owns="menu-v-28">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -177,7 +178,7 @@ exports[`Container List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-30" aria-expanded="false" aria-controls="menu-v-28" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-30" aria-expanded="false" aria-controls="menu-v-28" outlined="" value="10">
                   </div>
                   <!---->
                 </div>
@@ -196,15 +197,17 @@ exports[`Container List > Renders the component 1`] = `
             <!---->
           </div>
         </div>
-        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button></div>
+        </div>
       </div>
     </div>
     <!--v-if-->

--- a/ui/tests/components/Containers/__snapshots__/ContainerPendingList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerPendingList.spec.ts.snap
@@ -60,12 +60,13 @@ exports[`Container Pending List > Renders the component 1`] = `
         </transition-stub>
         <!---->
       </div>
-      <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-        <div>
-          <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+      <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+        <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -89,7 +90,7 @@ exports[`Container Pending List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
                   </div>
                   <!---->
                 </div>
@@ -108,15 +109,17 @@ exports[`Container Pending List > Renders the component 1`] = `
             <!---->
           </div>
         </div>
-        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button></div>
+        </div>
       </div>
     </div>
     <!--v-if-->

--- a/ui/tests/components/Containers/__snapshots__/ContainerRejectList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerRejectList.spec.ts.snap
@@ -60,12 +60,13 @@ exports[`Container Rejected List > Renders the component 1`] = `
         </transition-stub>
         <!---->
       </div>
-      <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-        <div>
-          <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+      <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+        <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -89,7 +90,7 @@ exports[`Container Rejected List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
                   </div>
                   <!---->
                 </div>
@@ -108,15 +109,17 @@ exports[`Container Rejected List > Renders the component 1`] = `
             <!---->
           </div>
         </div>
-        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button></div>
+        </div>
       </div>
     </div>
     <!--v-if-->

--- a/ui/tests/components/Devices/__snapshots__/DeviceList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DeviceList.spec.ts.snap
@@ -148,12 +148,13 @@ exports[`Device List > Renders the component 1`] = `
         </transition-stub>
         <!---->
       </div>
-      <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-        <div>
-          <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+      <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+        <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-28" aria-owns="menu-v-28">
+              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-28" aria-owns="menu-v-28">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -177,7 +178,7 @@ exports[`Device List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-30" aria-expanded="false" aria-controls="menu-v-28" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-30" aria-expanded="false" aria-controls="menu-v-28" outlined="" value="10">
                   </div>
                   <!---->
                 </div>
@@ -196,15 +197,17 @@ exports[`Device List > Renders the component 1`] = `
             <!---->
           </div>
         </div>
-        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button></div>
+        </div>
       </div>
     </div>
     <!--v-if-->

--- a/ui/tests/components/Devices/__snapshots__/DevicePendingList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DevicePendingList.spec.ts.snap
@@ -60,12 +60,13 @@ exports[`Device Pending List > Renders the component 1`] = `
         </transition-stub>
         <!---->
       </div>
-      <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-        <div>
-          <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+      <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+        <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -89,7 +90,7 @@ exports[`Device Pending List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
                   </div>
                   <!---->
                 </div>
@@ -108,15 +109,17 @@ exports[`Device Pending List > Renders the component 1`] = `
             <!---->
           </div>
         </div>
-        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button></div>
+        </div>
       </div>
     </div>
     <!--v-if-->

--- a/ui/tests/components/Devices/__snapshots__/DeviceRejectedList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DeviceRejectedList.spec.ts.snap
@@ -60,12 +60,13 @@ exports[`Device Rejected List > Renders the component 1`] = `
         </transition-stub>
         <!---->
       </div>
-      <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-        <div>
-          <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+      <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+        <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -89,7 +90,7 @@ exports[`Device Rejected List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
                   </div>
                   <!---->
                 </div>
@@ -108,15 +109,17 @@ exports[`Device Rejected List > Renders the component 1`] = `
             <!---->
           </div>
         </div>
-        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button></div>
+        </div>
       </div>
     </div>
     <!--v-if-->

--- a/ui/tests/components/PublicKeys/__snapshots__/PublicKeyList.spec.ts.snap
+++ b/ui/tests/components/PublicKeys/__snapshots__/PublicKeyList.spec.ts.snap
@@ -41,12 +41,13 @@ exports[`Public Key List > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -70,7 +71,7 @@ exports[`Public Key List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -89,15 +90,17 @@ exports[`Public Key List > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
 </div>"

--- a/ui/tests/components/Tables/DataTable.spec.ts
+++ b/ui/tests/components/Tables/DataTable.spec.ts
@@ -137,13 +137,16 @@ describe("DataTable", () => {
       combo.vm.$emit("update:modelValue", 25);
       await uiTick();
 
+      await combo.trigger("blur");
+      await uiTick();
+
       const pageEvents = wrapper.emitted("update:page");
       expect(pageEvents).toBeTruthy();
-      expect(pageEvents && pageEvents.some((e) => e[0] === 1)).toBe(true);
+      expect(pageEvents?.some((e) => e[0] === 1)).toBe(true);
 
       const ippEvents = wrapper.emitted("update:itemsPerPage");
       expect(ippEvents).toBeTruthy();
-      expect(ippEvents && ippEvents.at(-1)).toEqual([25]);
+      expect(ippEvents?.at(-1)).toEqual([25]);
     });
 
     it("increments/decrements page via chevrons and respects disabled states", async () => {

--- a/ui/tests/components/Tags/__snapshots__/TagList.spec.ts.snap
+++ b/ui/tests/components/Tags/__snapshots__/TagList.spec.ts.snap
@@ -41,12 +41,13 @@ exports[`Tag List > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -70,7 +71,7 @@ exports[`Tag List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -89,15 +90,17 @@ exports[`Tag List > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/tests/components/Team/ApiKeys/__snapshots__/ApiKeyList.spec.ts.snap
+++ b/ui/tests/components/Team/ApiKeys/__snapshots__/ApiKeyList.spec.ts.snap
@@ -48,12 +48,13 @@ exports[`Api Key List > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -77,7 +78,7 @@ exports[`Api Key List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -96,15 +97,17 @@ exports[`Api Key List > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
 </div>"

--- a/ui/tests/components/firewall/__snapshots__/FirewallRuleList.spec.ts.snap
+++ b/ui/tests/components/firewall/__snapshots__/FirewallRuleList.spec.ts.snap
@@ -60,12 +60,13 @@ exports[`Firewall Rule List > Renders the component 1`] = `
     <!---->
   </div>
   <!--v-if-->
-  <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-    <div>
-      <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+  <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+    <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-8" aria-owns="menu-v-8">
+          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-8" aria-owns="menu-v-8">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -89,7 +90,7 @@ exports[`Firewall Rule List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-10" aria-expanded="false" aria-controls="menu-v-8" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-10" aria-expanded="false" aria-controls="menu-v-8" outlined="" value="10">
               </div>
               <!---->
             </div>
@@ -108,15 +109,17 @@ exports[`Firewall Rule List > Renders the component 1`] = `
         <!---->
       </div>
     </div>
-    <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-        <!---->
-        <!---->
-      </button></div>
+    <div class="v-col v-col-auto pa-0">
+      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <!---->
+          <!---->
+        </button></div>
+    </div>
   </div>
 </div>"
 `;

--- a/ui/tests/views/__snapshots__/FirewallRules.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/FirewallRules.spec.ts.snap
@@ -62,12 +62,13 @@ exports[`Firewall Rules > Renders the component 1`] = `
       <!---->
     </div>
     <!--v-if-->
-    <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-      <div>
-        <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+    <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+      <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
+            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -91,7 +92,7 @@ exports[`Firewall Rules > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
                 </div>
                 <!---->
               </div>
@@ -110,15 +111,17 @@ exports[`Firewall Rules > Renders the component 1`] = `
           <!---->
         </div>
       </div>
-      <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-          <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-          <!---->
-          <!---->
-        </button></div>
+      <div class="v-col v-col-auto pa-0">
+        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+            <!---->
+            <!---->
+          </button></div>
+      </div>
     </div>
   </div>
 </div>"

--- a/ui/tests/views/__snapshots__/PublicKeys.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/PublicKeys.spec.ts.snap
@@ -58,12 +58,13 @@ exports[`Public Keys > Renders the component 1`] = `
         <!---->
       </div>
       <!--v-if-->
-      <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-        <div>
-          <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+      <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+        <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
+              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -87,7 +88,7 @@ exports[`Public Keys > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
                   </div>
                   <!---->
                 </div>
@@ -106,15 +107,17 @@ exports[`Public Keys > Renders the component 1`] = `
             <!---->
           </div>
         </div>
-        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button></div>
+        </div>
       </div>
     </div>
   </div>

--- a/ui/tests/views/__snapshots__/Sessions.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/Sessions.spec.ts.snap
@@ -75,12 +75,13 @@ exports[`Sessions View > Renders the component 1`] = `
         </transition-stub>
         <!---->
       </div>
-      <div class="d-flex w-100 justify-end align-center" data-test="pager"><span class="text-subtitle-2 mr-4" data-test="ipp-label">Items per page:</span>
-        <div>
-          <div class="v-input v-input--horizontal v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4" data-test="ipp-combo">
+      <div class="v-row align-center justify-end w-100 pt-3" data-test="pager">
+        <div class="v-col v-col-auto pa-0"><span class="text-subtitle-2 mr-4" data-test="ipp-label"> Items per page: </span></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-7" aria-owns="menu-v-7">
+              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-7" aria-owns="menu-v-7">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -104,7 +105,7 @@ exports[`Sessions View > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="text" id="input-v-9" aria-expanded="false" aria-controls="menu-v-7" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-9" aria-expanded="false" aria-controls="menu-v-7" outlined="" value="10">
                   </div>
                   <!---->
                 </div>
@@ -123,15 +124,17 @@ exports[`Sessions View > Renders the component 1`] = `
             <!---->
           </div>
         </div>
-        <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-            <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-            <!---->
-            <!---->
-          </button></div>
+        <div class="v-col v-col-auto pa-0">
+          <div class="d-flex align-center" data-test="pager-controls"><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-prev"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-left mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button><span class="text-subtitle-2" data-test="pager-text">1 of 1</span><button type="button" class="v-btn v-btn--disabled v-btn--icon v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-plain" disabled="" data-test="pager-next"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+              <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-chevron-right mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+              <!---->
+              <!---->
+            </button></div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Summary

This PR refactors the pagination controls in the `DataTable` component to improve both layout and input handling for the "Items per page" control.

## What’s Changed

- Replaced div-based layout with Vuetify's `v-row` and `v-col` for improved responsiveness and alignment.
- Introduced `internalItemsPerPage` as a controlled ref to decouple UI input from the external model.
- Added input sanitization logic to enforce values between 1 and 100.
- Implemented numeric-only input restrictions via keydown and paste events.
- Added validation rules with error messages for invalid inputs.
- Ensured model updates trigger pagination reset to page 1.

## Motivation

Previously, the input allowed arbitrary values and immediate binding, which could cause invalid or disruptive pagination behavior. This update adds guardrails, improving UX and data integrity.

How to Test

1. Use the "Items per page" combobox in the DataTable
- Try entering:
- Valid numbers (e.g., 10, 25, 50)
- Invalid numbers (e.g., 0, 200)
- Non-numeric input (e.g., letters, symbols)
2. Observe:
- Validation messages
- Auto-correction on blur or enter
- Pagination resets to page 1 after change

Notes

- This does not introduce new features but hardens the component.
- Should be safe to merge as-is, but QA feedback on edge cases is welcome.