### PR TITLE
refactor(ui): update import statements for createCleanRouter to named export

### DIFF
--- a/ui/tests/utils/router.ts
+++ b/ui/tests/utils/router.ts
@@ -38,7 +38,7 @@ import { routes as adminRoutes } from "@admin/router";
  * });
  * expect(router.currentRoute.value.path).toBe('/devices');
  */
-const createCleanRouter = (routes = appRoutes) => createRouter({
+export const createCleanRouter = (routes = appRoutes) => createRouter({
   history: createWebHistory(),
   routes,
 });
@@ -64,5 +64,3 @@ export const createCleanAdminRouter = (routes = adminRoutes) => createRouter({
   history: createWebHistory("/admin/"),
   routes,
 });
-
-export default createCleanRouter;

--- a/ui/tests/views/ConfirmAccount.spec.ts
+++ b/ui/tests/views/ConfirmAccount.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent, mockSnackbar } from "@tests/utils/mount";
 import ConfirmAccount from "@/views/ConfirmAccount.vue";
 import useUsersStore from "@/store/modules/users";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import { createAxiosError } from "@tests/utils/axiosError";
 
 vi.mock("@/store/api/users");

--- a/ui/tests/views/Containers.spec.ts
+++ b/ui/tests/views/Containers.spec.ts
@@ -1,7 +1,7 @@
 import { VueWrapper } from "@vue/test-utils";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mountComponent } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import Containers from "@/views/Containers.vue";
 
 describe("Containers View", () => {

--- a/ui/tests/views/DetailsDevice.spec.ts
+++ b/ui/tests/views/DetailsDevice.spec.ts
@@ -2,7 +2,7 @@ import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { Router } from "vue-router";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent, mockSnackbar } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import DetailsDevice from "@/views/DetailsDevice.vue";
 import { IDevice } from "@/interfaces/IDevice";
 import { envVariables } from "@/envVariables";

--- a/ui/tests/views/DetailsSessions.spec.ts
+++ b/ui/tests/views/DetailsSessions.spec.ts
@@ -2,7 +2,7 @@ import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { Router } from "vue-router";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent, mockSnackbar } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import DetailsSessions from "@/views/DetailsSessions.vue";
 import { ISession } from "@/interfaces/ISession";
 import { formatFullDateTime } from "@/utils/date";

--- a/ui/tests/views/Devices.spec.ts
+++ b/ui/tests/views/Devices.spec.ts
@@ -1,7 +1,7 @@
 import { VueWrapper } from "@vue/test-utils";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mountComponent } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import Devices from "@/views/Devices.vue";
 
 describe("Devices View", () => {

--- a/ui/tests/views/ForgotPassword.spec.ts
+++ b/ui/tests/views/ForgotPassword.spec.ts
@@ -1,7 +1,7 @@
 import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent, mockSnackbar } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import ForgotPassword from "@/views/ForgotPassword.vue";
 import useUsersStore from "@/store/modules/users";
 import { createAxiosError } from "@tests/utils/axiosError";

--- a/ui/tests/views/Login.spec.ts
+++ b/ui/tests/views/Login.spec.ts
@@ -2,7 +2,7 @@ import { flushPromises, VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RouteLocationAsRelativeGeneric, Router } from "vue-router";
 import { mountComponent, mockSnackbar } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import { createAxiosError } from "@tests/utils/axiosError";
 import Login from "@/views/Login.vue";
 import { envVariables } from "@/envVariables";

--- a/ui/tests/views/MfaLogin.spec.ts
+++ b/ui/tests/views/MfaLogin.spec.ts
@@ -2,7 +2,7 @@ import { flushPromises, VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RouteLocationAsRelativeGeneric, Router } from "vue-router";
 import { mountComponent } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import { createAxiosError } from "@tests/utils/axiosError";
 import MfaLogin from "@/views/MfaLogin.vue";
 import useAuthStore from "@/store/modules/auth";

--- a/ui/tests/views/MfaResetValidation.spec.ts
+++ b/ui/tests/views/MfaResetValidation.spec.ts
@@ -1,7 +1,7 @@
 import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import MfaResetValidation from "@/views/MfaResetValidation.vue";
 import useAuthStore from "@/store/modules/auth";
 import { createAxiosError } from "@tests/utils/axiosError";

--- a/ui/tests/views/NamespaceInviteCard.spec.ts
+++ b/ui/tests/views/NamespaceInviteCard.spec.ts
@@ -1,7 +1,7 @@
 import { VueWrapper } from "@vue/test-utils";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mountComponent } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import NamespaceInviteCard from "@/views/NamespaceInviteCard.vue";
 import { routes } from "@/router";
 

