### PR TITLE
fix(ui-react): add Escape key dismiss to Drawer and ConfirmDialog

### DIFF
--- a/ui-react/apps/admin/src/components/common/ConfirmDialog.tsx
+++ b/ui-react/apps/admin/src/components/common/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useState } from "react";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -24,6 +25,7 @@ export default function ConfirmDialog({
   confirmDisabled,
 }: ConfirmDialogProps) {
   const [confirming, setConfirming] = useState(false);
+  useEscapeKey(onClose, open);
 
   if (!open) return null;
 

--- a/ui-react/apps/admin/src/components/common/Drawer.tsx
+++ b/ui-react/apps/admin/src/components/common/Drawer.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface DrawerProps {
   open: boolean;
@@ -29,6 +30,8 @@ export default function Drawer({
   footer,
   bodyClassName,
 }: DrawerProps) {
+  useEscapeKey(onClose, open);
+
   return (
     <>
       <div


### PR DESCRIPTION
## Summary
- Add `useEscapeKey(onClose, open)` to the `Drawer` and `ConfirmDialog` components so pressing Escape dismisses them
- Previously, both overlay components could only be closed via the X button or clicking the backdrop

## Test plan
- [ ] Open any Drawer (Connect, Manage Tags, Edit Name, Generate API Key, Add Public Key) and press Escape — should close
- [ ] Open any ConfirmDialog (delete namespace, leave namespace, delete account, remove member, delete API key) and press Escape — should close
- [ ] Verify backdrop click still works on both components
- [ ] Verify X button still works on Drawer