### PR TITLE
refactor(ui): replace admin menu v-icon with UserIcon component

### DIFF
--- a/ui/admin/src/layouts/AppLayout.vue
+++ b/ui/admin/src/layouts/AppLayout.vue
@@ -106,10 +106,11 @@
           v-bind="props"
           class="mr-8"
         >
-          <v-icon
-            left
+          <UserIcon
+            size="1.5rem"
+            :email="currentUser"
             class="mr-2"
-            icon="mdi-account"
+            data-test="user-icon"
           />
           {{ currentUser || "ADMIN" }}
           <v-icon
@@ -188,6 +189,7 @@ import useLayoutStore from "@/store/modules/layout";
 import useAuthStore from "@admin/store/modules/auth";
 import useSpinnerStore from "@/store/modules/spinner";
 import Snackbar from "@/components/Snackbar/Snackbar.vue";
+import UserIcon from "@/components/User/UserIcon.vue";
 import Namespace from "@/components/Namespace/Namespace.vue";
 import Logo from "@/assets/logo-inverted.png";
 import { createNewAdminClient } from "@/api/http";

--- a/ui/src/components/User/UserIcon.vue
+++ b/ui/src/components/User/UserIcon.vue
@@ -24,10 +24,14 @@
 import { ref, watch, onMounted, computed } from "vue";
 import useAuthStore from "@/store/modules/auth";
 
-defineProps<{ size: string | number }>();
+const props = defineProps<{
+  size: string | number;
+  email?: string | null;
+}>();
 
 const authStore = useAuthStore();
 const userEmail = computed(() => authStore.email);
+const effectiveEmail = computed(() => props.email || userEmail.value);
 
 const avatarLoadingFailed = ref(false);
 const avatarUrl = ref("");
@@ -48,7 +52,7 @@ const generateGravatarUrl = async (email: string | null) => {
 };
 
 watch(
-  userEmail,
+  effectiveEmail,
   async (newEmail) => {
     avatarLoadingFailed.value = false;
     await generateGravatarUrl(newEmail);
@@ -61,7 +65,7 @@ const onImageError = () => {
 };
 
 onMounted(async () => {
-  await generateGravatarUrl(userEmail.value);
+  await generateGravatarUrl(effectiveEmail.value);
 });
 </script>
 

--- a/ui/tests/components/AppBar/__snapshots__/AppBar.spec.ts.snap
+++ b/ui/tests/components/AppBar/__snapshots__/AppBar.spec.ts.snap
@@ -51,7 +51,7 @@ exports[`AppBar Component > Renders the component 1`] = `
       </div>
       <!--teleport start-->
       <!--teleport end--><button type="button" class="v-btn v-btn--icon v-theme--light text-primary v-btn--density-default v-btn--variant-text" aria-haspopup="menu" aria-expanded="false" aria-controls="v-menu-v-9" aria-owns="v-menu-v-9" data-test="user-menu-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-        <!----><span class="v-btn__content" data-no-activator=""><div data-v-09753bb1="" class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat border" style="width: 1.5rem; height: 1.5rem;" email="test@example.com" data-test="user-icon"><div data-v-09753bb1="" class="v-responsive v-img v-img--booting" data-test="gravatar-image"><div class="v-responsive__sizer"></div><!----><transition-stub name="fade-transition" appear="false" persisted="false" css="true"><!----></transition-stub><!----><!----><!----><!----></div><!----><span class="v-avatar__underlay"></span>
+        <!----><span class="v-btn__content" data-no-activator=""><div data-v-09753bb1="" class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat border" style="width: 1.5rem; height: 1.5rem;" data-test="user-icon"><div data-v-09753bb1="" class="v-responsive v-img v-img--booting" data-test="gravatar-image"><div class="v-responsive__sizer"></div><!----><transition-stub name="fade-transition" appear="false" persisted="false" css="true"><!----></transition-stub><!----><!----><!----><!----></div><!----><span class="v-avatar__underlay"></span>
     </div></span>
     <!---->
     <!----></button>


### PR DESCRIPTION
# Summary

This PR refactors the `AppLayout` to use the reusable `UserIcon` component in place of the hardcoded `<v-icon>` for displaying user avatars. The new component renders `Gravatar` images based on user email and includes a fallback mechanism when no email is provided.

## Changes

- Replaced `<v-icon>` with `<UserIcon>` in `AppLayout.vue`
- Passed `currentUser` email to `UserIcon` as a prop
- Updated `UserIcon.vue`:
  - Added optional email prop
  - Introduced `effectiveEmail` logic to fallback to store value
  - Updated watchers and lifecycle logic to use `effectiveEmail`
  - Adjusted associated snapshot test to reflect the DOM structure change

## Reasoning:

The UserIcon component provides a cleaner, reusable way to manage user avatar rendering and ensures consistent use of Gravatar logic across the UI. This improves maintainability and centralizes logic for avatar display.

## Testing

- [x] Verified avatar renders correctly in AppLayout
- [x] Confirmed fallback logic works when no email is provided
- [x] Snapshot tests updated and passing