### PR TITLE
fix(ssh): remove EnterpriseBaseURL and route all internal calls to api:8080

### DIFF
--- a/.env
+++ b/.env
@@ -190,9 +190,6 @@ SHELLHUB_INTERNAL_HTTP_CLIENT_RETRY_MAX_WAIT_TIME=20
 # The base URL for the API service.
 SHELLHUB_INTERNAL_HTTP_CLIENT_API_BASE_URL=http://api:8080
 
-# The base URL for the Enterprise service.
-SHELLHUB_INTERNAL_HTTP_CLIENT_ENTERPRISE_BASE_URL=http://cloud:8080
-
 # Set false to disable access logs for gateway nginx
 SHELLHUB_GATEWAY_ACCESS_LOGS=true
 

--- a/pkg/api/internalclient/billing.go
+++ b/pkg/api/internalclient/billing.go
@@ -23,7 +23,7 @@ func (c *client) BillingReport(ctx context.Context, tenant string, action string
 		SetContext(ctx).
 		SetHeader("X-Tenant-ID", tenant).
 		SetQueryParam("action", action).
-		Post(c.config.EnterpriseBaseURL + "/internal/billing/report")
+		Post(c.config.APIBaseURL + "/internal/billing/report")
 
 	return HasError(res, err)
 }
