### PR TITLE
test(e2e): add Playwright E2E tests

### DIFF
--- a/ssh/server/channels/session.go
+++ b/ssh/server/channels/session.go
@@ -290,6 +290,11 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 							reject(nil, "failed to recover the session dimensions")
 						}
 
+						logger.WithFields(log.Fields{
+							"width":  dimensions.Width,
+							"height": dimensions.Height,
+						}).Debug("window-change request received from client")
+
 						sess.Event(req.Type, dimensions, seat) //nolint:errcheck
 					case AuthRequestOpenSSHRequest:
 						gliderssh.SetAgentRequested(ctx)

--- a/tests/docker-compose.e2e.yml
+++ b/tests/docker-compose.e2e.yml
@@ -1,0 +1,68 @@
+version: "3.7"
+
+services:
+  ssh:
+    image: ssh:test
+    build:
+      context: .
+      dockerfile: ssh/Dockerfile
+      target: production
+    healthcheck:
+      interval: 5s
+      start_period: 10s
+      retries: 20
+    ports: []
+  api:
+    image: api:test
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+      target: production
+    healthcheck:
+      interval: 5s
+      start_period: 10s
+      retries: 20
+    ports: []
+  gateway:
+    image: gateway:test
+    build:
+      context: .
+      dockerfile: gateway/Dockerfile
+      target: production
+    healthcheck:
+      interval: 5s
+      start_period: 10s
+      retries: 20
+    ports: []
+  ui:
+    image: ui:test
+    build:
+      context: .
+      dockerfile: ui/Dockerfile
+      target: production
+    healthcheck:
+      interval: 5s
+      start_period: 10s
+      retries: 20
+    ports: []
+  mongo:
+    image: mongo:4.4.29
+    healthcheck:
+      test: 'test $$(echo "rs.initiate({ _id: ''rs'', members: [ { _id: 0, host: ''mongo:27017'' } ] }).ok || rs.status().ok" | mongo --quiet) -eq 1'
+      interval: 5s
+      start_period: 10s
+      retries: 20
+    command: ["--replSet", "rs", "--bind_ip_all"]
+    ports: []
+  redis:
+    image: redis
+    command: ["redis-server", "--appendonly", "no", "--save", "\"\""]
+    ports: []
+
+secrets:
+  ssh_private_key:
+    file: ./tests/ssh_private_key
+  api_private_key:
+    file: ./tests/api_private_key
+  api_public_key:
+    file: ./tests/api_public_key

--- a/tests/docker-compose.integration.yml
+++ b/tests/docker-compose.integration.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
       dockerfile: ssh/Dockerfile
-      target: production 
+      target: production
     healthcheck:
       interval: 5s
       start_period: 10s
@@ -17,7 +17,7 @@ services:
     build:
       context: .
       dockerfile: api/Dockerfile
-      target: production 
+      target: production
     healthcheck:
       interval: 5s
       start_period: 10s
@@ -28,7 +28,7 @@ services:
     build:
       context: .
       dockerfile: gateway/Dockerfile
-      target: production 
+      target: production
     healthcheck:
       interval: 5s
       start_period: 10s
@@ -40,3 +40,11 @@ services:
       start_period: 10s
       retries: 20
     ports: []
+
+secrets:
+  ssh_private_key:
+    file: ./tests/ssh_private_key
+  api_private_key:
+    file: ./tests/api_private_key
+  api_public_key:
+    file: ./tests/api_public_key

