### PR TITLE
fix(ui): check Welcome's `hasDevices` only on mount

### DIFF
--- a/ui/src/components/User/UserWarning.vue
+++ b/ui/src/components/User/UserWarning.vue
@@ -4,10 +4,7 @@
     data-test="device-chooser-component"
   />
 
-  <Welcome
-    :has-namespaces
-    data-test="welcome-component"
-  />
+  <Welcome data-test="welcome-component" />
 
   <BillingWarning
     v-model="showBillingWarning"

--- a/ui/tests/components/Welcome/Welcome.spec.ts
+++ b/ui/tests/components/Welcome/Welcome.spec.ts
@@ -1,7 +1,7 @@
 import { createPinia, setActivePinia } from "pinia";
-import { DOMWrapper, flushPromises, mount } from "@vue/test-utils";
+import { DOMWrapper, flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { createVuetify } from "vuetify";
-import { expect, describe, it, beforeEach, vi } from "vitest";
+import { expect, describe, it, beforeEach, vi, afterEach } from "vitest";
 import Welcome from "@/components/Welcome/Welcome.vue";
 import { SnackbarPlugin } from "@/plugins/snackbar";
 import useNamespacesStore from "@/store/modules/namespaces";
@@ -25,6 +25,7 @@ const mockNamespace = {
 };
 
 describe("Welcome", () => {
+  let wrapper: VueWrapper<InstanceType<typeof Welcome>>;
   const vuetify = createVuetify();
   setActivePinia(createPinia());
   const namespacesStore = useNamespacesStore();
@@ -34,7 +35,7 @@ describe("Welcome", () => {
     vi.spyOn(Storage.prototype, "getItem").mockReturnValue("{}");
     vi.spyOn(Storage.prototype, "setItem");
     namespacesStore.currentNamespace = mockNamespace;
-
+    namespacesStore.namespaceList = [mockNamespace];
     statsStore.stats = {
       registered_devices: 0,
       pending_devices: 0,
@@ -42,45 +43,13 @@ describe("Welcome", () => {
       online_devices: 0,
       active_sessions: 0,
     };
+
+    wrapper = mount(Welcome, { global: { plugins: [vuetify, SnackbarPlugin] } });
   });
 
-  const mountWrapper = (hasNamespaces: boolean) => {
-    return mount(Welcome, {
-      global: { plugins: [vuetify, SnackbarPlugin] },
-      props: { hasNamespaces },
-    });
-  };
-
-  it("Does not render when hasNamespaces is false", async () => {
-    mountWrapper(false);
-    await flushPromises();
-    const dialog = new DOMWrapper(document.body);
-    expect(dialog.find('[data-test="welcome-window"]').exists()).toBe(false);
-  });
-
-  it("Does not render when namespace has already been shown", async () => {
-    vi.spyOn(Storage.prototype, "getItem").mockReturnValue('{"test-tenant":true}');
-    mountWrapper(true);
-
-    await flushPromises();
-
-    const dialog = new DOMWrapper(document.body);
-    expect(dialog.find('[data-test="welcome-window"]').exists()).toBe(false);
-  });
-
-  it("Does not render when namespace has devices", async () => {
-    statsStore.stats.registered_devices = 1;
-
-    mountWrapper(true);
-
-    await flushPromises();
-
-    const dialog = new DOMWrapper(document.body);
-    expect(dialog.find('[data-test="welcome-window"]').exists()).toBe(false);
-  });
+  afterEach(() => { wrapper.unmount(); });
 
   it("Enables 'Next' (confirm) button when the user sets up a device on step 2", async () => {
-    const wrapper = mountWrapper(true);
     await flushPromises();
 
     wrapper.vm.currentStep = 2;
@@ -93,5 +62,30 @@ describe("Welcome", () => {
     const confirmButton = dialog.find('[data-test="confirm-btn"]');
     expect(confirmButton.exists()).toBe(true);
     expect((confirmButton.element as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("Does not render when namespace has already been shown", async () => {
+    vi.spyOn(Storage.prototype, "getItem").mockReturnValue('{"test-tenant":true}');
+
+    await flushPromises();
+
+    const dialog = new DOMWrapper(document.body);
+    expect(dialog.find('[data-test="welcome-window"]').exists()).toBe(false);
+  });
+
+  it("Does not render when namespace has devices", async () => {
+    statsStore.stats.registered_devices = 1;
+
+    await flushPromises();
+
+    const dialog = new DOMWrapper(document.body);
+    expect(dialog.find('[data-test="welcome-window"]').exists()).toBe(false);
+  });
+
+  it("Does not render when hasNamespaces is false", async () => {
+    namespacesStore.namespaceList = [];
+    await flushPromises();
+    const dialog = new DOMWrapper(document.body);
+    expect(dialog.find('[data-test="welcome-window"]').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
This pull request fixes a bug in the Welcome dialog, which closed the dialog when the first device was found by the agent due to `hasDevices` being updated. Now, the ref is checked only on mounting, preventing unexpected closing after the user downloads the agent. Code was also cleaned up and tests fixed.