### PR TITLE
fix(gateway): prevent nil pointer panic in smoke test

### DIFF
--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -34,7 +35,7 @@ func TestMain_smoke(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	defer func() {
 		if err := container.Terminate(ctx); err != nil {
@@ -43,10 +44,10 @@ func TestMain_smoke(t *testing.T) {
 	}()
 
 	host, err := container.Host(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	port, err := container.MappedPort(ctx, "80")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	baseURL := fmt.Sprintf("http://%s:%s", host, port.Port())
 
@@ -57,7 +58,7 @@ func TestMain_smoke(t *testing.T) {
 	client := http.Client{Timeout: 5 * time.Second}
 
 	resp, err := client.Get(healthURL)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 


### PR DESCRIPTION
## Summary

- Replace `assert.NoError` with `require.NoError` for all fatal preconditions in `TestMain_smoke`
- When the HTTP healthcheck request times out, `resp` is `nil` and the deferred `resp.Body.Close()` causes a nil pointer panic
- `require.NoError` calls `t.FailNow()`, stopping test execution immediately and preventing the nil dereference

## Test plan

- [ ] Verify the `TestMain_smoke` test passes in CI
- [ ] Confirm no nil pointer panic when the healthcheck request times out