### PR TITLE
fix(ci): skip commit message check for dependabot push events

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   check-commit-message:
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]'  && github.event.pull_request.draft == false }}
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event.pull_request.draft == false || github.event_name == 'push')
     name: Check Commit Message
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Summary

- The commit message check workflow fails on push events to master when dependabot commits are merged
- The `if` condition used `github.event.pull_request.user.login` to detect dependabot, which is null on push events, so the check always ran
- Replace with `github.actor` which is set for both push and PR events

## Test plan

- [ ] Verify the workflow still runs for normal commits on this PR
- [ ] After merge, confirm the next dependabot push to master no longer triggers the check