### PR TITLE
feat(ui): show empty state message in admin lists

### DIFF
--- a/ui/admin/src/components/Announcement/AnnouncementList.vue
+++ b/ui/admin/src/components/Announcement/AnnouncementList.vue
@@ -1,5 +1,6 @@
 <template>
   <DataTable
+    v-if="loading || announcements.length"
     v-model:items-per-page="itemsPerPage"
     v-model:page="page"
     :headers
@@ -67,6 +68,14 @@
       </tr>
     </template>
   </DataTable>
+
+  <NoItemsMessage
+    v-else
+    class="mt-2"
+    item="Announcements"
+    icon="mdi-bullhorn"
+    data-test="announcements-empty-state"
+  />
 </template>
 
 <script setup lang="ts">
@@ -80,6 +89,7 @@ import DataTable from "@/components/Tables/DataTable.vue";
 import AnnouncementDelete from "./AnnouncementDelete.vue";
 import AnnouncementEdit from "./AnnouncementEdit.vue";
 import handleError from "@/utils/handleError";
+import NoItemsMessage from "@/components/NoItemsMessage.vue";
 
 const router = useRouter();
 const announcementStore = useAnnouncementStore();

--- a/ui/admin/src/components/Device/DeviceList.vue
+++ b/ui/admin/src/components/Device/DeviceList.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <DataTable
+      v-if="loading || devices.length"
       v-model:items-per-page="itemsPerPage"
       v-model:page="page"
       :headers
@@ -103,6 +104,14 @@
         </tr>
       </template>
     </DataTable>
+
+    <NoItemsMessage
+      v-else
+      class="mt-2"
+      item="Devices"
+      icon="mdi-developer-board"
+      data-test="devices-empty-state"
+    />
   </div>
 </template>
 
@@ -117,6 +126,7 @@ import { formatFullDateTime } from "@/utils/date";
 import { displayOnlyTenCharacters } from "@/utils/string";
 import showTag from "@/utils/tag";
 import handleError from "@/utils/handleError";
+import NoItemsMessage from "@/components/NoItemsMessage.vue";
 
 const router = useRouter();
 const snackbar = useSnackbar();

--- a/ui/admin/src/components/FirewallRules/FirewallRulesList.vue
+++ b/ui/admin/src/components/FirewallRules/FirewallRulesList.vue
@@ -1,5 +1,6 @@
 <template>
   <DataTable
+    v-if="loading || firewallRules.length"
     v-model:items-per-page="itemsPerPage"
     v-model:page="page"
     :headers
@@ -81,6 +82,14 @@
       </tr>
     </template>
   </DataTable>
+
+  <NoItemsMessage
+    v-else
+    class="mt-2"
+    item="Firewall Rules"
+    icon="mdi-shield-lock"
+    data-test="firewall-rules-empty-state"
+  />
 </template>
 
 <script setup lang="ts">
@@ -93,6 +102,7 @@ import DataTable from "@/components/Tables/DataTable.vue";
 import showTag from "@/utils/tag";
 import { displayOnlyTenCharacters, formatHostnameFilter, formatSourceIP, formatUsername } from "@/utils/string";
 import handleError from "@/utils/handleError";
+import NoItemsMessage from "@/components/NoItemsMessage.vue";
 
 const router = useRouter();
 const snackbar = useSnackbar();

--- a/ui/admin/src/components/Namespace/NamespaceList.vue
+++ b/ui/admin/src/components/Namespace/NamespaceList.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <DataTable
+      v-if="loading || namespaces.length"
       v-model:items-per-page="itemsPerPage"
       v-model:page="page"
       :headers="headers"
@@ -96,6 +97,14 @@
       </template>
     </DataTable>
 
+    <NoItemsMessage
+      v-else
+      class="mt-2"
+      item="Namespaces"
+      icon="mdi-domain"
+      data-test="namespaces-empty-state"
+    />
+
     <NamespaceEdit
       v-if="selectedNamespace"
       :key="selectedNamespace.tenant_id"
@@ -124,6 +133,7 @@ import DataTable from "@/components/Tables/DataTable.vue";
 import NamespaceEdit from "@admin/components/Namespace/NamespaceEdit.vue";
 import NamespaceDelete from "@admin/components/Namespace/NamespaceDelete.vue";
 import handleError from "@/utils/handleError";
+import NoItemsMessage from "@/components/NoItemsMessage.vue";
 
 const snackbar = useSnackbar();
 const namespacesStore = useNamespacesStore();

--- a/ui/admin/src/components/Sessions/SessionList.vue
+++ b/ui/admin/src/components/Sessions/SessionList.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <DataTable
+      v-if="loading || sessions.length"
       v-model:items-per-page="itemsPerPage"
       v-model:page="page"
       :headers
@@ -126,6 +127,14 @@
         </tr>
       </template>
     </DataTable>
