### PR TITLE
fix(ui): replace text-white with theme-safe emphasis colors

### DIFF
--- a/ui/admin/src/components/Device/DeviceList.vue
+++ b/ui/admin/src/components/Device/DeviceList.vue
@@ -41,7 +41,7 @@
           <td>
             <router-link
               :to="{ name: 'namespaceDetails', params: { id: item.tenant_id } }"
-              class="text-white"
+              class="hyper-link"
             >
               {{ item.namespace }}
             </router-link>
@@ -201,5 +201,18 @@ watch([itemsPerPage, page], async () => { await fetchDevices(); });
 
 onMounted(async () => { await fetchDevices(); });
 
-defineExpose({ headers, devices, loading, itemsPerPage });
+defineExpose({ headers, devices, loading, itemsPerPage, showTag });
 </script>
+
+<style scoped>
+.hyper-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.hyper-link:visited,
+.hyper-link:hover,
+.hyper-link:active {
+  color: inherit;
+}
+</style>

--- a/ui/admin/src/layouts/AppLayout.vue
+++ b/ui/admin/src/layouts/AppLayout.vue
@@ -11,7 +11,7 @@
     >
       <router-link
         :to="{ name: 'dashboard' }"
-        class="text-white text-decoration-none w-100"
+        class="text-decoration-none w-100"
       >
         <v-img
           :src="Logo"

--- a/ui/admin/src/views/DeviceDetails.vue
+++ b/ui/admin/src/views/DeviceDetails.vue
@@ -98,7 +98,7 @@
             <h3 class="item-title">Namespace:</h3>
             <router-link
               :to="{ name: 'namespaceDetails', params: { id: device.tenant_id } }"
-              class="text-white"
+              class="hyper-link"
             >
               {{ device.namespace }}
             </router-link>
@@ -208,3 +208,16 @@ onMounted(async () => {
   }
 });
 </script>
+
+<style scoped>
+.hyper-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.hyper-link:visited,
+.hyper-link:hover,
+.hyper-link:active {
+  color: inherit;
+}
+</style>

--- a/ui/admin/src/views/FirewallRulesDetails.vue
+++ b/ui/admin/src/views/FirewallRulesDetails.vue
@@ -48,7 +48,7 @@
             <h3 class="item-title">Namespace:</h3>
             <router-link
               :to="{ name: 'namespaceDetails', params: { id: firewallRule.tenant_id } }"
-              class="text-white"
+              class="hyper-link"
             >
               {{ firewallRule.tenant_id }}
             </router-link>
@@ -138,3 +138,16 @@ onMounted(async () => {
   }
 });
 </script>
+
+<style scoped>
+.hyper-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.hyper-link:visited,
+.hyper-link:hover,
+.hyper-link:active {
+  color: inherit;
+}
+</style>

--- a/ui/admin/src/views/SessionDetails.vue
+++ b/ui/admin/src/views/SessionDetails.vue
@@ -44,7 +44,7 @@
             <h3 class="item-title">Device:</h3>
             <router-link
               :to="{ name: 'deviceDetails', params: { id: session.device.uid } }"
-              class="text-white"
+              class="hyper-link"
             >
               {{ session.device.name || session.device.uid }}
             </router-link>
@@ -80,7 +80,7 @@
             <h3 class="item-title">Namespace:</h3>
             <router-link
               :to="{ name: 'namespaceDetails', params: { id: session.tenant_id } }"
-              class="text-white"
+              class="hyper-link"
             >
               {{ session.device.namespace }}
             </router-link>
@@ -139,3 +139,16 @@ onMounted(async () => {
   }
 });
 </script>
+
+<style scoped>
+.hyper-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.hyper-link:visited,
+.hyper-link:hover,
+.hyper-link:active {
+  color: inherit;
+}
+</style>

--- a/ui/admin/tests/unit/components/Device/DeviceList/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Device/DeviceList/__snapshots__/index.spec.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Device List > Renders the component 1`] = `
-"<div>
-  <div data-test="devices-list">
+"<div data-v-aca44803="">
+  <div data-v-aca44803="" data-test="devices-list">
     <div class="v-table v-theme--light v-table--density-default bg-background border rounded text-center" data-test="datatable">
       <!---->
       <div class="v-table__wrapper">
