### PR TITLE
chore: migrate to docker compose plugin (V2/V5+)

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -2,9 +2,8 @@
 
 . "$(dirname "$0")/utils"
 
-DOCKER_COMPOSE=$(evaluate_docker_compose)
 WORKDIR=$(dirname $(readlink_f $0))/../
 
 cd $WORKDIR
 
-exec $DOCKER_COMPOSE "$@"
+exec docker compose "$@"

--- a/bin/utils
+++ b/bin/utils
@@ -1,26 +1,5 @@
 #!/bin/sh
 
-# Evaluate the appropriate Docker Compose command based on availability and V2 compatibility.
-#
-# If a compatible command is found, it is set to $COMPOSE_COMMAND. If no compatible command
-# is found, the function exits with status 1.
-evaluate_docker_compose() {
-    local COMPOSE_COMMAND
-
-    if docker compose version --short 2> /dev/null | grep -q "^2\."; then
-        COMPOSE_COMMAND="docker compose"
-    elif docker-compose version --short 2> /dev/null | grep -q "^2\."; then
-        COMPOSE_COMMAND="docker-compose"
-    fi
-
-    if [ -z "$COMPOSE_COMMAND" ]; then
-        echo >&2 "ERROR: Cannot find Docker Compose compatible with V2 spec"
-        exit 1
-    fi
-
-    echo "$COMPOSE_COMMAND"
-}
-
 readlink_f() {
     (if uname | grep -q 'Darwin'; then
 	 # Use greadlink if available, otherwise it behaves like "readlink -f" option
@@ -46,10 +25,7 @@ readlink_f() {
 }
 
 exit_if_not_running() {
-  local DOCKER_COMPOSE
-  DOCKER_COMPOSE=$(evaluate_docker_compose)
-
-  SERVICES=$($DOCKER_COMPOSE ps -q | grep -v INFO: | xargs docker inspect -f '{{.State.Running}}' 2>/dev/null | grep -c 'true')
+  SERVICES=$(docker compose ps -q | grep -v INFO: | xargs docker inspect -f '{{.State.Running}}' 2>/dev/null | grep -c 'true')
 
   [ "$SERVICES" -le 0 ] && { echo "🚫 ERROR: ShellHub is not running. Exiting."; exit 1; }
 }


### PR DESCRIPTION
Replace docker-compose standalone with docker compose plugin.
Remove version detection logic as V1 is now obsolete and
V2/V5+ plugin is the standard.

Changes:
- Remove evaluate_docker_compose() function from bin/utils
- Use 'docker compose' directly instead of detecting V2 via version check
- Supports both Docker Compose V2 and V5+
