### PR TITLE
refactor(api): export GetConnection for transaction-aware store access

### DIFF
--- a/api/store/pg/api-key.go
+++ b/api/store/pg/api-key.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (pg *Pg) APIKeyCreate(ctx context.Context, apiKey *models.APIKey) (string, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	apiKey.CreatedAt = clock.Now()
 	apiKey.UpdatedAt = clock.Now()
@@ -23,7 +23,7 @@ func (pg *Pg) APIKeyCreate(ctx context.Context, apiKey *models.APIKey) (string, 
 }
 
 func (pg *Pg) APIKeyConflicts(ctx context.Context, tenantID string, target *models.APIKeyConflicts) ([]string, bool, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	if target.ID == "" && target.Name == "" {
 		return []string{}, false, nil
@@ -68,7 +68,7 @@ func (pg *Pg) APIKeyConflicts(ctx context.Context, tenantID string, target *mode
 }
 
 func (pg *Pg) APIKeyList(ctx context.Context, opts ...store.QueryOption) ([]models.APIKey, int, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	entities := make([]entity.APIKey, 0)
 
@@ -93,7 +93,7 @@ func (pg *Pg) APIKeyList(ctx context.Context, opts ...store.QueryOption) ([]mode
 }
 
 func (pg *Pg) APIKeyResolve(ctx context.Context, resolver store.APIKeyResolver, val string, opts ...store.QueryOption) (*models.APIKey, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	column, err := APIKeyResolverToString(resolver)
 	if err != nil {
@@ -115,7 +115,7 @@ func (pg *Pg) APIKeyResolve(ctx context.Context, resolver store.APIKeyResolver, 
 }
 
 func (pg *Pg) APIKeyUpdate(ctx context.Context, apiKey *models.APIKey) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	a := entity.APIKeyFromModel(apiKey)
 	a.UpdatedAt = clock.Now()
@@ -132,7 +132,7 @@ func (pg *Pg) APIKeyUpdate(ctx context.Context, apiKey *models.APIKey) error {
 }
 
 func (pg *Pg) APIKeyDelete(ctx context.Context, apiKey *models.APIKey) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	a := entity.APIKeyFromModel(apiKey)
 	r, err := db.NewDelete().Model(a).WherePK().Exec(ctx)

--- a/api/store/pg/device.go
+++ b/api/store/pg/device.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (pg *Pg) DeviceCreate(ctx context.Context, device *models.Device) (string, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	device.CreatedAt = clock.Now()
 
@@ -26,7 +26,7 @@ func (pg *Pg) DeviceCreate(ctx context.Context, device *models.Device) (string, 
 }
 
 func (pg *Pg) DeviceConflicts(ctx context.Context, target *models.DeviceConflicts) ([]string, bool, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	if target.Name == "" {
 		return []string{}, false, nil
@@ -65,7 +65,7 @@ func (pg *Pg) DeviceConflicts(ctx context.Context, target *models.DeviceConflict
 }
 
 func (pg *Pg) DeviceList(ctx context.Context, acceptable store.DeviceAcceptable, opts ...store.QueryOption) ([]models.Device, int, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	entities := make([]entity.Device, 0)
 
@@ -99,7 +99,7 @@ func (pg *Pg) DeviceList(ctx context.Context, acceptable store.DeviceAcceptable,
 }
 
 func (pg *Pg) DeviceResolve(ctx context.Context, resolver store.DeviceResolver, val string, opts ...store.QueryOption) (*models.Device, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	column, err := DeviceResolverToString(resolver)
 	if err != nil {
@@ -131,7 +131,7 @@ func (pg *Pg) DeviceResolve(ctx context.Context, resolver store.DeviceResolver, 
 }
 
 func (pg *Pg) DeviceUpdate(ctx context.Context, device *models.Device) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	d := entity.DeviceFromModel(device)
 	d.UpdatedAt = clock.Now()
@@ -149,7 +149,7 @@ func (pg *Pg) DeviceUpdate(ctx context.Context, device *models.Device) error {
 }
 
 func (pg *Pg) DeviceHeartbeat(ctx context.Context, ids []string, lastSeen time.Time) (int64, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	unnestExpr, unnestIDs := deviceExprUnnestIDs(ids)
 	r, err := db.NewUpdate().
@@ -179,7 +179,7 @@ func (pg *Pg) DeviceDelete(ctx context.Context, device *models.Device) error {
 }
 
 func (pg *Pg) DeviceDeleteMany(ctx context.Context, uids []string) (int64, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 	fn := pg.deviceDeleteManyFn(ctx, uids)
 
 	if tx, ok := db.(bun.Tx); ok {

--- a/api/store/pg/member.go
+++ b/api/store/pg/member.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (pg *Pg) NamespaceCreateMembership(ctx context.Context, tenantID string, membership *models.Member) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	membership.AddedAt = clock.Now()
 	entity := entity.MembershipFromModel(tenantID, membership)
@@ -22,7 +22,7 @@ func (pg *Pg) NamespaceCreateMembership(ctx context.Context, tenantID string, me
 }
 
 func (pg *Pg) NamespaceUpdateMembership(ctx context.Context, tenantID string, member *models.Member) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	e := entity.MembershipFromModel(tenantID, member)
 	e.UpdatedAt = clock.Now()
@@ -39,7 +39,7 @@ func (pg *Pg) NamespaceUpdateMembership(ctx context.Context, tenantID string, me
 }
 
 func (pg *Pg) NamespaceDeleteMembership(ctx context.Context, tenantID string, member *models.Member) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	e := entity.MembershipFromModel(tenantID, member)
 	r, err := db.NewDelete().Model(e).WherePK().Exec(ctx)

--- a/api/store/pg/membership-invitation.go
+++ b/api/store/pg/membership-invitation.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (pg *Pg) MembershipInvitationCreate(ctx context.Context, invitation *models.MembershipInvitation) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	now := clock.Now()
 	invitation.ID = uuid.Generate()
@@ -29,7 +29,7 @@ func (pg *Pg) MembershipInvitationCreate(ctx context.Context, invitation *models
 }
 
 func (pg *Pg) MembershipInvitationResolve(ctx context.Context, tenantID, userID string) (*models.MembershipInvitation, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	invitation := new(entity.MembershipInvitation)
 
@@ -51,7 +51,7 @@ func (pg *Pg) MembershipInvitationResolve(ctx context.Context, tenantID, userID 
 }
 
 func (pg *Pg) MembershipInvitationUpdate(ctx context.Context, invitation *models.MembershipInvitation) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	invitation.UpdatedAt = clock.Now()
 

--- a/api/store/pg/namespace.go
+++ b/api/store/pg/namespace.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (pg *Pg) NamespaceCreate(ctx context.Context, namespace *models.Namespace) (string, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	namespace.CreatedAt = clock.Now()
 	if namespace.TenantID == "" {
@@ -34,7 +34,7 @@ func (pg *Pg) NamespaceCreate(ctx context.Context, namespace *models.Namespace) 
 }
 
 func (pg *Pg) NamespaceConflicts(ctx context.Context, target *models.NamespaceConflicts) ([]string, bool, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	if target.Name == "" {
 		return []string{}, false, nil
@@ -72,7 +72,7 @@ func (pg *Pg) NamespaceConflicts(ctx context.Context, target *models.NamespaceCo
 }
 
 func (pg *Pg) NamespaceList(ctx context.Context, opts ...store.QueryOption) ([]models.Namespace, int, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	entities := make([]entity.Namespace, 0)
 	query := db.NewSelect().Model(&entities)
@@ -97,7 +97,7 @@ func (pg *Pg) NamespaceList(ctx context.Context, opts ...store.QueryOption) ([]m
 }
 
 func (pg *Pg) NamespaceResolve(ctx context.Context, resolver store.NamespaceResolver, val string) (*models.Namespace, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	column, err := NamespaceResolverToString(resolver)
 	if err != nil {
@@ -114,7 +114,7 @@ func (pg *Pg) NamespaceResolve(ctx context.Context, resolver store.NamespaceReso
 }
 
 func (pg *Pg) NamespaceGetPreferred(ctx context.Context, userID string) (*models.Namespace, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	ns := new(entity.Namespace)
 	if err := db.NewSelect().
@@ -133,7 +133,7 @@ func (pg *Pg) NamespaceGetPreferred(ctx context.Context, userID string) (*models
 }
 
 func (pg *Pg) NamespaceUpdate(ctx context.Context, namespace *models.Namespace) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	// First check if namespace exists
 	exists, err := db.NewSelect().Model((*entity.Namespace)(nil)).Where("id = ?", namespace.TenantID).Exists(ctx)
@@ -160,7 +160,7 @@ func (pg *Pg) NamespaceUpdate(ctx context.Context, namespace *models.Namespace) 
 }
 
 func (pg *Pg) NamespaceIncrementDeviceCount(ctx context.Context, tenantID string, status models.DeviceStatus, count int64) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	column := "devices_" + string(status) + "_count"
 	result, err := db.NewUpdate().
@@ -185,7 +185,7 @@ func (pg *Pg) NamespaceIncrementDeviceCount(ctx context.Context, tenantID string
 }
 
 func (pg *Pg) NamespaceSyncDeviceCounts(ctx context.Context) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	_, err := db.NewRaw(`
 		UPDATE namespaces SET
@@ -237,7 +237,7 @@ func (pg *Pg) NamespaceDelete(ctx context.Context, namespace *models.Namespace) 
 }
 
 func (pg *Pg) NamespaceDeleteMany(ctx context.Context, tenantIDs []string) (int64, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 	fn := pg.namespaceDeleteManyFn(ctx, tenantIDs)
 
 	if tx, ok := db.(bun.Tx); ok {

--- a/api/store/pg/private-key.go
+++ b/api/store/pg/private-key.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (pg *Pg) PrivateKeyCreate(ctx context.Context, privateKey *models.PrivateKey) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	privateKey.CreatedAt = clock.Now()
 
@@ -21,7 +21,7 @@ func (pg *Pg) PrivateKeyCreate(ctx context.Context, privateKey *models.PrivateKe
 }
 
 func (pg *Pg) PrivateKeyGet(ctx context.Context, fingerprint string) (*models.PrivateKey, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	privateKey := new(entity.PrivateKey)
 	if err := db.NewSelect().Model(privateKey).Where("fingerprint = ?", fingerprint).Scan(ctx); err != nil {

--- a/api/store/pg/public-key.go
+++ b/api/store/pg/public-key.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (pg *Pg) PublicKeyCreate(ctx context.Context, publicKey *models.PublicKey) (string, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	publicKey.CreatedAt = clock.Now()
 	e := entity.PublicKeyFromModel(publicKey)
@@ -41,7 +41,7 @@ func (pg *Pg) PublicKeyCreate(ctx context.Context, publicKey *models.PublicKey) 
 }
 
 func (pg *Pg) PublicKeyList(ctx context.Context, opts ...store.QueryOption) ([]models.PublicKey, int, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	entities := make([]entity.PublicKey, 0)
 
@@ -66,7 +66,7 @@ func (pg *Pg) PublicKeyList(ctx context.Context, opts ...store.QueryOption) ([]m
 }
 
 func (pg *Pg) PublicKeyUpdate(ctx context.Context, publicKey *models.PublicKey) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	a := entity.PublicKeyFromModel(publicKey)
 	a.UpdatedAt = clock.Now()
@@ -89,7 +89,7 @@ func (pg *Pg) PublicKeyUpdate(ctx context.Context, publicKey *models.PublicKey) 
 }
 
 func (pg *Pg) PublicKeyResolve(ctx context.Context, resolver store.PublicKeyResolver, value string, opts ...store.QueryOption) (*models.PublicKey, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	column, err := PublicKeyResolverToString(resolver)
 	if err != nil {
@@ -113,7 +113,7 @@ func (pg *Pg) PublicKeyResolve(ctx context.Context, resolver store.PublicKeyReso
 }
 
 func (pg *Pg) PublicKeyDelete(ctx context.Context, publicKey *models.PublicKey) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	a := entity.PublicKeyFromModel(publicKey)
 

--- a/api/store/pg/session.go
+++ b/api/store/pg/session.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (pg *Pg) SessionList(ctx context.Context, opts ...store.QueryOption) ([]models.Session, int, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	entities := make([]entity.Session, 0)
 	query := db.NewSelect().
@@ -51,7 +51,7 @@ func (pg *Pg) SessionList(ctx context.Context, opts ...store.QueryOption) ([]mod
 }
 
 func (pg *Pg) SessionResolve(ctx context.Context, resolver store.SessionResolver, value string, opts ...store.QueryOption) (*models.Session, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	var sessionID string
 	switch resolver {
@@ -79,7 +79,7 @@ func (pg *Pg) SessionResolve(ctx context.Context, resolver store.SessionResolver
 }
 
 func (pg *Pg) SessionCreate(ctx context.Context, session models.Session) (string, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	session.StartedAt = clock.Now()
 	session.LastSeen = session.StartedAt
@@ -105,7 +105,7 @@ func (pg *Pg) SessionCreate(ctx context.Context, session models.Session) (string
 }
 
 func (pg *Pg) SessionUpdate(ctx context.Context, session *models.Session) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	e := entity.SessionFromModel(session)
 	result, err := db.NewUpdate().Model(e).OmitZero().Where("id = ?", e.ID).Exec(ctx)
@@ -126,7 +126,7 @@ func (pg *Pg) SessionUpdate(ctx context.Context, session *models.Session) error 
 }
 
 func (pg *Pg) ActiveSessionCreate(ctx context.Context, session *models.Session) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	activeSession := &models.ActiveSession{UID: models.UID(session.UID), LastSeen: session.StartedAt, TenantID: session.TenantID}
 	e := entity.ActiveSessionFromModel(activeSession)
@@ -138,7 +138,7 @@ func (pg *Pg) ActiveSessionCreate(ctx context.Context, session *models.Session) 
 }
 
 func (pg *Pg) ActiveSessionResolve(ctx context.Context, resolver store.SessionResolver, value string) (*models.ActiveSession, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	var sessionID string
 	switch resolver {
@@ -157,7 +157,7 @@ func (pg *Pg) ActiveSessionResolve(ctx context.Context, resolver store.SessionRe
 }
 
 func (pg *Pg) ActiveSessionUpdate(ctx context.Context, activeSession *models.ActiveSession) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	e := entity.ActiveSessionFromModel(activeSession)
 	result, err := db.NewUpdate().Model(e).Where("session_id = ?", e.SessionID).Exec(ctx)
@@ -179,7 +179,7 @@ func (pg *Pg) ActiveSessionUpdate(ctx context.Context, activeSession *models.Act
 
 func (pg *Pg) ActiveSessionDelete(ctx context.Context, uid models.UID) error {
 	return pg.WithTransaction(ctx, func(ctx context.Context) error {
-		db := pg.getConnection(ctx)
+		db := pg.GetConnection(ctx)
 
 		result, err := db.NewUpdate().
 			Model((*entity.Session)(nil)).
@@ -207,7 +207,7 @@ func (pg *Pg) ActiveSessionDelete(ctx context.Context, uid models.UID) error {
 }
 
 func (pg *Pg) SessionEventsCreate(ctx context.Context, event *models.SessionEvent) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	e := entity.SessionEventFromModel(event)
 	e.ID = uuid.Generate()
@@ -220,7 +220,7 @@ func (pg *Pg) SessionEventsCreate(ctx context.Context, event *models.SessionEven
 }
 
 func (pg *Pg) SessionEventsList(ctx context.Context, uid models.UID, seat int, event models.SessionEventType, opts ...store.QueryOption) ([]models.SessionEvent, int, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	entities := make([]entity.SessionEvent, 0)
 	query := db.NewSelect().
@@ -254,7 +254,7 @@ func (pg *Pg) SessionEventsList(ctx context.Context, uid models.UID, seat int, e
 }
 
 func (pg *Pg) SessionEventsDelete(ctx context.Context, uid models.UID, seat int, event models.SessionEventType) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	if _, err := db.NewDelete().
 		Model((*entity.SessionEvent)(nil)).
@@ -269,7 +269,7 @@ func (pg *Pg) SessionEventsDelete(ctx context.Context, uid models.UID, seat int,
 }
 
 func (pg *Pg) SessionUpdateDeviceUID(ctx context.Context, oldUID models.UID, newUID models.UID) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	result, err := db.NewUpdate().
 		Model((*entity.Session)(nil)).

--- a/api/store/pg/stats.go
+++ b/api/store/pg/stats.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (pg *Pg) GetStats(ctx context.Context, tenantID string) (*models.Stats, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	onlineDevicesQuery := buildOnlineDevicesQuery(db, tenantID)
 	onlineDevices, err := onlineDevicesQuery.Count(ctx)

--- a/api/store/pg/system.go
+++ b/api/store/pg/system.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (pg *Pg) SystemGet(ctx context.Context) (*models.System, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	system := new(entity.System)
 	if err := db.NewSelect().Model(system).Limit(1).Scan(ctx); err != nil {
@@ -40,7 +40,7 @@ func (pg *Pg) SystemGet(ctx context.Context) (*models.System, error) {
 }
 
 func (pg *Pg) SystemSet(ctx context.Context, system *models.System) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	// Get existing system (should be only one)
 	existingSystem := new(entity.System)
@@ -54,11 +54,11 @@ func (pg *Pg) SystemSet(ctx context.Context, system *models.System) error {
 		if systemEntity.ID == "" {
 			systemEntity.ID = uuid.Generate()
 		}
-		_, err = pg.driver.NewInsert().Model(systemEntity).Exec(ctx)
+		_, err = db.NewInsert().Model(systemEntity).Exec(ctx)
 	case err == nil:
 		// System exists, update it (use existing ID)
 		systemEntity.ID = existingSystem.ID
-		_, err = pg.driver.NewUpdate().Model(systemEntity).WherePK().Exec(ctx)
+		_, err = db.NewUpdate().Model(systemEntity).WherePK().Exec(ctx)
 	}
 
 	return err

--- a/api/store/pg/tag.go
+++ b/api/store/pg/tag.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (pg *Pg) TagCreate(ctx context.Context, tag *models.Tag) (string, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	tag.CreatedAt = clock.Now()
 	tag.UpdatedAt = clock.Now()
@@ -34,7 +34,7 @@ func (pg *Pg) TagCreate(ctx context.Context, tag *models.Tag) (string, error) {
 }
 
 func (pg *Pg) TagConflicts(ctx context.Context, tenantID string, target *models.TagConflicts) ([]string, bool, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	if target.Name == "" {
 		return []string{}, false, nil
@@ -70,7 +70,7 @@ func (pg *Pg) TagConflicts(ctx context.Context, tenantID string, target *models.
 }
 
 func (pg *Pg) TagList(ctx context.Context, opts ...store.QueryOption) ([]models.Tag, int, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	entities := make([]entity.Tag, 0)
 	query := db.NewSelect().Model(&entities).Column("tag.*")
@@ -94,7 +94,7 @@ func (pg *Pg) TagList(ctx context.Context, opts ...store.QueryOption) ([]models.
 }
 
 func (pg *Pg) TagResolve(ctx context.Context, resolver store.TagResolver, value string, opts ...store.QueryOption) (*models.Tag, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	column, err := TagResolverToString(resolver)
 	if err != nil {
@@ -117,7 +117,7 @@ func (pg *Pg) TagResolve(ctx context.Context, resolver store.TagResolver, value 
 }
 
 func (pg *Pg) TagUpdate(ctx context.Context, tag *models.Tag) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	t := entity.TagFromModel(tag)
 	t.UpdatedAt = clock.Now()
@@ -135,7 +135,7 @@ func (pg *Pg) TagUpdate(ctx context.Context, tag *models.Tag) error {
 }
 
 func (pg *Pg) TagPushToTarget(ctx context.Context, id string, target store.TagTarget, targetID string) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	tag := new(entity.Tag)
 	if err := db.NewSelect().Model(tag).Where("id = ?", id).Scan(ctx); err != nil {
@@ -181,7 +181,7 @@ func (pg *Pg) TagPushToTarget(ctx context.Context, id string, target store.TagTa
 }
 
 func (pg *Pg) TagPullFromTarget(ctx context.Context, id string, target store.TagTarget, targetIDs ...string) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	tag := new(entity.Tag)
 	if err := db.NewSelect().Model(tag).Where("id = ?", id).Scan(ctx); err != nil {
@@ -229,7 +229,7 @@ func (pg *Pg) TagPullFromTarget(ctx context.Context, id string, target store.Tag
 }
 
 func (pg *Pg) TagDelete(ctx context.Context, tag *models.Tag) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	t := entity.TagFromModel(tag)
 

--- a/api/store/pg/transaction.go
+++ b/api/store/pg/transaction.go
@@ -12,13 +12,13 @@ type txKeyType struct{}
 
 var txKey = txKeyType{}
 
-// getConnection returns the appropriate executor for the given context.
+// GetConnection returns the appropriate executor for the given context.
 // If the context contains an active transaction, it returns the transaction handle.
 // Otherwise, it returns the base database driver.
 //
 // This allows store methods to be written agnostic of whether they are
 // running inside a transaction or not.
-func (pg *Pg) getConnection(ctx context.Context) bun.IDB {
+func (pg *Pg) GetConnection(ctx context.Context) bun.IDB {
 	if tx, ok := ctx.Value(txKey).(bun.Tx); ok {
 		log.Debug("reusing existing SQL transaction from context")
 
@@ -31,7 +31,7 @@ func (pg *Pg) getConnection(ctx context.Context) bun.IDB {
 // Example:
 //
 //	err := store.WithTransaction(ctx, func(ctx context.Context) error {
-//	    db := store.getExecutor(ctx)
+//	    db := store.GetConnection(ctx)
 //	    if _, err := db.NewDelete().Model(&Device{}).Where("id = ?", id).Exec(ctx); err != nil {
 //	        return err
 //	    }

--- a/api/store/pg/tunnel.go
+++ b/api/store/pg/tunnel.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (pg *Pg) TunnelUpdateDeviceUID(ctx context.Context, tenantID, oldUID, newUID string) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	_, err := db.NewUpdate().
 		Model((*entity.Tunnel)(nil)).

--- a/api/store/pg/user-invitation.go
+++ b/api/store/pg/user-invitation.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (pg *Pg) UserInvitationsUpsert(ctx context.Context, email string) (string, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	now := clock.Now()
 	normalizedEmail := strings.ToLower(email)

--- a/api/store/pg/user.go
+++ b/api/store/pg/user.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (pg *Pg) UserCreate(ctx context.Context, user *models.User) (string, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	user.CreatedAt = clock.Now()
 	if user.ID == "" {
@@ -27,7 +27,7 @@ func (pg *Pg) UserCreate(ctx context.Context, user *models.User) (string, error)
 }
 
 func (pg *Pg) UserConflicts(ctx context.Context, target *models.UserConflicts) ([]string, bool, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	if target.Email == "" && target.Username == "" {
 		return []string{}, false, nil
@@ -73,7 +73,7 @@ func (pg *Pg) UserConflicts(ctx context.Context, target *models.UserConflicts) (
 }
 
 func (pg *Pg) UserList(ctx context.Context, opts ...store.QueryOption) ([]models.User, int, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	entities := make([]entity.User, 0)
 	query := UserSelectQuery(db.NewSelect().Model(&entities))
@@ -98,7 +98,7 @@ func (pg *Pg) UserList(ctx context.Context, opts ...store.QueryOption) ([]models
 }
 
 func (pg *Pg) UserResolve(ctx context.Context, resolver store.UserResolver, val string, opts ...store.QueryOption) (*models.User, error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	column, err := UserResolverToString(resolver)
 	if err != nil {
@@ -122,7 +122,7 @@ func (pg *Pg) UserResolve(ctx context.Context, resolver store.UserResolver, val 
 }
 
 func (pg *Pg) UserGetInfo(ctx context.Context, userID string) (userInfo *models.UserInfo, err error) {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	var namespaceEntities []entity.Namespace
 	err = db.NewSelect().
@@ -153,7 +153,7 @@ func (pg *Pg) UserGetInfo(ctx context.Context, userID string) (userInfo *models.
 }
 
 func (pg *Pg) UserUpdate(ctx context.Context, user *models.User) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	u := entity.UserFromModel(user)
 	u.UpdatedAt = clock.Now()
@@ -171,7 +171,7 @@ func (pg *Pg) UserUpdate(ctx context.Context, user *models.User) error {
 }
 
 func (pg *Pg) UserDelete(ctx context.Context, user *models.User) error {
-	db := pg.getConnection(ctx)
+	db := pg.GetConnection(ctx)
 
 	u := entity.UserFromModel(user)
 


### PR DESCRIPTION
## Summary
- Exports `getConnection` as `GetConnection` on the `Pg` store type
- Allows external packages (cloud store) to obtain the transaction-aware `bun.IDB` from context
- Cloud-overridden store methods can now participate in core transactions started via `WithTransaction`

This is a pure rename from unexported to exported — no logic changes.