### PR TITLE
fix(ui): standardize WebEndpoints search bar placement

### DIFF
--- a/ui/src/views/WebEndpoints.vue
+++ b/ui/src/views/WebEndpoints.vue
@@ -7,19 +7,6 @@
     icon-color="primary"
   >
     <template #actions>
-      <v-text-field
-        v-if="showList"
-        v-model.trim="filter"
-        label="Search by Address"
-        variant="outlined"
-        color="primary"
-        single-line
-        hide-details
-        prepend-inner-icon="mdi-magnify"
-        density="compact"
-        data-test="search-text"
-        @keyup="searchWebEndpoints"
-      />
       <v-btn
         color="primary"
         variant="elevated"
@@ -32,6 +19,20 @@
       </v-btn>
     </template>
   </PageHeader>
+
+  <v-text-field
+    v-if="showList"
+    v-model.trim="filter"
+    label="Search by Address"
+    variant="outlined"
+    color="primary"
+    single-line
+    hide-details
+    prepend-inner-icon="mdi-magnify"
+    density="compact"
+    data-test="search-text"
+    @keyup="searchWebEndpoints"
+  />
 
   <WebEndpointList
     v-if="showList"


### PR DESCRIPTION
# Description

This PR updates the WebEndpoints view to follow the standard search bar
layout used across the UI. The search input has been moved out of the
`PageHeader` actions slot and placed below the header for consistent
positioning and spacing.

## What changed

- Moved the WebEndpoints search text field out of `PageHeader` actions
- Preserved existing search behavior and bindings
- Aligned the view with the standard search bar pattern used elsewhere

## Why this change

- The search bar layout was inconsistent with other list views
- Standardizing placement improves usability and visual consistency
- Simplifies future layout and styling changes