### PR TITLE
fix(ui-react): remove unnecessary z-10 from MigrationPage content container

### DIFF
--- a/ui-react/apps/admin/src/pages/MigrationPage.tsx
+++ b/ui-react/apps/admin/src/pages/MigrationPage.tsx
@@ -22,7 +22,7 @@ export default function MigrationPage() {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 flex flex-col items-center text-center px-6 animate-fade-in">
+      <div className="flex flex-col items-center text-center px-6 animate-fade-in">
         <img
           src="/v2/ui/logo.svg"
           alt="ShellHub"


### PR DESCRIPTION
## What

Removed `relative z-10` from the content container div in `MigrationPage.tsx`.

## Why

`MigrationPage` follows the same full-bleed layout pattern cleaned up in #5929: an `absolute inset-0 overflow-hidden pointer-events-none` decoration layer with a sibling content div. The `z-10` on the content div is unnecessary — DOM order already ensures it renders above the decoration layer, and `pointer-events-none` already prevents click interference.

Closes #5930