### PR TITLE
chore(gateway): serve ui-react at / and move legacy Vue UI to /v1

### DIFF
--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -45,7 +45,16 @@ server {
 
     {{ if eq $cfg.Database "migrate" }}
 
-    location /v2/ {
+    location /healthcheck {
+        default_type text/plain;
+        return 200 "OK";
+    }
+
+    location = / {
+        return 302 /migrate.html;
+    }
+
+    location / {
         set $upstream ui-react:8080;
 
         add_header Cache-Control "no-cache, no-store";
@@ -58,15 +67,6 @@ server {
         proxy_http_version 1.1;
         proxy_cache_bypass $http_upgrade;
         proxy_redirect off;
-    }
-
-    location /healthcheck {
-        default_type text/plain;
-        return 200 "OK";
-    }
-
-    location / {
-        return 302 /v2/ui/migrate.html;
     }
 
     {{ else }}
@@ -96,8 +96,8 @@ server {
         rewrite ^/(.*)$ /api/healthcheck break;
     }
 
-    location /v2/ {
-        set $upstream ui-react:8080;
+    location /v1/ {
+        set $upstream ui:8080;
 
         add_header Cache-Control "no-cache, no-store";
         add_header Pragma "no-cache";
@@ -112,7 +112,7 @@ server {
     }
 
     location / {
-        set $upstream ui:8080;
+        set $upstream ui-react:8080;
 
         add_header Cache-Control "no-cache, no-store";
         add_header Pragma "no-cache";

--- a/ui-react/apps/admin/src/api/__tests__/interceptors.test.ts
+++ b/ui-react/apps/admin/src/api/__tests__/interceptors.test.ts
@@ -106,7 +106,7 @@ describe("request interceptor", () => {
     expect(useAuthStore.getState().token).toBeNull();
 
     // Should redirect
-    expect(window.location.href).toBe("/v2/ui/login");
+    expect(window.location.href).toBe("/login");
   });
 
   it("rejects when token is malformed", async () => {
@@ -137,7 +137,7 @@ describe("response interceptor", () => {
     await expect(client.get("/test")).rejects.toBeDefined();
 
     expect(useAuthStore.getState().token).toBeNull();
-    expect(window.location.href).toBe("/v2/ui/login");
+    expect(window.location.href).toBe("/login");
   });
 
   it("marks API as up on successful response", async () => {

--- a/ui-react/apps/admin/src/api/interceptors.ts
+++ b/ui-react/apps/admin/src/api/interceptors.ts
@@ -44,7 +44,7 @@ export function setupInterceptors(instance: AxiosInstance) {
     if (token) {
       if (isTokenExpired(token)) {
         useAuthStore.getState().logout();
-        window.location.href = "/v2/ui/login";
+        window.location.href = "/login";
         return Promise.reject(new Error("Token expired"));
       }
       config.headers.Authorization = `Bearer ${token}`;
@@ -63,7 +63,7 @@ export function setupInterceptors(instance: AxiosInstance) {
     (error: AxiosError) => {
       if (error.response?.status === 401) {
         useAuthStore.getState().logout();
-        window.location.href = "/v2/ui/login";
+        window.location.href = "/login";
       } else if (isApiDown(error)) {
         scheduleMarkDown();
       }

--- a/ui-react/apps/admin/src/components/common/ConnectivityGuard.tsx
+++ b/ui-react/apps/admin/src/components/common/ConnectivityGuard.tsx
@@ -27,7 +27,7 @@ function ApiUnavailablePage() {
       {/* Content */}
       <div className="flex flex-col items-center text-center px-6 animate-fade-in">
         <img
-          src="/v2/ui/logo.svg"
+          src="/logo.svg"
           alt="ShellHub"
           className="h-8 mb-10 opacity-50"
         />

--- a/ui-react/apps/admin/src/components/common/NamespaceGuard.tsx
+++ b/ui-react/apps/admin/src/components/common/NamespaceGuard.tsx
@@ -8,7 +8,7 @@ import UserMenu from "../layout/UserMenu";
 function MinimalHeader() {
   return (
     <header className="h-14 bg-surface border-b border-border px-5 flex items-center justify-between shrink-0">
-      <img src="/v2/ui/logo.svg" alt="ShellHub" className="h-6" />
+      <img src="/logo.svg" alt="ShellHub" className="h-6" />
       <UserMenu />
     </header>
   );

--- a/ui-react/apps/admin/src/components/layout/Sidebar.tsx
+++ b/ui-react/apps/admin/src/components/layout/Sidebar.tsx
@@ -122,7 +122,7 @@ export default function Sidebar() {
       }`}
     >
       <div className="h-14 flex items-center justify-center border-b border-border">
-        <img src="/v2/ui/logo.svg" alt="ShellHub" className="h-8" />
+        <img src="/logo.svg" alt="ShellHub" className="h-8" />
       </div>
 
       <nav className="flex-1 px-3 pt-4 py-2 overflow-y-auto">

--- a/ui-react/apps/admin/src/env.ts
+++ b/ui-react/apps/admin/src/env.ts
@@ -16,7 +16,7 @@ export async function loadConfig(): Promise<ClientConfig> {
   if (cached !== defaultConfig) return cached;
 
   try {
-    const res = await fetch("/v2/ui/config.json");
+    const res = await fetch("/config.json");
     cached = { ...defaultConfig, ...(await res.json()) };
   } catch {
     cached = defaultConfig;

--- a/ui-react/apps/admin/src/main.tsx
+++ b/ui-react/apps/admin/src/main.tsx
@@ -12,7 +12,7 @@ loadConfig().then(() => {
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
       <ErrorBoundary>
-        <BrowserRouter basename="/v2/ui">
+        <BrowserRouter basename="/">
           <App />
         </BrowserRouter>
       </ErrorBoundary>

--- a/ui-react/apps/admin/src/pages/MigrationPage.tsx
+++ b/ui-react/apps/admin/src/pages/MigrationPage.tsx
@@ -24,7 +24,7 @@ export default function MigrationPage() {
       {/* Content */}
       <div className="flex flex-col items-center text-center px-6 animate-fade-in">
         <img
-          src="/v2/ui/logo.svg"
+          src="/logo.svg"
           alt="ShellHub"
           className="h-8 mb-10 opacity-50"
         />

--- a/ui-react/apps/admin/src/pages/Setup.tsx
+++ b/ui-react/apps/admin/src/pages/Setup.tsx
@@ -106,7 +106,7 @@ export default function Setup() {
         <div className="bg-surface border border-border rounded-lg overflow-hidden">
           <div className="px-8 pt-8 pb-6 border-b border-border bg-card/50">
             <div className="flex justify-center mb-5">
-              <img src="/v2/ui/logo.svg" alt="ShellHub" className="h-7" />
+              <img src="/logo.svg" alt="ShellHub" className="h-7" />
             </div>
             <p className="text-center text-2xs font-mono text-text-muted tracking-wider uppercase">
               Initial Setup
@@ -137,7 +137,7 @@ export default function Setup() {
       <div className="bg-surface border border-border rounded-lg overflow-hidden">
         <div className="px-8 pt-8 pb-6 border-b border-border bg-card/50">
           <div className="flex justify-center mb-5">
-            <img src="/v2/ui/logo.svg" alt="ShellHub" className="h-7" />
+            <img src="/logo.svg" alt="ShellHub" className="h-7" />
           </div>
           <h1 className="text-center text-sm font-semibold text-text-primary mb-1">
             Welcome to ShellHub

--- a/ui-react/apps/admin/src/stores/__tests__/namespacesStore.test.ts
+++ b/ui-react/apps/admin/src/stores/__tests__/namespacesStore.test.ts
@@ -155,7 +155,7 @@ describe("namespacesStore", () => {
 
       expect(mockedDeleteNamespace).toHaveBeenCalledWith("t1");
       expect(useAuthStore.getState().token).toBeNull();
-      expect(window.location.replace).toHaveBeenCalledWith("/v2/ui/login");
+      expect(window.location.replace).toHaveBeenCalledWith("/login");
     });
   });
 
@@ -167,7 +167,7 @@ describe("namespacesStore", () => {
 
       expect(mockedLeaveNamespace).toHaveBeenCalledWith("t1");
       expect(useAuthStore.getState().token).toBeNull();
-      expect(window.location.replace).toHaveBeenCalledWith("/v2/ui/login");
+      expect(window.location.replace).toHaveBeenCalledWith("/login");
     });
   });
 

--- a/ui-react/apps/admin/src/stores/authStore.ts
+++ b/ui-react/apps/admin/src/stores/authStore.ts
@@ -113,7 +113,7 @@ export const useAuthStore = create<AuthState>()(
       deleteUser: async () => {
         await apiDeleteUser();
         get().logout();
-        window.location.replace("/v2/ui/login");
+        window.location.replace("/login");
       },
     }),
     {

--- a/ui-react/apps/admin/src/stores/namespacesStore.ts
+++ b/ui-react/apps/admin/src/stores/namespacesStore.ts
@@ -96,12 +96,12 @@ export const useNamespacesStore = create<NamespacesState>((set) => ({
   deleteNamespace: async (tenantId: string) => {
     await deleteNamespaceApi(tenantId);
     useAuthStore.getState().logout();
-    window.location.replace("/v2/ui/login");
+    window.location.replace("/login");
   },
 
   leaveNamespace: async (tenantId: string) => {
     await leaveNamespaceApi(tenantId);
     useAuthStore.getState().logout();
-    window.location.replace("/v2/ui/login");
+    window.location.replace("/login");
   },
 }));

--- a/ui-react/apps/admin/vite.config.ts
+++ b/ui-react/apps/admin/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     }),
     healthcheck(),
   ],
-  base: "/v2/ui/",
+  base: "/",
   server: {
     port: 8080,
     allowedHosts: true,

--- a/ui-react/nginx.conf
+++ b/ui-react/nginx.conf
@@ -7,13 +7,10 @@ server {
         add_header Content-Type text/plain;
     }
 
-    location /v2/ui {
-        alias /usr/share/nginx/html/ui;
-        try_files $uri $uri/ /v2/ui/index.html;
-    }
-
-    location /v2 {
-        return 301 /v2/ui/;
+    location / {
+        root /usr/share/nginx/html/ui;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
     }
 
     error_page 500 502 503 504 /50x.html;

--- a/ui-react/packages/design-system/components/Footer.tsx
+++ b/ui-react/packages/design-system/components/Footer.tsx
@@ -5,7 +5,7 @@ export function Footer() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-10 mb-10">
           <div>
             <a href="#" className="inline-block mb-4">
-              <img src="/v2/logo-inverted.png" alt="ShellHub" className="h-8" />
+              <img src="/logo-inverted.png" alt="ShellHub" className="h-8" />
             </a>
             <p className="text-xs text-text-secondary max-w-[220px] leading-relaxed">The open source SSH gateway for remote access to Linux devices.</p>
           </div>

--- a/ui-react/scripts/gen-config.sh
+++ b/ui-react/scripts/gen-config.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Generates a JSON config file from SHELLHUB_* environment variables.
-# The output is served by nginx as the /v2/ui/config endpoint.
+# The output is served by nginx as the /config.json endpoint.
 #
 # Usage: gen-config.sh <output-file>
 

--- a/ui/admin/src/layouts/AppLayout.vue
+++ b/ui/admin/src/layouts/AppLayout.vue
@@ -196,7 +196,7 @@ watch(drawer, () => {
 
 const logout = () => {
   authStore.logout();
-  window.location.href = "/login";
+  window.location.href = "/v1/login";
   createNewAdminClient();
   layoutStore.layout = "LoginLayout";
 };

--- a/ui/admin/src/router/index.ts
+++ b/ui/admin/src/router/index.ts
@@ -121,7 +121,7 @@ export const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory("/admin/"),
+  history: createWebHistory("/v1/admin/"),
   routes,
 });
 
@@ -134,7 +134,7 @@ router.beforeEach(
     const requiresAdmin = to.meta.requiresAdmin ?? true;
 
     if (!authStore.isLoggedIn && requiresAuth) {
-      window.location.href = `/login?redirect=${encodeURIComponent(to.fullPath)}`;
+      window.location.href = `/v1/login?redirect=${encodeURIComponent(to.fullPath)}`;
       return next();
     }
 

--- a/ui/admin/src/views/Unauthorized.vue
+++ b/ui/admin/src/views/Unauthorized.vue
@@ -103,11 +103,11 @@ const actionItems = [
 ];
 
 const goToMainApp = () => {
-  window.location.href = "/";
+  window.location.href = "/v1/";
 };
 
 const logout = () => {
   authStore.logout();
-  window.location.href = "/login";
+  window.location.href = "/v1/login";
 };
 </script>

--- a/ui/admin/tests/unit/layouts/AppLayout.spec.ts
+++ b/ui/admin/tests/unit/layouts/AppLayout.spec.ts
@@ -13,8 +13,8 @@ const Component = { template: "<v-app><AppLayout /></v-app>" };
 // Mock window.location for router tests
 Object.defineProperty(window, "location", {
   value: {
-    href: "http://localhost:3000/admin/",
-    pathname: "/admin/",
+    href: "http://localhost:3000/v1/admin/",
+    pathname: "/v1/admin/",
     search: "",
     hash: "",
   },

--- a/ui/admin/tests/unit/views/Unauthorized.spec.ts
+++ b/ui/admin/tests/unit/views/Unauthorized.spec.ts
@@ -60,13 +60,13 @@ describe("Unauthorized", () => {
     await logoutButton.trigger("click");
 
     expect(authStore.logout).toHaveBeenCalled();
-    expect(window.location.href).toBe("/login");
+    expect(window.location.href).toBe("/v1/login");
   });
 
   it("redirects to main app when go to shellhub button is clicked", async () => {
     const goToMainAppButton = wrapper.findAll(".v-btn")[1];
     await goToMainAppButton.trigger("click");
 
-    expect(window.location.href).toBe("/");
+    expect(window.location.href).toBe("/v1/");
   });
 });

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -1,15 +1,21 @@
 server {
     listen 8080;
 
-    location / {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        try_files $uri $uri/ /index.html;
+    location /healthcheck {
+        access_log off;
+        return 200 "OK";
+        add_header Content-Type text/plain;
     }
 
-    location ^~ /admin {
-        root /usr/share/nginx/html;
-        try_files $uri $uri/ /admin/index.html;
+    location /v1/ {
+        alias /usr/share/nginx/html/;
+        index index.html index.htm;
+        try_files $uri $uri/ /v1/index.html;
+    }
+
+    location ^~ /v1/admin/ {
+        alias /usr/share/nginx/html/admin/;
+        try_files $uri $uri/ /v1/admin/index.html;
     }
 
     error_page 500 502 503 504 /50x.html;

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -12,7 +12,7 @@
           &mdash; 299 <code class="new-ui-bar-code">v-model</code> replaced with <code class="new-ui-bar-code">useState</code>
         </span>
         <a
-          href="/v2/ui/"
+          href="/"
           class="new-ui-bar-link"
         >
           <v-icon size="14" class="mr-1">

--- a/ui/src/api/interceptors.ts
+++ b/ui/src/api/interceptors.ts
@@ -24,7 +24,7 @@ const onResponseError = async (error: AxiosError, isAdmin: boolean): Promise<Axi
     const router = (await import("@admin/router")).default;
     if (error.response?.status === 401) {
       useAdminAuthStore().logout();
-      window.location.href = "/login";
+      window.location.href = "/v1/login";
     } else if (error.response?.status === 402) {
       await router.push({ name: "license" });
     }

--- a/ui/src/components/Namespace/Namespace.vue
+++ b/ui/src/components/Namespace/Namespace.vue
@@ -197,7 +197,7 @@ const availableNamespaces = computed(() => {
 });
 
 const navigateToAdminPanel = () => {
-  window.location.href = "/admin";
+  window.location.href = "/v1/admin";
 };
 
 const navigateToNamespaceSettings = async () => {
@@ -207,7 +207,7 @@ const navigateToNamespaceSettings = async () => {
 const handleNamespaceSwitch = async (tenantId: string) => {
   try {
     await namespacesStore.switchNamespace(tenantId);
-    if (props.isAdminContext && tenantId) window.location.href = "/";
+    if (props.isAdminContext && tenantId) window.location.href = "/v1/";
     else window.location.reload();
   } catch (error: unknown) {
     snackbar.showError("Failed to switch namespace");

--- a/ui/src/components/User/UserDeleteWarning.vue
+++ b/ui/src/components/User/UserDeleteWarning.vue
@@ -40,7 +40,7 @@
           Please access your
           <a
             class="font-weight-medium text-primary"
-            href="/admin/users"
+            href="/v1/admin/users"
             target="_blank"
             rel="noopener noreferrer"
           >Admin Console</a>

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -549,7 +549,7 @@ export const routes: Array<RouteRecordRaw> = [
 ];
 
 export const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory("/v1/"),
   routes,
 });
 

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -248,7 +248,7 @@ onMounted(async () => {
   statsStore.stats = {} as IStats;
   await authStore.loginWithToken(route.query.token as string);
 
-  window.location.href = "/";
+  window.location.href = "/v1/";
 });
 
 const login = async () => {

--- a/ui/tests/components/AppBar/DevicesDropdown.spec.ts
+++ b/ui/tests/components/AppBar/DevicesDropdown.spec.ts
@@ -319,7 +319,7 @@ describe("DevicesDropdown", () => {
 
     it("creates navigation links to device details", async () => {
       await flushPromises();
-      const link = drawer.find(`a[href="/devices/${mockRecentDevices[0].uid}"]`);
+      const link = drawer.find(`a[href="/v1/devices/${mockRecentDevices[0].uid}"]`);
       expect(link.exists()).toBe(true);
     });
   });
@@ -511,7 +511,7 @@ describe("DevicesDropdown", () => {
 
     it("links to devices page", () => {
       const button = drawer.find('[data-test="view-all-devices-btn"]');
-      expect(button.attributes("href")).toBe("/devices");
+      expect(button.attributes("href")).toBe("/v1/devices");
     });
   });
 

--- a/ui/tests/components/AuthMFA/MfaMailRecover.spec.ts
+++ b/ui/tests/components/AuthMFA/MfaMailRecover.spec.ts
@@ -33,7 +33,7 @@ describe("MfaMailRecover", () => {
   describe("navigation", () => {
     it("links to login page", () => {
       const loginLink = wrapper.find('[data-test="login-btn"]');
-      expect(loginLink.attributes("href")).toBe("/login");
+      expect(loginLink.attributes("href")).toBe("/v1/login");
     });
   });
 });

--- a/ui/tests/components/User/UserDeleteWarning.spec.ts
+++ b/ui/tests/components/User/UserDeleteWarning.spec.ts
@@ -140,7 +140,7 @@ describe("UserDeleteWarning", () => {
     });
 
     it("renders Admin Console link", () => {
-      const adminLink = dialog.find('a[href="/admin/users"]');
+      const adminLink = dialog.find('a[href="/v1/admin/users"]');
       expect(adminLink.exists()).toBe(true);
       expect(adminLink.attributes("target")).toBe("_blank");
       expect(adminLink.attributes("rel")).toBe("noopener noreferrer");

--- a/ui/tests/utils/router.ts
+++ b/ui/tests/utils/router.ts
@@ -39,7 +39,7 @@ import { routes as adminRoutes } from "@admin/router";
  * expect(router.currentRoute.value.path).toBe('/devices');
  */
 export const createCleanRouter = (routes = appRoutes) => createRouter({
-  history: createWebHistory(),
+  history: createWebHistory("/v1/"),
   routes,
 });
 
@@ -61,6 +61,6 @@ export const createCleanRouter = (routes = appRoutes) => createRouter({
  * });
  */
 export const createCleanAdminRouter = (routes = adminRoutes) => createRouter({
-  history: createWebHistory("/admin/"),
+  history: createWebHistory("/v1/admin/"),
   routes,
 });

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -12,6 +12,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "/v1/",
   build: {
     rollupOptions: {
       input: {
@@ -38,12 +39,12 @@ export default defineConfig({
       name: "admin-handler",
       configureServer(server) {
         server.middlewares.use(async (req, res, next) => {
-          if (!req.url?.startsWith("/admin")) return next();
+          if (!req.url?.startsWith("/v1/admin")) return next();
 
           const parsedUrl = new URL(req.url, "http://localhost");
           const { pathname } = parsedUrl;
 
-          const relativePath = pathname.replace("/admin", "");
+          const relativePath = pathname.replace("/v1/admin", "");
           const filePath = path.resolve(__dirname, "admin", `.${relativePath}`);
 
           if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {


### PR DESCRIPTION
## Problem

The React UI (ui-react) has been running in parallel at `/v2/` while the legacy Vue UI sits at `/`. Now that ui-react covers all the necessary features, it should be the default experience.

## Solution

Swap the routing so ui-react is served at `/` and the legacy Vue UI moves to `/v1/`:

- **Gateway nginx**: ui-react handles `/`, Vue handles `/v1/`
- **ui-react**: base path changed from `/v2/ui/` to `/`, all hardcoded `/v2/ui/` references removed
- **Vue UI**: base path set to `/v1/`, internal nginx adjusted to serve under that prefix
- **Migration mode**: now serves ui-react directly at `/` instead of redirecting to `/v2/ui/migrate.html`