### PR TITLE
feat(api): enable setup endpoint for Enterprise environments

### DIFF
--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -177,7 +177,7 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	publicAPI.GET(GetSessionRecordURL, gateway.Handler(handler.GetSessionRecord))
 	publicAPI.PUT(EditSessionRecordStatusURL, gateway.Handler(handler.EditSessionRecordStatus), routesmiddleware.RequiresPermission(authorizer.NamespaceEnableSessionRecord))
 
-	if envs.IsCommunity() {
+	if !envs.IsCloud() {
 		publicAPI.POST(SetupEndpoint, gateway.Handler(handler.Setup))
 	}
 

--- a/api/routes/setup_test.go
+++ b/api/routes/setup_test.go
@@ -21,7 +21,6 @@ func TestSetup(t *testing.T) {
 	envs.DefaultBackend = envMock
 
 	envMock.On("Get", "SHELLHUB_CLOUD").Return("false")
-	envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("false")
 
 	servicesMock := new(serviceMocks.Service)
 

--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -126,6 +126,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration114,
 		migration115,
 		migration116,
+		migration117,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_117.go
+++ b/api/store/mongo/migrations/migration_117.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	log "github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration117 = migrate.Migration{
+	Version:     117,
+	Description: "Set setup field in system collection for non-cloud environments",
+	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{
+			"component": "migration",
+			"version":   117,
+			"action":    "Up",
+		}).Info("Applying migration up")
+
+		if envs.IsCloud() {
+			return nil
+		}
+
+		usersCount, err := db.Collection("users").CountDocuments(ctx, bson.M{})
+		if err != nil {
+			return err
+		}
+
+		_, err = db.Collection("system").UpdateOne(ctx, bson.M{}, bson.M{"$set": bson.M{"setup": usersCount > 0}})
+
+		return err
+	}),
+	Down: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{
+			"component": "migration",
+			"version":   117,
+			"action":    "Down",
+		}).Info("Applying migration down")
+
+		log.Info("Unable to undo setup field changes")
+
+		return nil
+	}),
+}

--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -42,7 +42,7 @@ server {
     server_tokens off;
     resolver 127.0.0.11 ipv6=off;
 
-    {{ if and (not $cfg.EnableCloud) (not $cfg.EnableEnterprise) }}
+    {{ if not $cfg.EnableCloud }}
 
     location = /api/setup {
         set $upstream api:8080;


### PR DESCRIPTION
Enable the setup flow for both Community and Enterprise environments by changing the route condition from `IsCommunity()` to `!IsCloud()`.

Add migration 117 to set the `setup` field in the system collection based on existing users count for non-cloud environments.