### PR TITLE
fix(ui): remove namespace member's `status` field references

### DIFF
--- a/ui/admin/src/interfaces/INamespace.ts
+++ b/ui/admin/src/interfaces/INamespace.ts
@@ -1,6 +1,5 @@
-import { INamespace, INamespaceMember } from "@/interfaces/INamespace";
+import { INamespace } from "@/interfaces/INamespace";
 
-type AdminUserStatus = "accepted" | "pending";
 interface IAdminBilling {
   active: boolean;
   current_period_end: string;
@@ -13,11 +12,6 @@ interface IAdminBilling {
   subscription_id: string;
 }
 
-interface IAdminNamespaceMember extends Omit<INamespaceMember, "status"> {
-  status: AdminUserStatus
-}
-
-export interface IAdminNamespace extends Omit<INamespace, "billing" | "members"> {
+export interface IAdminNamespace extends Omit<INamespace, "billing"> {
   billing?: IAdminBilling;
-  members: IAdminNamespaceMember[];
 }

--- a/ui/admin/src/views/NamespaceDetails.vue
+++ b/ui/admin/src/views/NamespaceDetails.vue
@@ -208,13 +208,6 @@
                 />
                 {{ getRoleLabel(member.role) }}
               </v-chip>
-              <v-chip
-                size="small"
-                class="ml-2 text-capitalize"
-                data-test="namespace-member-status"
-              >
-                {{ member.status }}
-              </v-chip>
             </v-list-item-title>
 
             <v-list-item-subtitle class="d-flex flex-column">

--- a/ui/admin/tests/unit/mocks/namespace.ts
+++ b/ui/admin/tests/unit/mocks/namespace.ts
@@ -11,7 +11,6 @@ export const mockNamespace: IAdminNamespace = {
       email: "alice@example.com",
       added_at: "2024-01-01T00:00:00Z",
       expires_at: "0001-01-01T00:00:00Z",
-      status: "accepted" as const,
     },
     {
       id: "user-2",
@@ -19,7 +18,6 @@ export const mockNamespace: IAdminNamespace = {
       email: "bob@example.com",
       added_at: "2024-01-01T00:00:00Z",
       expires_at: "0001-01-01T00:00:00Z",
-      status: "accepted" as const,
     },
   ],
   max_devices: 10,

--- a/ui/admin/tests/unit/store/modules/namespaces.spec.ts
+++ b/ui/admin/tests/unit/store/modules/namespaces.spec.ts
@@ -19,7 +19,6 @@ const mockNamespaceBase: IAdminNamespace = {
       id: "member-id-1",
       email: "admin@example.com",
       role: "owner",
-      status: "accepted",
       added_at: "2026-01-06T00:00:00.000Z",
       expires_at: "2027-01-06T00:00:00.000Z",
     },

--- a/ui/admin/tests/unit/views/NamespaceDetails.spec.ts
+++ b/ui/admin/tests/unit/views/NamespaceDetails.spec.ts
@@ -140,12 +140,6 @@ describe("NamespaceDetails", () => {
       expect(roles[0].text()).toContain("owner");
     });
 
-    it("displays member statuses with correct values", () => {
-      const statuses = wrapper.findAll('[data-test="namespace-member-status"]');
-      expect(statuses.length).toBe(mockNamespace.members.length);
-      expect(statuses[0].text()).toBe(mockNamespace.members[0].status);
-    });
-
     it("displays member ids", () => {
       const memberIds = wrapper.findAll('[data-test="namespace-member-id"]');
       expect(memberIds.length).toBe(mockNamespace.members.length);


### PR DESCRIPTION
This pull request removes the `status` field from namespace members in the admin interface. The changes reflect the API changes, which removed the `status` field from the namespace members (if the user is a member, they are accepted).

- Removed the `IAdminNamespaceMember` type and the `status` field from the `IAdminNamespace` interface, so members no longer have a `status` property. 
- Removed the display of member status chips from the `NamespaceDetails` component.
- Removed the `status` property from mock namespace member data and updated tests to no longer check for member status. 