### PR TITLE
fix(api): restore MJML email template compilation for enterprise builds

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,6 +2,7 @@
 #
 # Build args:
 #   EDITION=community (default) | enterprise
+#   MJML_VERSION=4.10.1 (default)
 #
 # CE:  docker build --build-arg EDITION=community -f api/Dockerfile .
 # EE:  docker build --build-arg EDITION=enterprise \
@@ -12,6 +13,7 @@
 # Cloud source is provided separately via --build-context (never in main context).
 
 ARG EDITION=community
+ARG MJML_VERSION=4.10.1
 
 # ── cloud-src: empty by default, overridden via --build-context for EE ────────
 FROM scratch AS cloud-src
@@ -38,12 +40,20 @@ RUN go mod download
 FROM base AS builder
 
 ARG EDITION=community
+ARG MJML_VERSION
+
+RUN if [ "$EDITION" = "enterprise" ]; then \
+        apk add --no-cache npm && npm install -g mjml@${MJML_VERSION}; \
+    fi
 
 COPY ./pkg     /go/src/github.com/shellhub-io/shellhub/pkg
 COPY ./openapi /go/src/github.com/shellhub-io/shellhub/openapi
 COPY ./api     /go/src/github.com/shellhub-io/shellhub/api
 
 WORKDIR /go/src/github.com/shellhub-io/shellhub/api
+
+RUN mkdir -p /templates
+COPY ./install.sh /templates/install.sh
 
 RUN --mount=type=bind,from=cloud-src,target=/go/src/github.com/shellhub-io/cloud \
     if [ "$EDITION" = "enterprise" ]; then \
@@ -53,7 +63,8 @@ RUN --mount=type=bind,from=cloud-src,target=/go/src/github.com/shellhub-io/cloud
             ./github.com/shellhub-io/shellhub/api \
             ./github.com/shellhub-io/cloud && \
         cd /go/src/github.com/shellhub-io/shellhub/api && \
-        GOWORK=/go/src/go.work go build -tags enterprise -o /api .; \
+        GOWORK=/go/src/go.work go build -tags enterprise -o /api . && \
+        mjml /go/src/github.com/shellhub-io/cloud/templates/*.mjml -o /templates; \
     else \
         go build -o /api .; \
     fi
@@ -62,9 +73,11 @@ RUN --mount=type=bind,from=cloud-src,target=/go/src/github.com/shellhub-io/cloud
 FROM base AS development
 
 ARG GOPROXY
+ARG MJML_VERSION
 ENV GOPROXY=${GOPROXY}
 
-RUN apk add --update openssl build-base docker-cli
+RUN apk add --update openssl build-base docker-cli npm
+RUN npm install -g mjml@${MJML_VERSION}
 RUN go install github.com/air-verse/air@v1.62 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 && \
     go install github.com/vektra/mockery/v2/...@v2.53.2
@@ -84,8 +97,6 @@ FROM alpine:3.23.3 AS production
 RUN apk add --no-cache curl
 
 COPY --from=builder /api /api
-
-RUN mkdir -p /templates
-COPY ./install.sh /templates/install.sh
+COPY --from=builder /templates /templates
 
 ENTRYPOINT ["/api", "server"]

--- a/api/entrypoint-dev.sh
+++ b/api/entrypoint-dev.sh
@@ -20,6 +20,18 @@ WORKSPACE="/go/src/github.com/shellhub-io"
 if [ -d "$CLOUD_DIR" ]; then
     echo "Cloud sources found at $CLOUD_DIR — building api-enterprise (EE)"
 
+    # Compile email templates from MJML source into /templates.
+    # NOTE: Templates are compiled once at container startup.
+    # Restart the container to recompile after editing .mjml files.
+    if [ -d "$CLOUD_DIR/templates" ]; then
+        echo "Compiling email templates from $CLOUD_DIR/templates"
+        mjml "$CLOUD_DIR"/templates/*.mjml -o /templates || {
+            echo "ERROR: MJML template compilation failed" >&2
+            exit 1
+        }
+        echo "Email templates compiled successfully."
+    fi
+
     # Create go.work so the unified build can resolve both shellhub and cloud modules.
     go work init \
         "$WORKSPACE/shellhub" \


### PR DESCRIPTION
## What changed

The cloud Dockerfile previously installed `mjml` and compiled email templates from MJML source into `/templates` at build time. When cloud was merged into the shellhub `api` binary (`c04c8296`), this step was dropped — leaving enterprise builds without compiled email templates.

## How it works now

- **Builder stage**: `npm` + `mjml@4.10.1` are installed and templates compiled inside the `enterprise`-only branch, so community builds pay zero cost
- **Development stage**: `npm` + `mjml@4.10.1` are installed in the image; `entrypoint-dev.sh` compiles `cloud/templates/*.mjml` into `/templates` at container startup (cloud is a runtime volume mount, not available at image build time)
- **Production stage**: `COPY --from=builder /templates /templates` instead of recreating the directory empty

## How to test

**Builder stage (enterprise production build):**
```sh
docker build --build-arg EDITION=enterprise \
  --build-context cloud-src=../cloud \
  -f api/Dockerfile . --target builder
# Verify /templates/*.html exist in the builder layer
```

**Development (EE):**
```sh
# Mount cloud repo and start the stack
# Check container logs for "Email templates compiled successfully."
# Verify /templates/*.html are present inside the api container
```

**UI (EE dev environment):**
- Trigger any flow that sends a transactional email (sign up, forgot password, etc.)
- Confirm the request completes without an error response