### PR TITLE
fix(ui-react): prevent autofill on vault unlock password field

### DIFF
--- a/ui-react/apps/admin/src/components/vault/VaultUnlockDialog.tsx
+++ b/ui-react/apps/admin/src/components/vault/VaultUnlockDialog.tsx
@@ -77,8 +77,9 @@ export default function VaultUnlockDialog({ open, onClose, onReset }: Props) {
             </label>
             <input
               id="vault-unlock-password"
-              type="password"
+              type="text"
               autoComplete="off"
+              style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
               data-1p-ignore
               data-lpignore="true"
               data-form-type="other"
@@ -91,7 +92,10 @@ export default function VaultUnlockDialog({ open, onClose, onReset }: Props) {
               className={INPUT}
             />
             {error && (
-              <p id="vault-unlock-error" className="text-2xs text-accent-red mt-1.5">
+              <p
+                id="vault-unlock-error"
+                className="text-2xs text-accent-red mt-1.5"
+              >
                 {error}
               </p>
             )}


### PR DESCRIPTION
## Summary
- Use `type="text"` with `WebkitTextSecurity: "disc"` on vault unlock dialog to prevent Chrome from suggesting login credentials