### PR TITLE
fix(ui): allow viewing device info for pending and rejected devices

### DIFF
--- a/ui-react/apps/admin/src/pages/DeviceDetails.tsx
+++ b/ui-react/apps/admin/src/pages/DeviceDetails.tsx
@@ -22,6 +22,8 @@ import {
 import { useDevicesStore } from "../stores/devicesStore";
 import { useNamespacesStore } from "../stores/namespacesStore";
 import { useTerminalStore } from "../stores/terminalStore";
+import { Device } from "../types/device";
+import DeviceActionDialog from "./devices/DeviceActionDialog";
 import ConnectDrawer from "../components/ConnectDrawer";
 import CopyButton from "../components/common/CopyButton";
 import PlatformBadge from "../components/common/PlatformBadge";
@@ -273,6 +275,10 @@ export default function DeviceDetails() {
   const [connectOpen, setConnectOpen] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [operation, setOperation] = useState<{
+    device: Device;
+    action: "accept" | "reject" | "remove";
+  } | null>(null);
 
   useEffect(() => {
     if (uid) fetchDevice(uid);
@@ -323,6 +329,13 @@ export default function DeviceDetails() {
     } catch {
       setDeleting(false);
     }
+  };
+
+  const handleDeviceActionSuccess = () => {
+    if (!operation || !uid) return;
+
+    if (operation.action === "remove") navigate("/devices");
+    else fetchDevice(uid);
   };
 
   return (
@@ -394,28 +407,62 @@ export default function DeviceDetails() {
         {/* Actions */}
         <div className="flex items-center gap-2 shrink-0">
           {device.status === "accepted" && (
-            <button
-              onClick={() => {
-                if (existingSession) {
-                  restoreTerminal(existingSession.id);
-                } else {
-                  setConnectOpen(true);
-                }
-              }}
-              disabled={!device.online}
-              className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
-            >
-              <ChevronDoubleRightIcon className="w-4 h-4" strokeWidth={2} />
-              Connect
-            </button>
+            <>
+              <button
+                onClick={() => {
+                  if (existingSession) {
+                    restoreTerminal(existingSession.id);
+                  } else {
+                    setConnectOpen(true);
+                  }
+                }}
+                disabled={!device.online}
+                className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+              >
+                <ChevronDoubleRightIcon className="w-4 h-4" strokeWidth={2} />
+                Connect
+              </button>
+              <button
+                onClick={() => setShowDelete(true)}
+                className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
+                title="Delete device"
+              >
+                <TrashIcon className="w-4 h-4" />
+              </button>
+            </>
           )}
-          <button
-            onClick={() => setShowDelete(true)}
-            className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
-            title="Delete device"
-          >
-            <TrashIcon className="w-4 h-4" />
-          </button>
+          {device.status === "pending" && (
+            <>
+              <button
+                onClick={() => setOperation({ device, action: "accept" })}
+                className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold transition-all"
+              >
+                Accept
+              </button>
+              <button
+                onClick={() => setOperation({ device, action: "reject" })}
+                className="flex items-center gap-2 px-4 py-2.5 bg-accent-yellow/90 hover:bg-accent-yellow text-white rounded-lg text-sm font-semibold transition-all"
+              >
+                Reject
+              </button>
+            </>
+          )}
+          {device.status === "rejected" && (
+            <>
+              <button
+                onClick={() => setOperation({ device, action: "accept" })}
+                className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold transition-all"
+              >
+                Accept
+              </button>
+              <button
+                onClick={() => setOperation({ device, action: "remove" })}
+                className="flex items-center gap-2 px-4 py-2.5 bg-accent-red/90 hover:bg-accent-red text-white rounded-lg text-sm font-semibold transition-all"
+              >
+                Remove
+              </button>
+            </>
+          )}
         </div>
       </div>
 
@@ -562,6 +609,16 @@ export default function DeviceDetails() {
         deviceUid={device.uid}
         deviceName={device.name}
         sshid={sshid}
+      />
+
+      {/* Action Dialog (accept/reject/remove for pending/rejected devices) */}
+      <DeviceActionDialog
+        key={operation ? `${operation.action}/${operation.device.uid}` : "closed"}
+        open={!!operation}
+        device={operation?.device ?? null}
+        action={operation?.action ?? "accept"}
+        onClose={() => setOperation(null)}
+        onSuccess={handleDeviceActionSuccess}
       />
     </div>
   );

--- a/ui-react/apps/admin/src/pages/devices/DeviceActionDialog.tsx
+++ b/ui-react/apps/admin/src/pages/devices/DeviceActionDialog.tsx
@@ -30,11 +30,13 @@ function DeviceActionDialog({
   device,
   action,
   onClose,
+  onSuccess,
   open,
 }: {
   device: Device | null;
   action: "accept" | "reject" | "remove";
   onClose: () => void;
+  onSuccess?: () => void;
   open: boolean;
 }) {
   const accept = useDevicesStore((s) => s.accept);
@@ -48,7 +50,6 @@ function DeviceActionDialog({
     setError(null);
     try {
       await { accept, reject, remove }[action](device.uid);
-      onClose();
     } catch (err: unknown) {
       if (axios.isAxiosError(err)) {
         const status = err.response?.status;
@@ -70,7 +71,10 @@ function DeviceActionDialog({
       } else {
         setError(`Failed to ${action} device.`);
       }
+      return;
     }
+    onSuccess?.();
+    onClose();
   };
 
   const description = device ? (

--- a/ui-react/apps/admin/src/pages/devices/index.tsx
+++ b/ui-react/apps/admin/src/pages/devices/index.tsx
@@ -242,11 +242,8 @@ export default function Devices() {
                   return (
                     <tr
                       key={device.uid}
-                      onClick={() => {
-                        if (device.status === "accepted")
-                          navigate(`/devices/${device.uid}`);
-                      }}
-                      className={`group hover:bg-hover-subtle transition-colors ${device.status === "accepted" ? "cursor-pointer" : ""}`}
+                      onClick={() => navigate(`/devices/${device.uid}`)}
+                      className="group hover:bg-hover-subtle transition-colors cursor-pointer"
                     >
                       {/* Online dot — accepted only */}
                       {status === "accepted" && (


### PR DESCRIPTION
## What

Device rows in the listing page are now clickable regardless of status, and the device detail page shows status-appropriate action buttons (Accept/Reject for pending, Accept/Remove for rejected).

## Why

The v2 UI only allowed clicking on accepted devices to view their details. Pending and rejected devices had no way to access the detail page, preventing users from viewing device info or renaming devices before accepting them.

Closes #5994

## Changes

- **devices/index.tsx**: Removed the `status === "accepted"` guard on row click and conditional `cursor-pointer` class -- all rows now navigate to `/devices/:uid`
- **DeviceDetails.tsx**: Replaced the single Connect + Delete actions area with status-dependent buttons: accepted shows Connect + Delete (unchanged), pending shows Accept + Reject, rejected shows Accept + Remove. After accept/reject, the page refetches the device to reflect the new status. After remove, navigates back to the listing.
- **DeviceActionDialog.tsx**: Added an `onSuccess` callback prop, called after a confirmed action succeeds but before `onClose`. Restructured the try/catch so `onSuccess`/`onClose` only run on the success path -- errors no longer risk triggering post-action side effects.

## Testing

1. Add a pending device: `./devscripts/add-device --fake 00000000-0000-4000-0000-000000000000`
2. Verify its row is clickable and the detail page loads with Accept/Reject buttons
3. Accept from the detail page -- page should refresh to show Connect + Delete
4. Reject a pending device -- page should refresh to show Accept + Remove
5. Remove a rejected device -- should navigate back to `/devices`
6. Cancel any action dialog -- should stay on the detail page with no side effects
7. Accepted device behavior unchanged (Connect + Delete)