### PR TITLE
feat: simplify issue templates to reduce friction

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,73 +1,14 @@
 name: Bug report
-description: Create a bug report
-title: "bug: "
-labels: ["kind/bug"]
+description: Report a bug or issue
+labels: ["kind/bug", "triage"]
 body:
   - type: textarea
     id: description
     attributes:
-      label: Description
-      description: A concise description about what the issue is.
+      label: Describe the issue
+      placeholder: |
+        What happened? What did you expect?
+
+        Include steps to reproduce, version, logs, or anything else that might help.
     validations:
       required: true
-
-  - type: textarea
-    id: steps-to-reproduce
-    attributes:
-      label: Steps to Reproduce
-      description: Describe the specific steps to reproduce the issue.
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected-behavior
-    attributes:
-      label: Expected Behavior
-      description: A concise description about what you expected to happen.
-    validations:
-      required: true
-
-  - type: dropdown
-    id: edition
-    attributes:
-      label: Edition
-      description: The edition of ShellHub you are using.
-      options:
-        - Community
-        - Enterprise
-        - Cloud
-    validations:
-      required: true
-
-  - type: input
-    id: version
-    attributes:
-      label: Version
-      description: The version of ShellHub you are currently using.
-    validations:
-      required: true
-
-  - type: textarea
-    id: related-logs
-    attributes:
-      label: Related Logs
-      render: shell
-      description: Relevant log output. This will be automatically formatted into shell code.
-    validations:
-      required: false
-
-  - type: textarea
-    id: related-code
-    attributes:
-      label: Related Code
-      description: Links or snippets of (possibly) relevant code for debugging or reproducing the issue.
-    validations:
-      required: false
-
-  - type: textarea
-    id: additional-info
-    attributes:
-      label: Additional Information
-      description: Include any additional details such as screenshots or videos, if applicable.
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature request
-    about: Propose any new features here on our ideas board
+  - name: Feature Request
+    about: Suggest a new feature or improvement
     url: https://github.com/shellhub-io/shellhub/discussions/categories/ideas
   - name: Question
-    about: Ask the community a question
+    about: Get help from the community
     url: https://github.com/shellhub-io/shellhub/discussions/categories/q-a
+  - name: Documentation
+    about: Report issues with docs or suggest improvements
+    url: https://docs.shellhub.io
+  - name: Security Vulnerability
+    about: Privately report a security issue (do not create public issue)
+    url: https://github.com/shellhub-io/shellhub/security/advisories/new


### PR DESCRIPTION
- Reduced bug report to 1 required field (free-form text)
- Removed title field that was breaking template visibility
- Disabled blank issues
- Added links to documentation, security, questions, and feature requests
- Auto-labels: kind/bug, triage
