### PR TITLE
chore(openapi): add required fields to OpenAPI schemas

### DIFF
--- a/openapi/spec/components/schemas/announcement.yaml
+++ b/openapi/spec/components/schemas/announcement.yaml
@@ -10,3 +10,8 @@ properties:
   date:
     type: string
     format: date-time
+required:
+  - uuid
+  - title
+  - content
+  - date

--- a/openapi/spec/components/schemas/announcementShort.yaml
+++ b/openapi/spec/components/schemas/announcementShort.yaml
@@ -7,6 +7,10 @@ properties:
   date:
     type: string
     format: date-time
+required:
+  - uuid
+  - title
+  - date
 example:
   title: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   date: 2017-07-21T17:32:28Z

--- a/openapi/spec/components/schemas/apiKey.yaml
+++ b/openapi/spec/components/schemas/apiKey.yaml
@@ -39,3 +39,11 @@ properties:
       The UTC date when the key was last updated. It is updated whenever the key is modified.
     format: date
     example: 2020-05-01
+required:
+  - tenant_id
+  - created_by
+  - role
+  - name
+  - expires_in
+  - created_at
+  - updated_at

--- a/openapi/spec/components/schemas/apiKeyWithID.yaml
+++ b/openapi/spec/components/schemas/apiKeyWithID.yaml
@@ -46,3 +46,12 @@ properties:
       The UTC date when the key was last updated. It is updated whenever the key is modified.
     format: date
     example: 2020-05-01
+required:
+  - id
+  - tenant_id
+  - created_by
+  - role
+  - name
+  - expires_in
+  - created_at
+  - updated_at

--- a/openapi/spec/components/schemas/deviceIdentity.yaml
+++ b/openapi/spec/components/schemas/deviceIdentity.yaml
@@ -6,3 +6,5 @@ properties:
     type: string
     pattern: ^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$
     example: '00:00:00:00:00:00'
+required:
+  - mac

--- a/openapi/spec/components/schemas/deviceInfo.yaml
+++ b/openapi/spec/components/schemas/deviceInfo.yaml
@@ -24,3 +24,9 @@ properties:
       - docker
       - native
     example: docker
+required:
+  - id
+  - pretty_name
+  - version
+  - arch
+  - platform

--- a/openapi/spec/components/schemas/info.yaml
+++ b/openapi/spec/components/schemas/info.yaml
@@ -6,6 +6,7 @@ properties:
     example: 'v0.20.0'
   endpoints:
     type: object
+    nullable: true
     description: Network endpoints for the ShellHub instance.
     properties:
       ssh:
@@ -23,6 +24,7 @@ properties:
   authentication:
     description: Authentication methods available for the ShellHub instance.
     type: object
+    nullable: true
     properties:
       local:
         description: Indicates if local authentication using email and password is enabled.
@@ -32,3 +34,8 @@ properties:
         description: Indicates if SAML-based single sign-on (SSO) is enabled.
         type: boolean
         example: false
+required:
+  - version
+  - endpoints
+  - setup
+  - authentication

--- a/openapi/spec/components/schemas/membershipInvitation.yaml
+++ b/openapi/spec/components/schemas/membershipInvitation.yaml
@@ -8,11 +8,11 @@ properties:
       tenant_id:
         description: The namespace tenant ID
         type: string
-        example: "00000000-0000-4000-0000-000000000000"
+        example: '00000000-0000-4000-0000-000000000000'
       name:
         description: The namespace name
         type: string
-        example: "my-namespace"
+        example: 'my-namespace'
     required:
       - tenant_id
       - name
@@ -23,18 +23,18 @@ properties:
       id:
         description: The ID of the invited user
         type: string
-        example: "507f1f77bcf86cd799439011"
+        example: '507f1f77bcf86cd799439011'
       email:
         description: The email of the invited user
         type: string
-        example: "user@example.com"
+        example: 'user@example.com'
     required:
       - id
       - email
   invited_by:
     description: The ID of the user who sent the invitation
     type: string
-    example: "507f1f77bcf86cd799439012"
+    example: '507f1f77bcf86cd799439012'
   created_at:
     description: When the invitation was created
     type: string
@@ -63,3 +63,13 @@ properties:
     format: date-time
   role:
     $ref: ./namespaceMemberRole.yaml
