### PR TITLE
fix(agent): use TARGETVARIANT to set GOARM for ARMv6 (#5782)

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -31,6 +31,7 @@ FROM base AS builder
 ARG SHELLHUB_VERSION=latest
 ARG GOPROXY
 ARG TARGETARCH
+ARG TARGETVARIANT
 ARG TARGETOS=linux
 
 COPY ./pkg $GOPATH/src/github.com/shellhub-io/shellhub/pkg
@@ -43,7 +44,7 @@ RUN go mod download
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub/agent
 
 # Cross-compile for target architecture
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags docker -ldflags "-s -w -X main.AgentVersion=${SHELLHUB_VERSION}" -o agent
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -tags docker -ldflags "-s -w -X main.AgentVersion=${SHELLHUB_VERSION}" -o agent
 
 # Runtime utilities stage - CRITICAL: must use target platform
 FROM --platform=$TARGETPLATFORM alpine:${ALPINE_VERSION:-3.22} AS runtime-utils


### PR DESCRIPTION
The unified Dockerfile cross-compiles with GOARCH=${TARGETARCH}, but for ARM targets TARGETARCH is just "arm" for both v6 and v7. Without GOARM, Go defaults to 7, producing ARMv7 instructions that cause SIGILL on ARMv6 hardware (e.g. Raspberry Pi Zero/1).