### PR TITLE
refactor(ui): move `hasNamespaces` computed to namespaces store

### DIFF
--- a/ui/src/components/AppBar/AppBar.vue
+++ b/ui/src/components/AppBar/AppBar.vue
@@ -215,7 +215,7 @@ const userId = computed(() => authStore.id);
 const currentUser = computed(() => authStore.username);
 const isBillingActive = computed(() => billingStore.isActive);
 const theme = computed(() => layoutStore.theme);
-const hasNamespaces = computed(() => namespacesStore.namespaceList.length > 0);
+const hasNamespaces = computed(() => namespacesStore.hasNamespaces);
 const isChatCreated = computed(() => supportStore.isChatCreated);
 const identifier = computed(() => supportStore.identifier);
 const isDarkMode = ref(theme.value === "dark");

--- a/ui/src/components/Namespace/Namespace.vue
+++ b/ui/src/components/Namespace/Namespace.vue
@@ -166,7 +166,7 @@ const showAddDialog = ref(false);
 
 const currentNamespace = computed(() => namespacesStore.currentNamespace);
 const namespaceList = computed(() => namespacesStore.namespaceList);
-const hasNamespaces = computed(() => namespacesStore.namespaceList.length > 0);
+const hasNamespaces = computed(() => namespacesStore.hasNamespaces);
 const showInstructionsDialog = ref(false);
 const userId = computed(() => authStore.id || localStorage.getItem("id") || "");
 

--- a/ui/src/components/User/UserDelete.vue
+++ b/ui/src/components/User/UserDelete.vue
@@ -39,8 +39,7 @@ import useAuthStore from "@/store/modules/auth";
 import useNamespacesStore from "@/store/modules/namespaces";
 
 const authStore = useAuthStore();
-const { namespaceList } = useNamespacesStore();
-const hasNamespaces = namespaceList.length > 0;
+const { hasNamespaces } = useNamespacesStore();
 const snackbar = useSnackbar();
 const router = useRouter();
 const showDialog = defineModel<boolean>({ default: false });

--- a/ui/src/components/User/UserWarning.vue
+++ b/ui/src/components/User/UserWarning.vue
@@ -81,7 +81,7 @@ const showForceRecoveryMail = computed(() => authStore.showForceRecoveryMail);
 const showPaywall = computed(() => usersStore.showPaywall);
 const stats = computed(() => statsStore.stats);
 const currentAnnouncement = computed(() => announcementStore.currentAnnouncement);
-const hasNamespaces = computed(() => namespacesStore.namespaceList.length > 0);
+const hasNamespaces = computed(() => namespacesStore.hasNamespaces);
 const showDeviceChooser = computed(() => devicesStore.showDeviceChooser);
 const showBillingWarning = computed({
   get() {

--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -187,7 +187,7 @@ const namespacesStore = useNamespacesStore();
 const spinnerStore = useSpinnerStore();
 const { getPrivateKeyList } = usePrivateKeysStore();
 const currentRoute = computed(() => router.currentRoute);
-const hasNamespaces = computed(() => namespacesStore.namespaceList.length !== 0);
+const hasNamespaces = computed(() => namespacesStore.hasNamespaces);
 const theme = computed(() => layoutStore.theme);
 
 const { lgAndUp } = useDisplay();

--- a/ui/src/store/modules/namespaces.ts
+++ b/ui/src/store/modules/namespaces.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import * as namespacesApi from "../api/namespaces";
 import {
   INamespace,
@@ -14,6 +14,7 @@ const useNamespacesStore = defineStore("namespaces", () => {
   const currentNamespace = ref<INamespace>({} as INamespace);
   const namespaceList = ref<Array<INamespace>>([]);
   const userStatus = ref<string>();
+  const hasNamespaces = computed(() => namespaceList.value.length > 0);
 
   const fetchNamespaceList = async (data?: { page?: number; perPage?: number; filter?: string }) => {
     const res = await namespacesApi.fetchNamespaces(data?.page || 1, data?.perPage || 10, data?.filter);
@@ -99,6 +100,7 @@ const useNamespacesStore = defineStore("namespaces", () => {
     currentNamespace,
     namespaceList,
     userStatus,
+    hasNamespaces,
 
     createNamespace,
     fetchNamespaceList,


### PR DESCRIPTION
This pull request adds a `hasNamespaces` computed to the namespaces store, centralizing the check that was used in multiple components, keeping a single source of truth.