### PR TITLE
chore(ui): stop tracking generated config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ ssh_private_key
 go.work
 go.work.sum
 
+# Generated at runtime by gen-config.sh from env vars
+ui-react/apps/admin/public/config.json
+
 # Docker binaries
 agent/agent
 api/api

--- a/ui-react/apps/admin/public/config.json
+++ b/ui-react/apps/admin/public/config.json
@@ -1,5 +1,0 @@
-{
-  "version": "v0.22.0-rc.1",
-  "enterprise": true,
-  "cloud": false
-}


### PR DESCRIPTION
## Problem

`ui-react/apps/admin/public/config.json` is generated at runtime by `gen-config.sh` from environment variables (`SHELLHUB_VERSION`, `SHELLHUB_ENTERPRISE`, `SHELLHUB_CLOUD`). It was committed accidentally in the initial UI React commit and produces noisy diffs every time the env changes.

## Fix

Remove from git tracking and add to `.gitignore`.