+required:
+  - namespace
+  - user
+  - invited_by
+  - created_at
+  - updated_at
+  - expires_at
+  - status
+  - status_updated_at
+  - role

--- a/openapi/spec/components/schemas/mfaGenerate.yaml
+++ b/openapi/spec/components/schemas/mfaGenerate.yaml
@@ -20,3 +20,7 @@ properties:
       - IBWGL3IN42LTS3PP
       - 6DIGYYGM3JM7GXC4
       - 6UIHAIN3CYUEFY5X
+required:
+  - link
+  - secret
+  - recovery_codes

--- a/openapi/spec/components/schemas/namespace.yaml
+++ b/openapi/spec/components/schemas/namespace.yaml
@@ -58,16 +58,14 @@ properties:
           description: Member's email.
           example: john.doe@test.com
   settings:
-    $ref: namespaceSettings.yaml
+    nullable: true
+    allOf:
+      - $ref: namespaceSettings.yaml
   max_devices:
     description: Namespace's max device numbers
     type: integer
     minimum: 3
     default: 3
-  device_count:
-    description: Namespace's total devices
-    type: integer
-    minimum: 0
   created_at:
     description: Namespace's creation date
     type: string
@@ -76,6 +74,7 @@ properties:
   billing:
     description: Namespace's billing
     type: object
+    nullable: true
     example: null
   devices_pending_count:
     description: Number of devices currently in pending status awaiting approval
@@ -92,3 +91,15 @@ properties:
     type: integer
     minimum: 0
     example: 0
+required:
+  - name
+  - owner
+  - tenant_id
+  - members
+  - settings
+  - max_devices
+  - created_at
+  - billing
+  - devices_pending_count
+  - devices_accepted_count
+  - devices_rejected_count

--- a/openapi/spec/components/schemas/namespaceSettings.yaml
+++ b/openapi/spec/components/schemas/namespaceSettings.yaml
@@ -12,3 +12,6 @@ properties:
     maxLength: 4096
     format: alphanumunicode
     example: my awesome connection announcement
+required:
+  - session_record
+  - connection_announcement

--- a/openapi/spec/components/schemas/publicKeyResponse.yaml
+++ b/openapi/spec/components/schemas/publicKeyResponse.yaml
@@ -19,3 +19,11 @@ properties:
     $ref: publicKeyFilter.yaml
   username:
     $ref: publicKeyUsername.yaml
+required:
+  - data
+  - fingerprint
+  - created_at
+  - tenant_id
+  - name
+  - filter
+  - username

--- a/openapi/spec/components/schemas/session.yaml
+++ b/openapi/spec/components/schemas/session.yaml
@@ -6,7 +6,9 @@ properties:
   device_uid:
     $ref: deviceUID.yaml
   device:
-    $ref: device.yaml
+    nullable: true
+    allOf:
+      - $ref: device.yaml
   tenant_id:
     $ref: namespaceTenantID.yaml
   username:
@@ -97,3 +99,18 @@ properties:
               description: Seat where the event happened
               type: integer
               minimum: 0
+required:
+  - uid
+  - device
+  - tenant_id
+  - username
+  - ip_address
+  - started_at
+  - last_seen
+  - active
+  - authenticated
+  - recorded
+  - type
+  - term
+  - position
+  - events

--- a/openapi/spec/components/schemas/support.yaml
+++ b/openapi/spec/components/schemas/support.yaml
@@ -5,3 +5,5 @@ properties:
     type: string
     example: '1a1e64452ebba63e39983aa05ea176a31072241af66da72559a539af91d00f52'
     pattern: '^[a-fA-F0-9]{64}$'
+required:
+  - identifier

--- a/openapi/spec/components/schemas/tunnel.yaml
+++ b/openapi/spec/components/schemas/tunnel.yaml
@@ -26,3 +26,13 @@ properties:
     type: string
     format: date-time
     example: 2020-05-01T00:00:00.000Z
+required:
+  - address
+  - full_address
+  - namespace
+  - device
+  - host
+  - port
+  - ttl
+  - expires_in
+  - created_at

--- a/openapi/spec/components/schemas/userAdminResponse.yaml
+++ b/openapi/spec/components/schemas/userAdminResponse.yaml
@@ -31,3 +31,11 @@ properties:
     type: string
     minLength: 64
     maxLength: 64
+required:
+  - id
+  - admin
+  - created_at
+  - last_login
+  - name
+  - email
+  - username

