### PR TITLE
fix(ci): add ui-react to docker-publish matrix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        project: [api, ssh, gateway, ui, cli]
+        project: [api, ssh, gateway, ui, ui-react, cli]
 
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
## What
Adds `ui-react` to the docker-publish workflow build matrix so the image gets published on tag push.

## Why
The v0.22.0-rc.2 release failed to push `shellhubio/ui-react` because it wasn't in the matrix.