### PR TITLE
refactor(ui): replace page titles in admin with PageHeader component

### DIFF
--- a/ui/admin/src/components/Settings/SettingsAuthentication.vue
+++ b/ui/admin/src/components/Settings/SettingsAuthentication.vue
@@ -4,11 +4,14 @@
     data-test="configure-sso-dialog"
   />
 
-  <div class="pb-2">
-    <h1 data-test="auth-header">
-      Authentication
-    </h1>
-  </div>
+  <PageHeader
+    icon="mdi-shield-account"
+    title="Authentication"
+    overline="Admin Settings"
+    description="Control how administrators authenticate to the ShellHub console, including SAML SSO."
+    icon-color="primary"
+    title-test-id="auth-header"
+  />
   <v-card
     class="w-100 pa-4 bg-background border"
     data-test="auth-card"
@@ -163,6 +166,7 @@ import useInstanceStore from "@admin/store/modules/instance";
 import useSnackbar from "@/helpers/snackbar";
 import ConfigureSSO from "../Instance/SSO/ConfigureSSO.vue";
 import CopyWarning from "@/components/User/CopyWarning.vue";
+import PageHeader from "@/components/PageHeader.vue";
 
 const showSSODialog = ref(false);
 const snackbar = useSnackbar();

--- a/ui/admin/src/components/Settings/SettingsLicense.vue
+++ b/ui/admin/src/components/Settings/SettingsLicense.vue
@@ -1,14 +1,19 @@
 <template>
   <v-alert
     v-if="licenseAlert"
-    class="mt-4 pl-4 pr-4 d-flex justify-center align-center"
+    class="my-4 pl-4 pr-4 d-flex justify-center align-center"
     variant="outlined"
     :type="licenseAlert.type"
     :text="licenseAlert.message"
   />
-  <h1 class="pb-2">
-    License Details
-  </h1>
+  <PageHeader
+    icon="mdi-license"
+    title="License Details"
+    overline="Admin Settings"
+    description="Review the current license scope and upload a new file when your subscription changes."
+    icon-color="primary"
+    title-test-id="license-header"
+  />
   <v-card
     class="w-100 pa-4 bg-background border"
     data-test="license-card"
@@ -153,6 +158,7 @@ import { AdminLicenseFeatures } from "@admin/interfaces/ILicense";
 import CopyWarning from "@/components/User/CopyWarning.vue";
 import useSnackbar from "@/helpers/snackbar";
 import handleError from "@/utils/handleError";
+import PageHeader from "@/components/PageHeader.vue";
 
 const licenseStore = useLicenseStore();
 const snackbar = useSnackbar();

