### PR TITLE
Fix(agent): Improve tunnel preservation during agent upgrade when using tunnel. Housekeeping of shellhub-agent files in own directory

### DIFF
--- a/agent/installer.go
+++ b/agent/installer.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	agentEnvFile     = "/etc/shellhub-agent.env"
+	agentEnvFile     = "/etc/shellhub-agent/shellhub-agent.env"
 	agentServiceFile = "/etc/systemd/system/shellhub-agent.service"
 	agentServiceName = "shellhub-agent"
 )
@@ -26,7 +26,7 @@ Wants=network-online.target
 Requires=local-fs.target
 
 [Service]
-EnvironmentFile=/etc/shellhub-agent.env
+EnvironmentFile=/etc/shellhub-agent/shellhub-agent.env
 ExecStart={{.BinaryPath}}
 Restart=on-failure
 RestartSec=5
@@ -83,12 +83,12 @@ func registerInstallerCommands(rootCmd *cobra.Command) {
 
 	installCmd.Flags().String("server-address", "", "ShellHub server address")
 	installCmd.Flags().String("tenant-id", "", "Namespace tenant ID")
-	installCmd.Flags().String("private-key", "/etc/shellhub.key", "Path to the agent private key file")
+	installCmd.Flags().String("private-key", "/etc/shellhub-agent/shellhub.key", "Path to the agent private key file")
 	installCmd.Flags().String("preferred-hostname", "", "Preferred device hostname")
 	installCmd.Flags().String("preferred-identity", "", "Preferred device identity")
 	installCmd.Flags().Uint("keepalive-interval", 30, "Keepalive interval in seconds")
 	installCmd.MarkFlagRequired("server-address") //nolint:errcheck
-	installCmd.MarkFlagRequired("tenant-id")       //nolint:errcheck
+	installCmd.MarkFlagRequired("tenant-id")      //nolint:errcheck
 
 	rootCmd.AddCommand(installCmd)
 
@@ -129,6 +129,10 @@ func agentInstall(cfg installerConfig) error {
 	binaryPath, err := filepath.EvalSymlinks(exe)
 	if err != nil {
 		return fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(agentEnvFile), 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(agentEnvFile), err)
 	}
 
 	if err := writeAgentEnvFile(cfg); err != nil {

--- a/agent/installer.go
+++ b/agent/installer.go
@@ -117,9 +117,9 @@ func agentInstall(cfg installerConfig) error {
 		return fmt.Errorf("systemd is not available on this system")
 	}
 
-	// Stop existing service before overwriting files (re-install / upgrade).
-	// Ignore error — service may not exist yet.
-	exec.Command("systemctl", "disable", "--now", agentServiceName).Run() //nolint:errcheck
+	// Best practice would be to disable service here before install/upgrade
+	// If upgrade performed over tunnel, ssh session disconnect, binary gets sighup.
+	// Service will restart at end of install/upgrade
 
 	exe, err := os.Executable()
 	if err != nil {
@@ -147,8 +147,14 @@ func agentInstall(cfg installerConfig) error {
 		return fmt.Errorf("failed to reload systemd daemon: %w", err)
 	}
 
-	if err := exec.Command("systemctl", "enable", "--now", agentServiceName).Run(); err != nil {
+	// For upgrade over tunnel support, just enable service, service reboot later
+	if err := exec.Command("systemctl", "enable", agentServiceName).Run(); err != nil {
 		return fmt.Errorf("failed to enable service: %w", err)
+	}
+
+	// Restarts service to upgraded binary, session dies but tunnel remains active.
+	if err := exec.Command("systemctl", "restart", agentServiceName).Run(); err != nil {
+		return fmt.Errorf("failed to restart service: %w", err)
 	}
 
 	return nil

--- a/agent/installer.go
+++ b/agent/installer.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	agentEnvFile     = "/etc/shellhub-agent.env"
+	agentEnvFile     = "/etc/shellhub-agent/shellhub-agent.env"
 	agentServiceFile = "/etc/systemd/system/shellhub-agent.service"
 	agentServiceName = "shellhub-agent"
 )
@@ -27,7 +27,7 @@ Wants=network-online.target
 Requires=local-fs.target
 
 [Service]
-EnvironmentFile=/etc/shellhub-agent.env
+EnvironmentFile=/etc/shellhub-agent/shellhub-agent.env
 ExecStart={{.BinaryPath}}
 Restart=on-failure
 RestartSec=5
@@ -94,7 +94,11 @@ func registerInstallerCommands(rootCmd *cobra.Command) {
 
 	installCmd.Flags().String("server-address", "", "ShellHub server address")
 	installCmd.Flags().String("tenant-id", "", "Namespace tenant ID")
-	installCmd.Flags().String("private-key", "/etc/shellhub.key", "Path to the agent private key file")
+	installCmd.Flags().String(
+		"private-key",
+		"/etc/shellhub-agent/shellhub.key",
+		"Path to the agent private key file",
+	)
 	installCmd.Flags().String("install-key", "", "Install key used to enroll the device")
 	installCmd.Flags().String("preferred-hostname", "", "Preferred device hostname")
 	installCmd.Flags().String("preferred-identity", "", "Preferred device identity")
@@ -139,6 +143,10 @@ func agentInstall(cfg installerConfig) error {
 	binaryPath, err := filepath.EvalSymlinks(exe)
 	if err != nil {
 		return fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(agentEnvFile), 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(agentEnvFile), err)
 	}
 
 	if err := writeAgentEnvFile(cfg); err != nil {

--- a/agent/installer.go
+++ b/agent/installer.go
@@ -133,7 +133,10 @@ func agentInstall(cfg installerConfig) error {
 		return fmt.Errorf("systemd is not available on this system")
 	}
 
-	exec.Command("systemctl", "disable", "--now", agentServiceName).Run() //nolint:errcheck
+	// Do not disable/stop the service here. During an upgrade over the SSH tunnel,
+	// stopping the service disconnects the session and causes the agent to receive
+	// SIGHUP, which can cause the installation to fail. The service is restarted
+	// at the end of the install/upgrade procedure.
 
 	exe, err := os.Executable()
 	if err != nil {
@@ -161,8 +164,15 @@ func agentInstall(cfg installerConfig) error {
 		return fmt.Errorf("failed to reload systemd daemon: %w", err)
 	}
 
-	if err := exec.Command("systemctl", "enable", "--now", agentServiceName).Run(); err != nil {
+	// NOTE: Only enable the service here to maintain the SSH tunnel if one is active.
+	// The service will be restarted after the upgrade.
+	if err := exec.Command("systemctl", "enable", agentServiceName).Run(); err != nil {
 		return fmt.Errorf("failed to enable service: %w", err)
+	}
+
+	// Finally, restart the service with the newly installed version.
+	if err := exec.Command("systemctl", "restart", agentServiceName).Run(); err != nil {
+		return fmt.Errorf("failed to restart service: %w", err)
 	}
 
 	return nil

--- a/agent/packaging/config.json
+++ b/agent/packaging/config.json
@@ -16,7 +16,7 @@
             "__PREFERRED_HOSTNAME__",
             "__PREFERRED_IDENTITY__",
             "__KEEPALIVE_INTERVAL__",
-            "SHELLHUB_PRIVATE_KEY=/host/etc/shellhub.key"
+            "SHELLHUB_PRIVATE_KEY=/host/etc/shellhub-agent/shellhub.key"
         ],
         "cwd": "/",
         "capabilities": {

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ podman_install() {
   esac
 
   if [ -z "$MODE" ]; then
-    ARGS="$ARGS -e SHELLHUB_PRIVATE_KEY=${PRIVATE_KEY:-/host/etc/shellhub.key}"
+    ARGS="$ARGS -e SHELLHUB_PRIVATE_KEY=${PRIVATE_KEY:-/host/etc/shellhub-agent/shellhub.key}"
 
     echo "🚀 Starting ShellHub container in Agent mode..."
   fi
@@ -118,7 +118,7 @@ docker_install() {
   esac
 
   if [ -z "$MODE" ]; then
-    ARGS="$ARGS -e SHELLHUB_PRIVATE_KEY=${PRIVATE_KEY:-/host/etc/shellhub.key}"
+    ARGS="$ARGS -e SHELLHUB_PRIVATE_KEY=${PRIVATE_KEY:-/host/etc/shellhub-agent/shellhub.key}"
 
     echo "🚀 Starting ShellHub container in Agent mode..."
   fi
@@ -189,7 +189,7 @@ snap_install() {
 
     sudo snap set shellhub server-address="$SERVER_ADDRESS"
     sudo snap set shellhub tenant-id="$TENANT_ID"
-    sudo snap set shellhub private-key="${PRIVATE_KEY:-/etc/shellhub.key}"
+    sudo snap set shellhub private-key="${PRIVATE_KEY:-/etc/shellhub-agent/shellhub.key}"
 
     sudo snap start shellhub
   } || {

--- a/install.sh
+++ b/install.sh
@@ -206,7 +206,7 @@ podman_install() {
   esac
 
   if [ -z "$MODE" ]; then
-    ARGS="$ARGS -e SHELLHUB_PRIVATE_KEY=${PRIVATE_KEY:-/host/etc/shellhub.key}"
+    ARGS="$ARGS -e SHELLHUB_PRIVATE_KEY=${PRIVATE_KEY:-/host/etc/shellhub-agent/shellhub.key}"
 
     echo "🚀 Starting ShellHub container in Agent mode..."
   fi
@@ -294,7 +294,7 @@ docker_install() {
   esac
 
   if [ -z "$MODE" ]; then
-    ARGS="$ARGS -e SHELLHUB_PRIVATE_KEY=${PRIVATE_KEY:-/host/etc/shellhub.key}"
+    ARGS="$ARGS -e SHELLHUB_PRIVATE_KEY=${PRIVATE_KEY:-/host/etc/shellhub-agent/shellhub.key}"
 
     echo "🚀 Starting ShellHub container in Agent mode..."
   fi
@@ -378,7 +378,7 @@ snap_install() {
 
     sudo snap set shellhub server-address="$SERVER_ADDRESS"
     sudo snap set shellhub tenant-id="$TENANT_ID"
-    sudo snap set shellhub private-key="${PRIVATE_KEY:-/etc/shellhub.key}"
+    sudo snap set shellhub private-key="${PRIVATE_KEY:-/etc/shellhub-agent/shellhub.key}"
 
     sudo snap start shellhub
   } || {


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] New Feature
- [x] Feature Improvment
- [ ] Refactoring
- [ ] Documentation
- [x] Other, please describe:

### Description:

* Organized go based agent config and key files into own dedicated directory in `/etc/shellhub-agent/`
  * Does not remove existing `/etc/shellhub.key` and `/etc/shellhub-agent.env` or `/opt/shellhub/`
  * Best migration procedure would be to copy `shellhub.key` to `/etc/shellhub-agent/shellhub.key` prior to performing installation/upgrade
* Modified default PRIVATE_KEY location value for podman, snap and docker installation in shell install script to `/etc/shellhub-agent`
* ***Restarts shellhub-agent service at end of installation step instead of ending shellhub-agent at start of installation procedure.***
  * ***Reduces risk of removing device from shellhub tunnel network if agent installation/re-installation/upgrade process was performed over shellhub tunnel***


### Migration Guide \**Optional\**

The following guide also applies when migrating from `runc-shellhub-agent` to the native `go-shellhub-agent`.

The following steps are only needed if you want to retain the same device unique ID in ShellHub and avoid creating a new pending request.

If the migration steps are not performed, the device will be registered as a new device, and the pending request will need to be accepted.

1. Manually create `/etc/shellhub-agent/` directory
2. Copy `shellhub.key` from `/opt/shellhub-agent/shelhlub.key` or `/etc/shellhub.key` to `/etc/shellhub-agent/shellhub.key`
3. Perform agent installation/upgrade steps as normal
4. Ensure installation/upgrade was successful and tunnel is active 
5. Able to remove the following `/opt/shellhub-agent/` and `/etc/shellhub.key` and `/etc/shellhub-agent.env`