@@ -20,13 +20,13 @@ exports[`Device List > Renders the component 1`] = `
             </tr>
           </thead>
           <tbody data-test="tbody-has-items">
-            <tr>
-              <td><i class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default" style="color: rgb(229, 57, 53); caret-color: #E53935;" aria-hidden="true" data-test="error-icon"></i></td>
-              <td>39-5e-2a</td>
-              <td><span class="d-inline-flex align-center ga-2"><i data-test="device-icon" class="fl-linuxmint mr-1" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
-              <td><a href="/admin/namespace/fake-tenant-data" class="text-white">user</a></td>
-              <td>
-                <div><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-6"><!----><span class="v-chip__underlay"></span>
+            <tr data-v-aca44803="">
+              <td data-v-aca44803=""><i data-v-aca44803="" class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default" style="color: rgb(229, 57, 53); caret-color: #E53935;" aria-hidden="true" data-test="error-icon"></i></td>
+              <td data-v-aca44803="">39-5e-2a</td>
+              <td data-v-aca44803=""><span data-v-aca44803="" class="d-inline-flex align-center ga-2"><i data-v-aca44803="" data-test="device-icon" class="fl-linuxmint mr-1" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
+              <td data-v-aca44803=""><a data-v-aca44803="" href="/admin/namespace/fake-tenant-data" class="hyper-link">user</a></td>
+              <td data-v-aca44803="">
+                <div data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-6"><!----><span class="v-chip__underlay"></span>
                   <!---->
                   <!---->
                   <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -36,26 +36,26 @@ exports[`Device List > Renders the component 1`] = `
                   <!--teleport end-->
                 </div>
               </td>
-              <td>Wednesday, May 20th 2020, 6:58:53 pm</td>
-              <td><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal text-capitalize" draggable="false"><!----><span class="v-chip__underlay"></span>
+              <td data-v-aca44803="">Wednesday, May 20th 2020, 6:58:53 pm</td>
+              <td data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal text-capitalize" draggable="false"><!----><span class="v-chip__underlay"></span>
                 <!---->
                 <!---->
                 <div class="v-chip__content" data-no-activator="">accepted</div>
                 <!---->
                 <!----></span>
               </td>
-              <td><a class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-11"></a>
+              <td data-v-aca44803=""><a data-v-aca44803="" class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-11"></a>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
             </tr>
-            <tr>
-              <td><i class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" data-test="success-icon"></i></td>
-              <td>39-5e-2b</td>
-              <td><span class="d-inline-flex align-center ga-2"><i data-test="device-icon" class="fl-linuxmint mr-1" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
-              <td><a href="/admin/namespace/fake-tenant-data" class="text-white">user</a></td>
-              <td>
-                <div><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-12"><!----><span class="v-chip__underlay"></span>
+            <tr data-v-aca44803="">
+              <td data-v-aca44803=""><i data-v-aca44803="" class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" data-test="success-icon"></i></td>
+              <td data-v-aca44803="">39-5e-2b</td>
+              <td data-v-aca44803=""><span data-v-aca44803="" class="d-inline-flex align-center ga-2"><i data-v-aca44803="" data-test="device-icon" class="fl-linuxmint mr-1" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
+              <td data-v-aca44803=""><a data-v-aca44803="" href="/admin/namespace/fake-tenant-data" class="hyper-link">user</a></td>
+              <td data-v-aca44803="">
+                <div data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-12"><!----><span class="v-chip__underlay"></span>
                   <!---->
                   <!---->
                   <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -65,15 +65,15 @@ exports[`Device List > Renders the component 1`] = `
                   <!--teleport end-->
                 </div>
               </td>
-              <td>Wednesday, May 20th 2020, 7:58:53 pm</td>
-              <td><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal text-capitalize" draggable="false"><!----><span class="v-chip__underlay"></span>
+              <td data-v-aca44803="">Wednesday, May 20th 2020, 7:58:53 pm</td>
+              <td data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal text-capitalize" draggable="false"><!----><span class="v-chip__underlay"></span>
                 <!---->
                 <!---->
                 <div class="v-chip__content" data-no-activator="">accepted</div>
                 <!---->
                 <!----></span>
               </td>
-              <td><a class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-17"></a>
+              <td data-v-aca44803=""><a data-v-aca44803="" class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-17"></a>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
@@ -44,8 +44,8 @@ exports[`Device > Renders the component 1`] = `
   </div>
   <div class="v-spacer"></div>
 </div>