@@ -36,7 +36,7 @@ func (c *client) BillingEvaluate(ctx context.Context, tenantID string) (*models.
 		SetContext(ctx).
 		SetHeader("X-Tenant-ID", tenantID).
 		SetResult(&eval).
-		Post(c.config.EnterpriseBaseURL + "/internal/billing/evaluate")
+		Post(c.config.APIBaseURL + "/internal/billing/evaluate")
 	if err := HasError(resp, err); err != nil {
 		return nil, err
 	}

--- a/pkg/api/internalclient/client.go
+++ b/pkg/api/internalclient/client.go
@@ -68,8 +68,7 @@ func NewClient(cfg *Config, opts ...clientOption) (Client, error) {
 		httpClient.SetLogger(&LeveledLogger{c.logger})
 	}
 
-	// NOTE: Avoid setting a global base URL on the Resty client. Calls to enterprise endpoints
-	// will use c.config.EnterpriseBaseURL explicitly when needed.
+	// NOTE: Avoid setting a global base URL on the Resty client; each call sets its own URL.
 	httpClient.SetRetryCount(c.config.RetryCount)
 	httpClient.SetRetryWaitTime(time.Duration(c.config.RetryWaitTime) * time.Second)
 	httpClient.SetRetryMaxWaitTime(time.Duration(c.config.RetryMaxWaitTime) * time.Second)

--- a/pkg/api/internalclient/config.go
+++ b/pkg/api/internalclient/config.go
@@ -14,10 +14,8 @@ type Config struct {
 	RetryMaxWaitTime int `env:"SHELLHUB_INTERNAL_HTTP_CLIENT_RETRY_MAX_WAIT_TIME,default=20"`
 
 	// APIBaseURL defines the base URL for the API service.
+	// All routes — community and enterprise — are served by this single backend.
 	APIBaseURL string `env:"SHELLHUB_INTERNAL_HTTP_CLIENT_API_BASE_URL,default=http://api:8080"`
-
-	// EnterpriseBaseURL defines the base URL for enterprise endpoints (cloud component).
-	EnterpriseBaseURL string `env:"SHELLHUB_INTERNAL_HTTP_CLIENT_ENTERPRISE_BASE_URL,default=http://cloud:8080"`
 }
 
 func NewConfigFromEnv() (*Config, error) {
@@ -32,10 +30,9 @@ func NewConfigFromEnv() (*Config, error) {
 // DefaultConfig returns a Config struct with default values.
 func DefaultConfig() (*Config, error) {
 	return &Config{
-		RetryCount:        3,
-		RetryWaitTime:     5,
-		RetryMaxWaitTime:  20,
-		APIBaseURL:        "http://api:8080",
-		EnterpriseBaseURL: "http://cloud:8080",
+		RetryCount:       3,
+		RetryWaitTime:    5,
+		RetryMaxWaitTime: 20,
+		APIBaseURL:       "http://api:8080",
 	}, nil
 }

--- a/pkg/api/internalclient/device.go
+++ b/pkg/api/internalclient/device.go
@@ -35,7 +35,7 @@ type deviceAPI interface {
 func (c *client) DevicesOffline(ctx context.Context, uid string) error {
 	baseURL := c.config.APIBaseURL
 	if envs.IsCloud() || envs.IsEnterprise() {
-		baseURL = c.config.EnterpriseBaseURL
+		baseURL = c.config.APIBaseURL
 	}
 
 	res, err := c.http.
@@ -142,7 +142,7 @@ func (c *client) LookupWebEndpoints(ctx context.Context, address string) (*WebEn
 		SetContext(ctx).
 		SetPathParam("address", address).
 		SetResult(&endpoint).
-		Get(c.config.EnterpriseBaseURL + "/internal/web-endpoints/{address}")
+		Get(c.config.APIBaseURL + "/internal/web-endpoints/{address}")
 	if err := HasError(resp, err); err != nil {
 		return nil, err
 	}

--- a/pkg/api/internalclient/firewall.go
+++ b/pkg/api/internalclient/firewall.go
@@ -16,7 +16,7 @@ func (c *client) FirewallEvaluate(ctx context.Context, lookup map[string]string)
 		R().
 		SetContext(ctx).
 		SetQueryParams(lookup).
-		Get(c.config.EnterpriseBaseURL + "/internal/firewall/rules/evaluate")
+		Get(c.config.APIBaseURL + "/internal/firewall/rules/evaluate")
 
 	return HasError(resp, err)
 }

--- a/pkg/api/internalclient/license.go
+++ b/pkg/api/internalclient/license.go
@@ -17,7 +17,7 @@ func (c *client) LicenseEvaluate(ctx context.Context) (*models.BillingEvaluation
 		R().
 		SetContext(ctx).
 		SetResult(&eval).
-		Get(c.config.EnterpriseBaseURL + "/internal/license/evaluate")
+		Get(c.config.APIBaseURL + "/internal/license/evaluate")
 	if err := HasError(resp, err); err != nil {
 		return nil, err
 	}

--- a/pkg/api/internalclient/session.go
+++ b/pkg/api/internalclient/session.go
@@ -127,7 +127,7 @@ func (c *client) SaveSession(ctx context.Context, uid string, seat int) error {
 			"uid":  uid,
 			"seat": strconv.Itoa(seat),
 		}).
-		Post(c.config.EnterpriseBaseURL + "/internal/sessions/{uid}/records/{seat}")
+		Post(c.config.APIBaseURL + "/internal/sessions/{uid}/records/{seat}")
 	if err := HasError(resp, err); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

After the unified open-core refactor, the SSH service was still calling `http://cloud:8080/internal/license/evaluate` (and other enterprise endpoints), which no longer exists:

```
WARN RESTY Get "http://cloud:8080/internal/license/evaluate": dial tcp: lookup cloud: no such host
ERROR destination device has a firewall to blocked it or a billing issue
```

The `internalclient.Config` had a separate `EnterpriseBaseURL` field defaulting to `http://cloud:8080`, used for all `/internal/license/*`, `/internal/billing/*`, `/internal/firewall/*`, `/internal/sessions/*/records/*`, and `/internal/web-endpoints/*` calls.

## Fix

Remove `EnterpriseBaseURL` entirely — it is now redundant since enterprise routes are compiled into the `api` binary and served at the same `api:8080` address as all other internal routes.

Replace all `c.config.EnterpriseBaseURL` usages with `c.config.APIBaseURL` across:
- `billing.go`
- `firewall.go`
- `license.go`
- `session.go`
- `device.go`