### PR TITLE
refactor(ui): replace v-card layout with SettingsRow/Section

### DIFF
--- a/ui/src/components/Setting/SettingNamespace.vue
+++ b/ui/src/components/Setting/SettingNamespace.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/max-len -->
 <template>
   <v-container fluid>
     <NamespaceDelete
@@ -54,246 +55,146 @@
         </template>
       </template>
     </PageHeader>
-    <v-card
-      variant="flat"
-      class="bg-transparent"
-    >
-      <v-card-text class="pt-0">
-        <v-list
-          border
-          rounded
-          class="bg-background pa-0"
-          data-test="profile-details-list"
+    <SettingsSection data-test="profile-details-list">
+      <SettingsRow
+        icon="mdi-cloud-braces"
+        icon-test-id="name-icon"
+        title="Name"
+        title-test-id="name-title"
+        data-test="profile-details-item"
+      >
+        <v-text-field
+          v-model="name"
+          :error-messages="nameError"
+          :disabled="!editDataStatus"
+          :readonly="!editDataStatus"
+          required
+          :reverse="smAndUp"
+          :hide-details="!nameError"
+          density="compact"
+          :variant="editDataStatus ? 'outlined' : 'plain'"
+          data-test="name-input"
+        />
+      </SettingsRow>
+      <v-divider />
+      <SettingsRow
+        icon="mdi-shape-outline"
+        icon-test-id="type-icon"
+        title="Type"
+        title-test-id="type-title"
+        data-test="type-details-item"
+      >
+        <v-chip
+          class="text-capitalize"
+          data-test="type-chip"
         >
-          <v-card-item
-            style="grid-template-columns: max-content 1.5fr 2fr"
-            data-test="profile-details-item"
-          >
-            <template #prepend>
-              <v-icon data-test="name-icon">
-                mdi-cloud-braces
-              </v-icon>
+          <v-icon
+            size="small"
+            class="mr-1"
+            :icon="namespaceTypeIcon"
+          />
+          {{ namespace.type || "team" }}
+        </v-chip>
+      </SettingsRow>
+      <v-divider />
+      <SettingsRow
+        icon="mdi-identifier"
+        icon-test-id="tenant-icon"
+        title="Tenant ID"
+        title-test-id="tenant-title"
+        data-test="tenant-details-item"
+      >
+        <v-chip>
+          <v-tooltip location="top">
+            <template #activator="props">
+              <CopyWarning :copied-item="'Tenant ID'">
+                <template #default="{ copyText }">
+                  <span
+                    v-bind="props"
+                    class="hover-text"
+                    data-test="tenant-copy-btn"
+                    @click="copyText(tenantId)"
+                    @keypress="copyText(tenantId)"
+                  >
+                    {{ tenantId }}
+                    <v-icon icon="mdi-content-copy" />
+                  </span>
+                </template>
+              </CopyWarning>
             </template>
-            <template #title>
-              <span
-                class="text-subtitle-1"
-                data-test="name-title"
-              >Name</span>
-            </template>
-            <template #append>
-              <v-text-field
-                v-model="name"
-                :error-messages="nameError"
-                :disabled="!editDataStatus"
-                :readonly="!editDataStatus"
-                required
-                :hide-details="!nameError"
-                density="compact"
-                :variant="editDataStatus ? 'outlined' : 'plain'"
-                data-test="name-input"
-              />
-            </template>
-          </v-card-item>
-          <v-divider />
-          <v-card-item
-            style="grid-template-columns: max-content 1.5fr 2fr"
-            data-test="type-details-item"
-          >
-            <template #prepend>
-              <v-icon data-test="type-icon">
-                mdi-shape-outline
-              </v-icon>
-            </template>
-            <template #title>
-              <span
-                class="text-subtitle-1"
-                data-test="type-title"
-              >Type</span>
-            </template>
-            <template #append>
-              <v-chip
-                class="ml-1 text-capitalize"
-                data-test="type-chip"
-              >
-                <v-icon
-                  size="small"
-                  class="mr-1"
-                  :icon="namespaceTypeIcon"
-                />
-                {{ namespace.type || "team" }}
-              </v-chip>
-            </template>
-          </v-card-item>
-          <v-divider />
-          <v-card-item
-            style="grid-template-columns: max-content 1.5fr 2fr"
-            data-test="tenant-details-item"
-          >
-            <template #prepend>
-              <v-icon data-test="tenant-icon">
-                mdi-identifier
-              </v-icon>
-            </template>
-            <template #title>
-              <span
-                class="text-subtitle-1"
-                data-test="tenant-title"
-              >Tenant ID</span>
-            </template>
-            <template #append>
-              <v-chip class="ml-1">
-                <v-tooltip location="top">
-                  <template #activator="props">
-                    <CopyWarning :copied-item="'Tenant ID'">
-                      <template #default="{ copyText }">
-                        <span
-                          v-bind="props"
-                          class="hover-text"
-                          data-test="tenant-copy-btn"
-                          @click="copyText(tenantId)"
-                          @keypress="copyText(tenantId)"
-                        >
-                          {{ tenantId }}
-                          <v-icon icon="mdi-content-copy" />
-                        </span>
-                      </template>
-                    </CopyWarning>
-                  </template>
-                  <span data-test="tenant-tooltip">Copy ID</span>
-                </v-tooltip>
-              </v-chip>
-            </template>
-          </v-card-item>
-          <v-divider />
-          <v-card-item
-            style="grid-template-columns: max-content 1.5fr 2fr"
-            data-test="announcement-item"
-          >
-            <template #title>
-              <v-icon
-                data-test="announcement-icon"
-                size="18"
-                class="pl-1 mr-3"
-              >
-                mdi-bullhorn-variant-outline
-              </v-icon>
-              <span
-                class="text-subtitle-1"
-                data-test="announcement-title"
-              >Connection Announcement</span>
-            </template>
-            <v-card-text class="pt-1 pl-0">
-              <span data-test="announcement-subtitle">A connection announcement is a custom message written
-                during a session when a connection is established on a device
-                within the namespace.</span>
-            </v-card-text>
-            <template #append>
-              <v-btn
-                class="ml-4"
-                variant="text"
-                color="primary"
-                data-test="edit-announcement-btn"
-                @click="editAnnouncement = true"
-              >
-                Edit Announcement
-              </v-btn>
-            </template>
-          </v-card-item>
-          <v-divider />
-          <v-row class="ma-0">
-            <v-card
-              flat
-              class="bg-background"
-              data-test="record-item"
-            >
-              <template #title>
-                <v-icon
-                  data-test="record-icon"
-                  size="18"
-                  class="pl-1 mr-3"
-                >
-                  mdi-play-box-outline
-                </v-icon>
-                <span
-                  class="text-subtitle-1"
-                  data-test="record-title"
-                >Session Record</span>
-                <v-card-text
-                  class="pl-0 pt-1"
-                  data-test="record-description"
-                >
-                  Session record is a feature that allows you to check logged activity
-                  when connecting to a device.
-                </v-card-text>
-              </template>
-            </v-card>
-            <v-col class="d-flex align-center justify-end bg-background">
-              <SettingSessionRecording
-                :tenant-id
-                data-test="session-recording-setting-component"
-              />
-            </v-col>
-          </v-row>
-          <v-divider />
-          <v-card-item
-            style="grid-template-columns: max-content 1.5fr 2fr"
-            data-test="delete-leave-item"
-          >
-            <template #title>
-              <v-icon
-                data-test="delete-leave-icon"
-                size="18"
-                class="pl-1 mr-3"
-              >
-                mdi-delete
-              </v-icon>
-              <span
-                v-if="isOwner"
-                class="text-subtitle-1"
-                data-test="delete-leave-title"
-              >Delete Namespace</span>
-              <span
-                v-else
-                class="text-subtitle-1"
-                data-test="delete-leave-title"
-              >Leave Namespace</span>
-            </template>
-            <v-card-text class="pt-1 pl-0">
-              <span
-                v-if="isOwner"
-                data-test="delete-description"
-              >After deleting a namespace, there is no going back. Be sure. </span>
-              <span
-                v-else
-                data-test="leave-description"
-              >After leaving a namespace, you will need to be invited again to access it.</span>
-            </v-card-text>
-            <template #append>
-              <v-btn
-                v-if="isOwner"
-                class="ml-4"
-                variant="text"
-                color="error"
-                :disabled="billingInDebt"
-                data-test="delete-namespace-btn"
-                @click="namespaceDelete = true"
-              >
-                Delete
-              </v-btn>
-              <v-btn
-                v-else
-                variant="text"
-                color="error"
-                data-test="leave-namespace-btn"
-                @click="namespaceLeave = true"
-              >
-                Leave
-              </v-btn>
-            </template>
-          </v-card-item>
-        </v-list>
-      </v-card-text>
-    </v-card>
+            <span data-test="tenant-tooltip">Copy ID</span>
+          </v-tooltip>
+        </v-chip>
+      </SettingsRow>
+      <v-divider />
+      <SettingsRow
+        icon="mdi-bullhorn-variant-outline"
+        icon-test-id="announcement-icon"
+        title="Connection Announcement"
+        title-test-id="announcement-title"
+        subtitle="A connection announcement is a custom message written during a
+         session when a connection is established on a device within the namespace."
+        subtitle-test-id="announcement-subtitle"
+        data-test="announcement-item"
+      >
+        <v-btn
+          class="ml-4"
+          variant="text"
+          color="primary"
+          data-test="edit-announcement-btn"
+          @click="editAnnouncement = true"
+        >
+          Edit Announcement
+        </v-btn>
+      </SettingsRow>
+      <v-divider />
+      <SettingsRow
+        icon="mdi-play-box-outline"
+        icon-test-id="record-icon"
+        title="Session Record"
+        title-test-id="record-title"
+        subtitle="Session record is a feature that allows you to check logged activity when connecting to a device."
+        subtitle-test-id="record-description"
+        data-test="record-item"
+      >
+        <SettingSessionRecording
+          :tenant-id
+          class="mr-sm-4"
+          data-test="session-recording-setting-component"
+        />
+      </SettingsRow>
+      <v-divider />
+      <SettingsRow
+        icon="mdi-delete"
+        icon-test-id="delete-leave-icon"
+        :title="isOwner ? 'Delete Namespace' : 'Leave Namespace'"
+        title-test-id="delete-leave-title"
+        :subtitle="isOwner ? 'After deleting a namespace, there is no going back. Be sure.' : 'After leaving a namespace, you will need to be invited again to access it.'"
+        :subtitle-test-id="isOwner ? 'delete-description' : 'leave-description'"
+        data-test="delete-leave-item"
+      >
+        <v-btn
+          v-if="isOwner"
+          class="ml-4"
+          variant="text"
+          color="error"
+          :disabled="billingInDebt"
+          data-test="delete-namespace-btn"
+          @click="namespaceDelete = true"
+        >
+          Delete
+        </v-btn>
+        <v-btn
+          v-else
+          variant="text"
+          color="error"
+          data-test="leave-namespace-btn"
+          @click="namespaceLeave = true"
+        >
+          Leave
+        </v-btn>
+      </SettingsRow>
+    </SettingsSection>
   </v-container>
 </template>
 
