### PR TITLE
feat(ui): improve PageHeader responsiveness on small screens

### DIFF
--- a/ui/admin/tests/unit/components/License/License/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/License/License/__snapshots__/index.spec.ts.snap
@@ -19,16 +19,16 @@ exports[`License > Renders the component 1`] = `
   </div>
   <!---->
   <!---->
-  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+  <div class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between position-relative" style="z-index: 1;">
     <!-- Left side: Icon + Title + Description -->
-    <div class="d-flex align-start flex-grow-1">
-      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-license mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+    <div class="d-flex flex-column flex-sm-row align-start flex-grow-1 min-w-0">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-sm-4 mb-3 mb-sm-0" style="width: 48px; height: 48px;"><i class="mdi-license mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
         <!----><span class="v-avatar__underlay"></span>
       </div>
       <div>
         <div class="text-overline text-medium-emphasis mb-1">Admin Settings</div>
-        <div class="text-h5 font-weight-bold mb-2">License Details</div>
-        <div class="text-body-2 text-medium-emphasis">Review the current license scope and upload a new file when your subscription changes.</div>
+        <div class="text-h6 text-sm-h5 font-weight-bold mb-2 text-break">License Details</div>
+        <div class="text-body-2 text-medium-emphasis text-break">Review the current license scope and upload a new file when your subscription changes.</div>
         <!--v-if-->
       </div>
     </div><!-- Right side: Actions -->

--- a/ui/admin/tests/unit/components/Settings/SettingsAuthentication/__snapshots__/index.spec.ts.snap
+++ b/ui/admin/tests/unit/components/Settings/SettingsAuthentication/__snapshots__/index.spec.ts.snap
@@ -19,16 +19,16 @@ exports[`Authentication > renders correctly 1`] = `
   </div>
   <!---->
   <!---->
-  <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+  <div class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between position-relative" style="z-index: 1;">
     <!-- Left side: Icon + Title + Description -->
-    <div class="d-flex align-start flex-grow-1">
-      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-shield-account mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+    <div class="d-flex flex-column flex-sm-row align-start flex-grow-1 min-w-0">
+      <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-sm-4 mb-3 mb-sm-0" style="width: 48px; height: 48px;"><i class="mdi-shield-account mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
         <!----><span class="v-avatar__underlay"></span>
       </div>
       <div>
         <div class="text-overline text-medium-emphasis mb-1">Admin Settings</div>
-        <div class="text-h5 font-weight-bold mb-2">Authentication</div>
-        <div class="text-body-2 text-medium-emphasis">Control how administrators authenticate to the ShellHub console, including SAML SSO.</div>
+        <div class="text-h6 text-sm-h5 font-weight-bold mb-2 text-break">Authentication</div>
+        <div class="text-body-2 text-medium-emphasis text-break">Control how administrators authenticate to the ShellHub console, including SAML SSO.</div>
         <!--v-if-->
       </div>
     </div><!-- Right side: Actions -->

--- a/ui/src/components/PageHeader.vue
+++ b/ui/src/components/PageHeader.vue
@@ -5,15 +5,15 @@
     rounded="0"
   >
     <div
-      class="d-flex align-start justify-space-between position-relative"
+      class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between position-relative"
       style="z-index: 1;"
     >
       <!-- Left side: Icon + Title + Description -->
-      <div class="d-flex align-start flex-grow-1">
+      <div class="d-flex flex-column flex-sm-row align-start flex-grow-1 min-w-0">
         <v-avatar
           :color="iconColor"
           size="48"
-          class="mr-4"
+          class="mr-sm-4 mb-3 mb-sm-0"
         >
           <v-icon size="32">{{ icon }}</v-icon>
         </v-avatar>
@@ -24,16 +24,16 @@
           >
             {{ overline }}
           </div>
-          <div class="text-h5 font-weight-bold mb-2">{{ title }}</div>
+          <div class="text-h6 text-sm-h5 font-weight-bold mb-2 text-break">{{ title }}</div>
           <div
             v-if="description"
-            class="text-body-2 text-medium-emphasis"
+            class="text-body-2 text-medium-emphasis text-break"
           >
             {{ description }}
           </div>
           <div
             v-if="$slots.description"
-            class="text-body-2 text-medium-emphasis"
+            class="text-body-2 text-medium-emphasis text-break"
           >
             <slot name="description" />
           </div>
@@ -43,7 +43,7 @@
       <!-- Right side: Actions -->
       <div
         v-if="$slots.actions"
-        class="ml-4"
+        class="mt-4 mt-sm-0 ml-sm-4"
       >
         <slot name="actions" />
       </div>