-<div>
-  <div data-test="devices-list">
+<div data-v-aca44803="">
+  <div data-v-aca44803="" data-test="devices-list">
     <div class="v-table v-theme--light v-table--density-default bg-background border rounded text-center" data-test="datatable">
       <!---->
       <div class="v-table__wrapper">
@@ -63,13 +63,13 @@ exports[`Device > Renders the component 1`] = `
             </tr>
           </thead>
           <tbody data-test="tbody-has-items">
-            <tr>
-              <td><i class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default" style="color: rgb(229, 57, 53); caret-color: #E53935;" aria-hidden="true" data-test="error-icon"></i></td>
-              <td>39-5e-2a</td>
-              <td><span class="d-inline-flex align-center ga-2"><i data-test="device-icon" class="fl-linuxmint mr-1" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
-              <td><a href="/admin/namespace/fake-tenant-data" class="text-white">user</a></td>
-              <td>
-                <div><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-16"><!----><span class="v-chip__underlay"></span>
+            <tr data-v-aca44803="">
+              <td data-v-aca44803=""><i data-v-aca44803="" class="mdi-close-circle mdi v-icon notranslate v-theme--light v-icon--size-default" style="color: rgb(229, 57, 53); caret-color: #E53935;" aria-hidden="true" data-test="error-icon"></i></td>
+              <td data-v-aca44803="">39-5e-2a</td>
+              <td data-v-aca44803=""><span data-v-aca44803="" class="d-inline-flex align-center ga-2"><i data-v-aca44803="" data-test="device-icon" class="fl-linuxmint mr-1" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
+              <td data-v-aca44803=""><a data-v-aca44803="" href="/admin/namespace/fake-tenant-data" class="hyper-link">user</a></td>
+              <td data-v-aca44803="">
+                <div data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-16"><!----><span class="v-chip__underlay"></span>
                   <!---->
                   <!---->
                   <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -79,26 +79,26 @@ exports[`Device > Renders the component 1`] = `
                   <!--teleport end-->
                 </div>
               </td>
-              <td>Wednesday, May 20th 2020, 6:58:53 pm</td>
-              <td><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal text-capitalize" draggable="false"><!----><span class="v-chip__underlay"></span>
+              <td data-v-aca44803="">Wednesday, May 20th 2020, 6:58:53 pm</td>
+              <td data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal text-capitalize" draggable="false"><!----><span class="v-chip__underlay"></span>
                 <!---->
                 <!---->
                 <div class="v-chip__content" data-no-activator="">accepted</div>
                 <!---->
                 <!----></span>
               </td>
-              <td><a class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-21"></a>
+              <td data-v-aca44803=""><a data-v-aca44803="" class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-21"></a>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>
             </tr>
-            <tr>
-              <td><i class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" data-test="success-icon"></i></td>
-              <td>39-5e-2b</td>
-              <td><span class="d-inline-flex align-center ga-2"><i data-test="device-icon" class="fl-linuxmint mr-1" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
-              <td><a href="/admin/namespace/fake-tenant-data" class="text-white">user</a></td>
-              <td>
-                <div><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-22"><!----><span class="v-chip__underlay"></span>
+            <tr data-v-aca44803="">
+              <td data-v-aca44803=""><i data-v-aca44803="" class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" data-test="success-icon"></i></td>
+              <td data-v-aca44803="">39-5e-2b</td>
+              <td data-v-aca44803=""><span data-v-aca44803="" class="d-inline-flex align-center ga-2"><i data-v-aca44803="" data-test="device-icon" class="fl-linuxmint mr-1" style="font-size: 20px;"></i> Linux Mint 19.3</span></td>
+              <td data-v-aca44803=""><a data-v-aca44803="" href="/admin/namespace/fake-tenant-data" class="hyper-link">user</a></td>
+              <td data-v-aca44803="">
+                <div data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal" draggable="false" aria-describedby="v-tooltip-v-22"><!----><span class="v-chip__underlay"></span>
                   <!---->
                   <!---->
                   <div class="v-chip__content" data-no-activator="">test-tag</div>
