### PR TITLE
fix(ci): add -e flag to go mod tidy in prepare-release

### DIFF
--- a/devscripts/prepare-release
+++ b/devscripts/prepare-release
@@ -4,7 +4,7 @@ prepare_go_dir() {
     (
         cd $1
         rm -f go.sum
-        go mod tidy
+        go mod tidy -e
     )
 }
 


### PR DESCRIPTION
Added the -e flag to the go mod tidy command in devscripts/prepare-release so CI can generate go.sum even without access to private enterprise modules.

This is a temporary and palliative solution to allow CI to pass for the Community Edition without granting access to private cloud/enterprise modules. In the future, once enterprise code is properly isolated, this workaround can be removed.