@@ -302,6 +203,7 @@ import { onMounted, computed, ref } from "vue";
 import axios, { AxiosError } from "axios";
 import * as yup from "yup";
 import { useField } from "vee-validate";
+import { useDisplay } from "vuetify";
 import hasPermission from "@/utils/permission";
 import SettingSessionRecording from "./SettingSessionRecording.vue";
 import NamespaceDelete from "../Namespace/NamespaceDelete.vue";
@@ -309,6 +211,8 @@ import ConnectionAnnouncementEdit from "../Namespace/ConnectionAnnouncementEdit.
 import PageHeader from "../PageHeader.vue";
 import handleError from "@/utils/handleError";
 import NamespaceLeave from "../Namespace/NamespaceLeave.vue";
+import SettingsRow from "./SettingsRow.vue";
+import SettingsSection from "./SettingsSection.vue";
 import useSnackbar from "@/helpers/snackbar";
 import CopyWarning from "@/components/User/CopyWarning.vue";
 import useAuthStore from "@/store/modules/auth";
@@ -317,6 +221,7 @@ import useNamespacesStore from "@/store/modules/namespaces";
 const authStore = useAuthStore();
 const namespacesStore = useNamespacesStore();
 const snackbar = useSnackbar();
+const { smAndUp } = useDisplay();
 const namespace = computed(() => namespacesStore.currentNamespace);
 const isOwner = computed(() => namespace.value.owner === localStorage.getItem("id"));
 const { tenantId } = authStore;
