### PR TITLE
refactor(ui): improve admin's `NamespaceEdit` `defineModel`

### DIFF
--- a/ui/admin/src/components/Namespace/NamespaceEdit.vue
+++ b/ui/admin/src/components/Namespace/NamespaceEdit.vue
@@ -57,7 +57,7 @@ const emit = defineEmits(["update"]);
 const snackbar = useSnackbar();
 const namespacesStore = useNamespacesStore();
 const adminNamespacesStore = useAdminNamespacesStore();
-const showDialog = defineModel<boolean>({ default: false });
+const showDialog = defineModel<boolean>({ required: true });
 
 const {
   value: name,


### PR DESCRIPTION
This pull request makes small adjustments to the `NamespaceEdit.vue` component to improve its type safety and code clarity.

* Removed the import of `defineModel`, since it is automatically imported by Vue.
* Updated the `showDialog` model to be required instead of having a default value, ensuring that the parent component must provide this prop.