### PR TITLE
chore(ui): improve node_modules caching in dev environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,6 +47,7 @@ services:
         - NPM_CONFIG_REGISTRY=${SHELLHUB_NPM_REGISTRY:-}
     volumes:
       - ./ui:/src
+      - ui_node_modules:/src/node_modules
   gateway:
     image: gateway
     build:
@@ -93,3 +94,7 @@ services:
       - SHELLHUB_CLOUD=${SHELLHUB_CLOUD}
     networks:
       - shellhub
+
+volumes:
+  ui_node_modules:
+  ui_react_node_modules:

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,7 +17,7 @@ ENV NPM_CONFIG_REGISTRY ${NPM_CONFIG_REGISTRY}
 
 WORKDIR /src
 
-COPY --from=base /app/node_modules /node_modules
+COPY --from=base /app/node_modules ./node_modules
 
 COPY ui/scripts /scripts
 

--- a/ui/scripts/entrypoint-dev.sh
+++ b/ui/scripts/entrypoint-dev.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
-cp -a /node_modules .
+# Install dependencies only when package.json or package-lock.json changes
+STAMP="./node_modules/.install_hash"
+HASH=$(md5sum ./package.json ./package-lock.json 2>/dev/null | md5sum | cut -d' ' -f1)
+if [ ! -d ./node_modules/.bin ] || [ "$(cat "$STAMP" 2>/dev/null)" != "$HASH" ]; then
+    npm install
+    echo "$HASH" > "$STAMP"
+fi
 
 PREFIX=SHELLHUB
 


### PR DESCRIPTION
Use named Docker volumes for ui node_modules so they persist across container restarts. Update entrypoint to run npm install only when package.json changes. Fix node_modules COPY path in Dockerfile.