### PR TITLE
fix(ssh): add missing return after exit in web terminal handler

### DIFF
--- a/ssh/web/web.go
+++ b/ssh/web/web.go
@@ -109,6 +109,8 @@ func NewSSHServerBridge(router *echo.Echo, cache cache.Cache) {
 		creds, ok := manager.get(token)
 		if !ok {
 			exit(wsconn, ErrBridgeCredentialsNotFound)
+
+			return
 		}
 
 		conn := NewConn(wsconn)

--- a/ssh/web/web_test.go
+++ b/ssh/web/web_test.go
@@ -1,0 +1,50 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	cachemock "github.com/shellhub-io/shellhub/pkg/cache/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
+)
+
+func TestNewSSHServerBridge_CredentialsNotFound(t *testing.T) {
+	e := echo.New()
+	cache := new(cachemock.Cache)
+
+	NewSSHServerBridge(e, cache)
+
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws/ssh?token=nonexistent&cols=80&rows=24"
+	origin := server.URL
+
+	assert.NotPanics(t, func() {
+		cfg, err := websocket.NewConfig(wsURL, origin)
+		require.NoError(t, err)
+
+		cfg.Header.Set("X-Real-Ip", "127.0.0.1")
+
+		conn, err := websocket.DialConfig(cfg)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		var raw []byte
+		err = websocket.Message.Receive(conn, &raw)
+		require.NoError(t, err)
+
+		var msg Message
+		require.NoError(t, json.Unmarshal(raw, &msg))
+		assert.Equal(t, messageKindError, msg.Kind)
+
+		data, ok := msg.Data.(string)
+		require.True(t, ok)
+		assert.Contains(t, data, ErrBridgeCredentialsNotFound.Error())
+	}, "handler must not panic when credentials are not found")
+}


### PR DESCRIPTION
## What

Added the missing `return` after `exit()` in the WebSocket credential-lookup error path, preventing a nil pointer dereference panic in the web terminal handler.

## Why

When a user opens the web terminal connect drawer, fills in credentials (POST creates a token with 30s TTL), then waits more than 30 seconds before clicking "Connect", the credentials expire and `manager.get()` returns `nil`. The handler called `exit()` to send the error to the client but fell through to `creds.decryptPassword()`, panicking on the nil receiver.

Every other error check in the same handler already returns after `exit()` — this one was missed.

Closes #5901

## Changes

- **ssh/web/web.go**: Added `return` after `exit(wsconn, ErrBridgeCredentialsNotFound)` at line 112, matching the pattern of all other error guards in the same handler
- **ssh/web/web_test.go**: Regression test that registers the bridge with a mock cache, dials a WebSocket with a nonexistent token, and asserts the handler does not panic and returns `messageKindError` with the expected error

## Testing

```
/test ssh web -- -run TestNewSSHServerBridge_CredentialsNotFound -v
```

Without the fix, the test panics at `creds.decryptPassword()`. With the fix, the client receives the error message and the connection closes cleanly. Full `ssh/web` suite passes.