### PR TITLE
fix(api): handle orphaned MongoDB records in migration pipeline

### DIFF
--- a/api/store/migrate/deep_validate_namespaces.go
+++ b/api/store/migrate/deep_validate_namespaces.go
@@ -11,6 +11,11 @@ import (
 )
 
 func (m *Migrator) deepValidateNamespaces(ctx context.Context, r *ValidationReport) error {
+	validUsers, err := m.loadValidUsers(ctx)
+	if err != nil {
+		return err
+	}
+
 	cursor, err := m.mongo.Collection("namespaces").Find(ctx, bson.M{})
 	if err != nil {
 		return err
@@ -23,6 +28,12 @@ func (m *Migrator) deepValidateNamespaces(ctx context.Context, r *ValidationRepo
 		var doc mongoNamespace
 		if err := cursor.Decode(&doc); err != nil {
 			return err
+		}
+
+		// Skip namespaces whose owner was not migrated (same filter as migration).
+		ownerID := ObjectIDToUUID(doc.Owner)
+		if _, ok := validUsers[ownerID]; !ok {
+			continue
 		}
 
 		batch = append(batch, doc)
@@ -98,6 +109,11 @@ func (m *Migrator) deepValidateMemberships(ctx context.Context, r *ValidationRep
 		return err
 	}
 
+	validNS, err := m.loadValidNamespaces(ctx)
+	if err != nil {
+		return err
+	}
+
 	cursor, err := m.mongo.Collection("namespaces").Find(ctx, bson.M{
 		"members": bson.M{"$exists": true, "$ne": bson.A{}},
 	})
@@ -110,6 +126,11 @@ func (m *Migrator) deepValidateMemberships(ctx context.Context, r *ValidationRep
 		var doc mongoNamespace
 		if err := cursor.Decode(&doc); err != nil {
 			return err
+		}
+
+		// Skip namespaces not migrated (orphaned owner).
+		if _, ok := validNS[doc.TenantID]; !ok {
+			continue
 		}
 
 		for _, member := range doc.Members {

--- a/api/store/migrate/devices.go
+++ b/api/store/migrate/devices.go
@@ -137,6 +137,10 @@ func (m *Migrator) migrateDevices(ctx context.Context) error {
 		total += len(batch)
 	}
 
+	if skipped > 0 {
+		m.addOrphans("devices", skipped)
+	}
+
 	log.WithFields(log.Fields{
 		"scope":   "core",
 		"count":   total,

--- a/api/store/migrate/keys.go
+++ b/api/store/migrate/keys.go
@@ -99,6 +99,10 @@ func (m *Migrator) migratePublicKeys(ctx context.Context) error {
 		total += len(batch)
 	}
 
+	if skipped > 0 {
+		m.addOrphans("public_keys", skipped)
+	}
+
 	log.WithFields(log.Fields{
 		"scope":   "core",
 		"count":   total,
@@ -226,6 +230,10 @@ func (m *Migrator) migrateAPIKeys(ctx context.Context) error {
 			return err
 		}
 		total += len(batch)
+	}
+
+	if skipped > 0 {
+		m.addOrphans("api_keys", skipped)
 	}
 
 	log.WithFields(log.Fields{

--- a/api/store/migrate/migrate.go
+++ b/api/store/migrate/migrate.go
@@ -13,13 +13,39 @@ import (
 
 // Migrator orchestrates the migration of data from MongoDB to PostgreSQL.
 type Migrator struct {
-	mongo *mongo.Database
-	pg    *bun.DB
+	mongo   *mongo.Database
+	pg      *bun.DB
+	orphans map[string]int // tracks orphaned records skipped per table
 }
 
 // New creates a new Migrator instance.
 func New(mongo *mongo.Database, pg *bun.DB) *Migrator {
-	return &Migrator{mongo: mongo, pg: pg}
+	return &Migrator{mongo: mongo, pg: pg, orphans: make(map[string]int)}
+}
+
+// addOrphans records that n orphaned records were skipped for the given table.
+func (m *Migrator) addOrphans(table string, n int) {
+	m.orphans[table] += n
+}
+
+// logOrphanSummary prints a summary of all orphaned records found during migration.
+func (m *Migrator) logOrphanSummary() {
+	total := 0
+	for _, n := range m.orphans {
+		total += n
+	}
+
+	if total == 0 {
+		log.WithField("scope", "core").Info("No orphaned records found in MongoDB")
+
+		return
+	}
+
+	log.WithFields(log.Fields{"scope": "core", "total": total}).Warn("Orphaned records found in MongoDB (skipped during migration)")
+
+	for table, n := range m.orphans {
+		log.WithFields(log.Fields{"scope": "core", "table": table, "orphans": n}).Warn("Orphaned records skipped")
+	}
 }
 
 // tableFunc represents a function that migrates a single table.
@@ -38,21 +64,22 @@ func (m *Migrator) Run(ctx context.Context) error {
 	tables := []tableFunc{
 		// Phase 1: no dependencies
 		{"systems", m.migrateSystems},
-		// Phase 2
-		{"namespaces", m.migrateNamespaces},
-		// Phase 3: depends on namespaces
 		{"users", m.migrateUsers},
+		// Phase 2: depends on users
+		{"namespaces", m.migrateNamespaces},
 		{"tags", m.migrateTags},
-		// Phase 4: depends on users + namespaces
+		// Phase 2b: backfill preferred_namespace now that namespaces exist
+		{"user_preferences", m.restorePreferredNamespaces},
+		// Phase 3: depends on users + namespaces
 		{"memberships", m.migrateMemberships},
 		{"api_keys", m.migrateAPIKeys},
 		{"public_keys", m.migratePublicKeys},
 		{"devices", m.migrateDevices},
-		// Phase 5: depends on phase 4
+		// Phase 4: depends on phase 3
 		{"device_tags", m.migrateDeviceTags},
 		{"public_key_tags", m.migratePublicKeyTags},
 		{"sessions", m.migrateSessions},
-		// Phase 6: depends on sessions
+		// Phase 5: depends on sessions
 		{"session_events", m.migrateSessionEvents},
 	}
 
@@ -61,6 +88,8 @@ func (m *Migrator) Run(ctx context.Context) error {
 			return fmt.Errorf("migration of %s failed: %w", t.name, err)
 		}
 	}
+
+	m.logOrphanSummary()
 
 	log.WithField("scope", "core").Info("Migration complete, validating row counts")
 

--- a/api/store/migrate/namespaces.go
+++ b/api/store/migrate/namespaces.go
@@ -82,6 +82,11 @@ func convertMembership(tenantID string, member mongoMember) *entity.Membership {
 }
 
 func (m *Migrator) migrateNamespaces(ctx context.Context) error {
+	validUsers, err := m.loadValidUsers(ctx)
+	if err != nil {
+		return err
+	}
+
 	cursor, err := m.mongo.Collection("namespaces").Find(ctx, bson.M{})
 	if err != nil {
 		return err
@@ -90,6 +95,7 @@ func (m *Migrator) migrateNamespaces(ctx context.Context) error {
 
 	batch := make([]*entity.Namespace, 0, batchSize)
 	total := 0
+	skipped := 0
 
 	for cursor.Next(ctx) {
 		var doc mongoNamespace
@@ -97,7 +103,20 @@ func (m *Migrator) migrateNamespaces(ctx context.Context) error {
 			return err
 		}
 
-		batch = append(batch, convertNamespace(doc))
+		ns := convertNamespace(doc)
+		if _, ok := validUsers[ns.OwnerID]; !ok {
+			log.WithFields(log.Fields{
+				"scope":     "core",
+				"owner":     ns.OwnerID,
+				"namespace": doc.TenantID,
+				"name":      doc.Name,
+			}).Warn("Skipping namespace with orphaned owner")
+			skipped++
+
+			continue
+		}
+
+		batch = append(batch, ns)
 		if len(batch) >= batchSize {
 			if _, err := m.pg.NewInsert().Model(&batch).Exec(ctx); err != nil {
 				return err
@@ -118,7 +137,15 @@ func (m *Migrator) migrateNamespaces(ctx context.Context) error {
 		total += len(batch)
 	}
 
-	log.WithFields(log.Fields{"scope": "core", "count": total}).Info("Migrated namespaces")
+	if skipped > 0 {
+		m.addOrphans("namespaces", skipped)
+	}
+
+	log.WithFields(log.Fields{
+		"scope":   "core",
+		"count":   total,
+		"skipped": skipped,
+	}).Info("Migrated namespaces")
 
 	return nil
 }
@@ -145,6 +172,11 @@ func (m *Migrator) migrateMemberships(ctx context.Context) error {
 		return err
 	}
 
+	validNamespaces, err := m.loadValidNamespaces(ctx)
+	if err != nil {
+		return err
+	}
+
 	cursor, err := m.mongo.Collection("namespaces").Find(ctx, bson.M{})
 	if err != nil {
 		return err
@@ -159,6 +191,12 @@ func (m *Migrator) migrateMemberships(ctx context.Context) error {
 		var doc mongoNamespace
 		if err := cursor.Decode(&doc); err != nil {
 			return err
+		}
+
+		if _, ok := validNamespaces[doc.TenantID]; !ok {
+			skipped += len(doc.Members)
+
+			continue
 		}
 
 		for _, member := range doc.Members {
@@ -195,6 +233,10 @@ func (m *Migrator) migrateMemberships(ctx context.Context) error {
 			return err
 		}
 		total += len(batch)
+	}
+
+	if skipped > 0 {
+		m.addOrphans("memberships", skipped)
 	}
 
 	log.WithFields(log.Fields{

--- a/api/store/migrate/sessions.go
+++ b/api/store/migrate/sessions.go
@@ -150,6 +150,10 @@ func (m *Migrator) migrateSessions(ctx context.Context) error {
 		total += len(batch)
 	}
 
+	if skipped > 0 {
+		m.addOrphans("sessions", skipped)
+	}
+
 	log.WithFields(log.Fields{
 		"scope":   "core",
 		"count":   total,
@@ -248,6 +252,10 @@ func (m *Migrator) migrateSessionEvents(ctx context.Context) error {
 			return err
 		}
 		total += len(batch)
+	}
+
+	if skipped > 0 {
+		m.addOrphans("session_events", skipped)
 	}
 
 	log.WithFields(log.Fields{

--- a/api/store/migrate/tags.go
+++ b/api/store/migrate/tags.go
@@ -82,6 +82,10 @@ func (m *Migrator) migrateTags(ctx context.Context) error {
 		total += len(batch)
 	}
 
+	if skipped > 0 {
+		m.addOrphans("tags", skipped)
+	}
+
 	log.WithFields(log.Fields{
 		"scope":   "core",
 		"count":   total,

--- a/api/store/migrate/users.go
+++ b/api/store/migrate/users.go
@@ -99,13 +99,6 @@ func convertUser(doc mongoUser) *entity.User {
 }
 
 func (m *Migrator) migrateUsers(ctx context.Context) error {
-	// Load valid namespace IDs so we can clear dangling
-	// preferred_namespace references that would violate the FK.
-	validNS, err := m.loadValidNamespaces(ctx)
-	if err != nil {
-		return err
-	}
-
 	cursor, err := m.mongo.Collection("users").Find(ctx, bson.M{})
 	if err != nil {
 		return err
@@ -114,7 +107,6 @@ func (m *Migrator) migrateUsers(ctx context.Context) error {
 
 	batch := make([]*entity.User, 0, batchSize)
 	total := 0
-	cleared := 0
 
 	for cursor.Next(ctx) {
 		var doc mongoUser
@@ -123,17 +115,11 @@ func (m *Migrator) migrateUsers(ctx context.Context) error {
 		}
 
 		u := convertUser(doc)
-		if u.Preferences.PreferredNamespace != "" {
-			if _, ok := validNS[u.Preferences.PreferredNamespace]; !ok {
-				log.WithFields(log.Fields{
-					"scope":     "core",
-					"user":      u.Username,
-					"namespace": u.Preferences.PreferredNamespace,
-				}).Warn("Clearing dangling preferred_namespace_id")
-				u.Preferences.PreferredNamespace = ""
-				cleared++
-			}
-		}
+
+		// Clear preferred_namespace on insert; namespaces haven't been
+		// migrated yet so the FK would fail. A follow-up pass restores
+		// valid references after namespaces are in place.
+		u.Preferences.PreferredNamespace = ""
 
 		batch = append(batch, u)
 		if len(batch) >= batchSize {
@@ -157,10 +143,66 @@ func (m *Migrator) migrateUsers(ctx context.Context) error {
 	}
 
 	log.WithFields(log.Fields{
+		"scope": "core",
+		"count": total,
+	}).Info("Migrated users")
+
+	return nil
+}
+
+// restorePreferredNamespaces updates users' preferred_namespace_id from MongoDB
+// after both users and namespaces have been migrated to PG.
+func (m *Migrator) restorePreferredNamespaces(ctx context.Context) error {
+	validNS, err := m.loadValidNamespaces(ctx)
+	if err != nil {
+		return err
+	}
+
+	cursor, err := m.mongo.Collection("users").Find(ctx, bson.M{
+		"preferences.preferred_namespace": bson.M{"$exists": true, "$ne": ""},
+	})
+	if err != nil {
+		return err
+	}
+	defer cursor.Close(ctx)
+
+	total := 0
+	skipped := 0
+
+	for cursor.Next(ctx) {
+		var doc mongoUser
+		if err := cursor.Decode(&doc); err != nil {
+			return err
+		}
+
+		ns := doc.Preferences.PreferredNamespace
+		if _, ok := validNS[ns]; !ok {
+			skipped++
+
+			continue
+		}
+
+		userID := ObjectIDToUUID(doc.ID.Hex())
+		if _, err := m.pg.NewUpdate().
+			TableExpr("users").
+			Set("preferred_namespace_id = ?", ns).
+			Where("id = ?", userID).
+			Exec(ctx); err != nil {
+			return err
+		}
+
+		total++
+	}
+
+	if err := cursor.Err(); err != nil {
+		return err
+	}
+
+	log.WithFields(log.Fields{
 		"scope":   "core",
 		"count":   total,
-		"cleared": cleared,
-	}).Info("Migrated users")
+		"skipped": skipped,
+	}).Info("Restored preferred_namespace references")
 
 	return nil
 }

--- a/api/store/migrate/validate.go
+++ b/api/store/migrate/validate.go
@@ -16,7 +16,7 @@ var collectionTable = []struct {
 	allowSkip  bool
 }{
 	{"system", "systems", false},
-	{"namespaces", "namespaces", false},
+	{"namespaces", "namespaces", true},
 	{"users", "users", false},
 	{"tags", "tags", true},
 	{"devices", "devices", true},


### PR DESCRIPTION
## Summary

- Reorder migration phases (users before namespaces) to resolve circular FK dependency
- Clear `preferred_namespace` during user insert, backfill after namespaces are migrated
- Skip orphaned records in all migration phases with centralized tracking and summary log
- Filter orphans in deep validation using same criteria as migration
- Allow count mismatch for namespaces (orphaned owner skip)