### PR TITLE
bump(ui): revert Node.js LTS version bump

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25.2.1-alpine3.22 AS base
+FROM node:24.12.0-alpine3.22 AS base
 
 ARG NPM_CONFIG_REGISTRY
 


### PR DESCRIPTION
This pull request reverts the Node.js version bump from Dependabot, going back to the latest Long-Term Support version to prevent unexpected behavior and lack of support from other dependencies.