### PR TITLE
fix(ui): remove obsolete 'absolute' prop from drawer

### DIFF
--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -3,7 +3,6 @@
     v-model="showNavigationDrawer"
     :theme="theme"
     :permanent="permanent"
-    absolute
     app
     class="bg-v-theme-surface"
     data-test="navigation-drawer"


### PR DESCRIPTION
# Description:
This PR removes the absolute prop from the `<v-navigation-drawer>` component in `AppLayout.vue`. This change helps prevent potential layout conflicts and aligns the implementation with current Vuetify best practices.

## Why:
- The absolute prop is no longer needed or appropriate in this context.
- Removing it ensures more responsiveness on mobile, better layout stability and visual consistency.