### PR TITLE
fix(ui): fix `MemberInvite`'s email label spacing

### DIFF
--- a/ui/src/components/Team/Member/MemberInvite.vue
+++ b/ui/src/components/Team/Member/MemberInvite.vue
@@ -45,7 +45,7 @@
             </p>
             <v-text-field
               v-model="email"
-              class="mb-6"
+              class="mb-6 mt-2"
               label="Email"
               :error-messages="emailError"
               required

--- a/ui/tests/components/Team/Member/__snapshots__/MemberInvite.spec.ts.snap
+++ b/ui/tests/components/Team/Member/__snapshots__/MemberInvite.spec.ts.snap
@@ -79,7 +79,7 @@ exports[`Member Invite > Renders the component 1`] = `
                     <transition-stub name="" appear="false" persisted="false" css="true">
                       <div class="v-window-item v-window-item--active">
                         <p class="mb-4"> If this email isn't associated with an existing account, we'll send an email to sign-up. </p>
-                        <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mb-6" data-test="email-text">
+                        <div class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-text-field mb-6 mt-2" data-test="email-text">
                           <!---->
                           <div class="v-input__control">
                             <div class="v-field v-field--center-affix v-field--variant-filled v-theme--light v-locale--is-ltr">


### PR DESCRIPTION
This pull request fixes a bug in the `MemberInvite` dialog that was truncating the email field label. This PR adds margin to that field to properly have space for the label.