### PR TITLE
refactor(openapi): document X-Total-Count header on all paginated endpoints

### DIFF
--- a/openapi/spec/components/headers/XTotalCount.yaml
+++ b/openapi/spec/components/headers/XTotalCount.yaml
@@ -1,0 +1,5 @@
+description: Total number of items matching the query.
+schema:
+  type: integer
+  minimum: 0
+  readOnly: true

--- a/openapi/spec/paths/admin@api@announcements.yaml
+++ b/openapi/spec/paths/admin@api@announcements.yaml
@@ -28,11 +28,7 @@ get:
       description: Success to get the announcements.
       headers:
         X-Total-Count:
-          description: Announcements' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/admin@api@devices.yaml
+++ b/openapi/spec/paths/admin@api@devices.yaml
@@ -73,11 +73,7 @@ get:
       description: Success to get a list of devices.
       headers:
         X-Total-Count:
-          description: Devices' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/admin@api@export@namespaces.yaml
+++ b/openapi/spec/paths/admin@api@export@namespaces.yaml
@@ -48,6 +48,9 @@ get:
   responses:
     '200':
       description: Success to export namespaces.
+      headers:
+        X-Total-Count:
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/octet-stream:
           schema:

--- a/openapi/spec/paths/admin@api@export@users.yaml
+++ b/openapi/spec/paths/admin@api@export@users.yaml
@@ -45,6 +45,9 @@ get:
   responses:
     '200':
       description: Success to export users.
+      headers:
+        X-Total-Count:
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/octet-stream:
           schema:

--- a/openapi/spec/paths/admin@api@firewall@rules.yaml
+++ b/openapi/spec/paths/admin@api@firewall@rules.yaml
@@ -50,11 +50,7 @@ get:
       description: Success to get firewall rules.
       headers:
         X-Total-Count:
-          description: Firewall rules' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/admin@api@namespaces.yaml
+++ b/openapi/spec/paths/admin@api@namespaces.yaml
@@ -49,10 +49,7 @@ get:
       description: Success to get a namespace list.
       headers:
         X-Total-Count:
-          description: Namespaces' total number.
-          schema:
-            type: string
-            minimum: 0
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/admin@api@sessions.yaml
+++ b/openapi/spec/paths/admin@api@sessions.yaml
@@ -17,11 +17,7 @@ get:
       description: Success to get list of sessions.
       headers:
         X-Total-Count:
-          description: Sessions' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/admin@api@sshkeys@public-keys.yaml
+++ b/openapi/spec/paths/admin@api@sshkeys@public-keys.yaml
@@ -17,11 +17,7 @@ get:
       description: Success to get a list of public keys.
       headers:
         X-Total-Count:
-          description: Public keys' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/admin@api@users.yaml
+++ b/openapi/spec/paths/admin@api@users.yaml
@@ -50,11 +50,7 @@ get:
       description: Success to get a list of users.
       headers:
         X-Total-Count:
-          description: users' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@announcements.yaml
+++ b/openapi/spec/paths/api@announcements.yaml
@@ -28,11 +28,7 @@ get:
       description: Success to get the announcements.
       headers:
         X-Total-Count:
-          description: Announcements' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@billing@devices-most-used.yaml
+++ b/openapi/spec/paths/api@billing@devices-most-used.yaml
@@ -13,11 +13,7 @@ get:
       description: Success to get the most used devices.
       headers:
         X-Total-Count:
-          description: Devices' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@containers.yaml
+++ b/openapi/spec/paths/api@containers.yaml
@@ -44,11 +44,7 @@ get:
       description: Success to get a list of containers.
       headers:
         X-Total-Count:
-          description: Containers' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@devices.yaml
+++ b/openapi/spec/paths/api@devices.yaml
@@ -44,11 +44,7 @@ get:
       description: Success to get a list of devices.
       headers:
         X-Total-Count:
