### PR TITLE
fix(api): support X-Tenant-ID header in tag requests

### DIFF
--- a/api/routes/tags.go
+++ b/api/routes/tags.go
@@ -64,6 +64,9 @@ func (h *Handler) GetTags(c gateway.Context) error {
 		return err
 	}
 
+	req.Paginator.Normalize()
+	req.Sorter.Normalize()
+
 	tags, totalCount, err := h.service.ListTags(c.Ctx(), req)
 	if err != nil {
 		return err

--- a/pkg/api/requests/tags.go
+++ b/pkg/api/requests/tags.go
@@ -3,12 +3,12 @@ package requests
 import "github.com/shellhub-io/shellhub/pkg/api/query"
 
 type CreateTag struct {
-	TenantID string `param:"tenant" validate:"required,uuid"`
+	TenantID string `param:"tenant" header:"X-Tenant-ID" validate:"required,uuid"`
 	Name     string `json:"name" validate:"required,min=3,max=255,alphanum,ascii,excludes=/@&:"`
 }
 
 type PushTag struct {
-	TenantID string `param:"tenant" validate:"required,uuid"`
+	TenantID string `param:"tenant" header:"X-Tenant-ID" validate:"required,uuid"`
 	Name     string `param:"name" validate:"required,min=3,max=255,alphanum,ascii,excludes=/@&:"`
 	// TargetID is the identifier of the target to push the tag on.
 	// For the reason cannot of it can be a list of things (UID for device, ID for firewall, etc...), it
@@ -17,7 +17,7 @@ type PushTag struct {
 }
 
 type PullTag struct {
-	TenantID string `param:"tenant" validate:"required,uuid"`
+	TenantID string `param:"tenant" header:"X-Tenant-ID" validate:"required,uuid"`
 	Name     string `param:"name" validate:"required,min=3,max=255,alphanum,ascii,excludes=/@&:"`
 	// TargetID is the identifier of the target to pull the tag of.
 	// For the reason cannot of it can be a list of things (UID for device, ID for firewall, etc...), it
@@ -26,21 +26,21 @@ type PullTag struct {
 }
 
 type ListTags struct {
-	TenantID string `param:"tenant" validate:"required,uuid"`
+	TenantID string `param:"tenant" header:"X-Tenant-ID" validate:"required,uuid"`
 	query.Paginator
 	query.Filters
 	query.Sorter
 }
 
 type UpdateTag struct {
-	TenantID string `param:"tenant" validate:"required,uuid"`
+	TenantID string `param:"tenant" header:"X-Tenant-ID" validate:"required,uuid"`
 	Name     string `param:"name" validate:"required"`
 	// Similar to [UpdateTag.Name], but is used to update the tag's name instead of retrieve the tag.
 	NewName string `json:"name" validate:"omitempty,min=3,max=255,alphanum,ascii,excludes=/@&:"`
 }
 
 type DeleteTag struct {
-	TenantID string `param:"tenant" validate:"required,uuid"`
+	TenantID string `param:"tenant" header:"X-Tenant-ID" validate:"required,uuid"`
 	Name     string `param:"name" validate:"required"`
 }
 


### PR DESCRIPTION
Add header binding for X-Tenant-ID alongside param binding in tag request structs, allowing new endpoints without :tenant path param to work correctly. Also normalize paginator and sorter in GetTags.