### PR TITLE
fix(tests): replace EventuallyWithT with timeout-guarded goroutine in resize test

### DIFF
--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -973,20 +973,42 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					require.NoError(t, err)
 
 					expected := fmt.Sprintf("%d %d", newHeight, newWidth)
-					// Each retry uses a unique marker to avoid matching stale output
-					// left in the buffer from a previous attempt.
-					sizeCheckCounter := 0
-					require.EventuallyWithT(t, func(tt *assert.CollectT) {
-						sizeCheckCounter++
-						marker := fmt.Sprintf("SIZE_CHECK_%d_%d", i, sizeCheckCounter)
+					// Poll until stty reports the expected size. Each attempt
+					// uses a unique marker so stale output from prior attempts
+					// is never matched.
+					//
+					// readMarkedOutput blocks on ReadString which cannot be
+					// interrupted, so each attempt runs in a goroutine with a
+					// per-attempt timeout. On timeout we abort immediately
+					// (the deferred sess/conn Close unblocks the reader).
+					deadline := time.Now().Add(5 * time.Second)
+					var lastOutput string
+					matched := false
+					for attempt := 0; !matched && time.Now().Before(deadline); attempt++ {
+						marker := fmt.Sprintf("SIZE_CHECK_%d_%d", i, attempt)
 
-						output, err := readMarkedOutput(stdin, reader, marker)
-						if !assert.NoError(tt, err) {
-							return
+						type readResult struct {
+							output string
+							err    error
 						}
+						ch := make(chan readResult, 1)
+						go func() {
+							out, err := readMarkedOutput(stdin, reader, marker)
+							ch <- readResult{out, err}
+						}()
 
-						assert.Equal(tt, expected, output)
-					}, 500*time.Millisecond, 50*time.Millisecond)
+						select {
+						case r := <-ch:
+							require.NoError(t, r.err)
+							lastOutput = r.output
+							matched = (r.output == expected)
+						case <-time.After(2 * time.Second):
+							require.Fail(t, "timeout reading stty output",
+								"marker=%s expected=%s", marker, expected)
+						}
+					}
+					require.True(t, matched,
+						"expected terminal size %q but got %q", expected, lastOutput)
 				}
 			},
 		},


### PR DESCRIPTION
## What

Fixed the flaky `terminal_window_size_change` integration test by replacing `EventuallyWithT` with a timeout-guarded goroutine pattern.

Supersedes #5917

## Why

`EventuallyWithT` runs each callback in a goroutine that blocks on `ReadString` — a call backed by `sync.Cond.Wait` that cannot be interrupted. When the shell is slow to respond, the callback goroutine leaks and races on the shared `bufio.Reader` with the next attempt, causing flaky hangs that can last 20+ minutes before the test framework times out.

## Changes

- **tests/ssh_test.go**: Replaced `EventuallyWithT` with an explicit retry loop where each `readMarkedOutput` call runs in a goroutine behind a `select`/`time.After` guard (5s deadline, 2s per-attempt timeout). On timeout the test aborts immediately with `require.Fail`; deferred `sess`/`conn` Close unblocks the leaked reader. Each attempt uses a unique marker to prevent matching stale buffered output.

## Testing

Ran with `-count=5` (5 sequential runs) — all passed consistently in ~3.6s each:

```
--- PASS: TestSSH/connection_v1/terminal_window_size_change (3.62s)
--- PASS: TestSSH/connection_v1/terminal_window_size_change (3.59s)
--- PASS: TestSSH/connection_v1/terminal_window_size_change (3.67s)
--- PASS: TestSSH/connection_v1/terminal_window_size_change (3.60s)
--- PASS: TestSSH/connection_v1/terminal_window_size_change (3.62s)
```