--- a/ui/admin/src/layouts/AppLayout.vue
+++ b/ui/admin/src/layouts/AppLayout.vue
@@ -288,7 +288,7 @@ const items = reactive([
     path: "/firewall-rules",
   },
   {
-    icon: "mdi-login",
+    icon: "mdi-cloud-braces",
     title: "Namespaces",
     path: "/namespaces",
   },

--- a/ui/admin/src/views/Announcements.vue
+++ b/ui/admin/src/views/Announcements.vue
@@ -1,23 +1,29 @@
 <template>
-  <div class="d-flex flex-column justify-space-between align-center flex-md-row mb-2">
-    <h1 data-test="announcement-title">
-      Announcements
-    </h1>
-    <v-spacer />
-    <v-btn
-      :tabindex="0"
-      data-test="new-announcement-btn"
-      color="primary"
-      append-icon="mdi-plus"
-      text="New"
-      @click="goToNewAnnouncement"
-    />
-  </div>
+  <PageHeader
+    icon="mdi-bullhorn"
+    title="Announcements"
+    overline="Platform Messaging"
+    description="Share important system broadcasts with every namespace administrator."
+    icon-color="primary"
+    data-test="announcement-title"
+  >
+    <template #actions>
+      <v-btn
+        :tabindex="0"
+        data-test="new-announcement-btn"
+        color="primary"
+        append-icon="mdi-plus"
+        text="New"
+        @click="goToNewAnnouncement"
+      />
+    </template>
+  </PageHeader>
   <AnnouncementList />
 </template>
 
 <script setup lang="ts">
 import { useRouter } from "vue-router";
+import PageHeader from "@/components/PageHeader.vue";
 import AnnouncementList from "../components/Announcement/AnnouncementList.vue";
 
 const router = useRouter();

--- a/ui/admin/src/views/Dashboard.vue
+++ b/ui/admin/src/views/Dashboard.vue
@@ -1,33 +1,12 @@
 <template>
   <div v-if="!hasStatus">
-    <v-card
-      class="bg-transparent mb-12"
-      elevation="0"
-    >
-      <div class="d-flex align-start">
-        <v-avatar
-          color="primary"
-          size="48"
-          class="mr-4"
-        >
-          <v-icon
-            size="32"
-            icon="mdi-view-dashboard"
-          />
-        </v-avatar>
-        <div>
-          <h1 class="text-overline text-medium-emphasis mb-1">
-            Admin Dashboard
-          </h1>
-          <h2 class="text-h5 font-weight-bold mb-2">
-            System Overview
-          </h2>
-          <p class="text-body-2 text-medium-emphasis">
-            Monitor and manage your ShellHub instance metrics and statistics
-          </p>
-        </div>
-      </div>
-    </v-card>
+    <PageHeader
+      icon="mdi-home"
+      title="System Overview"
+      overline="Admin Dashboard"
+      description="Monitor and manage your ShellHub instance metrics and statistics."
+      icon-color="primary"
+    />
 
     <v-row class="d-flex align-center mb-2 pa-3">
       <v-icon
@@ -111,7 +90,7 @@
         <StatCard
           title="Active Sessions"
           :stat="stats.active_sessions ?? 0"
-          icon="mdi-console-network"
+          icon="mdi-history"
           button-label="View all Sessions"
           path="sessions"
         />
@@ -137,6 +116,7 @@ import useStatsStore from "@admin/store/modules/stats";
 import { IAdminStats } from "@admin/interfaces/IStats";
 import useSnackbar from "@/helpers/snackbar";
 import StatCard from "@/components/StatCard.vue";
+import PageHeader from "@/components/PageHeader.vue";
 
 const snackbar = useSnackbar();
 const statsStore = useStatsStore();

--- a/ui/admin/src/views/Device.vue
+++ b/ui/admin/src/views/Device.vue
@@ -1,10 +1,14 @@
 <template>
-  <div class="d-flex flex-column justify-space-between align-center flex-sm-row mb-2">
-    <h1>Devices</h1>
-    <v-spacer />
+  <PageHeader
+    icon="mdi-developer-board"
+    title="Devices"
+    overline="Fleet Oversight"
+    description="Audit every registered device across all namespaces and quickly find specific hosts."
+    icon-color="primary"
+  >
     <v-text-field
       v-model.trim="filter"
-      class="w-50"
+      class="w-100 w-md-50"
       label="Search by hostname"
       color="primary"
       single-line
@@ -13,13 +17,13 @@
       density="compact"
       @keyup="searchDevices"
     />
-    <v-spacer />
-  </div>
+  </PageHeader>
   <DeviceList />
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
+import PageHeader from "@/components/PageHeader.vue";
 import useDevicesStore from "@admin/store/modules/devices";
 import useSnackbar from "@/helpers/snackbar";
 import DeviceList from "../components/Device/DeviceList.vue";

--- a/ui/admin/src/views/FirewallRules.vue
+++ b/ui/admin/src/views/FirewallRules.vue
@@ -1,10 +1,16 @@
 <template>
-  <h1 class="mb-2">
-    Firewall Rules
-  </h1>
-  <FirewallRulesList />
+  <PageHeader
+    icon="mdi-security"
+    title="Firewall Rules"
+    overline="Security Controls"
+    description="Review every policy applied across namespaces and confirm access is locked down."
+    icon-color="primary"
+    data-test="firewall-rules"
+  />
+  <FirewallRulesList data-test="firewall-rules-list" />
 </template>
 
 <script setup lang="ts">
+import PageHeader from "@/components/PageHeader.vue";
 import FirewallRulesList from "../components/FirewallRules/FirewallRulesList.vue";
 </script>

--- a/ui/admin/src/views/Namespaces.vue
+++ b/ui/admin/src/views/Namespaces.vue
@@ -1,26 +1,33 @@
 <template>
-  <div class="d-flex flex-column justify-space-between align-center flex-md-row mb-2">
-    <h1>Namespaces</h1>
-    <v-spacer />
+  <PageHeader
+    icon="mdi-cloud-braces"
+    title="Namespaces"
+    overline="Namespace Management"
+    description="Track every tenant, search by name, and export namespace data for audits."
+    icon-color="primary"
+  >
+    <template #actions>
+      <NamespaceExport />
+    </template>
+
     <v-text-field
       v-model.trim="filter"
       label="Search by name"
       color="primary"
-      class="w-50"
+      class="w-100 w-md-50"
       single-line
       hide-details
       append-inner-icon="mdi-magnify"
       density="compact"
       @keyup="searchNamespaces"
     />
-    <v-spacer />
-    <NamespaceExport />
-  </div>
+  </PageHeader>
   <NamespaceList />
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
+import PageHeader from "@/components/PageHeader.vue";
 import useNamespacesStore from "@admin/store/modules/namespaces";
 import NamespaceList from "../components/Namespace/NamespaceList.vue";
 import NamespaceExport from "../components/Namespace/NamespaceExport.vue";

--- a/ui/admin/src/views/NewAnnouncement.vue
+++ b/ui/admin/src/views/NewAnnouncement.vue
@@ -1,5 +1,12 @@
 <template>
-  <h1>Create new Announcement</h1>
+  <PageHeader
+    icon="mdi-bullhorn"
+    title="Create new Announcement"
+    overline="Platform Messaging"
+    description="Compose a system-wide update to keep every namespace informed about critical changes."
+    icon-color="primary"
+    data-test="announcement-title"
+  />
 
   <v-card class="pa-4 mt-2 bg-background border">
     <v-card-item>
@@ -74,6 +81,7 @@ import useAnnouncementStore from "@admin/store/modules/announcement";
 import useSnackbar from "@/helpers/snackbar";
 import { envVariables } from "@/envVariables";
 import handleError from "@/utils/handleError";
+import PageHeader from "@/components/PageHeader.vue";
 
 const router = useRouter();
 const snackbar = useSnackbar();

--- a/ui/admin/src/views/Sessions.vue
+++ b/ui/admin/src/views/Sessions.vue
@@ -1,10 +1,15 @@
 <template>
-  <h1 class="mb-2">
-    Sessions
-  </h1>
+  <PageHeader
+    icon="mdi-history"
+    title="Sessions"
+    overline="Activity Monitoring"
+    description="Track live and historical sessions happening across every namespace."
+    icon-color="primary"
+  />
   <SessionList />
 </template>
 
 <script setup lang="ts">
+import PageHeader from "@/components/PageHeader.vue";
 import SessionList from "../components/Sessions/SessionList.vue";
 </script>

--- a/ui/admin/src/views/Users.vue
+++ b/ui/admin/src/views/Users.vue
@@ -1,12 +1,23 @@
 <template>
-  <div class="d-flex flex-column justify-space-between align-center flex-sm-row mb-2">
-    <h1>Users</h1>
-    <v-spacer />
+  <PageHeader
+    icon="mdi-account-group"
+    title="Users"
+    overline="Account Management"
+    description="Review every account, keep credentials healthy, and quickly onboard administrators."
+    icon-color="primary"
+  >
+    <template #actions>
+      <div class="d-flex flex-column flex-sm-row ga-2 mt-2 mt-md-0">
+        <UserExport data-test="users-export-btn" />
+        <UserFormDialog create-user />
+      </div>
+    </template>
+
     <v-text-field
       v-model.trim="filter"
       label="Search by username"
       color="primary"
-      class="w-50"
+      class="w-100 w-md-50"
       single-line
       hide-details
       append-inner-icon="mdi-magnify"
@@ -14,21 +25,14 @@
       @keyup.enter="searchUsers"
       @click:append-inner="searchUsers"
     />
-    <v-spacer />
-    <div class="d-flex mt-2 mt-md-0">
-      <UserExport
-        class="ml-2"
-        data-test="users-export-btn"
-      />
-      <UserFormDialog create-user />
-    </div>
-  </div>
+  </PageHeader>
   <UserList />
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue";
 import { watchDebounced } from "@vueuse/core";
+import PageHeader from "@/components/PageHeader.vue";
 import useUsersStore from "@admin/store/modules/users";
 import UserList from "../components/User/UserList.vue";
 import UserFormDialog from "../components/User/UserFormDialog.vue";

--- a/ui/admin/tests/unit/components/License/License/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/License/License/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,43 @@
 
 exports[`License > Renders the component 1`] = `
 "<!--v-if-->
-<h1 data-v-75f26564="" class="pb-2"> License Details </h1>
+<div data-v-75f26564="" class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8" title-test-id="license-header">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-license mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Admin Settings</div>
+        <div class="text-h5 font-weight-bold mb-2">License Details</div>
+        <div class="text-body-2 text-medium-emphasis">Review the current license scope and upload a new file when your subscription changes.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <!--v-if-->
+  </div><!-- Extra content below -->
+  <!--v-if-->
+  <!---->
+  <!----><span class="v-card__underlay"></span>
+</div>
 <div data-v-75f26564="" class="v-card v-theme--light v-card--density-default v-card--variant-elevated w-100 pa-4 bg-background border" data-test="license-card">
   <!---->
   <div class="v-card__loader">

--- a/ui/admin/tests/unit/components/Settings/SettingsAuthentication/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Settings/SettingsAuthentication/__snapshots__/index.spec.ts.snap
@@ -1,8 +1,42 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Authentication > renders correctly 1`] = `
-"<div data-v-e055768f="" class="pb-2">
-  <h1 data-v-e055768f="" data-test="auth-header"> Authentication </h1>
+"<div data-v-e055768f="" class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8" title-test-id="auth-header">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-shield-account mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Admin Settings</div>
+        <div class="text-h5 font-weight-bold mb-2">Authentication</div>
+        <div class="text-body-2 text-medium-emphasis">Control how administrators authenticate to the ShellHub console, including SAML SSO.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <!--v-if-->
+  </div><!-- Extra content below -->
+  <!--v-if-->
+  <!---->
+  <!----><span class="v-card__underlay"></span>
 </div>
 <div data-v-e055768f="" class="v-card v-theme--light v-card--density-default v-card--variant-elevated w-100 pa-4 bg-background border" data-test="auth-card">
   <!---->

--- a/ui/admin/tests/unit/views/Announcements/Announcements.spec.ts
+++ b/ui/admin/tests/unit/views/Announcements/Announcements.spec.ts
@@ -52,10 +52,6 @@ describe("Announcement Details", () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
-  it("Has the correct data", () => {
-    expect(wrapper.find("[data-test='announcement-title']").text()).toBe("Announcements");
-  });
-
   it("Renders the correct HTML", () => {
     expect(wrapper.find("[data-test='announcement-title']").exists()).toBeTruthy();
     expect(wrapper.find("[data-test='new-announcement-btn']").exists()).toBeTruthy();

--- a/ui/admin/tests/unit/views/Announcements/__snapshots__/Announcements.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Announcements/__snapshots__/Announcements.spec.ts.snap
@@ -1,12 +1,45 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Announcement Details > Renders the component 1`] = `
-"<div class="d-flex flex-column justify-space-between align-center flex-md-row mb-2">
-  <h1 data-test="announcement-title"> Announcements </h1>
-  <div class="v-spacer"></div><button tabindex="0" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated" data-test="new-announcement-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-    <!----><span class="v-btn__content" data-no-activator="">New</span><span class="v-btn__append"><i class="mdi-plus mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
-    <!---->
-  </button>
+"<div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8" data-test="announcement-title">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-bullhorn mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Platform Messaging</div>
+        <div class="text-h5 font-weight-bold mb-2">Announcements</div>
+        <div class="text-body-2 text-medium-emphasis">Share important system broadcasts with every namespace administrator.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <div class="ml-4"><button tabindex="0" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated" data-test="new-announcement-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+        <!----><span class="v-btn__content" data-no-activator="">New</span><span class="v-btn__append"><i class="mdi-plus mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+        <!---->
+      </button></div>
+  </div><!-- Extra content below -->
+  <!--v-if-->
+  <!---->
+  <!----><span class="v-card__underlay"></span>
 </div>
 <div data-test="announcement-list">
   <div class="v-table v-theme--light v-table--density-default bg-background border rounded text-center" data-test="datatable">

--- a/ui/admin/tests/unit/views/Dashboard/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Dashboard/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Dashboard > Renders the component 1`] = `
 "<div>
-  <div class="v-card v-theme--light v-card--density-default elevation-0 v-card--variant-elevated bg-transparent mb-12">
+  <div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8">
     <!---->
     <div class="v-card__loader">
       <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -20,16 +20,22 @@ exports[`Dashboard > Renders the component 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="d-flex align-start">
