### PR TITLE
chore(ui-react): add vitest config for admin app

### DIFF
--- a/ui-react/apps/admin/vite.config.ts
+++ b/ui-react/apps/admin/vite.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
-    setupFiles: ["./src/test/setup.ts"],
+    globals: true,
+    setupFiles: [path.resolve(__dirname, "./src/test/setup.ts")],
+    exclude: ["**/node_modules/**", "**/dist/**", "**/build/**"],
   },
 });

--- a/ui-react/package.json
+++ b/ui-react/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",
-    "dev:admin": "npm run dev -w @shellhub/admin"
+    "dev:admin": "npm run dev -w @shellhub/admin",
+    "test:admin": "TZ=UTC vitest run -w ./apps/admin --config ./apps/admin/vite.config.ts"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## What

Configured Vitest for the admin app in the ui-react monorepo so tests can be run from the workspace root.

## Changes

- **ui-react/apps/admin/vite.config.ts**: Enabled `globals`, resolved `setupFiles` path with `path.resolve(__dirname, ...)` for correct resolution from monorepo root, added standard `exclude` patterns
- **ui-react/package.json**: Added `test:admin` script that runs Vitest with explicit workspace and config path, pinned to UTC timezone for deterministic date tests