@@ -424,4 +329,11 @@ onMounted(async () => {
   --v-field-padding-end: 16px;
   --v-field-padding-bottom: 8px;
 }
+
+@media (max-width: 600px) {
+  :deep(.v-text-field .v-field__input) {
+    text-align: center;
+  }
+}
+
 </style>

--- a/ui/src/components/Setting/SettingProfile.vue
+++ b/ui/src/components/Setting/SettingProfile.vue
@@ -53,219 +53,151 @@
       </template>
     </PageHeader>
 
-    <v-card
-      variant="flat"
-      class="bg-transparent"
-    >
-      <v-card-text class="pt-0">
-        <v-list
-          border
-          rounded
-          class="bg-background pa-0"
-          data-test="profile-details-list"
+    <SettingsSection data-test="profile-details-list">
+      <SettingsRow
+        icon="mdi-badge-account"
+        title="Name"
+        title-test-id="name-field"
+      >
+        <v-text-field
+          v-model="name"
+          :error-messages="nameError"
+          :disabled="!editDataStatus"
+          :readonly="!editDataStatus"
+          required
+          :hide-details="!nameError"
+          density="compact"
+          :variant="editDataStatus ? 'outlined' : 'plain'"
+          :reverse="smAndUp"
+          data-test="name-input"
+        />
+      </SettingsRow>
+      <v-divider />
+      <SettingsRow
+        v-if="isLocalAuth || isCloud"
+        icon="mdi-account"
+        title="Username"
+        title-test-id="username-field"
+      >
+        <v-text-field
+          v-model="username"
+          :error-messages="usernameError"
+          :disabled="!editDataStatus"
+          :readonly="!editDataStatus"
+          density="compact"
+          :variant="editDataStatus ? 'outlined' : 'plain'"
+          required
+          :hide-details="!usernameError"
+          :reverse="smAndUp"
+          data-test="username-input"
+        />
+      </SettingsRow>
+      <v-divider v-if="isLocalAuth || isCloud" />
+      <SettingsRow
+        icon="mdi-email"
+        title="Email"
+        title-test-id="email-field"
+      >
+        <v-text-field
+          v-model="email"
+          :error-messages="emailError"
+          :disabled="!editDataStatus"
+          :readonly="!editDataStatus"
+          density="compact"
+          :variant="editDataStatus ? 'outlined' : 'plain'"
+          required
+          :hide-details="!emailError"
+          :reverse="smAndUp"
+          data-test="email-input"
+        />
+      </SettingsRow>
+      <v-divider />
+      <SettingsRow
+        v-if="isLocalAuth || isCloud"
+        icon="mdi-email-lock"
+        title="Recovery Email"
+        title-test-id="recovery-email-field"
+      >
+        <v-text-field
+          v-model="recoveryEmail"
+          :error-messages="recoveryEmailError"
+          :disabled="!editDataStatus"
+          :readonly="!editDataStatus"
+          density="compact"
+          :variant="editDataStatus ? 'outlined' : 'plain'"
+          required
+          :hide-details="!recoveryEmailError"
+          :reverse="smAndUp"
+          data-test="recovery-email-input"
+        />
+      </SettingsRow>
+      <v-divider v-if="isLocalAuth || isCloud" />
+      <SettingsRow
+        v-if="isLocalAuth || isCloud"
+        icon="mdi-key"
+        title="Password"
+      >
+        <v-btn
+          variant="text"
+          color="primary"
+          @click="showChangePassword = true"
         >
-          <v-card-item style="grid-template-columns: max-content 1.5fr 2fr">
-            <template #prepend>
-              <v-icon>mdi-badge-account</v-icon>
-            </template>
-            <template #title>
-              <span
-                class="text-subtitle-1"
-                data-test="name-field"
-              >Name</span>
-            </template>
-            <template #append>
-              <v-text-field
-                v-model="name"
-                :error-messages="nameError"
-                :disabled="!editDataStatus"
-                :readonly="!editDataStatus"
-                required
-                :hide-details="!nameError"
-                density="compact"
-                :variant="editDataStatus ? 'outlined' : 'plain'"
-                data-test="name-input"
-              />
-            </template>
-          </v-card-item>
-          <v-divider />
-          <div v-if="isLocalAuth || isCloud">
-            <v-card-item style="grid-template-columns: max-content 1.5fr 2fr">
-              <template #prepend>
-                <v-icon>mdi-account</v-icon>
-              </template>
-              <template #title>
-                <span
-                  class="text-subtitle-1"
-                  data-test="username-field"
-                >Username</span>
-              </template>
-              <template #append>
-                <v-text-field
-                  v-model="username"
-                  :error-messages="usernameError"
-                  :disabled="!editDataStatus"
-                  :readonly="!editDataStatus"
-                  density="compact"
-                  :variant="editDataStatus ? 'outlined' : 'plain'"
-                  required
-                  :hide-details="!usernameError"
-                  data-test="username-input"
-                />
-              </template>
-            </v-card-item>
-            <v-divider />
-          </div>
-          <v-card-item style="grid-template-columns: max-content 1.5fr 2fr">
-            <template #prepend>
-              <v-icon>mdi-email</v-icon>
-            </template>
-            <template #title>
-              <span
-                class="text-subtitle-1"
-                data-test="email-field"
-              >Email</span>
-            </template>
-            <template #append>
-              <v-text-field
-                v-model="email"
-                :error-messages="emailError"
-                :disabled="!editDataStatus"
-                :readonly="!editDataStatus"
-                density="compact"
-                :variant="editDataStatus ? 'outlined' : 'plain'"
-                required
-                :hide-details="!emailError"
-                data-test="email-input"
-              />
-            </template>
-          </v-card-item>
-          <v-divider />
-
-          <div v-if="isLocalAuth || isCloud">
-            <v-card-item style="grid-template-columns: max-content 1.5fr 2fr">
-              <template #prepend>
-                <v-icon>mdi-email-lock</v-icon>
-              </template>
-              <template #title>
-                <span
-                  class="text-subtitle-1"
-                  data-test="recovery-email-field"
-                >Recovery Email</span>
-              </template>
-              <template #append>
-                <v-text-field
-                  v-model="recoveryEmail"
-                  :error-messages="recoveryEmailError"
-                  :disabled="!editDataStatus"
-                  :readonly="!editDataStatus"
-                  density="compact"
-                  :variant="editDataStatus ? 'outlined' : 'plain'"
-                  required
-                  :hide-details="!recoveryEmailError"
-                  data-test="recovery-email-input"
-                />
-              </template>
-            </v-card-item>
-            <v-divider />
-            <v-card-item
-              v-if="isLocalAuth || isCloud"
-              style="grid-template-columns: max-content 1.5fr 2fr"
+          Change Password
+        </v-btn>
+        <ChangePassword v-model="showChangePassword" />
+      </SettingsRow>
+      <v-divider v-if="isLocalAuth || isCloud" />
+      <SettingsRow
+        v-if="isLocalAuth || isCloud"
+        icon="mdi-fingerprint"
+        title="Multi-factor Authentication"
+        subtitle="Enable multi-factor authentication (MFA) to add an extra layer of security to your account.
+         You'll need to enter a one-time verification code from your preferred TOTP provider to log in."
+        subtitle-test-id="mfa-text"
+        data-test="mfa-card"
+      >
+        <v-tooltip
+          location="top"
+          text="Only available for Cloud or Enterprise accounts!"
+          :disabled="!isCommunity"
+        >
+          <template #activator="{ props }">
+            <div
+              v-bind="props"
+              class="d-flex align-center"
             >
-              <template #prepend>
-                <v-icon>mdi-key</v-icon>
-              </template>
-              <template #title>
-                <span class="text-subtitle-1">Password</span>
-              </template>
-              <template #append>
-                <v-btn
-                  variant="text"
-                  color="primary"
-                  @click="showChangePassword = true"
-                >
-                  Change Password
-                </v-btn>
-                <ChangePassword v-model="showChangePassword" />
-              </template>
-            </v-card-item>
-            <v-divider />
-            <div class="d-flex align-center justify-space-between pr-4">
-              <v-card
+              <v-switch
+                v-model="isMfaEnabled"
+                class="mr-sm-4"
+                hide-details
+                inset
+                color="primary"
                 :disabled="isCommunity"
-                flat
-                class="bg-background"
-                :class="lgAndUp ? 'w-100' : 'w-75'"
-                prepend-icon="mdi-fingerprint"
-                data-test="mfa-card"
-              >
-                <template #title>
-                  <span class="text-subtitle-1">Multi-factor Authentication</span>
-                </template>
-                <div class="d-flex flex-no-wrap justify-space-between">
-                  <div>
-                    <v-card-text
-                      class="pt-0 text-justify"
-                      data-test="mfa-text"
-                    >
-                      Enable multi-factor authentication (MFA) to add an extra layer of security to your account.
-                      You'll need to enter a one-time verification code from your preferred TOTP provider to log in.
-                    </v-card-text>
-                  </div>
-                </div>
-              </v-card>
-              <v-tooltip
-                location="top"
-                text="Only available for Cloud or Enterprise accounts!"
-                :disabled="!isCommunity"
-              >
-                <template #activator="{ props }">
-                  <div
-                    v-bind="props"
-                    class="d-flex align-center bg-background"
-                    style="height: fit-content;"
-                  >
-                    <v-switch
-                      v-model="isMfaEnabled"
-                      hide-details
-                      inset
-                      color="primary"
-                      :disabled="isCommunity"
-                      data-test="switch-mfa"
-                      @click.prevent="toggleMfa()"
-                    />
-                    <MfaSettings v-model="showMfaSettingsDialog" />
-                    <MfaDisable v-model="showMfaDisableDialog" />
-                  </div>
-                </template>
-              </v-tooltip>
+                data-test="switch-mfa"
+                @click.prevent="toggleMfa()"
+              />
+              <MfaSettings v-model="showMfaSettingsDialog" />
+              <MfaDisable v-model="showMfaDisableDialog" />
             </div>
-          </div>
-          <v-divider />
-          <v-card-item style="grid-template-columns: max-content 1.5fr 2fr">
-            <template #prepend>
-              <v-icon>mdi-delete</v-icon>
-            </template>
-            <template #title>
-              <span
-                class="text-subtitle-1"
-                data-test="delete-account"
-              >Delete Account</span>
-            </template>
-            <template #append>
-              <v-btn
-                variant="text"
-                color="error"
-                data-test="delete-account-btn"
-                @click="showDeleteAccountDialog = true"
-              >
-                Delete
-              </v-btn>
-            </template>
-          </v-card-item>
-        </v-list>
-      </v-card-text>
-    </v-card>
+          </template>
+        </v-tooltip>
+      </SettingsRow>
+      <v-divider v-if="isLocalAuth || isCloud" />
+      <SettingsRow
+        icon="mdi-delete"
+        title="Delete Account"
+        title-test-id="delete-account"
+      >
+        <v-btn
+          variant="text"
+          color="error"
+          data-test="delete-account-btn"
+          @click="showDeleteAccountDialog = true"
+        >
+          Delete
+        </v-btn>
+      </SettingsRow>
+    </SettingsSection>
   </v-container>
 </template>
 
@@ -283,6 +215,8 @@ import UserDeleteWarning from "../User/UserDeleteWarning.vue";
 import PageHeader from "../PageHeader.vue";
 import { envVariables } from "@/envVariables";
 import ChangePassword from "../User/ChangePassword.vue";
+import SettingsRow from "./SettingsRow.vue";
+import SettingsSection from "./SettingsSection.vue";
 import useSnackbar from "@/helpers/snackbar";
 import useAuthStore from "@/store/modules/auth";
 import useUsersStore from "@/store/modules/users";
@@ -303,7 +237,7 @@ const authMethods = computed(() => authStore.authMethods);
 const isLocalAuth = computed(() => authMethods.value.includes("local"));
 const { isEnterprise, isCommunity, isCloud } = envVariables;
 const showUserDeleteWarning = computed(() => isCommunity || isEnterprise);
-const { lgAndUp } = useDisplay();
+const { smAndUp } = useDisplay();
 
 const {
   value: name,
@@ -471,4 +405,11 @@ onMounted(async () => {
   --v-field-padding-end: 16px;
   --v-field-padding-bottom: 8px;
 }
+
+@media (max-width: 600px) {
+  :deep(.v-text-field .v-field__input) {
+    text-align: center;
+  }
+}
+
 </style>

--- a/ui/src/components/Setting/SettingsRow.vue
+++ b/ui/src/components/Setting/SettingsRow.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-row class="ma-0 px-3 align-center">
+    <v-col
+      cols="12"
+      sm="6"
+      md="6"
+      class="d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start"
+    >
+      <div class="text-center text-sm-start">
+        <div
+          v-if="title || $slots.title"
+          class="text-subtitle-1"
+          :data-test="titleTestId"
+        >
+          <v-icon
+            v-if="icon"
+            class="mr-3"
+            :data-test="iconTestId"
+          >
+            {{ icon }}
+          </v-icon>
+          <slot name="title">{{ title }}</slot>
+        </div>
+        <div
+          v-if="subtitle || $slots.subtitle"
+          class="text-body-2 mt-1"
+          :data-test="subtitleTestId"
+        >
+          <slot name="subtitle">{{ subtitle }}</slot>
+        </div>
+      </div>
+    </v-col>
+    <v-col
+      cols="12"
+      sm="6"
+      md="6"
+      class="px-0 d-flex align-center justify-center justify-sm-end"
+    >
+      <div class="w-100 d-flex justify-center justify-sm-end">
+        <slot />
+      </div>
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  icon?: string;
+  iconTestId?: string;
+  title?: string;
+  titleTestId?: string;
+  subtitle?: string;
+  subtitleTestId?: string;
+}>();
+</script>

--- a/ui/src/components/Setting/SettingsSection.vue
+++ b/ui/src/components/Setting/SettingsSection.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-card
+    variant="flat"
+    class="bg-transparent"
+  >
+    <v-card-text class="pt-0">
+      <v-list
+        v-bind="attrs"
+        border
+        rounded
+        class="bg-background pa-0"
+      >
+        <slot />
+      </v-list>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import { useAttrs } from "vue";
+
+defineOptions({ inheritAttrs: false });
+
+const attrs = useAttrs();
+</script>

--- a/ui/tests/components/Setting/SettingsRow.spec.ts
+++ b/ui/tests/components/Setting/SettingsRow.spec.ts
@@ -1,0 +1,39 @@
+import { createVuetify } from "vuetify";
+import { mount, VueWrapper } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import SettingsRow from "@/components/Setting/SettingsRow.vue";
+
+describe("SettingsRow", () => {
+  let wrapper: VueWrapper<InstanceType<typeof SettingsRow>>;
+  const vuetify = createVuetify();
+
+  const mountComponent = () => {
+    wrapper = mount(SettingsRow, {
+      props: {
+        icon: "mdi-test-icon",
+        iconTestId: "row-icon",
+        title: "Row Title",
+        titleTestId: "row-title",
+        subtitle: "Row subtitle",
+        subtitleTestId: "row-subtitle",
+      },
+      slots: {
+        default: '<div data-test="row-field">Field</div>',
+      },
+      global: {
+        plugins: [vuetify],
+      },
+    });
+  };
+
+  it("renders icon, title, subtitle, and field slot", () => {
+    mountComponent();
+
+    const icon = wrapper.find('[data-test="row-icon"]');
+    expect(icon.exists()).toBe(true);
+    expect(icon.classes().join(" ")).toContain("mdi-test-icon");
+    expect(wrapper.find('[data-test="row-title"]').text()).toBe("Row Title");
+    expect(wrapper.find('[data-test="row-subtitle"]').text()).toBe("Row subtitle");
+    expect(wrapper.find('[data-test="row-field"]').exists()).toBe(true);
+  });
+});

--- a/ui/tests/components/Setting/SettingsSection.spec.ts
+++ b/ui/tests/components/Setting/SettingsSection.spec.ts
@@ -1,0 +1,26 @@
+import { createVuetify } from "vuetify";
+import { mount, VueWrapper } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import SettingsSection from "@/components/Setting/SettingsSection.vue";
+
+describe("SettingsSection", () => {
+  let wrapper: VueWrapper<InstanceType<typeof SettingsSection>>;
+  const vuetify = createVuetify();
+
+  it("renders the slot content and forwards list attributes", () => {
+    wrapper = mount(SettingsSection, {
+      attrs: {
+        "data-test": "settings-section-list",
+      },
+      slots: {
+        default: '<div data-test="settings-section-item">Item</div>',
+      },
+      global: {
+        plugins: [vuetify],
+      },
+    });
+
+    expect(wrapper.find('[data-test="settings-section-list"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="settings-section-item"]').exists()).toBe(true);
+  });
+});

--- a/ui/tests/components/Setting/__snapshots__/SettingNamespace.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingNamespace.spec.ts.snap
@@ -67,183 +67,170 @@ exports[`Setting Namespace > Renders the component 1`] = `
     </div>
     <!---->
     <!---->
-    <div data-v-80a16399="" class="v-card-text pt-0">
-      <div data-v-80a16399="" class="v-list v-theme--light v-list--border v-list--density-default v-list--one-line v-list--rounded bg-background pa-0" tabindex="0" role="list" data-test="profile-details-list">
-        <div data-v-80a16399="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;" data-test="profile-details-item">
-          <div class="v-card-item__prepend"><i data-v-80a16399="" class="mdi-cloud-braces mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" data-test="name-icon"></i></div>
-          <div class="v-card-item__content">
-            <div class="v-card-title"><span data-v-80a16399="" class="text-subtitle-1" data-test="name-title">Name</span></div>
-            <!---->
-            <!---->
-          </div>
-          <div class="v-card-item__append">
-            <div data-v-80a16399="" class="v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-input--readonly v-text-field v-input--plain-underlined" data-test="name-input">
-              <!---->
-              <div class="v-input__control">
-                <div class="v-field v-field--active v-field--disabled v-field--dirty v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
-                  <div class="v-field__overlay"></div>
-                  <div class="v-field__loader">
-                    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
-                      <!---->
-                      <div class="v-progress-linear__background"></div>
-                      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
-                      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-                        <div class="v-progress-linear__indeterminate">
-                          <div class="v-progress-linear__indeterminate long"></div>
-                          <div class="v-progress-linear__indeterminate short"></div>
-                        </div>
-                      </transition-stub>
-                      <!---->
-                    </div>
-                  </div>
-                  <!---->
-                  <div class="v-field__field" data-no-activator="">
-                    <!---->
-                    <!---->
-                    <!----><input readonly="" disabled="" size="1" type="text" aria-labelledby="input-v-2-label" id="input-v-2" required="" class="v-field__input" value="test">
-                    <!---->
-                  </div>
-                  <!---->
-                  <!---->
-                  <div class="v-field__outline">
-                    <!---->
-                    <!---->
-                  </div>
-                </div>
-              </div>
-              <!---->
-              <!---->
+    <div class="v-card-text pt-0">
+      <div class="v-list v-theme--light v-list--border v-list--density-default v-list--one-line v-list--rounded bg-background pa-0" tabindex="0" role="list" data-test="profile-details-list">
+        <div data-v-80a16399="" class="v-row ma-0 px-3 align-center" data-test="profile-details-item">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="name-title"><i class="mdi-cloud-braces mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true" data-test="name-icon"></i>Name</div>
+              <!--v-if-->
             </div>
           </div>
-        </div>
-        <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-        <div data-v-80a16399="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;" data-test="type-details-item">
-          <div class="v-card-item__prepend"><i data-v-80a16399="" class="mdi-shape-outline mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" data-test="type-icon"></i></div>
-          <div class="v-card-item__content">
-            <div class="v-card-title"><span data-v-80a16399="" class="text-subtitle-1" data-test="type-title">Type</span></div>
-            <!---->
-            <!---->
-          </div>
-          <div class="v-card-item__append"><span data-v-80a16399="" class="v-chip v-theme--light v-chip--density-default v-chip--size-default v-chip--variant-tonal ml-1 text-capitalize" draggable="false" data-test="type-chip"><!----><span class="v-chip__underlay"></span>
-            <!---->
-            <!---->
-            <div class="v-chip__content" data-no-activator=""><i data-v-80a16399="" class="mdi-account-group mdi v-icon notranslate v-theme--light v-icon--size-small mr-1" aria-hidden="true"></i> team</div>
-            <!---->
-            <!----></span>
-          </div>
-        </div>
-        <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-        <div data-v-80a16399="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;" data-test="tenant-details-item">
-          <div class="v-card-item__prepend"><i data-v-80a16399="" class="mdi-identifier mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" data-test="tenant-icon"></i></div>
-          <div class="v-card-item__content">
-            <div class="v-card-title"><span data-v-80a16399="" class="text-subtitle-1" data-test="tenant-title">Tenant ID</span></div>
-            <!---->
-            <!---->
-          </div>
-          <div class="v-card-item__append"><span data-v-80a16399="" class="v-chip v-theme--light v-chip--density-default v-chip--size-default v-chip--variant-tonal ml-1" draggable="false"><!----><span class="v-chip__underlay"></span>
-            <!---->
-            <!---->
-            <div class="v-chip__content" data-no-activator="">
-              <div data-v-80a16399=""><span data-v-80a16399="" isactive="false" targetref="target => {
-    el.value = target;
-  }" props="[object Object]" class="hover-text" data-test="tenant-copy-btn">fake-tenant <i data-v-80a16399="" class="mdi-content-copy mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end">
+              <div data-v-80a16399="" class="v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-input--readonly v-text-field v-input--plain-underlined" data-test="name-input">
                 <!---->
-                <!---->
-              </div>
-              <!--teleport start-->
-              <!--teleport end-->
-            </div>
-            <!---->
-            <!----></span>
-          </div>
-        </div>
-        <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-        <div data-v-80a16399="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;" data-test="announcement-item">
-          <!---->
-          <div class="v-card-item__content">
-            <div class="v-card-title"><i data-v-80a16399="" class="mdi-bullhorn-variant-outline mdi v-icon notranslate v-theme--light pl-1 mr-3" style="font-size: 18px; height: 18px; width: 18px;" aria-hidden="true" data-test="announcement-icon"></i><span data-v-80a16399="" class="text-subtitle-1" data-test="announcement-title">Connection Announcement</span></div>
-            <!---->
-            <div data-v-80a16399="" class="v-card-text pt-1 pl-0"><span data-v-80a16399="" data-test="announcement-subtitle">A connection announcement is a custom message written during a session when a connection is established on a device within the namespace.</span></div>
-          </div>
-          <div class="v-card-item__append"><button data-v-80a16399="" type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-text ml-4" data-test="edit-announcement-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-              <!----><span class="v-btn__content" data-no-activator=""> Edit Announcement </span>
-              <!---->
-              <!---->
-            </button></div>
-        </div>
-        <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-        <div data-v-80a16399="" class="v-row ma-0">
-          <div data-v-80a16399="" class="v-card v-card--flat v-theme--light v-card--density-default v-card--variant-elevated bg-background" data-test="record-item">
-            <!---->
-            <div class="v-card__loader">
-              <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
-                <!---->
-                <div class="v-progress-linear__background"></div>
-                <div class="v-progress-linear__buffer" style="width: 0%;"></div>
-                <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-                  <div class="v-progress-linear__indeterminate">
-                    <div class="v-progress-linear__indeterminate long"></div>
-                    <div class="v-progress-linear__indeterminate short"></div>
-                  </div>
-                </transition-stub>
-                <!---->
-              </div>
-            </div>
-            <div class="v-card-item">
-              <!---->
-              <div class="v-card-item__content">
-                <div class="v-card-title"><i data-v-80a16399="" class="mdi-play-box-outline mdi v-icon notranslate v-theme--light pl-1 mr-3" style="font-size: 18px; height: 18px; width: 18px;" aria-hidden="true" data-test="record-icon"></i><span data-v-80a16399="" class="text-subtitle-1" data-test="record-title">Session Record</span>
-                  <div data-v-80a16399="" class="v-card-text pl-0 pt-1" data-test="record-description"> Session record is a feature that allows you to check logged activity when connecting to a device. </div>
-                </div>
-                <!---->
-                <!---->
-              </div>
-              <!---->
-            </div>
-            <!---->
-            <!---->
-            <!---->
-            <!----><span class="v-card__underlay"></span>
-          </div>
-          <div data-v-80a16399="" class="v-col d-flex align-center justify-end bg-background">
-            <div data-v-80a16399="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-switch v-switch--inset" data-test="session-recording-setting-component">
-              <!---->
-              <div class="v-input__control">
-                <div class="v-selection-control v-selection-control--dirty v-selection-control--density-default">
-                  <div class="v-selection-control__wrapper text-primary">
-                    <div class="v-switch__track bg-primary">
-                      <!---->
-                      <!---->
-                    </div>
-                    <div class="v-selection-control__input"><input checked="" id="switch-v-10" aria-disabled="false" type="checkbox" value="true">
-                      <div class="v-switch__thumb">
-                        <transition-stub name="scale-transition" appear="false" persisted="false" css="true">
-                          <!---->
+                <div class="v-input__control">
+                  <div class="v-field v-field--active v-field--disabled v-field--dirty v-field--reverse v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
+                    <div class="v-field__overlay"></div>
+                    <div class="v-field__loader">
+                      <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                        <!---->
+                        <div class="v-progress-linear__background"></div>
+                        <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                        <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                          <div class="v-progress-linear__indeterminate">
+                            <div class="v-progress-linear__indeterminate long"></div>
+                            <div class="v-progress-linear__indeterminate short"></div>
+                          </div>
                         </transition-stub>
+                        <!---->
                       </div>
                     </div>
+                    <!---->
+                    <div class="v-field__field" data-no-activator="">
+                      <!---->
+                      <!---->
+                      <!----><input readonly="" disabled="" size="1" type="text" aria-labelledby="input-v-2-label" id="input-v-2" required="" class="v-field__input" value="test">
+                      <!---->
+                    </div>
+                    <!---->
+                    <!---->
+                    <div class="v-field__outline">
+                      <!---->
+                      <!---->
+                    </div>
                   </div>
-                  <!---->
                 </div>
+                <!---->
+                <!---->
               </div>
-              <!---->
-              <!---->
             </div>
           </div>
         </div>
         <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-        <div data-v-80a16399="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;" data-test="delete-leave-item">
-          <!---->
-          <div class="v-card-item__content">
-            <div class="v-card-title"><i data-v-80a16399="" class="mdi-delete mdi v-icon notranslate v-theme--light pl-1 mr-3" style="font-size: 18px; height: 18px; width: 18px;" aria-hidden="true" data-test="delete-leave-icon"></i><span data-v-80a16399="" class="text-subtitle-1" data-test="delete-leave-title">Leave Namespace</span></div>
-            <!---->
-            <div data-v-80a16399="" class="v-card-text pt-1 pl-0"><span data-v-80a16399="" data-test="leave-description">After leaving a namespace, you will need to be invited again to access it.</span></div>
+        <div data-v-80a16399="" class="v-row ma-0 px-3 align-center" data-test="type-details-item">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="type-title"><i class="mdi-shape-outline mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true" data-test="type-icon"></i>Type</div>
+              <!--v-if-->
+            </div>
           </div>
-          <div class="v-card-item__append"><button data-v-80a16399="" type="button" class="v-btn v-theme--light text-error v-btn--density-default v-btn--size-default v-btn--variant-text" data-test="leave-namespace-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-              <!----><span class="v-btn__content" data-no-activator=""> Leave </span>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end"><span data-v-80a16399="" class="v-chip v-theme--light v-chip--density-default v-chip--size-default v-chip--variant-tonal text-capitalize" draggable="false" data-test="type-chip"><!----><span class="v-chip__underlay"></span>
               <!---->
               <!---->
-            </button></div>
+              <div class="v-chip__content" data-no-activator=""><i data-v-80a16399="" class="mdi-account-group mdi v-icon notranslate v-theme--light v-icon--size-small mr-1" aria-hidden="true"></i> team</div>
+              <!---->
+              <!----></span>
+            </div>
+          </div>
+        </div>
+        <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
+        <div data-v-80a16399="" class="v-row ma-0 px-3 align-center" data-test="tenant-details-item">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="tenant-title"><i class="mdi-identifier mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true" data-test="tenant-icon"></i>Tenant ID</div>
+              <!--v-if-->
+            </div>
+          </div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end"><span data-v-80a16399="" class="v-chip v-theme--light v-chip--density-default v-chip--size-default v-chip--variant-tonal" draggable="false"><!----><span class="v-chip__underlay"></span>
+              <!---->
+              <!---->
+              <div class="v-chip__content" data-no-activator="">
+                <div data-v-80a16399=""><span data-v-80a16399="" isactive="false" targetref="target => {
+    el.value = target;
+  }" props="[object Object]" class="hover-text" data-test="tenant-copy-btn">fake-tenant <i data-v-80a16399="" class="mdi-content-copy mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></span>
+                  <!---->
+                  <!---->
+                </div>
+                <!--teleport start-->
+                <!--teleport end-->
+              </div>
+              <!---->
+              <!----></span>
+            </div>
+          </div>
+        </div>
+        <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
+        <div data-v-80a16399="" class="v-row ma-0 px-3 align-center" data-test="announcement-item">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="announcement-title"><i class="mdi-bullhorn-variant-outline mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true" data-test="announcement-icon"></i>Connection Announcement</div>
+              <div class="text-body-2 mt-1" data-test="announcement-subtitle">A connection announcement is a custom message written during a
+                session when a connection is established on a device within the namespace.</div>
+            </div>
+          </div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end"><button data-v-80a16399="" type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-text ml-4" data-test="edit-announcement-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <!----><span class="v-btn__content" data-no-activator=""> Edit Announcement </span>
+                <!---->
+                <!---->
+              </button></div>
+          </div>
+        </div>
+        <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
+        <div data-v-80a16399="" class="v-row ma-0 px-3 align-center" data-test="record-item">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="record-title"><i class="mdi-play-box-outline mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true" data-test="record-icon"></i>Session Record</div>
+              <div class="text-body-2 mt-1" data-test="record-description">Session record is a feature that allows you to check logged activity when connecting to a device.</div>
+            </div>
+          </div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end">
+              <div data-v-80a16399="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-switch v-switch--inset mr-sm-4" data-test="session-recording-setting-component">
+                <!---->
+                <div class="v-input__control">
+                  <div class="v-selection-control v-selection-control--dirty v-selection-control--density-default">
+                    <div class="v-selection-control__wrapper text-primary">
+                      <div class="v-switch__track bg-primary">
+                        <!---->
+                        <!---->
+                      </div>
+                      <div class="v-selection-control__input"><input checked="" id="switch-v-10" aria-disabled="false" type="checkbox" value="true">
+                        <div class="v-switch__thumb">
+                          <transition-stub name="scale-transition" appear="false" persisted="false" css="true">
+                            <!---->
+                          </transition-stub>
+                        </div>
+                      </div>
+                    </div>
+                    <!---->
+                  </div>
+                </div>
+                <!---->
+                <!---->
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr data-v-80a16399="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
+        <div data-v-80a16399="" class="v-row ma-0 px-3 align-center" data-test="delete-leave-item">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="delete-leave-title"><i class="mdi-delete mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true" data-test="delete-leave-icon"></i>Leave Namespace</div>
+              <div class="text-body-2 mt-1" data-test="leave-description">After leaving a namespace, you will need to be invited again to access it.</div>
+            </div>
+          </div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end"><button data-v-80a16399="" type="button" class="v-btn v-theme--light text-error v-btn--density-default v-btn--size-default v-btn--variant-text" data-test="leave-namespace-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <!----><span class="v-btn__content" data-no-activator=""> Leave </span>
+                <!---->
+                <!---->
+              </button></div>
+          </div>
         </div>
       </div>
     </div>

--- a/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
+++ b/ui/tests/components/Setting/__snapshots__/SettingProfile.spec.ts.snap
@@ -63,69 +63,71 @@ exports[`Settings Namespace > Renders the component 1`] = `
     </div>
     <!---->
     <!---->
-    <div data-v-b3fa301d="" class="v-card-text pt-0">
-      <div data-v-b3fa301d="" class="v-list v-theme--light v-list--border v-list--density-default v-list--one-line v-list--rounded bg-background pa-0" tabindex="0" role="list" data-test="profile-details-list">
-        <div data-v-b3fa301d="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;">
-          <div class="v-card-item__prepend"><i data-v-b3fa301d="" class="mdi-badge-account mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-          <div class="v-card-item__content">
-            <div class="v-card-title"><span data-v-b3fa301d="" class="text-subtitle-1" data-test="name-field">Name</span></div>
-            <!---->
-            <!---->
+    <div class="v-card-text pt-0">
+      <div class="v-list v-theme--light v-list--border v-list--density-default v-list--one-line v-list--rounded bg-background pa-0" tabindex="0" role="list" data-test="profile-details-list">
+        <div data-v-b3fa301d="" class="v-row ma-0 px-3 align-center">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="name-field"><i class="mdi-badge-account mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true"></i>Name</div>
+              <!--v-if-->
+            </div>
           </div>
-          <div class="v-card-item__append">
-            <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined" data-test="name-input">
-              <!---->
-              <div class="v-input__control">
-                <div class="v-field v-field--disabled v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
-                  <div class="v-field__overlay"></div>
-                  <div class="v-field__loader">
-                    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end">
+              <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined" data-test="name-input">
+                <!---->
+                <div class="v-input__control">
+                  <div class="v-field v-field--disabled v-field--reverse v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
+                    <div class="v-field__overlay"></div>
+                    <div class="v-field__loader">
+                      <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                        <!---->
+                        <div class="v-progress-linear__background"></div>
+                        <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                        <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                          <div class="v-progress-linear__indeterminate">
+                            <div class="v-progress-linear__indeterminate long"></div>
+                            <div class="v-progress-linear__indeterminate short"></div>
+                          </div>
+                        </transition-stub>
+                        <!---->
+                      </div>
+                    </div>
+                    <!---->
+                    <div class="v-field__field" data-no-activator="">
                       <!---->
-                      <div class="v-progress-linear__background"></div>
-                      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
-                      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-                        <div class="v-progress-linear__indeterminate">
-                          <div class="v-progress-linear__indeterminate long"></div>
-                          <div class="v-progress-linear__indeterminate short"></div>
-                        </div>
-                      </transition-stub>
+                      <!---->
+                      <!----><input readonly="" disabled="" size="1" type="text" aria-labelledby="input-v-2-label" id="input-v-2" required="" class="v-field__input" value="">
+                      <!---->
+                    </div>
+                    <!---->
+                    <!---->
+                    <div class="v-field__outline">
+                      <!---->
                       <!---->
                     </div>
                   </div>
-                  <!---->
-                  <div class="v-field__field" data-no-activator="">
-                    <!---->
-                    <!---->
-                    <!----><input readonly="" disabled="" size="1" type="text" aria-labelledby="input-v-2-label" id="input-v-2" required="" class="v-field__input" value="">
-                    <!---->
-                  </div>
-                  <!---->
-                  <!---->
-                  <div class="v-field__outline">
-                    <!---->
-                    <!---->
-                  </div>
                 </div>
+                <!---->
+                <!---->
               </div>
-              <!---->
-              <!---->
             </div>
           </div>
         </div>
         <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-        <div data-v-b3fa301d="">
-          <div data-v-b3fa301d="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;">
-            <div class="v-card-item__prepend"><i data-v-b3fa301d="" class="mdi-account mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-            <div class="v-card-item__content">
-              <div class="v-card-title"><span data-v-b3fa301d="" class="text-subtitle-1" data-test="username-field">Username</span></div>
-              <!---->
-              <!---->
+        <div data-v-b3fa301d="" class="v-row ma-0 px-3 align-center">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="username-field"><i class="mdi-account mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true"></i>Username</div>
+              <!--v-if-->
             </div>
-            <div class="v-card-item__append">
+          </div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end">
               <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined" data-test="username-input">
                 <!---->
                 <div class="v-input__control">
-                  <div class="v-field v-field--disabled v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
+                  <div class="v-field v-field--disabled v-field--reverse v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
                     <div class="v-field__overlay"></div>
                     <div class="v-field__loader">
                       <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -161,69 +163,71 @@ exports[`Settings Namespace > Renders the component 1`] = `
               </div>
             </div>
           </div>
-          <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
         </div>
-        <div data-v-b3fa301d="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;">
-          <div class="v-card-item__prepend"><i data-v-b3fa301d="" class="mdi-email mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-          <div class="v-card-item__content">
-            <div class="v-card-title"><span data-v-b3fa301d="" class="text-subtitle-1" data-test="email-field">Email</span></div>
-            <!---->
-            <!---->
+        <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
+        <div data-v-b3fa301d="" class="v-row ma-0 px-3 align-center">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="email-field"><i class="mdi-email mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true"></i>Email</div>
+              <!--v-if-->
+            </div>
           </div>
-          <div class="v-card-item__append">
-            <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined" data-test="email-input">
-              <!---->
-              <div class="v-input__control">
-                <div class="v-field v-field--disabled v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
-                  <div class="v-field__overlay"></div>
-                  <div class="v-field__loader">
-                    <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end">
+              <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined" data-test="email-input">
+                <!---->
+                <div class="v-input__control">
+                  <div class="v-field v-field--disabled v-field--reverse v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
+                    <div class="v-field__overlay"></div>
+                    <div class="v-field__loader">
+                      <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
+                        <!---->
+                        <div class="v-progress-linear__background"></div>
+                        <div class="v-progress-linear__buffer" style="width: 0%;"></div>
+                        <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
+                          <div class="v-progress-linear__indeterminate">
+                            <div class="v-progress-linear__indeterminate long"></div>
+                            <div class="v-progress-linear__indeterminate short"></div>
+                          </div>
+                        </transition-stub>
+                        <!---->
+                      </div>
+                    </div>
+                    <!---->
+                    <div class="v-field__field" data-no-activator="">
                       <!---->
-                      <div class="v-progress-linear__background"></div>
-                      <div class="v-progress-linear__buffer" style="width: 0%;"></div>
-                      <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-                        <div class="v-progress-linear__indeterminate">
-                          <div class="v-progress-linear__indeterminate long"></div>
-                          <div class="v-progress-linear__indeterminate short"></div>
-                        </div>
-                      </transition-stub>
+                      <!---->
+                      <!----><input readonly="" disabled="" size="1" type="text" aria-labelledby="input-v-8-label" id="input-v-8" required="" class="v-field__input" value="">
+                      <!---->
+                    </div>
+                    <!---->
+                    <!---->
+                    <div class="v-field__outline">
+                      <!---->
                       <!---->
                     </div>
                   </div>
-                  <!---->
-                  <div class="v-field__field" data-no-activator="">
-                    <!---->
-                    <!---->
-                    <!----><input readonly="" disabled="" size="1" type="text" aria-labelledby="input-v-8-label" id="input-v-8" required="" class="v-field__input" value="">
-                    <!---->
-                  </div>
-                  <!---->
-                  <!---->
-                  <div class="v-field__outline">
-                    <!---->
-                    <!---->
-                  </div>
                 </div>
+                <!---->
+                <!---->
               </div>
-              <!---->
-              <!---->
             </div>
           </div>
         </div>
         <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-        <div data-v-b3fa301d="">
-          <div data-v-b3fa301d="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;">
-            <div class="v-card-item__prepend"><i data-v-b3fa301d="" class="mdi-email-lock mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-            <div class="v-card-item__content">
-              <div class="v-card-title"><span data-v-b3fa301d="" class="text-subtitle-1" data-test="recovery-email-field">Recovery Email</span></div>
-              <!---->
-              <!---->
+        <div data-v-b3fa301d="" class="v-row ma-0 px-3 align-center">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="recovery-email-field"><i class="mdi-email-lock mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true"></i>Recovery Email</div>
+              <!--v-if-->
             </div>
-            <div class="v-card-item__append">
+          </div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end">
               <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--density-compact v-theme--light v-locale--is-ltr v-input--disabled v-input--readonly v-text-field v-input--plain-underlined" data-test="recovery-email-input">
                 <!---->
                 <div class="v-input__control">
-                  <div class="v-field v-field--disabled v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
+                  <div class="v-field v-field--disabled v-field--reverse v-field--no-label v-field--variant-plain v-theme--light v-locale--is-ltr">
                     <div class="v-field__overlay"></div>
                     <div class="v-field__loader">
                       <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
@@ -259,15 +263,17 @@ exports[`Settings Namespace > Renders the component 1`] = `
               </div>
             </div>
           </div>
-          <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-          <div data-v-b3fa301d="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;">
-            <div class="v-card-item__prepend"><i data-v-b3fa301d="" class="mdi-key mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-            <div class="v-card-item__content">
-              <div class="v-card-title"><span data-v-b3fa301d="" class="text-subtitle-1">Password</span></div>
-              <!---->
-              <!---->
+        </div>
+        <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
+        <div data-v-b3fa301d="" class="v-row ma-0 px-3 align-center">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1"><i class="mdi-key mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true"></i>Password</div>
+              <!--v-if-->
             </div>
-            <div class="v-card-item__append"><button data-v-b3fa301d="" type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-text"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+          </div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end"><button data-v-b3fa301d="" type="button" class="v-btn v-theme--light text-primary v-btn--density-default v-btn--size-default v-btn--variant-text"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
                 <!----><span class="v-btn__content" data-no-activator=""> Change Password </span>
                 <!---->
                 <!---->
@@ -276,90 +282,67 @@ exports[`Settings Namespace > Renders the component 1`] = `
               <!---->
             </div>
           </div>
-          <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-          <div data-v-b3fa301d="" class="d-flex align-center justify-space-between pr-4">
-            <div data-v-b3fa301d="" tabindex="-1" class="v-card v-card--disabled v-card--flat v-theme--light v-card--density-default v-card--variant-elevated bg-background w-75" data-test="mfa-card">
-              <!---->
-              <div class="v-card__loader">
-                <div class="v-progress-linear v-theme--light v-locale--is-ltr" style="top: 0px; height: 0px; --v-progress-linear-height: 2px;" role="progressbar" aria-hidden="true" aria-valuemin="0" aria-valuemax="100">
-                  <!---->
-                  <div class="v-progress-linear__background"></div>
-                  <div class="v-progress-linear__buffer" style="width: 0%;"></div>
-                  <transition-stub name="fade-transition" appear="false" persisted="false" css="true">
-                    <div class="v-progress-linear__indeterminate">
-                      <div class="v-progress-linear__indeterminate long"></div>
-                      <div class="v-progress-linear__indeterminate short"></div>
-                    </div>
-                  </transition-stub>
-                  <!---->
-                </div>
-              </div>
-              <div class="v-card-item">
-                <div class="v-card-item__prepend">
-                  <!----><i class="mdi-fingerprint mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true" density="default"></i>
-                </div>
-                <div class="v-card-item__content">
-                  <div class="v-card-title"><span data-v-b3fa301d="" class="text-subtitle-1">Multi-factor Authentication</span></div>
-                  <!---->
-                  <!---->
-                </div>
-                <!---->
-              </div>
-              <!---->
-              <div data-v-b3fa301d="" class="d-flex flex-no-wrap justify-space-between">
-                <div data-v-b3fa301d="">
-                  <div data-v-b3fa301d="" class="v-card-text pt-0 text-justify" data-test="mfa-text"> Enable multi-factor authentication (MFA) to add an extra layer of security to your account. You'll need to enter a one-time verification code from your preferred TOTP provider to log in. </div>
-                </div>
-              </div>
-              <!---->
-              <!----><span class="v-card__underlay"></span>
+        </div>
+        <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
+        <div data-v-b3fa301d="" class="v-row ma-0 px-3 align-center" data-test="mfa-card">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1"><i class="mdi-fingerprint mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true"></i>Multi-factor Authentication</div>
+              <div class="text-body-2 mt-1" data-test="mfa-text">Enable multi-factor authentication (MFA) to add an extra layer of security to your account.
+                You'll need to enter a one-time verification code from your preferred TOTP provider to log in.</div>
             </div>
-            <div data-v-b3fa301d="" aria-describedby="v-tooltip-v-14" class="d-flex align-center bg-background">
-              <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-switch v-switch--inset" data-test="switch-mfa">
-                <!---->
-                <div class="v-input__control">
-                  <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default">
-                    <div class="v-selection-control__wrapper">
-                      <div class="v-switch__track">
-                        <!---->
-                        <!---->
-                      </div>
-                      <div class="v-selection-control__input"><input disabled="" id="switch-v-15" aria-disabled="true" type="checkbox" value="true">
-                        <div class="v-switch__thumb">
-                          <transition-stub name="scale-transition" appear="false" persisted="false" css="true">
-                            <!---->
-                          </transition-stub>
+          </div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end">
+              <div data-v-b3fa301d="" aria-describedby="v-tooltip-v-14" class="d-flex align-center">
+                <div data-v-b3fa301d="" class="v-input v-input--horizontal v-input--center-affix v-input--density-default v-theme--light v-locale--is-ltr v-input--dirty v-input--disabled v-switch v-switch--inset mr-sm-4" data-test="switch-mfa">
+                  <!---->
+                  <div class="v-input__control">
+                    <div class="v-selection-control v-selection-control--disabled v-selection-control--density-default">
+                      <div class="v-selection-control__wrapper">
+                        <div class="v-switch__track">
+                          <!---->
+                          <!---->
+                        </div>
+                        <div class="v-selection-control__input"><input disabled="" id="switch-v-15" aria-disabled="true" type="checkbox" value="true">
+                          <div class="v-switch__thumb">
+                            <transition-stub name="scale-transition" appear="false" persisted="false" css="true">
+                              <!---->
+                            </transition-stub>
+                          </div>
                         </div>
                       </div>
+                      <!---->
                     </div>
-                    <!---->
                   </div>
+                  <!---->
+                  <!---->
                 </div>
                 <!---->
                 <!---->
+                <!---->
+                <!---->
               </div>
-              <!---->
-              <!---->
-              <!---->
-              <!---->
+              <!--teleport start-->
+              <!--teleport end-->
             </div>
-            <!--teleport start-->
-            <!--teleport end-->
           </div>
         </div>
         <hr data-v-b3fa301d="" class="v-divider v-theme--light" style="border-style: solid;" aria-orientation="horizontal" role="separator">
-        <div data-v-b3fa301d="" class="v-card-item" style="grid-template-columns: max-content 1.5fr 2fr;">
-          <div class="v-card-item__prepend"><i data-v-b3fa301d="" class="mdi-delete mdi v-icon notranslate v-theme--light v-icon--size-default" aria-hidden="true"></i></div>
-          <div class="v-card-item__content">
-            <div class="v-card-title"><span data-v-b3fa301d="" class="text-subtitle-1" data-test="delete-account">Delete Account</span></div>
-            <!---->
-            <!---->
+        <div data-v-b3fa301d="" class="v-row ma-0 px-3 align-center">
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 d-flex ga-3 align-center align-sm-start justify-center justify-sm-start text-center text-sm-start">
+            <div class="text-center text-sm-start">
+              <div class="text-subtitle-1" data-test="delete-account"><i class="mdi-delete mdi v-icon notranslate v-theme--light v-icon--size-default mr-3" aria-hidden="true"></i>Delete Account</div>
+              <!--v-if-->
+            </div>
           </div>
-          <div class="v-card-item__append"><button data-v-b3fa301d="" type="button" class="v-btn v-theme--light text-error v-btn--density-default v-btn--size-default v-btn--variant-text" data-test="delete-account-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
-              <!----><span class="v-btn__content" data-no-activator=""> Delete </span>
-              <!---->
-              <!---->
-            </button></div>
+          <div class="v-col-sm-6 v-col-md-6 v-col-12 px-0 d-flex align-center justify-center justify-sm-end">
+            <div class="w-100 d-flex justify-center justify-sm-end"><button data-v-b3fa301d="" type="button" class="v-btn v-theme--light text-error v-btn--density-default v-btn--size-default v-btn--variant-text" data-test="delete-account-btn"><span class="v-btn__overlay"></span><span class="v-btn__underlay"></span>
+                <!----><span class="v-btn__content" data-no-activator=""> Delete </span>
+                <!---->
+                <!---->
+              </button></div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description
This PR refactors the layouts of `SettingNamespace.vue` and `SettingProfile.vue` to use the new `SettingsRow` and `SettingsSection` components. These reusable components improve visual consistency, reduce layout duplication, and enhance responsiveness across settings pages.

## Changes Made

- Replaced legacy `v-card`, `v-list`, and `v-card-item` structures with `SettingsRow` and `SettingsSection`
- Updated all related Vuetify layout bindings (e.g., alignment, responsiveness)
- Improved accessibility and readability by consistently applying `data-test` IDs and ARIA-friendly markup
- Added `useDisplay` for responsive logic (e.g., `smAndUp`)
- Applied text alignment tweaks for small viewports via scoped CSS
- Updated snapshot tests to reflect new structure and layout

## Why

- The previous layout implementation involved repeated boilerplate and inconsistent spacing/alignment. Consolidating layout logic into two dedicated components:
- Reduces duplication and simplifies future updates
- Ensures a cohesive UI/UX across all settings views
- Makes the codebase easier to maintain and extend

## Testing

- [x] Verified visually on small and large screens
- [x] All unit and snapshot tests updated and passing
- [x] Confirmed functional parity with previous implementation (editing, toggles, tooltips, etc.)