+
+    <NoItemsMessage
+      v-else
+      class="mt-2"
+      item="Sessions"
+      icon="mdi-console"
+      data-test="sessions-empty-state"
+    />
   </div>
 </template>
 
@@ -138,6 +147,7 @@ import DataTable from "@/components/Tables/DataTable.vue";
 import { getTimeFromNow, formatFullDateTime } from "@/utils/date";
 import { displayOnlyTenCharacters } from "@/utils/string";
 import handleError from "@/utils/handleError";
+import NoItemsMessage from "@/components/NoItemsMessage.vue";
 
 const router = useRouter();
 const snackbar = useSnackbar();

--- a/ui/admin/src/components/User/UserList.vue
+++ b/ui/admin/src/components/User/UserList.vue
@@ -1,5 +1,6 @@
 <template>
   <DataTable
+    v-if="loading || users.length"
     v-model:items-per-page="itemsPerPage"
     v-model:page="page"
     :headers
@@ -94,6 +95,14 @@
       </tr>
     </template>
   </DataTable>
+
+  <NoItemsMessage
+    v-else
+    class="mt-2"
+    item="Users"
+    icon="mdi-account-multiple"
+    data-test="users-empty-state"
+  />
 </template>
 
 <script setup lang="ts">
@@ -109,6 +118,7 @@ import UserFormDialog from "./UserFormDialog.vue";
 import UserDelete from "./UserDelete.vue";
 import UserResetPassword from "./UserResetPassword.vue";
 import handleError from "@/utils/handleError";
+import NoItemsMessage from "@/components/NoItemsMessage.vue";
 
 const router = useRouter();
 const snackbar = useSnackbar();

--- a/ui/admin/tests/unit/components/Session/SessionList.spec.ts
+++ b/ui/admin/tests/unit/components/Session/SessionList.spec.ts
@@ -92,7 +92,7 @@ describe("SessionList", () => {
       await mountWrapper(0);
       await flushPromises();
 
-      const emptyState = wrapper.find('[data-test="empty-state"]');
+      const emptyState = wrapper.find('[data-test="sessions-empty-state"]');
       expect(emptyState.exists()).toBe(true);
     });
   });

--- a/ui/admin/tests/unit/views/Announcements.spec.ts
+++ b/ui/admin/tests/unit/views/Announcements.spec.ts
@@ -40,7 +40,9 @@ describe("Announcements", () => {
   });
 
   it("displays the announcement list component", () => {
-    expect(wrapper.find('[data-test="announcement-list"]').exists()).toBe(true);
+    const list = wrapper.find('[data-test="announcement-list"]');
+    const emptyState = wrapper.find('[data-test="announcements-empty-state"]');
+    expect(list.exists() || emptyState.exists()).toBe(true);
   });
 
   it("navigates to new announcement page when button is clicked", async () => {

--- a/ui/admin/tests/unit/views/Sessions.spec.ts
+++ b/ui/admin/tests/unit/views/Sessions.spec.ts
@@ -24,6 +24,8 @@ describe("Sessions", () => {
   });
 
   it("renders the session list component", () => {
-    expect(wrapper.find('[data-test="session-list"]').exists()).toBe(true);
+    const list = wrapper.find('[data-test="session-list"]');
+    const emptyState = wrapper.find('[data-test="sessions-empty-state"]');
+    expect(list.exists() || emptyState.exists()).toBe(true);
   });
 });

--- a/ui/admin/tests/unit/views/Users.spec.ts
+++ b/ui/admin/tests/unit/views/Users.spec.ts
@@ -39,6 +39,8 @@ describe("Users", () => {
   });
 
   it("displays the users list component", () => {
-    expect(wrapper.find('[data-test="users-list"]').exists()).toBe(true);
+    const list = wrapper.find('[data-test="users-list"]');
+    const emptyState = wrapper.find('[data-test="users-empty-state"]');
+    expect(list.exists() || emptyState.exists()).toBe(true);
   });
 });


### PR DESCRIPTION
# Description:

This PR enhances the user experience in the admin panel by introducing consistent empty state messaging across the following list components:

- Announcements
- Devices
- Firewall Rules
- Namespaces
- Sessions
- Users

## What’s new:

- Displays a `NoItemsMessage` component when a list is empty and not loading.
- Icons and labels are customized per list to match context.
- Adds v-if/v-else rendering logic around each `DataTable`.
- Updates unit tests to support the new empty state structure with proper data-test selectors.

## Test coverage:

- Unit tests for Sessions, Announcements, and Users have been updated to assert presence of the new empty state.
- All existing functionality remains intact when lists are populated.

## Why it matters:

Users visiting list pages with no data previously saw nothing or an ambiguous interface. This change provides clear feedback, improving usability and aligning with design best practices.