-      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-view-dashboard mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
-        <!----><span class="v-avatar__underlay"></span>
-      </div>
-      <div>
-        <h1 class="text-overline text-medium-emphasis mb-1"> Admin Dashboard </h1>
-        <h2 class="text-h5 font-weight-bold mb-2"> System Overview </h2>
-        <p class="text-body-2 text-medium-emphasis"> Monitor and manage your ShellHub instance metrics and statistics </p>
-      </div>
-    </div>
+    <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+      <!-- Left side: Icon + Title + Description -->
+      <div class="d-flex align-start flex-grow-1">
+        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-home mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+          <!----><span class="v-avatar__underlay"></span>
+        </div>
+        <div>
+          <div class="text-overline text-medium-emphasis mb-1">Admin Dashboard</div>
+          <div class="text-h5 font-weight-bold mb-2">System Overview</div>
+          <div class="text-body-2 text-medium-emphasis">Monitor and manage your ShellHub instance metrics and statistics.</div>
+          <!--v-if-->
+        </div>
+      </div><!-- Right side: Actions -->
+      <!--v-if-->
+    </div><!-- Extra content below -->
+    <!--v-if-->
     <!---->
     <!----><span class="v-card__underlay"></span>
   </div>
@@ -216,7 +222,7 @@ exports[`Dashboard > Renders the component 1`] = `
         </div>
         <!---->
         <!---->
-        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mb-4" style="width: 64px; height: 64px;"><i class="mdi-console-network mdi v-icon notranslate v-theme--light" style="font-size: 40px; height: 40px; width: 40px;" aria-hidden="true"></i>
+        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mb-4" style="width: 64px; height: 64px;"><i class="mdi-history mdi v-icon notranslate v-theme--light" style="font-size: 40px; height: 40px; width: 40px;" aria-hidden="true"></i>
           <!----><span class="v-avatar__underlay"></span>
         </div>
         <div class="v-card-title text-overline text-medium-emphasis mb-2">Active Sessions</div>

--- a/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Device/__snapshots__/index.spec.ts.snap
@@ -1,48 +1,81 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Device > Renders the component 1`] = `
-"<div class="d-flex flex-column justify-space-between align-center flex-sm-row mb-2">
-  <h1>Devices</h1>
-  <div class="v-spacer"></div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field w-50">
-    <!---->
-    <div class="v-input__control">
-      <div class="v-field v-field--appended v-field--center-affix v-field--single-line v-field--variant-filled v-theme--light v-locale--is-ltr">
-        <div class="v-field__overlay"></div>
-        <div class="v-field__loader">
-          <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+"<div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-developer-board mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Fleet Oversight</div>
+        <div class="text-h5 font-weight-bold mb-2">Devices</div>
+        <div class="text-body-2 text-medium-emphasis">Audit every registered device across all namespaces and quickly find specific hosts.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <!--v-if-->
+  </div><!-- Extra content below -->
+  <div class="mt-4 position-relative" style="z-index: 1;">
+    <div class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field w-100 w-md-50">
+      <!---->
+      <div class="v-input__control">
+        <div class="v-field v-field--appended v-field--center-affix v-field--single-line v-field--variant-filled v-theme--light v-locale--is-ltr">
+          <div class="v-field__overlay"></div>
+          <div class="v-field__loader">
+            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+              <!---->
+              <div class="v-progress-linear__background bg-primary"></div>
+              <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
+              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                <div class="v-progress-linear__indeterminate">
+                  <div class="v-progress-linear__indeterminate long bg-primary"></div>
+                  <div class="v-progress-linear__indeterminate short bg-primary"></div>
+                </div>
+              </transition-stub>
+              <!---->
+            </div>
+          </div>
+          <!---->
+          <div class="v-field__field" data-no-activator="">
+            <!----><label class="v-label v-field-label" id="input-v-1-label" for="input-v-1" aria-hidden="false">
+              <!---->Search by hostname
+            </label>
+            <!----><input size="1" type="text" aria-labelledby="input-v-1-label" id="input-v-1" class="v-field__input" value="">
             <!---->
-            <div class="v-progress-linear__background bg-primary"></div>
-            <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
-            <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-              <div class="v-progress-linear__indeterminate">
-                <div class="v-progress-linear__indeterminate long bg-primary"></div>
-                <div class="v-progress-linear__indeterminate short bg-primary"></div>
-              </div>
-            </transition-stub>
+          </div>
+          <!---->
+          <div class="v-field__append-inner"><i class="mdi-magnify mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
+          <div class="v-field__outline">
+            <!---->
             <!---->
           </div>
         </div>
-        <!---->
-        <div class="v-field__field" data-no-activator="">
-          <!----><label class="v-label v-field-label" id="input-v-1-label" for="input-v-1" aria-hidden="false">
-            <!---->Search by hostname
-          </label>
-          <!----><input size="1" type="text" aria-labelledby="input-v-1-label" id="input-v-1" class="v-field__input" value="">
-          <!---->
-        </div>
-        <!---->
-        <div class="v-field__append-inner"><i class="mdi-magnify mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-        <div class="v-field__outline">
-          <!---->
-          <!---->
-        </div>
       </div>
+      <!---->
+      <!---->
     </div>
-    <!---->
-    <!---->
   </div>
-  <div class="v-spacer"></div>
+  <!---->
+  <!----><span class="v-card__underlay"></span>
 </div>
 <div data-v-aca44803="">
   <div data-v-aca44803="" data-test="devices-list">

--- a/ui/admin/tests/unit/views/Device/index.spec.ts
+++ b/ui/admin/tests/unit/views/Device/index.spec.ts
@@ -119,7 +119,6 @@ describe("Device", () => {
   });
 
   it("Should render all the components in the screen", () => {
-    expect(wrapper.find("h1").text()).toContain("Devices");
     expect(wrapper.find("input").exists()).toBe(true);
     expect(wrapper.find("[data-test='devices-list']").exists()).toBe(true);
   });

--- a/ui/admin/tests/unit/views/FirewallRules/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/FirewallRules/__snapshots__/index.spec.ts.snap
@@ -1,7 +1,43 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Firewall Rules > Renders the component 1`] = `
-"<h1 class="mb-2"> Firewall Rules </h1>
+"<div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8" data-test="firewall-rules">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-security mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Security Controls</div>
+        <div class="text-h5 font-weight-bold mb-2">Firewall Rules</div>
+        <div class="text-body-2 text-medium-emphasis">Review every policy applied across namespaces and confirm access is locked down.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <!--v-if-->
+  </div><!-- Extra content below -->
+  <!--v-if-->
+  <!---->
+  <!----><span class="v-card__underlay"></span>
+</div>
 <div data-test="firewall-rules-list">
   <div class="v-table v-theme--light v-table--density-default bg-background border rounded text-center" data-test="datatable">
     <!---->

--- a/ui/admin/tests/unit/views/FirewallRules/index.spec.ts
+++ b/ui/admin/tests/unit/views/FirewallRules/index.spec.ts
@@ -62,7 +62,6 @@ describe("Firewall Rules", () => {
   });
 
   it("Should render all the components in the screen", () => {
-    expect(wrapper.find("h1").text()).toContain("Firewall Rules");
     expect(wrapper.find("[data-test='firewall-rules-list']").exists()).toBe(true);
   });
 });

--- a/ui/admin/tests/unit/views/Namespaces/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Namespaces/__snapshots__/index.spec.ts.snap
@@ -1,54 +1,88 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Namespaces > Renders the component 1`] = `
-"<div class="d-flex flex-column justify-space-between align-center flex-md-row mb-2">
-  <h1>Namespaces</h1>
-  <div class="v-spacer"></div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field w-50">
-    <!---->
-    <div class="v-input__control">
-      <div class="v-field v-field--appended v-field--center-affix v-field--single-line v-field--variant-filled v-theme--light v-locale--is-ltr">
-        <div class="v-field__overlay"></div>
-        <div class="v-field__loader">
-          <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+"<div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-cloud-braces mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Namespace Management</div>
+        <div class="text-h5 font-weight-bold mb-2">Namespaces</div>
+        <div class="text-body-2 text-medium-emphasis">Track every tenant, search by name, and export namespace data for audits.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <div class="ml-4"><button type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-outlined mr-2 mt-2 mt-md-0" data-test="namespaces-export-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+        <!----><span class="v-btn__content" data-no-activator="">Export CSV</span>
+        <!---->
+        <!---->
+      </button>
+      <!---->
+      <!---->
+    </div>
+  </div><!-- Extra content below -->
+  <div class="mt-4 position-relative" style="z-index: 1;">
+    <div class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field w-100 w-md-50">
+      <!---->
+      <div class="v-input__control">
+        <div class="v-field v-field--appended v-field--center-affix v-field--single-line v-field--variant-filled v-theme--light v-locale--is-ltr">
+          <div class="v-field__overlay"></div>
+          <div class="v-field__loader">
+            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+              <!---->
+              <div class="v-progress-linear__background bg-primary"></div>
+              <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
+              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                <div class="v-progress-linear__indeterminate">
+                  <div class="v-progress-linear__indeterminate long bg-primary"></div>
+                  <div class="v-progress-linear__indeterminate short bg-primary"></div>
+                </div>
+              </transition-stub>
+              <!---->
+            </div>
+          </div>
+          <!---->
+          <div class="v-field__field" data-no-activator="">
+            <!----><label class="v-label v-field-label" id="input-v-2-label" for="input-v-2" aria-hidden="false">
+              <!---->Search by name
+            </label>
+            <!----><input size="1" type="text" aria-labelledby="input-v-2-label" id="input-v-2" class="v-field__input" value="">
             <!---->
-            <div class="v-progress-linear__background bg-primary"></div>
-            <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
-            <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-              <div class="v-progress-linear__indeterminate">
-                <div class="v-progress-linear__indeterminate long bg-primary"></div>
-                <div class="v-progress-linear__indeterminate short bg-primary"></div>
-              </div>
-            </transition-stub>
+          </div>
+          <!---->
+          <div class="v-field__append-inner"><i class="mdi-magnify mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
+          <div class="v-field__outline">
+            <!---->
             <!---->
           </div>
         </div>
-        <!---->
-        <div class="v-field__field" data-no-activator="">
-          <!----><label class="v-label v-field-label" id="input-v-1-label" for="input-v-1" aria-hidden="false">
-            <!---->Search by name
-          </label>
-          <!----><input size="1" type="text" aria-labelledby="input-v-1-label" id="input-v-1" class="v-field__input" value="">
-          <!---->
-        </div>
-        <!---->
-        <div class="v-field__append-inner"><i class="mdi-magnify mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-        <div class="v-field__outline">
-          <!---->
-          <!---->
-        </div>
       </div>
+      <!---->
+      <!---->
     </div>
-    <!---->
-    <!---->
   </div>
-  <div class="v-spacer"></div><button type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-outlined mr-2 mt-2 mt-md-0" data-test="namespaces-export-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-    <!----><span class="v-btn__content" data-no-activator="">Export CSV</span>
-    <!---->
-    <!---->
-  </button>
   <!---->
-  <!---->
+  <!----><span class="v-card__underlay"></span>
 </div>
 <div data-v-ec7d46d0="">
   <div data-v-ec7d46d0="" data-test="namespaces-list">

--- a/ui/admin/tests/unit/views/Namespaces/index.spec.ts
+++ b/ui/admin/tests/unit/views/Namespaces/index.spec.ts
@@ -45,7 +45,6 @@ describe("Namespaces", () => {
   });
 
   it("Should render all the components in the screen", () => {
-    expect(wrapper.find("h1").text()).toContain("Namespaces");
     expect(wrapper.find("[data-test='namespaces-list']").exists()).toBe(true);
     expect(wrapper.find("[data-test='namespaces-export-btn']").exists()).toBe(true);
     expect(wrapper.find("input").exists()).toBe(true);

--- a/ui/admin/tests/unit/views/NewAnnouncement/NewAnnouncement.spec.ts
+++ b/ui/admin/tests/unit/views/NewAnnouncement/NewAnnouncement.spec.ts
@@ -39,10 +39,6 @@ describe("New Announcement", () => {
     expect(html).toMatchSnapshot();
   });
 
-  it("Has the correct title", () => {
-    expect(wrapper.find("h1").text()).toBe("Create new Announcement");
-  });
-
   it("Renders the correct HTML", () => {
     expect(wrapper.find("[data-test='announcement-title']").exists()).toBeTruthy();
     expect(wrapper.find("[data-test='announcement-content']").exists()).toBeTruthy();

--- a/ui/admin/tests/unit/views/NewAnnouncement/__snapshots__/NewAnnouncement.spec.ts.snap
+++ b/ui/admin/tests/unit/views/NewAnnouncement/__snapshots__/NewAnnouncement.spec.ts.snap
@@ -1,7 +1,43 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`New Announcement > Renders the component 1`] = `
-"<h1>Create new Announcement</h1>
+"<div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8" data-test="announcement-title">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-bullhorn mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Platform Messaging</div>
+        <div class="text-h5 font-weight-bold mb-2">Create new Announcement</div>
+        <div class="text-body-2 text-medium-emphasis">Compose a system-wide update to keep every namespace informed about critical changes.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <!--v-if-->
+  </div><!-- Extra content below -->
+  <!--v-if-->
+  <!---->
+  <!----><span class="v-card__underlay"></span>
+</div>
 <div class="v-card v-theme--light v-card--density-default v-card--variant-elevated pa-4 mt-2 bg-background border">
   <!---->
   <div class="v-card__loader">