--- a/openapi/spec/components/schemas/userAuth.yaml
+++ b/openapi/spec/components/schemas/userAuth.yaml
@@ -32,3 +32,16 @@ properties:
     example: false
   max_namespaces:
     $ref: maxNamespaces.yaml
+required:
+  - token
+  - id
+  - origin
+  - user
+  - name
+  - email
+  - recovery_email
+  - tenant
+  - role
+  - mfa
+  - max_namespaces
+  - admin

--- a/openapi/spec/components/schemas/webendpoint.yaml
+++ b/openapi/spec/components/schemas/webendpoint.yaml
@@ -11,7 +11,9 @@ properties:
   device_uid:
     $ref: deviceUID.yaml
   device:
-    $ref: device.yaml
+    nullable: true
+    allOf:
+      - $ref: device.yaml
   host:
     $ref: webendpointHost.yaml
   port:
@@ -30,3 +32,14 @@ properties:
     type: string
     format: date-time
     example: 2020-05-01T00:00:00.000Z
+required:
+  - address
+  - full_address
+  - namespace
+  - device_uid
+  - host
+  - port
+  - tls
+  - ttl
+  - expires_in
+  - created_at

--- a/openapi/spec/paths/admin@api@users.yaml
+++ b/openapi/spec/paths/admin@api@users.yaml
@@ -63,6 +63,7 @@ get:
                 - id: 507f1f77bcf86cd799439011
                   namespaces: 0
                   confirmed: false
+                  admin: false
                   created_at: 2020-05-01T00:00:00.000Z
                   last_login: 2020-05-01T00:00:00.000Z
                   name: example
@@ -74,6 +75,7 @@ get:
                 - id: 507f1f77bcf86cd799439011
                   namespaces: 0
                   confirmed: true
+                  admin: false
                   created_at: 2020-05-01T00:00:00.000Z
                   last_login: 2020-05-01T00:00:00.000Z
                   name: example
@@ -83,6 +85,7 @@ get:
                 - id: 507f191e810c19729de860ea
                   namespaces: 2
                   confirmed: false
+                  admin: true
                   created_at: 2012-01-02T00:00:00.000Z
                   last_login: 2012-01-02T00:00:00.000Z
                   name: example


### PR DESCRIPTION
## What

Added `required` arrays to 18 OpenAPI schemas that were missing them, and `nullable: true` to pointer-type fields. This is the main blocker for migrating the React UI API layer to a generated SDK via `@hey-api/openapi-ts` — without `required`, all properties generate as `T | undefined`, forcing null-coalescing everywhere.

## Why

Tracked by shellhub-io/team#80. The `device` and `tag` schemas were already fixed; these are the remaining 18.

## Changes

- **Schema `required` arrays**: Added to all 18 schemas based on Go struct `json` tags. Rule: a field is required when its tag has no `omitempty` and it is not a pointer type.
- **Pointer fields (`nullable: true`)**: Go pointer types without `omitempty` are always serialized (as `null` when nil). These get `required` + `nullable: true` to produce `T | null` instead of `T | undefined` in codegen. Affected fields:
  - `namespace.settings` (`*NamespaceSettings`) — wrapped bare `$ref` in `allOf` + `nullable`
  - `namespace.billing` (`*Billing`) — added `nullable` to inline object
  - `session.device` (`*Device`) — wrapped bare `$ref` in `allOf` + `nullable`
  - `info.endpoints` / `info.authentication` (`*Struct`) — added `nullable` to inline objects
  - `webendpoint.device` (`*Device`) — wrapped bare `$ref` in `allOf` + `nullable` (left optional conservatively)
  - `membershipInvitation.expires_at` — already had `nullable`, now also in `required`
- **`namespace.device_count` removed**: Go field has `json:"-"`, never serialized
- **Admin users examples**: Added missing `admin` field to example values to pass schema validation

## Out of scope

Structural mismatches between schemas and Go responses (field renames, missing fields) are tracked separately — they risk breaking the existing Vue UI client. Examples: `apiKeyWithID.created_by` vs Go `user_id`, `userAdminResponse.confirmed` vs Go `status`.

## Testing

```bash
# Lint (should pass with only pre-existing warnings)
./bin/docker-compose exec openapi redocly lint spec/openapi.yaml

# Format check
./bin/docker-compose exec openapi prettier -c 'spec/**/*.yaml'
```