### PR TITLE
fix(api): create go.work in workspace root before starting enterprise air

### DIFF
--- a/api/entrypoint-dev.sh
+++ b/api/entrypoint-dev.sh
@@ -15,9 +15,18 @@ ln -sf $PWD/api /api
 # If the cloud repo is mounted at the expected container path, run air
 # with -tags enterprise (EE). Otherwise run a plain CE build.
 CLOUD_DIR="/go/src/github.com/shellhub-io/cloud"
+WORKSPACE="/go/src/github.com/shellhub-io"
 
 if [ -d "$CLOUD_DIR" ]; then
     echo "Cloud sources found at $CLOUD_DIR — building api-enterprise (EE)"
+
+    # Create go.work so the unified build can resolve both shellhub and cloud modules.
+    go work init \
+        "$WORKSPACE/shellhub" \
+        "$WORKSPACE/shellhub/openapi" \
+        "$WORKSPACE/shellhub/api" \
+        "$WORKSPACE/cloud"
+
     exec air -c .air.enterprise.toml
 else
     exec air


### PR DESCRIPTION
## Problem

When starting the API container in enterprise dev mode, air failed to build with:

```
enterprise/imports.go:9:2: no required module provides package github.com/shellhub-io/cloud/enterprise
```

The entrypoint detected the cloud mount and called `go work init`, but it ran in the current directory (`/go/src/github.com/shellhub-io/shellhub/api`), placing `go.work` there.

Air's `root = "../../"` in `.air.enterprise.toml` means the build command runs from `/go/src/github.com/shellhub-io/`. Go searches for `go.work` upward from that directory — it won't descend into subdirectories — so the `go.work` created inside `api/` was never found.

## Fix

Pass absolute paths to `go work init` so it creates `go.work` at the workspace root (`/go/src/github.com/shellhub-io/`), where the air build can find it.