### PR TITLE
ci: use GitHub App token for cloud repo dispatch

### DIFF
--- a/.github/workflows/notify-cloud.yml
+++ b/.github/workflows/notify-cloud.yml
@@ -11,10 +11,19 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLOUD_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CLOUD_DISPATCH_APP_PRIVATE_KEY }}
+          owner: shellhub-io
+          repositories: cloud
+
       - name: Dispatch to cloud
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.CLOUD_REPO_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.repos.createDispatchEvent({
               owner: 'shellhub-io',


### PR DESCRIPTION
Replaces the PAT-based token with a GitHub App token in `notify-cloud.yml`.

Requires two secrets to be configured in the repo:
- `CLOUD_DISPATCH_APP_ID`
- `CLOUD_DISPATCH_APP_PRIVATE_KEY`