--- a/ui/tests/components/Setting/__snapshots__/SettingBilling.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingBilling.spec.ts.snap
@@ -22,20 +22,20 @@ exports[`Billing Settings Free Mode > Renders the component 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <div class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between position-relative" style="z-index: 1;">
       <!-- Left side: Icon + Title + Description -->
-      <div class="d-flex align-start flex-grow-1">
-        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-credit-card mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+      <div class="d-flex flex-column flex-sm-row align-start flex-grow-1 min-w-0">
+        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-sm-4 mb-3 mb-sm-0" style="width: 48px; height: 48px;"><i class="mdi-credit-card mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
           <!----><span class="v-avatar__underlay"></span>
         </div>
         <div>
           <div class="text-overline text-medium-emphasis mb-1">Settings</div>
-          <div class="text-h5 font-weight-bold mb-2">Billing</div>
-          <div class="text-body-2 text-medium-emphasis">Manage your subscription plan, payment methods, and billing information.</div>
+          <div class="text-h6 text-sm-h5 font-weight-bold mb-2 text-break">Billing</div>
+          <div class="text-body-2 text-medium-emphasis text-break">Manage your subscription plan, payment methods, and billing information.</div>
           <!--v-if-->
         </div>
       </div><!-- Right side: Actions -->
-      <div class="ml-4"><button data-v-d7a09f69="" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated align-content-lg-center text-none text-uppercase" data-test="subscribe-button"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <div class="mt-4 mt-sm-0 ml-sm-4"><button data-v-d7a09f69="" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated align-content-lg-center text-none text-uppercase" data-test="subscribe-button"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator=""> Subscribe </span>
           <!---->
           <!---->

--- a/ui/tests/components/Setting/__snapshots__/SettingNamespace.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingNamespace.spec.ts.snap
@@ -26,20 +26,20 @@ exports[`Setting Namespace > Renders the component 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <div class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between position-relative" style="z-index: 1;">
       <!-- Left side: Icon + Title + Description -->
-      <div class="d-flex align-start flex-grow-1">
-        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-cloud-braces mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+      <div class="d-flex flex-column flex-sm-row align-start flex-grow-1 min-w-0">
+        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-sm-4 mb-3 mb-sm-0" style="width: 48px; height: 48px;"><i class="mdi-cloud-braces mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
           <!----><span class="v-avatar__underlay"></span>
         </div>
         <div>
           <div class="text-overline text-medium-emphasis mb-1">Settings</div>
-          <div class="text-h5 font-weight-bold mb-2">Namespace</div>
-          <div class="text-body-2 text-medium-emphasis">Manage the namespace settings including name, type, and access controls.</div>
+          <div class="text-h6 text-sm-h5 font-weight-bold mb-2 text-break">Namespace</div>
+          <div class="text-body-2 text-medium-emphasis text-break">Manage the namespace settings including name, type, and access controls.</div>
           <!--v-if-->
         </div>
       </div><!-- Right side: Actions -->
-      <div class="ml-4"><button data-v-80a16399="" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated" data-test="edit-namespace-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <div class="mt-4 mt-sm-0 ml-sm-4"><button data-v-80a16399="" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated" data-test="edit-namespace-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator=""> Edit Namespace </span>
           <!---->
           <!---->

--- a/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
@@ -22,20 +22,20 @@ exports[`Settings Namespace > Renders the component 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="d-flex align-start justify-space-between position-relative" style="z-index: 1;">
+    <div class="d-flex flex-column flex-sm-row align-start align-sm-center justify-space-between position-relative" style="z-index: 1;">
       <!-- Left side: Icon + Title + Description -->
-      <div class="d-flex align-start flex-grow-1">
-        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-4" style="width: 48px; height: 48px;"><i class="mdi-account-circle mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
+      <div class="d-flex flex-column flex-sm-row align-start flex-grow-1 min-w-0">
+        <div class="v-avatar v-theme--light bg-primary v-avatar--density-default v-avatar--variant-flat mr-sm-4 mb-3 mb-sm-0" style="width: 48px; height: 48px;"><i class="mdi-account-circle mdi v-icon notranslate v-theme--light" style="font-size: 32px; height: 32px; width: 32px;" aria-hidden="true"></i>
           <!----><span class="v-avatar__underlay"></span>
         </div>
         <div>
           <div class="text-overline text-medium-emphasis mb-1">Settings</div>
-          <div class="text-h5 font-weight-bold mb-2">Account Profile</div>
-          <div class="text-body-2 text-medium-emphasis">Manage your personal account information, authentication settings, and security preferences.</div>
+          <div class="text-h6 text-sm-h5 font-weight-bold mb-2 text-break">Account Profile</div>
+          <div class="text-body-2 text-medium-emphasis text-break">Manage your personal account information, authentication settings, and security preferences.</div>
           <!--v-if-->
         </div>
       </div><!-- Right side: Actions -->
-      <div class="ml-4"><button data-v-b3fa301d="" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated" data-test="edit-profile-button"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+      <div class="mt-4 mt-sm-0 ml-sm-4"><button data-v-b3fa301d="" type="button" class="v-btn v-btn--elevated v-theme--light bg-primary v-btn--density-default v-btn--size-default v-btn--variant-elevated" data-test="edit-profile-button"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
           <!----><span class="v-btn__content" data-no-activator=""> Edit Profile </span>
           <!---->
           <!---->


### PR DESCRIPTION
# Description

This PR improves the responsiveness of the `PageHeader` component by adapting its layout and typography for small and medium screens, ensuring better readability and alignment without affecting desktop behavior.

# Changes

- Switched the main layout to a column-first flow on small screens, returning to a row layout from sm and up.
- Adjusted alignment rules (`align-start → align-sm-center`) to avoid vertical misalignment on mobile.
- Generated test suite snapshots.
- Improved spacing behavior:
  - Avatar stacks naturally above text on small screens.
  - Action slot moves below content on mobile and aligns to the right on larger screens.
  - Made title and description break-safe (`text-break, min-w-0`) to prevent overflow in constrained widths.
  - Scaled typography responsively (`text-h6` on mobile → `text-h5 `on larger screens).