### PR TITLE
fix(ui): redirect to `Setup` if user doesn't have first account

### DIFF
--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -90,7 +90,7 @@ export const routes: Array<RouteRecordRaw> = [
       requiresAuth: false,
     },
     beforeEnter: (to, from, next) => {
-      if (envVariables.isCommunity && !useUsersStore().systemInfo.setup) {
+      if (!envVariables.isCloud && !useUsersStore().systemInfo.setup) {
         next({ name: "Setup" });
       }
       next();


### PR DESCRIPTION
This pull request fixes the router behavior to redirect users who did not create their first account from `/login` to `/setup` in Community and Enterprise instances.