### PR TITLE
refactor(ui): move details pages `item-title` class to `global.css`

### DIFF
--- a/ui/admin/src/views/AnnouncementDetails.vue
+++ b/ui/admin/src/views/AnnouncementDetails.vue
@@ -155,16 +155,6 @@ defineExpose({ announcement, contentToHtml });
 </script>
 
 <style lang="scss" scoped>
-.item-title {
-  margin-top: 0.75rem;
-  // Vuetify's text-overline styles
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-
 :deep(.content-announcement) {
   p, span, div, h1, h2, h3, h4, h5, h6 {
     margin: .5rem;

--- a/ui/admin/src/views/DeviceDetails.vue
+++ b/ui/admin/src/views/DeviceDetails.vue
@@ -208,15 +208,3 @@ onMounted(async () => {
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.item-title {
-  margin-top: 0.75rem;
-  // Vuetify's text-overline styles
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-</style>

--- a/ui/admin/src/views/FirewallRulesDetails.vue
+++ b/ui/admin/src/views/FirewallRulesDetails.vue
@@ -138,15 +138,3 @@ onMounted(async () => {
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.item-title {
-  margin-top: 0.75rem;
-  // Vuetify's text-overline styles
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-</style>

--- a/ui/admin/src/views/NamespaceDetails.vue
+++ b/ui/admin/src/views/NamespaceDetails.vue
@@ -346,15 +346,6 @@ defineExpose({ namespace });
 </script>
 
 <style scoped>
-.item-title {
-  margin-top: 0.75rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-
 .unstyled-link {
   all: unset;
 }

--- a/ui/admin/src/views/SessionDetails.vue
+++ b/ui/admin/src/views/SessionDetails.vue
@@ -139,15 +139,3 @@ onMounted(async () => {
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.item-title {
-  margin-top: 0.75rem;
-  // Vuetify's text-overline styles
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-</style>

--- a/ui/admin/src/views/UserDetails.vue
+++ b/ui/admin/src/views/UserDetails.vue
@@ -291,14 +291,3 @@ onBeforeMount(async () => {
 
 defineExpose({ user });
 </script>
-
-<style lang="scss" scoped>
-.item-title {
-  margin-top: 0.75rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-</style>

--- a/ui/src/assets/global.css
+++ b/ui/src/assets/global.css
@@ -1,3 +1,13 @@
 .full-height {
     height: 100vh;
 }
+
+.item-title {
+    margin-top: 0.75rem;
+    /* Vuetify's text-overline styles */
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.1666666667em;
+    line-height: 2.667;
+}

--- a/ui/src/components/Welcome/WelcomeThirdScreen.vue
+++ b/ui/src/components/Welcome/WelcomeThirdScreen.vue
@@ -150,15 +150,3 @@ onBeforeMount(async () => {
   }
 });
 </script>
-
-<style lang="scss" scoped>
-.item-title {
-  margin-top: 0.75rem;
-  // Vuetify's text-overline styles
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-</style>

--- a/ui/src/views/DetailsDevice.vue
+++ b/ui/src/views/DetailsDevice.vue
@@ -255,17 +255,4 @@ const refreshDevices = async () => {
     handleError(error);
   }
 };
-
 </script>
-
-<style lang="scss" scoped>
-.item-title {
-  margin-top: 0.75rem;
-  // Vuetify's text-overline styles
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-</style>

--- a/ui/src/views/DetailsSessions.vue
+++ b/ui/src/views/DetailsSessions.vue
@@ -237,15 +237,3 @@ onMounted(async () => {
   await getSession();
 });
 </script>
-
-<style lang="scss" scoped>
-.item-title {
-  margin-top: 0.75rem;
-  // Vuetify's text-overline styles
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1666666667em;
-  line-height: 2.667;
-}
-</style>

--- a/ui/tests/components/Welcome/__snapshots__/WelcomeThirdScreen.spec.ts.snap
+++ b/ui/tests/components/Welcome/__snapshots__/WelcomeThirdScreen.spec.ts.snap
@@ -1,37 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Welcome Third Screen > Renders the component 1`] = `
-"<div data-v-9fa0b2b1="" class="pa-6">
-  <div data-v-9fa0b2b1="" class="text-center mb-6">
-    <div data-v-9fa0b2b1="" class="v-avatar v-theme--light bg-success v-avatar--density-default v-avatar--variant-flat mb-4" style="width: 64px; height: 64px;"><i data-v-9fa0b2b1="" class="mdi-check-circle mdi v-icon notranslate v-theme--light text-white" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+"<div class="pa-6">
+  <div class="text-center mb-6">
+    <div class="v-avatar v-theme--light bg-success v-avatar--density-default v-avatar--variant-flat mb-4" style="width: 64px; height: 64px;"><i class="mdi-check-circle mdi v-icon notranslate v-theme--light text-white" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
       <!----><span class="v-avatar__underlay"></span>
     </div>
-    <h2 data-v-9fa0b2b1="" class="text-h4 mb-2"> Device Detected! </h2>
-    <p data-v-9fa0b2b1="" class="text-subtitle-1 text-medium-emphasis"> Confirm this device to add it to your account </p>
+    <h2 class="text-h4 mb-2"> Device Detected! </h2>
+    <p class="text-subtitle-1 text-medium-emphasis"> Confirm this device to add it to your account </p>
   </div>
-  <div data-v-9fa0b2b1="" class="v-alert v-theme--light text-success v-alert--density-default v-alert--variant-tonal mb-4" role="alert" data-test="welcome-third-screen-name">
+  <div class="v-alert v-theme--light text-success v-alert--density-default v-alert--variant-tonal mb-4" role="alert" data-test="welcome-third-screen-name">
     <!----><span class="v-alert__underlay"></span>
     <!---->
     <div class="v-alert__prepend"><i class="mdi-lan-connect mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"></i></div>
     <div class="v-alert__content">
       <div class="v-alert-title">Connection Successful</div>
       <!---->
-      <p data-v-9fa0b2b1="" class="mb-0" data-test="welcome-third-screen-text"> A device has been detected and is ready for enrollment. Please verify the device information below and confirm it belongs to you. </p>
+      <p class="mb-0" data-test="welcome-third-screen-text"> A device has been detected and is ready for enrollment. Please verify the device information below and confirm it belongs to you. </p>
     </div>
     <!---->
     <!---->
   </div>
-  <div data-v-9fa0b2b1="" class="v-expansion-panels v-theme--light v-expansion-panels--variant-default">
-    <div data-v-9fa0b2b1="" class="v-expansion-panel border bg-background rounded">
+  <div class="v-expansion-panels v-theme--light v-expansion-panels--variant-default">
+    <div class="v-expansion-panel border bg-background rounded">
       <div class="v-expansion-panel__shadow"></div>
       <!---->
-      <!----><button data-v-9fa0b2b1="" class="v-expansion-panel-title text-white bg-v-theme-surface border-b d-flex align-center" type="button" aria-expanded="false"><span class="v-expansion-panel-title__overlay"></span><i data-v-9fa0b2b1="" data-test="device-icon" class="fl-linuxmint mr-1 mr-3" style="font-size: 20px;" size="32"></i>
-        <div data-v-9fa0b2b1="">
-          <div data-v-9fa0b2b1="" class="text-h6" data-test="device-field">39-5e-2a</div>
-          <div data-v-9fa0b2b1="" class="text-body-2 text-white" data-test="device-pretty-name-field">Linux Mint 19.3</div>
+      <!----><button class="v-expansion-panel-title text-white bg-v-theme-surface border-b d-flex align-center" type="button" aria-expanded="false"><span class="v-expansion-panel-title__overlay"></span><i data-test="device-icon" class="fl-linuxmint mr-1 mr-3" style="font-size: 20px;" size="32"></i>
+        <div>
+          <div class="text-h6" data-test="device-field">39-5e-2a</div>
+          <div class="text-body-2 text-white" data-test="device-pretty-name-field">Linux Mint 19.3</div>
         </div><span class="v-expansion-panel-title__icon"><i class="mdi-chevron-down mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       </button>
-      <transition-stub data-v-9fa0b2b1="" name="expand-transition" appear="false" persisted="false" css="true">
+      <transition-stub name="expand-transition" appear="false" persisted="false" css="true">
         <div class="v-expansion-panel-text pt-2" style="display: none;">
           <!---->
         </div>

--- a/ui/tests/views/__snapshots__/DetailsDevice.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/DetailsDevice.spec.ts.snap
@@ -1,10 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Details Device > Renders the component 1`] = `
-"<div data-v-46133275="" class="d-flex pa-0 align-center">
-  <h1 data-v-46133275="">Device Details</h1>
+"<div class="d-flex pa-0 align-center">
+  <h1>Device Details</h1>
 </div>
-<div data-v-46133275="" class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
+<div class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
   <!---->
   <div class="v-card__loader">
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -22,8 +22,8 @@ exports[`Details Device > Renders the component 1`] = `
   </div>
   <!---->
   <!---->
-  <div data-v-46133275="" class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
-    <div data-v-46133275="" class="d-flex align-center ml-2">
+  <div class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
+    <div class="d-flex align-center ml-2">
       <div data-v-35d3a308="" class="v-row d-flex align-center flex-column">
         <div data-v-35d3a308="" class="v-btn-group v-btn-group--horizontal v-btn-group--divided v-theme--light v-btn-group--density-compact"><button data-v-35d3a308="" type="button" class="v-btn v-btn--disabled v-btn--flat v-theme--light text-normal v-btn--density-compact v-btn--size-default v-btn--variant-outlined" style="height: auto;" disabled="" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
             <!----><span class="v-btn__content" data-no-activator="">Offline</span>
@@ -40,8 +40,8 @@ exports[`Details Device > Renders the component 1`] = `
       <!---->
       <!---->
       <!---->
-      <!----><span data-v-46133275="" class="ml-6">39-5e-2a</span>
-    </div><button data-v-46133275="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <!----><span class="ml-6">39-5e-2a</span>
+    </div><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
       <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       <!---->
       <!---->
@@ -49,30 +49,30 @@ exports[`Details Device > Renders the component 1`] = `
     <!--teleport start-->
     <!--teleport end-->
   </div>
-  <hr data-v-46133275="" class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
-  <div data-v-46133275="" class="v-card-text pa-4 pt-0">
-    <div data-v-46133275="" class="v-row py-3">
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-uid-field">
-          <div data-v-46133275="" class="item-title"> UID: </div>
-          <p data-v-46133275="" class="text-truncate">a582b47a42d</p>
+  <hr class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
+  <div class="v-card-text pa-4 pt-0">
+    <div class="v-row py-3">
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-uid-field">
+          <div class="item-title"> UID: </div>
+          <p class="text-truncate">a582b47a42d</p>
         </div>
-        <div data-v-46133275="" data-test="device-mac-field">
-          <div data-v-46133275="" class="item-title"> MAC: </div><code data-v-46133275="">00:00:00:00:00:00</code>
+        <div data-test="device-mac-field">
+          <div class="item-title"> MAC: </div><code>00:00:00:00:00:00</code>
         </div>
-        <div data-v-46133275="" data-test="device-pretty-name-field">
-          <div data-v-46133275="" class="item-title"> Operating System: </div>
-          <div data-v-46133275=""><i data-v-46133275="" data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span data-v-46133275="">Linux Mint 19.3</span></div>
+        <div data-test="device-pretty-name-field">
+          <div class="item-title"> Operating System: </div>
+          <div><i data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span>Linux Mint 19.3</span></div>
         </div>
       </div>
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-version-field">
-          <div data-v-46133275="" class="item-title"> Agent Version: </div>
-          <p data-v-46133275=""></p>
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-version-field">
+          <div class="item-title"> Agent Version: </div>
+          <p></p>
         </div>
-        <div data-v-46133275="" data-test="device-tags-field">
-          <div data-v-46133275="" class="item-title"> Tags: </div>
-          <div data-v-46133275=""><span data-v-46133275="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal mr-2" draggable="false" aria-describedby="v-tooltip-v-5"><!----><span class="v-chip__underlay"></span>
+        <div data-test="device-tags-field">
+          <div class="item-title"> Tags: </div>
+          <div><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal mr-2" draggable="false" aria-describedby="v-tooltip-v-5"><!----><span class="v-chip__underlay"></span>
             <!---->
             <!---->
             <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -82,9 +82,9 @@ exports[`Details Device > Renders the component 1`] = `
             <!--teleport end-->
           </div>
         </div>
-        <div data-v-46133275="" data-test="device-last-seen-field">
-          <div data-v-46133275="" class="item-title"> Last Seen: </div>
-          <p data-v-46133275="">Wednesday, May 20th 2020, 6:58:53 pm</p>
+        <div data-test="device-last-seen-field">
+          <div class="item-title"> Last Seen: </div>
+          <p>Wednesday, May 20th 2020, 6:58:53 pm</p>
         </div>
       </div>
     </div>
@@ -95,10 +95,10 @@ exports[`Details Device > Renders the component 1`] = `
 `;
 
 exports[`Details Device > Renders the component when device has no last seen date 1`] = `
-"<div data-v-46133275="" class="d-flex pa-0 align-center">
-  <h1 data-v-46133275="">Device Details</h1>
+"<div class="d-flex pa-0 align-center">
+  <h1>Device Details</h1>
 </div>
-<div data-v-46133275="" class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
+<div class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
   <!---->
   <div class="v-card__loader">
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -116,8 +116,8 @@ exports[`Details Device > Renders the component when device has no last seen dat
   </div>
   <!---->
   <!---->
-  <div data-v-46133275="" class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
-    <div data-v-46133275="" class="d-flex align-center ml-2">
+  <div class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
+    <div class="d-flex align-center ml-2">
       <div data-v-35d3a308="" class="v-row d-flex align-center flex-column">
         <div data-v-35d3a308="" class="v-btn-group v-btn-group--horizontal v-btn-group--divided v-theme--light v-btn-group--density-compact"><button data-v-35d3a308="" type="button" class="v-btn v-btn--disabled v-btn--flat v-theme--light text-normal v-btn--density-compact v-btn--size-default v-btn--variant-outlined" style="height: auto;" disabled="" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
             <!----><span class="v-btn__content" data-no-activator="">Offline</span>
@@ -134,8 +134,8 @@ exports[`Details Device > Renders the component when device has no last seen dat
       <!---->
       <!---->
       <!---->
-      <!----><span data-v-46133275="" class="ml-6">39-5e-2a</span>
-    </div><button data-v-46133275="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <!----><span class="ml-6">39-5e-2a</span>
+    </div><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
       <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       <!---->
       <!---->
@@ -143,30 +143,30 @@ exports[`Details Device > Renders the component when device has no last seen dat
     <!--teleport start-->
     <!--teleport end-->
   </div>
-  <hr data-v-46133275="" class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
-  <div data-v-46133275="" class="v-card-text pa-4 pt-0">
-    <div data-v-46133275="" class="v-row py-3">
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-uid-field">
-          <div data-v-46133275="" class="item-title"> UID: </div>
-          <p data-v-46133275="" class="text-truncate">a582b47a42d</p>
+  <hr class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
+  <div class="v-card-text pa-4 pt-0">
+    <div class="v-row py-3">
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-uid-field">
+          <div class="item-title"> UID: </div>
+          <p class="text-truncate">a582b47a42d</p>
         </div>
-        <div data-v-46133275="" data-test="device-mac-field">
-          <div data-v-46133275="" class="item-title"> MAC: </div><code data-v-46133275="">00:00:00:00:00:00</code>
+        <div data-test="device-mac-field">
+          <div class="item-title"> MAC: </div><code>00:00:00:00:00:00</code>
         </div>
-        <div data-v-46133275="" data-test="device-pretty-name-field">
-          <div data-v-46133275="" class="item-title"> Operating System: </div>
-          <div data-v-46133275=""><i data-v-46133275="" data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span data-v-46133275="">Linux Mint 19.3</span></div>
+        <div data-test="device-pretty-name-field">
+          <div class="item-title"> Operating System: </div>
+          <div><i data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span>Linux Mint 19.3</span></div>
         </div>
       </div>
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-version-field">
-          <div data-v-46133275="" class="item-title"> Agent Version: </div>
-          <p data-v-46133275=""></p>
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-version-field">
+          <div class="item-title"> Agent Version: </div>
+          <p></p>
         </div>
-        <div data-v-46133275="" data-test="device-tags-field">
-          <div data-v-46133275="" class="item-title"> Tags: </div>
-          <div data-v-46133275=""><span data-v-46133275="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal mr-2" draggable="false" aria-describedby="v-tooltip-v-5"><!----><span class="v-chip__underlay"></span>
+        <div data-test="device-tags-field">
+          <div class="item-title"> Tags: </div>
+          <div><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal mr-2" draggable="false" aria-describedby="v-tooltip-v-5"><!----><span class="v-chip__underlay"></span>
             <!---->
             <!---->
             <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -176,9 +176,9 @@ exports[`Details Device > Renders the component when device has no last seen dat
             <!--teleport end-->
           </div>
         </div>
-        <div data-v-46133275="" data-test="device-last-seen-field">
-          <div data-v-46133275="" class="item-title"> Last Seen: </div>
-          <p data-v-46133275="">No date found</p>
+        <div data-test="device-last-seen-field">
+          <div class="item-title"> Last Seen: </div>
+          <p>No date found</p>
         </div>
       </div>
     </div>
@@ -189,10 +189,10 @@ exports[`Details Device > Renders the component when device has no last seen dat
 `;
 
 exports[`Details Device > Renders the component when device has no tags 1`] = `
-"<div data-v-46133275="" class="d-flex pa-0 align-center">
-  <h1 data-v-46133275="">Device Details</h1>
+"<div class="d-flex pa-0 align-center">
+  <h1>Device Details</h1>
 </div>
-<div data-v-46133275="" class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
+<div class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
   <!---->
   <div class="v-card__loader">
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -210,8 +210,8 @@ exports[`Details Device > Renders the component when device has no tags 1`] = `
   </div>
   <!---->
   <!---->
-  <div data-v-46133275="" class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
-    <div data-v-46133275="" class="d-flex align-center ml-2">
+  <div class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
+    <div class="d-flex align-center ml-2">
       <div data-v-35d3a308="" class="v-row d-flex align-center flex-column">
         <div data-v-35d3a308="" class="v-btn-group v-btn-group--horizontal v-btn-group--divided v-theme--light v-btn-group--density-compact"><button data-v-35d3a308="" type="button" class="v-btn v-btn--disabled v-btn--flat v-theme--light text-normal v-btn--density-compact v-btn--size-default v-btn--variant-outlined" style="height: auto;" disabled="" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
             <!----><span class="v-btn__content" data-no-activator="">Offline</span>
@@ -228,8 +228,8 @@ exports[`Details Device > Renders the component when device has no tags 1`] = `
       <!---->
       <!---->
       <!---->
-      <!----><span data-v-46133275="" class="ml-6">39-5e-2a</span>
-    </div><button data-v-46133275="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <!----><span class="ml-6">39-5e-2a</span>
+    </div><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
       <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       <!---->
       <!---->
@@ -237,31 +237,31 @@ exports[`Details Device > Renders the component when device has no tags 1`] = `
     <!--teleport start-->
     <!--teleport end-->
   </div>
-  <hr data-v-46133275="" class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
-  <div data-v-46133275="" class="v-card-text pa-4 pt-0">
-    <div data-v-46133275="" class="v-row py-3">
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-uid-field">
-          <div data-v-46133275="" class="item-title"> UID: </div>
-          <p data-v-46133275="" class="text-truncate">a582b47a42d</p>
+  <hr class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
+  <div class="v-card-text pa-4 pt-0">
+    <div class="v-row py-3">
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-uid-field">
+          <div class="item-title"> UID: </div>
+          <p class="text-truncate">a582b47a42d</p>
         </div>
-        <div data-v-46133275="" data-test="device-mac-field">
-          <div data-v-46133275="" class="item-title"> MAC: </div><code data-v-46133275="">00:00:00:00:00:00</code>
+        <div data-test="device-mac-field">
+          <div class="item-title"> MAC: </div><code>00:00:00:00:00:00</code>
         </div>
-        <div data-v-46133275="" data-test="device-pretty-name-field">
-          <div data-v-46133275="" class="item-title"> Operating System: </div>
-          <div data-v-46133275=""><i data-v-46133275="" data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span data-v-46133275="">Linux Mint 19.3</span></div>
+        <div data-test="device-pretty-name-field">
+          <div class="item-title"> Operating System: </div>
+          <div><i data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span>Linux Mint 19.3</span></div>
         </div>
       </div>
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-version-field">
-          <div data-v-46133275="" class="item-title"> Agent Version: </div>
-          <p data-v-46133275=""></p>
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-version-field">
+          <div class="item-title"> Agent Version: </div>
+          <p></p>
         </div>
         <!--v-if-->
-        <div data-v-46133275="" data-test="device-last-seen-field">
-          <div data-v-46133275="" class="item-title"> Last Seen: </div>
-          <p data-v-46133275="">Wednesday, May 20th 2020, 6:58:53 pm</p>
+        <div data-test="device-last-seen-field">
+          <div class="item-title"> Last Seen: </div>
+          <p>Wednesday, May 20th 2020, 6:58:53 pm</p>
         </div>
       </div>
     </div>
@@ -272,10 +272,10 @@ exports[`Details Device > Renders the component when device has no tags 1`] = `
 `;
 
 exports[`Details Device > Renders the component when device is offline 1`] = `
-"<div data-v-46133275="" class="d-flex pa-0 align-center">
-  <h1 data-v-46133275="">Device Details</h1>
+"<div class="d-flex pa-0 align-center">
+  <h1>Device Details</h1>
 </div>
-<div data-v-46133275="" class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
+<div class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
   <!---->
   <div class="v-card__loader">
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -293,8 +293,8 @@ exports[`Details Device > Renders the component when device is offline 1`] = `
   </div>
   <!---->
   <!---->
-  <div data-v-46133275="" class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
-    <div data-v-46133275="" class="d-flex align-center ml-2">
+  <div class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
+    <div class="d-flex align-center ml-2">
       <div data-v-35d3a308="" class="v-row d-flex align-center flex-column">
         <div data-v-35d3a308="" class="v-btn-group v-btn-group--horizontal v-btn-group--divided v-theme--light v-btn-group--density-compact"><button data-v-35d3a308="" type="button" class="v-btn v-btn--disabled v-btn--flat v-theme--light text-normal v-btn--density-compact v-btn--size-default v-btn--variant-outlined" style="height: auto;" disabled="" data-test="connect-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
             <!----><span class="v-btn__content" data-no-activator="">Offline</span>
@@ -311,8 +311,8 @@ exports[`Details Device > Renders the component when device is offline 1`] = `
       <!---->
       <!---->
       <!---->
-      <!----><span data-v-46133275="" class="ml-6">39-5e-2a</span>
-    </div><button data-v-46133275="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <!----><span class="ml-6">39-5e-2a</span>
+    </div><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
       <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       <!---->
       <!---->
@@ -320,30 +320,30 @@ exports[`Details Device > Renders the component when device is offline 1`] = `
     <!--teleport start-->
     <!--teleport end-->
   </div>
-  <hr data-v-46133275="" class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
-  <div data-v-46133275="" class="v-card-text pa-4 pt-0">
-    <div data-v-46133275="" class="v-row py-3">
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-uid-field">
-          <div data-v-46133275="" class="item-title"> UID: </div>
-          <p data-v-46133275="" class="text-truncate">a582b47a42d</p>
+  <hr class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
+  <div class="v-card-text pa-4 pt-0">
+    <div class="v-row py-3">
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-uid-field">
+          <div class="item-title"> UID: </div>
+          <p class="text-truncate">a582b47a42d</p>
         </div>
-        <div data-v-46133275="" data-test="device-mac-field">
-          <div data-v-46133275="" class="item-title"> MAC: </div><code data-v-46133275="">00:00:00:00:00:00</code>
+        <div data-test="device-mac-field">
+          <div class="item-title"> MAC: </div><code>00:00:00:00:00:00</code>
         </div>
-        <div data-v-46133275="" data-test="device-pretty-name-field">
-          <div data-v-46133275="" class="item-title"> Operating System: </div>
-          <div data-v-46133275=""><i data-v-46133275="" data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span data-v-46133275="">Linux Mint 19.3</span></div>
+        <div data-test="device-pretty-name-field">
+          <div class="item-title"> Operating System: </div>
+          <div><i data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span>Linux Mint 19.3</span></div>
         </div>
       </div>
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-version-field">
-          <div data-v-46133275="" class="item-title"> Agent Version: </div>
-          <p data-v-46133275=""></p>
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-version-field">
+          <div class="item-title"> Agent Version: </div>
+          <p></p>
         </div>
-        <div data-v-46133275="" data-test="device-tags-field">
-          <div data-v-46133275="" class="item-title"> Tags: </div>
-          <div data-v-46133275=""><span data-v-46133275="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal mr-2" draggable="false" aria-describedby="v-tooltip-v-5"><!----><span class="v-chip__underlay"></span>
+        <div data-test="device-tags-field">
+          <div class="item-title"> Tags: </div>
+          <div><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal mr-2" draggable="false" aria-describedby="v-tooltip-v-5"><!----><span class="v-chip__underlay"></span>
             <!---->
             <!---->
             <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -353,9 +353,9 @@ exports[`Details Device > Renders the component when device is offline 1`] = `
             <!--teleport end-->
           </div>
         </div>
-        <div data-v-46133275="" data-test="device-last-seen-field">
-          <div data-v-46133275="" class="item-title"> Last Seen: </div>
-          <p data-v-46133275="">Wednesday, May 20th 2020, 6:58:53 pm</p>
+        <div data-test="device-last-seen-field">
+          <div class="item-title"> Last Seen: </div>
+          <p>Wednesday, May 20th 2020, 6:58:53 pm</p>
         </div>
       </div>
     </div>
@@ -366,10 +366,10 @@ exports[`Details Device > Renders the component when device is offline 1`] = `
 `;
 
 exports[`Details Device > Renders the component when device status is not accepted 1`] = `
-"<div data-v-46133275="" class="d-flex pa-0 align-center">
-  <h1 data-v-46133275="">Device Details</h1>
+"<div class="d-flex pa-0 align-center">
+  <h1>Device Details</h1>
 </div>
-<div data-v-46133275="" class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
+<div class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background">
   <!---->
   <div class="v-card__loader">
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -387,10 +387,10 @@ exports[`Details Device > Renders the component when device status is not accept
   </div>
   <!---->
   <!---->
-  <div data-v-46133275="" class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
-    <div data-v-46133275="" class="d-flex align-center ml-2">
-      <!--v-if--><span data-v-46133275="" class="ml-6">39-5e-2a</span>
-    </div><button data-v-46133275="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+  <div class="v-card-title pa-4 d-flex align-center justify-space-between bg-v-theme-surface">
+    <div class="d-flex align-center ml-2">
+      <!--v-if--><span class="ml-6">39-5e-2a</span>
+    </div><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
       <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       <!---->
       <!---->
@@ -398,30 +398,30 @@ exports[`Details Device > Renders the component when device status is not accept
     <!--teleport start-->
     <!--teleport end-->
   </div>
-  <hr data-v-46133275="" class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
-  <div data-v-46133275="" class="v-card-text pa-4 pt-0">
-    <div data-v-46133275="" class="v-row py-3">
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-uid-field">
-          <div data-v-46133275="" class="item-title"> UID: </div>
-          <p data-v-46133275="" class="text-truncate">a582b47a42d</p>
+  <hr class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
+  <div class="v-card-text pa-4 pt-0">
+    <div class="v-row py-3">
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-uid-field">
+          <div class="item-title"> UID: </div>
+          <p class="text-truncate">a582b47a42d</p>
         </div>
-        <div data-v-46133275="" data-test="device-mac-field">
-          <div data-v-46133275="" class="item-title"> MAC: </div><code data-v-46133275="">00:00:00:00:00:00</code>
+        <div data-test="device-mac-field">
+          <div class="item-title"> MAC: </div><code>00:00:00:00:00:00</code>
         </div>
-        <div data-v-46133275="" data-test="device-pretty-name-field">
-          <div data-v-46133275="" class="item-title"> Operating System: </div>
-          <div data-v-46133275=""><i data-v-46133275="" data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span data-v-46133275="">Linux Mint 19.3</span></div>
+        <div data-test="device-pretty-name-field">
+          <div class="item-title"> Operating System: </div>
+          <div><i data-test="device-icon" class="fl-linuxmint mr-1 mr-2" style="font-size: 20px;"></i><span>Linux Mint 19.3</span></div>
         </div>
       </div>
-      <div data-v-46133275="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-46133275="" data-test="device-version-field">
-          <div data-v-46133275="" class="item-title"> Agent Version: </div>
-          <p data-v-46133275=""></p>
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="device-version-field">
+          <div class="item-title"> Agent Version: </div>
+          <p></p>
         </div>
-        <div data-v-46133275="" data-test="device-tags-field">
-          <div data-v-46133275="" class="item-title"> Tags: </div>
-          <div data-v-46133275=""><span data-v-46133275="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal mr-2" draggable="false" aria-describedby="v-tooltip-v-5"><!----><span class="v-chip__underlay"></span>
+        <div data-test="device-tags-field">
+          <div class="item-title"> Tags: </div>
+          <div><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal mr-2" draggable="false" aria-describedby="v-tooltip-v-5"><!----><span class="v-chip__underlay"></span>
             <!---->
             <!---->
             <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -431,9 +431,9 @@ exports[`Details Device > Renders the component when device status is not accept
             <!--teleport end-->
           </div>
         </div>
-        <div data-v-46133275="" data-test="device-last-seen-field">
-          <div data-v-46133275="" class="item-title"> Last Seen: </div>
-          <p data-v-46133275="">Wednesday, May 20th 2020, 6:58:53 pm</p>
+        <div data-test="device-last-seen-field">
+          <div class="item-title"> Last Seen: </div>
+          <p>Wednesday, May 20th 2020, 6:58:53 pm</p>
         </div>
       </div>
     </div>
@@ -444,10 +444,10 @@ exports[`Details Device > Renders the component when device status is not accept
 `;
 
 exports[`Details Device > Renders the component when deviceIsEmpty is true 1`] = `
-"<div data-v-46133275="" class="d-flex pa-0 align-center">
-  <h1 data-v-46133275="">Device Details</h1>
+"<div class="d-flex pa-0 align-center">
+  <h1>Device Details</h1>
 </div>
-<div data-v-46133275="" class="v-card v-theme--light v-card--density-default v-card--variant-elevated mt-2 pa-4 bg-v-theme-surface">
+<div class="v-card v-theme--light v-card--density-default v-card--variant-elevated mt-2 pa-4 bg-v-theme-surface">
   <!---->
   <div class="v-card__loader">
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -465,7 +465,7 @@ exports[`Details Device > Renders the component when deviceIsEmpty is true 1`] =
   </div>
   <!---->
   <!---->
-  <p data-v-46133275="" class="text-center"> Something is wrong, try again ! </p>
+  <p class="text-center"> Something is wrong, try again ! </p>
   <!---->
   <!----><span class="v-card__underlay"></span>
 </div>"

--- a/ui/tests/views/__snapshots__/DetailsSessions.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/DetailsSessions.spec.ts.snap
@@ -1,10 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Details Sessions > Renders the component 1`] = `
-"<div data-v-727a3051="" class="d-flex pa-0 align-center">
-  <h1 data-v-727a3051="">Session Details</h1>
+"<div class="d-flex pa-0 align-center">
+  <h1>Session Details</h1>
 </div>
-<div data-v-727a3051="" class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background" data-test="session-details-card">
+<div class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated mt-2 border rounded bg-background" data-test="session-details-card">
   <!---->
   <div class="v-card__loader">
     <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -22,14 +22,14 @@ exports[`Details Sessions > Renders the component 1`] = `
   </div>
   <!---->
   <!---->
-  <div data-v-727a3051="" class="v-card-title bg-v-theme-surface pa-4 d-flex align-center justify-space-between">
-    <div data-v-727a3051="" class="d-flex align-center"><i data-v-727a3051="" class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-small text-white" aria-hidden="true" aria-describedby="v-tooltip-v-0" data-test="session-active-icon"></i>
+  <div class="v-card-title bg-v-theme-surface pa-4 d-flex align-center justify-space-between">
+    <div class="d-flex align-center"><i class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-small text-white" aria-hidden="true" aria-describedby="v-tooltip-v-0" data-test="session-active-icon"></i>
       <!--teleport start-->
-      <!--teleport end--><button data-v-727a3051="" type="button" class="v-btn v-btn--elevated v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-elevated text-none border rounded bg-v-theme-background ml-2"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span><span class="v-btn__prepend"><i class="mdi-developer-board mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span><span class="v-btn__content" data-no-activator="">00-00-00-00-00-01</span>
+      <!--teleport end--><button type="button" class="v-btn v-btn--elevated v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-elevated text-none border rounded bg-v-theme-background ml-2"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span><span class="v-btn__prepend"><i class="mdi-developer-board mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span><span class="v-btn__content" data-no-activator="">00-00-00-00-00-01</span>
         <!---->
         <!---->
       </button>
-    </div><button data-v-727a3051="" type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2" aria-owns="v-menu-v-2"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+    </div><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2" aria-owns="v-menu-v-2"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
       <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       <!---->
       <!---->
@@ -37,35 +37,35 @@ exports[`Details Sessions > Renders the component 1`] = `
     <!--teleport start-->
     <!--teleport end-->
   </div>
-  <hr data-v-727a3051="" class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
-  <div data-v-727a3051="" class="v-card-text pa-4 pt-0">
-    <div data-v-727a3051="" class="v-row py-3">
-      <div data-v-727a3051="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-727a3051="" data-test="session-uid-field">
-          <div data-v-727a3051="" class="item-title"> UID: </div>
-          <p data-v-727a3051="" class="text-truncate">1</p>
+  <hr class="v-divider v-theme--light" aria-orientation="horizontal" role="separator">
+  <div class="v-card-text pa-4 pt-0">
+    <div class="v-row py-3">
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="session-uid-field">
+          <div class="item-title"> UID: </div>
+          <p class="text-truncate">1</p>
         </div>
-        <div data-v-727a3051="" data-test="session-user-field">
-          <div data-v-727a3051="" class="item-title"> User: </div>
-          <p data-v-727a3051="">test</p>
+        <div data-test="session-user-field">
+          <div class="item-title"> User: </div>
+          <p>test</p>
         </div>
-        <div data-v-727a3051="" data-test="session-authenticated-field">
-          <div data-v-727a3051="" class="item-title"> Authenticated: </div><i data-v-727a3051="" class="mdi-shield-check mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" aria-describedby="v-tooltip-v-7"></i>
+        <div data-test="session-authenticated-field">
+          <div class="item-title"> Authenticated: </div><i class="mdi-shield-check mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" aria-describedby="v-tooltip-v-7"></i>
           <!--teleport start-->
           <!--teleport end-->
         </div>
       </div>
-      <div data-v-727a3051="" class="v-col-md-6 v-col-12 my-0 py-0">
-        <div data-v-727a3051="" data-test="session-ip-address-field">
-          <div data-v-727a3051="" class="item-title"> IP address: </div><code data-v-727a3051="" class="bg-tabs pa-1">192.168.0.1</code>
+      <div class="v-col-md-6 v-col-12 my-0 py-0">
+        <div data-test="session-ip-address-field">
+          <div class="item-title"> IP address: </div><code class="bg-tabs pa-1">192.168.0.1</code>
         </div>
-        <div data-v-727a3051="" data-test="session-started-at-field">
-          <div data-v-727a3051="" class="item-title"> Started: </div>
-          <p data-v-727a3051="">Thursday, January 2nd 2025, 12:00:00 am</p>
+        <div data-test="session-started-at-field">
+          <div class="item-title"> Started: </div>
+          <p>Thursday, January 2nd 2025, 12:00:00 am</p>
         </div>
-        <div data-v-727a3051="" data-test="session-last-seen-field">
-          <div data-v-727a3051="" class="item-title"> Last seen: </div>
-          <p data-v-727a3051="">Thursday, January 2nd 2025, 12:00:00 am</p>
+        <div data-test="session-last-seen-field">
+          <div class="item-title"> Last seen: </div>
+          <p>Thursday, January 2nd 2025, 12:00:00 am</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request refactors the styling of the `.item-title` class by moving its definition from multiple local component style blocks to a single global CSS file. This change ensures consistent styling across the application and simplifies maintenance by centralizing the style definition.

* Removed duplicate `.item-title` style blocks from several Vue component files (`AnnouncementDetails.vue`, `DeviceDetails.vue`, `FirewallRulesDetails.vue`, `NamespaceDetails.vue`, `SessionDetails.vue`, `UserDetails.vue`, `WelcomeThirdScreen.vue`, `DetailsDevice.vue`, `DetailsSessions.vue`) to eliminate redundancy and potential inconsistencies.
* Added the `.item-title` style definition to the global stylesheet (`ui/src/assets/global.css`), ensuring the style is applied consistently throughout the app.