@@ -108,15 +108,15 @@ exports[`Device > Renders the component 1`] = `
                   <!--teleport end-->
                 </div>
               </td>
-              <td>Wednesday, May 20th 2020, 7:58:53 pm</td>
-              <td><span class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal text-capitalize" draggable="false"><!----><span class="v-chip__underlay"></span>
+              <td data-v-aca44803="">Wednesday, May 20th 2020, 7:58:53 pm</td>
+              <td data-v-aca44803=""><span data-v-aca44803="" class="v-chip v-theme--light v-chip--density-default v-chip--size-small v-chip--variant-tonal text-capitalize" draggable="false"><!----><span class="v-chip__underlay"></span>
                 <!---->
                 <!---->
                 <div class="v-chip__content" data-no-activator="">accepted</div>
                 <!---->
                 <!----></span>
               </td>
-              <td><a class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-27"></a>
+              <td data-v-aca44803=""><a data-v-aca44803="" class="mdi-information mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" dark="" aria-describedby="v-tooltip-v-27"></a>
                 <!--teleport start-->
                 <!--teleport end-->
               </td>

--- a/ui/admin/tests/unit/views/SessionDetails/index.spec.ts
+++ b/ui/admin/tests/unit/views/SessionDetails/index.spec.ts
@@ -72,11 +72,6 @@ describe("Session Details", async () => {
     expect(wrapper.find(".text-h6").text()).toBe(sessionDetail.uid);
   });
 
-  it("Shows active status icon with tooltip", () => {
-    const icon = wrapper.find('[data-test="active-icon"]');
-    expect(icon.classes()).toContain("text-white");
-  });
-
   it("Displays session UID", () => {
     const uidField = wrapper.find('[data-test="session-uid-field"]');
     expect(uidField.text()).toContain("UID:");

--- a/ui/src/components/CopyCommandField.vue
+++ b/ui/src/components/CopyCommandField.vue
@@ -9,7 +9,7 @@
         data-test="copy-command-field"
         :persistent-hint
         :hide-details
-        class="code text-white"
+        class="code"
         readonly
         density="compact"
       >

--- a/ui/src/components/Welcome/WelcomeFirstScreen.vue
+++ b/ui/src/components/Welcome/WelcomeFirstScreen.vue
@@ -43,11 +43,11 @@
           class="mr-4"
           :icon="feature.icon"
         />
-        <div class="text-white">
-          <v-card-title class="text-h6 mb-1 pa-0">
+        <div class="text-high-emphasis">
+          <v-card-title class="text-h6 mb-1 pa-0 text-high-emphasis">
             {{ feature.title }}
           </v-card-title>
-          <v-card-subtitle class="mb-0 pl-0">
+          <v-card-subtitle class="mb-0 pl-0 text-medium-emphasis">
             {{ feature.description }}
           </v-card-subtitle>
         </div>

--- a/ui/src/components/Welcome/WelcomeFourthScreen.vue
+++ b/ui/src/components/Welcome/WelcomeFourthScreen.vue
@@ -51,7 +51,7 @@
       class="pa-4 mb-4"
     >
       <div class="mb-3">
-        <h4 class="text-h6 mb-3 d-flex align-center text-white">
+        <h4 class="text-h6 mb-3 d-flex align-center text-high-emphasis">
           <v-icon
             color="primary"
             class="mr-2"

--- a/ui/src/components/Welcome/WelcomeSecondScreen.vue
+++ b/ui/src/components/Welcome/WelcomeSecondScreen.vue
@@ -25,8 +25,8 @@
       class="pa-4 mb-4"
       color="primary"
     >
-      <div class="mb-1 text-white">
-        <h3>Requirements:</h3>
+      <div class="mb-1 text-high-emphasis">
+        <h3 class="text-h6">Requirements:</h3>
         <v-list
           class="bg-transparent"
           :lines="false"

--- a/ui/src/components/Welcome/WelcomeThirdScreen.vue
+++ b/ui/src/components/Welcome/WelcomeThirdScreen.vue
@@ -44,7 +44,7 @@
       <v-expansion-panel
         class="border bg-background rounded"
       >
-        <v-expansion-panel-title class="text-white bg-v-theme-surface border-b d-flex align-center">
+        <v-expansion-panel-title class="text-high-emphasis bg-v-theme-surface border-b d-flex align-center">
           <DeviceIcon
             v-if="firstPendingDevice.info"
             :icon="firstPendingDevice.info.id"
@@ -60,7 +60,7 @@
             </div>
             <div
               v-if="firstPendingDevice.info"
-              class="text-body-2 text-white"
+              class="text-body-2 text-medium-emphasis"
               data-test="device-pretty-name-field"
             >
               {{ firstPendingDevice.info.pretty_name }}

--- a/ui/tests/components/Containers/__snapshots__/ContainerAdd.spec.ts.snap
+++ b/ui/tests/components/Containers/__snapshots__/ContainerAdd.spec.ts.snap
@@ -61,7 +61,7 @@ exports[`ContainerAdd > Renders the component 1`] = `
               <p class="text-body-2 mb-2"> The easiest way to install the ShellHub Connector is with our automatic one-line installation script, which connects to the Docker API and exposes the running containers within ShellHub. </p>
               <p class="text-body-2 font-weight-bold mt-3"> Run the following command on your Docker host: </p>
               <div data-v-0cebd2fd="" class="mt-1 mb-3">
