### PR TITLE
fix(ci): use correct ARM32 architecture names for rootfs artifacts

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -67,12 +67,12 @@ jobs:
         if: "contains(github.ref, 'refs/tags/v')"
         run: |
           mkdir -p rootfs
-          for arch in amd64 arm64v8 armv7 armv6 i386; do
+          for arch in amd64 arm64v8 arm32v7 arm32v6 i386; do
             case $arch in
               amd64) platform="linux/amd64" ;;
               arm64v8) platform="linux/arm64/v8" ;;
-              armv7) platform="linux/arm/v7" ;;
-              armv6) platform="linux/arm/v6" ;;
+              arm32v7) platform="linux/arm/v7" ;;
+              arm32v6) platform="linux/arm/v6" ;;
               i386) platform="linux/386" ;;
             esac
 


### PR DESCRIPTION
## Summary
- Fix ARM32 rootfs artifact naming in build workflow
- Change `armv6`/`armv7` to `arm32v6`/`arm32v7` to match what `install.sh` expects

## Problem
The standalone agent installation fails on ARM32 devices (armv6l/armv7l) for versions v0.21.x+ because:
- `install.sh` expects: `rootfs-arm32v6.tar.gz`, `rootfs-arm32v7.tar.gz`
- Workflow generates: `rootfs-armv6.tar.gz`, `rootfs-armv7.tar.gz`

## Test plan
- [ ] Verify next release includes correctly named ARM32 rootfs files
- [ ] Test standalone installation on ARM32 device

Closes #5764