### PR TITLE
refactor(ui): remove search field from Tags view

### DIFF
--- a/ui/src/components/Tags/TagList.vue
+++ b/ui/src/components/Tags/TagList.vue
@@ -101,8 +101,6 @@ import useTagsStore from "@/store/modules/tags";
 import useSnackbar from "@/helpers/snackbar";
 import { formatShortDateTime } from "@/utils/date";
 
-const props = defineProps<{ filter: string }>();
-
 const headers = ref([
   {
     text: "Name",
@@ -121,19 +119,10 @@ const headers = ref([
 const tagsStore = useTagsStore();
 const snackbar = useSnackbar();
 const loading = ref(false);
-const itemsPerPage = ref(10);
+const itemsPerPage = ref(100);
 const page = ref(1);
 const tags = computed(() => tagsStore.tags);
 const tagCount = computed(() => tagsStore.tagCount);
-
-const encodeFilter = () => {
-  if (!props.filter) return undefined;
-  const filterObject = [{
-    type: "property",
-    params: { name: "name", operator: "contains", value: props.filter },
-  }];
-  return Buffer.from(JSON.stringify(filterObject)).toString("base64");
-};
 
 const getTags = async () => {
   loading.value = true;
@@ -141,7 +130,6 @@ const getTags = async () => {
     await tagsStore.fetchTagList({
       perPage: itemsPerPage.value,
       page: page.value,
-      filter: encodeFilter(),
     });
   } catch (error) {
     snackbar.showError("Failed to load tags.");
@@ -150,11 +138,6 @@ const getTags = async () => {
     loading.value = false;
   }
 };
-
-watch(() => props.filter, async () => {
-  page.value = 1;
-  await getTags();
-}, { immediate: true });
 
 watch([page, itemsPerPage], async () => { await getTags(); });
 

--- a/ui/src/views/Tags.vue
+++ b/ui/src/views/Tags.vue
@@ -13,19 +13,6 @@
     data-test="tags-settings-card"
   >
     <template #actions>
-      <v-text-field
-        v-if="showTags"
-        v-model.trim="filter"
-        class="w-sm-50"
-        label="Search by Tag Name"
-        variant="outlined"
-        color="primary"
-        single-line
-        hide-details
-        prepend-inner-icon="mdi-magnify"
-        density="compact"
-        data-test="search-text"
-      />
       <v-btn
         v-if="showTags"
         color="primary"
@@ -40,7 +27,6 @@
   <TagList
     v-if="showTags"
     ref="tagListRef"
-    :filter
   />
 
   <NoItemsMessage
@@ -80,7 +66,6 @@ const tagsDescription = "Organize and categorize your resources with tags. "
 const tagsStore = useTagsStore();
 const tagListRef = ref<InstanceType<typeof TagList> | null>(null);
 const showCreateTagDialog = ref(false);
-const filter = ref("");
 const showTags = computed(() => tagsStore.showTags);
 
 const openCreateTagDialog = () => { showCreateTagDialog.value = true; };

--- a/ui/tests/views/Tags.spec.ts
+++ b/ui/tests/views/Tags.spec.ts
@@ -30,11 +30,6 @@ describe("Tags View", () => {
       expect(pageHeader.text()).toContain("Organization");
     });
 
-    it("displays the search field", () => {
-      const searchField = wrapper.find('[data-test="search-text"]');
-      expect(searchField.exists()).toBe(true);
-    });
-
     it("displays the create tag button in header", () => {
       const createButton = wrapper.find('[data-test="tag-create-button"]');
       expect(createButton.exists()).toBe(true);
@@ -58,14 +53,6 @@ describe("Tags View", () => {
       const dialog = wrapper.findComponent({ name: "TagCreate" });
       expect(dialog.exists()).toBe(true);
       expect(dialog.props("modelValue")).toBe(true);
-    });
-
-    it("allows searching for tags", async () => {
-      const searchField = wrapper.find('[data-test="search-text"]').find("input");
-      await searchField.setValue("test-tag");
-      await flushPromises();
-
-      expect(searchField.element.value).toBe("test-tag");
     });
   });
 


### PR DESCRIPTION
This pull request removes the search field from the tags view, since it was not really necessary. Tests were also updated not to validate the field existence anymore.
Additionally, the default `itemsPerPage` of the Tags view was changed to 100.