### PR TITLE
fix(cli): use absolute path for air build output

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -9,4 +9,4 @@ cd $(dirname $(readlink_f $0))/../
 
 exit_if_not_running
 
-exec docker compose exec cli ./cli $@
+exec docker compose exec cli /cli "$@"

--- a/cli/.air.toml
+++ b/cli/.air.toml
@@ -2,7 +2,7 @@ root = "../"
 tmp_dir = "/tmp/air"
 
 [build]
-  cmd = "go build -o /tmp/air/cli ."
+  cmd = "go build -o /cli ."
   bin = "/bin/true"
   delay = 1000
   exclude_regex = ["_test.go"]


### PR DESCRIPTION
## Summary
- Change air build output from `/tmp/air/cli` to `/cli` so the binary is at a stable, absolute path
- Update `bin/cli` wrapper to exec `/cli` instead of `./cli`
- Fixes the CLI container crashing in dev with `stat ./cli: no such file or directory` because the volume mount hides the binary built during `docker build`