### PR TITLE
fix(ui): replace HMR clientPort with allowedHosts in vite config

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -71,9 +71,7 @@ export default defineConfig({
   ],
   server: {
     port: 8080,
-    hmr: {
-      clientPort: 80,
-    },
+    allowedHosts: true,
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
Replace the HMR clientPort configuration with allowedHosts to allow
connections from any host in the Vite development server.
