### PR TITLE
fix(agent): correct setpriv binary path in Dockerfile

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -77,7 +77,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy required utilities
 COPY --from=builder /usr/bin/nsenter /usr/bin/
-COPY --from=builder /bin/setpriv /usr/bin/
+COPY --from=builder /bin/setpriv /bin/
 
 # Copy shared libraries
 COPY --from=builder /usr/lib/libcap-ng.so.* /usr/lib/


### PR DESCRIPTION
The setpriv utility was being copied from /bin/setpriv in the builder
stage but placed in /usr/bin/ in the final scratch image. This caused
shell execution to fail as it couldn't find setpriv at runtime.
