### PR TITLE
feat(ui): add custom default items per page to table preferences composable

### DIFF
--- a/ui/src/composables/useTablePreference.ts
+++ b/ui/src/composables/useTablePreference.ts
@@ -4,18 +4,24 @@ import handleError from "@/utils/handleError";
 export type TableName = "sessions" | "devices" | "containers" | "firewallRules" | "publicKeys" | "apiKeys" | "invitations" | "tags" | "connectors" | "webEndpoints" | "adminSessions" | "adminDevices" | "adminNamespaces" | "adminUsers" | "adminFirewallRules" | "adminAnnouncements";
 
 const STORAGE_KEY = "tablePreferences";
-const DEFAULT_ITEMS_PER_PAGE = 10;
+const DEFAULT_ITEMS_PER_PAGE = 10; // Default fallback value
+
+// Custom default items per page for specific tables
+const CUSTOM_DEFAULT_ITEMS_PER_PAGE_MAP: Partial<Record<TableName, number>> = {
+  tags: 100,
+};
 
 export function useTablePreference() {
   const getItemsPerPage = (tableName: TableName): number => {
+    const defaultItemsPerPage = CUSTOM_DEFAULT_ITEMS_PER_PAGE_MAP[tableName] ?? DEFAULT_ITEMS_PER_PAGE;
     try {
       const preferencesItem = localStorage.getItem(STORAGE_KEY);
-      if (!preferencesItem) return DEFAULT_ITEMS_PER_PAGE;
+      if (!preferencesItem) return defaultItemsPerPage;
 
       const preferencesObject = JSON.parse(preferencesItem) as Record<TableName, number>;
-      return preferencesObject[tableName] ?? DEFAULT_ITEMS_PER_PAGE;
+      return preferencesObject[tableName] ?? defaultItemsPerPage;
     } catch {
-      return DEFAULT_ITEMS_PER_PAGE;
+      return defaultItemsPerPage;
     }
   };
 

--- a/ui/tests/components/Tags/TagList.spec.ts
+++ b/ui/tests/components/Tags/TagList.spec.ts
@@ -30,7 +30,7 @@ describe("Tag List", () => {
   localStorage.setItem("tenant", "fake-tenant-data");
 
   mockTagsApi
-    .onGet("http://localhost:3000/api/tags?page=1&per_page=10")
+    .onGet("http://localhost:3000/api/tags?page=1&per_page=100")
     .reply(200, tags, { "x-total-count": "2" });
 
   const wrapper = mount(TagList, { global: { plugins: [vuetify, router, SnackbarPlugin] } });

--- a/ui/tests/components/Tags/__snapshots__/TagList.spec.ts.snap
+++ b/ui/tests/components/Tags/__snapshots__/TagList.spec.ts.snap
@@ -74,7 +74,7 @@ exports[`Tag List > Renders the component 1`] = `
               <div class="v-field__input" data-no-activator="">
                 <!---->
                 <!---->
-                <div class="v-combobox__selection"><span class="v-combobox__selection-text">10<!----></span></div><input size="1" role="combobox" type="number" aria-labelledby="input-v-2-label" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" value="10">
+                <div class="v-combobox__selection"><span class="v-combobox__selection-text">100<!----></span></div><input size="1" role="combobox" type="number" aria-labelledby="input-v-2-label" id="input-v-2" aria-expanded="false" aria-controls="menu-v-0" value="100">
               </div>
               <!---->
             </div>

--- a/ui/tests/composables/useTablePreference.spec.ts
+++ b/ui/tests/composables/useTablePreference.spec.ts
@@ -22,6 +22,12 @@ describe("useTablePreference", () => {
       expect(getItemsPerPage("sessions")).toBe(10);
     });
 
+    it("should return custom default value 100 for tags when localStorage is empty", () => {
+      const { getItemsPerPage } = useTablePreference();
+
+      expect(getItemsPerPage("tags")).toBe(100);
+    });
+
     it("should return default value 10 for missing table key", () => {
       const { getItemsPerPage } = useTablePreference();
       localStorage.setItem(STORAGE_KEY, JSON.stringify({ devices: 20 }));
@@ -29,11 +35,32 @@ describe("useTablePreference", () => {
       expect(getItemsPerPage("sessions")).toBe(10);
     });
 
+    it("should return custom default value 100 for tags when key is missing", () => {
+      const { getItemsPerPage } = useTablePreference();
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ devices: 20 }));
+
+      expect(getItemsPerPage("tags")).toBe(100);
+    });
+
     it("should return preferencesObject value for existing table", () => {
       const { getItemsPerPage } = useTablePreference();
       localStorage.setItem(STORAGE_KEY, JSON.stringify({ sessions: 50 }));
 
       expect(getItemsPerPage("sessions")).toBe(50);
+    });
+
+    it("should return user preference over custom default for tags", () => {
+      const { getItemsPerPage } = useTablePreference();
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ tags: 25 }));
+
+      expect(getItemsPerPage("tags")).toBe(25);
+    });
+
+    it("should return custom default when JSON parse errors occur for tags", () => {
+      const { getItemsPerPage } = useTablePreference();
+      localStorage.setItem(STORAGE_KEY, "invalid json{");
+
+      expect(getItemsPerPage("tags")).toBe(100);
     });
 
     it("should handle JSON parse errors gracefully", () => {


### PR DESCRIPTION
This pull request adds a new feature to the `useTablePreferences` composable: custom default items per page. Some tables (e.g. tags) require a default items per page different than 10, due to having simpler information and being capable of showing more data without overloading the user. This PR adds the logic to utilize this and updates the `useTablePreferences` tests.