### PR TITLE
fix(api): correct namespace device counter cache discrepancies

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -141,6 +141,7 @@ func (s *Server) Setup(ctx context.Context) error {
 
 	s.worker.HandleTask(services.TaskDevicesHeartbeat, service.DevicesHeartbeat(), asynq.BatchTask())
 	s.worker.HandleCron(services.CronDeviceCleanup, service.DeviceCleanup(), asynq.Unique())
+	s.worker.HandleCron(services.CronNamespaceDeviceCountSync, service.NamespaceDeviceCountSync(), asynq.Unique())
 
 	log.Info("Server setup completed successfully")
 

--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -163,7 +163,12 @@ func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*mod
 		device.DisconnectedAt = nil
 
 		if device.RemovedAt != nil {
+			device.RemovedAt = nil
 			device.Status = models.DeviceStatusPending
+			device.StatusUpdatedAt = clock.Now()
+			if err := s.store.NamespaceIncrementDeviceCount(ctx, req.TenantID, models.DeviceStatusRemoved, -1); err != nil {
+				return nil, err
+			}
 			if err := s.store.NamespaceIncrementDeviceCount(ctx, req.TenantID, models.DeviceStatusPending, 1); err != nil {
 				return nil, err
 			}

--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -527,6 +527,10 @@ func TestAuthDevice(t *testing.T) {
 					Return(device, nil).
 					Once()
 				storeMock.
+					On("NamespaceIncrementDeviceCount", ctx, "00000000-0000-4000-0000-000000000000", models.DeviceStatusRemoved, int64(-1)).
+					Return(nil).
+					Once()
+				storeMock.
 					On("NamespaceIncrementDeviceCount", ctx, "00000000-0000-4000-0000-000000000000", models.DeviceStatusPending, int64(1)).
 					Return(nil).
 					Once()
@@ -534,8 +538,9 @@ func TestAuthDevice(t *testing.T) {
 				expectedDevice := *device
 				expectedDevice.LastSeen = now
 				expectedDevice.DisconnectedAt = nil
-				expectedDevice.RemovedAt = &now
+				expectedDevice.RemovedAt = nil
 				expectedDevice.Status = models.DeviceStatusPending
+				expectedDevice.StatusUpdatedAt = now
 
 				storeMock.
 					On("DeviceUpdate", ctx, device).

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -813,6 +813,24 @@ func (_m *Store) NamespaceIncrementDeviceCount(ctx context.Context, tenantID str
 	return r0
 }
 
+// NamespaceSyncDeviceCounts provides a mock function with given fields: ctx
+func (_m *Store) NamespaceSyncDeviceCounts(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for NamespaceSyncDeviceCounts")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NamespaceList provides a mock function with given fields: ctx, opts
 func (_m *Store) NamespaceList(ctx context.Context, opts ...store.QueryOption) ([]models.Namespace, int, error) {
 	_va := make([]interface{}, len(opts))

--- a/api/store/mongo/migrations/main.go
+++ b/api/store/mongo/migrations/main.go
@@ -129,6 +129,7 @@ func GenerateMigrations() []migrate.Migration {
 		migration117,
 		migration118,
 		migration119,
+		migration120,
 	}
 }
 

--- a/api/store/mongo/migrations/migration_120.go
+++ b/api/store/mongo/migrations/migration_120.go
@@ -1,0 +1,121 @@
+package migrations
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var migration120 = migrate.Migration{
+	Version:     120,
+	Description: "Reconcile namespace device counter caches and convert to int64",
+	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{"component": "migration", "version": 120, "action": "Up"}).Info("Applying migration")
+
+		initDoc := bson.M{
+			"$set": bson.M{
+				"devices_accepted_count": int64(0),
+				"devices_pending_count":  int64(0),
+				"devices_rejected_count": int64(0),
+				"devices_removed_count":  int64(0),
+			},
+		}
+
+		if _, err := db.Collection("namespaces").UpdateMany(ctx, bson.M{}, initDoc); err != nil {
+			log.WithError(err).Error("Failed to initialize namespace device counts")
+
+			return err
+		}
+
+		pipeline := []bson.M{
+			{
+				"$group": bson.M{
+					"_id": bson.M{
+						"tenant_id": "$tenant_id",
+						"status":    "$status",
+					},
+					"count": bson.M{"$sum": 1},
+				},
+			},
+			{
+				"$group": bson.M{
+					"_id": "$_id.tenant_id",
+					"counts": bson.M{
+						"$push": bson.M{
+							"status": "$_id.status",
+							"count":  "$count",
+						},
+					},
+				},
+			},
+		}
+
+		cursor, err := db.Collection("devices").Aggregate(ctx, pipeline)
+		if err != nil {
+			log.WithError(err).Error("Failed to aggregate device counts")
+
+			return err
+		}
+		defer cursor.Close(ctx)
+
+		for cursor.Next(ctx) {
+			var result struct {
+				ID     string `bson:"_id"`
+				Counts []struct {
+					Status string `bson:"status"`
+					Count  int64  `bson:"count"`
+				} `bson:"counts"`
+			}
+
+			if err := cursor.Decode(&result); err != nil {
+				log.WithError(err).Error("Failed to decode aggregation result")
+
+				continue
+			}
+
+			updateDoc := bson.M{
+				"devices_accepted_count": int64(0),
+				"devices_pending_count":  int64(0),
+				"devices_rejected_count": int64(0),
+				"devices_removed_count":  int64(0),
+			}
+
+			for _, count := range result.Counts {
+				switch count.Status {
+				case "accepted":
+					updateDoc["devices_accepted_count"] = count.Count
+				case "pending":
+					updateDoc["devices_pending_count"] = count.Count
+				case "rejected":
+					updateDoc["devices_rejected_count"] = count.Count
+				case "removed":
+					updateDoc["devices_removed_count"] = count.Count
+				}
+			}
+
+			if _, err := db.Collection("namespaces").UpdateOne(ctx, bson.M{"tenant_id": result.ID}, bson.M{"$set": updateDoc}); err != nil {
+				log.WithFields(log.Fields{"tenant_id": result.ID, "error": err}).Error("Failed to update namespace device counts")
+
+				continue
+			}
+
+			log.WithFields(log.Fields{"tenant_id": result.ID, "counts": result.Counts}).Info("Reconciled namespace device counts")
+		}
+
+		if err := cursor.Err(); err != nil {
+			log.WithError(err).Error("Cursor error during migration")
+
+			return err
+		}
+
+		return nil
+	}),
+	Down: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
+		log.WithFields(log.Fields{"component": "migration", "version": 120, "action": "Down"}).Info("Reverting migration")
+
+		return nil
+	}),
+}

