### PR TITLE
fix(ui-react): remove unnecessary z-10 from full-bleed content containers

### DIFF
--- a/ui-react/apps/admin/src/components/common/ConnectivityGuard.tsx
+++ b/ui-react/apps/admin/src/components/common/ConnectivityGuard.tsx
@@ -25,7 +25,7 @@ function ApiUnavailablePage() {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 flex flex-col items-center text-center px-6 animate-fade-in">
+      <div className="flex flex-col items-center text-center px-6 animate-fade-in">
         <img
           src="/v2/ui/logo.svg"
           alt="ShellHub"

--- a/ui-react/apps/admin/src/components/common/CreateNamespace.tsx
+++ b/ui-react/apps/admin/src/components/common/CreateNamespace.tsx
@@ -232,7 +232,7 @@ export default function CreateNamespace() {
     <div className="relative w-full min-h-0 flex-1 flex overflow-auto">
       <AmbientBackground />
 
-      <div className="relative z-10 w-full max-w-5xl mx-auto px-8 py-12 flex flex-col">
+      <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col">
         {/* Hero */}
         <div className="text-center mb-12 animate-fade-in">
           <div className="animate-float mb-6 inline-block">

--- a/ui-react/apps/admin/src/components/common/FeatureGate.tsx
+++ b/ui-react/apps/admin/src/components/common/FeatureGate.tsx
@@ -40,7 +40,7 @@ export default function FeatureGate({
         <div className="absolute inset-0 grid-bg opacity-30" />
       </div>
 
-      <div className="relative z-10 flex-1 flex items-center justify-center px-8 py-12">
+      <div className="flex-1 flex items-center justify-center px-8 py-12">
         <div className="w-full max-w-2xl animate-fade-in">
           {/* Header */}
           <div className="text-center mb-10">

--- a/ui-react/apps/admin/src/pages/WebEndpoints.tsx
+++ b/ui-react/apps/admin/src/pages/WebEndpoints.tsx
@@ -889,7 +889,7 @@ function WebEndpointsContent() {
             <div className="absolute inset-0 grid-bg opacity-30" />
           </div>
 
-          <div className="relative z-10 flex-1 flex items-center justify-center px-8 py-12">
+          <div className="flex-1 flex items-center justify-center px-8 py-12">
             <div className="w-full max-w-2xl animate-fade-in">
               {/* Header */}
               <div className="text-center mb-10">

--- a/ui-react/apps/admin/src/pages/firewall-rules/index.tsx
+++ b/ui-react/apps/admin/src/pages/firewall-rules/index.tsx
@@ -75,7 +75,7 @@ export default function FirewallRules() {
             <div className="absolute inset-0 grid-bg opacity-30" />
           </div>
 
-          <div className="relative z-10 flex-1 flex items-center justify-center px-8 py-12">
+          <div className="flex-1 flex items-center justify-center px-8 py-12">
             <div className="w-full max-w-2xl animate-fade-in">
               <div className="text-center mb-10">
                 <div className="w-16 h-16 rounded-2xl bg-primary/10 border border-primary/20 flex items-center justify-center mx-auto mb-6 shadow-lg shadow-primary/5">

--- a/ui-react/apps/admin/src/pages/public-keys/index.tsx
+++ b/ui-react/apps/admin/src/pages/public-keys/index.tsx
@@ -194,7 +194,7 @@ export default function PublicKeys() {
             />
             <div className="absolute inset-0 grid-bg opacity-30" />
           </div>
-          <div className="relative z-10 flex-1 flex items-center justify-center px-8 py-12">
+          <div className="flex-1 flex items-center justify-center px-8 py-12">
             <div className="w-full max-w-2xl animate-fade-in">
               <div className="text-center mb-10">
                 <div className="w-16 h-16 rounded-2xl bg-primary/10 border border-primary/20 flex items-center justify-center mx-auto mb-6">


### PR DESCRIPTION
## What

Removed `relative z-10` from the content container div in 6 full-bleed page components. This restores AppBar dropdown interactivity (UserMenu, NamespaceSelector) on pages that use background decorations.

## Why

`z-10` on the content div creates a stacking context that competes with the AppBar's own `z-10`. Because the full-bleed containers use `-m-8` to escape `<main>`'s padding and extend into the AppBar's visual area, the content's stacking context traps the AppBar's `z-50` dropdown children behind it, making them unclickable.

The `z-10` was never necessary: DOM order already ensures content renders above the absolute-positioned decoration layer, and `pointer-events-none` on the decoration containers already prevents click interference.

Closes #5907

## Changes

- **WebEndpoints, FeatureGate, ConnectivityGuard, public-keys, firewall-rules**: removed `relative z-10` from the content container sibling of the `absolute inset-0 pointer-events-none` decoration wrapper
- **CreateNamespace**: same removal from the content container sibling of `<AmbientBackground />` (which renders as `absolute inset-0 overflow-hidden pointer-events-none`)

## Testing

On each affected page, verify:
- Background decorations (blur orbs, grid) render behind page content
- AppBar UserMenu dropdown opens and Settings/Logout items are clickable
- Page content (buttons, links, inputs) remains interactive