### PR TITLE
refactor(ui): improve session play button and active status display

### DIFF
--- a/ui/src/views/DetailsSessions.vue
+++ b/ui/src/views/DetailsSessions.vue
@@ -10,21 +10,26 @@
   >
     <v-card-title class="bg-v-theme-surface pa-4 d-flex align-center justify-space-between">
       <div class="d-flex align-center">
-        <v-tooltip
-          location="bottom"
-          :disabled="session.active"
+        <SessionPlay
+          v-slot="{ loading, disabled, openDialog }"
+          :uid="session.uid"
+          :recorded="session.recorded"
+          :authenticated="session.authenticated"
         >
-          <template #activator="{ props }">
-            <v-icon
-              v-bind="props"
-              :color="session.active ? 'success' : 'white'"
-              size="small"
-              data-test="session-active-icon"
-              icon="mdi-check-circle"
-            />
-          </template>
-          <span>{{ getTimeFromNow(session.last_seen) }}</span>
-        </v-tooltip>
+          <v-btn
+            color="primary"
+            prepend-icon="mdi-play"
+            variant="outlined"
+            :loading="loading"
+            density="comfortable"
+            class="mr-3"
+            data-test="session-details-play-btn"
+            :disabled="disabled"
+            @click="openDialog"
+          >
+            Play
+          </v-btn>
+        </SessionPlay>
         <DeviceLink
           v-if="session.device"
           :device-uid="session.device.uid"
@@ -53,30 +58,6 @@
           lines="two"
           density="compact"
         >
-          <SessionPlay
-            v-slot="{ loading, disabled, openDialog }"
-            :uid="session.uid"
-            :recorded="session.recorded"
-            :authenticated="session.authenticated"
-          >
-            <div>
-              <v-list-item
-                :loading
-                :disabled
-                @click="openDialog"
-              >
-                <div class="d-flex align-center">
-                  <v-icon
-                    icon="mdi-play"
-                    class="mr-2"
-                  />
-                  <v-list-item-title>
-                    Play Session
-                  </v-list-item-title>
-                </div>
-              </v-list-item>
-            </div>
-          </SessionPlay>
           <v-tooltip
             location="bottom"
             class="text-center"
@@ -160,6 +141,19 @@
               <span>{{ authenticatedTooltipAttrs.text }}</span>
             </v-tooltip>
           </div>
+
+          <div data-test="session-active-field">
+            <div class="item-title">
+              Active session:
+            </div>
+            <div class="d-flex align-center">
+              <v-icon
+                :icon="session.active ? 'mdi-check-circle' : 'mdi-alert-circle'"
+                :color="session.active ? 'success' : 'error'"
+                data-test="session-active-icon"
+              />
+            </div>
+          </div>
         </v-col>
 
         <v-col
@@ -204,7 +198,7 @@
 <script setup lang="ts">
 import { computed, onMounted } from "vue";
 import { useRoute } from "vue-router";
-import { formatFullDateTime, getTimeFromNow } from "@/utils/date";
+import { formatFullDateTime } from "@/utils/date";
 import hasPermission from "@/utils/permission";
 import SessionDelete from "@/components/Sessions/SessionDelete.vue";
 import SessionClose from "@/components/Sessions/SessionClose.vue";

--- a/ui/tests/views/DetailsSessions.spec.ts
+++ b/ui/tests/views/DetailsSessions.spec.ts
@@ -96,8 +96,10 @@ describe("Details Sessions", () => {
     expect(wrapper.find('[data-test="session-uid-field"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="session-user-field"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="session-authenticated-field"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="session-active-field"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="session-ip-address-field"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="session-started-at-field"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="session-last-seen-field"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="session-details-play-btn"]').exists()).toBe(true);
   });
 });

--- a/ui/tests/views/__snapshots__/DetailsSessions.spec.ts.snap
+++ b/ui/tests/views/__snapshots__/DetailsSessions.spec.ts.snap
@@ -23,13 +23,19 @@ exports[`Details Sessions > Renders the component 1`] = `
   <!---->
   <!---->
   <div class="v-card-title bg-v-theme-surface pa-4 d-flex align-center justify-space-between">
-    <div class="d-flex align-center"><i class="mdi-check-circle mdi v-icon notranslate v-theme--light v-icon--size-small text-white" aria-hidden="true" aria-describedby="v-tooltip-v-0" data-test="session-active-icon"></i>
+    <div class="d-flex align-center">
+      <div aria-describedby="v-tooltip-v-0"><button type="button" class="v-btn v-theme--light text-primary v-btn--density-comfortable v-btn--size-default v-btn--variant-outlined mr-3" data-test="session-details-play-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span><span class="v-btn__prepend"><i class="mdi-play mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span><span class="v-btn__content" data-no-activator=""> Play </span>
+          <!---->
+          <!---->
+        </button></div>
       <!--teleport start-->
-      <!--teleport end--><button type="button" class="v-btn v-btn--elevated v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-elevated text-none border rounded bg-v-theme-background ml-2"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span><span class="v-btn__prepend"><i class="mdi-developer-board mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span><span class="v-btn__content" data-no-activator="">00-00-00-00-00-01</span>
+      <!--teleport end-->
+      <!---->
+      <!----><button type="button" class="v-btn v-btn--elevated v-theme--light v-btn--density-default v-btn--size-default v-btn--variant-elevated text-none border rounded bg-v-theme-background ml-2"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span><span class="v-btn__prepend"><i class="mdi-developer-board mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span><span class="v-btn__content" data-no-activator="">00-00-00-00-00-01</span>
         <!---->
         <!---->
       </button>
-    </div><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-2" aria-owns="v-menu-v-2"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+    </div><button type="button" class="v-btn v-btn--icon v-theme--light v-btn--density-comfortable v-btn--size-default v-btn--variant-plain border rounded bg-v-theme-background" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-3" aria-owns="v-menu-v-3"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
       <!----><span class="v-btn__content" data-no-activator=""><i class="mdi-format-list-bulleted mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
       <!---->
       <!---->
@@ -53,6 +59,10 @@ exports[`Details Sessions > Renders the component 1`] = `
           <div class="item-title"> Authenticated: </div><i class="mdi-shield-check mdi v-icon notranslate v-theme--light v-icon--size-default text-success" aria-hidden="true" aria-describedby="v-tooltip-v-7"></i>
           <!--teleport start-->
           <!--teleport end-->
+        </div>
+        <div data-test="session-active-field">
+          <div class="item-title"> Active session: </div>
+          <div class="d-flex align-center"><i class="mdi-alert-circle mdi v-icon notranslate v-theme--light v-icon--size-default text-error" aria-hidden="true" data-test="session-active-icon"></i></div>
         </div>
       </div>
       <div class="v-col-md-6 v-col-12 my-0 py-0">


### PR DESCRIPTION
# Description

This PR improves the UI/UX of the session details page by:

- Replacing the old "Play Session" list item with a top-level Play button.
  - Now more prominent and easier to access.
  - Uses the existing `<SessionPlay>` component.
- Moving the active session status icon into the session details field area.
  - Adds clearer labeling: "Active session:".
  - Shows `mdi-check-circle` for active, `mdi-alert-circle` for inactive.
- Removing the now-unused tooltip and redundant layout code.

## Tests & Snapshots

Updated unit test to assert presence of:
1. `session-details-play-btn`
2. `session-active-field`

Snapshot updated to reflect the new DOM structure.