--- a/api/store/mongo/migrations/migration_120_test.go
+++ b/api/store/mongo/migrations/migration_120_test.go
@@ -1,0 +1,151 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	migrate "github.com/xakep666/mongo-migrate"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestMigration120Up(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		description string
+		setup       func() error
+		verify      func(tt *testing.T)
+	}{
+		{
+			description: "succeeds syncing counters and converting types",
+			setup: func() error {
+				namespaces := []bson.M{
+					{
+						"tenant_id":              "tenant-1",
+						"name":                   "namespace-1",
+						"devices_accepted_count": int32(99),
+						"devices_pending_count":  int32(99),
+						"devices_rejected_count": int32(99),
+						"devices_removed_count":  int32(99),
+					},
+					{
+						"tenant_id":              "tenant-2",
+						"name":                   "namespace-2",
+						"devices_accepted_count": int32(0),
+						"devices_pending_count":  int32(0),
+						"devices_rejected_count": int32(0),
+						"devices_removed_count":  int32(0),
+					},
+				}
+
+				if _, err := c.Database("test").Collection("namespaces").InsertMany(ctx, []any{namespaces[0], namespaces[1]}); err != nil {
+					return err
+				}
+
+				devices := []bson.M{
+					{"tenant_id": "tenant-1", "uid": "dev-1", "status": "accepted"},
+					{"tenant_id": "tenant-1", "uid": "dev-2", "status": "accepted"},
+					{"tenant_id": "tenant-1", "uid": "dev-3", "status": "pending"},
+					{"tenant_id": "tenant-1", "uid": "dev-4", "status": "rejected"},
+					{"tenant_id": "tenant-1", "uid": "dev-5", "status": "removed"},
+					{"tenant_id": "tenant-2", "uid": "dev-6", "status": "accepted"},
+				}
+
+				_, err := c.Database("test").Collection("devices").InsertMany(ctx, []any{
+					devices[0], devices[1], devices[2], devices[3], devices[4], devices[5],
+				})
+
+				return err
+			},
+			verify: func(tt *testing.T) {
+				ns1 := make(map[string]any)
+				require.NoError(tt, c.Database("test").Collection("namespaces").FindOne(ctx, bson.M{"tenant_id": "tenant-1"}).Decode(&ns1))
+				assert.Equal(tt, int64(2), ns1["devices_accepted_count"])
+				assert.Equal(tt, int64(1), ns1["devices_pending_count"])
+				assert.Equal(tt, int64(1), ns1["devices_rejected_count"])
+				assert.Equal(tt, int64(1), ns1["devices_removed_count"])
+
+				ns2 := make(map[string]any)
+				require.NoError(tt, c.Database("test").Collection("namespaces").FindOne(ctx, bson.M{"tenant_id": "tenant-2"}).Decode(&ns2))
+				assert.Equal(tt, int64(1), ns2["devices_accepted_count"])
+				assert.Equal(tt, int64(0), ns2["devices_pending_count"])
+				assert.Equal(tt, int64(0), ns2["devices_rejected_count"])
+				assert.Equal(tt, int64(0), ns2["devices_removed_count"])
+			},
+		},
+		{
+			description: "succeeds with namespaces that have no devices",
+			setup: func() error {
+				namespace := bson.M{
+					"tenant_id":              "tenant-empty",
+					"name":                   "empty-namespace",
+					"devices_accepted_count": int32(10),
+					"devices_pending_count":  int32(5),
+					"devices_rejected_count": int32(3),
+					"devices_removed_count":  int32(1),
+				}
+				_, err := c.Database("test").Collection("namespaces").InsertOne(ctx, namespace)
+
+				return err
+			},
+			verify: func(tt *testing.T) {
+				ns := make(map[string]any)
+				require.NoError(tt, c.Database("test").Collection("namespaces").FindOne(ctx, bson.M{"tenant_id": "tenant-empty"}).Decode(&ns))
+				assert.Equal(tt, int64(0), ns["devices_accepted_count"])
+				assert.Equal(tt, int64(0), ns["devices_pending_count"])
+				assert.Equal(tt, int64(0), ns["devices_rejected_count"])
+				assert.Equal(tt, int64(0), ns["devices_removed_count"])
+			},
+		},
+		{
+			description: "succeeds with removed devices counted correctly",
+			setup: func() error {
+				namespace := bson.M{
+					"tenant_id":              "tenant-removed",
+					"name":                   "removed-namespace",
+					"devices_accepted_count": int32(0),
+					"devices_pending_count":  int32(0),
+					"devices_rejected_count": int32(0),
+					"devices_removed_count":  int32(0),
+				}
+				if _, err := c.Database("test").Collection("namespaces").InsertOne(ctx, namespace); err != nil {
+					return err
+				}
+
+				devices := []bson.M{
+					{"tenant_id": "tenant-removed", "uid": "dev-r1", "status": "removed"},
+					{"tenant_id": "tenant-removed", "uid": "dev-r2", "status": "removed"},
+					{"tenant_id": "tenant-removed", "uid": "dev-r3", "status": "removed"},
+					{"tenant_id": "tenant-removed", "uid": "dev-a1", "status": "accepted"},
+				}
+
+				_, err := c.Database("test").Collection("devices").InsertMany(ctx, []any{
+					devices[0], devices[1], devices[2], devices[3],
+				})
+
+				return err
+			},
+			verify: func(tt *testing.T) {
+				ns := make(map[string]any)
+				require.NoError(tt, c.Database("test").Collection("namespaces").FindOne(ctx, bson.M{"tenant_id": "tenant-removed"}).Decode(&ns))
+				assert.Equal(tt, int64(1), ns["devices_accepted_count"])
+				assert.Equal(tt, int64(0), ns["devices_pending_count"])
+				assert.Equal(tt, int64(0), ns["devices_rejected_count"])
+				assert.Equal(tt, int64(3), ns["devices_removed_count"])
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(tt *testing.T) {
+			tt.Cleanup(func() { assert.NoError(tt, srv.Reset()) })
+			require.NoError(tt, tc.setup())
+
+			migrates := migrate.NewMigrate(c.Database("test"), GenerateMigrations()[119])
+			require.NoError(tt, migrates.Up(ctx, migrate.AllAvailable))
+			tc.verify(tt)
+		})
+	}
+}

