### PR TITLE
fix(ci): increase verify test timeout from 10m to 20m

### DIFF
--- a/.github/workflows/verify-fix.yml
+++ b/.github/workflows/verify-fix.yml
@@ -55,7 +55,7 @@ jobs:
               FAILED=false
               for MOD in $MODULES; do
                 echo "--- $MOD ---"
-                if ! (cd "$MOD" && go test -timeout 10m -count=1 ./... 2>&1); then
+                if ! (cd "$MOD" && go test -timeout 20m -count=1 ./... 2>&1); then
                   FAILED=true
                 fi
               done
@@ -67,7 +67,7 @@ jobs:
             else
               for MOD in $MODULES; do
                 echo "--- $MOD ---"
-                (cd "$MOD" && go test -timeout 10m -count=1 ./...)
+                (cd "$MOD" && go test -timeout 20m -count=1 ./...)
               done
               echo "Passed ✓"
             fi


### PR DESCRIPTION
## Summary

- Increases `go test -timeout` in the verify-fix workflow from 10m to 20m
- The integration tests in `tests/` consistently time out at 10 minutes (SSH test suite), causing spurious CI failures
- The `qa.yml` workflow already uses 25m for the same tests

## Test plan

- [ ] Verify workflow completes without timeout on a PR that touches `tests/`