### PR TITLE
fix(cli): update air to v1.62 to fix environment startup

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -33,7 +33,7 @@ RUN go build
 FROM builder AS development
 
 RUN apk add --update openssl build-base docker-cli
-RUN go install github.com/cosmtrek/air@v1.51.0 && \
+RUN go install github.com/air-verse/air@v1.62 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub


### PR DESCRIPTION
The CLI Dockerfile was the only service still using the deprecated cosmtrek/air@v1.51.0, which does not handle absolute paths in tmp_dir correctly. This caused the container to fail on startup with "mkdir ../tmp/air: no such file or directory" after the .air.toml changes in 02d8486f6.