-                <div data-v-0cebd2fd="" class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--readonly v-text-field v-text-field--prefixed code text-white" data-test="copy-command-field">
+                <div data-v-0cebd2fd="" class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--readonly v-text-field v-text-field--prefixed code" data-test="copy-command-field">
                   <!---->
                   <div class="v-input__control">
                     <div class="v-field v-field--active v-field--center-affix v-field--dirty v-field--no-label v-field--variant-filled v-theme--light v-locale--is-ltr">

--- a/ui/tests/components/CopyCommandField/__snapshots__/CopyCommandField.spec.ts.snap
+++ b/ui/tests/components/CopyCommandField/__snapshots__/CopyCommandField.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`CopyCommandField > renders the component 1`] = `
 "<div data-v-0cebd2fd="" copied-item="Command" persistentplaceholder="true">
-  <div data-v-0cebd2fd="" class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--readonly v-text-field v-text-field--prefixed code text-white" data-test="copy-command-field">
+  <div data-v-0cebd2fd="" class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--readonly v-text-field v-text-field--prefixed code" data-test="copy-command-field">
     <!---->
     <div class="v-input__control">
       <div class="v-field v-field--active v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr">

--- a/ui/tests/components/Welcome/__snapshots__/WelcomeFirstScreen.spec.ts.snap
+++ b/ui/tests/components/Welcome/__snapshots__/WelcomeFirstScreen.spec.ts.snap
@@ -29,9 +29,9 @@ exports[`Welcome First Screen > Renders the component 1`] = `
     <!---->
     <!---->
     <div class="d-flex align-center h-100"><i class="mdi-monitor mdi v-icon notranslate v-theme--light text-primary mr-4" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
-      <div class="text-white">
-        <div class="v-card-title text-h6 mb-1 pa-0">Remote Access</div>
-        <div class="v-card-subtitle mb-0 pl-0">Access your Linux devices from anywhere via CLI or web interface</div>
+      <div class="text-high-emphasis">
+        <div class="v-card-title text-h6 mb-1 pa-0 text-high-emphasis">Remote Access</div>
+        <div class="v-card-subtitle mb-0 pl-0 text-medium-emphasis">Access your Linux devices from anywhere via CLI or web interface</div>
       </div>
     </div>
     <!---->
