### PR TITLE
feat(ui-react): add inline error banner to terminal sessions

### DIFF
--- a/ui-react/apps/admin/src/components/terminal/TerminalControls.tsx
+++ b/ui-react/apps/admin/src/components/terminal/TerminalControls.tsx
@@ -11,7 +11,11 @@ import TerminalSettingsDrawer from "./TerminalSettingsDrawer";
 
 /** Terminal info shown on the left side of the AppBar */
 export function TerminalInfo({ session }: { session: TerminalSession }) {
-  const { connectionStatus: status } = session;
+  const status = useTerminalStore(
+    (s) =>
+      s.sessions.find((ss) => ss.id === session.id)?.connectionStatus ??
+      "disconnected",
+  );
 
   return (
     <div className="flex items-center gap-2.5 min-w-0">

--- a/ui-react/apps/admin/src/components/terminal/TerminalErrorBanner.tsx
+++ b/ui-react/apps/admin/src/components/terminal/TerminalErrorBanner.tsx
@@ -1,0 +1,75 @@
+import { Link } from "react-router-dom";
+import { ExclamationCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useTerminalStore } from "../../stores/terminalStore";
+import type { TerminalError } from "./terminalErrors";
+
+interface TerminalErrorBannerProps {
+  error: TerminalError;
+  sessionId: string;
+}
+
+export default function TerminalErrorBanner({
+  error,
+  sessionId,
+}: TerminalErrorBannerProps) {
+  return (
+    <div
+      role="alert"
+      className="bg-accent-red/[0.08] border-b border-accent-red/20 px-5 py-3.5 flex items-start gap-3 animate-slide-down"
+    >
+      <ExclamationCircleIcon
+        className="w-4 h-4 text-accent-red shrink-0 mt-0.5"
+        strokeWidth={1.5}
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 mb-1">
+          <span className="text-sm font-semibold text-text-primary">
+            {error.title}
+          </span>
+          <span className="text-sm text-text-muted">{error.message}</span>
+        </div>
+        {error.hints.length > 0 && (
+          <p className="text-sm text-text-secondary leading-relaxed mb-1.5">
+            {error.hints.join(" ")}
+          </p>
+        )}
+        {(error.links.length > 0 || error.reconnect) && (
+          <div className="flex items-center gap-3">
+            {error.links.map((link) => (
+              <Link
+                key={link.to}
+                to={link.to}
+                onClick={() => useTerminalStore.getState().close(sessionId)}
+                className="text-sm text-primary hover:text-primary-600 font-medium transition-colors"
+              >
+                {link.label}
+              </Link>
+            ))}
+            {error.links.length > 0 && error.reconnect && (
+              <span className="w-px h-3.5 bg-border-light" />
+            )}
+            {error.reconnect && (
+              <button
+                type="button"
+                onClick={() => {
+                  useTerminalStore.getState().closeAndReconnect(sessionId);
+                }}
+                className="px-2.5 py-1 bg-primary hover:bg-primary-600 text-white rounded text-xs font-semibold transition-colors"
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={() => useTerminalStore.getState().close(sessionId)}
+        className="text-text-muted hover:text-text-primary transition-colors p-0.5 shrink-0"
+      >
+        <XMarkIcon className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/ui-react/apps/admin/src/components/terminal/TerminalInstance.tsx
+++ b/ui-react/apps/admin/src/components/terminal/TerminalInstance.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -7,31 +7,52 @@ import apiClient from "../../api/client";
 import type { TerminalSession } from "../../stores/terminalStore";
 import { useTerminalStore } from "../../stores/terminalStore";
 import { useTerminalThemeStore } from "../../stores/terminalThemeStore";
+import type { TerminalError } from "./terminalErrors";
+import TerminalErrorBanner from "./TerminalErrorBanner";
+import {
+  WS_KIND,
+  HTTP_CONNECT_ERROR,
+  WS_CLOSE_ERROR,
+  WS_NETWORK_ERROR,
+  parseMessage,
+  resolveError,
+} from "./terminalErrors";
 
 interface TerminalInstanceProps {
   session: TerminalSession;
   visible: boolean;
 }
 
-export default function TerminalInstance({ session, visible }: TerminalInstanceProps) {
+export default function TerminalInstance({
+  session,
+  visible,
+}: TerminalInstanceProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
   const prevVisibleRef = useRef(visible);
+  const [error, setError] = useState<TerminalError | null>(null);
 
   const { theme, fontFamilyWithFallback, fontSize } = useTerminalThemeStore();
 
-  const updateStatus = useCallback((s: "connecting" | "connected" | "disconnected") => {
-    useTerminalStore.getState().setConnectionStatus(session.id, s);
-  }, [session.id]);
+  const updateStatus = useCallback(
+    (s: "connecting" | "connected" | "disconnected") => {
+      useTerminalStore.getState().setConnectionStatus(session.id, s);
+    },
+    [session.id],
+  );
 
   // Connect on mount, cleanup on unmount
   useEffect(() => {
     let cancelled = false;
-    const { theme: initTheme, fontFamilyWithFallback: initFont, fontSize: initSize } =
-      useTerminalThemeStore.getState();
+    let lastError = false;
+    const {
+      theme: initTheme,
+      fontFamilyWithFallback: initFont,
+      fontSize: initSize,
+    } = useTerminalThemeStore.getState();
 
     async function connect() {
       updateStatus("connecting");
@@ -45,7 +66,9 @@ export default function TerminalInstance({ session, visible }: TerminalInstanceP
         });
         token = res.data.token;
       } catch {
+        if (cancelled) return;
         updateStatus("disconnected");
+        setError(HTTP_CONNECT_ERROR);
         return;
       }
 
@@ -88,34 +111,49 @@ export default function TerminalInstance({ session, visible }: TerminalInstanceP
       };
 
       ws.onmessage = async (event) => {
+        if (cancelled) return;
         if (event.data instanceof Blob) {
           term.write(await event.data.text());
         } else {
-          term.write(event.data);
+          const msg = parseMessage(event.data);
+          if (msg?.kind === WS_KIND.ERROR) {
+            lastError = true;
+            updateStatus("disconnected");
+            setError(resolveError(msg.data, session.deviceUid));
+          } else if (!lastError) {
+            term.write(event.data);
+          }
         }
       };
 
       ws.onclose = () => {
         if (cancelled) return;
         updateStatus("disconnected");
-        term.write("\r\n\x1b[1;31mDisconnected.\x1b[0m\r\n");
+        if (!lastError) {
+          setError(WS_CLOSE_ERROR);
+        }
       };
 
       ws.onerror = () => {
         if (cancelled) return;
+        lastError = true;
         updateStatus("disconnected");
-        term.write("\r\n\x1b[1;31mConnection error.\x1b[0m\r\n");
+        setError(WS_NETWORK_ERROR);
       };
 
       term.onData((data) => {
         if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ kind: 1, data: data.slice(0, 4096) }));
+          ws.send(
+            JSON.stringify({ kind: WS_KIND.INPUT, data: data.slice(0, 4096) }),
+          );
         }
       });
 
       term.onResize(({ cols, rows }) => {
         if (ws.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ kind: 2, data: { cols, rows } }));
+          ws.send(
+            JSON.stringify({ kind: WS_KIND.RESIZE, data: { cols, rows } }),
+          );
         }
       });
 
@@ -135,7 +173,10 @@ export default function TerminalInstance({ session, visible }: TerminalInstanceP
       observerRef.current?.disconnect();
       observerRef.current = null;
       if (wsRef.current) {
+        wsRef.current.onopen = null;
         wsRef.current.onclose = null;
+        wsRef.current.onerror = null;
+        wsRef.current.onmessage = null;
         wsRef.current.close();
         wsRef.current = null;
       }
@@ -143,7 +184,7 @@ export default function TerminalInstance({ session, visible }: TerminalInstanceP
       termRef.current = null;
       fitRef.current = null;
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session.id]);
 
   // Live theme/font updates
@@ -167,20 +208,35 @@ export default function TerminalInstance({ session, visible }: TerminalInstanceP
     fitRef.current?.fit();
   }, [fontSize]);
 
+  // Hide cursor on error
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term || error === null) return;
+    term.options.cursorBlink = false;
+    term.blur();
+    term.write("\x1b[?25l"); // CSI sequence to hide cursor
+  }, [error]);
+
   // Handle visibility changes (minimize/restore)
   useEffect(() => {
-    if (!prevVisibleRef.current && visible) {
+    if (!prevVisibleRef.current && visible && error === null) {
       requestAnimationFrame(() => {
         fitRef.current?.fit();
         termRef.current?.focus();
       });
     }
     prevVisibleRef.current = visible;
-  }, [visible]);
+  }, [visible, error]);
 
   return (
-    <div className="flex-1 overflow-hidden">
-      <div ref={containerRef} className="w-full h-full" />
+    <div className="relative flex-1 flex flex-col overflow-hidden">
+      {error !== null && (
+        <TerminalErrorBanner error={error} sessionId={session.id} />
+      )}
+      <div
+        ref={containerRef}
+        className={`flex-1 ${error !== null ? "opacity-30 pointer-events-none" : ""}`}
+      />
     </div>
   );
 }

