### PR TITLE
fix(agent): prevent trailing comma in config.json env array (#5782)

### DIFF
--- a/agent/packaging/config.json
+++ b/agent/packaging/config.json
@@ -13,10 +13,10 @@
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             "SHELLHUB_SERVER_ADDRESS=__SERVER_ADDRESS__",
             "SHELLHUB_TENANT_ID=__TENANT_ID__",
-            "SHELLHUB_PRIVATE_KEY=/host/etc/shellhub.key",
             "__PREFERRED_HOSTNAME__",
             "__PREFERRED_IDENTITY__",
-            "__KEEPALIVE_INTERVAL__"
+            "__KEEPALIVE_INTERVAL__",
+            "SHELLHUB_PRIVATE_KEY=/host/etc/shellhub.key"
         ],
         "cwd": "/",
         "capabilities": {


### PR DESCRIPTION
Reorder the env array in the OCI runtime spec template so that SHELLHUB_PRIVATE_KEY (always present) is the last element. When optional placeholders are deleted by the install script via sed, the fixed last entry keeps the JSON valid, preventing runc from failing with "invalid character ']' looking for beginning of value".