### PR TITLE
test(store): add unit tests for PG entity conversion functions

### DIFF
--- a/api/store/pg/entity/api-key_test.go
+++ b/api/store/pg/entity/api-key_test.go
@@ -1,0 +1,152 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIKeyFromModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		model    *models.APIKey
+		expected *APIKey
+	}{
+		{
+			name: "full fields",
+			model: &models.APIKey{
+				ID:        "digest-abc123",
+				Name:      "my-api-key",
+				TenantID:  "namespace-id-1",
+				Role:      authorizer.RoleAdministrator,
+				CreatedBy: "user-id-1",
+				CreatedAt: now,
+				UpdatedAt: now.Add(time.Hour),
+				ExpiresIn: 3600,
+			},
+			expected: &APIKey{
+				KeyDigest:   "digest-abc123",
+				Name:        "my-api-key",
+				NamespaceID: "namespace-id-1",
+				Role:        "administrator",
+				UserID:      "user-id-1",
+				CreatedAt:   now,
+				UpdatedAt:   now.Add(time.Hour),
+				ExpiresIn:   3600,
+			},
+		},
+		{
+			name: "observer role and zero ExpiresIn",
+			model: &models.APIKey{
+				ID:        "digest-def456",
+				Name:      "read-only-key",
+				TenantID:  "namespace-id-2",
+				Role:      authorizer.RoleObserver,
+				CreatedBy: "user-id-2",
+				CreatedAt: now,
+				UpdatedAt: now,
+				ExpiresIn: 0,
+			},
+			expected: &APIKey{
+				KeyDigest:   "digest-def456",
+				Name:        "read-only-key",
+				NamespaceID: "namespace-id-2",
+				Role:        "observer",
+				UserID:      "user-id-2",
+				CreatedAt:   now,
+				UpdatedAt:   now,
+				ExpiresIn:   0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := APIKeyFromModel(tt.model)
+			assert.Equal(t, tt.expected.KeyDigest, result.KeyDigest)
+			assert.Equal(t, tt.expected.Name, result.Name)
+			assert.Equal(t, tt.expected.NamespaceID, result.NamespaceID)
+			assert.Equal(t, tt.expected.Role, result.Role)
+			assert.Equal(t, tt.expected.UserID, result.UserID)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.Equal(t, tt.expected.UpdatedAt, result.UpdatedAt)
+			assert.Equal(t, tt.expected.ExpiresIn, result.ExpiresIn)
+		})
+	}
+}
+
+func TestAPIKeyToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		entity   *APIKey
+		expected *models.APIKey
+	}{
+		{
+			name: "full fields",
+			entity: &APIKey{
+				KeyDigest:   "digest-abc123",
+				Name:        "my-api-key",
+				NamespaceID: "namespace-id-1",
+				Role:        "administrator",
+				UserID:      "user-id-1",
+				CreatedAt:   now,
+				UpdatedAt:   now.Add(time.Hour),
+				ExpiresIn:   3600,
+			},
+			expected: &models.APIKey{
+				ID:        "digest-abc123",
+				Name:      "my-api-key",
+				TenantID:  "namespace-id-1",
+				Role:      authorizer.RoleAdministrator,
+				CreatedBy: "user-id-1",
+				CreatedAt: now,
+				UpdatedAt: now.Add(time.Hour),
+				ExpiresIn: 3600,
+			},
+		},
+		{
+			name: "zero ExpiresIn",
+			entity: &APIKey{
+				KeyDigest:   "digest-def456",
+				Name:        "no-expiry-key",
+				NamespaceID: "namespace-id-2",
+				Role:        "observer",
+				UserID:      "user-id-2",
+				CreatedAt:   now,
+				UpdatedAt:   now,
+				ExpiresIn:   0,
+			},
+			expected: &models.APIKey{
+				ID:        "digest-def456",
+				Name:      "no-expiry-key",
+				TenantID:  "namespace-id-2",
+				Role:      authorizer.RoleObserver,
+				CreatedBy: "user-id-2",
+				CreatedAt: now,
+				UpdatedAt: now,
+				ExpiresIn: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := APIKeyToModel(tt.entity)
+			assert.Equal(t, tt.expected.ID, result.ID)
+			assert.Equal(t, tt.expected.Name, result.Name)
+			assert.Equal(t, tt.expected.TenantID, result.TenantID)
+			assert.Equal(t, tt.expected.Role, result.Role)
+			assert.Equal(t, tt.expected.CreatedBy, result.CreatedBy)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.Equal(t, tt.expected.UpdatedAt, result.UpdatedAt)
+			assert.Equal(t, tt.expected.ExpiresIn, result.ExpiresIn)
+		})
+	}
+}

