### PR TITLE
chore: remove delve debugger from dev environment

### DIFF
--- a/agent/.air.toml
+++ b/agent/.air.toml
@@ -1,18 +1,13 @@
 root = "../"
-tmp_dir = "tmp"
+tmp_dir = "/tmp/air"
 
 [build]
 pre_cmd = []
-cmd = "go build -tags docker -ldflags \"-X main.AgentVersion=latest\" -gcflags=\"all=-N -l\" -o ./tmp/main ."
+cmd = "go build -tags docker -ldflags \"-X main.AgentVersion=latest\" -o /tmp/air/main ."
 post_cmd = []
-bin = ""
-full_bin = "dlv exec ./tmp/main"
-args_bin = [
-  "--listen=0.0.0.0:2345",
-  "--headless",
-  "--continue",
-  "--accept-multiclient",
-]
+bin = "/tmp/air/main"
+full_bin = ""
+args_bin = []
 delay = 500
 exclude_dir = ["assets", "tmp", "vendor", "testdata"]
 exclude_file = []

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -60,7 +60,6 @@ ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl openssh-client util-linux setpriv
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/go-delve/delve/cmd/dlv@v1.25 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub

--- a/agent/entrypoint-dev.sh
+++ b/agent/entrypoint-dev.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
-# Cleanup function to kill Delve processes on exit
 cleanup() {
-    echo "Cleaning up Delve processes..."
-    pkill -9 dlv
     exit 0
 }
 

--- a/api/.air.toml
+++ b/api/.air.toml
@@ -1,18 +1,13 @@
 root = "../"
-tmp_dir = "tmp"
+tmp_dir = "/tmp/air"
 
 [build]
 pre_cmd = []
-cmd = "go build -gcflags=\"all=-N -l\" -o ./tmp/main ."
+cmd = "go build -o /tmp/air/main ."
 post_cmd = []
-bin = ""
-full_bin = "dlv exec ./tmp/main"
+bin = "/tmp/air/main"
+full_bin = ""
 args_bin = [
-    "--listen=0.0.0.0:2345",
-    "--headless",
-    "--continue",
-    "--accept-multiclient",
-    "--",
     "server",
 ]
 delay = 500

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -46,7 +46,6 @@ ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl build-base docker-cli
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/go-delve/delve/cmd/dlv@v1.25 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 && \
     go install github.com/vektra/mockery/v2/...@v2.53.2
 

--- a/cli/.air.toml
+++ b/cli/.air.toml
@@ -1,7 +1,8 @@
 root = "../"
+tmp_dir = "/tmp/air"
 
 [build]
-  cmd = "go build -o cli ."
+  cmd = "go build -o /tmp/air/cli ."
   bin = "/bin/true"
   delay = 1000
   exclude_regex = ["_test.go"]

--- a/gateway/.air.toml
+++ b/gateway/.air.toml
@@ -1,18 +1,13 @@
 root = "../"
-tmp_dir = "tmp"
+tmp_dir = "/tmp/air"
 
 [build]
 pre_cmd = []
-cmd = "go build -gcflags=\"all=-N -l\" -o ./tmp/main ."
+cmd = "go build -o /tmp/air/main ."
 post_cmd = []
-bin = ""
-full_bin = "dlv exec ./tmp/main"
-args_bin = [
-  "--listen=0.0.0.0:2345",
-  "--headless",
-  "--continue",
-  "--accept-multiclient",
-]
+bin = "/tmp/air/main"
+full_bin = ""
+args_bin = []
 delay = 500
 exclude_dir = ["assets", "tmp", "vendor", "testdata"]
 exclude_file = []

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -41,7 +41,6 @@ RUN mkdir -p /var/run/openresty /etc/letsencrypt && \
 
 RUN apk add --update openssl build-base
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/go-delve/delve/cmd/dlv@v1.25 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 && \
     go install github.com/vektra/mockery/v2/...@v2.20.0
 

--- a/openapi/.air.toml
+++ b/openapi/.air.toml
@@ -1,9 +1,9 @@
 root = "../"
-tmp_dir = "tmp"
+tmp_dir = "/tmp/air"
 
 [build]
 pre_cmd = []
-cmd = "go build -gcflags=\"all=-N -l\" -o ./tmp/main ."
+cmd = "go build -gcflags=\"all=-N -l\" -o /tmp/air/main ."
 post_cmd = []
 bin = ""
 full_bin = ""

--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -14,7 +14,6 @@ RUN npm install -g @stoplight/prism-cli@4.6.1
 RUN npm install -g prettier@2.8.7
 
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/go-delve/delve/cmd/dlv@v1.25 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 && \
     go install github.com/vektra/mockery/v2/...@v2.53.2
 

--- a/ssh/.air.toml
+++ b/ssh/.air.toml
@@ -1,18 +1,13 @@
 root = "../"
-tmp_dir = "tmp"
+tmp_dir = "/tmp/air"
 
 [build]
 pre_cmd = []
-cmd = "go build -gcflags=\"all=-N -l\" -o ./tmp/main ."
+cmd = "go build -o /tmp/air/main ."
 post_cmd = []
-bin = ""
-full_bin = "dlv exec ./tmp/main"
-args_bin = [
-  "--listen=0.0.0.0:2345",
-  "--headless",
-  "--continue",
-  "--accept-multiclient",
-]
+bin = "/tmp/air/main"
+full_bin = ""
+args_bin = []
 delay = 500
 exclude_dir = ["assets", "tmp", "vendor", "testdata"]
 exclude_file = []

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -41,7 +41,6 @@ ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/go-delve/delve/cmd/dlv@v1.25 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 && \
     go install github.com/vektra/mockery/v2/...@v2.20.0
 


### PR DESCRIPTION
Remove Delve DAP debugger from all Go services. Services now run directly via air instead of through dlv.