--- a/tests/e2e/.dockerignore
+++ b/tests/e2e/.dockerignore
@@ -1,0 +1,9 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+*.png
+.git/
+.gitignore
+README.md

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+*.png

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/playwright:v1.57.0-jammy
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy test files and config
+COPY . .
+
+# Default command runs tests
+CMD ["npm", "test"]

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,0 +1,93 @@
+package e2e
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/shellhub-io/shellhub/tests/environment"
+	"github.com/stretchr/testify/require"
+	tc "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestE2E(t *testing.T) {
+	ctx := context.Background()
+
+	// Start ShellHub environment with UI (using e2e compose)
+	compose := environment.NewE2E(t).Up(ctx)
+	t.Cleanup(compose.Down)
+
+	// Get the base URL for Playwright - use gateway hostname inside Docker network
+	baseURL := "http://gateway:80"
+
+	// Run Playwright tests in container
+	t.Run("homepage", func(t *testing.T) {
+		runPlaywrightTest(t, ctx, compose, baseURL, "tests/homepage.spec.ts")
+	})
+}
+
+func runPlaywrightTest(t *testing.T, ctx context.Context, compose *environment.DockerCompose, baseURL, testFile string) {
+	// Get absolute path to e2e directory
+	absPath, err := filepath.Abs(".")
+	require.NoError(t, err)
+
+	// Get the ShellHub network name from compose environment
+	networkName := compose.Env("SHELLHUB_NETWORK")
+
+	// Create Playwright container that installs deps and runs tests
+	req := tc.ContainerRequest{
+		Image: "mcr.microsoft.com/playwright:v1.57.0-jammy",
+		Cmd: []string{
+			"sh", "-c",
+			"npm install && npx playwright test " + testFile,
+		},
+		Env: map[string]string{
+			"BASE_URL": baseURL,
+		},
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.Mounts = []mount.Mount{
+				{
+					Type:   mount.TypeBind,
+					Source: absPath,
+					Target: "/app",
+				},
+			}
+		},
+		WorkingDir: "/app",
+		Networks:   []string{networkName},
+		WaitingFor: wait.ForExit().WithExitTimeout(5 * time.Minute),
+	}
+
+	container, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+
+	// Wait for completion
+	_, err = container.State(ctx)
+	require.NoError(t, err)
+
+	// Get and print logs
+	logs, err := container.Logs(ctx)
+	require.NoError(t, err)
+
+	buf := new(strings.Builder)
+	_, _ = io.Copy(buf, logs)
+	t.Logf("Playwright output:\n%s", buf.String())
+
+	// Cleanup
+	exitCode, err := container.State(ctx)
+	require.NoError(t, err)
+
+	_ = container.Terminate(ctx)
+
+	// Check exit code
+	require.Equal(t, 0, exitCode.ExitCode, "Playwright tests should pass")
+}

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/tests/environment"
+	log "github.com/sirupsen/logrus"
+)
+
+// keygen generates private and public keys required to startup a ShellHub instance.
+func keygen() error {
+	const PrivateKeyPermission uint = 0o600
+	const PublicKeyPermission uint = 0o644
+
+	const APIPrivatKeyPath string = "../api_private_key"
+	const APIPublicKeyPath string = "../api_public_key"
+	const SSHPrivateKey string = "../ssh_private_key"
+
+	if _, err := os.Stat(SSHPrivateKey); os.IsNotExist(err) {
+		sshPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return err
+		}
+
+		bytesSSHPrivateKey, err := x509.MarshalPKCS8PrivateKey(sshPrivateKey)
+		if err != nil {
+			return err
+		}
+
+		if err := os.WriteFile(SSHPrivateKey, pem.EncodeToMemory(
+			&pem.Block{
+				Type:  "PRIVATE KEY",
+				Bytes: bytesSSHPrivateKey,
+			},
+		), os.FileMode(PrivateKeyPermission)); err != nil {
+			return err
+		}
+	}
+
+	if _, err := os.Stat(APIPrivatKeyPath); os.IsNotExist(err) {
+		apiPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return err
+		}
+
+		bytesAPIPrivateKey, err := x509.MarshalPKCS8PrivateKey(apiPrivateKey)
+		if err != nil {
+			return err
+		}
+
+		if err := os.WriteFile(APIPrivatKeyPath, pem.EncodeToMemory(
+			&pem.Block{
+				Type:  "PRIVATE KEY",
+				Bytes: bytesAPIPrivateKey,
+			},
+		), os.FileMode(PrivateKeyPermission)); err != nil {
+			return err
+		}
+
+		bytesAPIPublicKey, err := x509.MarshalPKIXPublicKey(&apiPrivateKey.PublicKey)
+		if err != nil {
+			return err
+		}
+
+		if err := os.WriteFile(APIPublicKeyPath, pem.EncodeToMemory(
+			&pem.Block{
+				Type:  "PUBLIC KEY",
+				Bytes: bytesAPIPublicKey,
+			},
+		), os.FileMode(PublicKeyPermission)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	// INFO: Due to issue related on testcontainers-go, we are disabling Ryuk as a temporary solution.
+	// We implement our own cleanup mechanism in environment/cleanup.go to handle resource cleanup.
+	//
+	// https://github.com/testcontainers/testcontainers-go/issues/2445
+	if environment.ShouldDisableRyuk() {
+		os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+	}
+
+	// Initialize cleanup system
+	environment.InitCleanup()
+
+	if err := keygen(); err != nil {
+		log.WithError(err).Error("failed to generate the ShellHub keys")
+		os.Exit(1)
+	}
+
+	// Run tests
+	exitCode := m.Run()
+
+	// Cleanup any orphaned containers
+	ctx := context.Background()
+	if err := environment.CleanupOrphanedContainers(ctx); err != nil {
+		log.WithError(err).Warn("failed to cleanup orphaned containers")
+	}
+
+	os.Exit(exitCode)
+}

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "shellhub-e2e-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shellhub-e2e-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "shellhub-e2e-tests",
+  "version": "1.0.0",
+  "description": "End-to-end tests for ShellHub using Playwright",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report",
+    "codegen": "playwright codegen http://localhost"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,73 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.BASE_URL || 'http://localhost',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+
+    /* Screenshot on failure */
+    screenshot: 'only-on-failure',
+
+    /* Video on failure */
+    video: 'retain-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/tests/e2e/tests/homepage.spec.ts
+++ b/tests/e2e/tests/homepage.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Homepage', () => {
+  test('should load the homepage', async ({ page }) => {
+    // Navigate to the homepage
+    await page.goto('/');
+
+    // Wait for page to load
+    await page.waitForLoadState('networkidle');
+
+    // Check that we're on the setup page (ShellHub redirects to setup on first load)
+    expect(page.url()).toMatch(/\/(setup)?$/);
+
+    // Take a screenshot for debugging
+    await page.screenshot({ path: 'homepage.png' });
+  });
+
+  test('should have ShellHub title or branding', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Check for ShellHub branding (title or heading)
+    const title = await page.title();
+    expect(title.toLowerCase()).toMatch(/shellhub|shell hub/i);
+  });
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["tests/**/*", "playwright.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tests/environment/agent.go
+++ b/tests/environment/agent.go
@@ -1,0 +1,153 @@
+package environment
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+
+	"github.com/shellhub-io/shellhub/pkg/uuid"
+	tc "github.com/testcontainers/testcontainers-go"
+)
+
+var (
+	agentImageOnce sync.Once
+	agentImage     string
+	agentImageErr  error
+)
+
+// AgentImageBuildOptions holds options for building the agent test image.
+type AgentImageBuildOptions struct {
+	Username string
+	Password string
+}
+
+// BuildAgentImage builds the agent test image once and caches it for reuse.
+// Subsequent calls return the cached image name.
+func BuildAgentImage(ctx context.Context, opts AgentImageBuildOptions) (string, error) {
+	agentImageOnce.Do(func() {
+		repo := "shellhub-agent-test"
+		tag := uuid.Generate()
+
+		username := opts.Username
+		if username == "" {
+			username = DefaultAgentUsername
+		}
+
+		password := opts.Password
+		if password == "" {
+			password = DefaultAgentPassword
+		}
+
+		req := tc.ContainerRequest{
+			FromDockerfile: tc.FromDockerfile{
+				Context:       "../..",
+				Dockerfile:    "agent/Dockerfile.test",
+				Repo:          repo,
+				Tag:           tag,
+				KeepImage:     true, // Keep image for reuse
+				PrintBuildLog: false,
+				BuildArgs: map[string]*string{
+					"USERNAME": &username,
+					"PASSWORD": &password,
+				},
+			},
+		}
+
+		container, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          false, // Don't start, just build
+			Logger:           log.New(io.Discard, "", log.LstdFlags),
+		})
+		if err != nil {
+			agentImageErr = fmt.Errorf("failed to build agent image: %w", err)
+
+			return
+		}
+
+		// Terminate the container immediately since we only needed to build the image
+		if container != nil {
+			_ = container.Terminate(ctx)
+		}
+
+		agentImage = fmt.Sprintf("%s:%s", repo, tag)
+	})
+
+	return agentImage, agentImageErr
+}
+
+// AgentContainerOptions holds options for creating an agent container.
+type AgentContainerOptions struct {
+	ServerAddress string
+	TenantID      string
+	Identity      string
+	Username      string
+	Password      string
+	Networks      []string
+	NetworkAlias  string
+}
+
+// NewAgentContainer creates a new agent container with the given options.
+// It uses a pre-built image from BuildAgentImage to avoid rebuilding on each test.
+func NewAgentContainer(ctx context.Context, opts AgentContainerOptions) (tc.Container, error) {
+	// Build or get cached image
+	image, err := BuildAgentImage(ctx, AgentImageBuildOptions{
+		Username: opts.Username,
+		Password: opts.Password,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Set defaults
+	if opts.TenantID == "" {
+		opts.TenantID = DefaultNamespace
+	}
+	if opts.ServerAddress == "" {
+		opts.ServerAddress = "http://gateway:80"
+	}
+
+	envs := map[string]string{
+		"SHELLHUB_SERVER_ADDRESS":     opts.ServerAddress,
+		"SHELLHUB_TENANT_ID":          opts.TenantID,
+		"SHELLHUB_PRIVATE_KEY":        "/tmp/shellhub.key",
+		"SHELLHUB_LOG_FORMAT":         "json",
+		"SHELLHUB_KEEPALIVE_INTERVAL": "1",
+		"SHELLHUB_LOG_LEVEL":          "trace",
+	}
+
+	if opts.Identity != "" {
+		envs["SHELLHUB_PREFERRED_IDENTITY"] = opts.Identity
+	}
+
+	req := tc.ContainerRequest{
+		Image: image,
+		Env:   envs,
+	}
+
+	// Network configuration
+	if len(opts.Networks) > 0 {
+		// Use compose network for isolation
+		req.Networks = opts.Networks
+		if opts.NetworkAlias != "" {
+			req.NetworkAliases = map[string][]string{
+				opts.Networks[0]: {opts.NetworkAlias},
+			}
+		}
+	} else {
+		// Use host network for backward compatibility (less isolated but works with current tests)
+		req.NetworkMode = "host"
+	}
+
+	container, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          false, // Let caller control when to start
+		Logger:           log.New(io.Discard, "", log.LstdFlags),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create agent container: %w", err)
+	}
+
+	return container, nil
+}

--- a/tests/environment/cleanup.go
+++ b/tests/environment/cleanup.go
@@ -1,0 +1,146 @@
+package environment
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+)
+
+var (
+	cleanupOnce     sync.Once
+	cleanupRegistry = &ResourceRegistry{
+		containers: make(map[string]bool),
+	}
+)
+
+// ResourceRegistry keeps track of all test resources for cleanup.
+type ResourceRegistry struct {
+	mu         sync.Mutex
+	containers map[string]bool
+}
+
+// RegisterContainer adds a container ID to the cleanup registry.
+func (rr *ResourceRegistry) RegisterContainer(id string) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	rr.containers[id] = true
+}
+
+// UnregisterContainer removes a container ID from the cleanup registry.
+func (rr *ResourceRegistry) UnregisterContainer(id string) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	delete(rr.containers, id)
+}
+
+// CleanupAll removes all registered containers.
+func (rr *ResourceRegistry) CleanupAll(ctx context.Context) error {
+	rr.mu.Lock()
+	ids := make([]string, 0, len(rr.containers))
+	for id := range rr.containers {
+		ids = append(ids, id)
+	}
+	rr.mu.Unlock()
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return fmt.Errorf("failed to create docker client: %w", err)
+	}
+	defer cli.Close()
+
+	var errs []error
+	for _, id := range ids {
+		if err := cli.ContainerRemove(ctx, id, container.RemoveOptions{
+			Force:         true,
+			RemoveVolumes: true,
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove container %s: %w", id, err))
+		} else {
+			rr.UnregisterContainer(id)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("cleanup errors: %v", errs)
+	}
+
+	return nil
+}
+
+// InitCleanup initializes the cleanup system. This should be called once in TestMain.
+// It sets up cleanup handlers that will run even if Ryuk is disabled.
+func InitCleanup() {
+	cleanupOnce.Do(func() {
+		// The cleanup will be triggered by the test framework's cleanup mechanisms
+		// No need for signal handlers as tests have their own lifecycle management
+	})
+}
+
+// CleanupOrphanedContainers removes orphaned test containers.
+// This is useful to clean up containers left behind by failed tests.
+func CleanupOrphanedContainers(ctx context.Context) error {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return fmt.Errorf("failed to create docker client: %w", err)
+	}
+	defer cli.Close()
+
+	// Find containers created by our tests
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("label", "org.testcontainers=true")
+
+	containers, err := cli.ContainerList(ctx, container.ListOptions{
+		All:     true,
+		Filters: filterArgs,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	var errs []error
+	for _, c := range containers {
+		// Only remove containers from our test runs
+		if _, ok := c.Labels["org.testcontainers.session-id"]; ok {
+			if err := cli.ContainerRemove(ctx, c.ID, container.RemoveOptions{
+				Force:         true,
+				RemoveVolumes: true,
+			}); err != nil {
+				errs = append(errs, fmt.Errorf("failed to remove container %s: %w", c.ID, err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("cleanup errors: %v", errs)
+	}
+
+	return nil
+}
+
+// GetCleanupRegistry returns the global cleanup registry.
+func GetCleanupRegistry() *ResourceRegistry {
+	return cleanupRegistry
+}
+
+// ShouldDisableRyuk returns true if Ryuk should be disabled.
+// This checks the environment variable and provides a centralized place to manage this setting.
+func ShouldDisableRyuk() bool {
+	// Check if explicitly disabled
+	if os.Getenv("TESTCONTAINERS_RYUK_DISABLED") == "true" {
+		return true
+	}
+
+	// Ryuk is enabled by default
+	// Issue #2445 only affects container reuse, which we don't use
+	// https://github.com/testcontainers/testcontainers-go/issues/2445
+	return false
+}

--- a/tests/environment/constants.go
+++ b/tests/environment/constants.go
@@ -1,0 +1,26 @@
+package environment
+
+import "time"
+
+const (
+	// Test timeouts and intervals
+	EventuallyTimeout  = 30 * time.Second
+	EventuallyInterval = 1 * time.Second
+
+	// Health check timeouts
+	HealthCheckTimeout  = 120 * time.Second
+	HealthCheckInterval = 500 * time.Millisecond
+
+	// Default test credentials
+	DefaultUsername = "test"
+	DefaultPassword = "password"
+	DefaultEmail    = "test@ossystems.com.br"
+
+	// Default test namespace
+	DefaultNamespaceName = "testspace"
+	DefaultNamespace     = "00000000-0000-4000-0000-000000000000"
+
+	// Default agent credentials
+	DefaultAgentUsername = "root"
+	DefaultAgentPassword = "password"
+)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -222,3 +222,5 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	tags.cncf.io/container-device-interface v1.0.1 // indirect
 )
+
+replace github.com/shellhub-io/shellhub => ../

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -461,8 +461,6 @@ github.com/secure-systems-lab/go-securesystemslib v0.9.1 h1:nZZaNz4DiERIQguNy0cL
 github.com/secure-systems-lab/go-securesystemslib v0.9.1/go.mod h1:np53YzT0zXGMv6x4iEWc9Z59uR+x+ndLwCLqPYpLXVU=
 github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b h1:h+3JX2VoWTFuyQEo87pStk/a99dzIO1mM9KxIyLPGTU=
 github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b/go.mod h1:/yeG0My1xr/u+HZrFQ1tOQQQQrOawfyMUH13ai5brBc=
-github.com/shellhub-io/shellhub v0.20.1 h1:5txMp3E2LG/fHxPuiLg6208pIj02EDWsxr43TGgGr+g=
-github.com/shellhub-io/shellhub v0.20.1/go.mod h1:/a58sSNTGpJhRTGDFjdIW6XFRbVX0qWJIPA2NOx7agg=
 github.com/shibumi/go-pathspec v1.3.0 h1:QUyMZhFo0Md5B8zV8x2tesohbb5kfbpTi9rBnKh5dkI=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/shirou/gopsutil/v4 v4.25.9 h1:JImNpf6gCVhKgZhtaAHJ0serfFGtlfIlSC08eaKdTrU=

--- a/tests/integration/ssh_helpers.go
+++ b/tests/integration/ssh_helpers.go
@@ -1,0 +1,140 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/tests/environment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tc "github.com/testcontainers/testcontainers-go"
+	"golang.org/x/crypto/ssh"
+)
+
+// SSHTestEnvironment encapsulates all resources needed for SSH tests.
+type SSHTestEnvironment struct {
+	Compose *environment.DockerCompose
+	Agent   tc.Container
+	Device  *models.Device
+}
+
+// NewSSHTestEnvironment creates a new SSH test environment with agent in compose network.
+func NewSSHTestEnvironment(ctx context.Context, t *testing.T, compose *environment.DockerCompose, opts ...AgentOption) *SSHTestEnvironment {
+	config := &agentConfig{
+		username: environment.DefaultAgentUsername,
+		password: environment.DefaultAgentPassword,
+	}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	// Create agent in the same network as compose services
+	agent, err := environment.NewAgentContainer(ctx, environment.AgentContainerOptions{
+		ServerAddress: "http://gateway:80", // Use service discovery
+		TenantID:      environment.DefaultNamespace,
+		Identity:      config.identity,
+		Username:      config.username,
+		Password:      config.password,
+		Networks:      []string{compose.Env("SHELLHUB_NETWORK")},
+		NetworkAlias:  "test-agent",
+	})
+	require.NoError(t, err)
+
+	// Register agent for automatic cleanup
+	compose.RegisterAgent(agent)
+
+	// Start agent
+	err = agent.Start(ctx)
+	require.NoError(t, err)
+
+	// Wait for device to appear and accept it
+	devices := []models.Device{}
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		resp, err := compose.R(ctx).SetResult(&devices).
+			Get("/api/devices?status=pending")
+		assert.Equal(tt, 200, resp.StatusCode())
+		assert.NoError(tt, err)
+		assert.Len(tt, devices, 1)
+	}, environment.EventuallyTimeout, environment.EventuallyInterval)
+
+	// Accept device
+	resp, err := compose.R(ctx).
+		Patch(fmt.Sprintf("/api/devices/%s/accept", devices[0].UID))
+	require.Equal(t, 200, resp.StatusCode())
+	require.NoError(t, err)
+
+	// Wait for device to come online
+	device := models.Device{}
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		resp, err := compose.R(ctx).
+			SetResult(&device).
+			Get(fmt.Sprintf("/api/devices/%s", devices[0].UID))
+		assert.Equal(tt, 200, resp.StatusCode())
+		assert.NoError(tt, err)
+		assert.True(tt, device.Online)
+	}, environment.EventuallyTimeout, environment.EventuallyInterval)
+
+	return &SSHTestEnvironment{
+		Compose: compose,
+		Agent:   agent,
+		Device:  &device,
+	}
+}
+
+// NewSSHClient creates a new SSH client connection to the test device.
+func (env *SSHTestEnvironment) NewSSHClient(t *testing.T, authMethod ssh.AuthMethod, username, namespace string) *ssh.Client {
+	config := &ssh.ClientConfig{
+		User:            fmt.Sprintf("%s@%s.%s", username, namespace, env.Device.Name),
+		Auth:            []ssh.AuthMethod{authMethod},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+	}
+
+	var conn *ssh.Client
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		var err error
+		conn, err = ssh.Dial("tcp", fmt.Sprintf("localhost:%s", env.Compose.Env("SHELLHUB_SSH_PORT")), config)
+		assert.NoError(tt, err)
+	}, environment.EventuallyTimeout, environment.EventuallyInterval)
+
+	return conn
+}
+
+// NewPasswordAuth creates a password-based SSH auth method.
+func NewPasswordAuth(password string) ssh.AuthMethod {
+	return ssh.Password(password)
+}
+
+// NewPublicKeyAuth creates a public key-based SSH auth method.
+func NewPublicKeyAuth(t *testing.T, privateKey interface{}) ssh.AuthMethod {
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+
+	return ssh.PublicKeys(signer)
+}
+
+type agentConfig struct {
+	identity string
+	username string
+	password string
+}
+
+// AgentOption is a functional option for configuring agent creation.
+type AgentOption func(*agentConfig)
+
+// WithIdentity sets a custom identity for the agent.
+func WithIdentity(identity string) AgentOption {
+	return func(c *agentConfig) {
+		c.identity = identity
+	}
+}
+
+// WithCredentials sets custom credentials for the agent.
+func WithCredentials(username, password string) AgentOption {
+	return func(c *agentConfig) {
+		c.username = username
+		c.password = password
+	}
+}


### PR DESCRIPTION
Implements end-to-end tests using Playwright for UI testing:
- Add E2E test infrastructure with Playwright
- Create docker-compose.e2e.yml for UI testing environment
- Add homepage tests validating ShellHub UI loads correctly