--- a/ui/admin/tests/unit/views/Sessions/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Sessions/__snapshots__/index.spec.ts.snap
@@ -1,7 +1,43 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Sessions > Renders the component 1`] = `
-"<h1 class="mb-2"> Sessions </h1>
+"<div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-history mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Activity Monitoring</div>
+        <div class="text-h5 font-weight-bold mb-2">Sessions</div>
+        <div class="text-body-2 text-medium-emphasis">Track live and historical sessions happening across every namespace.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <!--v-if-->
+  </div><!-- Extra content below -->
+  <!--v-if-->
+  <!---->
+  <!----><span class="v-card__underlay"></span>
+</div>
 <div data-v-d900b695="">
   <div data-v-d900b695="" data-test="session-list">
     <div class="v-table v-theme--light v-table--density-default bg-background border rounded text-center" data-test="datatable">

--- a/ui/admin/tests/unit/views/Sessions/index.spec.ts
+++ b/ui/admin/tests/unit/views/Sessions/index.spec.ts
@@ -35,7 +35,6 @@ describe("Sessions", () => {
   });
 
   it("Should render all the components in the screen", () => {
-    expect(wrapper.find("h1").text()).toContain("Sessions");
     expect(wrapper.find("[data-test='session-list']").exists()).toBe(true);
   });
 });

