### PR TITLE
ci: enable experimental agent teams in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -118,3 +118,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "@claude"
+          settings: |
+            {
+              "env": {
+                "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+              }
+            }


### PR DESCRIPTION
## Summary

- Adds the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable to the Claude GitHub Action settings, enabling the agent teams experimental feature for CI-triggered Claude Code runs.

## Test plan

- [ ] Verify the Claude workflow triggers correctly with the new setting
- [ ] Confirm agent teams functionality works in CI runs