### PR TITLE
chore(ui-react): add `ui-react` generated build files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,16 @@ docker-compose.override.yml
 
 *~
 */tmp
+*.orig
+
+# UI build and dependencies artifacts
 **/node_modules
+**/dist
 **/.vite
 **/.astro
-*.orig
+**/*.map
+**/*.tsbuildinfo
+**/vite.config.d.ts
 
 api_private_key
 api_public_key


### PR DESCRIPTION
# What

Added `dist`, `.map`, `.tsbuildinfo`, and `vite.config.d.ts` files to the project's `.gitignore` to prevent those files from appearing in the version control system after running the build process in `ui-react`.

# Why 

Those files are generated by `tsc` to make the build process faster, tracking the modified files and updated dependencies more easily, and significantly improving the build speed. However, those files weren't properly ignored and required being removed from the VCS every time.