--- a/api/store/pg/entity/device_test.go
+++ b/api/store/pg/entity/device_test.go
@@ -1,0 +1,278 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceFromModel(t *testing.T) {
+	now := time.Now()
+	disconnectedAt := now.Add(-time.Hour)
+
+	tests := []struct {
+		name  string
+		model *models.Device
+		check func(t *testing.T, result *Device)
+	}{
+		{
+			name: "full fields",
+			model: &models.Device{
+				UID:            "device-uid-1",
+				TenantID:       "tenant-id-1",
+				CreatedAt:      now,
+				LastSeen:       now,
+				Status:         models.DeviceStatusAccepted,
+				Name:           "my-device",
+				PublicKey:      "ssh-rsa AAAA...",
+				DisconnectedAt: &disconnectedAt,
+				Identity:       &models.DeviceIdentity{MAC: "00:11:22:33:44:55"},
+				Position:       &models.DevicePosition{Longitude: 1.23, Latitude: 4.56},
+				Info: &models.DeviceInfo{
+					ID:         "device-info-id",
+					PrettyName: "My Device",
+					Version:    "1.0.0",
+					Arch:       "amd64",
+					Platform:   "linux",
+				},
+			},
+			check: func(t *testing.T, result *Device) {
+				assert.Equal(t, "device-uid-1", result.ID)
+				assert.Equal(t, "tenant-id-1", result.NamespaceID)
+				assert.Equal(t, "accepted", result.Status)
+				assert.Equal(t, "my-device", result.Name)
+				assert.Equal(t, "ssh-rsa AAAA...", result.PublicKey)
+				assert.Equal(t, disconnectedAt, result.DisconnectedAt)
+				assert.Equal(t, "00:11:22:33:44:55", result.MAC)
+				assert.InDelta(t, 1.23, result.Longitude, 0.001)
+				assert.InDelta(t, 4.56, result.Latitude, 0.001)
+				assert.Equal(t, "device-info-id", result.Identifier)
+				assert.Equal(t, "My Device", result.PrettyName)
+				assert.Equal(t, "1.0.0", result.Version)
+				assert.Equal(t, "amd64", result.Arch)
+				assert.Equal(t, "linux", result.Platform)
+				assert.Equal(t, now, result.CreatedAt)
+				assert.Equal(t, now, result.LastSeen)
+				assert.True(t, result.UpdatedAt.IsZero())
+			},
+		},
+		{
+			name: "empty Status defaults to pending",
+			model: &models.Device{
+				UID:    "device-uid-2",
+				Status: "",
+			},
+			check: func(t *testing.T, result *Device) {
+				assert.Equal(t, "pending", result.Status)
+			},
+		},
+		{
+			name: "nil Identity, Position, Info, DisconnectedAt",
+			model: &models.Device{
+				UID:            "device-uid-3",
+				Status:         models.DeviceStatusPending,
+				Identity:       nil,
+				Position:       nil,
+				Info:           nil,
+				DisconnectedAt: nil,
+			},
+			check: func(t *testing.T, result *Device) {
+				assert.Equal(t, "", result.MAC)
+				assert.InDelta(t, 0.0, result.Longitude, 0.001)
+				assert.InDelta(t, 0.0, result.Latitude, 0.001)
+				assert.Equal(t, "", result.Identifier)
+				assert.Equal(t, "", result.PrettyName)
+				assert.True(t, result.DisconnectedAt.IsZero())
+			},
+		},
+		{
+			name: "Tags from model.Tags (full)",
+			model: &models.Device{
+				UID:    "device-uid-4",
+				Status: models.DeviceStatusAccepted,
+				Taggable: models.Taggable{
+					Tags: []models.Tag{
+						{ID: "tag-1", Name: "prod", TenantID: "t1"},
+						{ID: "tag-2", Name: "staging", TenantID: "t1"},
+					},
+				},
+			},
+			check: func(t *testing.T, result *Device) {
+				require.Len(t, result.Tags, 2)
+				assert.Equal(t, "tag-1", result.Tags[0].ID)
+				assert.Equal(t, "prod", result.Tags[0].Name)
+				assert.Equal(t, "tag-2", result.Tags[1].ID)
+			},
+		},
+		{
+			name: "Tags from model.TagIDs (IDs only)",
+			model: &models.Device{
+				UID:    "device-uid-5",
+				Status: models.DeviceStatusAccepted,
+				Taggable: models.Taggable{
+					TagIDs: []string{"tag-1", "tag-2"},
+				},
+			},
+			check: func(t *testing.T, result *Device) {
+				require.Len(t, result.Tags, 2)
+				assert.Equal(t, "tag-1", result.Tags[0].ID)
+				assert.Equal(t, "tag-2", result.Tags[1].ID)
+				// Only ID is set when using TagIDs
+				assert.Equal(t, "", result.Tags[0].Name)
+			},
+		},
+		{
+			name: "no tags",
+			model: &models.Device{
+				UID:    "device-uid-6",
+				Status: models.DeviceStatusAccepted,
+			},
+			check: func(t *testing.T, result *Device) {
+				assert.Empty(t, result.Tags)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DeviceFromModel(tt.model)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestDeviceToModel(t *testing.T) {
+	now := time.Now()
+	disconnectedAt := now.Add(-time.Hour)
+
+	tests := []struct {
+		name   string
+		entity *Device
+		check  func(t *testing.T, result *models.Device)
+	}{
+		{
+			name: "full fields with Namespace loaded",
+			entity: &Device{
+				ID:             "device-uid-1",
+				NamespaceID:    "tenant-id-1",
+				CreatedAt:      now,
+				LastSeen:       now,
+				Status:         "accepted",
+				Name:           "my-device",
+				PublicKey:      "ssh-rsa AAAA...",
+				Online:         true,
+				Acceptable:     false,
+				DisconnectedAt: disconnectedAt,
+				MAC:            "00:11:22:33:44:55",
+				Longitude:      1.23,
+				Latitude:       4.56,
+				Identifier:     "info-id",
+				PrettyName:     "My Device",
+				Version:        "1.0.0",
+				Arch:           "amd64",
+				Platform:       "linux",
+				Namespace:      &Namespace{Name: "my-namespace"},
+				Tags: []*Tag{
+					{ID: "tag-1", NamespaceID: "t1", Name: "prod"},
+				},
+			},
+			check: func(t *testing.T, result *models.Device) {
+				assert.Equal(t, "device-uid-1", result.UID)
+				assert.Equal(t, "tenant-id-1", result.TenantID)
+				assert.Equal(t, models.DeviceStatusAccepted, result.Status)
+				assert.Equal(t, "my-device", result.Name)
+				assert.Equal(t, "ssh-rsa AAAA...", result.PublicKey)
+				assert.Equal(t, now, result.CreatedAt)
+				assert.Equal(t, now, result.LastSeen)
+				assert.Equal(t, "my-namespace", result.Namespace)
+				assert.True(t, result.Online)
+				assert.False(t, result.Acceptable)
+				require.NotNil(t, result.DisconnectedAt)
+				assert.Equal(t, disconnectedAt, *result.DisconnectedAt)
+				require.NotNil(t, result.Position)
+				assert.InDelta(t, 1.23, result.Position.Longitude, 0.001)
+				assert.InDelta(t, 4.56, result.Position.Latitude, 0.001)
+				require.NotNil(t, result.Info)
+				assert.Equal(t, "info-id", result.Info.ID)
+				assert.Equal(t, "My Device", result.Info.PrettyName)
+				assert.Equal(t, "1.0.0", result.Info.Version)
+				assert.Equal(t, "amd64", result.Info.Arch)
+				assert.Equal(t, "linux", result.Info.Platform)
+				require.NotNil(t, result.Identity)
+				assert.Equal(t, "00:11:22:33:44:55", result.Identity.MAC)
+				require.Len(t, result.Tags, 1)
+				assert.Equal(t, "tag-1", result.Tags[0].ID)
+				require.Len(t, result.TagIDs, 1)
+				assert.Equal(t, "tag-1", result.TagIDs[0])
+			},
+		},
+		{
+			name: "nil Namespace regression - must not panic",
+			entity: &Device{
+				ID:        "device-uid-2",
+				Status:    "pending",
+				Namespace: nil,
+			},
+			check: func(t *testing.T, result *models.Device) {
+				assert.Equal(t, "", result.Namespace)
+			},
+		},
+		{
+			name: "zero DisconnectedAt",
+			entity: &Device{
+				ID:             "device-uid-3",
+				Status:         "accepted",
+				DisconnectedAt: time.Time{},
+			},
+			check: func(t *testing.T, result *models.Device) {
+				assert.Nil(t, result.DisconnectedAt)
+			},
+		},
+		{
+			name: "non-zero DisconnectedAt",
+			entity: &Device{
+				ID:             "device-uid-4",
+				Status:         "accepted",
+				DisconnectedAt: disconnectedAt,
+			},
+			check: func(t *testing.T, result *models.Device) {
+				require.NotNil(t, result.DisconnectedAt)
+				assert.Equal(t, disconnectedAt, *result.DisconnectedAt)
+			},
+		},
+		{
+			name: "without Tags",
+			entity: &Device{
+				ID:     "device-uid-5",
+				Status: "accepted",
+				Tags:   []*Tag{},
+			},
+			check: func(t *testing.T, result *models.Device) {
+				assert.Empty(t, result.Tags)
+				assert.Nil(t, result.TagIDs)
+			},
+		},
+		{
+			name: "nil Tags",
+			entity: &Device{
+				ID:     "device-uid-6",
+				Status: "accepted",
+				Tags:   nil,
+			},
+			check: func(t *testing.T, result *models.Device) {
+				assert.Empty(t, result.Tags)
+				assert.Nil(t, result.TagIDs)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DeviceToModel(tt.entity)
+			tt.check(t, result)
+		})
+	}
+}

--- a/api/store/pg/entity/membership-invitation_test.go
+++ b/api/store/pg/entity/membership-invitation_test.go
@@ -1,0 +1,250 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMembershipInvitationFromModel(t *testing.T) {
+	now := time.Now()
+	expiresAt := now.Add(24 * time.Hour)
+
+	tests := []struct {
+		name     string
+		model    *models.MembershipInvitation
+		expected *MembershipInvitation
+	}{
+		{
+			name: "full fields",
+			model: &models.MembershipInvitation{
+				ID:              "inv-id-1",
+				TenantID:        "tenant-id-1",
+				UserID:          "user-id-1",
+				InvitedBy:       "admin-id-1",
+				Role:            authorizer.RoleOperator,
+				Status:          models.MembershipInvitationStatusAccepted,
+				StatusUpdatedAt: now,
+				ExpiresAt:       &expiresAt,
+				Invitations:     3,
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			},
+			expected: &MembershipInvitation{
+				ID:              "inv-id-1",
+				TenantID:        "tenant-id-1",
+				UserID:          "user-id-1",
+				InvitedBy:       "admin-id-1",
+				Role:            "operator",
+				Status:          "accepted",
+				StatusUpdatedAt: now,
+				ExpiresAt:       &expiresAt,
+				Invitations:     3,
+				CreatedAt:       now,
+				UpdatedAt:       now,
+			},
+		},
+		{
+			name: "empty Role defaults to observer",
+			model: &models.MembershipInvitation{
+				ID:       "inv-id-2",
+				TenantID: "tenant-id-2",
+				UserID:   "user-id-2",
+				Role:     "",
+				Status:   models.MembershipInvitationStatusPending,
+			},
+			expected: &MembershipInvitation{
+				ID:       "inv-id-2",
+				TenantID: "tenant-id-2",
+				UserID:   "user-id-2",
+				Role:     "observer",
+				Status:   "pending",
+			},
+		},
+		{
+			name: "empty Status defaults to pending",
+			model: &models.MembershipInvitation{
+				ID:       "inv-id-3",
+				TenantID: "tenant-id-3",
+				UserID:   "user-id-3",
+				Role:     authorizer.RoleAdministrator,
+				Status:   "",
+			},
+			expected: &MembershipInvitation{
+				ID:       "inv-id-3",
+				TenantID: "tenant-id-3",
+				UserID:   "user-id-3",
+				Role:     "administrator",
+				Status:   "pending",
+			},
+		},
+		{
+			name: "nil ExpiresAt",
+			model: &models.MembershipInvitation{
+				ID:        "inv-id-4",
+				TenantID:  "tenant-id-4",
+				UserID:    "user-id-4",
+				Role:      authorizer.RoleObserver,
+				Status:    models.MembershipInvitationStatusPending,
+				ExpiresAt: nil,
+			},
+			expected: &MembershipInvitation{
+				ID:        "inv-id-4",
+				TenantID:  "tenant-id-4",
+				UserID:    "user-id-4",
+				Role:      "observer",
+				Status:    "pending",
+				ExpiresAt: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MembershipInvitationFromModel(tt.model)
+			assert.Equal(t, tt.expected.ID, result.ID)
+			assert.Equal(t, tt.expected.TenantID, result.TenantID)
+			assert.Equal(t, tt.expected.UserID, result.UserID)
+			assert.Equal(t, tt.expected.InvitedBy, result.InvitedBy)
+			assert.Equal(t, tt.expected.Role, result.Role)
+			assert.Equal(t, tt.expected.Status, result.Status)
+			assert.Equal(t, tt.expected.ExpiresAt, result.ExpiresAt)
+			assert.Equal(t, tt.expected.Invitations, result.Invitations)
+			assert.Equal(t, tt.expected.StatusUpdatedAt, result.StatusUpdatedAt)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.Equal(t, tt.expected.UpdatedAt, result.UpdatedAt)
+		})
+	}
+}
+
+func TestMembershipInvitationToModel(t *testing.T) {
+	now := time.Now()
+	expiresAt := now.Add(24 * time.Hour)
+
+	tests := []struct {
+		name     string
+		entity   *MembershipInvitation
+		expected *models.MembershipInvitation
+	}{
+		{
+			name: "Namespace and User loaded",
+			entity: &MembershipInvitation{
+				ID:              "inv-id-1",
+				TenantID:        "tenant-id-1",
+				UserID:          "user-id-1",
+				InvitedBy:       "admin-id-1",
+				Role:            "administrator",
+				Status:          "accepted",
+				StatusUpdatedAt: now,
+				ExpiresAt:       &expiresAt,
+				Invitations:     2,
+				CreatedAt:       now,
+				UpdatedAt:       now,
+				Namespace:       &Namespace{Name: "my-namespace"},
+				User:            &User{Email: "user@example.com"},
+			},
+			expected: &models.MembershipInvitation{
+				ID:              "inv-id-1",
+				TenantID:        "tenant-id-1",
+				UserID:          "user-id-1",
+				InvitedBy:       "admin-id-1",
+				Role:            authorizer.RoleAdministrator,
+				Status:          models.MembershipInvitationStatusAccepted,
+				StatusUpdatedAt: now,
+				ExpiresAt:       &expiresAt,
+				Invitations:     2,
+				CreatedAt:       now,
+				UpdatedAt:       now,
+				NamespaceName:   "my-namespace",
+				UserEmail:       "user@example.com",
+			},
+		},
+		{
+			name: "nil Namespace",
+			entity: &MembershipInvitation{
+				ID:        "inv-id-2",
+				TenantID:  "tenant-id-2",
+				UserID:    "user-id-2",
+				Role:      "observer",
+				Status:    "pending",
+				Namespace: nil,
+				User:      &User{Email: "user2@example.com"},
+			},
+			expected: &models.MembershipInvitation{
+				ID:            "inv-id-2",
+				TenantID:      "tenant-id-2",
+				UserID:        "user-id-2",
+				Role:          authorizer.RoleObserver,
+				Status:        models.MembershipInvitationStatusPending,
+				NamespaceName: "",
+				UserEmail:     "user2@example.com",
+			},
+		},
+		{
+			name: "nil User with UserInvitation fallback",
+			entity: &MembershipInvitation{
+				ID:             "inv-id-3",
+				TenantID:       "tenant-id-3",
+				UserID:         "user-id-3",
+				Role:           "operator",
+				Status:         "pending",
+				Namespace:      &Namespace{Name: "test-ns"},
+				User:           nil,
+				UserInvitation: &UserInvitation{Email: "invited@example.com"},
+			},
+			expected: &models.MembershipInvitation{
+				ID:            "inv-id-3",
+				TenantID:      "tenant-id-3",
+				UserID:        "user-id-3",
+				Role:          authorizer.RoleOperator,
+				Status:        models.MembershipInvitationStatusPending,
+				NamespaceName: "test-ns",
+				UserEmail:     "invited@example.com",
+			},
+		},
+		{
+			name: "nil Namespace and nil User and nil UserInvitation",
+			entity: &MembershipInvitation{
+				ID:             "inv-id-4",
+				TenantID:       "tenant-id-4",
+				UserID:         "user-id-4",
+				Role:           "observer",
+				Status:         "pending",
+				Namespace:      nil,
+				User:           nil,
+				UserInvitation: nil,
+			},
+			expected: &models.MembershipInvitation{
+				ID:            "inv-id-4",
+				TenantID:      "tenant-id-4",
+				UserID:        "user-id-4",
+				Role:          authorizer.RoleObserver,
+				Status:        models.MembershipInvitationStatusPending,
+				NamespaceName: "",
+				UserEmail:     "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MembershipInvitationToModel(tt.entity)
+			assert.Equal(t, tt.expected.ID, result.ID)
+			assert.Equal(t, tt.expected.TenantID, result.TenantID)
+			assert.Equal(t, tt.expected.UserID, result.UserID)
+			assert.Equal(t, tt.expected.InvitedBy, result.InvitedBy)
+			assert.Equal(t, tt.expected.Role, result.Role)
+			assert.Equal(t, tt.expected.Status, result.Status)
+			assert.Equal(t, tt.expected.ExpiresAt, result.ExpiresAt)
+			assert.Equal(t, tt.expected.Invitations, result.Invitations)
+			assert.Equal(t, tt.expected.NamespaceName, result.NamespaceName)
+			assert.Equal(t, tt.expected.UserEmail, result.UserEmail)
+			assert.Equal(t, tt.expected.StatusUpdatedAt, result.StatusUpdatedAt)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.Equal(t, tt.expected.UpdatedAt, result.UpdatedAt)
+		})
+	}
+}

--- a/api/store/pg/entity/membership_test.go
+++ b/api/store/pg/entity/membership_test.go
@@ -1,0 +1,115 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMembershipFromModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name        string
+		namespaceID string
+		member      *models.Member
+		expected    *Membership
+	}{
+		{
+			name:        "full fields",
+			namespaceID: "ns-id-1",
+			member: &models.Member{
+				ID:      "user-id-1",
+				AddedAt: now,
+				Role:    authorizer.RoleAdministrator,
+			},
+			expected: &Membership{
+				UserID:      "user-id-1",
+				NamespaceID: "ns-id-1",
+				CreatedAt:   now,
+				UpdatedAt:   time.Time{},
+				Role:        "administrator",
+			},
+		},
+		{
+			name:        "empty Role defaults to observer",
+			namespaceID: "ns-id-2",
+			member: &models.Member{
+				ID:      "user-id-2",
+				AddedAt: now,
+				Role:    "",
+			},
+			expected: &Membership{
+				UserID:      "user-id-2",
+				NamespaceID: "ns-id-2",
+				CreatedAt:   now,
+				UpdatedAt:   time.Time{},
+				Role:        "observer",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MembershipFromModel(tt.namespaceID, tt.member)
+			assert.Equal(t, tt.expected.UserID, result.UserID)
+			assert.Equal(t, tt.expected.NamespaceID, result.NamespaceID)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.True(t, result.UpdatedAt.IsZero(), "UpdatedAt should be zero")
+			assert.Equal(t, tt.expected.Role, result.Role)
+		})
+	}
+}
+
+func TestMembershipToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		entity   *Membership
+		expected *models.Member
+	}{
+		{
+			name: "with User loaded",
+			entity: &Membership{
+				UserID:    "user-id-1",
+				CreatedAt: now,
+				Role:      "administrator",
+				User: &User{
+					Email: "user@example.com",
+				},
+			},
+			expected: &models.Member{
+				ID:      "user-id-1",
+				AddedAt: now,
+				Role:    authorizer.RoleAdministrator,
+				Email:   "user@example.com",
+			},
+		},
+		{
+			name: "nil User",
+			entity: &Membership{
+				UserID:    "user-id-2",
+				CreatedAt: now,
+				Role:      "observer",
+				User:      nil,
+			},
+			expected: &models.Member{
+				ID:      "user-id-2",
+				AddedAt: now,
+				Role:    authorizer.RoleObserver,
+				Email:   "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MembershipToModel(tt.entity)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/api/store/pg/entity/namespace_test.go
+++ b/api/store/pg/entity/namespace_test.go
@@ -1,0 +1,267 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespaceFromModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		model    *models.Namespace
+		expected *Namespace
+	}{
+		{
+			name: "full fields with Settings and Members",
+			model: &models.Namespace{
+				TenantID: "ns-id-1",
+				Name:     "my-namespace",
+				Owner:    "owner-id-1",
+				Type:     models.TypeTeam,
+				Settings: &models.NamespaceSettings{
+					SessionRecord:          true,
+					ConnectionAnnouncement: "Welcome!",
+				},
+				Members: []models.Member{
+					{
+						ID:      "user-id-1",
+						AddedAt: now,
+						Role:    authorizer.RoleAdministrator,
+					},
+					{
+						ID:      "user-id-2",
+						AddedAt: now,
+						Role:    authorizer.RoleObserver,
+					},
+				},
+				MaxDevices:           10,
+				DevicesAcceptedCount: 5,
+				DevicesPendingCount:  2,
+				DevicesRejectedCount: 1,
+				DevicesRemovedCount:  3,
+				CreatedAt:            now,
+			},
+			expected: &Namespace{
+				ID:      "ns-id-1",
+				Name:    "my-namespace",
+				OwnerID: "owner-id-1",
+				Type:    "team",
+				Settings: NamespaceSettings{
+					MaxDevices:             10,
+					SessionRecord:          true,
+					ConnectionAnnouncement: "Welcome!",
+				},
+				Memberships: []Membership{
+					{
+						UserID:      "user-id-1",
+						NamespaceID: "ns-id-1",
+						CreatedAt:   now,
+						Role:        "administrator",
+					},
+					{
+						UserID:      "user-id-2",
+						NamespaceID: "ns-id-1",
+						CreatedAt:   now,
+						Role:        "observer",
+					},
+				},
+				DevicesAcceptedCount: 5,
+				DevicesPendingCount:  2,
+				DevicesRejectedCount: 1,
+				DevicesRemovedCount:  3,
+				CreatedAt:            now,
+			},
+		},
+		{
+			name: "empty Type defaults to personal",
+			model: &models.Namespace{
+				TenantID: "ns-id-2",
+				Name:     "personal-ns",
+				Owner:    "owner-id-2",
+				Type:     "",
+				Members:  []models.Member{},
+			},
+			expected: &Namespace{
+				ID:          "ns-id-2",
+				Name:        "personal-ns",
+				OwnerID:     "owner-id-2",
+				Type:        "personal",
+				Memberships: []Membership{},
+			},
+		},
+		{
+			name: "nil Settings with MaxDevices still set",
+			model: &models.Namespace{
+				TenantID:   "ns-id-3",
+				Name:       "no-settings",
+				Owner:      "owner-id-3",
+				Type:       models.TypePersonal,
+				Settings:   nil,
+				MaxDevices: 15,
+				Members:    []models.Member{},
+			},
+			expected: &Namespace{
+				ID:      "ns-id-3",
+				Name:    "no-settings",
+				OwnerID: "owner-id-3",
+				Type:    "personal",
+				Settings: NamespaceSettings{
+					MaxDevices: 15,
+				},
+				Memberships: []Membership{},
+			},
+		},
+		{
+			name: "empty Members",
+			model: &models.Namespace{
+				TenantID: "ns-id-4",
+				Name:     "empty-members",
+				Owner:    "owner-id-4",
+				Type:     models.TypeTeam,
+				Members:  []models.Member{},
+			},
+			expected: &Namespace{
+				ID:          "ns-id-4",
+				Name:        "empty-members",
+				OwnerID:     "owner-id-4",
+				Type:        "team",
+				Memberships: []Membership{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NamespaceFromModel(tt.model)
+			assert.Equal(t, tt.expected.ID, result.ID)
+			assert.Equal(t, tt.expected.Name, result.Name)
+			assert.Equal(t, tt.expected.OwnerID, result.OwnerID)
+			assert.Equal(t, tt.expected.Type, result.Type)
+			assert.Equal(t, tt.expected.Settings.MaxDevices, result.Settings.MaxDevices)
+			assert.Equal(t, tt.expected.Settings.SessionRecord, result.Settings.SessionRecord)
+			assert.Equal(t, tt.expected.Settings.ConnectionAnnouncement, result.Settings.ConnectionAnnouncement)
+			assert.Equal(t, tt.expected.DevicesAcceptedCount, result.DevicesAcceptedCount)
+			assert.Equal(t, tt.expected.DevicesPendingCount, result.DevicesPendingCount)
+			assert.Equal(t, tt.expected.DevicesRejectedCount, result.DevicesRejectedCount)
+			assert.Equal(t, tt.expected.DevicesRemovedCount, result.DevicesRemovedCount)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			require.Len(t, result.Memberships, len(tt.expected.Memberships))
+			for i, m := range tt.expected.Memberships {
+				assert.Equal(t, m.UserID, result.Memberships[i].UserID)
+				assert.Equal(t, m.NamespaceID, result.Memberships[i].NamespaceID)
+				assert.Equal(t, m.Role, result.Memberships[i].Role)
+				assert.Equal(t, m.CreatedAt, result.Memberships[i].CreatedAt)
+			}
+		})
+	}
+}
+
+func TestNamespaceToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		entity   *Namespace
+		expected *models.Namespace
+	}{
+		{
+			name: "full fields",
+			entity: &Namespace{
+				ID:      "ns-id-1",
+				Name:    "my-namespace",
+				OwnerID: "owner-id-1",
+				Type:    "team",
+				Settings: NamespaceSettings{
+					MaxDevices:             10,
+					SessionRecord:          true,
+					ConnectionAnnouncement: "Hello!",
+				},
+				Memberships: []Membership{
+					{
+						UserID:    "user-id-1",
+						CreatedAt: now,
+						Role:      "administrator",
+					},
+				},
+				DevicesAcceptedCount: 5,
+				DevicesPendingCount:  2,
+				DevicesRejectedCount: 1,
+				DevicesRemovedCount:  3,
+				CreatedAt:            now,
+			},
+			expected: &models.Namespace{
+				TenantID: "ns-id-1",
+				Name:     "my-namespace",
+				Owner:    "owner-id-1",
+				Type:     models.TypeTeam,
+				Settings: &models.NamespaceSettings{
+					SessionRecord:          true,
+					ConnectionAnnouncement: "Hello!",
+				},
+				MaxDevices: 10,
+				Members: []models.Member{
+					{
+						ID:      "user-id-1",
+						AddedAt: now,
+						Role:    authorizer.RoleAdministrator,
+					},
+				},
+				DevicesAcceptedCount: 5,
+				DevicesPendingCount:  2,
+				DevicesRejectedCount: 1,
+				DevicesRemovedCount:  3,
+				CreatedAt:            now,
+			},
+		},
+		{
+			name: "empty Memberships",
+			entity: &Namespace{
+				ID:          "ns-id-2",
+				Name:        "empty-ns",
+				OwnerID:     "owner-id-2",
+				Type:        "personal",
+				Memberships: []Membership{},
+			},
+			expected: &models.Namespace{
+				TenantID: "ns-id-2",
+				Name:     "empty-ns",
+				Owner:    "owner-id-2",
+				Type:     models.TypePersonal,
+				Settings: &models.NamespaceSettings{},
+				Members:  []models.Member{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NamespaceToModel(tt.entity)
+			assert.Equal(t, tt.expected.TenantID, result.TenantID)
+			assert.Equal(t, tt.expected.Name, result.Name)
+			assert.Equal(t, tt.expected.Owner, result.Owner)
+			assert.Equal(t, tt.expected.Type, result.Type)
+			assert.Equal(t, tt.expected.MaxDevices, result.MaxDevices)
+			require.NotNil(t, result.Settings, "Settings should never be nil")
+			assert.Equal(t, tt.expected.Settings.SessionRecord, result.Settings.SessionRecord)
+			assert.Equal(t, tt.expected.Settings.ConnectionAnnouncement, result.Settings.ConnectionAnnouncement)
+			assert.Equal(t, tt.expected.DevicesAcceptedCount, result.DevicesAcceptedCount)
+			assert.Equal(t, tt.expected.DevicesPendingCount, result.DevicesPendingCount)
+			assert.Equal(t, tt.expected.DevicesRejectedCount, result.DevicesRejectedCount)
+			assert.Equal(t, tt.expected.DevicesRemovedCount, result.DevicesRemovedCount)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			require.Len(t, result.Members, len(tt.expected.Members))
+			for i, m := range tt.expected.Members {
+				assert.Equal(t, m.ID, result.Members[i].ID)
+				assert.Equal(t, m.Role, result.Members[i].Role)
+				assert.Equal(t, m.AddedAt, result.Members[i].AddedAt)
+			}
+		})
+	}
+}

--- a/api/store/pg/entity/private-key_test.go
+++ b/api/store/pg/entity/private-key_test.go
@@ -1,0 +1,107 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrivateKeyFromModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		model    *models.PrivateKey
+		expected *PrivateKey
+	}{
+		{
+			name: "full fields",
+			model: &models.PrivateKey{
+				Fingerprint: "SHA256:abc123",
+				Data:        []byte("private-key-data"),
+				CreatedAt:   now,
+			},
+			expected: &PrivateKey{
+				Fingerprint: "SHA256:abc123",
+				Data:        []byte("private-key-data"),
+				CreatedAt:   now,
+				UpdatedAt:   time.Time{},
+			},
+		},
+		{
+			name: "nil Data",
+			model: &models.PrivateKey{
+				Fingerprint: "SHA256:def456",
+				Data:        nil,
+				CreatedAt:   now,
+			},
+			expected: &PrivateKey{
+				Fingerprint: "SHA256:def456",
+				Data:        nil,
+				CreatedAt:   now,
+				UpdatedAt:   time.Time{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PrivateKeyFromModel(tt.model)
+			assert.Equal(t, tt.expected.Fingerprint, result.Fingerprint)
+			assert.Equal(t, tt.expected.Data, result.Data)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.True(t, result.UpdatedAt.IsZero(), "UpdatedAt should be zero")
+		})
+	}
+}
+
+func TestPrivateKeyToModel(t *testing.T) {
+	// Use a non-UTC timezone to verify .UTC() conversion
+	loc := time.FixedZone("UTC+5", 5*60*60)
+	createdAt := time.Date(2024, 6, 15, 10, 30, 0, 0, loc)
+
+	tests := []struct {
+		name     string
+		entity   *PrivateKey
+		expected *models.PrivateKey
+	}{
+		{
+			name: "converts CreatedAt to UTC",
+			entity: &PrivateKey{
+				Fingerprint: "SHA256:abc123",
+				Data:        []byte("key-data"),
+				CreatedAt:   createdAt,
+			},
+			expected: &models.PrivateKey{
+				Fingerprint: "SHA256:abc123",
+				Data:        []byte("key-data"),
+				CreatedAt:   createdAt.UTC(),
+			},
+		},
+		{
+			name: "already UTC",
+			entity: &PrivateKey{
+				Fingerprint: "SHA256:def456",
+				Data:        []byte("other-key"),
+				CreatedAt:   time.Date(2024, 6, 15, 5, 30, 0, 0, time.UTC),
+			},
+			expected: &models.PrivateKey{
+				Fingerprint: "SHA256:def456",
+				Data:        []byte("other-key"),
+				CreatedAt:   time.Date(2024, 6, 15, 5, 30, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PrivateKeyToModel(tt.entity)
+			assert.Equal(t, tt.expected.Fingerprint, result.Fingerprint)
+			assert.Equal(t, tt.expected.Data, result.Data)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.Equal(t, time.UTC, result.CreatedAt.Location())
+		})
+	}
+}

--- a/api/store/pg/entity/public-key_test.go
+++ b/api/store/pg/entity/public-key_test.go
@@ -1,0 +1,172 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicKeyFromModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name  string
+		model *models.PublicKey
+		check func(t *testing.T, result *PublicKey)
+	}{
+		{
+			name: "full fields with Tags",
+			model: &models.PublicKey{
+				TenantID:    "tenant-id-1",
+				Fingerprint: "SHA256:abc123",
+				Data:        []byte("ssh-rsa AAAA..."),
+				CreatedAt:   now,
+				PublicKeyFields: models.PublicKeyFields{
+					Name: "my-key",
+					Filter: models.PublicKeyFilter{
+						Hostname: "*.example.com",
+						Taggable: models.Taggable{
+							Tags: []models.Tag{
+								{ID: "tag-1", Name: "prod", TenantID: "t1"},
+								{ID: "tag-2", Name: "staging", TenantID: "t1"},
+							},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, result *PublicKey) {
+				assert.Equal(t, "tenant-id-1", result.NamespaceID)
+				assert.Equal(t, "SHA256:abc123", result.Fingerprint)
+				assert.Equal(t, []byte("ssh-rsa AAAA..."), result.Data)
+				assert.Equal(t, "my-key", result.Name)
+				assert.Equal(t, "*.example.com", result.FilterHostname)
+				assert.Equal(t, now, result.CreatedAt)
+				require.Len(t, result.Tags, 2)
+				assert.Equal(t, "tag-1", result.Tags[0].ID)
+				assert.Equal(t, "prod", result.Tags[0].Name)
+				assert.True(t, result.UpdatedAt.IsZero())
+			},
+		},
+		{
+			name: "Tags from TagIDs",
+			model: &models.PublicKey{
+				Fingerprint: "SHA256:def456",
+				PublicKeyFields: models.PublicKeyFields{
+					Name: "id-key",
+					Filter: models.PublicKeyFilter{
+						Hostname: "host",
+						Taggable: models.Taggable{
+							TagIDs: []string{"tag-1", "tag-2"},
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, result *PublicKey) {
+				require.Len(t, result.Tags, 2)
+				assert.Equal(t, "tag-1", result.Tags[0].ID)
+				assert.Equal(t, "", result.Tags[0].Name)
+			},
+		},
+		{
+			name: "no tags",
+			model: &models.PublicKey{
+				Fingerprint: "SHA256:ghi789",
+				PublicKeyFields: models.PublicKeyFields{
+					Name: "no-tag-key",
+					Filter: models.PublicKeyFilter{
+						Hostname: "host",
+					},
+				},
+			},
+			check: func(t *testing.T, result *PublicKey) {
+				assert.Empty(t, result.Tags)
+			},
+		},
+		{
+			name: "Data as []byte",
+			model: &models.PublicKey{
+				Fingerprint: "SHA256:jkl012",
+				Data:        []byte{0x00, 0x01, 0x02},
+				PublicKeyFields: models.PublicKeyFields{
+					Name:   "binary-key",
+					Filter: models.PublicKeyFilter{},
+				},
+			},
+			check: func(t *testing.T, result *PublicKey) {
+				assert.Equal(t, []byte{0x00, 0x01, 0x02}, result.Data)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PublicKeyFromModel(tt.model)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestPublicKeyToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		entity *PublicKey
+		check  func(t *testing.T, result *models.PublicKey)
+	}{
+		{
+			name: "full fields with Tags",
+			entity: &PublicKey{
+				NamespaceID:    "tenant-id-1",
+				Fingerprint:    "SHA256:abc123",
+				Data:           []byte("ssh-rsa AAAA..."),
+				CreatedAt:      now,
+				Name:           "my-key",
+				FilterHostname: "*.example.com",
+				Tags: []*Tag{
+					{ID: "tag-1", NamespaceID: "t1", Name: "prod"},
+					{ID: "tag-2", NamespaceID: "t1", Name: "staging"},
+				},
+			},
+			check: func(t *testing.T, result *models.PublicKey) {
+				assert.Equal(t, "tenant-id-1", result.TenantID)
+				assert.Equal(t, "SHA256:abc123", result.Fingerprint)
+				assert.Equal(t, []byte("ssh-rsa AAAA..."), result.Data)
+				assert.Equal(t, now, result.CreatedAt)
+				assert.Equal(t, "my-key", result.PublicKeyFields.Name)
+				assert.Equal(t, "", result.PublicKeyFields.Username)
+				assert.Equal(t, "*.example.com", result.Filter.Hostname)
+				require.Len(t, result.Filter.Tags, 2)
+				assert.Equal(t, "tag-1", result.Filter.Tags[0].ID)
+				require.Len(t, result.Filter.TagIDs, 2)
+				assert.Equal(t, "tag-1", result.Filter.TagIDs[0])
+			},
+		},
+		{
+			name: "no Tags",
+			entity: &PublicKey{
+				NamespaceID:    "tenant-id-2",
+				Fingerprint:    "SHA256:def456",
+				Name:           "empty-key",
+				FilterHostname: "host",
+				Tags:           []*Tag{},
+			},
+			check: func(t *testing.T, result *models.PublicKey) {
+				assert.Empty(t, result.Filter.Tags)
+				assert.Nil(t, result.Filter.TagIDs)
+				assert.Equal(t, "host", result.Filter.Hostname)
+				assert.Equal(t, "empty-key", result.PublicKeyFields.Name)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PublicKeyToModel(tt.entity)
+			tt.check(t, result)
+		})
+	}
+}

--- a/api/store/pg/entity/session.go
+++ b/api/store/pg/entity/session.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/uptrace/bun"
 )
@@ -45,6 +46,8 @@ func SessionFromModel(model *models.Session) *Session {
 		sessionType = "shell"
 	}
 
+	now := clock.Now()
+
 	session := &Session{
 		ID:            model.UID,
 		DeviceID:      string(model.DeviceUID),
@@ -59,8 +62,8 @@ func SessionFromModel(model *models.Session) *Session {
 		Term:          model.Term,
 		Longitude:     model.Position.Longitude,
 		Latitude:      model.Position.Latitude,
-		CreatedAt:     time.Now(),
-		UpdatedAt:     time.Now(),
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	}
 
 	return session
@@ -112,7 +115,7 @@ func ActiveSessionFromModel(model *models.ActiveSession) *ActiveSession {
 	return &ActiveSession{
 		SessionID: string(model.UID),
 		SeenAt:    model.LastSeen,
-		CreatedAt: time.Now(),
+		CreatedAt: clock.Now(),
 	}
 }
 

--- a/api/store/pg/entity/session_test.go
+++ b/api/store/pg/entity/session_test.go
@@ -1,0 +1,471 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/clock"
+	clockmock "github.com/shellhub-io/shellhub/pkg/clock/mocks"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionFromModel(t *testing.T) {
+	now := time.Now()
+
+	clockMock := clockmock.NewClock(t)
+	oldClock := clock.DefaultBackend
+	clock.DefaultBackend = clockMock
+	t.Cleanup(func() { clock.DefaultBackend = oldClock })
+
+	tests := []struct {
+		name  string
+		model *models.Session
+		check func(t *testing.T, result *Session)
+	}{
+		{
+			name: "full fields",
+			model: &models.Session{
+				UID:           "session-uid-1",
+				DeviceUID:     "device-uid-1",
+				Username:      "root",
+				IPAddress:     "192.168.1.1",
+				StartedAt:     now,
+				LastSeen:      now,
+				Closed:        false,
+				Authenticated: true,
+				Recorded:      true,
+				Type:          "shell",
+				Term:          "xterm-256color",
+				Position: models.SessionPosition{
+					Longitude: 1.23,
+					Latitude:  4.56,
+				},
+			},
+			check: func(t *testing.T, result *Session) {
+				assert.Equal(t, "session-uid-1", result.ID)
+				assert.Equal(t, "device-uid-1", result.DeviceID)
+				assert.Equal(t, "root", result.Username)
+				assert.Equal(t, "192.168.1.1", result.IPAddress)
+				assert.Equal(t, now, result.StartedAt)
+				assert.Equal(t, now, result.SeenAt)
+				assert.False(t, result.Closed)
+				assert.True(t, result.Authenticated)
+				assert.True(t, result.Recorded)
+				assert.Equal(t, "shell", result.Type)
+				assert.Equal(t, "xterm-256color", result.Term)
+				assert.InDelta(t, 1.23, result.Longitude, 0.001)
+				assert.InDelta(t, 4.56, result.Latitude, 0.001)
+				assert.Equal(t, now, result.CreatedAt)
+				assert.Equal(t, now, result.UpdatedAt)
+			},
+		},
+		{
+			name: "empty Type defaults to shell",
+			model: &models.Session{
+				UID:  "session-uid-2",
+				Type: "",
+			},
+			check: func(t *testing.T, result *Session) {
+				assert.Equal(t, "shell", result.Type)
+				assert.InDelta(t, 0.0, result.Longitude, 0.001)
+				assert.InDelta(t, 0.0, result.Latitude, 0.001)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clockMock.On("Now").Return(now).Once()
+			result := SessionFromModel(tt.model)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestSessionToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		entity *Session
+		check  func(t *testing.T, result *models.Session)
+	}{
+		{
+			name: "full fields with Device",
+			entity: &Session{
+				ID:            "session-uid-1",
+				DeviceID:      "device-uid-1",
+				Username:      "root",
+				IPAddress:     "192.168.1.1",
+				StartedAt:     now,
+				SeenAt:        now,
+				Active:        true,
+				Closed:        false,
+				Authenticated: true,
+				Recorded:      true,
+				Type:          "shell",
+				Term:          "xterm",
+				Longitude:     1.23,
+				Latitude:      4.56,
+				EventTypes:    "pty-output,window-change",
+				EventSeats:    "0,1",
+				Device: &Device{
+					ID:          "device-uid-1",
+					NamespaceID: "ns-id-1",
+					Status:      "accepted",
+				},
+			},
+			check: func(t *testing.T, result *models.Session) {
+				assert.Equal(t, "session-uid-1", result.UID)
+				assert.Equal(t, models.UID("device-uid-1"), result.DeviceUID)
+				assert.Equal(t, "root", result.Username)
+				assert.Equal(t, "192.168.1.1", result.IPAddress)
+				assert.Equal(t, now, result.StartedAt)
+				assert.Equal(t, now, result.LastSeen)
+				assert.True(t, result.Active)
+				assert.False(t, result.Closed)
+				assert.True(t, result.Authenticated)
+				assert.True(t, result.Recorded)
+				assert.Equal(t, "shell", result.Type)
+				assert.Equal(t, "xterm", result.Term)
+				assert.InDelta(t, 1.23, result.Position.Longitude, 0.001)
+				assert.InDelta(t, 4.56, result.Position.Latitude, 0.001)
+				assert.Equal(t, []string{"pty-output", "window-change"}, result.Events.Types)
+				assert.Equal(t, []int{0, 1}, result.Events.Seats)
+				assert.NotNil(t, result.Device)
+				assert.Equal(t, "ns-id-1", result.TenantID)
+			},
+		},
+		{
+			name: "nil Device",
+			entity: &Session{
+				ID:       "session-uid-2",
+				DeviceID: "device-uid-2",
+				Type:     "exec",
+				Device:   nil,
+			},
+			check: func(t *testing.T, result *models.Session) {
+				assert.Nil(t, result.Device)
+				assert.Equal(t, "", result.TenantID)
+			},
+		},
+		{
+			name: "whitespace trimming on ID",
+			entity: &Session{
+				ID:       "  session-uid-3  ",
+				DeviceID: "  device-uid-3  ",
+				Type:     "shell",
+			},
+			check: func(t *testing.T, result *models.Session) {
+				assert.Equal(t, "session-uid-3", result.UID)
+				assert.Equal(t, models.UID("device-uid-3"), result.DeviceUID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SessionToModel(tt.entity)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestActiveSessionFromModel(t *testing.T) {
+	now := time.Now()
+
+	clockMock := clockmock.NewClock(t)
+	oldClock := clock.DefaultBackend
+	clock.DefaultBackend = clockMock
+	t.Cleanup(func() { clock.DefaultBackend = oldClock })
+
+	tests := []struct {
+		name  string
+		model *models.ActiveSession
+		check func(t *testing.T, result *ActiveSession)
+	}{
+		{
+			name: "full fields",
+			model: &models.ActiveSession{
+				UID:      "active-session-1",
+				LastSeen: now,
+			},
+			check: func(t *testing.T, result *ActiveSession) {
+				assert.Equal(t, "active-session-1", result.SessionID)
+				assert.Equal(t, now, result.SeenAt)
+				assert.Equal(t, now, result.CreatedAt)
+			},
+		},
+		{
+			name: "zero-value LastSeen",
+			model: &models.ActiveSession{
+				UID: "active-session-2",
+			},
+			check: func(t *testing.T, result *ActiveSession) {
+				assert.Equal(t, "active-session-2", result.SessionID)
+				assert.True(t, result.SeenAt.IsZero())
+				assert.Equal(t, now, result.CreatedAt)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clockMock.On("Now").Return(now).Once()
+			result := ActiveSessionFromModel(tt.model)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestActiveSessionToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		entity *ActiveSession
+		check  func(t *testing.T, result *models.ActiveSession)
+	}{
+		{
+			name: "with Session and Device loaded",
+			entity: &ActiveSession{
+				SessionID: "active-session-1",
+				SeenAt:    now,
+				Session: &Session{
+					Device: &Device{
+						NamespaceID: "ns-id-1",
+					},
+				},
+			},
+			check: func(t *testing.T, result *models.ActiveSession) {
+				assert.Equal(t, models.UID("active-session-1"), result.UID)
+				assert.Equal(t, now, result.LastSeen)
+				assert.Equal(t, "ns-id-1", result.TenantID)
+			},
+		},
+		{
+			name: "nil Session",
+			entity: &ActiveSession{
+				SessionID: "active-session-2",
+				SeenAt:    now,
+				Session:   nil,
+			},
+			check: func(t *testing.T, result *models.ActiveSession) {
+				assert.Equal(t, models.UID("active-session-2"), result.UID)
+				assert.Equal(t, "", result.TenantID)
+			},
+		},
+		{
+			name: "Session with nil Device",
+			entity: &ActiveSession{
+				SessionID: "active-session-3",
+				SeenAt:    now,
+				Session: &Session{
+					Device: nil,
+				},
+			},
+			check: func(t *testing.T, result *models.ActiveSession) {
+				assert.Equal(t, models.UID("active-session-3"), result.UID)
+				assert.Equal(t, "", result.TenantID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ActiveSessionToModel(tt.entity)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestSessionEventFromModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name  string
+		model *models.SessionEvent
+		check func(t *testing.T, result *SessionEvent)
+	}{
+		{
+			name: "full fields with Data",
+			model: &models.SessionEvent{
+				Session:   "session-1",
+				Type:      models.SessionEventTypePtyOutput,
+				Timestamp: now,
+				Seat:      0,
+				Data:      map[string]interface{}{"output": "hello"},
+			},
+			check: func(t *testing.T, result *SessionEvent) {
+				assert.Equal(t, "session-1", result.SessionID)
+				assert.Equal(t, "pty-output", result.Type)
+				assert.Equal(t, now, result.CreatedAt)
+				assert.Equal(t, 0, result.Seat)
+				assert.Equal(t, `{"output":"hello"}`, result.Data)
+			},
+		},
+		{
+			name: "nil Data",
+			model: &models.SessionEvent{
+				Session:   "session-2",
+				Type:      models.SessionEventTypeShell,
+				Timestamp: now,
+				Seat:      1,
+				Data:      nil,
+			},
+			check: func(t *testing.T, result *SessionEvent) {
+				assert.Equal(t, "session-2", result.SessionID)
+				assert.Equal(t, "shell", result.Type)
+				assert.Equal(t, "", result.Data)
+				assert.Equal(t, 1, result.Seat)
+				assert.Equal(t, now, result.CreatedAt)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SessionEventFromModel(tt.model)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestSessionEventToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		entity *SessionEvent
+		check  func(t *testing.T, result *models.SessionEvent)
+	}{
+		{
+			name: "full fields with Data string",
+			entity: &SessionEvent{
+				SessionID: "session-1",
+				Type:      "pty-output",
+				CreatedAt: now,
+				Seat:      0,
+				Data:      `{"output":"hello"}`,
+			},
+			check: func(t *testing.T, result *models.SessionEvent) {
+				assert.Equal(t, "session-1", result.Session)
+				assert.Equal(t, models.SessionEventTypePtyOutput, result.Type)
+				assert.Equal(t, now, result.Timestamp)
+				assert.Equal(t, 0, result.Seat)
+				require.NotNil(t, result.Data)
+				assert.Equal(t, map[string]interface{}{"output": "hello"}, result.Data)
+			},
+		},
+		{
+			name: "empty Data",
+			entity: &SessionEvent{
+				SessionID: "session-2",
+				Type:      "shell",
+				CreatedAt: now,
+				Data:      "",
+			},
+			check: func(t *testing.T, result *models.SessionEvent) {
+				assert.Nil(t, result.Data)
+			},
+		},
+		{
+			name: "invalid JSON",
+			entity: &SessionEvent{
+				SessionID: "session-3",
+				Type:      "exec",
+				CreatedAt: now,
+				Data:      "not-json{",
+			},
+			check: func(t *testing.T, result *models.SessionEvent) {
+				assert.Nil(t, result.Data)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SessionEventToModel(tt.entity)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestParseEventTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "single",
+			input:    "pty-output",
+			expected: []string{"pty-output"},
+		},
+		{
+			name:     "multiple",
+			input:    "pty-output,window-change,shell",
+			expected: []string{"pty-output", "window-change", "shell"},
+		},
+		{
+			name:     "trailing commas",
+			input:    "pty-output,window-change,",
+			expected: []string{"pty-output", "window-change"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseEventTypes(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseEventSeats(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []int
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: []int{},
+		},
+		{
+			name:     "single",
+			input:    "0",
+			expected: []int{0},
+		},
+		{
+			name:     "multiple",
+			input:    "0,1,2",
+			expected: []int{0, 1, 2},
+		},
+		{
+			name:     "invalid number skipped",
+			input:    "0,abc,2",
+			expected: []int{0, 2},
+		},
+		{
+			name:     "trailing commas",
+			input:    "0,1,",
+			expected: []int{0, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseEventSeats(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/api/store/pg/entity/system_test.go
+++ b/api/store/pg/entity/system_test.go
@@ -1,0 +1,278 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemFromModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		model *models.System
+		check func(t *testing.T, result *System)
+	}{
+		{
+			name:  "nil input",
+			model: nil,
+			check: func(t *testing.T, result *System) {
+				require.NotNil(t, result)
+				assert.False(t, result.Setup)
+			},
+		},
+		{
+			name: "full fields with all nesting",
+			model: &models.System{
+				Setup: true,
+				Authentication: &models.SystemAuthentication{
+					Local: &models.SystemAuthenticationLocal{
+						Enabled: true,
+					},
+					SAML: &models.SystemAuthenticationSAML{
+						Enabled: true,
+						Idp: &models.SystemIdpSAML{
+							EntityID:     "https://idp.example.com",
+							Certificates: []string{"cert1", "cert2"},
+							Mappings:     map[string]string{"email": "user.email"},
+							Binding: &models.SystemAuthenticationBinding{
+								Post:      "https://idp.example.com/post",
+								Redirect:  "https://idp.example.com/redirect",
+								Preferred: "post",
+							},
+						},
+						Sp: &models.SystemSpSAML{
+							SignAuthRequests: true,
+							Certificate:      "sp-cert",
+							PrivateKey:       "sp-key",
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, result *System) {
+				assert.True(t, result.Setup)
+				assert.True(t, result.Authentication.Local.Enabled)
+				assert.True(t, result.Authentication.SAML.Enabled)
+				assert.Equal(t, "https://idp.example.com", result.Authentication.SAML.Idp.EntityID)
+				assert.Equal(t, []string{"cert1", "cert2"}, result.Authentication.SAML.Idp.Certificates)
+				assert.Equal(t, map[string]string{"email": "user.email"}, result.Authentication.SAML.Idp.Mappings)
+				assert.Equal(t, "https://idp.example.com/post", result.Authentication.SAML.Idp.Binding.Post)
+				assert.Equal(t, "https://idp.example.com/redirect", result.Authentication.SAML.Idp.Binding.Redirect)
+				assert.Equal(t, "post", result.Authentication.SAML.Idp.Binding.Preferred)
+				assert.True(t, result.Authentication.SAML.Sp.SignAuthRequests)
+				assert.Equal(t, "sp-cert", result.Authentication.SAML.Sp.Certificate)
+				assert.Equal(t, "sp-key", result.Authentication.SAML.Sp.PrivateKey)
+			},
+		},
+		{
+			name: "nil Authentication",
+			model: &models.System{
+				Setup:          true,
+				Authentication: nil,
+			},
+			check: func(t *testing.T, result *System) {
+				assert.True(t, result.Setup)
+				assert.False(t, result.Authentication.Local.Enabled)
+				assert.False(t, result.Authentication.SAML.Enabled)
+			},
+		},
+		{
+			name: "nil Local",
+			model: &models.System{
+				Authentication: &models.SystemAuthentication{
+					Local: nil,
+					SAML:  &models.SystemAuthenticationSAML{Enabled: true},
+				},
+			},
+			check: func(t *testing.T, result *System) {
+				assert.False(t, result.Authentication.Local.Enabled)
+				assert.True(t, result.Authentication.SAML.Enabled)
+			},
+		},
+		{
+			name: "nil SAML",
+			model: &models.System{
+				Authentication: &models.SystemAuthentication{
+					Local: &models.SystemAuthenticationLocal{Enabled: true},
+					SAML:  nil,
+				},
+			},
+			check: func(t *testing.T, result *System) {
+				assert.True(t, result.Authentication.Local.Enabled)
+				assert.False(t, result.Authentication.SAML.Enabled)
+			},
+		},
+		{
+			name: "nil Idp",
+			model: &models.System{
+				Authentication: &models.SystemAuthentication{
+					SAML: &models.SystemAuthenticationSAML{
+						Enabled: true,
+						Idp:     nil,
+						Sp:      &models.SystemSpSAML{Certificate: "cert"},
+					},
+				},
+			},
+			check: func(t *testing.T, result *System) {
+				assert.True(t, result.Authentication.SAML.Enabled)
+				assert.Equal(t, "", result.Authentication.SAML.Idp.EntityID)
+				assert.Equal(t, "cert", result.Authentication.SAML.Sp.Certificate)
+			},
+		},
+		{
+			name: "nil Idp.Binding",
+			model: &models.System{
+				Authentication: &models.SystemAuthentication{
+					SAML: &models.SystemAuthenticationSAML{
+						Enabled: true,
+						Idp: &models.SystemIdpSAML{
+							EntityID: "entity-1",
+							Binding:  nil,
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, result *System) {
+				assert.Equal(t, "entity-1", result.Authentication.SAML.Idp.EntityID)
+				assert.Equal(t, "", result.Authentication.SAML.Idp.Binding.Post)
+				assert.Equal(t, "", result.Authentication.SAML.Idp.Binding.Redirect)
+			},
+		},
+		{
+			name: "nil Sp",
+			model: &models.System{
+				Authentication: &models.SystemAuthentication{
+					SAML: &models.SystemAuthenticationSAML{
+						Enabled: true,
+						Idp:     &models.SystemIdpSAML{EntityID: "entity-1"},
+						Sp:      nil,
+					},
+				},
+			},
+			check: func(t *testing.T, result *System) {
+				assert.Equal(t, "entity-1", result.Authentication.SAML.Idp.EntityID)
+				assert.False(t, result.Authentication.SAML.Sp.SignAuthRequests)
+				assert.Equal(t, "", result.Authentication.SAML.Sp.Certificate)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SystemFromModel(tt.model)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestSystemToModel(t *testing.T) {
+	tests := []struct {
+		name   string
+		entity *System
+		check  func(t *testing.T, result *models.System)
+	}{
+		{
+			name:   "nil input",
+			entity: nil,
+			check: func(t *testing.T, result *models.System) {
+				require.NotNil(t, result)
+				assert.False(t, result.Setup)
+				assert.Nil(t, result.Authentication)
+			},
+		},
+		{
+			name: "zero-value authentication sub-structs",
+			entity: &System{
+				Setup: true,
+			},
+			check: func(t *testing.T, result *models.System) {
+				assert.True(t, result.Setup)
+				require.NotNil(t, result.Authentication)
+				require.NotNil(t, result.Authentication.Local)
+				assert.False(t, result.Authentication.Local.Enabled)
+				require.NotNil(t, result.Authentication.SAML)
+				assert.False(t, result.Authentication.SAML.Enabled)
+				require.NotNil(t, result.Authentication.SAML.Idp)
+				assert.Equal(t, "", result.Authentication.SAML.Idp.EntityID)
+				require.NotNil(t, result.Authentication.SAML.Idp.Binding)
+				assert.Equal(t, "", result.Authentication.SAML.Idp.Binding.Post)
+				require.NotNil(t, result.Authentication.SAML.Sp)
+				assert.False(t, result.Authentication.SAML.Sp.SignAuthRequests)
+			},
+		},
+		{
+			name: "only SAML enabled",
+			entity: &System{
+				Setup: true,
+				Authentication: SystemAuthentication{
+					Local: SystemAuthenticationLocal{Enabled: false},
+					SAML: SystemAuthenticationSAML{
+						Enabled: true,
+						Idp: SystemIdpSAML{
+							EntityID: "https://idp.example.com",
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, result *models.System) {
+				assert.True(t, result.Setup)
+				require.NotNil(t, result.Authentication)
+				require.NotNil(t, result.Authentication.Local)
+				assert.False(t, result.Authentication.Local.Enabled)
+				require.NotNil(t, result.Authentication.SAML)
+				assert.True(t, result.Authentication.SAML.Enabled)
+				assert.Equal(t, "https://idp.example.com", result.Authentication.SAML.Idp.EntityID)
+				assert.False(t, result.Authentication.SAML.Sp.SignAuthRequests)
+			},
+		},
+		{
+			name: "full fields",
+			entity: &System{
+				Setup: true,
+				Authentication: SystemAuthentication{
+					Local: SystemAuthenticationLocal{Enabled: true},
+					SAML: SystemAuthenticationSAML{
+						Enabled: true,
+						Idp: SystemIdpSAML{
+							EntityID:     "https://idp.example.com",
+							Certificates: []string{"cert1"},
+							Mappings:     map[string]string{"email": "user.email"},
+							Binding: SystemAuthenticationBinding{
+								Post:      "https://idp.example.com/post",
+								Redirect:  "https://idp.example.com/redirect",
+								Preferred: "post",
+							},
+						},
+						Sp: SystemSpSAML{
+							SignAuthRequests: true,
+							Certificate:      "sp-cert",
+							PrivateKey:       "sp-key",
+						},
+					},
+				},
+			},
+			check: func(t *testing.T, result *models.System) {
+				assert.True(t, result.Setup)
+				require.NotNil(t, result.Authentication)
+				require.NotNil(t, result.Authentication.Local)
+				assert.True(t, result.Authentication.Local.Enabled)
+				require.NotNil(t, result.Authentication.SAML)
+				assert.True(t, result.Authentication.SAML.Enabled)
+				require.NotNil(t, result.Authentication.SAML.Idp)
+				assert.Equal(t, "https://idp.example.com", result.Authentication.SAML.Idp.EntityID)
+				require.NotNil(t, result.Authentication.SAML.Idp.Binding)
+				assert.Equal(t, "https://idp.example.com/post", result.Authentication.SAML.Idp.Binding.Post)
+				require.NotNil(t, result.Authentication.SAML.Sp)
+				assert.True(t, result.Authentication.SAML.Sp.SignAuthRequests)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SystemToModel(tt.entity)
+			tt.check(t, result)
+		})
+	}
+}

--- a/api/store/pg/entity/tag_test.go
+++ b/api/store/pg/entity/tag_test.go
@@ -1,0 +1,121 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagFromModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		model    *models.Tag
+		expected *Tag
+	}{
+		{
+			name: "full fields",
+			model: &models.Tag{
+				ID:        "tag-id-1",
+				TenantID:  "tenant-id-1",
+				Name:      "production",
+				CreatedAt: now,
+				UpdatedAt: now.Add(time.Hour),
+			},
+			expected: &Tag{
+				ID:          "tag-id-1",
+				NamespaceID: "tenant-id-1",
+				Name:        "production",
+				CreatedAt:   now,
+				UpdatedAt:   now.Add(time.Hour),
+			},
+		},
+		{
+			name: "zero-value times",
+			model: &models.Tag{
+				ID:       "tag-id-2",
+				TenantID: "tenant-id-2",
+				Name:     "staging",
+			},
+			expected: &Tag{
+				ID:          "tag-id-2",
+				NamespaceID: "tenant-id-2",
+				Name:        "staging",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TagFromModel(tt.model)
+			assert.Equal(t, tt.expected.ID, result.ID)
+			assert.Equal(t, tt.expected.NamespaceID, result.NamespaceID)
+			assert.Equal(t, tt.expected.Name, result.Name)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.Equal(t, tt.expected.UpdatedAt, result.UpdatedAt)
+		})
+	}
+}
+
+func TestTagToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		entity   *Tag
+		expected *models.Tag
+	}{
+		{
+			name: "full fields",
+			entity: &Tag{
+				ID:          "tag-id-1",
+				NamespaceID: "tenant-id-1",
+				Name:        "production",
+				CreatedAt:   now,
+				UpdatedAt:   now.Add(time.Hour),
+			},
+			expected: &models.Tag{
+				ID:        "tag-id-1",
+				TenantID:  "tenant-id-1",
+				Name:      "production",
+				CreatedAt: now,
+				UpdatedAt: now.Add(time.Hour),
+			},
+		},
+		{
+			name: "zero-value times",
+			entity: &Tag{
+				ID:          "tag-id-2",
+				NamespaceID: "tenant-id-2",
+				Name:        "staging",
+			},
+			expected: &models.Tag{
+				ID:       "tag-id-2",
+				TenantID: "tenant-id-2",
+				Name:     "staging",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TagToModel(tt.entity)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewDeviceTag(t *testing.T) {
+	result := NewDeviceTag("tag-123", "device-456")
+	assert.Equal(t, "tag-123", result.TagID)
+	assert.Equal(t, "device-456", result.DeviceID)
+}
+
+func TestNewPublicKeyTag(t *testing.T) {
+	result := NewPublicKeyTag("tag-123", "fingerprint-456")
+	assert.Equal(t, "tag-123", result.TagID)
+	assert.Equal(t, "fingerprint-456", result.PublicKeyFingerprint)
+}

--- a/api/store/pg/entity/user_test.go
+++ b/api/store/pg/entity/user_test.go
@@ -1,0 +1,252 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserFromModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		model    *models.User
+		expected *User
+	}{
+		{
+			name: "full fields",
+			model: &models.User{
+				ID:             "user-id-1",
+				Origin:         models.UserOriginLocal,
+				ExternalID:     "ext-id-1",
+				Status:         models.UserStatusConfirmed,
+				MaxNamespaces:  5,
+				CreatedAt:      now,
+				LastLogin:      now.Add(-time.Hour),
+				EmailMarketing: true,
+				UserData: models.UserData{
+					Name:          "John Doe",
+					Username:      "johndoe",
+					Email:         "john@example.com",
+					RecoveryEmail: "recovery@example.com",
+				},
+				Password: models.UserPassword{
+					Hash: "hashed-password-123",
+				},
+				MFA: models.UserMFA{
+					Enabled:       true,
+					Secret:        "mfa-secret",
+					RecoveryCodes: []string{"code1", "code2"},
+				},
+				Preferences: models.UserPreferences{
+					PreferredNamespace: "ns-id-1",
+					AuthMethods:        []models.UserAuthMethod{models.UserAuthMethodLocal, models.UserAuthMethodSAML},
+				},
+				Admin: true,
+			},
+			expected: &User{
+				ID:             "user-id-1",
+				Origin:         "local",
+				ExternalID:     "ext-id-1",
+				Status:         "confirmed",
+				Name:           "John Doe",
+				Username:       "johndoe",
+				Email:          "john@example.com",
+				PasswordDigest: "hashed-password-123",
+				Admin:          true,
+				CreatedAt:      now,
+				LastLogin:      now.Add(-time.Hour),
+				Preferences: UserPreferences{
+					PreferredNamespace: "ns-id-1",
+					AuthMethods:        []string{"local", "saml"},
+					SecurityEmail:      "recovery@example.com",
+					MaxNamespaces:      5,
+					EmailMarketing:     true,
+				},
+				MFA: UserMFA{
+					Enabled:       true,
+					Secret:        "mfa-secret",
+					RecoveryCodes: []string{"code1", "code2"},
+				},
+			},
+		},
+		{
+			name: "empty Origin defaults to local",
+			model: &models.User{
+				ID:     "user-id-2",
+				Origin: "",
+				Status: models.UserStatusConfirmed,
+			},
+			expected: &User{
+				ID:     "user-id-2",
+				Origin: "local",
+				Status: "confirmed",
+				Preferences: UserPreferences{
+					AuthMethods: []string{},
+				},
+			},
+		},
+		{
+			name: "empty Status defaults to confirmed",
+			model: &models.User{
+				ID:     "user-id-3",
+				Origin: models.UserOriginLocal,
+				Status: "",
+			},
+			expected: &User{
+				ID:     "user-id-3",
+				Origin: "local",
+				Status: "confirmed",
+				Preferences: UserPreferences{
+					AuthMethods: []string{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := UserFromModel(tt.model)
+			assert.Equal(t, tt.expected.ID, result.ID)
+			assert.Equal(t, tt.expected.Origin, result.Origin)
+			assert.Equal(t, tt.expected.ExternalID, result.ExternalID)
+			assert.Equal(t, tt.expected.Status, result.Status)
+			assert.Equal(t, tt.expected.Name, result.Name)
+			assert.Equal(t, tt.expected.Username, result.Username)
+			assert.Equal(t, tt.expected.Email, result.Email)
+			assert.Equal(t, tt.expected.PasswordDigest, result.PasswordDigest)
+			assert.Equal(t, tt.expected.Admin, result.Admin)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.Equal(t, tt.expected.LastLogin, result.LastLogin)
+			assert.Equal(t, tt.expected.Preferences.PreferredNamespace, result.Preferences.PreferredNamespace)
+			assert.Equal(t, tt.expected.Preferences.AuthMethods, result.Preferences.AuthMethods)
+			assert.Equal(t, tt.expected.Preferences.SecurityEmail, result.Preferences.SecurityEmail)
+			assert.Equal(t, tt.expected.Preferences.MaxNamespaces, result.Preferences.MaxNamespaces)
+			assert.Equal(t, tt.expected.Preferences.EmailMarketing, result.Preferences.EmailMarketing)
+			assert.Equal(t, tt.expected.MFA.Enabled, result.MFA.Enabled)
+			assert.Equal(t, tt.expected.MFA.Secret, result.MFA.Secret)
+			assert.Equal(t, tt.expected.MFA.RecoveryCodes, result.MFA.RecoveryCodes)
+			assert.True(t, result.UpdatedAt.IsZero(), "UpdatedAt should be zero")
+		})
+	}
+}
+
+func TestUserToModel(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		entity   *User
+		expected *models.User
+	}{
+		{
+			name: "full fields with UserData disaggregation",
+			entity: &User{
+				ID:             "user-id-1",
+				Origin:         "local",
+				ExternalID:     "ext-id-1",
+				Status:         "confirmed",
+				Name:           "John Doe",
+				Username:       "johndoe",
+				Email:          "john@example.com",
+				PasswordDigest: "hashed-password-123",
+				Admin:          true,
+				CreatedAt:      now,
+				LastLogin:      now.Add(-time.Hour),
+				Preferences: UserPreferences{
+					PreferredNamespace: "ns-id-1",
+					AuthMethods:        []string{"local", "saml"},
+					SecurityEmail:      "recovery@example.com",
+					MaxNamespaces:      5,
+					EmailMarketing:     true,
+				},
+				MFA: UserMFA{
+					Enabled:       true,
+					Secret:        "mfa-secret",
+					RecoveryCodes: []string{"code1", "code2"},
+				},
+			},
+			expected: &models.User{
+				ID:             "user-id-1",
+				Origin:         models.UserOriginLocal,
+				ExternalID:     "ext-id-1",
+				Status:         models.UserStatusConfirmed,
+				MaxNamespaces:  5,
+				CreatedAt:      now,
+				LastLogin:      now.Add(-time.Hour),
+				EmailMarketing: true,
+				Admin:          true,
+				UserData: models.UserData{
+					Name:          "John Doe",
+					Username:      "johndoe",
+					Email:         "john@example.com",
+					RecoveryEmail: "recovery@example.com",
+				},
+				Password: models.UserPassword{
+					Hash: "hashed-password-123",
+				},
+				MFA: models.UserMFA{
+					Enabled:       true,
+					Secret:        "mfa-secret",
+					RecoveryCodes: []string{"code1", "code2"},
+				},
+				Preferences: models.UserPreferences{
+					PreferredNamespace: "ns-id-1",
+					AuthMethods:        []models.UserAuthMethod{"local", "saml"},
+				},
+			},
+		},
+		{
+			name: "SAML origin with non-confirmed status and empty auth methods",
+			entity: &User{
+				ID:     "user-id-2",
+				Origin: "SAML",
+				Status: "not-confirmed",
+				Preferences: UserPreferences{
+					AuthMethods: []string{},
+				},
+			},
+			expected: &models.User{
+				ID:       "user-id-2",
+				Origin:   models.UserOriginSAML,
+				Status:   models.UserStatusNotConfirmed,
+				UserData: models.UserData{},
+				Password: models.UserPassword{},
+				MFA:      models.UserMFA{},
+				Preferences: models.UserPreferences{
+					AuthMethods: []models.UserAuthMethod{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := UserToModel(tt.entity)
+			assert.Equal(t, tt.expected.ID, result.ID)
+			assert.Equal(t, tt.expected.Origin, result.Origin)
+			assert.Equal(t, tt.expected.ExternalID, result.ExternalID)
+			assert.Equal(t, tt.expected.Status, result.Status)
+			assert.Equal(t, tt.expected.MaxNamespaces, result.MaxNamespaces)
+			assert.Equal(t, tt.expected.CreatedAt, result.CreatedAt)
+			assert.Equal(t, tt.expected.LastLogin, result.LastLogin)
+			assert.Equal(t, tt.expected.EmailMarketing, result.EmailMarketing)
+			assert.Equal(t, tt.expected.Admin, result.Admin)
+			// UserData disaggregation
+			assert.Equal(t, tt.expected.Name, result.Name)
+			assert.Equal(t, tt.expected.Username, result.Username)
+			assert.Equal(t, tt.expected.Email, result.Email)
+			assert.Equal(t, tt.expected.RecoveryEmail, result.RecoveryEmail)
+			// Password
+			assert.Equal(t, tt.expected.Password.Hash, result.Password.Hash)
+			// MFA
+			assert.Equal(t, tt.expected.MFA, result.MFA)
+			// Preferences
+			assert.Equal(t, tt.expected.Preferences, result.Preferences)
+			// entity.Namespaces is scanonly (populated by DB queries) and intentionally not mapped by UserToModel.
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add comprehensive table-driven unit tests for all `ToModel` and `FromModel` conversion functions in `api/store/pg/entity/`
- 11 new test files covering tag, private-key, api-key, membership, membership-invitation, user, namespace, device, public-key, session, and system entities
- Tests cover field mapping, default value handling, nil pointer safety, and edge cases (including the nil Namespace regression in DeviceToModel from #5859)

Companion PR: shellhub-io/cloud — `test/pg-entity-conversion-tests`

## Test plan

- [x] `./bin/docker-compose exec api go test -v ./store/pg/entity/...` — 68 test cases, all passing