@@ -56,9 +56,9 @@ exports[`Welcome First Screen > Renders the component 1`] = `
     <!---->
     <!---->
     <div class="d-flex align-center h-100"><i class="mdi-shield-check mdi v-icon notranslate v-theme--light text-primary mr-4" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
-      <div class="text-white">
-        <div class="v-card-title text-h6 mb-1 pa-0">Secure Connection</div>
-        <div class="v-card-subtitle mb-0 pl-0">Bypass firewalls and NAT with secure, encrypted connections</div>
+      <div class="text-high-emphasis">
+        <div class="v-card-title text-h6 mb-1 pa-0 text-high-emphasis">Secure Connection</div>
+        <div class="v-card-subtitle mb-0 pl-0 text-medium-emphasis">Bypass firewalls and NAT with secure, encrypted connections</div>
       </div>
     </div>
     <!---->
@@ -83,9 +83,9 @@ exports[`Welcome First Screen > Renders the component 1`] = `
     <!---->
     <!---->
     <div class="d-flex align-center h-100"><i class="mdi-cogs mdi v-icon notranslate v-theme--light text-primary mr-4" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
-      <div class="text-white">
-        <div class="v-card-title text-h6 mb-1 pa-0">Easy Setup</div>
-        <div class="v-card-subtitle mb-0 pl-0">Automated access process with seamless device management</div>
+      <div class="text-high-emphasis">
+        <div class="v-card-title text-h6 mb-1 pa-0 text-high-emphasis">Easy Setup</div>
+        <div class="v-card-subtitle mb-0 pl-0 text-medium-emphasis">Automated access process with seamless device management</div>
       </div>
     </div>
     <!---->

--- a/ui/tests/components/Welcome/__snapshots__/WelcomeFourthScreen.spec.ts.snap
+++ b/ui/tests/components/Welcome/__snapshots__/WelcomeFourthScreen.spec.ts.snap
@@ -55,7 +55,7 @@ exports[`Welcome Fourth Screen > Renders the component 1`] = `
     <!---->
     <!---->
     <div class="mb-3">
-      <h4 class="text-h6 mb-3 d-flex align-center text-white"><i class="mdi-compass mdi v-icon notranslate v-theme--light v-icon--size-default text-primary mr-2" aria-hidden="true"></i> Helpful Resources </h4>
+      <h4 class="text-h6 mb-3 d-flex align-center text-high-emphasis"><i class="mdi-compass mdi v-icon notranslate v-theme--light v-icon--size-default text-primary mr-2" aria-hidden="true"></i> Helpful Resources </h4>
       <div class="d-flex flex-wrap ga-4"><a href="http://docs.shellhub.io/" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-tonal" target="_blank" rel="noopener noreferrer" data-test="welcome-fourth-links"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span><span class="v-btn__prepend"><i class="mdi-book-open-variant mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span><span class="v-btn__content" data-no-activator=""> Documentation <i class="mdi-open-in-new mdi v-icon notranslate v-theme--light ml-1" style="font-size: 12px; height: 12px; width: 12px;" aria-hidden="true"></i></span>
           <!---->
           <!---->

--- a/ui/tests/components/Welcome/__snapshots__/WelcomeSecondScreen.spec.ts.snap
+++ b/ui/tests/components/Welcome/__snapshots__/WelcomeSecondScreen.spec.ts.snap
@@ -27,8 +27,8 @@ exports[`Welcome Second Screen > Renders the component 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="mb-1 text-white">
-      <h3>Requirements:</h3>
+    <div class="mb-1 text-high-emphasis">
+      <h3 class="text-h6">Requirements:</h3>
       <div class="v-list v-theme--light v-list--density-default bg-transparent" tabindex="0" role="list">
         <div class="v-list-item v-theme--light v-list-item--density-compact rounded-0 v-list-item--variant-text d-flex align-center pa-0" role="listitem">
           <!----><span class="v-list-item__underlay"></span>