--- a/ui/admin/tests/unit/views/Users/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/views/Users/__snapshots__/index.spec.ts.snap
@@ -1,62 +1,96 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Users > Renders the component 1`] = `
-"<div class="d-flex flex-column justify-space-between align-center flex-sm-row mb-2">
-  <h1>Users</h1>
-  <div class="v-spacer"></div>
-  <div class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field w-50">
-    <!---->
-    <div class="v-input__control">
-      <div class="v-field v-field--appended v-field--center-affix v-field--single-line v-field--variant-filled v-theme--light v-locale--is-ltr">
-        <div class="v-field__overlay"></div>
-        <div class="v-field__loader">
-          <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+"<div class="v-card v-theme--light v-card--density-default elevation-0 rounded-0 v-card--variant-elevated pa-6 bg-transparent mb-6 position-relative overflow-hidden border-b mx-n8 mt-n8">
+  <!---->
+  <div class="v-card__loader">
+    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+      <!---->
+      <div class="v-progress-linear__background"></div>
+      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+        <div class="v-progress-linear__indeterminate">
+          <div class="v-progress-linear__indeterminate long"></div>
+          <div class="v-progress-linear__indeterminate short"></div>
+        </div>
+      </transition-stub>
+      <!---->
+    </div>
+  </div>
+  <!---->
+  <!---->
+  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <!-- Left side: Icon + Title + Description -->
+    <div class="d-flex align-start flex-grow-1">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-account-group mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+        <!----><span class="v-avatar__underlay"></span>
+      </div>
+      <div>
+        <div class="text-overline text-medium-emphasis mb-1">Account Management</div>
+        <div class="text-h5 font-weight-bold mb-2">Users</div>
+        <div class="text-body-2 text-medium-emphasis">Review every account, keep credentials healthy, and quickly onboard administrators.</div>
+        <!--v-if-->
+      </div>
+    </div><!-- Right side: Actions -->
+    <div class="ml-4">
+      <div class="d-flex flex-column flex-sm-row ga-2 mt-2 mt-md-0"><button type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-outlined mr-6" data-test="users-export-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator="">Export CSV</span>
+          <!---->
+          <!---->
+        </button>
+        <!---->
+        <!----><button tabindex="0" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated mr-2" data-test="user-add-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          <!----><span class="v-btn__content" data-no-activator="">Add User</span>
+          <!---->
+          <!---->
+        </button>
+        <!---->
+        <!---->
+      </div>
+    </div>
+  </div><!-- Extra content below -->
+  <div class="mt-4 position-relative" style="z-index: 1;">
+    <div class="v-input v-input--horizontal v-input--center-affix v-input--density-compact v-theme--light v-locale--is-ltr v-text-field w-100 w-md-50">
+      <!---->
+      <div class="v-input__control">
+        <div class="v-field v-field--appended v-field--center-affix v-field--single-line v-field--variant-filled v-theme--light v-locale--is-ltr">
+          <div class="v-field__overlay"></div>
+          <div class="v-field__loader">
+            <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+              <!---->
+              <div class="v-progress-linear__background bg-primary"></div>
+              <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
+              <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                <div class="v-progress-linear__indeterminate">
+                  <div class="v-progress-linear__indeterminate long bg-primary"></div>
+                  <div class="v-progress-linear__indeterminate short bg-primary"></div>
+                </div>
+              </transition-stub>
+              <!---->
+            </div>
+          </div>
+          <!---->
+          <div class="v-field__field" data-no-activator="">
+            <!----><label class="v-label v-field-label" id="input-v-3-label" for="input-v-3" aria-hidden="false">
+              <!---->Search by username
+            </label>
+            <!----><input size="1" type="text" aria-labelledby="input-v-3-label" id="input-v-3" class="v-field__input" value="">
             <!---->
