### PR TITLE
fix(ui): enable `TagSelector` even when namespace has no tags

### DIFF
--- a/ui/src/components/Tags/TagSelector.vue
+++ b/ui/src/components/Tags/TagSelector.vue
@@ -21,13 +21,13 @@
             variant="outlined"
             append-icon="mdi-chevron-down"
             text="Tags"
-            :disabled="fetchedTags.length === 0"
           />
         </v-badge>
       </template>
 
       <div class="bg-v-theme-surface">
         <v-list
+          v-if="fetchedTags.length > 0"
           ref="scrollArea"
           density="compact"
           style="max-height: 320px; overflow-y: auto"
@@ -57,7 +57,7 @@
             />
           </div>
         </v-list>
-        <v-divider />
+        <v-divider v-if="fetchedTags.length > 0" />
         <v-btn
           color="primary"
           text="Manage Tags"

--- a/ui/tests/components/Tags/__snapshots__/TagSelector.spec.ts.snap
+++ b/ui/tests/components/Tags/__snapshots__/TagSelector.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Tag Selector > Renders the component 1`] = `
 "<div class="mr-4">
   <div class="v-badge v-badge--bordered" value="0">
-    <div class="v-badge__wrapper"><button type="button" class="v-btn v-btn--disabled v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-outlined" disabled="" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-0" aria-owns="v-menu-v-0" data-test="tags-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+    <div class="v-badge__wrapper"><button type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-outlined" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-0" aria-owns="v-menu-v-0" data-test="tags-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
         <!----><span class="v-btn__content" data-no-activator="">Tags</span><span class="v-btn__append"><i class="mdi-chevron-down mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
         <!---->
       </button>


### PR DESCRIPTION
This pull request changes the `TagSelector` `disabled` condition, making it enabled even when there are no tags, so the Manage Tags button remains accessible.