### PR TITLE
fix: exclude removed devices from DeviceConflicts checks

### DIFF
--- a/api/store/mongo/device.go
+++ b/api/store/mongo/device.go
@@ -225,6 +225,7 @@ func (s *Store) DeviceConflicts(ctx context.Context, target *models.DeviceConfli
 				"$or": []bson.M{
 					{"name": target.Name},
 				},
+				"status": bson.M{"$ne": models.DeviceStatusRemoved},
 			},
 		},
 	}

--- a/api/store/mongo/device_test.go
+++ b/api/store/mongo/device_test.go
@@ -775,6 +775,12 @@ func TestDeviceConflicts(t *testing.T) {
 			fixtures:    []string{fixtureDevices},
 			expected:    Expected{[]string{"name"}, true, nil},
 		},
+		{
+			description: "no conflict with removed device name",
+			target:      &models.DeviceConflicts{Name: "device-removed"},
+			fixtures:    []string{fixtureDevicesWithRemoved},
+			expected:    Expected{[]string{}, false, nil},
+		},
 	}
 
 	for _, tc := range cases {

--- a/api/store/mongo/fixtures/devices_with_removed.json
+++ b/api/store/mongo/fixtures/devices_with_removed.json
@@ -1,0 +1,42 @@
+{
+    "devices": {
+        "656f605bafb652df9927adef": {
+            "created_at": "2023-01-01T12:00:00.000Z",
+            "removed_at": null,
+            "last_seen": "2023-01-01T12:00:00.000Z",
+            "disconnected_at": null,
+            "status_updated_at": "2023-01-01T12:00:00.000Z",
+            "identity": {
+                "mac": "mac-1"
+            },
+            "info": null,
+            "name": "device-1",
+            "position": null,
+            "public_key": "",
+            "remote_addr": "",
+            "status": "accepted",
+            "tag_ids": [],
+            "tenant_id": "00000000-0000-4000-0000-000000000000",
+            "uid": "5300530e3ca2f637636b4d025d2235269014865db5204b6d115386cbee89809f"
+        },
+        "656f60dbda27dad292686e35": {
+            "created_at": "2023-01-05T12:00:00.000Z",
+            "removed_at": "2023-01-06T12:00:00.000Z",
+            "last_seen": "2023-01-05T12:00:00.000Z",
+            "disconnected_at": null,
+            "status_updated_at": "2023-01-06T12:00:00.000Z",
+            "identity": {
+                "mac": "mac-removed"
+            },
+            "info": null,
+            "name": "device-removed",
+            "position": null,
+            "public_key": "",
+            "remote_addr": "",
+            "status": "removed",
+            "tag_ids": [],
+            "tenant_id": "00000000-0000-4000-0000-000000000000",
+            "uid": "6600660e3ca2f637636b4d025d2235269014865db5204b6d115386cbee89809a"
+        }
+    }
+}

--- a/api/store/mongo/store_test.go
+++ b/api/store/mongo/store_test.go
@@ -26,6 +26,7 @@ var (
 const (
 	fixtureAPIKeys               = "api-key"                // Check "store.mongo.fixtures.api-keys" for fixture info
 	fixtureDevices               = "devices"                // Check "store.mongo.fixtures.devices" for fixture info
+	fixtureDevicesWithRemoved    = "devices_with_removed"   // Check "store.mongo.fixtures.devices_with_removed" for fixture info
 	fixtureSessions              = "sessions"               // Check "store.mongo.fixtures.sessions" for fixture info
 	fixtureActiveSessions        = "active_sessions"        // Check "store.mongo.fixtures.active_sessions" for fixture info
 	fixtureFirewallRules         = "firewall_rules"         // Check "store.mongo.fixtures.firewall_rules" for fixture info


### PR DESCRIPTION
When renaming or updating a device, the DeviceConflicts function was
incorrectly detecting conflicts with devices that have status "removed".
This prevented reusing device names from soft-deleted devices.

Changes:
- Modified DeviceConflicts to filter out devices with status "removed"
- Added test case to verify removed devices don't cause conflicts
- Added fixture for a removed device in test data
