### PR TITLE
test(ui): improve Admin's store modules' tests

### DIFF
--- a/ui/admin/tests/unit/store/modules/announcements.spec.ts
+++ b/ui/admin/tests/unit/store/modules/announcements.spec.ts
@@ -1,44 +1,207 @@
-import { describe, expect, it } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useAnnouncementStore from "@admin/store/modules/announcement";
+import { IAdminAnnouncement, IAdminAnnouncementShort, IAdminAnnouncementRequestBody } from "@admin/interfaces/IAnnouncement";
+import { buildUrl } from "@tests/utils/url";
 
-const announcements = [
-  {
-    uuid: "52088548-2b99-4f38-ac09-3a8f8988476f",
-    title: "This is a announcement",
-    content: "## ShellHub new features \n - New feature 1 \n - New feature 2 \n - New feature 3",
-    date: "2022-12-15T19:45:45.618Z",
-  },
-  {
-    uuid: "52188548-2b99-4f38-ac09-3a8f8988476f",
-    title: "This is a new announcement",
-    content: "## ShellHub new features \n - New feature 1 \n - New feature 2 \n - New feature 3",
-    date: "2022-12-15T19:46:45.618Z",
-  },
-];
+const mockAnnouncementShort: IAdminAnnouncementShort = {
+  uuid: "52088548-2b99-4f38-ac09-3a8f8988476f",
+  title: "This is an announcement",
+  date: "2026-01-06T10:00:00.000Z",
+};
 
-const [firstAnnouncement] = announcements;
-const announcementCount = 2;
+const mockAnnouncement: IAdminAnnouncement = {
+  ...mockAnnouncementShort,
+  content: "## ShellHub new features \n - New feature 1 \n - New feature 2 \n - New feature 3",
+};
 
