### PR TITLE
refactor(ui): simplify and validate items-per-page input handling

### DIFF
--- a/ui/admin/tests/unit/components/Announcement/AnnouncementList/__snapshots__/AnnouncementList.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Announcement/AnnouncementList/__snapshots__/AnnouncementList.spec.ts.snap
@@ -73,7 +73,7 @@ exports[`Announcement List > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -97,7 +97,7 @@ exports[`Announcement List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" value="10">
               </div>
               <!---->
             </div>

--- a/ui/admin/tests/unit/components/Device/DeviceList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Device/DeviceList/__snapshots__/index.spec.ts.snap
@@ -90,7 +90,7 @@ exports[`Device List > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-18" aria-owns="menu-v-18">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-18" aria-owns="menu-v-18">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -114,7 +114,7 @@ exports[`Device List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-20" aria-expanded="false" aria-controls="menu-v-18" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-20" aria-expanded="false" aria-controls="menu-v-18" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/admin/tests/unit/components/FirewallRules/FirewallRulesList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/FirewallRules/FirewallRulesList/__snapshots__/index.spec.ts.snap
@@ -52,7 +52,7 @@ exports[`Firewall Rules List > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -76,7 +76,7 @@ exports[`Firewall Rules List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" value="10">
               </div>
               <!---->
             </div>

--- a/ui/admin/tests/unit/components/Namespaces/NamespaceList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Namespaces/NamespaceList/__snapshots__/index.spec.ts.snap
@@ -57,7 +57,7 @@ exports[`Namespace List > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -81,7 +81,7 @@ exports[`Namespace List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/admin/tests/unit/components/Session/SessionList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Session/SessionList/__snapshots__/index.spec.ts.snap
@@ -105,7 +105,7 @@ exports[`Sessions List > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-16" aria-owns="menu-v-16">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-16" aria-owns="menu-v-16">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -129,7 +129,7 @@ exports[`Sessions List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-18" aria-expanded="false" aria-controls="menu-v-16" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-18" aria-expanded="false" aria-controls="menu-v-16" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/admin/tests/unit/components/User/UserList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/User/UserList/__snapshots__/index.spec.ts.snap
@@ -60,7 +60,7 @@ exports[`UserList > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-7" aria-owns="menu-v-7">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-7" aria-owns="menu-v-7">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -84,7 +84,7 @@ exports[`UserList > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-9" aria-expanded="false" aria-controls="menu-v-7" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-9" aria-expanded="false" aria-controls="menu-v-7" value="10">
               </div>
               <!---->
             </div>

--- a/ui/admin/tests/unit/views/Announcements/__snapshots__/Announcements.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Announcements/__snapshots__/Announcements.spec.ts.snap
@@ -57,7 +57,7 @@ exports[`Announcement Details > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -81,7 +81,7 @@ exports[`Announcement Details > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" value="10">
               </div>
               <!---->
             </div>

--- a/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
@@ -135,7 +135,7 @@ exports[`Device > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -159,7 +159,7 @@ exports[`Device > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/admin/tests/unit/views/FirewallRules/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/FirewallRules/__snapshots__/index.spec.ts.snap
@@ -53,7 +53,7 @@ exports[`Firewall Rules > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -77,7 +77,7 @@ exports[`Firewall Rules > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" value="10">
               </div>
               <!---->
             </div>

--- a/ui/admin/tests/unit/views/Namespaces/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Namespaces/__snapshots__/index.spec.ts.snap
@@ -83,7 +83,7 @@ exports[`Namespaces > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -107,7 +107,7 @@ exports[`Namespaces > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/admin/tests/unit/views/Sessions/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Sessions/__snapshots__/index.spec.ts.snap
@@ -37,7 +37,7 @@ exports[`Sessions > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -61,7 +61,7 @@ exports[`Sessions > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/admin/tests/unit/views/Users/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Users/__snapshots__/index.spec.ts.snap
@@ -90,7 +90,7 @@ exports[`Users > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-5" aria-owns="menu-v-5">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-5" aria-owns="menu-v-5">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -114,7 +114,7 @@ exports[`Users > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-7" aria-expanded="false" aria-controls="menu-v-5" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-7" aria-expanded="false" aria-controls="menu-v-5" value="10">
               </div>
               <!---->
             </div>

--- a/ui/tests/components/Connectors/__snapshots__/ConnectorList.spec.ts.snap
+++ b/ui/tests/components/Connectors/__snapshots__/ConnectorList.spec.ts.snap
@@ -94,7 +94,7 @@ exports[`Connector List > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -118,7 +118,7 @@ exports[`Connector List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" value="10">
               </div>
               <!---->
             </div>

--- a/ui/tests/components/Containers/__snapshots__/ContainerList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerList.spec.ts.snap
@@ -164,7 +164,7 @@ exports[`Container List > Renders the component 1`] = `
           <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-30" aria-owns="menu-v-30">
+              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-30" aria-owns="menu-v-30">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -188,7 +188,7 @@ exports[`Container List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-32" aria-expanded="false" aria-controls="menu-v-30" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-32" aria-expanded="false" aria-controls="menu-v-30" value="10">
                   </div>
                   <!---->
                 </div>

--- a/ui/tests/components/Containers/__snapshots__/ContainerPendingList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerPendingList.spec.ts.snap
@@ -66,7 +66,7 @@ exports[`Container Pending List > Renders the component 1`] = `
           <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -90,7 +90,7 @@ exports[`Container Pending List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" value="10">
                   </div>
                   <!---->
                 </div>

--- a/ui/tests/components/Containers/__snapshots__/ContainerRejectList.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerRejectList.spec.ts.snap
@@ -66,7 +66,7 @@ exports[`Container Rejected List > Renders the component 1`] = `
           <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -90,7 +90,7 @@ exports[`Container Rejected List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" value="10">
                   </div>
                   <!---->
                 </div>

--- a/ui/tests/components/Devices/__snapshots__/DeviceList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DeviceList.spec.ts.snap
@@ -164,7 +164,7 @@ exports[`Device List > Renders the component 1`] = `
           <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-30" aria-owns="menu-v-30">
+              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-30" aria-owns="menu-v-30">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -188,7 +188,7 @@ exports[`Device List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-32" aria-expanded="false" aria-controls="menu-v-30" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-32" aria-expanded="false" aria-controls="menu-v-30" value="10">
                   </div>
                   <!---->
                 </div>

--- a/ui/tests/components/Devices/__snapshots__/DevicePendingList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DevicePendingList.spec.ts.snap
@@ -66,7 +66,7 @@ exports[`Device Pending List > Renders the component 1`] = `
           <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -90,7 +90,7 @@ exports[`Device Pending List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" value="10">
                   </div>
                   <!---->
                 </div>

--- a/ui/tests/components/Devices/__snapshots__/DeviceRejectedList.spec.ts.snap
+++ b/ui/tests/components/Devices/__snapshots__/DeviceRejectedList.spec.ts.snap
@@ -66,7 +66,7 @@ exports[`Device Rejected List > Renders the component 1`] = `
           <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
+              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-9" aria-owns="menu-v-9">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -90,7 +90,7 @@ exports[`Device Rejected List > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-11" aria-expanded="false" aria-controls="menu-v-9" value="10">
                   </div>
                   <!---->
                 </div>

--- a/ui/tests/components/PublicKeys/__snapshots__/PublicKeyList.spec.ts.snap
+++ b/ui/tests/components/PublicKeys/__snapshots__/PublicKeyList.spec.ts.snap
@@ -47,7 +47,7 @@ exports[`Public Key List > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-4" aria-owns="menu-v-4">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -71,7 +71,7 @@ exports[`Public Key List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-6" aria-expanded="false" aria-controls="menu-v-4" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/tests/components/Tables/DataTable.spec.ts
+++ b/ui/tests/components/Tables/DataTable.spec.ts
@@ -127,7 +127,7 @@ describe("DataTable", () => {
       expect(getPagerRoot().exists()).toBe(false);
     });
 
-    it("resets to first page when itemsPerPage changes via combobox", async () => {
+    it("resets to first page when itemsPerPage changes via combobox selection", async () => {
       await wrapper.setProps({ page: 3 });
       await uiTick();
 
@@ -135,9 +135,6 @@ describe("DataTable", () => {
       expect(combo.exists()).toBe(true);
 
       combo.vm.$emit("update:modelValue", 25);
-      await uiTick();
-
-      await combo.trigger("blur");
       await uiTick();
 
       const pageEvents = wrapper.emitted("update:page");

--- a/ui/tests/components/Tags/__snapshots__/TagList.spec.ts.snap
+++ b/ui/tests/components/Tags/__snapshots__/TagList.spec.ts.snap
@@ -50,7 +50,7 @@ exports[`Tag List > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-0" aria-owns="menu-v-0">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -74,7 +74,7 @@ exports[`Tag List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" value="10">
               </div>
               <!---->
             </div>

--- a/ui/tests/components/Team/ApiKeys/__snapshots__/ApiKeyList.spec.ts.snap
+++ b/ui/tests/components/Team/ApiKeys/__snapshots__/ApiKeyList.spec.ts.snap
@@ -54,7 +54,7 @@ exports[`Api Key List > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-10" aria-owns="menu-v-10">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -78,7 +78,7 @@ exports[`Api Key List > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-12" aria-expanded="false" aria-controls="menu-v-10" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/tests/components/firewall/__snapshots__/FirewallRuleList.spec.ts.snap
+++ b/ui/tests/components/firewall/__snapshots__/FirewallRuleList.spec.ts.snap
@@ -66,7 +66,7 @@ exports[`Firewall Rule List > Renders the component 1`] = `
       <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
         <!---->
         <div class="v-input__control">
-          <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-8" aria-owns="menu-v-8">
+          <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-8" aria-owns="menu-v-8">
             <div class="v-field__overlay"></div>
             <div class="v-field__loader">
               <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -90,7 +90,7 @@ exports[`Firewall Rule List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-10" aria-expanded="false" aria-controls="menu-v-8" outlined="" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-10" aria-expanded="false" aria-controls="menu-v-8" value="10">
               </div>
               <!---->
             </div>

--- a/ui/tests/views/__snapshots__/FirewallRules.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/FirewallRules.spec.ts.snap
@@ -68,7 +68,7 @@ exports[`Firewall Rules > Renders the component 1`] = `
         <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
           <!---->
           <div class="v-input__control">
-            <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
+            <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
                 <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -92,7 +92,7 @@ exports[`Firewall Rules > Renders the component 1`] = `
                 <div class="v-field__input" data-no-activator="">
                   <!---->
                   <!---->
-                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
+                  <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" value="10">
                 </div>
                 <!---->
               </div>

--- a/ui/tests/views/__snapshots__/PublicKeys.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/PublicKeys.spec.ts.snap
@@ -64,7 +64,7 @@ exports[`Public Keys > Renders the component 1`] = `
           <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
+              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-6" aria-owns="menu-v-6">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -88,7 +88,7 @@ exports[`Public Keys > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-8" aria-expanded="false" aria-controls="menu-v-6" value="10">
                   </div>
                   <!---->
                 </div>

--- a/ui/tests/views/__snapshots__/Sessions.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/Sessions.spec.ts.snap
@@ -81,7 +81,7 @@ exports[`Sessions View > Renders the component 1`] = `
           <div class="v-input v-input--horizontal v-input--hide-spin-buttons v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-text-field v-input--plain-underlined v-combobox v-combobox--single mb-4 mr-1 w-100" data-test="ipp-combo">
             <!---->
             <div class="v-input__control">
-              <div class="v-field v-field--active v-field--appended v-field--center-affix v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-7" aria-owns="menu-v-7">
+              <div class="v-field v-field--active v-field--appended v-field--dirty v-field--no-label v-field--variant-underlined v-theme--light v-locale--is-ltr" role="combobox" aria-haspopup="menu" aria-expanded="false" aria-controls="menu-v-7" aria-owns="menu-v-7">
                 <div class="v-field__overlay"></div>
                 <div class="v-field__loader">
                   <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -105,7 +105,7 @@ exports[`Sessions View > Renders the component 1`] = `
                   <div class="v-field__input" data-no-activator="">
                     <!---->
                     <!---->
-                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-9" aria-expanded="false" aria-controls="menu-v-7" outlined="" value="10">
+                    <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" id="input-v-9" aria-expanded="false" aria-controls="menu-v-7" value="10">
                   </div>
                   <!---->
                 </div>


### PR DESCRIPTION
# Description:

This PR refactors how the `itemsPerPage` value is handled in the `DataTable` component to simplify state management and improve user input validation. Key changes include:

## Refactors

- Removed unnecessary v-model and internal state tracking for `itemsPerPage`
- Replaced outlined and center-affix props with cleaner input markup
- Introduced explicit parsing, clamping, and error messaging for invalid values
- Reset page to 1 only when the value changes meaningfully
- Simplified event handling (`@blur`, `@keydown.enter`, etc.)

## Tests & Snapshots

- Updated unit test descriptions for clarity (via combobox selection)
- Adjusted all affected snapshots to reflect new rendered DOM
- Ensured form validation behaves as expected across views

## Affected Areas

This change impacts all components and views using the `DataTable` with pagination, including:

- DeviceList
- UserList
- NamespaceList
- SessionList
- PublicKeyList
- Tags, Connectors, Containers, and related pending/rejected views

## Why?

- Reduce unnecessary complexity from dual v-model bindings
- Improve robustness of numeric input handling
- Prevent invalid values and make validation UX clearer