### PR TITLE
fix(tests): support testcontainers in Docker-in-Docker environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,6 +32,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./.golangci.yaml:/.golangci.yaml
     environment:
+      - TESTCONTAINERS_DOCKER_NETWORK=${SHELLHUB_NETWORK}
       - SHELLHUB_ENTERPRISE=${SHELLHUB_ENTERPRISE}
       - SHELLHUB_CLOUD=${SHELLHUB_CLOUD}
       - SHELLHUB_ENV=${SHELLHUB_ENV}


### PR DESCRIPTION
Add support for TESTCONTAINERS_DOCKER_NETWORK environment variable
in dbtest.Server to enable running testcontainers inside Docker.