-          description: Devices' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@devices@{uid}@tunnels.yaml
+++ b/openapi/spec/paths/api@devices@{uid}@tunnels.yaml
@@ -18,6 +18,9 @@ get:
   responses:
     '200':
       description: Success to get the tunnels.
+      headers:
+        X-Total-Count:
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@firewall@rules.yaml
+++ b/openapi/spec/paths/api@firewall@rules.yaml
@@ -50,11 +50,7 @@ get:
       description: Success to get firewall rules.
       headers:
         X-Total-Count:
-          description: Firewall rules' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@namespaces.yaml
+++ b/openapi/spec/paths/api@namespaces.yaml
@@ -48,10 +48,7 @@ get:
       description: Success to get a namespace list.
       headers:
         X-Total-Count:
-          description: Namespaces' total number.
-          schema:
-            type: string
-            minimum: 0
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@namespaces@api-key.yaml
+++ b/openapi/spec/paths/api@namespaces@api-key.yaml
@@ -69,11 +69,7 @@ get:
       description: Success.
       headers:
         X-Total-Count:
-          description: Total matched documents.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@namespaces@{tenant}@invitations.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@invitations.yaml
@@ -28,10 +28,7 @@ get:
       description: Successfully retrieved namespace membership invitations list.
       headers:
         X-Total-Count:
-          description: Total number of membership invitations.
-          schema:
-            type: integer
-            minimum: 0
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@namespaces@{tenant}@tags.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@tags.yaml
@@ -19,10 +19,7 @@ get:
       description: Success to get tag list.
       headers:
         X-Total-Count:
-          description: Tags' total number.
-          schema:
-            type: string
-            minimum: 0
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@sessions.yaml
+++ b/openapi/spec/paths/api@sessions.yaml
@@ -16,11 +16,7 @@ get:
       description: Success to get list of sessions.
       headers:
         X-Total-Count:
-          description: Sessions' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@sessions@{uid}@records.yaml
+++ b/openapi/spec/paths/api@sessions@{uid}@records.yaml
@@ -18,11 +18,7 @@ get:
       description: Success to list the session records.
       headers:
         X-Total-Count:
-          description: Session records' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
     '400':
       $ref: ../components/responses/400.yaml
     '404':

--- a/openapi/spec/paths/api@sshkeys@public-keys.yaml
+++ b/openapi/spec/paths/api@sshkeys@public-keys.yaml
@@ -17,11 +17,7 @@ get:
       description: Success to get a list of public keys.
       headers:
         X-Total-Count:
-          description: Public keys' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@tags.yaml
+++ b/openapi/spec/paths/api@tags.yaml
@@ -17,10 +17,7 @@ get:
       description: Success to get tag list.
       headers:
         X-Total-Count:
-          description: Tags' total number.
-          schema:
-            type: string
-            minimum: 0
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@users@invitations.yaml
+++ b/openapi/spec/paths/api@users@invitations.yaml
@@ -27,10 +27,7 @@ get:
       description: Successfully retrieved membership invitations list.
       headers:
         X-Total-Count:
-          description: Total number of membership invitations.
-          schema:
-            type: integer
-            minimum: 0
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:

--- a/openapi/spec/paths/api@web-endpoints.yaml
+++ b/openapi/spec/paths/api@web-endpoints.yaml
@@ -28,11 +28,7 @@ get:
       description: Success to get the web-endpoints.
       headers:
         X-Total-Count:
-          description: Web endpoints' total number.
-          schema:
-            type: string
-            minimum: 0
-            readOnly: true
+          $ref: ../components/headers/XTotalCount.yaml
       content:
         application/json:
           schema:


### PR DESCRIPTION
Add a reusable `components/headers/XTotalCount.yaml` component and replace all inline X-Total-Count header definitions across every paginated list endpoint with a `$ref` to it.

Previously, the header was either missing (3 endpoints) or duplicated inline with inconsistent descriptions and mixed types (string vs integer). All 25 paginated endpoints now reference the shared component, which defines the schema as an integer with `minimum: 0` and `readOnly: true`.

Closes #5828.