### PR TITLE
chore: pin Go base image to 1.24.9 across all services

### DIFF
--- a/agent/Dockerfile.test
+++ b/agent/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine3.22
+FROM golang:1.24.9-alpine3.22
 
 ARG GOPROXY
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # base stage
-FROM golang:1.26-alpine3.22 AS base
+FROM golang:1.24.9-alpine3.22 AS base
 
 ARG GOPROXY
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,5 @@
 # base stage
-FROM golang:1.24-alpine3.22 AS base
+FROM golang:1.24.9-alpine3.22 AS base
 
 RUN apk add --no-cache git ca-certificates
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # base stage
-FROM golang:1.26-alpine3.22 AS base
+FROM golang:1.24.9-alpine3.22 AS base
 
 ARG GOPROXY
 

--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine3.22 AS base
+FROM golang:1.24.9-alpine3.22 AS base
 
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY}

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -1,5 +1,5 @@
 # base stage
-FROM golang:1.25-alpine3.22 AS base
+FROM golang:1.24.9-alpine3.22 AS base
 
 ARG GOPROXY
 


### PR DESCRIPTION
Standardize all Go service Dockerfiles to use golang:1.24.9-alpine3.22, replacing mixed versions (1.24, 1.25, 1.26).