### PR TITLE
fix(ui-react): add PasswordInput component to prevent browser credential prompts

### DIFF
--- a/ui-react/apps/admin/src/components/ConnectDrawer.tsx
+++ b/ui-react/apps/admin/src/components/ConnectDrawer.tsx
@@ -11,6 +11,7 @@ import { useVaultStore } from "../stores/vaultStore";
 import { getFingerprint, validatePrivateKey } from "../utils/ssh-keys";
 import CopyButton from "./common/CopyButton";
 import Drawer from "./common/Drawer";
+import PasswordInput from "./common/PasswordInput";
 import VaultLockedBanner from "./vault/VaultLockedBanner";
 import VaultUnlockDialog from "./vault/VaultUnlockDialog";
 import { LABEL, INPUT } from "../utils/styles";
@@ -262,23 +263,11 @@ export default function ConnectDrawer({
             <div className="flex-1 h-px bg-border" />
           </div>
 
-          {/* Decoy to prevent Chrome username autofill */}
-          <input
-            type="text"
-            name="fake-user"
-            autoComplete="username"
-            className="absolute w-0 h-0 opacity-0 pointer-events-none"
-            tabIndex={-1}
-            aria-hidden="true"
-          />
-
           {/* Username */}
           <div>
             <label className={LABEL}>Username</label>
             <input
               type="text"
-              name="device-user"
-              id="device-user"
               autoComplete="off"
               value={state.username}
               onChange={(e) =>
@@ -373,18 +362,12 @@ export default function ConnectDrawer({
           {state.authMethod === "password" && (
             <div>
               <label className={LABEL}>Password</label>
-              <input
-                type="text"
-                name="device-pass"
-                id="device-pass"
-                autoComplete="off"
-                style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
+              <PasswordInput
                 value={state.password}
                 onChange={(e) =>
                   dispatch({ type: "setPassword", value: e.target.value })
                 }
                 placeholder="Enter device password"
-                className={INPUT}
               />
             </div>
           )}
@@ -460,9 +443,7 @@ export default function ConnectDrawer({
                   {selectedVaultKey?.hasPassphrase && (
                     <div>
                       <label className={LABEL}>Passphrase</label>
-                      <input
-                        type="password"
-                        autoComplete="off"
+                      <PasswordInput
                         value={state.passphrase}
                         onChange={(e) =>
                           dispatch({
@@ -471,7 +452,6 @@ export default function ConnectDrawer({
                           })
                         }
                         placeholder="Key passphrase"
-                        className={INPUT}
                       />
                     </div>
                   )}
@@ -492,9 +472,7 @@ export default function ConnectDrawer({
                   {state.manualKeyEncrypted && (
                     <div>
                       <label className={LABEL}>Passphrase</label>
-                      <input
-                        type="password"
-                        autoComplete="off"
+                      <PasswordInput
                         value={state.passphrase}
                         onChange={(e) =>
                           dispatch({
@@ -503,7 +481,6 @@ export default function ConnectDrawer({
                           })
                         }
                         placeholder="Enter passphrase for encrypted key"
-                        className={INPUT}
                       />
                       <p className="text-2xs text-text-muted mt-1.5">
                         This key is encrypted and requires a passphrase.

--- a/ui-react/apps/admin/src/components/common/PasswordInput.tsx
+++ b/ui-react/apps/admin/src/components/common/PasswordInput.tsx
@@ -1,0 +1,39 @@
+import { InputHTMLAttributes, forwardRef } from "react";
+import { INPUT } from "@/utils/styles";
+
+/**
+ * Password input that uses `type="text"` + CSS masking to prevent
+ * browsers from triggering credential management (save/autofill prompts)
+ * on non-login forms.
+ *
+ * Use this for master passwords, vault passphrases, device passwords,
+ * and any field where browser credential management should not interfere.
+ *
+ * For actual login/signup forms, use a regular `<input type="password">`
+ * with proper `autoComplete` values (`current-password`, `new-password`).
+ */
+const PasswordInput = forwardRef<
+  HTMLInputElement,
+  Omit<InputHTMLAttributes<HTMLInputElement>, "type">
+>(({ className, ...props }, ref) => (
+  <input
+    ref={ref}
+    type="text"
+    autoComplete="off"
+    spellCheck={false}
+    autoCapitalize="off"
+    autoCorrect="off"
+    className={className ?? INPUT}
+    style={
+      {
+        WebkitTextSecurity: "disc",
+        textSecurity: "disc",
+      } as React.CSSProperties
+    }
+    {...props}
+  />
+));
+
+PasswordInput.displayName = "PasswordInput";
+
+export default PasswordInput;

--- a/ui-react/apps/admin/src/components/vault/VaultSetupDialog.tsx
+++ b/ui-react/apps/admin/src/components/vault/VaultSetupDialog.tsx
@@ -6,7 +6,7 @@ import {
 import { useVaultStore } from "@/stores/vaultStore";
 import { getVaultBackend } from "@/utils/vault-backend-factory";
 import { useAuthStore } from "@/stores/authStore";
-import { INPUT } from "@/utils/styles";
+import PasswordInput from "@/components/common/PasswordInput";
 
 interface Props {
   open: boolean;
@@ -106,11 +106,8 @@ export default function VaultSetupDialog({ open, onClose }: Props) {
             >
               Master Password
             </label>
-            <input
+            <PasswordInput
               id="vault-password"
-              type="text"
-              autoComplete="off"
-              style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Minimum 8 characters"
@@ -119,7 +116,6 @@ export default function VaultSetupDialog({ open, onClose }: Props) {
               aria-describedby={
                 passwordTooShort ? "vault-password-error" : undefined
               }
-              className={INPUT}
             />
             {passwordTooShort && (
               <p
@@ -138,11 +134,8 @@ export default function VaultSetupDialog({ open, onClose }: Props) {
             >
               Confirm Password
             </label>
-            <input
+            <PasswordInput
               id="vault-confirm"
-              type="text"
-              autoComplete="off"
-              style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}
               placeholder="Re-enter your password"
@@ -150,7 +143,6 @@ export default function VaultSetupDialog({ open, onClose }: Props) {
               aria-describedby={
                 passwordsMismatch ? "vault-confirm-error" : undefined
               }
-              className={INPUT}
             />
             {passwordsMismatch && (
               <p

--- a/ui-react/apps/admin/src/components/vault/VaultUnlockDialog.tsx
+++ b/ui-react/apps/admin/src/components/vault/VaultUnlockDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FormEvent } from "react";
 import { LockClosedIcon } from "@heroicons/react/24/outline";
 import { useVaultStore } from "@/stores/vaultStore";
-import { INPUT } from "@/utils/styles";
+import PasswordInput from "@/components/common/PasswordInput";
 
 interface Props {
   open: boolean;
@@ -75,23 +75,20 @@ export default function VaultUnlockDialog({ open, onClose, onReset }: Props) {
             >
               Master Password
             </label>
-            <input
+            <PasswordInput
               id="vault-unlock-password"
-              type="password"
-              autoComplete="off"
-              data-1p-ignore
-              data-lpignore="true"
-              data-form-type="other"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Enter your master password"
               autoFocus
               aria-invalid={!!error}
               aria-describedby={error ? "vault-unlock-error" : undefined}
-              className={INPUT}
             />
             {error && (
-              <p id="vault-unlock-error" className="text-2xs text-accent-red mt-1.5">
+              <p
+                id="vault-unlock-error"
+                className="text-2xs text-accent-red mt-1.5"
+              >
                 {error}
               </p>
             )}

--- a/ui-react/apps/admin/src/pages/Setup.tsx
+++ b/ui-react/apps/admin/src/pages/Setup.tsx
@@ -418,7 +418,7 @@ function PasswordField({
         <input
           id={id}
           type={visible ? "text" : "password"}
-          autoComplete="off"
+          autoComplete="new-password"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onBlur={onBlur}


### PR DESCRIPTION
## Summary

- Add `PasswordInput` component that uses `type="text"` with CSS text masking (`-webkit-text-security: disc`) to prevent browsers from triggering save/autofill credential prompts on non-login forms
- Replace raw password inputs with `PasswordInput` in ConnectDrawer, VaultSetupDialog, and VaultUnlockDialog
- Remove decoy inputs and inline style hacks from ConnectDrawer
- Set `autoComplete="new-password"` on Setup page password fields (signup form where browser saving is appropriate)