-            <div class="v-progress-linear__background bg-primary"></div>
-            <div class="v-progress-linear__buffer bg-primary" style="width: 0%;"></div>
-            <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-              <div class="v-progress-linear__indeterminate">
-                <div class="v-progress-linear__indeterminate long bg-primary"></div>
-                <div class="v-progress-linear__indeterminate short bg-primary"></div>
-              </div>
-            </transition-stub>
+          </div>
+          <!---->
+          <div class="v-field__append-inner"><i class="mdi-magnify mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" aria-label="Search by username appended action"></i></div>
+          <div class="v-field__outline">
+            <!---->
             <!---->
           </div>
         </div>
-        <!---->
-        <div class="v-field__field" data-no-activator="">
-          <!----><label class="v-label v-field-label" id="input-v-1-label" for="input-v-1" aria-hidden="false">
-            <!---->Search by username
-          </label>
-          <!----><input size="1" type="text" aria-labelledby="input-v-1-label" id="input-v-1" class="v-field__input" value="">
-          <!---->
-        </div>
-        <!---->
-        <div class="v-field__append-inner"><i class="mdi-magnify mdi v-icon notranslate v-theme--light v-icon--size-default v-icon--clickable" role="button" aria-hidden="false" tabindex="0" aria-label="Search by username appended action"></i></div>
-        <div class="v-field__outline">
-          <!---->
-          <!---->
-        </div>
       </div>
