### PR TITLE
fix(gateway): use relative redirects to preserve host and port

### DIFF
--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -40,6 +40,7 @@ server {
     {{ end }}
     server_name {{ $cfg.Domain }};
     server_tokens off;
+    absolute_redirect off;
     resolver 127.0.0.11 valid=10s ipv6=off;
 
     {{ if not $cfg.EnableCloud }}


### PR DESCRIPTION
## Summary
- Add `absolute_redirect off` to the nginx server block so redirects (like `/admin` → `/admin/`) generate relative `Location` headers instead of absolute ones
- Fixes the redirect dropping the port when accessing the gateway on non-standard ports (e.g. `localhost:8088/admin` redirected to `http://localhost/admin/` instead of `/admin/`)

## Test plan
- [ ] Access `curl -v localhost:8088/admin` and verify `Location` header is `/admin/` (relative) instead of `http://localhost/admin/` (absolute)