### PR TITLE
revert: prevent browser autofill on non-login forms

### DIFF
--- a/ui-react/apps/admin/src/components/ConnectDrawer.tsx
+++ b/ui-react/apps/admin/src/components/ConnectDrawer.tsx
@@ -123,20 +123,12 @@ export default function ConnectDrawer({
     (state.authMethod === "password"
       ? state.password.trim().length > 0
       : effectiveKeySource === "vault"
-        ? !!selectedVaultKey &&
-          (!selectedVaultKey.hasPassphrase ||
-            state.passphrase.trim().length > 0)
-        : state.manualKeyValid &&
-          (!state.manualKeyEncrypted || state.passphrase.trim().length > 0));
+        ? !!selectedVaultKey && (!selectedVaultKey.hasPassphrase || state.passphrase.trim().length > 0)
+        : state.manualKeyValid && (!state.manualKeyEncrypted || state.passphrase.trim().length > 0));
 
   const handleManualKeyChange = (pem: string) => {
     if (!pem.trim()) {
-      dispatch({
-        type: "setManualKey",
-        value: pem,
-        valid: false,
-        encrypted: false,
-      });
+      dispatch({ type: "setManualKey", value: pem, valid: false, encrypted: false });
       return;
     }
     const result = validatePrivateKey(pem.trim());
@@ -160,39 +152,22 @@ export default function ConnectDrawer({
         password: state.password,
       });
     } else {
-      const key =
-        effectiveKeySource === "vault" && selectedVaultKey
-          ? selectedVaultKey.data
-          : state.privateKey.trim();
-      const phrase =
-        effectiveKeySource === "vault" && selectedVaultKey
-          ? selectedVaultKey.hasPassphrase
-            ? state.passphrase
-            : undefined
-          : state.manualKeyEncrypted
-            ? state.passphrase
-            : undefined;
+      const key = effectiveKeySource === "vault" && selectedVaultKey
+        ? selectedVaultKey.data
+        : state.privateKey.trim();
+      const phrase = effectiveKeySource === "vault" && selectedVaultKey
+        ? (selectedVaultKey.hasPassphrase ? state.passphrase : undefined)
+        : (state.manualKeyEncrypted ? state.passphrase : undefined);
 
       let fingerprint: string;
       try {
         fingerprint = getFingerprint(key, phrase);
       } catch {
-        dispatch({
-          type: "setKeyError",
-          value: "Failed to read private key. Check the key or passphrase.",
-        });
+        dispatch({ type: "setKeyError", value: "Failed to read private key. Check the key or passphrase." });
         return;
       }
-      if (
-        effectiveKeySource === "vault" &&
-        selectedVaultKey &&
-        fingerprint !== selectedVaultKey.fingerprint
-      ) {
-        dispatch({
-          type: "setKeyError",
-          value:
-            "Key data appears corrupted. Try re-importing the key into the vault.",
-        });
+      if (effectiveKeySource === "vault" && selectedVaultKey && fingerprint !== selectedVaultKey.fingerprint) {
+        dispatch({ type: "setKeyError", value: "Key data appears corrupted. Try re-importing the key into the vault." });
         return;
       }
       dispatch({ type: "setKeyError", value: null });
@@ -212,10 +187,7 @@ export default function ConnectDrawer({
 
   return (
     <>
-      <VaultUnlockDialog
-        open={unlockOpen}
-        onClose={() => setUnlockOpen(false)}
-      />
+      <VaultUnlockDialog open={unlockOpen} onClose={() => setUnlockOpen(false)} />
       <Drawer
         open={open}
         onClose={onClose}
@@ -262,28 +234,13 @@ export default function ConnectDrawer({
             <div className="flex-1 h-px bg-border" />
           </div>
 
-          {/* Decoy to prevent Chrome username autofill */}
-          <input
-            type="text"
-            name="fake-user"
-            autoComplete="username"
-            className="absolute w-0 h-0 opacity-0 pointer-events-none"
-            tabIndex={-1}
-            aria-hidden="true"
-          />
-
           {/* Username */}
           <div>
             <label className={LABEL}>Username</label>
             <input
               type="text"
-              name="device-user"
-              id="device-user"
-              autoComplete="off"
               value={state.username}
-              onChange={(e) =>
-                dispatch({ type: "setUsername", value: e.target.value })
-              }
+              onChange={(e) => dispatch({ type: "setUsername", value: e.target.value })}
               placeholder="e.g. root"
               autoFocus={open}
               className={INPUT}
@@ -296,9 +253,7 @@ export default function ConnectDrawer({
             <div className="space-y-2">
               <button
                 type="button"
-                onClick={() =>
-                  dispatch({ type: "setAuthMethod", value: "password" })
-                }
+                onClick={() => dispatch({ type: "setAuthMethod", value: "password" })}
                 className={`flex items-start gap-3 w-full px-3.5 py-3 rounded-lg border text-left transition-all ${
                   state.authMethod === "password"
                     ? "bg-primary/[0.06] border-primary/30 ring-1 ring-primary/10"
@@ -332,9 +287,7 @@ export default function ConnectDrawer({
               </button>
               <button
                 type="button"
-                onClick={() =>
-                  dispatch({ type: "setAuthMethod", value: "key" })
-                }
+                onClick={() => dispatch({ type: "setAuthMethod", value: "key" })}
                 className={`flex items-start gap-3 w-full px-3.5 py-3 rounded-lg border text-left transition-all ${
                   state.authMethod === "key"
                     ? "bg-primary/[0.06] border-primary/30 ring-1 ring-primary/10"
@@ -374,15 +327,9 @@ export default function ConnectDrawer({
             <div>
               <label className={LABEL}>Password</label>
               <input
-                type="text"
-                name="device-pass"
-                id="device-pass"
-                autoComplete="off"
-                style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
+                type="password"
                 value={state.password}
-                onChange={(e) =>
-                  dispatch({ type: "setPassword", value: e.target.value })
-                }
+                onChange={(e) => dispatch({ type: "setPassword", value: e.target.value })}
                 placeholder="Enter device password"
                 className={INPUT}
               />
@@ -404,9 +351,7 @@ export default function ConnectDrawer({
                   <div className="flex gap-1 p-0.5 bg-card border border-border rounded-lg">
                     <button
                       type="button"
-                      onClick={() =>
-                        dispatch({ type: "setKeySource", value: "vault" })
-                      }
+                      onClick={() => dispatch({ type: "setKeySource", value: "vault" })}
                       className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all ${
                         state.keySource === "vault"
                           ? "bg-primary/10 text-primary border border-primary/20"
@@ -418,9 +363,7 @@ export default function ConnectDrawer({
                     </button>
                     <button
                       type="button"
-                      onClick={() =>
-                        dispatch({ type: "setKeySource", value: "manual" })
-                      }
+                      onClick={() => dispatch({ type: "setKeySource", value: "manual" })}
                       className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all ${
                         state.keySource === "manual"
                           ? "bg-primary/10 text-primary border border-primary/20"
@@ -441,12 +384,7 @@ export default function ConnectDrawer({
                     <label className={LABEL}>Select Key</label>
                     <select
                       value={state.selectedKeyId}
-                      onChange={(e) =>
-                        dispatch({
-                          type: "setSelectedKeyId",
-                          value: e.target.value,
-                        })
-                      }
+                      onChange={(e) => dispatch({ type: "setSelectedKeyId", value: e.target.value })}
                       className={INPUT}
                     >
                       <option value="">Choose a key...</option>
@@ -462,14 +400,8 @@ export default function ConnectDrawer({
                       <label className={LABEL}>Passphrase</label>
                       <input
                         type="password"
-                        autoComplete="off"
                         value={state.passphrase}
-                        onChange={(e) =>
-                          dispatch({
-                            type: "setPassphrase",
-                            value: e.target.value,
-                          })
-                        }
+                        onChange={(e) => dispatch({ type: "setPassphrase", value: e.target.value })}
                         placeholder="Key passphrase"
                         className={INPUT}
                       />
@@ -496,12 +428,7 @@ export default function ConnectDrawer({
                         type="password"
                         autoComplete="off"
                         value={state.passphrase}
-                        onChange={(e) =>
-                          dispatch({
-                            type: "setPassphrase",
-                            value: e.target.value,
-                          })
-                        }
+                        onChange={(e) => dispatch({ type: "setPassphrase", value: e.target.value })}
                         placeholder="Enter passphrase for encrypted key"
                         className={INPUT}
                       />
@@ -523,6 +450,7 @@ export default function ConnectDrawer({
           )}
         </form>
       </Drawer>
+
     </>
   );
 }

--- a/ui-react/apps/admin/src/components/vault/VaultSetupDialog.tsx
+++ b/ui-react/apps/admin/src/components/vault/VaultSetupDialog.tsx
@@ -41,7 +41,8 @@ export default function VaultSetupDialog({ open, onClose }: Props) {
 
   const passwordTooShort = password.length > 0 && password.length < 8;
   const passwordsMismatch = confirm.length > 0 && password !== confirm;
-  const canSubmit = password.length >= 8 && password === confirm && !loading;
+  const canSubmit =
+    password.length >= 8 && password === confirm && !loading;
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -92,8 +93,8 @@ export default function VaultSetupDialog({ open, onClose }: Props) {
             <ExclamationTriangleIcon className="w-4 h-4 text-accent-yellow shrink-0 mt-0.5" />
             <p className="text-xs text-text-secondary">
               <strong className="text-text-primary">{legacyCount}</strong>{" "}
-              existing {legacyCount === 1 ? "key" : "keys"} will be imported and
-              encrypted.
+              existing {legacyCount === 1 ? "key" : "keys"} will be imported
+              and encrypted.
             </p>
           </div>
         )}
@@ -108,24 +109,18 @@ export default function VaultSetupDialog({ open, onClose }: Props) {
             </label>
             <input
               id="vault-password"
-              type="text"
+              type="password"
               autoComplete="off"
-              style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="Minimum 8 characters"
               autoFocus
               aria-invalid={passwordTooShort}
-              aria-describedby={
-                passwordTooShort ? "vault-password-error" : undefined
-              }
+              aria-describedby={passwordTooShort ? "vault-password-error" : undefined}
               className={INPUT}
             />
             {passwordTooShort && (
-              <p
-                id="vault-password-error"
-                className="text-2xs text-accent-red mt-1.5"
-              >
+              <p id="vault-password-error" className="text-2xs text-accent-red mt-1.5">
                 Password must be at least 8 characters
               </p>
             )}
@@ -140,29 +135,25 @@ export default function VaultSetupDialog({ open, onClose }: Props) {
             </label>
             <input
               id="vault-confirm"
-              type="text"
+              type="password"
               autoComplete="off"
-              style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}
               placeholder="Re-enter your password"
               aria-invalid={passwordsMismatch}
-              aria-describedby={
-                passwordsMismatch ? "vault-confirm-error" : undefined
-              }
+              aria-describedby={passwordsMismatch ? "vault-confirm-error" : undefined}
               className={INPUT}
             />
             {passwordsMismatch && (
-              <p
-                id="vault-confirm-error"
-                className="text-2xs text-accent-red mt-1.5"
-              >
+              <p id="vault-confirm-error" className="text-2xs text-accent-red mt-1.5">
                 Passwords do not match
               </p>
             )}
           </div>
 
-          {error && <p className="text-xs text-accent-red">{error}</p>}
+          {error && (
+            <p className="text-xs text-accent-red">{error}</p>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <button

--- a/ui-react/apps/admin/src/pages/Login.tsx
+++ b/ui-react/apps/admin/src/pages/Login.tsx
@@ -165,7 +165,6 @@ export default function Login() {
             <input
               id="username"
               type="text"
-              autoComplete="username"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
@@ -185,7 +184,6 @@ export default function Login() {
             <input
               id="password"
               type="password"
-              autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required

--- a/ui-react/apps/admin/src/pages/Profile.tsx
+++ b/ui-react/apps/admin/src/pages/Profile.tsx
@@ -137,6 +137,7 @@ function DeleteAccountDialog({
 
   const isNamespaceOwner = namespaces.some((ns) => ns.owner === userId);
 
+
   const handleDelete = async () => {
     setError("");
     try {
@@ -277,8 +278,8 @@ function DeleteAccountWarningDialog({
             </>
           ) : (
             <p>
-              In Enterprise instances, user accounts can only be deleted via the
-              Admin Console. Please access your{" "}
+              In Enterprise instances, user accounts can only be deleted via
+              the Admin Console. Please access your{" "}
               <a
                 href="/admin/users"
                 target="_blank"
@@ -433,7 +434,6 @@ export function EditProfileDrawer({
           <label className={LABEL}>Name</label>
           <input
             type="text"
-            autoComplete="off"
             value={name}
             onChange={(e) => setName(e.target.value)}
             autoFocus={open}
@@ -455,7 +455,6 @@ export function EditProfileDrawer({
           </div>
           <input
             type="text"
-            autoComplete="off"
             value={username}
             onChange={(e) => setUsername(e.target.value.toLowerCase())}
             className={INPUT}
@@ -473,7 +472,6 @@ export function EditProfileDrawer({
           <label className={LABEL}>Email</label>
           <input
             type="email"
-            autoComplete="off"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className={INPUT}
@@ -487,7 +485,6 @@ export function EditProfileDrawer({
           <label className={LABEL}>Recovery Email</label>
           <input
             type="email"
-            autoComplete="off"
             value={recoveryEmail}
             onChange={(e) => setRecoveryEmail(e.target.value)}
             className={INPUT}

--- a/ui-react/apps/admin/src/pages/Setup.tsx
+++ b/ui-react/apps/admin/src/pages/Setup.tsx
@@ -210,7 +210,6 @@ export default function Setup() {
                 <input
                   id="sign"
                   type="text"
-                  autoComplete="off"
                   value={sign}
                   onChange={(e) => setSign(e.target.value)}
                   required
@@ -368,7 +367,6 @@ function InputField({
       <input
         id={id}
         type={type}
-        autoComplete="off"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onBlur={onBlur}
@@ -418,7 +416,6 @@ function PasswordField({
         <input
           id={id}
           type={visible ? "text" : "password"}
-          autoComplete="off"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onBlur={onBlur}


### PR DESCRIPTION
## Summary
- Reverts daeacc87f — the autofill prevention hacks (hidden decoys, WebkitTextSecurity, autoComplete="off") were causing more problems than solving