### PR TITLE
feat(api): add migration extension point for cloud/enterprise

### DIFF
--- a/api/store/migrate/extensions.go
+++ b/api/store/migrate/extensions.go
@@ -1,0 +1,36 @@
+package migrate
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/uptrace/bun"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// MigrationExtension is a function that performs additional migration steps
+// after the core migration completes. Cloud/enterprise packages register
+// extensions to migrate their own tables and extra columns.
+type MigrationExtension func(ctx context.Context, mongo *mongo.Database, pg *bun.DB) error
+
+// migrationExtensions holds all registered migration extensions.
+var migrationExtensions []MigrationExtension
+
+// RegisterMigrationExtension registers a migration extension. Must be called
+// before Migrator.Run() — typically from a cloud package's init() function.
+func RegisterMigrationExtension(ext MigrationExtension) {
+	migrationExtensions = append(migrationExtensions, ext)
+}
+
+// applyMigrationExtensions invokes all registered migration extensions.
+func applyMigrationExtensions(ctx context.Context, mongo *mongo.Database, pg *bun.DB) error {
+	for _, ext := range migrationExtensions {
+		if err := ext(ctx, mongo, pg); err != nil {
+			log.WithError(err).Error("failed to apply migration extension")
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/api/store/migrate/migrate.go
+++ b/api/store/migrate/migrate.go
@@ -68,6 +68,12 @@ func (m *Migrator) Run(ctx context.Context) error {
 		return fmt.Errorf("post-migration validation failed: %w", err)
 	}
 
+	log.Info("Running migration extensions")
+
+	if err := applyMigrationExtensions(ctx, m.mongo, m.pg); err != nil {
+		return fmt.Errorf("migration extension failed: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Add `RegisterMigrationExtension` to the core migration package, following the same pattern as `RegisterRouteExtension` and `RegisterWorkerExtension`
- Extensions are invoked at the end of `Migrator.Run()`, after core tables are migrated and validated
- Allows cloud/enterprise builds to register their own migration logic via `init()` without contaminating the core codebase