### PR TITLE
chore: revert Node.js 25 upgrade and configure Dependabot to keep LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,10 @@ updates:
     interval: weekly
   commit-message:
     prefix: "docker: ui"
+  ignore:
+    - dependency-name: "node"
+      update-types: ["version-update:semver-major"]
+      versions: [">=25"]
 - package-ecosystem: docker
   directory: "/agent"
   schedule:

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25.3.0-alpine3.22 AS base
+FROM node:24.12.0-alpine3.22 AS base
 
 ARG NPM_CONFIG_REGISTRY
 


### PR DESCRIPTION
- Revert Node.js upgrade from 24.12.0 (LTS) to 25.3.0 (non-LTS)
- Configure Dependabot to ignore Node.js versions >= 25
