### PR TITLE
fix(ui-react): check `isCloud` directly in `AuthFooterLinks`

### DIFF
--- a/ui-react/apps/admin/src/components/common/AuthFooterLinks.tsx
+++ b/ui-react/apps/admin/src/components/common/AuthFooterLinks.tsx
@@ -1,11 +1,8 @@
+import { getConfig } from "@/env";
 import { BookOpenIcon, UserPlusIcon } from "@heroicons/react/24/outline";
 import { Link } from "react-router-dom";
 
-interface AuthFooterLinksProps {
-  isCloud: boolean;
-}
-
-export default function AuthFooterLinks({ isCloud }: AuthFooterLinksProps) {
+export default function AuthFooterLinks() {
   return (
     <div
       className="flex items-center justify-center gap-6 mt-10 animate-fade-in"
@@ -32,7 +29,7 @@ export default function AuthFooterLinks({ isCloud }: AuthFooterLinksProps) {
         </svg>
         Community
       </a>
-      {isCloud && (
+      {getConfig().cloud && (
         <>
           <span className="w-px h-3 bg-border" />
           <Link

--- a/ui-react/apps/admin/src/pages/Login.tsx
+++ b/ui-react/apps/admin/src/pages/Login.tsx
@@ -246,7 +246,7 @@ export default function Login() {
       </div>
 
       {/* Footer links */}
-      <AuthFooterLinks isCloud={isCloud} />
+      <AuthFooterLinks />
     </div>
   );
 }


### PR DESCRIPTION
## What

Remove `AuthFooterLinks`' `isCloud` prop, import `getConfig` and make the check directly in the component.

## Why

That component is called in multiple places, so making the `isCloud` check and passing as a prop every time is repetitive and unnecessary, since that check can be made by the component itself.