@@ -68,7 +68,7 @@ exports[`Welcome Second Screen > Renders the component 1`] = `
         <!---->
         <div data-test="welcome-second-run-title"> Ready to install? Copy the command below and run it on your target device: </div>
         <div data-v-0cebd2fd="" class="mt-3">
-          <div data-v-0cebd2fd="" class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--readonly v-text-field v-text-field--prefixed code text-white" data-test="copy-command-field">
+          <div data-v-0cebd2fd="" class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--readonly v-text-field v-text-field--prefixed code" data-test="copy-command-field">
             <!---->
             <div class="v-input__control">
               <div class="v-field v-field--active v-field--center-affix v-field--dirty v-field--no-label v-field--variant-filled v-theme--light v-locale--is-ltr">

--- a/ui/tests/components/Welcome/__snapshots__/WelcomeThirdScreen.spec.ts.snap
+++ b/ui/tests/components/Welcome/__snapshots__/WelcomeThirdScreen.spec.ts.snap
@@ -25,10 +25,10 @@ exports[`Welcome Third Screen > Renders the component 1`] = `
     <div class="v-expansion-panel border bg-background rounded">
       <div class="v-expansion-panel__shadow"></div>
       <!---->
-      <!----><button class="v-expansion-panel-title text-white bg-v-theme-surface border-b d-flex align-center" type="button" aria-expanded="false"><span class="v-expansion-panel-title__overlay"></span><i data-test="device-icon" class="fl-linuxmint mr-1 mr-3" style="font-size: 20px;" size="32"></i>
+      <!----><button class="v-expansion-panel-title text-high-emphasis bg-v-theme-surface border-b d-flex align-center" type="button" aria-expanded="false"><span class="v-expansion-panel-title__overlay"></span><i data-test="device-icon" class="fl-linuxmint mr-1 mr-3" style="font-size: 20px;" size="32"></i>
         <div>
           <div class="text-h6" data-test="device-field">39-5e-2a</div>
-          <div class="text-body-2 text-white" data-test="device-pretty-name-field">Linux Mint 19.3</div>
+          <div class="text-body-2 text-medium-emphasis" data-test="device-pretty-name-field">Linux Mint 19.3</div>
         </div><span class="v-expansion-panel-title__icon"><i class="mdi-chevron-down mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       </button>
       <transition-stub name="expand-transition" appear="false" persisted="false" css="true">

--- a/ui/tests/views/__snapshots__/Setup.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/Setup.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`Setup Account > Renders the component 1`] = `
           <div class="v-window-item v-window-item--active">
             <div class="v-card-subtitle text-wrap text-justify px-0" data-test="subtitle-1"> To set up your account, please run the following command in your terminal to generate a signature. Use the generated signature in the "Sign" field below to proceed. </div>
             <div data-v-0cebd2fd="" class="my-4" data-test="setup-command-field">
-              <div data-v-0cebd2fd="" class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--readonly v-text-field v-text-field--prefixed code text-white" data-test="copy-command-field">
+              <div data-v-0cebd2fd="" class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--readonly v-text-field v-text-field--prefixed code" data-test="copy-command-field">
                 <!---->
                 <div class="v-input__control">
                   <div class="v-field v-field--active v-field--center-affix v-field--dirty v-field--variant-filled v-theme--light v-locale--is-ltr">


### PR DESCRIPTION
# Description

This PR fixes multiple UI text contrast issues that occur when using the
light theme. Several components relied on hardcoded text-white styles,
which made text unreadable on light backgrounds.

The fix replaces those styles with Vuetify theme-aware emphasis classes
and introduces a reusable hyperlink style that inherits the active theme
color.

## What changed

Replaced `text-white` with `text-high-emphasis` and
`text-medium-emphasis` across admin and user UIs
Added a `.hyper-link` class for router links that respects theme colors
Updated layout and welcome screens to use theme-safe text styles
Adjusted unit tests impacted by the removal of `text-white`

## Why this change

text-white breaks readability in light mode
Vuetify provides built-in emphasis utilities designed for theming
Ensures consistent behavior across light and dark themes
Improves accessibility and visual consistency

## Testing

Verified affected screens in both light and dark themes
Unit tests updated and passing