### PR TITLE
fix(api): allow core User entity to scan MFA columns

### DIFF
--- a/api/store/pg/entity/user.go
+++ b/api/store/pg/entity/user.go
@@ -22,7 +22,7 @@ type User struct {
 	Email          string          `bun:"email"`
 	PasswordDigest string          `bun:"password_digest"`
 	Preferences    UserPreferences `bun:"embed:"`
-	MFA            UserMFA         `bun:"-"`
+	MFA            UserMFA         `bun:"embed:mfa_"`
 	Admin          bool            `bun:"admin"`
 	Namespaces     int             `bun:"namespaces,scanonly"`
 }


### PR DESCRIPTION
## Summary

- Cloud migration 009 adds `mfa_enabled`, `mfa_secret`, `mfa_recovery_codes` to the `users` table. The core entity tagged MFA with `bun:"-"`, causing bun to crash when `SELECT "user".*` returns those columns.
- Change the tag to `bun:"embed:mfa_"` so `UserMFA` fields map correctly. In community mode the columns don't exist, so no impact.