--- a/api/store/mongo/store_test.go
+++ b/api/store/mongo/store_test.go
@@ -32,6 +32,7 @@ func TestMongoStore(t *testing.T) {
 		suite.TestNamespaceConflicts(t)
 		suite.TestNamespaceUpdate(t)
 		suite.TestNamespaceIncrementDeviceCount(t)
+		suite.TestNamespaceSyncDeviceCounts(t)
 		suite.TestNamespaceDelete(t)
 		suite.TestNamespaceDeleteMany(t)
 	})

--- a/api/store/namespace.go
+++ b/api/store/namespace.go
@@ -49,4 +49,8 @@ type NamespaceStore interface {
 
 	NamespaceDelete(ctx context.Context, namespace *models.Namespace) error
 	NamespaceDeleteMany(ctx context.Context, tenantIDs []string) (int64, error)
+
+	// NamespaceSyncDeviceCounts recalculates and sets the device counter cache fields
+	// for all namespaces based on actual device data.
+	NamespaceSyncDeviceCounts(ctx context.Context) error
 }

--- a/api/store/pg/store_test.go
+++ b/api/store/pg/store_test.go
@@ -32,6 +32,7 @@ func TestPgStore(t *testing.T) {
 		suite.TestNamespaceConflicts(t)
 		suite.TestNamespaceUpdate(t)
 		suite.TestNamespaceIncrementDeviceCount(t)
+		suite.TestNamespaceSyncDeviceCounts(t)
 		suite.TestNamespaceDelete(t)
 		suite.TestNamespaceDeleteMany(t)
 	})

--- a/api/store/storetest/suite.go
+++ b/api/store/storetest/suite.go
@@ -24,6 +24,7 @@ func (s *Suite) Run(t *testing.T) {
 		s.TestNamespaceConflicts(t)
 		s.TestNamespaceUpdate(t)
 		s.TestNamespaceIncrementDeviceCount(t)
+		s.TestNamespaceSyncDeviceCounts(t)
 		s.TestNamespaceDelete(t)
 		s.TestNamespaceDeleteMany(t)
 	})


### PR DESCRIPTION
- Clear device.RemovedAt and decrement devices_removed_count when a removed device reconnects, preventing repeated pending count inflation
- Add migration 120 to reconcile all namespace counters with actual device data and convert counter fields from int32 to int64
- Add NamespaceSyncDeviceCounts store method for atomic counter recalculation via MongoDB aggregation pipeline
- Add daily cron job (3 AM) for periodic counter reconciliation