### PR TITLE
chore(openapi): add required name field to PUT /devices/{uid} request body

### DIFF
--- a/openapi/spec/paths/api@devices@{uid}.yaml
+++ b/openapi/spec/paths/api@devices@{uid}.yaml
@@ -62,6 +62,8 @@ put:
               $ref: ../components/schemas/deviceName.yaml
             public_url:
               $ref: ../components/schemas/devicePublicURL.yaml
+          required:
+            - name
   responses:
     '200':
       description: Success to update device's data.


### PR DESCRIPTION
This PR adds the `name` field to the required properties of the rename device endpoint, since, obviously, the name is necessary for renaming the device.

Closes #5829 