### PR TITLE
feat(api): add store wrapper factory for cloud store injection

### DIFF
--- a/api/store/wrapper.go
+++ b/api/store/wrapper.go
@@ -1,0 +1,23 @@
+package store
+
+import "github.com/shellhub-io/shellhub/pkg/cache"
+
+// StoreWrapperFactory is a function that wraps a Store with additional
+// functionality. Cloud packages register a factory via RegisterStoreWrapper in
+// their init() functions so the core server can apply it after creating the
+// base store.
+type StoreWrapperFactory func(s Store, c cache.Cache) (Store, error)
+
+var storeWrapper StoreWrapperFactory
+
+// RegisterStoreWrapper registers the factory function that wraps the store.
+// This must be called before the server's Setup() is invoked — typically from a
+// cloud package's init() function.
+func RegisterStoreWrapper(f StoreWrapperFactory) {
+	storeWrapper = f
+}
+
+// StoreWrapper returns the registered StoreWrapperFactory, or nil in CE builds.
+func StoreWrapper() StoreWrapperFactory {
+	return storeWrapper
+}


### PR DESCRIPTION
## Problem

Cloud migrations add columns to core tables (e.g. `mfa_*` on `users`, `converted` on `sessions`) that the core entities skip with `bun:"-"`. When `SELECT "user".*` returns these columns, bun crashes because the core entity has no fields to scan them into.

The cloud store already has overrides (`UserResolve`, `UserList`, `SessionResolve`, `SessionList`) that use cloud entities with the extra fields. But the core API service creates its own `pg.Pg` store in `server.go` and passes it to the core service — the cloud store wrapper is never injected, so the core service always calls the core methods.

## Solution

Add a `StoreWrapperFactory` registration mechanism in `api/store/wrapper.go`, following the exact same pattern as `BillingProviderFactory` in `services/billing.go`. The cloud registers a wrapper in `init()`, the core applies it after creating the store but before creating the service.

This ensures a single shared store instance is used by both core and cloud, eliminating the duplicate connection and fixing the column scan errors.

**Companion PR:** shellhub-io/cloud (cloud side)