--- a/ui-react/apps/admin/src/components/terminal/terminalErrors.ts
+++ b/ui-react/apps/admin/src/components/terminal/terminalErrors.ts
@@ -1,0 +1,184 @@
+import { getConfig } from "../../env";
+
+interface ErrorEntry {
+  message: string;
+  reconnect: boolean;
+  hints: string[];
+  links?: Array<{ label: string; to: string }>;
+}
+
+export interface TerminalError {
+  title: string;
+  message: string;
+  reconnect: boolean;
+  hints: string[];
+  links: Array<{ label: string; to: string }>;
+}
+
+// Keys must match error strings from ssh/web/errors.go exactly.
+// If backend error messages change, update these keys accordingly.
+const errorMap: Record<string, ErrorEntry> = {
+  "failed to authenticate to device": {
+    message: "The username or password is incorrect.",
+    reconnect: true,
+    hints: [
+      "The username must match the OS user on the device, not your ShellHub account.",
+    ],
+  },
+  "failed to find the device": {
+    message: "Cannot reach this device.",
+    reconnect: false,
+    hints: ["The device may be offline or removed from ShellHub."],
+    links: [{ label: "Device details", to: "/devices/$uid" }],
+  },
+  "failed to connect to device": {
+    message: "Cannot reach this device.",
+    reconnect: false,
+    hints: [
+      "Make sure the device is powered on and the ShellHub agent is running.",
+    ],
+    links: [{ label: "Device details", to: "/devices/$uid" }],
+  },
+  "failed to create a session between the server to the agent": {
+    message: "Connected to the device but could not start a session.",
+    reconnect: false,
+    hints: [
+      "This is usually temporary. Wait a few seconds and try again.",
+      "If it persists, the ShellHub agent on the device may need to be restarted.",
+    ],
+  },
+  "failed to get the shell to agent": {
+    message: "Connected to the device but it refused to open a shell.",
+    reconnect: false,
+    hints: [
+      "Check that the user has a valid login shell (not /usr/sbin/nologin or /bin/false).",
+      "On containerized agents, make sure a shell is available inside the container.",
+    ],
+  },
+  "failed to request the pty to agent": {
+    message: "Connected to the device but terminal allocation was denied.",
+    reconnect: false,
+    hints: [
+      "The device may have too many open terminals. Close unused sessions and try again.",
+    ],
+  },
+  "failed to find the credentials": {
+    message: "Your session credentials have expired.",
+    reconnect: false,
+    hints: [
+      "This happens when the connection takes too long to establish. Close and open a new terminal.",
+    ],
+  },
+  "failed to get auth data from key": {
+    message: "The selected public key could not be used for authentication.",
+    reconnect: false,
+    hints: [
+      "The key may have been deleted or modified since you selected it.",
+      "Verify the key is still registered in your SSH key settings.",
+    ],
+  },
+  "failed to use the public key for this action": {
+    message: "This public key is not authorized for this device.",
+    reconnect: false,
+    hints: [
+      "Public keys must be associated with the target device or its tags.",
+    ],
+  },
+  "connections using public keys are not permitted when the agent version is 0.5.x or earlier":
+    {
+      message: "This device does not support public key authentication.",
+      reconnect: true,
+      hints: [
+        "The ShellHub agent is v0.5.x or earlier. Update to v0.6.0+ for public key support, or reconnect using a password.",
+      ],
+      links: [{ label: "Device details", to: "/devices/$uid" }],
+    },
+};
+
+// Values match ssh/web/messages.go messageKind iota.
+// SIGNATURE (3) is omitted — handled internally during
+// public-key auth and never reaches the terminal UI.
+export const WS_KIND = { INPUT: 1, RESIZE: 2, ERROR: 4 } as const;
+
+export const HTTP_CONNECT_ERROR: TerminalError = {
+  title: "Connection failed",
+  message: "Could not start the session.",
+  reconnect: true,
+  hints: [
+    "The ShellHub server may be temporarily unavailable. Try again in a moment.",
+  ],
+  links: [],
+};
+
+export const WS_CLOSE_ERROR: TerminalError = {
+  title: "Disconnected",
+  message: "The session has ended.",
+  reconnect: false,
+  hints: [],
+  links: [],
+};
+
+export const WS_NETWORK_ERROR: TerminalError = {
+  title: "Connection error",
+  message: "Could not reach the device.",
+  reconnect: false,
+  hints: [
+    "Check your network connection and make sure the ShellHub server is running.",
+  ],
+  links: [],
+};
+
+export function parseMessage(
+  data: string,
+): { kind: number; data: string } | null {
+  try {
+    const msg = JSON.parse(data);
+    if (
+      typeof msg === "object" &&
+      msg !== null &&
+      typeof msg.kind === "number" &&
+      typeof msg.data === "string"
+    ) {
+      return { kind: msg.kind, data: msg.data };
+    }
+  } catch {
+    // Not JSON — regular text frame
+  }
+  return null;
+}
+
+export function resolveError(raw: string, deviceUid: string): TerminalError {
+  const entry = errorMap[raw];
+  if (!entry) {
+    return {
+      title: "Connection failed",
+      message: "An unexpected error occurred.",
+      reconnect: false,
+      hints: [],
+      links: [],
+    };
+  }
+
+  const hasFirewall = getConfig().cloud || getConfig().enterprise;
+
+  const hints = [...entry.hints];
+  if (hasFirewall) {
+    hints.push("A firewall rule may be blocking this connection.");
+  }
+
+  const links = (entry.links ?? []).map((l) => ({
+    ...l,
+    to: l.to.split("$uid").join(deviceUid),
+  }));
+  if (hasFirewall) {
+    links.push({ label: "Firewall rules", to: "/firewall/rules" });
+  }
+
+  return {
+    title: "Connection failed",
+    message: entry.message,
+    reconnect: entry.reconnect,
+    hints,
+    links,
+  };
+}

--- a/ui-react/apps/admin/src/pages/DeviceDetails.tsx
+++ b/ui-react/apps/admin/src/pages/DeviceDetails.tsx
@@ -251,6 +251,7 @@ export default function DeviceDetails() {
     searchParams.get("connect") === "true" &&
     device?.online &&
     !existingSession;
+
   const [autoConnectDone, setAutoConnectDone] = useState(false);
   if (shouldAutoConnect && !autoConnectDone) {
     setAutoConnectDone(true);


### PR DESCRIPTION
## Summary
- Replace raw ANSI error output with a structured inline banner at the top of the terminal area on connection failures
- Add error map that resolves server error strings into user-friendly messages with contextual hints and navigation links
- Dim terminal and hide cursor when error is displayed
- Close terminal tab when clicking the X button or navigation links