### PR TITLE
fix(openapi): remove device tags `minItems`

### DIFF
--- a/openapi/spec/components/schemas/deviceTags.yaml
+++ b/openapi/spec/components/schemas/deviceTags.yaml
@@ -2,7 +2,6 @@ description: Device's Tags list
 type: array
 items:
   $ref: ./tag.yaml
-minItems: 1
 maxItems: 3
 example:
   - name: tag1


### PR DESCRIPTION
Removed the `minItems` constraint from the deviceTags, since devices can have 0 tags, returning an empty array.

Closes #5827 