+      <!---->
+      <!---->
     </div>
-    <!---->
-    <!---->
   </div>
-  <div class="v-spacer"></div>
-  <div class="d-flex mt-2 mt-md-0"><button type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-outlined mr-6 ml-2" data-test="users-export-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-      <!----><span class="v-btn__content" data-no-activator="">Export CSV</span>
-      <!---->
-      <!---->
-    </button>
-    <!---->
-    <!----><button tabindex="0" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated mr-2" data-test="user-add-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-      <!----><span class="v-btn__content" data-no-activator="">Add User</span>
-      <!---->
-      <!---->
-    </button>
-    <!---->
-    <!---->
-  </div>
+  <!---->
+  <!----><span class="v-card__underlay"></span>
 </div>
 <div data-test="users-list">
   <div class="v-table v-theme--light v-table--density-default bg-background border rounded text-center" data-test="datatable">

--- a/ui/admin/tests/unit/views/Users/index.spec.ts
+++ b/ui/admin/tests/unit/views/Users/index.spec.ts
@@ -41,7 +41,6 @@ describe("Users", () => {
   });
 
   it("Should render all the components in the screen", () => {
-    expect(wrapper.find("h1").text()).toContain("Users");
     expect(wrapper.find("[data-test='users-list']").exists()).toBe(true);
     expect(wrapper.find("[data-test='users-export-btn']").exists()).toBe(true);
     expect(wrapper.find("[data-test='user-add-btn']").exists()).toBe(true);


### PR DESCRIPTION
# Description

This PR refactors multiple views in the admin UI to consistently use the new `<PageHeader />` component. The goal is to unify page layout, improve visual hierarchy, and provide clearer context for each section of the platform.

## Changes Included:

Replaced custom headers (`<h1>`, icon/avatar blocks, etc.) with `<PageHeader />` across:
Added relevant icons, overlines, and descriptions to each view for improved clarity.
Updated `mdi-login` icon to `mdi-cloud-braces` for the "Namespaces" menu item to match new visual design.

## Why:

- Ensures a consistent user experience across all views.
- Reduces code duplication by centralizing layout logic into a reusable component.
- Improves onboarding and discoverability by clarifying the purpose of each section.