### PR TITLE
fix(api): replace global unique constraint on api_keys name

### DIFF
--- a/api/store/pg/migrations/020_fix_api_keys_unique_constraint.go
+++ b/api/store/pg/migrations/020_fix_api_keys_unique_constraint.go
@@ -1,0 +1,49 @@
+package migrations
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	migrations.MustRegister(migration020Up, migration020Down)
+}
+
+func migration020Up(ctx context.Context, db *bun.DB) error {
+	if _, err := db.ExecContext(ctx, `ALTER TABLE api_keys DROP CONSTRAINT IF EXISTS api_keys_name_key`); err != nil {
+		log.WithError(err).Error("failed to drop api_keys_name_key constraint in migration 020")
+
+		return err
+	}
+
+	if _, err := db.NewCreateIndex().
+		Model((*struct {
+			bun.BaseModel `bun:"table:api_keys"`
+		})(nil)).
+		Index("api_keys_namespace_id_name_unique").
+		Column("namespace_id", "name").
+		Unique().
+		IfNotExists().
+		Exec(ctx); err != nil {
+		log.WithError(err).Error("failed to create api_keys_namespace_id_name_unique index in migration 020")
+
+		return err
+	}
+
+	return nil
+}
+
+// migration020Down drops the composite unique index but intentionally does not
+// restore the original api_keys_name_key constraint, which enforced global
+// uniqueness on name — a bug, not intended behavior.
+func migration020Down(ctx context.Context, db *bun.DB) error {
+	if _, err := db.ExecContext(ctx, `DROP INDEX IF EXISTS api_keys_namespace_id_name_unique`); err != nil {
+		log.WithError(err).Error("failed to revert migration 020")
+
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## What

Corrects the unique constraint on the `api_keys` table so API key names are unique per namespace rather than globally.

## Why

Migration 006 intended to create a composite unique index on `(namespace_id, name)`, but bun's `CreateTable` auto-generated `api_keys_name_key` as `UNIQUE(name)` — making names globally unique across all namespaces. The intended composite index `api_keys_namespace_id_name_unique` was never created in the running database.

Fixes #6001

## Changes

- **migration 020**: Drops the incorrect `api_keys_name_key` constraint and creates `api_keys_namespace_id_name_unique` on `(namespace_id, name)` with `IF NOT EXISTS` for idempotency

## Testing

1. Start the API service and let migrations run
2. Verify indexes: `SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'api_keys';`
   - `api_keys_namespace_id_name_unique` on `(namespace_id, name)` should exist
   - `api_keys_name_key` on `(name)` should be gone
3. Create two API keys with the same name in different namespaces — should succeed
4. Create two API keys with the same name in the same namespace — should fail