### PR TITLE
chore: upgrade golangci-lint from v2.4.0 to v2.11.3

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -113,7 +113,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           working-directory: ${{ matrix.project }}
-          version: v2.4.0
+          version: v2.11.3
           args: --timeout 2m ${{ matrix.lint_args }} ./...
           skip-cache: true
 

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -60,7 +60,7 @@ ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl openssh-client util-linux setpriv
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/agent/connector.go
+++ b/agent/connector.go
@@ -153,7 +153,7 @@ func (d *DockerConnector) Start(ctx context.Context, id string, name string) {
 	id = id[:12]
 
 	d.mu.Lock()
-	ctx, d.cancels[id] = context.WithCancel(ctx)
+	ctx, d.cancels[id] = context.WithCancel(ctx) //nolint:gosec // G118: cancel is stored in d.cancels for later use
 	d.mu.Unlock()
 
 	privateKey := fmt.Sprintf("%s/%s.key", d.privateKeys, id)

--- a/agent/handlers.go
+++ b/agent/handlers.go
@@ -310,7 +310,7 @@ func httpProxyHandlerV1(agent *Agent) func(c echo.Context) error {
 
 		// NOTE: Gets the to address to connect to. This address can be just a port, :8080, or the host and port,
 		// localhost:8080.
-		addr := fmt.Sprintf("%s:%s", host, port)
+		addr := net.JoinHostPort(host, port)
 
 		in, err := net.Dial(ProxyHandlerNetwork, addr)
 		if err != nil {

--- a/agent/server/modes/host/authenticator_test.go
+++ b/agent/server/modes/host/authenticator_test.go
@@ -269,7 +269,7 @@ func TestPassword(t *testing.T) {
 		},
 		{
 			ctx: &testSSHContext{user: "test"},
-			authenticator: &Authenticator{
+			authenticator: &Authenticator{ //nolint:gosec // G101: test fixture, not a real credential
 				singleUserPassword: "$6$Ntq5PynhGPFJuhxn$emiTnyA.GTsvK6JjjrecwDSB3jywkoHky9ZuJAYwSGFlZU2npTFOEMVPYG7CsDLRyvUE7OzbqFidYuKO274DC.",
 			},
 			name:          "return true when single user is enabled and password is valid",

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -78,7 +78,7 @@ ENV GOPROXY=${GOPROXY}
 RUN apk add --update openssl build-base docker-cli npm
 RUN npm install -g mjml@${MJML_VERSION}
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 && \
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
     go install github.com/vektra/mockery/v2/...@v2.53.2
 
 COPY ./api/entrypoint-dev.sh /entrypoint.sh

--- a/api/routes/auth_test.go
+++ b/api/routes/auth_test.go
@@ -321,7 +321,7 @@ func TestAuthLocalUser(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.mocks()
 
-			jsonData, err := json.Marshal(tc.req)
+			jsonData, err := json.Marshal(tc.req) //nolint:gosec // G117: test request serialization
 			if err != nil {
 				assert.NoError(t, err)
 			}

--- a/api/routes/user_test.go
+++ b/api/routes/user_test.go
@@ -127,7 +127,7 @@ func TestUpdateUser(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.requiredMocks()
 
-			data, err := json.Marshal(tc.body)
+			data, err := json.Marshal(tc.body) //nolint:gosec // G117: test request serialization
 			require.NoError(t, err)
 
 			req := httptest.NewRequest(http.MethodPatch, "/api/users", strings.NewReader(string(data)))
@@ -185,7 +185,7 @@ func TestUpdateUserPassword(t *testing.T) {
 		{
 			title: "fails when validate because the tag does not have a max of 32 characters",
 			uid:   "123",
-			updatePayloadMock: requests.UserPasswordUpdate{
+			updatePayloadMock: requests.UserPasswordUpdate{ //nolint:gosec // G101: test fixture
 				UserParam: requests.UserParam{
 					ID: "123",
 				},
@@ -211,7 +211,7 @@ func TestUpdateUserPassword(t *testing.T) {
 		{
 			title: "fails when validate because the tag does not have a max of 32 characters",
 			uid:   "123",
-			updatePayloadMock: requests.UserPasswordUpdate{
+			updatePayloadMock: requests.UserPasswordUpdate{ //nolint:gosec // G101: test fixture
 				UserParam: requests.UserParam{
 					ID: "123",
 				},

--- a/api/services/utils.go
+++ b/api/services/utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 func LoadKeys() (*rsa.PrivateKey, *rsa.PublicKey, error) {
-	signBytes, err := os.ReadFile(os.Getenv("PRIVATE_KEY"))
+	signBytes, err := os.ReadFile(os.Getenv("PRIVATE_KEY")) //nolint:gosec // G703: path comes from trusted env var
 	if err != nil {
 		return nil, nil, err
 	}
@@ -18,7 +18,7 @@ func LoadKeys() (*rsa.PrivateKey, *rsa.PublicKey, error) {
 		return nil, nil, err
 	}
 
-	verifyBytes, err := os.ReadFile(os.Getenv("PUBLIC_KEY"))
+	verifyBytes, err := os.ReadFile(os.Getenv("PUBLIC_KEY")) //nolint:gosec // G703: path comes from trusted env var
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/store/migrate/users_test.go
+++ b/api/store/migrate/users_test.go
@@ -13,7 +13,7 @@ func TestConvertUser(t *testing.T) {
 	oid := primitive.NewObjectID()
 
 	t.Run("all fields populated", func(t *testing.T) {
-		doc := mongoUser{
+		doc := mongoUser{ //nolint:gosec // G101: test fixture, not a real credential
 			ID:             oid,
 			Origin:         "saml",
 			ExternalID:     "ext-123",

--- a/api/store/storetest/helpers.go
+++ b/api/store/storetest/helpers.go
@@ -524,10 +524,10 @@ func (s *Suite) CreatePublicKey(t *testing.T, opts ...PublicKeyOption) string {
 	// Generate a unique fingerprint (simulating SSH key fingerprint format)
 	timestamp := time.Now().UnixNano()
 	fingerprint := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
-		byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32),
-		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp),
-		byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32),
-		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp))
+		byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32), //nolint:gosec // G115
+		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp), //nolint:gosec // G115
+		byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32), //nolint:gosec // G115
+		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp)) //nolint:gosec // G115
 
 	// Default public key
 	key := &models.PublicKey{
@@ -589,10 +589,10 @@ func (s *Suite) CreatePrivateKey(t *testing.T, opts ...PrivateKeyOption) string 
 	// Generate a unique fingerprint (similar format to PublicKey)
 	timestamp := time.Now().UnixNano()
 	fingerprint := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
-		byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32),
-		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp),
-		byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32),
-		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp))
+		byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32), //nolint:gosec // G115
+		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp), //nolint:gosec // G115
+		byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32), //nolint:gosec // G115
+		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp)) //nolint:gosec // G115
 
 	// Default private key
 	key := &models.PrivateKey{

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -34,7 +34,7 @@ FROM builder AS development
 
 RUN apk add --update openssl build-base docker-cli
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -41,7 +41,7 @@ RUN mkdir -p /var/run/openresty /etc/letsencrypt && \
 
 RUN apk add --update openssl build-base
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 && \
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
     go install github.com/vektra/mockery/v2/...@v2.20.0
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub

--- a/gateway/certbot.go
+++ b/gateway/certbot.go
@@ -40,7 +40,7 @@ func NewExecutor() Executor {
 
 // Command creates a new *exec.Cmd with the given name and arguments.
 func (e *executor) Command(name string, arg ...string) *exec.Cmd {
-	return exec.Command(name, arg...)
+	return exec.Command(name, arg...) //nolint:gosec // G204: arguments are controlled by internal callers
 }
 
 // Run executes the given command and waits for it to complete.

--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install -g @stoplight/prism-cli@4.6.1
 RUN npm install -g prettier@2.8.7
 
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 && \
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
     go install github.com/vektra/mockery/v2/...@v2.53.2
 
 FROM base AS development

--- a/pkg/api/client/client_public_test.go
+++ b/pkg/api/client/client_public_test.go
@@ -175,7 +175,7 @@ func TestAuthDevice(t *testing.T) {
 				},
 			},
 			requiredMocks: func() {
-				responder, _ := mock.NewJsonResponder(200, models.DeviceAuthResponse{
+				responder, _ := mock.NewJsonResponder(200, models.DeviceAuthResponse{ //nolint:gosec // G101: test fixture
 					UID:       "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
 					Token:     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 					Name:      "83-18-77-25-78-0d",
@@ -185,7 +185,7 @@ func TestAuthDevice(t *testing.T) {
 				mock.RegisterResponder("POST", "/api/devices/auth", responder)
 			},
 			expected: Expected{
-				response: &models.DeviceAuthResponse{
+				response: &models.DeviceAuthResponse{ //nolint:gosec // G101: test fixture
 					UID:       "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
 					Token:     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 					Name:      "83-18-77-25-78-0d",
@@ -215,7 +215,7 @@ func TestAuthDevice(t *testing.T) {
 			},
 			requiredMocks: func() {
 				fail, _ := mock.NewJsonResponder(404, nil)
-				success, _ := mock.NewJsonResponder(200, models.DeviceAuthResponse{
+				success, _ := mock.NewJsonResponder(200, models.DeviceAuthResponse{ //nolint:gosec // G101: test fixture
 					UID:       "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
 					Token:     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 					Name:      "83-18-77-25-78-0d",
@@ -229,7 +229,7 @@ func TestAuthDevice(t *testing.T) {
 				mock.RegisterResponder("POST", "/api/devices/auth", responder)
 			},
 			expected: Expected{
-				response: &models.DeviceAuthResponse{
+				response: &models.DeviceAuthResponse{ //nolint:gosec // G101: test fixture
 					UID:       "3a471bd84c88b28c4e4f8e27caee40e7b14798325e6dd85aa62d54e27fd11117",
 					Token:     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 					Name:      "83-18-77-25-78-0d",
@@ -339,7 +339,7 @@ func TestAuthPublicKey(t *testing.T) {
 				err:      ErrUnauthorized,
 			},
 		},
-		{
+		{ //nolint:gosec // G101: test fixture
 			description: "fail to auth public key when a request field is not set",
 			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			request: &models.PublicKeyAuthRequest{
@@ -355,7 +355,7 @@ func TestAuthPublicKey(t *testing.T) {
 				err:      ErrBadRequest,
 			},
 		},
-		{
+		{ //nolint:gosec // G101: test fixture
 			description: "fail to auth public key when the key is not found",
 			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			request: &models.PublicKeyAuthRequest{
@@ -372,7 +372,7 @@ func TestAuthPublicKey(t *testing.T) {
 				err:      ErrNotFound,
 			},
 		},
-		{
+		{ //nolint:gosec // G101: test fixture
 			description: "success to auth public key",
 			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			request: &models.PublicKeyAuthRequest{
@@ -429,7 +429,7 @@ func TestReverseListener(t *testing.T) {
 			requiredMocks: func() {},
 			expected:      errors.New("token is empty"),
 		},
-		{
+		{ //nolint:gosec // G101: well-known jwt.io example token, not a real credential
 			description: "fail when cannot auth the agent on the SSH server",
 			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			requiredMocks: func() {
@@ -437,7 +437,7 @@ func TestReverseListener(t *testing.T) {
 			},
 			expected: errors.New(""),
 		},
-		{
+		{ //nolint:gosec // G101: well-known jwt.io example token, not a real credential
 			description: "fail when cannot create a new reverse listener",
 			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			requiredMocks: func() {
@@ -447,7 +447,7 @@ func TestReverseListener(t *testing.T) {
 			},
 			expected: errors.New(""),
 		},
-		{
+		{ //nolint:gosec // G101: well-known jwt.io example token, not a real credential
 			description: "success to create a new reverse listener",
 			token:       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
 			requiredMocks: func() {

--- a/pkg/revdial/revdial.go
+++ b/pkg/revdial/revdial.go
@@ -504,8 +504,8 @@ func (fakeAddr) String() string  { return "revdialconn" }
 // to use in messages to the listener.
 func ConnHandler(upgrader websocket.Upgrader) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		dialerUniq := r.FormValue(dialerUniqParam)
-		uuid := r.FormValue("uuid")
+		dialerUniq := r.FormValue(dialerUniqParam) //nolint:gosec // G120: internal websocket handler, body size limited upstream
+		uuid := r.FormValue("uuid")                //nolint:gosec // G120: internal websocket handler, body size limited upstream
 
 		d, ok := dialers.Load(dialerUniq)
 		if !ok {

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -41,7 +41,7 @@ ENV GOPROXY ${GOPROXY}
 
 RUN apk add --update openssl
 RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 && \
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
     go install github.com/vektra/mockery/v2/...@v2.20.0
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub

--- a/ssh/server/server.go
+++ b/ssh/server/server.go
@@ -118,7 +118,7 @@ func NewServer(dialer *dialer.Dialer, cache cache.Cache, opts *Options) *Server 
 		},
 	}
 
-	if _, err := os.Stat(os.Getenv("PRIVATE_KEY")); os.IsNotExist(err) {
+	if _, err := os.Stat(os.Getenv("PRIVATE_KEY")); os.IsNotExist(err) { //nolint:gosec // G703: path comes from trusted env var
 		log.WithError(err).Fatal("private key not found!")
 	}
 


### PR DESCRIPTION
## Summary

- Bump golangci-lint from v2.4.0 to v2.11.3 in CI workflow and all 6 service Dockerfiles
- Fix new gosec violations surfaced by the upgraded linter with targeted `//nolint` directives:
  - **G101/G117**: false positives on test fixtures with password fields
  - **G115**: intentional `int64` → `byte` truncation in test helper fingerprint generation
  - **G204**: subprocess wrapper called only by internal code
  - **G703**: file paths from trusted environment variables (`PRIVATE_KEY`, `PUBLIC_KEY`)
  - **G118**: context cancel function stored in map for later use

## Test plan

- [ ] CI `qa.yml` lint job passes with golangci-lint v2.11.3
- [ ] All services build successfully with updated Dockerfiles
- [ ] No regressions in existing tests