-describe("Announcement Store (Pinia)", () => {
-  setActivePinia(createPinia());
-  const announcementStore = useAnnouncementStore();
+const mockAnnouncementRequestBody: IAdminAnnouncementRequestBody = {
+  title: "New announcement",
+  content: "## Content here",
+};
 
-  it("Returns default state", () => {
-    expect(announcementStore.announcements).toEqual([]);
-    expect(announcementStore.announcement).toEqual({});
-    expect(announcementStore.announcementCount).toBe(0);
+describe("Admin Announcement Store", () => {
+  let announcementStore: ReturnType<typeof useAnnouncementStore>;
+  let mockAdminApi: MockAdapter;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    announcementStore = useAnnouncementStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
   });
 
-  it("Sets announcements and updates count", () => {
-    announcementStore.announcements = announcements;
-    announcementStore.announcementCount = announcementCount;
-    expect(announcementStore.announcements).toEqual(announcements);
-    expect(announcementStore.announcementCount).toBe(announcementCount);
+  afterEach(() => { mockAdminApi.reset(); });
+
+  describe("Initial State", () => {
+    it("should have empty announcements array", () => {
+      expect(announcementStore.announcements).toEqual([]);
+    });
+
+    it("should have empty announcement object", () => {
+      expect(announcementStore.announcement).toEqual({});
+    });
+
+    it("should have zero announcement count", () => {
+      expect(announcementStore.announcementCount).toBe(0);
+    });
   });
 
-  it("Sets a single announcement", () => {
-    announcementStore.announcement = firstAnnouncement;
-    expect(announcementStore.announcement).toEqual(firstAnnouncement);
+  describe("createAnnouncement", () => {
+    const baseUrl = "http://localhost:3000/admin/api/announcements";
+
+    it("should create announcement successfully and update state", async () => {
+      mockAdminApi.onPost(baseUrl, mockAnnouncementRequestBody).reply(201, mockAnnouncement);
+
+      await expect(announcementStore.createAnnouncement(mockAnnouncementRequestBody)).resolves.not.toThrow();
+
+      expect(announcementStore.announcement).toEqual(mockAnnouncement);
+    });
+
+    it("should throw on server error when creating announcement", async () => {
+      mockAdminApi.onPost(baseUrl, mockAnnouncementRequestBody).reply(500);
+
+      await expect(announcementStore.createAnnouncement(mockAnnouncementRequestBody)).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when creating announcement", async () => {
+      mockAdminApi.onPost(baseUrl, mockAnnouncementRequestBody).networkError();
+
+      await expect(announcementStore.createAnnouncement(mockAnnouncementRequestBody)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("updateAnnouncement", () => {
+    const uuid = "52088548-2b99-4f38-ac09-3a8f8988476f";
+    const baseUrl = `http://localhost:3000/admin/api/announcements/${uuid}`;
+
+    it("should update announcement successfully", async () => {
+      mockAdminApi.onPut(baseUrl, mockAnnouncementRequestBody).reply(200);
+
+      await expect(announcementStore.updateAnnouncement(uuid, mockAnnouncementRequestBody)).resolves.not.toThrow();
+    });
+
+    it("should throw on not found error when updating announcement", async () => {
+      mockAdminApi.onPut(baseUrl, mockAnnouncementRequestBody).reply(404, { message: "Announcement not found" });
+
+      await expect(announcementStore.updateAnnouncement(uuid, mockAnnouncementRequestBody)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when updating announcement", async () => {
+      mockAdminApi.onPut(baseUrl, mockAnnouncementRequestBody).networkError();
+
+      await expect(announcementStore.updateAnnouncement(uuid, mockAnnouncementRequestBody)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("fetchAnnouncement", () => {
+    const uuid = "52088548-2b99-4f38-ac09-3a8f8988476f";
+    const baseUrl = `http://localhost:3000/admin/api/announcements/${uuid}`;
+
+    it("should fetch announcement successfully and update state", async () => {
+      mockAdminApi.onGet(baseUrl).reply(200, mockAnnouncement);
+
+      await expect(announcementStore.fetchAnnouncement(uuid)).resolves.not.toThrow();
+
+      expect(announcementStore.announcement).toEqual(mockAnnouncement);
+    });
+
+    it("should throw on not found error when fetching announcement", async () => {
+      mockAdminApi.onGet(baseUrl).reply(404, { message: "Announcement not found" });
+
+      await expect(announcementStore.fetchAnnouncement(uuid)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when fetching announcement", async () => {
+      mockAdminApi.onGet(baseUrl).networkError();
+
+      await expect(announcementStore.fetchAnnouncement(uuid)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("fetchAnnouncementList", () => {
+    const baseUrl = "http://localhost:3000/admin/api/announcements";
+
+    it("should fetch announcements list successfully with asc ordering", async () => {
+      const announcementsList = [mockAnnouncementShort];
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { page: "1", per_page: "10", order_by: "asc" }))
+        .reply(200, announcementsList, { "x-total-count": "1" });
+
+      await expect(announcementStore.fetchAnnouncementList({ page: 1, perPage: 10, orderBy: "asc" })).resolves.not.toThrow();
+
+      expect(announcementStore.announcements).toEqual(announcementsList);
+      expect(announcementStore.announcementCount).toBe(1);
+    });
+
+    it("should fetch announcements list successfully with desc ordering", async () => {
+      const announcementsList = [
+        mockAnnouncementShort,
+        { ...mockAnnouncementShort, uuid: "another-uuid", title: "Another announcement" },
+      ];
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { page: "1", per_page: "10", order_by: "desc" }))
+        .reply(200, announcementsList, { "x-total-count": "2" });
+
+      await expect(announcementStore.fetchAnnouncementList({ page: 1, perPage: 10, orderBy: "desc" })).resolves.not.toThrow();
+
+      expect(announcementStore.announcements).toEqual(announcementsList);
+      expect(announcementStore.announcementCount).toBe(2);
+    });
+
+    it("should fetch empty announcements list successfully", async () => {
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { page: "1", per_page: "10", order_by: "asc" }))
+        .reply(200, [], { "x-total-count": "0" });
+
+      await expect(announcementStore.fetchAnnouncementList({ page: 1, perPage: 10, orderBy: "asc" })).resolves.not.toThrow();
+
+      expect(announcementStore.announcements).toEqual([]);
+      expect(announcementStore.announcementCount).toBe(0);
+    });
+
+    it("should throw on server error when fetching announcements list", async () => {
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { page: "1", per_page: "10", order_by: "asc" }))
+        .reply(500);
+
+      await expect(announcementStore.fetchAnnouncementList({ page: 1, perPage: 10, orderBy: "asc" })).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when fetching announcements list", async () => {
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { page: "1", per_page: "10", order_by: "asc" }))
+        .networkError();
+
+      await expect(announcementStore.fetchAnnouncementList({ page: 1, perPage: 10, orderBy: "asc" })).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("deleteAnnouncement", () => {
+    const uuid = "52088548-2b99-4f38-ac09-3a8f8988476f";
+    const baseUrl = `http://localhost:3000/admin/api/announcements/${uuid}`;
+
+    it("should delete announcement successfully and update state", async () => {
+      mockAdminApi.onDelete(baseUrl).reply(200, mockAnnouncement);
+
+      await expect(announcementStore.deleteAnnouncement(uuid)).resolves.not.toThrow();
+
+      expect(announcementStore.announcement).toEqual(mockAnnouncement);
+    });
+
+    it("should throw on not found error when deleting announcement", async () => {
+      mockAdminApi.onDelete(baseUrl).reply(403, { message: "Forbidden" });
+
+      await expect(announcementStore.deleteAnnouncement(uuid)).rejects.toBeAxiosErrorWithStatus(403);
+    });
+
+    it("should throw on network error when deleting announcement", async () => {
+      mockAdminApi.onDelete(baseUrl).networkError();
+
+      await expect(announcementStore.deleteAnnouncement(uuid)).rejects.toThrow("Network Error");
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/auth.spec.ts
+++ b/ui/admin/tests/unit/store/modules/auth.spec.ts
@@ -1,48 +1,113 @@
-import { describe, expect, it, beforeEach } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useAuthStore from "@admin/store/modules/auth";
 
-describe("Auth", () => {
-  setActivePinia(createPinia());
-  const authStore = useAuthStore();
+describe("Admin Auth Store", () => {
+  let authStore: ReturnType<typeof useAuthStore>;
+  let mockAdminApi: MockAdapter;
 
   beforeEach(() => {
+    setActivePinia(createPinia());
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
+    localStorage.clear();
+    authStore = useAuthStore();
+  });
+
+  afterEach(() => {
+    mockAdminApi.reset();
     localStorage.clear();
   });
 
-  it("returns initial states", () => {
-    expect(authStore.status).toBe("");
-    expect(authStore.token).toBe("");
-    expect(authStore.currentUser).toBe("");
-    expect(authStore.isLoggedIn).toBe(false);
+  describe("Initial State", () => {
+    it("should have empty status", () => {
+      expect(authStore.status).toBe("");
+    });
+
+    it("should have empty token", () => {
+      expect(authStore.token).toBe("");
+    });
+
+    it("should have empty current user", () => {
+      expect(authStore.currentUser).toBe("");
+    });
+
+    it("should have isAdmin as false", () => {
+      expect(authStore.isAdmin).toBe(false);
+    });
+
+    it("should have isLoggedIn as false when no token", () => {
+      expect(authStore.isLoggedIn).toBe(false);
+    });
+
+    it("should load token from localStorage if present", () => {
+      localStorage.setItem("token", "stored-token");
+      localStorage.setItem("user", "stored-user");
+      localStorage.setItem("admin", "true");
+
+      setActivePinia(createPinia());
+      const newStore = useAuthStore();
+
+      expect(newStore.token).toBe("stored-token");
+      expect(newStore.currentUser).toBe("stored-user");
+      expect(newStore.isAdmin).toBe(true);
+      expect(newStore.isLoggedIn).toBe(true);
+    });
   });
 
-  it("handles login states correctly", () => {
-    const statusLoading = "loading";
-    const statusError = "error";
-    const statusSuccess = "success";
-    const token = "eyJhbGciOiJSUzI1NiIsInR5c";
-    const user = "user";
+  describe("getLoginToken", () => {
+    const baseUrl = "http://localhost:3000/admin/api/auth/token";
 
-    authStore.status = statusLoading;
-    expect(authStore.status).toBe(statusLoading);
+    it("should fetch token successfully and return it", async () => {
+      const userId = "user-123";
+      const mockResponse = {
+        token: "generated-token-abc123",
+      };
 
-    authStore.status = statusError;
-    expect(authStore.status).toBe(statusError);
+      mockAdminApi.onGet(`${baseUrl}/${userId}`).reply(200, mockResponse);
 
-    authStore.status = statusSuccess;
-    authStore.token = token;
-    authStore.currentUser = user;
+      const result = await authStore.getLoginToken(userId);
 
-    expect(authStore.status).toBe(statusSuccess);
-    expect(authStore.isLoggedIn).toBe(true);
-    expect(authStore.currentUser).toBe(user);
+      expect(result).toBe("generated-token-abc123");
+      expect(authStore.status).toBe("");
+    });
 
-    authStore.logout();
+    it("should set status to error on 500 and throw", async () => {
+      const userId = "user-123";
 
-    expect(authStore.status).toBe("");
-    expect(authStore.isLoggedIn).toBe(false);
-    expect(authStore.currentUser).toBe("");
-    expect(authStore.token).toBe("");
+      mockAdminApi.onGet(`${baseUrl}/${userId}`).reply(500);
+
+      await expect(authStore.getLoginToken(userId)).rejects.toBeAxiosErrorWithStatus(500);
+      expect(authStore.status).toBe("error");
+    });
+
+    it("should set status to error on network error and throw", async () => {
+      const userId = "user-123";
+
+      mockAdminApi.onGet(`${baseUrl}/${userId}`).networkError();
+
+      await expect(authStore.getLoginToken(userId)).rejects.toThrow("Network Error");
+      expect(authStore.status).toBe("error");
+    });
+  });
+
+  describe("logout", () => {
+    it("should clear all state and localStorage", () => {
+      authStore.status = "success";
+      authStore.token = "test-token";
+      authStore.currentUser = "test-user";
+      localStorage.setItem("token", "test-token");
+      localStorage.setItem("user", "test-user");
+
+      authStore.logout();
+
+      expect(authStore.status).toBe("");
+      expect(authStore.token).toBe("");
+      expect(authStore.currentUser).toBe("");
+      expect(authStore.isLoggedIn).toBe(false);
+      expect(localStorage.getItem("token")).toBeNull();
+      expect(localStorage.getItem("user")).toBeNull();
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/devices.spec.ts
+++ b/ui/admin/tests/unit/store/modules/devices.spec.ts
@@ -1,71 +1,229 @@
-import { describe, expect, it } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useDevicesStore from "@admin/store/modules/devices";
-import { IDevice } from "@/interfaces/IDevice";
+import { IAdminDevice } from "@admin/interfaces/IDevice";
+import { buildUrl } from "@tests/utils/url";
 
-describe("Devices", () => {
-  setActivePinia(createPinia());
-  const devicesStore = useDevicesStore();
+const mockDeviceBase: IAdminDevice = {
+  uid: "device-uid-123",
+  name: "admin-device",
+  identity: {
+    mac: "00:1A:2B:3C:4D:5E",
+  },
+  info: {
+    id: "debian",
+    pretty_name: "Debian GNU/Linux 11",
+    version: "11",
+    arch: "x86_64",
+    platform: "docker",
+  },
+  public_key: "ssh-rsa AAAAB3NzaC1...",
+  tenant_id: "tenant-id-789",
+  last_seen: "2026-01-01T12:00:00.000Z",
+  status_updated_at: "2026-01-01T12:00:00.000Z",
+  online: true,
+  namespace: "admin-namespace",
+  status: "accepted",
+  created_at: "2026-01-01T00:00:00.000Z",
+  remote_addr: "192.168.1.100",
+  position: { latitude: 0, longitude: 0 },
+  tags: [{
+    name: "admin",
+    tenant_id: "tenant-id-789",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  }],
+};
 
-  const devices = [
-    {
-      created_at: "2020-05-20T19:58:53.276Z",
-      identity: { mac: "00:00:00:00:00:00" },
-      info: {
-        arch: "x86_64",
-        id: "linuxmint",
-        platform: "linuxmint",
-        pretty_name: "Linux Mint 19.3",
-        version: "18.4.2",
-      },
-      last_seen: "2020-05-20T19:58:53.276Z",
-      name: "tests",
-      namespace: "dev",
-      online: true,
-      position: { latitude: 12, longitude: 12 },
-      public_key: "xxxxxxxxxxxxxxxx",
-      remote_addr: "127.0.0.1",
-      status: "accepted",
-      tags: ["xxxx", "yyyyy"],
-      tenant_id: "00000000",
-      uid: "a582b47a42d",
-    },
-    {
-      created_at: "2022-05-20T19:58:53.276Z",
-      identity: { mac: "00:00:00:00:00:00" },
-      info: {
-        arch: "x86_64",
-        id: "linuxmint",
-        platform: "linuxmint",
-        pretty_name: "Linux Mint 19.3",
-        version: "18.4.2",
-      },
-      last_seen: "2020-05-20T19:58:53.276Z",
-      name: "ossystems",
-      namespace: "ossystems",
-      online: true,
-      position: { latitude: 12, longitude: 12 },
-      public_key: "xxxxxxxxxxxxxxxx",
-      remote_addr: "127.0.0.1",
-      status: "accepted",
-      tags: [{ name: "xxxx" }, { name: "yyyyy" }],
-      tenant_id: "00000000",
-      uid: "a582b47a42d",
-    },
-  ];
+describe("Admin Devices Store", () => {
+  let devicesStore: ReturnType<typeof useDevicesStore>;
+  let mockAdminApi: MockAdapter;
 
-  const deviceCount = 2;
-
-  it("returns devices store default variables", () => {
-    expect(devicesStore.devices).toEqual([]);
-    expect(devicesStore.deviceCount).toBe(0);
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    devicesStore = useDevicesStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
   });
 
-  it("sets devices and number of devices", () => {
-    devicesStore.devices = devices as IDevice[];
-    devicesStore.deviceCount = deviceCount;
+  afterEach(() => { mockAdminApi.reset(); });
 
-    expect(devicesStore.devices).toEqual(devices);
-    expect(devicesStore.deviceCount).toBe(deviceCount);
+  describe("Initial State", () => {
+    it("should have empty devices array", () => {
+      expect(devicesStore.devices).toEqual([]);
+    });
+
+    it("should have zero device count", () => {
+      expect(devicesStore.deviceCount).toBe(0);
+    });
+
+    it("should have empty current filter", () => {
+      expect(devicesStore.currentFilter).toBe("");
+    });
+
+    it("should have undefined current sort field", () => {
+      expect(devicesStore.currentSortField).toBeUndefined();
+    });
+
+    it("should have undefined current sort order", () => {
+      expect(devicesStore.currentSortOrder).toBeUndefined();
+    });
+  });
+
+  describe("setFilter", () => {
+    it("should set filter value", () => {
+      devicesStore.setFilter("status:accepted");
+      expect(devicesStore.currentFilter).toBe("status:accepted");
+    });
+
+    it("should set empty string when filter is empty", () => {
+      devicesStore.setFilter("");
+      expect(devicesStore.currentFilter).toBe("");
+    });
+  });
+
+  describe("setSort", () => {
+    it("should set sort field and order", () => {
+      devicesStore.setSort("name", "asc");
+      expect(devicesStore.currentSortField).toBe("name");
+      expect(devicesStore.currentSortOrder).toBe("asc");
+    });
+
+    it("should set undefined sort field and order when not provided", () => {
+      devicesStore.setSort();
+      expect(devicesStore.currentSortField).toBeUndefined();
+      expect(devicesStore.currentSortOrder).toBeUndefined();
+    });
+  });
+
+  describe("fetchDeviceList", () => {
+    const baseUrl = "http://localhost:3000/admin/api/devices";
+
+    it("should fetch devices list successfully with default pagination", async () => {
+      const devicesList = [mockDeviceBase];
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" }))
+        .reply(200, devicesList, { "x-total-count": "1" });
+
+      await expect(devicesStore.fetchDeviceList()).resolves.not.toThrow();
+
+      expect(devicesStore.devices).toEqual(devicesList);
+      expect(devicesStore.deviceCount).toBe(1);
+    });
+
+    it("should fetch devices list successfully with custom pagination", async () => {
+      const devicesList = [mockDeviceBase];
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "", page: "2", per_page: "20" }))
+        .reply(200, devicesList, { "x-total-count": "1" });
+
+      await expect(devicesStore.fetchDeviceList({ page: 2, perPage: 20 })).resolves.not.toThrow();
+
+      expect(devicesStore.devices).toEqual(devicesList);
+      expect(devicesStore.deviceCount).toBe(1);
+    });
+
+    it("should fetch devices list with filter successfully", async () => {
+      const devicesList = [mockDeviceBase];
+      const filter = "test";
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter, page: "1", per_page: "10" }))
+        .reply(200, devicesList, { "x-total-count": "1" });
+
+      await expect(devicesStore.fetchDeviceList({ filter })).resolves.not.toThrow();
+
+      expect(devicesStore.devices).toEqual(devicesList);
+      expect(devicesStore.deviceCount).toBe(1);
+    });
+
+    it("should fetch devices list with sort successfully", async () => {
+      const devicesList = [mockDeviceBase];
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10", sort_by: "name", order_by: "asc" }))
+        .reply(200, devicesList, { "x-total-count": "1" });
+
+      await expect(devicesStore.fetchDeviceList({ sortField: "name", sortOrder: "asc" })).resolves.not.toThrow();
+
+      expect(devicesStore.devices).toEqual(devicesList);
+      expect(devicesStore.deviceCount).toBe(1);
+    });
+
+    it("should use current filter and sort when not provided in parameters", async () => {
+      devicesStore.setFilter("old_filter");
+      devicesStore.setSort("created_at", "desc");
+
+      const devicesList = [mockDeviceBase];
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "old_filter", page: "1", per_page: "10", sort_by: "created_at", order_by: "desc" }))
+        .reply(200, devicesList, { "x-total-count": "1" });
+
+      await expect(devicesStore.fetchDeviceList()).resolves.not.toThrow();
+
+      expect(devicesStore.devices).toEqual(devicesList);
+      expect(devicesStore.deviceCount).toBe(1);
+    });
+
+    it("should fetch empty devices list successfully", async () => {
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" }))
+        .reply(200, [], { "x-total-count": "0" });
+
+      await expect(devicesStore.fetchDeviceList()).resolves.not.toThrow();
+
+      expect(devicesStore.devices).toEqual([]);
+      expect(devicesStore.deviceCount).toBe(0);
+    });
+
+    it("should throw on server error when fetching devices list", async () => {
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" }))
+        .reply(500);
+
+      await expect(devicesStore.fetchDeviceList()).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when fetching devices list", async () => {
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" }))
+        .networkError();
+
+      await expect(devicesStore.fetchDeviceList()).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("fetchDeviceById", () => {
+    const baseGetDeviceUrl = (deviceUid: string) => `http://localhost:3000/admin/api/devices/${deviceUid}`;
+
+    it("should fetch device by id successfully and return data", async () => {
+      const deviceUid = "device-uid-123";
+
+      mockAdminApi.onGet(baseGetDeviceUrl(deviceUid)).reply(200, mockDeviceBase);
+
+      const result = await devicesStore.fetchDeviceById(deviceUid);
+
+      expect(result).toEqual(mockDeviceBase);
+    });
+
+    it("should throw on not found error when fetching device by id", async () => {
+      const deviceUid = "non-existent-device";
+
+      mockAdminApi.onGet(baseGetDeviceUrl(deviceUid)).reply(404, { message: "Device not found" });
+
+      await expect(devicesStore.fetchDeviceById(deviceUid)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when fetching device by id", async () => {
+      const deviceUid = "device-uid-123";
+
+      mockAdminApi.onGet(baseGetDeviceUrl(deviceUid)).networkError();
+
+      await expect(devicesStore.fetchDeviceById(deviceUid)).rejects.toThrow("Network Error");
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/firewall_rules.spec.ts
+++ b/ui/admin/tests/unit/store/modules/firewall_rules.spec.ts
@@ -1,44 +1,121 @@
-import { describe, expect, it } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useFirewallRulesStore from "@admin/store/modules/firewall_rules";
+import { IAdminFirewallRule } from "@admin/interfaces/IFirewallRule";
+import { buildUrl } from "@tests/utils/url";
 
-const mockFirewallRules = [
-  {
-    id: "5f1996c84d2190a22d5857bb",
-    tenant_id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    priority: 4,
-    action: "allow" as const,
-    active: true,
-    source_ip: "127.0.0.1",
-    username: "shellhub",
-    filter: { hostname: "shellhub", tags: [] },
-  },
-  {
-    id: "5f1996c84d2190a22d5857cc",
-    tenant_id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    priority: 3,
-    action: "deny" as const,
-    active: false,
-    source_ip: "127.0.0.1",
-    username: "shellhub",
-    filter: { hostname: "shellhub", tags: [] },
-  },
-];
+const mockFirewallRuleBase: IAdminFirewallRule = {
+  id: "5f1996c84d2190a22d5857bb",
+  tenant_id: "tenant-id-123",
+  priority: 4,
+  action: "allow",
+  active: true,
+  source_ip: "192.168.1.100",
+  username: "admin",
+  filter: { hostname: "admin-server", tags: [] },
+};
 
-describe("Firewall Rules Store", () => {
-  setActivePinia(createPinia());
-  const firewallRulesStore = useFirewallRulesStore();
+describe("Admin Firewall Rules Store", () => {
+  let firewallRulesStore: ReturnType<typeof useFirewallRulesStore>;
+  let mockAdminApi: MockAdapter;
 
-  it("returns default values", () => {
-    expect(firewallRulesStore.firewallRules).toEqual([]);
-    expect(firewallRulesStore.firewallRulesCount).toEqual(0);
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    firewallRulesStore = useFirewallRulesStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
   });
 
-  it("sets firewalls and total count", () => {
-    firewallRulesStore.firewallRules = mockFirewallRules;
-    firewallRulesStore.firewallRulesCount = mockFirewallRules.length;
+  afterEach(() => { mockAdminApi.reset(); });
 
-    expect(firewallRulesStore.firewallRules).toEqual(mockFirewallRules);
-    expect(firewallRulesStore.firewallRulesCount).toBe(2);
+  describe("Initial State", () => {
+    it("should have empty firewall rules array", () => {
+      expect(firewallRulesStore.firewallRules).toEqual([]);
+    });
+
+    it("should have zero firewall rules count", () => {
+      expect(firewallRulesStore.firewallRulesCount).toBe(0);
+    });
+  });
+
+  describe("fetchFirewallRulesList", () => {
+    const baseUrl = "http://localhost:3000/admin/api/firewall/rules";
+
+    it("should fetch firewall rules list successfully with default pagination", async () => {
+      const rulesList = [mockFirewallRuleBase];
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "1", per_page: "10" })).reply(200, rulesList, { "x-total-count": "1" });
+
+      await expect(firewallRulesStore.fetchFirewallRulesList()).resolves.not.toThrow();
+
+      expect(firewallRulesStore.firewallRules).toEqual(rulesList);
+      expect(firewallRulesStore.firewallRulesCount).toBe(1);
+    });
+
+    it("should fetch firewall rules list successfully with custom pagination", async () => {
+      const rulesList = [
+        mockFirewallRuleBase,
+        { ...mockFirewallRuleBase, id: "5f1996c84d2190a22d5857cc", priority: 3 },
+      ];
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "2", per_page: "20" })).reply(200, rulesList, { "x-total-count": "2" });
+
+      await expect(firewallRulesStore.fetchFirewallRulesList({ page: 2, perPage: 20 })).resolves.not.toThrow();
+
+      expect(firewallRulesStore.firewallRules).toEqual(rulesList);
+      expect(firewallRulesStore.firewallRulesCount).toBe(2);
+    });
+
+    it("should fetch empty firewall rules list successfully", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "1", per_page: "10" })).reply(200, [], { "x-total-count": "0" });
+
+      await expect(firewallRulesStore.fetchFirewallRulesList()).resolves.not.toThrow();
+
+      expect(firewallRulesStore.firewallRules).toEqual([]);
+      expect(firewallRulesStore.firewallRulesCount).toBe(0);
+    });
+
+    it("should throw on server error when fetching firewall rules list", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "1", per_page: "10" })).reply(500);
+
+      await expect(firewallRulesStore.fetchFirewallRulesList()).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when fetching firewall rules list", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "1", per_page: "10" })).networkError();
+
+      await expect(firewallRulesStore.fetchFirewallRulesList()).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("fetchFirewallRuleById", () => {
+    const generateGetRuleUrl = (ruleId: string) => `http://localhost:3000/admin/api/firewall/rules/${ruleId}`;
+
+    it("should fetch firewall rule by id successfully and return data", async () => {
+      const ruleId = "5f1996c84d2190a22d5857bb";
+
+      mockAdminApi.onGet(generateGetRuleUrl(ruleId)).reply(200, mockFirewallRuleBase);
+
+      const result = await firewallRulesStore.fetchFirewallRuleById(ruleId);
+
+      expect(result).toEqual(mockFirewallRuleBase);
+    });
+
+    it("should throw on not found error when fetching firewall rule by id", async () => {
+      const ruleId = "non-existent-rule";
+
+      mockAdminApi.onGet(generateGetRuleUrl(ruleId)).reply(404, { message: "Firewall rule not found" });
+
+      await expect(firewallRulesStore.fetchFirewallRuleById(ruleId)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when fetching firewall rule by id", async () => {
+      const ruleId = "5f1996c84d2190a22d5857bb";
+
+      mockAdminApi.onGet(generateGetRuleUrl(ruleId)).networkError();
+
+      await expect(firewallRulesStore.fetchFirewallRuleById(ruleId)).rejects.toThrow("Network Error");
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/instance.spec.ts
+++ b/ui/admin/tests/unit/store/modules/instance.spec.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useInstanceStore from "@admin/store/modules/instance";
+import { IAdminAuth, IAdminUpdateSAML } from "@admin/interfaces/IInstance";
 
-const mockAuthenticationSettings = {
+const mockAuthenticationSettings: IAdminAuth = {
   local: {
     enabled: true,
   },
@@ -20,48 +23,185 @@ const mockAuthenticationSettings = {
     },
     sp: {
       sign_auth_requests: true,
-      certificate: "cert",
+      certificate: "cert-sp-123",
     },
   },
 };
 
-describe("Instance Pinia Store", () => {
-  setActivePinia(createPinia());
-  const instanceStore = useInstanceStore();
+const mockSAMLUpdate: IAdminUpdateSAML = {
+  enable: false,
+  idp: {
+    entity_id: "new-entity",
+    binding: {
+      post: "https://new-url.com/post",
+      redirect: "https://new-url.com/redirect",
+    },
+  },
+  sp: {
+    sign_requests: false,
+  },
+};
 
-  it("should have the correct initial state", () => {
-    expect(instanceStore.authenticationSettings).toEqual({
-      local: { enabled: false },
-      saml: {
-        enabled: false,
-        auth_url: "",
-        assertion_url: "",
-        idp: {
-          entity_id: "",
-          binding: {
-            post: "",
-            redirect: "",
+describe("Admin Instance Store", () => {
+  let instanceStore: ReturnType<typeof useInstanceStore>;
+  let mockAdminApi: MockAdapter;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    instanceStore = useInstanceStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
+  });
+
+  afterEach(() => { mockAdminApi.reset(); });
+
+  describe("Initial State", () => {
+    it("should have default authentication settings", () => {
+      expect(instanceStore.authenticationSettings).toEqual({
+        local: { enabled: false },
+        saml: {
+          enabled: false,
+          auth_url: "",
+          assertion_url: "",
+          idp: {
+            entity_id: "",
+            binding: {
+              post: "",
+              redirect: "",
+            },
+            certificates: [],
           },
-          certificates: [],
+          sp: {
+            sign_auth_requests: false,
+            certificate: "",
+          },
         },
-        sp: {
-          sign_auth_requests: false,
-          certificate: "",
-        },
-      },
+      });
+    });
+
+    it("should have isLocalAuthEnabled as false", () => {
+      expect(instanceStore.isLocalAuthEnabled).toBe(false);
+    });
+
+    it("should have isSamlEnabled as false", () => {
+      expect(instanceStore.isSamlEnabled).toBe(false);
     });
   });
 
-  it("should return authenticationSettings", () => {
-    instanceStore.authenticationSettings = mockAuthenticationSettings;
-    expect(instanceStore.authenticationSettings).toEqual(mockAuthenticationSettings);
+  describe("Computed Properties", () => {
+    it("should compute isLocalAuthEnabled correctly when enabled", () => {
+      instanceStore.authenticationSettings = {
+        ...instanceStore.authenticationSettings,
+        local: { enabled: true },
+      };
+
+      expect(instanceStore.isLocalAuthEnabled).toBe(true);
+    });
+
+    it("should compute isSamlEnabled correctly when enabled", () => {
+      instanceStore.authenticationSettings = {
+        ...instanceStore.authenticationSettings,
+        saml: {
+          ...instanceStore.authenticationSettings.saml,
+          enabled: true,
+        },
+      };
+
+      expect(instanceStore.isSamlEnabled).toBe(true);
+    });
   });
 
-  it("should return whether local authentication is enabled", () => {
-    expect(instanceStore.isLocalAuthEnabled).toBe(true);
+  describe("fetchAuthenticationSettings", () => {
+    const baseUrl = "http://localhost:3000/admin/api/authentication";
+
+    it("should fetch authentication settings successfully and update state", async () => {
+      mockAdminApi.onGet(baseUrl).reply(200, mockAuthenticationSettings);
+
+      await instanceStore.fetchAuthenticationSettings();
+
+      expect(instanceStore.authenticationSettings).toEqual(mockAuthenticationSettings);
+      expect(instanceStore.isLocalAuthEnabled).toBe(true);
+      expect(instanceStore.isSamlEnabled).toBe(true);
+    });
+
+    it("should throw on server error when fetching settings", async () => {
+      mockAdminApi.onGet(baseUrl).reply(500);
+
+      await expect(instanceStore.fetchAuthenticationSettings()).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when fetching settings", async () => {
+      mockAdminApi.onGet(baseUrl).networkError();
+
+      await expect(instanceStore.fetchAuthenticationSettings()).rejects.toThrow("Network Error");
+    });
   });
 
-  it("should return whether SAML is enabled", () => {
-    expect(instanceStore.isSamlEnabled).toBe(true);
+  describe("updateLocalAuthentication", () => {
+    const updateUrl = "http://localhost:3000/admin/api/authentication/local";
+    const fetchUrl = "http://localhost:3000/admin/api/authentication";
+
+    it("should update local authentication and refresh settings", async () => {
+      const updatedSettings = {
+        ...mockAuthenticationSettings,
+        local: { enabled: false },
+      };
+
+      mockAdminApi.onPut(updateUrl, { enable: false }).reply(200);
+      mockAdminApi.onGet(fetchUrl).reply(200, updatedSettings);
+
+      await instanceStore.updateLocalAuthentication(false);
+
+      expect(instanceStore.authenticationSettings).toEqual(updatedSettings);
+      expect(instanceStore.isLocalAuthEnabled).toBe(false);
+    });
+
+    it("should throw on server error when updating local auth", async () => {
+      mockAdminApi.onPut(updateUrl, { enable: true }).reply(500);
+
+      await expect(instanceStore.updateLocalAuthentication(true)).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when updating local auth", async () => {
+      mockAdminApi.onPut(updateUrl, { enable: true }).networkError();
+
+      await expect(instanceStore.updateLocalAuthentication(true)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("updateSamlAuthentication", () => {
+    const updateUrl = "http://localhost:3000/admin/api/authentication/saml";
+    const fetchUrl = "http://localhost:3000/admin/api/authentication";
+
+    it("should update SAML authentication and refresh settings", async () => {
+      const updatedSettings = {
+        ...mockAuthenticationSettings,
+        saml: {
+          ...mockSAMLUpdate,
+        },
+      };
+
+      // Payload sends "enable", but response uses "enabled"
+      const updatedSettingsResponse = { ...updatedSettings, saml: { ...updatedSettings.saml, enabled: false } };
+
+      mockAdminApi.onPut(updateUrl, mockSAMLUpdate).reply(200);
+      mockAdminApi.onGet(fetchUrl).reply(200, updatedSettingsResponse);
+
+      await instanceStore.updateSamlAuthentication(mockSAMLUpdate);
+
+      expect(instanceStore.authenticationSettings).toEqual(updatedSettingsResponse);
+      expect(instanceStore.isSamlEnabled).toBe(false);
+    });
+
+    it("should throw on server error when updating SAML auth", async () => {
+      mockAdminApi.onPut(updateUrl, mockSAMLUpdate).reply(500);
+
+      await expect(instanceStore.updateSamlAuthentication(mockSAMLUpdate)).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when updating SAML auth", async () => {
+      mockAdminApi.onPut(updateUrl, mockSAMLUpdate).networkError();
+
+      await expect(instanceStore.updateSamlAuthentication(mockSAMLUpdate)).rejects.toThrow("Network Error");
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/license.spec.ts
+++ b/ui/admin/tests/unit/store/modules/license.spec.ts
@@ -1,45 +1,153 @@
-import { describe, expect, it } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
+import axios from "axios";
 import useLicenseStore from "@admin/store/modules/license";
+import { IAdminLicense } from "@admin/interfaces/ILicense";
 
-const mockLicense = {
+const mockLicense: IAdminLicense = {
   expired: false,
   about_to_expire: false,
   grace_period: false,
   id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-  issued_at: -1,
-  starts_at: -1,
-  expires_at: -1,
+  issued_at: 1704067200,
+  starts_at: 1704067200,
+  expires_at: 1735689600,
   allowed_regions: [],
   customer: {
-    id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    id: "customer-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     name: "ShellHub",
-    email: "contato@ossystems.com.br",
-    company: "O.S. Systems",
+    email: "contact@shellhub.io",
+    company: "ShellHub Inc",
   },
   features: {
-    devices: -1,
+    devices: 100,
     session_recording: true,
     firewall_rules: true,
-    reports: false,
-    login_link: false,
-    billing: false,
+    reports: true,
+    login_link: true,
+    billing: true,
   },
 };
 
-describe("License Pinia Store", () => {
-  setActivePinia(createPinia());
-  const licenseStore = useLicenseStore();
+const mockExpiredLicense: IAdminLicense = {
+  ...mockLicense,
+  expired: true,
+};
 
-  it("returns default license state", () => {
-    expect(licenseStore.license).toEqual({});
-    expect(licenseStore.isExpired).toBe(true);
+describe("Admin License Store", () => {
+  let licenseStore: ReturnType<typeof useLicenseStore>;
+  let mockAdminApi: MockAdapter;
+  let mockAxios: MockAdapter;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    licenseStore = useLicenseStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
+    mockAxios = new MockAdapter(axios);
+    localStorage.clear();
   });
 
-  it("updates license state correctly", () => {
-    licenseStore.license = mockLicense;
+  afterEach(() => {
+    mockAdminApi.reset();
+    mockAxios.reset();
+    localStorage.clear();
+  });
 
-    expect(licenseStore.license).toEqual(mockLicense);
-    expect(licenseStore.isExpired).toBe(false);
+  describe("Initial State", () => {
+    it("should have empty license object", () => {
+      expect(licenseStore.license).toEqual({});
+    });
+
+    it("should have isExpired as true when license is empty", () => {
+      expect(licenseStore.isExpired).toBe(true);
+    });
+  });
+
+  describe("Computed Properties", () => {
+    it("should compute isExpired as false when license is not expired", () => {
+      licenseStore.license = mockLicense;
+
+      expect(licenseStore.isExpired).toBe(false);
+    });
+
+    it("should compute isExpired as true when license is expired", () => {
+      licenseStore.license = mockExpiredLicense;
+
+      expect(licenseStore.isExpired).toBe(true);
+    });
+
+    it("should compute isExpired as true when expired field is undefined", () => {
+      const licenseWithoutExpired = { ...mockLicense };
+      delete (licenseWithoutExpired as Partial<IAdminLicense>).expired;
+      licenseStore.license = licenseWithoutExpired as IAdminLicense;
+
+      expect(licenseStore.isExpired).toBe(true);
+    });
+  });
+
+  describe("getLicense", () => {
+    const baseUrl = "http://localhost:3000/admin/api/license";
+
+    it("should fetch license successfully and update state", async () => {
+      mockAdminApi.onGet(baseUrl).reply(200, mockLicense);
+
+      await licenseStore.getLicense();
+
+      expect(licenseStore.license).toEqual(mockLicense);
+      expect(licenseStore.isExpired).toBe(false);
+    });
+
+    it("should throw on not found error when fetching license", async () => {
+      mockAdminApi.onGet(baseUrl).reply(404);
+
+      await expect(licenseStore.getLicense()).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when fetching license", async () => {
+      mockAdminApi.onGet(baseUrl).networkError();
+
+      await expect(licenseStore.getLicense()).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("uploadLicense", () => {
+    const uploadUrl = `${window.location.origin}/admin/api/license`;
+
+    it("should upload license file successfully with FormData", async () => {
+      const mockFile = new File(["license content"], "license.txt", { type: "text/plain" });
+      const token = "test-bearer-token";
+      localStorage.setItem("token", token);
+
+      mockAxios
+        .onPost(uploadUrl)
+        .reply((config) => {
+          expect(config.data).toBeInstanceOf(FormData);
+          expect(config.headers?.Authorization).toBe(`Bearer ${token}`);
+          expect(config.headers?.["Content-Type"]).toBe("multipart/form-data");
+          return [200, { success: true }];
+        });
+
+      await licenseStore.uploadLicense(mockFile);
+    });
+
+    it("should throw on server error when uploading license", async () => {
+      const mockFile = new File(["license content"], "license.txt", { type: "text/plain" });
+      localStorage.setItem("token", "test-token");
+
+      mockAxios.onPost(uploadUrl).reply(500);
+
+      await expect(licenseStore.uploadLicense(mockFile)).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when uploading license", async () => {
+      const mockFile = new File(["license content"], "license.txt", { type: "text/plain" });
+      localStorage.setItem("token", "test-token");
+
+      mockAxios.onPost(uploadUrl).networkError();
+
+      await expect(licenseStore.uploadLicense(mockFile)).rejects.toThrow("Network Error");
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/namespaces.spec.ts
+++ b/ui/admin/tests/unit/store/modules/namespaces.spec.ts
@@ -1,13 +1,257 @@
-import { describe, expect, it } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useNamespacesStore from "@admin/store/modules/namespaces";
+import { IAdminNamespace } from "@admin/interfaces/INamespace";
+import { buildUrl } from "@tests/utils/url";
 
-describe("Namespaces Pinia Store", () => {
-  setActivePinia(createPinia());
-  const namespacesStore = useNamespacesStore();
+const mockNamespaceBase: IAdminNamespace = {
+  name: "admin-namespace",
+  owner: "admin-user-id",
+  type: "personal",
+  devices_accepted_count: 5,
+  devices_pending_count: 1,
+  devices_rejected_count: 0,
+  tenant_id: "tenant-id-123",
+  members: [
+    {
+      id: "member-id-1",
+      email: "admin@example.com",
+      role: "owner",
+      status: "accepted",
+      added_at: "2026-01-06T00:00:00.000Z",
+      expires_at: "2027-01-06T00:00:00.000Z",
+    },
+  ],
+  settings: {
+    session_record: true,
+    connection_announcement: "",
+  },
+  created_at: "2026-01-06T00:00:00.000Z",
+  max_devices: 10,
+};
 
-  it("returns default state", () => {
-    expect(namespacesStore.namespaces).toEqual([]);
-    expect(namespacesStore.namespaceCount).toEqual(0);
+describe("Admin Namespaces Store", () => {
+  let namespacesStore: ReturnType<typeof useNamespacesStore>;
+  let mockAdminApi: MockAdapter;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    namespacesStore = useNamespacesStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
+  });
+
+  afterEach(() => { mockAdminApi.reset(); });
+
+  describe("Initial State", () => {
+    it("should have empty namespaces array", () => {
+      expect(namespacesStore.namespaces).toEqual([]);
+    });
+
+    it("should have zero namespace count", () => {
+      expect(namespacesStore.namespaceCount).toBe(0);
+    });
+
+    it("should have empty current filter", () => {
+      expect(namespacesStore.currentFilter).toBe("");
+    });
+  });
+
+  describe("setFilter", () => {
+    it("should set filter value", () => {
+      namespacesStore.setFilter("owner:admin");
+      expect(namespacesStore.currentFilter).toBe("owner:admin");
+    });
+
+    it("should set empty string when filter is empty", () => {
+      namespacesStore.setFilter("");
+      expect(namespacesStore.currentFilter).toBe("");
+    });
+  });
+
+  describe("fetchNamespaceList", () => {
+    const baseUrl = "http://localhost:3000/admin/api/namespaces";
+
+    it("should fetch namespaces list successfully with default pagination", async () => {
+      const namespacesList = [mockNamespaceBase];
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" })).reply(200, namespacesList, { "x-total-count": "1" });
+
+      await expect(namespacesStore.fetchNamespaceList()).resolves.not.toThrow();
+
+      expect(namespacesStore.namespaces).toEqual(namespacesList);
+      expect(namespacesStore.namespaceCount).toBe(1);
+    });
+
+    it("should fetch namespaces list successfully with custom pagination", async () => {
+      const namespacesList = [mockNamespaceBase];
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "2", per_page: "20" })).reply(200, namespacesList, { "x-total-count": "1" });
+
+      await expect(namespacesStore.fetchNamespaceList({ page: 2, perPage: 20 })).resolves.not.toThrow();
+
+      expect(namespacesStore.namespaces).toEqual(namespacesList);
+      expect(namespacesStore.namespaceCount).toBe(1);
+    });
+
+    it("should fetch namespaces list with filter successfully", async () => {
+      const namespacesList = [mockNamespaceBase];
+      const filter = "test";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter, page: "1", per_page: "10" })).reply(200, namespacesList, { "x-total-count": "1" });
+
+      await expect(namespacesStore.fetchNamespaceList({ filter })).resolves.not.toThrow();
+
+      expect(namespacesStore.namespaces).toEqual(namespacesList);
+      expect(namespacesStore.namespaceCount).toBe(1);
+    });
+
+    it("should use current filter when not provided in parameters", async () => {
+      namespacesStore.setFilter("old_filter");
+
+      const namespacesList = [mockNamespaceBase];
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "old_filter", page: "1", per_page: "10" }))
+        .reply(200, namespacesList, { "x-total-count": "1" });
+
+      await expect(namespacesStore.fetchNamespaceList()).resolves.not.toThrow();
+
+      expect(namespacesStore.namespaces).toEqual(namespacesList);
+      expect(namespacesStore.namespaceCount).toBe(1);
+    });
+
+    it("should fetch empty namespaces list successfully", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" })).reply(200, [], { "x-total-count": "0" });
+
+      await expect(namespacesStore.fetchNamespaceList()).resolves.not.toThrow();
+
+      expect(namespacesStore.namespaces).toEqual([]);
+      expect(namespacesStore.namespaceCount).toBe(0);
+    });
+
+    it("should throw on server error when fetching namespaces list", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" })).reply(500);
+
+      await expect(namespacesStore.fetchNamespaceList()).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when fetching namespaces list", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" })).networkError();
+
+      await expect(namespacesStore.fetchNamespaceList()).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("fetchNamespaceById", () => {
+    const namespaceId = "tenant-id-123";
+    const baseGetNamespaceUrl = `http://localhost:3000/admin/api/namespaces/${namespaceId}`;
+
+    it("should fetch namespace by id successfully and return data", async () => {
+      mockAdminApi.onGet(baseGetNamespaceUrl).reply(200, mockNamespaceBase);
+
+      const result = await namespacesStore.fetchNamespaceById(namespaceId);
+
+      expect(result).toEqual(mockNamespaceBase);
+    });
+
+    it("should throw on not found error when fetching namespace by id", async () => {
+      mockAdminApi.onGet(baseGetNamespaceUrl).reply(404, { message: "Namespace not found" });
+
+      await expect(namespacesStore.fetchNamespaceById(namespaceId)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when fetching namespace by id", async () => {
+      mockAdminApi.onGet(baseGetNamespaceUrl).networkError();
+
+      await expect(namespacesStore.fetchNamespaceById(namespaceId)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("exportNamespacesToCsv", () => {
+    const baseUrl = "http://localhost:3000/admin/api/export/namespaces";
+    const csvData = "name,owner,devices\nadmin-namespace,admin,5";
+
+    it("should export namespaces to CSV successfully and return data", async () => {
+      const filter = "";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter })).reply(200, csvData);
+
+      const result = await namespacesStore.exportNamespacesToCsv(filter);
+
+      expect(result).toBe(csvData);
+    });
+
+    it("should export namespaces with filter to CSV successfully", async () => {
+      const filter = "owner:admin";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter })).reply(200, csvData);
+
+      const result = await namespacesStore.exportNamespacesToCsv(filter);
+
+      expect(result).toBe(csvData);
+    });
+
+    it("should throw on not found error when exporting namespaces", async () => {
+      const filter = "";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter })).reply(404, { message: "No namespaces to export" });
+
+      await expect(namespacesStore.exportNamespacesToCsv(filter)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when exporting namespaces", async () => {
+      const filter = "";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter })).networkError();
+
+      await expect(namespacesStore.exportNamespacesToCsv(filter)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("updateNamespace", () => {
+    const baseUrl = `http://localhost:3000/admin/api/namespaces-update/${mockNamespaceBase.tenant_id}`;
+
+    it("should update namespace successfully", async () => {
+      mockAdminApi.onPut(baseUrl, mockNamespaceBase).reply(200);
+
+      await expect(namespacesStore.updateNamespace(mockNamespaceBase)).resolves.not.toThrow();
+    });
+
+    it("should throw on not found error when updating namespace", async () => {
+      mockAdminApi.onPut(baseUrl, mockNamespaceBase).reply(404, { message: "Namespace not found" });
+
+      await expect(namespacesStore.updateNamespace(mockNamespaceBase)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when updating namespace", async () => {
+      mockAdminApi.onPut(baseUrl, mockNamespaceBase).networkError();
+
+      await expect(namespacesStore.updateNamespace(mockNamespaceBase)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("deleteNamespace", () => {
+    const tenantId = "tenant-id-123";
+    const baseUrl = `http://localhost:3000/admin/api/namespaces/${tenantId}`;
+
+    it("should delete namespace successfully", async () => {
+      mockAdminApi.onDelete(baseUrl).reply(200);
+
+      await expect(namespacesStore.deleteNamespace(tenantId)).resolves.not.toThrow();
+    });
+
+    it("should throw on not found error when deleting namespace", async () => {
+      mockAdminApi.onDelete(baseUrl).reply(404, { message: "Namespace not found" });
+
+      await expect(namespacesStore.deleteNamespace(tenantId)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when deleting namespace", async () => {
+      mockAdminApi.onDelete(baseUrl).networkError();
+
+      await expect(namespacesStore.deleteNamespace(tenantId)).rejects.toThrow("Network Error");
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/sessions.spec.ts
+++ b/ui/admin/tests/unit/store/modules/sessions.spec.ts
@@ -1,64 +1,158 @@
-import { describe, expect, it } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useSessionsStore from "@admin/store/modules/sessions";
 import { IAdminSession } from "@admin/interfaces/ISession";
+import { buildUrl } from "@tests/utils/url";
 
-const session = {
-  uid: "8c354a00f50",
-  device_uid: "a582b47a42d",
+const mockSessionBase: IAdminSession = {
+  uid: "session-uid-123",
+  device_uid: "device-uid-456",
   device: {
-    uid: "a582b47a42d",
-    name: "39-5e-2a",
+    uid: "device-uid-456",
+    name: "admin-device",
     identity: {
-      mac: "00:00:00:00:00:00",
+      mac: "00:1A:2B:3C:4D:5E",
     },
     info: {
       id: "debian",
-      pretty_name: "Debian GNU/Linux 10 (buster)",
-      version: "v0.2.5",
+      pretty_name: "Debian GNU/Linux 11",
+      version: "11",
+      arch: "x86_64",
+      platform: "docker",
     },
-    public_key: "----- PUBLIC KEY -----",
-    tenant_id: "00000000",
-    last_seen: "2020-05-18T13:27:02.498Z",
-    online: false,
-    namespace: "user",
+    public_key: "ssh-rsa AAAAB3NzaC1...",
+    tenant_id: "tenant-id-789",
+    last_seen: "2026-01-01T12:00:00.000Z",
+    status_updated_at: "2026-01-01T12:00:00.000Z",
+    online: true,
+    namespace: "admin-namespace",
+    status: "accepted",
+    created_at: "2026-01-01T00:00:00.000Z",
+    remote_addr: "192.168.1.100",
+    position: { latitude: 0, longitude: 0 },
+    tags: [{
+      name: "admin",
+      tenant_id: "tenant-id-789",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    }],
   },
-  tenant_id: "00000000",
-  username: "user",
-  ip_address: "000.000.000.000",
-  started_at: "2020-05-18T12:30:28.824Z",
-  last_seen: "2020-05-18T12:30:30.205Z",
-  active: false,
-  authenticated: false,
-} as IAdminSession;
+  tenant_id: "tenant-id-789",
+  username: "admin",
+  ip_address: "192.168.1.50",
+  started_at: "2026-01-01T10:00:00.000Z",
+  last_seen: "2026-01-01T12:00:00.000Z",
+  active: true,
+  authenticated: true,
+  recorded: true,
+  type: "shell",
+  term: "xterm-256color",
+  position: { latitude: 0, longitude: 0 },
+};
 
-const sessions = [
-  { ...session },
-  {
-    ...session,
-    device: {
-      ...session.device,
-      name: "b4-2e-99",
-    },
-  },
-];
+describe("Admin Sessions Store", () => {
+  let sessionsStore: ReturnType<typeof useSessionsStore>;
+  let mockAdminApi: MockAdapter;
 
-const sessionCount = 2;
-
-describe("Sessions Pinia Store", () => {
-  setActivePinia(createPinia());
-  const sessionsStore = useSessionsStore();
-
-  it("returns default session state", () => {
-    expect(sessionsStore.sessions).toEqual([]);
-    expect(sessionsStore.sessionCount).toEqual(0);
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    sessionsStore = useSessionsStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
   });
 
-  it("sets sessions and total count", () => {
-    sessionsStore.sessions = sessions;
-    sessionsStore.sessionCount = sessionCount;
+  afterEach(() => { mockAdminApi.reset(); });
 
-    expect(sessionsStore.sessions).toEqual(sessions);
-    expect(sessionsStore.sessionCount).toEqual(sessionCount);
+  describe("Initial State", () => {
+    it("should have empty sessions array", () => {
+      expect(sessionsStore.sessions).toEqual([]);
+    });
+
+    it("should have zero session count", () => {
+      expect(sessionsStore.sessionCount).toBe(0);
+    });
+  });
+
+  describe("fetchSessionList", () => {
+    const baseUrl = "http://localhost:3000/admin/api/sessions";
+
+    it("should fetch sessions list successfully with pagination", async () => {
+      const sessionList = [mockSessionBase];
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "1", per_page: "10" })).reply(200, sessionList, { "x-total-count": "1" });
+
+      await expect(sessionsStore.fetchSessionList({ perPage: 10, page: 1 })).resolves.not.toThrow();
+
+      expect(sessionsStore.sessions).toEqual(sessionList);
+      expect(sessionsStore.sessionCount).toBe(1);
+    });
+
+    it("should fetch sessions list with multiple sessions", async () => {
+      const sessionList = [
+        mockSessionBase,
+        { ...mockSessionBase, uid: "session-uid-456" },
+      ];
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "2", per_page: "20" })).reply(200, sessionList, { "x-total-count": "2" });
+
+      await expect(sessionsStore.fetchSessionList({ perPage: 20, page: 2 })).resolves.not.toThrow();
+
+      expect(sessionsStore.sessions).toEqual(sessionList);
+      expect(sessionsStore.sessionCount).toBe(2);
+    });
+
+    it("should fetch empty sessions list successfully", async () => {
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { page: "1", per_page: "10" }))
+        .reply(200, [], { "x-total-count": "0" });
+
+      await expect(sessionsStore.fetchSessionList({ perPage: 10, page: 1 })).resolves.not.toThrow();
+
+      expect(sessionsStore.sessions).toEqual([]);
+      expect(sessionsStore.sessionCount).toBe(0);
+    });
+
+    it("should throw on server error when fetching sessions list", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "1", per_page: "10" })).reply(500);
+
+      await expect(sessionsStore.fetchSessionList({ perPage: 10, page: 1 })).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when fetching sessions list", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { page: "1", per_page: "10" })).networkError();
+
+      await expect(sessionsStore.fetchSessionList({ perPage: 10, page: 1 })).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("fetchSessionById", () => {
+    const generateGetSessionUrl = (sessionUid: string) => `http://localhost:3000/admin/api/sessions/${sessionUid}`;
+
+    it("should fetch session by id successfully and return data", async () => {
+      const sessionUid = "session-uid-123";
+
+      mockAdminApi.onGet(generateGetSessionUrl(sessionUid)).reply(200, mockSessionBase);
+
+      const result = await sessionsStore.fetchSessionById(sessionUid);
+
+      expect(result).toEqual(mockSessionBase);
+    });
+
+    it("should throw on not found error when fetching session by id", async () => {
+      const sessionUid = "non-existent-session";
+
+      mockAdminApi.onGet(generateGetSessionUrl(sessionUid)).reply(404, { message: "Session not found" });
+
+      await expect(sessionsStore.fetchSessionById(sessionUid)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when fetching session by id", async () => {
+      const sessionUid = "session-uid-123";
+
+      mockAdminApi.onGet(generateGetSessionUrl(sessionUid)).networkError();
+
+      await expect(sessionsStore.fetchSessionById(sessionUid)).rejects.toThrow("Network Error");
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/stats.spec.ts
+++ b/ui/admin/tests/unit/store/modules/stats.spec.ts
@@ -1,23 +1,52 @@
-import { describe, expect, it, vi } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useStatsStore from "@admin/store/modules/stats";
+import { IAdminStats } from "@admin/interfaces/IStats";
 
-const stats = {
-  registered_devices: 2,
-  online_devices: 1,
-  active_sessions: 1,
-  pending_devices: 1,
-  registered_users: 10,
-  rejected_devices: 0,
+const mockStats: IAdminStats = {
+  registered_devices: 10,
+  online_devices: 5,
+  active_sessions: 3,
+  pending_devices: 2,
+  rejected_devices: 1,
+  registered_users: 15,
 };
 
-describe("Stats Pinia Store", () => {
-  setActivePinia(createPinia());
-  const statsStore = useStatsStore();
+describe("Admin Stats Store", () => {
+  let statsStore: ReturnType<typeof useStatsStore>;
+  let mockAdminApi: MockAdapter;
 
-  it("returns default stats state", async () => {
-    statsStore.getStats = vi.fn().mockResolvedValue(stats);
-    const responseData = await statsStore.getStats();
-    expect(responseData).toEqual(stats);
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    statsStore = useStatsStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
+  });
+
+  afterEach(() => { mockAdminApi.reset(); });
+
+  describe("getStats", () => {
+    const baseUrl = "http://localhost:3000/admin/api/stats";
+
+    it("should fetch stats successfully and return data", async () => {
+      mockAdminApi.onGet(baseUrl).reply(200, mockStats);
+
+      const result = await statsStore.getStats();
+
+      expect(result).toEqual(mockStats);
+    });
+
+    it("should throw on not found error when fetching stats", async () => {
+      mockAdminApi.onGet(baseUrl).reply(404, { message: "Stats not found" });
+
+      await expect(statsStore.getStats()).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when fetching stats", async () => {
+      mockAdminApi.onGet(baseUrl).networkError();
+
+      await expect(statsStore.getStats()).rejects.toThrow("Network Error");
+    });
   });
 });

--- a/ui/admin/tests/unit/store/modules/users.spec.ts
+++ b/ui/admin/tests/unit/store/modules/users.spec.ts
@@ -1,44 +1,310 @@
-import { describe, expect, it } from "vitest";
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
+import MockAdapter from "axios-mock-adapter";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { adminApi } from "@/api/http";
 import useUsersStore from "@admin/store/modules/users";
-import { IAdminUser } from "@admin/interfaces/IUser";
+import { IAdminUser, IAdminUserFormData } from "@admin/interfaces/IUser";
+import { buildUrl } from "@tests/utils/url";
 
-const users = [
-  {
-    id: "xxxxxxxx",
-    name: "user",
-    email: "user@email.com",
-    username: "username",
+const mockUserBase: IAdminUser = {
+  id: "user-id-123",
+  status: "confirmed",
+  max_namespaces: 5,
+  created_at: "2026-01-01T00:00:00.000Z",
+  last_login: "2026-01-01T10:00:00.000Z",
+  name: "Admin User",
+  username: "admin",
+  email: "admin@example.com",
+  recovery_email: "recovery@example.com",
+  mfa: { enabled: false },
+  namespacesOwned: 2,
+  preferences: {
+    auth_methods: ["local"],
   },
-  {
-    id: "xxxxxxx2",
-    name: "user2",
-    email: "user2@email.com",
-    username: "username2",
-  },
-  {
-    id: "xxxxxxx3",
-    name: "user3",
-    email: "user3@email.com",
-    username: "username3",
-  },
-];
+  email_marketing: false,
+  admin: true,
+};
 
-const numberUsers = 3;
+const mockUserFormData: IAdminUserFormData = {
+  name: "New User",
+  email: "newuser@example.com",
+  username: "newuser",
+  password: "password123",
+  max_namespaces: 3,
+  status: "confirmed",
+  admin: false,
+};
 
-describe("Users Pinia Store", () => {
-  setActivePinia(createPinia());
-  const usersStore = useUsersStore();
+describe("Admin Users Store", () => {
+  let usersStore: ReturnType<typeof useUsersStore>;
+  let mockAdminApi: MockAdapter;
 
-  it("returns users default state", () => {
-    expect(usersStore.users).toEqual([]);
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    usersStore = useUsersStore();
+    mockAdminApi = new MockAdapter(adminApi.getAxios());
   });
 
-  it("sets users and total count", () => {
-    usersStore.users = users as IAdminUser[];
-    usersStore.usersCount = numberUsers;
+  afterEach(() => { mockAdminApi.reset(); });
 
-    expect(usersStore.users).toEqual(users);
-    expect(usersStore.usersCount).toEqual(numberUsers);
+  describe("Initial State", () => {
+    it("should have empty users array", () => {
+      expect(usersStore.users).toEqual([]);
+    });
+
+    it("should have zero users count", () => {
+      expect(usersStore.usersCount).toBe(0);
+    });
+
+    it("should have empty current filter", () => {
+      expect(usersStore.currentFilter).toBe("");
+    });
+  });
+
+  describe("setFilter", () => {
+    it("should set filter value", () => {
+      usersStore.setFilter("status:confirmed");
+      expect(usersStore.currentFilter).toBe("status:confirmed");
+    });
+
+    it("should set empty string when filter is empty", () => {
+      usersStore.setFilter("");
+      expect(usersStore.currentFilter).toBe("");
+    });
+  });
+
+  describe("fetchUsersList", () => {
+    const baseUrl = "http://localhost:3000/admin/api/users";
+
+    it("should fetch users list successfully with default pagination", async () => {
+      const usersList = [mockUserBase];
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" })).reply(200, usersList, { "x-total-count": "1" });
+
+      await expect(usersStore.fetchUsersList()).resolves.not.toThrow();
+
+      expect(usersStore.users).toEqual(usersList);
+      expect(usersStore.usersCount).toBe(1);
+    });
+
+    it("should fetch users list successfully with custom pagination", async () => {
+      const usersList = [mockUserBase, { ...mockUserBase, id: "user-id-456" }];
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "2", per_page: "20" })).reply(200, usersList, { "x-total-count": "2" });
+
+      await expect(usersStore.fetchUsersList({ page: 2, perPage: 20 })).resolves.not.toThrow();
+
+      expect(usersStore.users).toEqual(usersList);
+      expect(usersStore.usersCount).toBe(2);
+    });
+
+    it("should fetch users list with filter successfully", async () => {
+      const usersList = [mockUserBase];
+      const filter = "test";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter, page: "1", per_page: "10" })).reply(200, usersList, { "x-total-count": "1" });
+
+      await expect(usersStore.fetchUsersList({ filter })).resolves.not.toThrow();
+
+      expect(usersStore.users).toEqual(usersList);
+      expect(usersStore.usersCount).toBe(1);
+    });
+
+    it("should use current filter when not provided in parameters", async () => {
+      usersStore.setFilter("old_filter");
+
+      const usersList = [mockUserBase];
+
+      mockAdminApi
+        .onGet(buildUrl(baseUrl, { filter: "old_filter", page: "1", per_page: "10" }))
+        .reply(200, usersList, { "x-total-count": "1" });
+
+      await expect(usersStore.fetchUsersList()).resolves.not.toThrow();
+
+      expect(usersStore.users).toEqual(usersList);
+      expect(usersStore.usersCount).toBe(1);
+    });
+
+    it("should fetch empty users list successfully", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" })).reply(200, [], { "x-total-count": "0" });
+
+      await expect(usersStore.fetchUsersList()).resolves.not.toThrow();
+
+      expect(usersStore.users).toEqual([]);
+      expect(usersStore.usersCount).toBe(0);
+    });
+
+    it("should throw on server error when fetching users list", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" })).reply(500);
+
+      await expect(usersStore.fetchUsersList()).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when fetching users list", async () => {
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter: "", page: "1", per_page: "10" })).networkError();
+
+      await expect(usersStore.fetchUsersList()).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("exportUsersToCsv", () => {
+    const baseUrl = "http://localhost:3000/admin/api/export/users";
+    const csvData = "id,name,email,username\nuser-id-123,Admin User,admin@example.com,admin";
+
+    it("should export users to CSV successfully and return data", async () => {
+      const filter = "";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter })).reply(200, csvData);
+
+      const result = await usersStore.exportUsersToCsv(filter);
+
+      expect(result).toBe(csvData);
+    });
+
+    it("should export users with filter to CSV successfully", async () => {
+      const filter = "admin:true";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter })).reply(200, csvData);
+
+      const result = await usersStore.exportUsersToCsv(filter);
+
+      expect(result).toBe(csvData);
+    });
+
+    it("should throw on server error when exporting users", async () => {
+      const filter = "";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter })).reply(500);
+
+      await expect(usersStore.exportUsersToCsv(filter)).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when exporting users", async () => {
+      const filter = "";
+
+      mockAdminApi.onGet(buildUrl(baseUrl, { filter })).networkError();
+
+      await expect(usersStore.exportUsersToCsv(filter)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("addUser", () => {
+    const baseUrl = "http://localhost:3000/admin/api/users";
+    const { status: _status, ...userData } = mockUserFormData;
+    it("should add user successfully", async () => {
+      mockAdminApi.onPost(baseUrl, userData).reply(201);
+
+      await expect(usersStore.addUser(mockUserFormData)).resolves.not.toThrow();
+    });
+
+    it("should throw on forbidden error when adding user", async () => {
+      mockAdminApi.onPost(baseUrl, userData).reply(403, { message: "Forbidden" });
+
+      await expect(usersStore.addUser(mockUserFormData)).rejects.toBeAxiosErrorWithStatus(403);
+    });
+
+    it("should throw on network error when adding user", async () => {
+      mockAdminApi.onPost(baseUrl, userData).networkError();
+
+      await expect(usersStore.addUser(mockUserFormData)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("fetchUserById", () => {
+    const userId = "user-id-123";
+    const baseGetUserUrl = `http://localhost:3000/admin/api/users/${userId}`;
+
+    it("should fetch user by id successfully and return data", async () => {
+      mockAdminApi.onGet(baseGetUserUrl).reply(200, mockUserBase);
+
+      const result = await usersStore.fetchUserById(userId);
+
+      expect(result).toEqual(mockUserBase);
+    });
+
+    it("should throw on not found error when fetching user by id", async () => {
+      mockAdminApi.onGet(baseGetUserUrl).reply(404, { message: "User not found" });
+
+      await expect(usersStore.fetchUserById(userId)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when fetching user by id", async () => {
+      mockAdminApi.onGet(baseGetUserUrl).networkError();
+
+      await expect(usersStore.fetchUserById(userId)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("updateUser", () => {
+    const userId = "user-id-123";
+    const updateData = { ...mockUserFormData, id: userId };
+    const baseUrl = `http://localhost:3000/admin/api/users/${userId}`;
+
+    it("should update user successfully", async () => {
+      mockAdminApi.onPut(baseUrl, mockUserFormData).reply(200);
+
+      await expect(usersStore.updateUser(updateData)).resolves.not.toThrow();
+    });
+
+    it("should throw on not found error when updating user", async () => {
+      mockAdminApi.onPut(baseUrl, mockUserFormData).reply(404, { message: "User not found" });
+
+      await expect(usersStore.updateUser(updateData)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when updating user", async () => {
+      mockAdminApi.onPut(baseUrl, mockUserFormData).networkError();
+
+      await expect(usersStore.updateUser(updateData)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("deleteUser", () => {
+    const userId = "user-id-123";
+    const baseUrl = `http://localhost:3000/admin/api/users/${userId}`;
+
+    it("should delete user successfully", async () => {
+      mockAdminApi.onDelete(baseUrl).reply(200);
+
+      await expect(usersStore.deleteUser(userId)).resolves.not.toThrow();
+    });
+
+    it("should throw on not found error when deleting user", async () => {
+      mockAdminApi.onDelete(baseUrl).reply(404, { message: "User not found" });
+
+      await expect(usersStore.deleteUser(userId)).rejects.toBeAxiosErrorWithStatus(404);
+    });
+
+    it("should throw on network error when deleting user", async () => {
+      mockAdminApi.onDelete(baseUrl).networkError();
+
+      await expect(usersStore.deleteUser(userId)).rejects.toThrow("Network Error");
+    });
+  });
+
+  describe("resetUserPassword", () => {
+    const userId = "user-id-123";
+    const baseUrl = `http://localhost:3000/admin/api/users/${userId}/password/reset`;
+    const newPassword = "new-temp-password-123";
+
+    it("should reset user password successfully and return new password", async () => {
+      mockAdminApi.onPatch(baseUrl).reply(200, newPassword);
+
+      const result = await usersStore.resetUserPassword(userId);
+
+      expect(result).toBe(newPassword);
+    });
+
+    it("should throw on server error when resetting user password", async () => {
+      mockAdminApi.onPatch(baseUrl).reply(500);
+
+      await expect(usersStore.resetUserPassword(userId)).rejects.toBeAxiosErrorWithStatus(500);
+    });
+
+    it("should throw on network error when resetting user password", async () => {
+      mockAdminApi.onPatch(baseUrl).networkError();
+
+      await expect(usersStore.resetUserPassword(userId)).rejects.toThrow("Network Error");
+    });
   });
 });


### PR DESCRIPTION
This PR makes a comprehensive rework of the admin store module tests to follow the main UI testing pattern using Axios Mock Adapter for actual store action testing instead of stub-based approaches. Now, the tests are much more trustworthy and able to catch regressions and unexpected behaviors.

### Testing Pattern
All tests now follow the established pattern:
- Use `adminApi.getAxios()` with MockAdapter for HTTP mocking
- Test actual store actions without stubs
- Comprehensive error handling (404, 500, network errors)
- Custom `toBeAxiosErrorWithStatus` matcher for error validation
- Proper beforeEach/afterEach cleanup with `setActivePinia(createPinia())`

All 10 admin store modules now have passing tests with comprehensive coverage of actions, state mutations, and error scenarios.