### PR TITLE
refactor(api): decouple cloud collections from namespace delete

### DIFF
--- a/api/services/namespace.go
+++ b/api/services/namespace.go
@@ -154,6 +154,10 @@ func (s *service) DeleteNamespace(ctx context.Context, tenantID string) error {
 		}
 	}
 
+	if err := fireNamespaceDelete(ctx, n); err != nil {
+		return err
+	}
+
 	return s.store.NamespaceDelete(ctx, n)
 }
 

--- a/api/services/namespace_hooks.go
+++ b/api/services/namespace_hooks.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+)
+
+// NamespaceDeleteHookFn is called when a namespace is about to be deleted.
+// The hook receives the namespace that will be deleted. Hooks run before the
+// actual deletion, so a returned error will abort the entire operation.
+type NamespaceDeleteHookFn func(ctx context.Context, namespace *models.Namespace) error
+
+var namespaceDeleteHooks []NamespaceDeleteHookFn
+
+// OnNamespaceDelete registers a hook that fires when a namespace is deleted.
+// It must be called during package init, before the server starts handling
+// requests. Cloud packages use this to clean up cloud-only resources
+// (firewall rules, tunnels, recorded sessions, etc.).
+func OnNamespaceDelete(fn NamespaceDeleteHookFn) {
+	if fn == nil {
+		panic("services: OnNamespaceDelete called with nil hook")
+	}
+
+	namespaceDeleteHooks = append(namespaceDeleteHooks, fn)
+}
+
+// fireNamespaceDelete dispatches all registered delete hooks sequentially.
+// The first error aborts execution (the caller rolls back the operation).
+func fireNamespaceDelete(ctx context.Context, ns *models.Namespace) error {
+	for _, fn := range namespaceDeleteHooks {
+		if err := fn(ctx, ns); err != nil {
+			return fmt.Errorf("namespace delete hook failed: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/api/services/namespace_hooks_test.go
+++ b/api/services/namespace_hooks_test.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFireNamespaceDelete(t *testing.T) {
+	// Save and restore global hooks so tests don't leak.
+	saved := namespaceDeleteHooks
+	t.Cleanup(func() { namespaceDeleteHooks = saved })
+
+	ctx := context.Background()
+	ns := &models.Namespace{TenantID: "00000000-0000-4000-0000-000000000000", Name: "test"}
+
+	t.Run("nil hook panics", func(t *testing.T) {
+		namespaceDeleteHooks = nil
+		assert.PanicsWithValue(t, "services: OnNamespaceDelete called with nil hook", func() {
+			OnNamespaceDelete(nil)
+		})
+	})
+
+	t.Run("no hooks registered", func(t *testing.T) {
+		namespaceDeleteHooks = nil
+		assert.NoError(t, fireNamespaceDelete(ctx, ns))
+	})
+
+	t.Run("single hook called with correct args", func(t *testing.T) {
+		namespaceDeleteHooks = nil
+
+		var called bool
+		OnNamespaceDelete(func(gotCtx context.Context, gotNS *models.Namespace) error {
+			called = true
+			assert.Equal(t, ctx, gotCtx)
+			assert.Equal(t, ns, gotNS)
+
+			return nil
+		})
+
+		assert.NoError(t, fireNamespaceDelete(ctx, ns))
+		assert.True(t, called)
+	})
+
+	t.Run("error aborts remaining hooks", func(t *testing.T) {
+		namespaceDeleteHooks = nil
+		hookErr := errors.New("hook failed")
+
+		OnNamespaceDelete(func(context.Context, *models.Namespace) error {
+			return hookErr
+		})
+
+		var secondCalled bool
+		OnNamespaceDelete(func(context.Context, *models.Namespace) error {
+			secondCalled = true
+
+			return nil
+		})
+
+		assert.ErrorIs(t, fireNamespaceDelete(ctx, ns), hookErr)
+		assert.False(t, secondCalled)
+	})
+
+	t.Run("multiple hooks run in order", func(t *testing.T) {
+		namespaceDeleteHooks = nil
+
+		var order []int
+		OnNamespaceDelete(func(context.Context, *models.Namespace) error {
+			order = append(order, 1)
+
+			return nil
+		})
+		OnNamespaceDelete(func(context.Context, *models.Namespace) error {
+			order = append(order, 2)
+
+			return nil
+		})
+
+		assert.NoError(t, fireNamespaceDelete(ctx, ns))
+		assert.Equal(t, []int{1, 2}, order)
+	})
+}

--- a/api/store/mongo/namespace.go
+++ b/api/store/mongo/namespace.go
@@ -411,7 +411,7 @@ func (s *Store) NamespaceDeleteMany(ctx context.Context, tenantIDs []string) (in
 			}
 		}
 
-		collections := []string{"devices", "sessions", "firewall_rules", "public_keys", "recorded_sessions", "api_keys", "tunnels"}
+		collections := []string{"devices", "sessions", "public_keys", "api_keys"}
 		for _, collection := range collections {
 			if _, err := s.db.Collection(collection).DeleteMany(sessCtx, bson.M{"tenant_id": bson.M{"$in": tenantIDs}}); err != nil {
 				return 0, FromMongoError(err)


### PR DESCRIPTION
## Summary

- Introduced `OnNamespaceDelete` / `fireNamespaceDelete` hook system following the existing `OnDeviceMerge` pattern
- Removed `firewall_rules`, `recorded_sessions`, and `tunnels` from the community `NamespaceDeleteMany` collection list — these are cloud-only resources
- Cloud registers its own cleanup hook during `init()` (implemented in the cloud repo)