### PR TITLE
feat: allow immediate device slot reuse after deletion

### DIFF
--- a/pkg/models/namespace.go
+++ b/pkg/models/namespace.go
@@ -31,15 +31,10 @@ func (n *Namespace) HasMaxDevices() bool {
 }
 
 // HasMaxDevicesReached checks if the namespace has reached the maximum number of devices.
+// Only counts accepted devices. Removed devices no longer count towards the limit,
+// allowing immediate slot reuse after deletion.
 func (n *Namespace) HasMaxDevicesReached() bool {
 	return n.DevicesAcceptedCount >= int64(n.MaxDevices)
-}
-
-// HasLimitDevicesReached checks if the namespace limit was reached using the removed devices collection.
-//
-// This method is intended to be run only when the ShellHub instance is Cloud.
-func (n *Namespace) HasLimitDevicesReached() bool {
-	return n.DevicesAcceptedCount+n.DevicesRemovedCount >= int64(n.MaxDevices)
 }
 
 // FindMember checks if a member with the specified ID exists in the namespace.


### PR DESCRIPTION
Changed device limit logic to only count accepted devices, allowing
users to immediately reuse slots after deleting devices. Removed
devices no longer count toward the namespace limit while still being
soft-deleted for audit purposes.

Changes:
- Simplified HasMaxDevicesReached() to only count accepted devices
- Removed HasLimitDevicesReached() function (no longer needed)
- Unified device deletion logic across Cloud/Enterprise/Community
- Always soft-delete accepted devices for audit trail
- Hard-delete pending/rejected devices (no audit needed)
