### PR TITLE
fix(api): add missing username column to public_keys table

### DIFF
--- a/api/store/pg/entity/public-key.go
+++ b/api/store/pg/entity/public-key.go
@@ -15,6 +15,7 @@ type PublicKey struct {
 	CreatedAt      time.Time `bun:"created_at"`
 	UpdatedAt      time.Time `bun:"updated_at"`
 	Name           string    `bun:"name"`
+	Username       string    `bun:"username"`
 	Data           []byte    `bun:"data,type:bytea"`
 	FilterHostname string    `bun:"filter_hostname"`
 
@@ -28,6 +29,7 @@ func PublicKeyFromModel(model *models.PublicKey) *PublicKey {
 		CreatedAt:      model.CreatedAt,
 		UpdatedAt:      time.Time{},
 		Name:           model.PublicKeyFields.Name,
+		Username:       model.PublicKeyFields.Username,
 		Data:           model.Data,
 		FilterHostname: model.Filter.Hostname,
 		Tags:           []*Tag{},
@@ -59,7 +61,7 @@ func PublicKeyToModel(entity *PublicKey) *models.PublicKey {
 		CreatedAt:   entity.CreatedAt,
 		PublicKeyFields: models.PublicKeyFields{
 			Name:     entity.Name,
-			Username: "",
+			Username: entity.Username,
 			Filter: models.PublicKeyFilter{
 				Hostname: entity.FilterHostname,
 				Taggable: models.Taggable{

--- a/api/store/pg/migrations/007_create_public_keys_table.go
+++ b/api/store/pg/migrations/007_create_public_keys_table.go
@@ -20,6 +20,7 @@ func migration007Up(ctx context.Context, db *bun.DB) error {
 		CreatedAt      time.Time `bun:"created_at,type:timestamptz,notnull"`
 		UpdatedAt      time.Time `bun:"updated_at,type:timestamptz,notnull"`
 		Name           string    `bun:"name,type:varchar,notnull"`
+		Username       string    `bun:"username,type:varchar,notnull,default:''"`
 		Data           []byte    `bun:"data,type:bytea,nullzero"`
 		FilterHostname string    `bun:"filter_hostname,type:varchar,default:''"`
 	}{}


### PR DESCRIPTION
## Summary
- Added `username` column to the `public_keys` PostgreSQL table (migration 007)
- Updated the PG entity struct and `FromModel`/`ToModel` converters to map the field
- Previously the `username` field from the domain model was silently dropped on writes and hard-coded to `""` on reads