--- a/ui/tests/views/NotFound.spec.ts
+++ b/ui/tests/views/NotFound.spec.ts
@@ -1,7 +1,7 @@
 import { vi, expect, describe, it } from "vitest";
 import { mountComponent } from "@tests/utils/mount";
 import NotFound from "@/views/NotFound.vue";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 
 describe("Not Found Page", () => {
   const router = createCleanRouter();

--- a/ui/tests/views/Sessions.spec.ts
+++ b/ui/tests/views/Sessions.spec.ts
@@ -1,7 +1,7 @@
 import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { mountComponent, mockSnackbar } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import Sessions from "@/views/Sessions.vue";
 import { mockSession } from "@tests/views/mocks";
 import useSessionsStore from "@/store/modules/sessions";

--- a/ui/tests/views/Setup.spec.ts
+++ b/ui/tests/views/Setup.spec.ts
@@ -1,7 +1,7 @@
 import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import Setup from "@/views/Setup.vue";
 import useUsersStore from "@/store/modules/users";
 import { createAxiosError } from "@tests/utils/axiosError";

--- a/ui/tests/views/SignUp.spec.ts
+++ b/ui/tests/views/SignUp.spec.ts
@@ -1,7 +1,7 @@
 import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import SignUp from "@/views/SignUp.vue";
 import useUsersStore from "@/store/modules/users";
 import { createAxiosError } from "@tests/utils/axiosError";

--- a/ui/tests/views/UpdatePassword.spec.ts
+++ b/ui/tests/views/UpdatePassword.spec.ts
@@ -2,7 +2,7 @@ import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { Router } from "vue-router";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent, mockSnackbar } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import UpdatePassword from "@/views/UpdatePassword.vue";
 import useUsersStore from "@/store/modules/users";
 import { createAxiosError } from "@tests/utils/axiosError";

--- a/ui/tests/views/ValidationAccount.spec.ts
+++ b/ui/tests/views/ValidationAccount.spec.ts
@@ -2,7 +2,7 @@ import { VueWrapper, flushPromises } from "@vue/test-utils";
 import { Router } from "vue-router";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { mountComponent, mockSnackbar } from "@tests/utils/mount";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 import ValidationAccount from "@/views/ValidationAccount.vue";
 import useUsersStore from "@/store/modules/users";
 import { createAxiosError } from "@tests/utils/axiosError";

--- a/ui/tests/views/WebEndpoints.spec.ts
+++ b/ui/tests/views/WebEndpoints.spec.ts
@@ -4,7 +4,7 @@ import { mountComponent, mockSnackbar } from "@tests/utils/mount";
 import WebEndpoints from "@/views/WebEndpoints.vue";
 import useWebEndpointsStore from "@/store/modules/web_endpoints";
 import { createAxiosError } from "@tests/utils/axiosError";
-import createCleanRouter from "@tests/utils/router";
+import { createCleanRouter } from "@tests/utils/router";
 
 vi.mock("@/store/api/web_endpoints");
 vi.mock("@/store/api/devices", () => ({


### PR DESCRIPTION
This pull request refactors how the `createCleanRouter` utility is exported from `@tests/utils/router.ts`, changing from a default to a named export. This change aims to simplify the exports, keeping both utils from that file (main UI and admin utils) using the same export pattern. The test files that use the util were also updated.