### PR TITLE
feat(ui): add Rename Device button to accepted devices list

### DIFF
--- a/ui/src/components/Devices/DeviceRename.vue
+++ b/ui/src/components/Devices/DeviceRename.vue
@@ -58,6 +58,10 @@ const props = defineProps<{
   name: string
 }>();
 
+const emit = defineEmits<{
+  update: [];
+}>();
+
 const showDialog = ref(false);
 const snackbar = useSnackbar();
 const messages = ref(
@@ -90,6 +94,7 @@ const rename = async () => {
     });
 
     close();
+    emit("update");
     snackbar.showSuccess("Device renamed successfully.");
   } catch (error: unknown) {
     if (axios.isAxiosError(error)) {

--- a/ui/src/components/Tables/DeviceTable.vue
+++ b/ui/src/components/Tables/DeviceTable.vue
@@ -165,6 +165,13 @@
                   <span> You don't have this kind of authorization. </span>
                 </v-tooltip>
 
+                <DeviceRename
+                  :uid="item.uid"
+                  :name="item.name"
+                  data-test="device-rename-component"
+                  @update="getDevices"
+                />
+
                 <v-tooltip
                   location="bottom"
                   class="text-center"
@@ -278,6 +285,7 @@ import DataTable from "./DataTable.vue";
 import DeviceIcon from "../Devices/DeviceIcon.vue";
 import DeviceActionButton from "../Devices/DeviceActionButton.vue";
 import DeviceDelete from "../Devices/DeviceDelete.vue";
+import DeviceRename from "../Devices/DeviceRename.vue";
 import TagFormUpdate from "../Tags/TagFormUpdate.vue";
 import TerminalConnectButton from "../Terminal/TerminalConnectButton.vue";
 import CopyWarning from "@/components/User/CopyWarning.vue";


### PR DESCRIPTION
This pull request adds the "Rename Device" button to the accepted device list's actions menu, making it easier to quickly give a meaningful name to a device directly in the list.