### PR TITLE
fix(ci): use GitHub App token for cloud repo checkout in docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           app-id: ${{ secrets.CLOUD_DISPATCH_APP_ID }}
           private-key: ${{ secrets.CLOUD_DISPATCH_APP_PRIVATE_KEY }}
+          owner: shellhub-io
           repositories: cloud
 
       - name: Checkout cloud source


### PR DESCRIPTION
## What
Replaces the missing `CLOUD_REPO_TOKEN` PAT with a GitHub App token generated from the existing `CLOUD_DISPATCH_APP_ID`/`CLOUD_DISPATCH_APP_PRIVATE_KEY` credentials — the same pattern every other workflow already uses to access `shellhub-io/cloud`.

## Why
The `api-enterprise` job in `docker-publish` was failing on tag push with `Input required and not supplied: token`, breaking the v0.22.0-rc.2 release build.