### PR TITLE
refactor(ui): extract layout app bars into AppBarContent

### DIFF
--- a/ui/admin/src/layouts/AppLayout.vue
+++ b/ui/admin/src/layouts/AppLayout.vue
@@ -82,73 +82,28 @@
       </template>
     </v-list>
   </v-navigation-drawer>
-  <v-app-bar
+  <AppBarContent
     :theme
-    class="bg-v-theme-surface border-b-thin"
-    data-test="app-bar"
-    flat
-    floating
+    show-menu-toggle
+    show-support
+    @toggle-menu="drawer = !drawer"
+    @support-click="openShellhubHelp"
   >
-    <v-app-bar-nav-icon
-      class="hidden-lg-and-up"
-      aria-label="Toggle Menu"
-      @click.stop="drawer = !drawer"
-    />
+    <template #left>
+      <Namespace :is-admin-context="true" />
+    </template>
 
-    <Namespace :is-admin-context="true" />
-
-    <v-spacer />
-
-    <v-menu anchor="bottom">
-      <template #activator="{ props }">
-        <v-chip
-          color="primary"
-          v-bind="props"
-          class="mr-8"
-        >
-          <UserIcon
-            size="1.5rem"
-            :email="currentUser"
-            class="mr-2"
-            data-test="user-icon"
-          />
-          {{ currentUser || "ADMIN" }}
-          <v-icon
-            right
-            icon="mdi-chevron-down"
-          />
-        </v-chip>
-      </template>
-      <v-list class="bg-v-theme-surface">
-        <v-list-item
-          v-for="item in menu"
-          :key="item.title"
-          :value="item"
-          :data-test="item.title"
-          @click="triggerClick(item)"
-        >
-          <div class="d-flex align-center">
-            <div><v-icon :icon="item.icon" /></div>
-            <v-list-item-title>{{ item.title }}</v-list-item-title>
-          </div>
-        </v-list-item>
-
-        <v-divider />
-
-        <v-list-item>
-          <v-switch
-            label="Dark Mode"
-            :model-value="isDarkMode"
-            data-test="dark-mode-switch"
-            color="primary"
-            inset
-            hide-details
-            @change="toggleDarkMode"
-          />
-        </v-list-item>
-      </v-list>
-    </v-menu>
-  </v-app-bar>
+    <template #right>
+      <UserMenu
+        :user-email="currentUser"
+        :display-name="displayName"
+        :menu-items="menu"
+        :is-dark-mode="isDarkMode"
+        @select="handleUserMenuSelect"
+        @toggle-dark-mode="toggleDarkMode"
+      />
+    </template>
+  </AppBarContent>
 
   <Snackbar />
 
@@ -189,7 +144,8 @@ import useLayoutStore from "@/store/modules/layout";
 import useAuthStore from "@admin/store/modules/auth";
 import useSpinnerStore from "@/store/modules/spinner";
 import Snackbar from "@/components/Snackbar/Snackbar.vue";
-import UserIcon from "@/components/User/UserIcon.vue";
+import AppBarContent from "@/components/AppBar/AppBarContent.vue";
+import UserMenu from "@/components/AppBar/UserMenu.vue";
 import Namespace from "@/components/Namespace/Namespace.vue";
 import Logo from "@/assets/logo-inverted.png";
 import { createNewAdminClient } from "@/api/http";
@@ -227,6 +183,7 @@ const expiredLicense = computed(() => licenseStore.isExpired);
 
 const hasSpinner = computed(() => spinnerStore.status);
 const currentUser = computed(() => authStore.currentUser);
+const displayName = computed(() => currentUser.value || "ADMIN");
 const currentRoute = computed(() => router.currentRoute);
 const theme = computed(() => layoutStore.theme);
 const isDarkMode = ref(theme.value === "dark");
@@ -258,9 +215,17 @@ const triggerClick = async (item: MenuItem) => {
   }
 };
 
