### PR TITLE
fix(ui-react): fix dialog style specificity breaking backdrop rendering

### DIFF
--- a/ui-react/packages/design-system/css/base.css
+++ b/ui-react/packages/design-system/css/base.css
@@ -16,7 +16,7 @@
     overflow: hidden;
   }
 
-  dialog[data-custom-backdrop] {
+  dialog {
     all: unset;
     cursor: auto;
     user-select: text;


### PR DESCRIPTION
## What

The `all: unset` reset for custom dialogs used a `[data-custom-backdrop]` attribute selector, giving it specificity (0,1,1) — higher than Tailwind's single-class utilities (0,1,0). This caused `all: unset` to win the cascade, nuking every Tailwind utility applied to the dialog (`fixed`, `inset-0`, `z-[60]`, `flex`, etc.) and resetting them to initial values. The dialog rendered as an unstyled inline element with no positioning or backdrop.

## Why

Both the Welcome Wizard and Create Namespace dialogs were visually broken: no backdrop overlay, content rendering without proper positioning, background page fully visible and interactive behind the dialog.

## Changes

- **base.css**: Removed `[data-custom-backdrop]` from the `dialog` reset selector, lowering specificity to (0,0,1). Tailwind utilities now win the cascade and the dialog renders correctly. The `::backdrop` rule keeps the attribute selector since `::backdrop` styles are not overridden by utilities.