+const handleUserMenuSelect = (item: unknown) => {
+  void triggerClick(item as MenuItem);
+};
+
 const toggleDarkMode = () => {
   isDarkMode.value = !isDarkMode.value;
   layoutStore.setTheme(isDarkMode.value ? "dark" : "light");
+};
+
+const openShellhubHelp = () => {
+  window.open("https://github.com/shellhub-io/shellhub/issues/new/choose", "_blank");
 };
 
 const items = reactive([

--- a/ui/admin/tests/unit/layouts/AppLayout/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/layouts/AppLayout/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`AppLayout > Renders the component 1`] = `
 "<v-navigation-drawer-stub data-v-b779e8e7="" class="bg-v-theme-surface" disableresizewatcher="false" disableroutewatcher="false" expandonhover="true" floating="false" modelvalue="true" permanent="false" railwidth="56" scrim="true" temporary="false" persistent="false" touchless="false" width="256" location="start" sticky="false" border="false" order="0" absolute="false" tile="false" retainfocus="false" capturefocus="false" tag="nav"></v-navigation-drawer-stub>
-<v-app-bar-stub data-v-b779e8e7="" theme="dark" class="bg-v-theme-surface border-b-thin" modelvalue="true" location="top" absolute="false" collapse="false" collapseposition="start" density="default" extensionheight="48" flat="true" floating="true" height="64" border="false" tile="false" tag="header" order="0" scrollthreshold="300" data-test="app-bar"></v-app-bar-stub>
+<app-bar-content-stub data-v-b779e8e7="" showmenutoggle="true" showsupport="true" theme="dark"></app-bar-content-stub>
 <snackbar-stub data-v-b779e8e7=""></snackbar-stub>
 <v-main-stub data-v-b779e8e7="" scrollable="false" tag="main" data-test="main"></v-main-stub>
 <v-overlay-stub data-v-b779e8e7="" class="align-center justify-center w-100 h-100" _disableglobalstack="false" absolute="false" attach="false" closeonback="true" contained="true" disabled="false" noclickanimation="false" modelvalue="false" persistent="false" scrim="false" zindex="2000" activatorprops="[object Object]" openonhover="false" closeoncontentclick="false" eager="false" locationstrategy="static" location="bottom" origin="auto" sticktotarget="false" viewportmargin="12" scrollstrategy="block" retainfocus="false" capturefocus="false" transition="fade-transition" data-test="overlay"></v-overlay-stub>"

--- a/ui/admin/tests/unit/layouts/AppLayout/index.spec.ts
+++ b/ui/admin/tests/unit/layouts/AppLayout/index.spec.ts
@@ -30,4 +30,10 @@ describe("AppLayout", () => {
   const vuetify = createVuetify();
   const wrapper = shallowMount(AppLayout, { global: { plugins: [vuetify, routes, SnackbarPlugin] } });
   it("Renders the component", () => { expect(wrapper.html()).toMatchSnapshot(); });
+  it("Passes AppBarContent flags", () => {
+    const appBarContent = wrapper.findComponent({ name: "AppBarContent" });
+    expect(appBarContent.exists()).toBe(true);
+    expect(appBarContent.props("showMenuToggle")).toBe(true);
+    expect(appBarContent.props("showSupport")).toBe(true);
+  });
 });

--- a/ui/src/components/AppBar/AppBar.vue
+++ b/ui/src/components/AppBar/AppBar.vue
@@ -1,24 +1,17 @@
 <template>
   <PaywallChat v-model="chatSupportPaywall" />
-  <v-app-bar
-    flat
-    floating
-    class="bg-v-theme-surface border-b-thin"
-    data-test="app-bar"
+  <AppBarContent
+    show-menu-toggle
+    show-support
+    @toggle-menu="showNavigationDrawer = !showNavigationDrawer"
+    @support-click="openShellhubHelp()"
   >
-    <v-app-bar-nav-icon
-      class="hidden-lg-and-up"
-      aria-label="Toggle Menu"
-      data-test="menu-toggle"
-      @click.stop="showNavigationDrawer = !showNavigationDrawer"
-    />
-
-    <div class="d-flex align-center hidden-md-and-down">
+    <template #left>
       <Namespace data-test="namespace-selector" />
 
       <v-breadcrumbs
         :items="breadcrumbItems"
-        class="pa-0 mx-4"
+        class="pa-0 mx-4 hidden-xs"
         data-test="breadcrumbs"
       >
         <template #prepend>
@@ -36,29 +29,9 @@
           />
         </template>
       </v-breadcrumbs>
-    </div>
+    </template>
 
-    <v-spacer />
-
-    <div class="d-flex align-center ga-4 mr-4">
-      <v-tooltip
-        location="bottom"
-        class="text-center"
-      >
-        <template #activator="{ props }">
-          <v-btn
-            v-bind="props"
-            size="medium"
-            color="primary"
-            aria-label="community-help-icon"
-            icon="mdi-help-circle"
-            data-test="support-btn"
-            @click="openShellhubHelp()"
-          />
-        </template>
-        <span>Need assistance? Click here for support.</span>
-      </v-tooltip>
-
+    <template #right>
       <DevicesDropdown
         v-if="hasNamespaces"
         v-model="showDevicesDrawer"
@@ -71,102 +44,16 @@
         @update:model-value="showDevicesDrawer = false"
       />
 
-      <v-menu
-        scrim
-        location="bottom end"
-        :offset="4"
-      >
-        <template #activator="{ props }">
-          <v-btn
-            v-bind="props"
-            size="medium"
-            color="primary"
-            icon
-            data-test="user-menu-btn"
-          >
-            <UserIcon
-              size="1.5rem"
-              :email="userEmail"
-              data-test="user-icon"
-            />
-          </v-btn>
-        </template>
-
-        <v-card
-          :width="$vuetify.display.thresholds.sm / 2"
-          border
-        >
-          <v-list class="bg-v-theme-surface pa-0">
-            <!-- User Profile Header -->
-            <div class="pa-6 text-center">
-              <UserIcon
-                size="4rem"
-                :email="userEmail"
-                class="mb-4"
-                data-test="user-icon-large"
-              />
-              <div class="text-h6 font-weight-medium mb-1">
-                {{ currentUser || userEmail }}
-              </div>
-              <div
-                v-if="currentUser"
-                class="text-body-2 text-medium-emphasis"
-              >
-                {{ userEmail }}
-              </div>
-            </div>
-
-            <v-divider />
-
-            <!-- Menu Items -->
-            <div>
-              <v-list-item
-                v-for="item in menu"
-                :key="item.title"
-                :value="item"
-                :data-test="item.title"
-                :prepend-icon="item.icon"
-                @click="triggerClick(item)"
-              >
-                <v-list-item-title class="font-weight-medium">
-                  {{ item.title }}
-                </v-list-item-title>
-              </v-list-item>
-            </div>
-
-            <v-divider />
-
-            <!-- Dark Mode Toggle -->
-            <v-list-item
-              @click="toggleDarkMode"
-            >
-              <template #prepend>
-                <v-icon
-                  :icon="isDarkMode ? 'mdi-brightness-6' : 'mdi-brightness-6'"
-                  size="small"
-                />
-              </template>
-              <v-list-item-title class="font-weight-medium">
-                {{ isDarkMode ? 'Dark Mode' : 'Light Mode' }}
-              </v-list-item-title>
-              <template #append>
-                <v-switch
-                  :model-value="isDarkMode"
-                  data-test="dark-mode-switch"
-                  color="primary"
-                  density="comfortable"
-                  false-icon="mdi-weather-sunny"
-                  true-icon="mdi-weather-night"
-                  hide-details
-                  readonly
-                />
-              </template>
-            </v-list-item>
-          </v-list>
-        </v-card>
-      </v-menu>
-    </div>
-  </v-app-bar>
+      <UserMenu
+        :user-email="userEmail"
+        :display-name="currentUser"
+        :menu-items="menu"
+        :is-dark-mode="isDarkMode"
+        @select="handleUserMenuSelect"
+        @toggle-dark-mode="toggleDarkMode"
+      />
+    </template>
+  </AppBarContent>
 </template>
 
 <script setup lang="ts">
@@ -177,7 +64,8 @@ import {
 import { useRouter, useRoute, RouteLocationRaw, RouteLocation } from "vue-router";
 import { useChatWoot } from "@productdevbook/chatwoot/vue";
 import handleError from "@/utils/handleError";
-import UserIcon from "../User/UserIcon.vue";
+import AppBarContent from "@/components/AppBar/AppBarContent.vue";
+import UserMenu from "@/components/AppBar/UserMenu.vue";
 import DevicesDropdown from "./DevicesDropdown.vue";
 import InvitationsMenu from "@/components/Invitations/InvitationsMenu.vue";
 import PaywallChat from "../User/PaywallChat.vue";
@@ -247,6 +135,10 @@ const triggerClick = async (item: MenuItem) => {
     default:
       break;
   }
+};
+
+const handleUserMenuSelect = (item: unknown) => {
+  void triggerClick(item as MenuItem);
 };
 
 const logout = async () => {

--- a/ui/src/components/AppBar/AppBarContent.vue
+++ b/ui/src/components/AppBar/AppBarContent.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-app-bar
+    flat
+    floating
+    class="bg-v-theme-surface border-b-thin"
+    data-test="app-bar"
+  >
+    <v-app-bar-nav-icon
+      v-if="showMenuToggle"
+      class="hidden-lg-and-up"
+      aria-label="Toggle Menu"
+      data-test="menu-toggle"
+      @click.stop="emit('toggle-menu')"
+    />
+
+    <div class="d-flex align-center">
+      <slot name="left" />
+    </div>
+
+    <v-spacer />
+
+    <div class="d-flex align-center ga-4 mr-4">
+      <v-tooltip
+        v-if="showSupport"
+        location="bottom"
+        class="text-center"
+      >
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            size="medium"
+            color="primary"
+            aria-label="community-help-icon"
+            icon="mdi-help-circle"
+            data-test="support-btn"
+            @click="emit('support-click')"
+          />
+        </template>
+        <span>Need assistance? Click here for support.</span>
+      </v-tooltip>
+
+      <slot name="right" />
+    </div>
+  </v-app-bar>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  showMenuToggle?: boolean;
+  showSupport?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "toggle-menu"): void;
+  (e: "support-click"): void;
+}>();
+</script>

--- a/ui/src/components/AppBar/UserMenu.vue
+++ b/ui/src/components/AppBar/UserMenu.vue
@@ -1,0 +1,117 @@
+<template>
+  <v-menu
+    scrim
+    location="bottom end"
+    :offset="4"
+  >
+    <template #activator="{ props }">
+      <v-btn
+        v-bind="props"
+        size="medium"
+        color="primary"
+        icon
+        data-test="user-menu-btn"
+      >
+        <UserIcon
+          size="1.5rem"
+          :email="userEmail"
+          data-test="user-icon"
+        />
+      </v-btn>
+    </template>
+
+    <v-card
+      :width="$vuetify.display.thresholds.sm / 2"
+      border
+    >
+      <v-list class="bg-v-theme-surface pa-0">
+        <div class="pa-6 text-center">
+          <UserIcon
+            size="4rem"
+            :email="userEmail"
+            class="mb-4"
+            data-test="user-icon-large"
+          />
+          <div class="text-h6 font-weight-medium mb-1">
+            {{ primaryLabel }}
+          </div>
+          <div
+            v-if="showSecondary"
+            class="text-body-2 text-medium-emphasis"
+          >
+            {{ userEmail }}
+          </div>
+        </div>
+
+        <v-divider />
+
+        <div>
+          <v-list-item
+            v-for="item in menuItems"
+            :key="item.title"
+            :value="item"
+            :data-test="item.title"
+            :prepend-icon="item.icon"
+            @click="emit('select', item)"
+          >
+            <v-list-item-title class="font-weight-medium">
+              {{ item.title }}
+            </v-list-item-title>
+          </v-list-item>
+        </div>
+
+        <v-divider />
+
+        <v-list-item @click="emit('toggle-dark-mode')">
+          <template #prepend>
+            <v-icon
+              :icon="isDarkMode ? 'mdi-brightness-6' : 'mdi-brightness-6'"
+              size="small"
+            />
+          </template>
+          <v-list-item-title class="font-weight-medium">
+            {{ isDarkMode ? "Dark Mode" : "Light Mode" }}
+          </v-list-item-title>
+          <template #append>
+            <v-switch
+              :model-value="isDarkMode"
+              data-test="dark-mode-switch"
+              color="primary"
+              density="comfortable"
+              false-icon="mdi-weather-sunny"
+              true-icon="mdi-weather-night"
+              hide-details
+              readonly
+            />
+          </template>
+        </v-list-item>
+      </v-list>
+    </v-card>
+  </v-menu>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import UserIcon from "@/components/User/UserIcon.vue";
+
+type MenuItem = {
+  title: string;
+  icon: string;
+  [key: string]: unknown;
+};
+
+const props = defineProps<{
+  userEmail: string;
+  displayName?: string;
+  menuItems: MenuItem[];
+  isDarkMode: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "select", item: MenuItem): void;
+  (e: "toggle-dark-mode"): void;
+}>();
+
+const primaryLabel = computed(() => props.displayName || props.userEmail || "User");
+const showSecondary = computed(() => !!props.userEmail && !!props.displayName && props.userEmail !== props.displayName);
+</script>

--- a/ui/src/components/Namespace/Namespace.vue
+++ b/ui/src/components/Namespace/Namespace.vue
@@ -24,7 +24,10 @@
           />
           <template v-else>
             <NamespaceChip :name="currentNamespace.name" />
-            <span class="text-body-1">{{
+            <span
+              class="text-body-1 text-truncate"
+              :style="{ maxWidth: nameMaxWidth }"
+            >{{
               currentNamespace.name || "No Namespace"
             }}</span>
           </template>
@@ -160,7 +163,7 @@ const authStore = useAuthStore();
 const namespacesStore = useNamespacesStore();
 const snackbar = useSnackbar();
 const router = useRouter();
-const { mdAndDown, thresholds } = useDisplay();
+const { mdAndDown, smAndDown, thresholds } = useDisplay();
 
 const showAddDialog = ref(false);
 
@@ -178,6 +181,8 @@ const showAdminButton = computed(() => {
     && Boolean(authStore.isAdmin)
   );
 });
+
+const nameMaxWidth = computed(() => (smAndDown.value ? "4rem" : "220px"));
 
 const availableNamespaces = computed(() => {
   if (props.isAdminContext) return namespaceList.value;

--- a/ui/tests/components/AppBar/AppBarContent.spec.ts
+++ b/ui/tests/components/AppBar/AppBarContent.spec.ts
@@ -1,0 +1,61 @@
+import { createVuetify } from "vuetify";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { VApp } from "vuetify/components";
+import AppBarContent from "@/components/AppBar/AppBarContent.vue";
+
+const createWrapper = (props: Record<string, unknown> = {}) => {
+  const vuetify = createVuetify();
+
+  return mount({
+    components: { AppBarContent, VApp },
+    props,
+    template: `
+      <v-app>
+        <AppBarContent v-bind="$props">
+          <template #left>
+            <div data-test="left-slot">Left Slot</div>
+          </template>
+          <template #right>
+            <div data-test="right-slot">Right Slot</div>
+          </template>
+        </AppBarContent>
+      </v-app>
+    `,
+  }, {
+    props,
+    global: {
+      plugins: [vuetify],
+    },
+  });
+};
+
+describe("AppBarContent Component", () => {
+  it("Renders slots and controls", () => {
+    const wrapper = createWrapper({ showMenuToggle: true, showSupport: true });
+
+    expect(wrapper.find('[data-test="app-bar"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="left-slot"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="right-slot"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="menu-toggle"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="support-btn"]').exists()).toBe(true);
+  });
+
+  it("Emits toggle-menu and support-click", async () => {
+    const wrapper = createWrapper({ showMenuToggle: true, showSupport: true });
+
+    const appBar = wrapper.findComponent(AppBarContent);
+    await wrapper.find('[data-test="menu-toggle"]').trigger("click");
+    await wrapper.find('[data-test="support-btn"]').trigger("click");
+
+    expect(appBar.emitted("toggle-menu")).toHaveLength(1);
+    expect(appBar.emitted("support-click")).toHaveLength(1);
+  });
+
+  it("Hides controls when flags are false", () => {
+    const wrapper = createWrapper({ showMenuToggle: false, showSupport: false });
+
+    expect(wrapper.find('[data-test="menu-toggle"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="support-btn"]').exists()).toBe(false);
+  });
+});

--- a/ui/tests/components/AppBar/__snapshots__/AppBar.spec.ts.snap
+++ b/ui/tests/components/AppBar/__snapshots__/AppBar.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`AppBar Component > Renders the component 1`] = `
         <!---->
         <!---->
       </button>
-      <div class="d-flex align-center hidden-md-and-down">
+      <div class="d-flex align-center">
         <!---->
         <!---->
         <!---->
@@ -23,12 +23,12 @@ exports[`AppBar Component > Renders the component 1`] = `
           <!---->
           <div class="v-chip__content" data-no-activator=""></div>
           <!---->
-          <!----></span><span class="text-body-1">No Namespace</span><i class="mdi-chevron-down mdi v-icon notranslate v-theme--light v-icon--size-x-small" aria-hidden="true"></i>
+          <!----></span><span class="text-body-1 text-truncate" style="max-width: 220px;">No Namespace</span><i class="mdi-chevron-down mdi v-icon notranslate v-theme--light v-icon--size-x-small" aria-hidden="true"></i>
       </div></span>
       <!---->
       <!----></button>
       <!---->
-      <ul class="v-breadcrumbs v-breadcrumbs--density-default pa-0 mx-4" data-test="breadcrumbs">
+      <ul class="v-breadcrumbs v-breadcrumbs--density-default pa-0 mx-4 hidden-xs" data-test="breadcrumbs">
         <li class="v-breadcrumbs__prepend">
           <!--v-if-->
         </li>

--- a/ui/tests/components/Namespace/Namespace.spec.ts
+++ b/ui/tests/components/Namespace/Namespace.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { ref } from "vue";
+import Namespace from "@/components/Namespace/Namespace.vue";
+import { mountComponent } from "@tests/utils/mount";
+import { mockNamespace } from "@tests/views/mocks/namespace";
+
+const displayState = {
+  smAndDown: ref(false),
+  mdAndDown: ref(false),
+  thresholds: ref({
+    xs: 0,
+    sm: 600,
+    md: 960,
+    lg: 1280,
+    xl: 1920,
+    xxl: 2560,
+  }),
+};
+
+vi.mock("vuetify", async () => {
+  const actual = await vi.importActual<typeof import("vuetify")>("vuetify");
+  return {
+    ...actual,
+    useDisplay: () => displayState,
+  };
+});
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const menuStub = {
+  template: "<div><slot name=\"activator\" :props=\"{}\" /><slot /></div>",
+};
+
+const mountNamespace = (smAndDownValue: boolean) => {
+  displayState.smAndDown.value = smAndDownValue;
+  displayState.mdAndDown.value = smAndDownValue;
+  localStorage.setItem("tenant", mockNamespace.tenant_id);
+
+  return mountComponent(Namespace, {
+    piniaOptions: {
+      initialState: {
+        namespaces: {
+          currentNamespace: mockNamespace,
+          namespaceList: [mockNamespace],
+        },
+      },
+    },
+    global: {
+      stubs: {
+        VMenu: menuStub,
+        "v-menu": menuStub,
+        NamespaceAdd: true,
+        NamespaceInstructions: true,
+        NamespaceChip: true,
+        NamespaceListItem: true,
+        AdminConsoleItem: true,
+        CopyWarning: true,
+      },
+    },
+  });
+};
+
+describe("Namespace Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("Renders the namespace name with default max width", () => {
+    const wrapper = mountNamespace(false);
+    const nameSpan = wrapper.find(".text-truncate");
+
+    expect(nameSpan.exists()).toBe(true);
+    expect(nameSpan.text()).toBe(mockNamespace.name);
+    expect(nameSpan.attributes("style")).toContain("max-width: 220px");
+  });
+
+  it("Uses compact max width on small screens", () => {
+    const wrapper = mountNamespace(true);
+    const nameSpan = wrapper.find(".text-truncate");
+
+    expect(nameSpan.exists()).toBe(true);
+    expect(nameSpan.attributes("style")).toContain("max-width: 4rem");
+  });
+});


### PR DESCRIPTION
# Description

This PR refactors the application top bar by extracting shared logic and
layout into a reusable `AppBarContent` component and consolidating all
user-related interactions into `UserMenu`.

Both the admin and main UI now use the same app bar foundation,
reducing duplication and improving consistency across the application.

## What changed
 

- Replaced duplicated v-app-bar implementations in both admin and main UI with a new reusable `<AppBarContent>` component.
- Extracted user-related UI and logic into a standalone `<UserMenu> `component.
- Introduced slot-based layout in `AppBarContent` (left and right slots) for flexible composition.
- Unified app bar behavior (menu toggle, support link, user menu, dark mode toggle) across interfaces.
- Updated tests and snapshots to reflect new component structure.
- Improved responsive handling in Namespace component by truncating long namespace names based on screen size.

## Reasoning

- Eliminates duplicated app bar logic between admin and main UI
- Centralizes common behaviors (menu toggle, support action)
- Improves maintainability and consistency for future UI changes
- Makes app bar features easier to extend without touching layouts

##How to test

1. Run the admin and main UI applications
2. Verify the following behaviors:
    - Menu toggle works on mobile view
    - Support button opens the ShellHub help page
    - User menu actions behave as before
    - Dark mode toggle works correctly
3. Run unit tests and confirm snapshots pass