### PR TITLE
refactor(api): remove SAML types from core models

### DIFF
--- a/api/pkg/responses/system.go
+++ b/api/pkg/responses/system.go
@@ -9,7 +9,6 @@ type SystemInfo struct {
 
 type SystemAuthenticationInfo struct {
 	Local bool `json:"local"`
-	SAML  bool `json:"saml"`
 }
 
 type SystemEndpointsInfo struct {

--- a/api/services/system.go
+++ b/api/services/system.go
@@ -36,7 +36,6 @@ func (s *service) GetSystemInfo(ctx context.Context, req *requests.GetSystemInfo
 		},
 		Authentication: &responses.SystemAuthenticationInfo{
 			Local: system.Authentication.Local.Enabled,
-			SAML:  system.Authentication.SAML.Enabled,
 		},
 	}
 

--- a/api/store/migrate/deep_validate_system.go
+++ b/api/store/migrate/deep_validate_system.go
@@ -45,16 +45,6 @@ func (m *Migrator) deepValidateSystems(ctx context.Context, r *ValidationReport)
 
 	r.CheckField(t, id, "Setup", expected.Setup, actual.Setup)
 	r.CheckField(t, id, "Auth.Local.Enabled", expected.Authentication.Local.Enabled, actual.Authentication.Local.Enabled)
-	r.CheckField(t, id, "Auth.SAML.Enabled", expected.Authentication.SAML.Enabled, actual.Authentication.SAML.Enabled)
-	r.CheckField(t, id, "Auth.SAML.Idp.EntityID", expected.Authentication.SAML.Idp.EntityID, actual.Authentication.SAML.Idp.EntityID)
-	r.CheckField(t, id, "Auth.SAML.Idp.Binding.Post", expected.Authentication.SAML.Idp.Binding.Post, actual.Authentication.SAML.Idp.Binding.Post)
-	r.CheckField(t, id, "Auth.SAML.Idp.Binding.Redirect", expected.Authentication.SAML.Idp.Binding.Redirect, actual.Authentication.SAML.Idp.Binding.Redirect)
-	r.CheckField(t, id, "Auth.SAML.Idp.Binding.Preferred", expected.Authentication.SAML.Idp.Binding.Preferred, actual.Authentication.SAML.Idp.Binding.Preferred)
-	r.CheckStrings(t, id, "Auth.SAML.Idp.Certificates", expected.Authentication.SAML.Idp.Certificates, actual.Authentication.SAML.Idp.Certificates)
-	r.CheckStringMap(t, id, "Auth.SAML.Idp.Mappings", expected.Authentication.SAML.Idp.Mappings, actual.Authentication.SAML.Idp.Mappings)
-	r.CheckField(t, id, "Auth.SAML.Sp.SignAuthRequests", expected.Authentication.SAML.Sp.SignAuthRequests, actual.Authentication.SAML.Sp.SignAuthRequests)
-	r.CheckFieldRedacted(t, id, "Auth.SAML.Sp.Certificate", expected.Authentication.SAML.Sp.Certificate, actual.Authentication.SAML.Sp.Certificate)
-	r.CheckFieldRedacted(t, id, "Auth.SAML.Sp.PrivateKey", expected.Authentication.SAML.Sp.PrivateKey, actual.Authentication.SAML.Sp.PrivateKey)
 
 	return nil
 }

--- a/api/store/migrate/system.go
+++ b/api/store/migrate/system.go
@@ -16,36 +16,10 @@ type mongoSystem struct {
 
 type mongoSystemAuth struct {
 	Local *mongoSystemAuthLocal `bson:"local"`
-	SAML  *mongoSystemAuthSAML  `bson:"saml"`
 }
 
 type mongoSystemAuthLocal struct {
 	Enabled bool `bson:"enabled"`
-}
-
-type mongoSystemAuthSAML struct {
-	Enabled bool            `bson:"enabled"`
-	Idp     *mongoSystemIdp `bson:"idp"`
-	Sp      *mongoSystemSp  `bson:"sp"`
-}
-
-type mongoSystemIdp struct {
-	EntityID     string              `bson:"entity_id"`
-	Binding      *mongoSystemBinding `bson:"binding"`
-	Certificates []string            `bson:"certificates"`
-	Mappings     map[string]string   `bson:"mappings"`
-}
-
-type mongoSystemBinding struct {
-	Post      string `bson:"post"`
-	Redirect  string `bson:"redirect"`
-	Preferred string `bson:"preferred"`
-}
-
-type mongoSystemSp struct {
-	SignAuthRequests bool   `bson:"sign_auth_requests"`
-	Certificate      string `bson:"certificate"`
-	PrivateKey       string `bson:"private_key"`
 }
 
 func convertSystem(doc mongoSystem) *entity.System {
@@ -57,24 +31,6 @@ func convertSystem(doc mongoSystem) *entity.System {
 	if doc.Authentication != nil {
 		if doc.Authentication.Local != nil {
 			e.Authentication.Local.Enabled = doc.Authentication.Local.Enabled
-		}
-		if doc.Authentication.SAML != nil {
-			e.Authentication.SAML.Enabled = doc.Authentication.SAML.Enabled
-			if doc.Authentication.SAML.Idp != nil {
-				e.Authentication.SAML.Idp.EntityID = doc.Authentication.SAML.Idp.EntityID
-				e.Authentication.SAML.Idp.Certificates = doc.Authentication.SAML.Idp.Certificates
-				e.Authentication.SAML.Idp.Mappings = doc.Authentication.SAML.Idp.Mappings
-				if doc.Authentication.SAML.Idp.Binding != nil {
-					e.Authentication.SAML.Idp.Binding.Post = doc.Authentication.SAML.Idp.Binding.Post
-					e.Authentication.SAML.Idp.Binding.Redirect = doc.Authentication.SAML.Idp.Binding.Redirect
-					e.Authentication.SAML.Idp.Binding.Preferred = doc.Authentication.SAML.Idp.Binding.Preferred
-				}
-			}
-			if doc.Authentication.SAML.Sp != nil {
-				e.Authentication.SAML.Sp.SignAuthRequests = doc.Authentication.SAML.Sp.SignAuthRequests
-				e.Authentication.SAML.Sp.Certificate = doc.Authentication.SAML.Sp.Certificate
-				e.Authentication.SAML.Sp.PrivateKey = doc.Authentication.SAML.Sp.PrivateKey
-			}
 		}
 	}
 

--- a/api/store/migrate/system_test.go
+++ b/api/store/migrate/system_test.go
@@ -20,7 +20,6 @@ func TestConvertSystem(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, result.Setup)
 		assert.False(t, result.Authentication.Local.Enabled)
-		assert.False(t, result.Authentication.SAML.Enabled)
 	})
 
 	t.Run("nil authentication", func(t *testing.T) {
@@ -46,69 +45,6 @@ func TestConvertSystem(t *testing.T) {
 		result := convertSystem(doc)
 
 		assert.True(t, result.Authentication.Local.Enabled)
-		assert.False(t, result.Authentication.SAML.Enabled)
-	})
-
-	t.Run("full SAML configuration", func(t *testing.T) {
-		doc := mongoSystem{
-			Setup: true,
-			Authentication: &mongoSystemAuth{
-				Local: &mongoSystemAuthLocal{Enabled: true},
-				SAML: &mongoSystemAuthSAML{
-					Enabled: true,
-					Idp: &mongoSystemIdp{
-						EntityID:     "https://idp.example.com",
-						Certificates: []string{"cert1", "cert2"},
-						Mappings:     map[string]string{"email": "mail", "name": "displayName"},
-						Binding: &mongoSystemBinding{
-							Post:      "https://idp.example.com/sso/post",
-							Redirect:  "https://idp.example.com/sso/redirect",
-							Preferred: "post",
-						},
-					},
-					Sp: &mongoSystemSp{
-						SignAuthRequests: true,
-						Certificate:      "sp-cert",
-						PrivateKey:       "sp-key",
-					},
-				},
-			},
-		}
-
-		result := convertSystem(doc)
-
-		assert.True(t, result.Authentication.Local.Enabled)
-		assert.True(t, result.Authentication.SAML.Enabled)
-		assert.Equal(t, "https://idp.example.com", result.Authentication.SAML.Idp.EntityID)
-		assert.Equal(t, []string{"cert1", "cert2"}, result.Authentication.SAML.Idp.Certificates)
-		assert.Equal(t, map[string]string{"email": "mail", "name": "displayName"}, result.Authentication.SAML.Idp.Mappings)
-		assert.Equal(t, "https://idp.example.com/sso/post", result.Authentication.SAML.Idp.Binding.Post)
-		assert.Equal(t, "https://idp.example.com/sso/redirect", result.Authentication.SAML.Idp.Binding.Redirect)
-		assert.Equal(t, "post", result.Authentication.SAML.Idp.Binding.Preferred)
-		assert.True(t, result.Authentication.SAML.Sp.SignAuthRequests)
-		assert.Equal(t, "sp-cert", result.Authentication.SAML.Sp.Certificate)
-		assert.Equal(t, "sp-key", result.Authentication.SAML.Sp.PrivateKey)
-	})
-
-	t.Run("SAML without binding and sp", func(t *testing.T) {
-		doc := mongoSystem{
-			Setup: true,
-			Authentication: &mongoSystemAuth{
-				SAML: &mongoSystemAuthSAML{
-					Enabled: true,
-					Idp: &mongoSystemIdp{
-						EntityID: "https://idp.example.com",
-					},
-				},
-			},
-		}
-
-		result := convertSystem(doc)
-
-		assert.True(t, result.Authentication.SAML.Enabled)
-		assert.Equal(t, "https://idp.example.com", result.Authentication.SAML.Idp.EntityID)
-		assert.Empty(t, result.Authentication.SAML.Idp.Binding.Post)
-		assert.False(t, result.Authentication.SAML.Sp.SignAuthRequests)
 	})
 
 	t.Run("unique IDs", func(t *testing.T) {

--- a/api/store/mongo/migrations/migration_107.go
+++ b/api/store/mongo/migrations/migration_107.go
@@ -3,7 +3,6 @@ package migrations
 import (
 	"context"
 
-	"github.com/shellhub-io/shellhub/pkg/models"
 	log "github.com/sirupsen/logrus"
 	migrate "github.com/xakep666/mongo-migrate"
 	"go.mongodb.org/mongo-driver/bson"
@@ -16,13 +15,20 @@ var migration107 = migrate.Migration{
 	Up: migrate.MigrationFunc(func(ctx context.Context, db *mongo.Database) error {
 		log.WithFields(log.Fields{"component": "migration", "version": 107, "action": "Up"}).Info("Applying migration")
 
-		system := &models.System{}
-		if err := db.Collection("system").FindOne(ctx, bson.M{}).Decode(system); err != nil {
+		var doc struct {
+			Authentication struct {
+				SAML struct {
+					Enabled bool `bson:"enabled"`
+				} `bson:"saml"`
+			} `bson:"authentication"`
+		}
+
+		if err := db.Collection("system").FindOne(ctx, bson.M{}).Decode(&doc); err != nil {
 			return err
 		}
 
 		preferred := ""
-		if system.Authentication.SAML.Enabled {
+		if doc.Authentication.SAML.Enabled {
 			preferred = "post"
 		}
 

--- a/api/store/pg/entity/system.go
+++ b/api/store/pg/entity/system.go
@@ -15,36 +15,10 @@ type System struct {
 
 type SystemAuthentication struct {
 	Local SystemAuthenticationLocal `bun:"embed:local_"`
-	SAML  SystemAuthenticationSAML  `bun:"embed:saml_"`
 }
 
 type SystemAuthenticationLocal struct {
 	Enabled bool `bun:"enabled"`
-}
-
-type SystemAuthenticationSAML struct {
-	Enabled bool          `bun:"enabled"`
-	Idp     SystemIdpSAML `bun:"embed:idp_"`
-	Sp      SystemSpSAML  `bun:"embed:sp_"`
-}
-
-type SystemAuthenticationBinding struct {
-	Post      string `bun:"binding_post"`
-	Redirect  string `bun:"binding_redirect"`
-	Preferred string `bun:"binding_preferred"`
-}
-
-type SystemIdpSAML struct {
-	EntityID     string                      `bun:"entity_id"`
-	Binding      SystemAuthenticationBinding `bun:"embed:"`
-	Certificates []string                    `bun:"certificates,array"`
-	Mappings     map[string]string           `bun:"mappings,type:jsonb"`
-}
-
-type SystemSpSAML struct {
-	SignAuthRequests bool   `bun:"sign_auth_requests"`
-	Certificate      string `bun:"certificate"`
-	PrivateKey       string `bun:"private_key"`
 }
 
 func SystemFromModel(model *models.System) *System {
@@ -59,28 +33,6 @@ func SystemFromModel(model *models.System) *System {
 	if model.Authentication != nil {
 		if model.Authentication.Local != nil {
 			entity.Authentication.Local.Enabled = model.Authentication.Local.Enabled
-		}
-
-		if model.Authentication.SAML != nil {
-			entity.Authentication.SAML.Enabled = model.Authentication.SAML.Enabled
-
-			if model.Authentication.SAML.Idp != nil {
-				entity.Authentication.SAML.Idp.EntityID = model.Authentication.SAML.Idp.EntityID
-				entity.Authentication.SAML.Idp.Certificates = model.Authentication.SAML.Idp.Certificates
-				entity.Authentication.SAML.Idp.Mappings = model.Authentication.SAML.Idp.Mappings
-
-				if model.Authentication.SAML.Idp.Binding != nil {
-					entity.Authentication.SAML.Idp.Binding.Post = model.Authentication.SAML.Idp.Binding.Post
-					entity.Authentication.SAML.Idp.Binding.Redirect = model.Authentication.SAML.Idp.Binding.Redirect
-					entity.Authentication.SAML.Idp.Binding.Preferred = model.Authentication.SAML.Idp.Binding.Preferred
-				}
-			}
-
-			if model.Authentication.SAML.Sp != nil {
-				entity.Authentication.SAML.Sp.SignAuthRequests = model.Authentication.SAML.Sp.SignAuthRequests
-				entity.Authentication.SAML.Sp.Certificate = model.Authentication.SAML.Sp.Certificate
-				entity.Authentication.SAML.Sp.PrivateKey = model.Authentication.SAML.Sp.PrivateKey
-			}
 		}
 	}
 
@@ -97,24 +49,6 @@ func SystemToModel(entity *System) *models.System {
 		Authentication: &models.SystemAuthentication{
 			Local: &models.SystemAuthenticationLocal{
 				Enabled: entity.Authentication.Local.Enabled,
-			},
-			SAML: &models.SystemAuthenticationSAML{
-				Enabled: entity.Authentication.SAML.Enabled,
-				Idp: &models.SystemIdpSAML{
-					EntityID:     entity.Authentication.SAML.Idp.EntityID,
-					Certificates: entity.Authentication.SAML.Idp.Certificates,
-					Mappings:     entity.Authentication.SAML.Idp.Mappings,
-					Binding: &models.SystemAuthenticationBinding{
-						Post:      entity.Authentication.SAML.Idp.Binding.Post,
-						Redirect:  entity.Authentication.SAML.Idp.Binding.Redirect,
-						Preferred: entity.Authentication.SAML.Idp.Binding.Preferred,
-					},
-				},
-				Sp: &models.SystemSpSAML{
-					SignAuthRequests: entity.Authentication.SAML.Sp.SignAuthRequests,
-					Certificate:      entity.Authentication.SAML.Sp.Certificate,
-					PrivateKey:       entity.Authentication.SAML.Sp.PrivateKey,
-				},
 			},
 		},
 	}

--- a/api/store/pg/entity/system_test.go
+++ b/api/store/pg/entity/system_test.go
@@ -23,46 +23,18 @@ func TestSystemFromModel(t *testing.T) {
 			},
 		},
 		{
-			name: "full fields with all nesting",
+			name: "full fields",
 			model: &models.System{
 				Setup: true,
 				Authentication: &models.SystemAuthentication{
 					Local: &models.SystemAuthenticationLocal{
 						Enabled: true,
 					},
-					SAML: &models.SystemAuthenticationSAML{
-						Enabled: true,
-						Idp: &models.SystemIdpSAML{
-							EntityID:     "https://idp.example.com",
-							Certificates: []string{"cert1", "cert2"},
-							Mappings:     map[string]string{"email": "user.email"},
-							Binding: &models.SystemAuthenticationBinding{
-								Post:      "https://idp.example.com/post",
-								Redirect:  "https://idp.example.com/redirect",
-								Preferred: "post",
-							},
-						},
-						Sp: &models.SystemSpSAML{
-							SignAuthRequests: true,
-							Certificate:      "sp-cert",
-							PrivateKey:       "sp-key",
-						},
-					},
 				},
 			},
 			check: func(t *testing.T, result *System) {
 				assert.True(t, result.Setup)
 				assert.True(t, result.Authentication.Local.Enabled)
-				assert.True(t, result.Authentication.SAML.Enabled)
-				assert.Equal(t, "https://idp.example.com", result.Authentication.SAML.Idp.EntityID)
-				assert.Equal(t, []string{"cert1", "cert2"}, result.Authentication.SAML.Idp.Certificates)
-				assert.Equal(t, map[string]string{"email": "user.email"}, result.Authentication.SAML.Idp.Mappings)
-				assert.Equal(t, "https://idp.example.com/post", result.Authentication.SAML.Idp.Binding.Post)
-				assert.Equal(t, "https://idp.example.com/redirect", result.Authentication.SAML.Idp.Binding.Redirect)
-				assert.Equal(t, "post", result.Authentication.SAML.Idp.Binding.Preferred)
-				assert.True(t, result.Authentication.SAML.Sp.SignAuthRequests)
-				assert.Equal(t, "sp-cert", result.Authentication.SAML.Sp.Certificate)
-				assert.Equal(t, "sp-key", result.Authentication.SAML.Sp.PrivateKey)
 			},
 		},
 		{
@@ -74,7 +46,6 @@ func TestSystemFromModel(t *testing.T) {
 			check: func(t *testing.T, result *System) {
 				assert.True(t, result.Setup)
 				assert.False(t, result.Authentication.Local.Enabled)
-				assert.False(t, result.Authentication.SAML.Enabled)
 			},
 		},
 		{
@@ -82,78 +53,21 @@ func TestSystemFromModel(t *testing.T) {
 			model: &models.System{
 				Authentication: &models.SystemAuthentication{
 					Local: nil,
-					SAML:  &models.SystemAuthenticationSAML{Enabled: true},
 				},
 			},
 			check: func(t *testing.T, result *System) {
 				assert.False(t, result.Authentication.Local.Enabled)
-				assert.True(t, result.Authentication.SAML.Enabled)
 			},
 		},
 		{
-			name: "nil SAML",
+			name: "local disabled",
 			model: &models.System{
 				Authentication: &models.SystemAuthentication{
-					Local: &models.SystemAuthenticationLocal{Enabled: true},
-					SAML:  nil,
+					Local: &models.SystemAuthenticationLocal{Enabled: false},
 				},
 			},
 			check: func(t *testing.T, result *System) {
-				assert.True(t, result.Authentication.Local.Enabled)
-				assert.False(t, result.Authentication.SAML.Enabled)
-			},
-		},
-		{
-			name: "nil Idp",
-			model: &models.System{
-				Authentication: &models.SystemAuthentication{
-					SAML: &models.SystemAuthenticationSAML{
-						Enabled: true,
-						Idp:     nil,
-						Sp:      &models.SystemSpSAML{Certificate: "cert"},
-					},
-				},
-			},
-			check: func(t *testing.T, result *System) {
-				assert.True(t, result.Authentication.SAML.Enabled)
-				assert.Equal(t, "", result.Authentication.SAML.Idp.EntityID)
-				assert.Equal(t, "cert", result.Authentication.SAML.Sp.Certificate)
-			},
-		},
-		{
-			name: "nil Idp.Binding",
-			model: &models.System{
-				Authentication: &models.SystemAuthentication{
-					SAML: &models.SystemAuthenticationSAML{
-						Enabled: true,
-						Idp: &models.SystemIdpSAML{
-							EntityID: "entity-1",
-							Binding:  nil,
-						},
-					},
-				},
-			},
-			check: func(t *testing.T, result *System) {
-				assert.Equal(t, "entity-1", result.Authentication.SAML.Idp.EntityID)
-				assert.Equal(t, "", result.Authentication.SAML.Idp.Binding.Post)
-				assert.Equal(t, "", result.Authentication.SAML.Idp.Binding.Redirect)
-			},
-		},
-		{
-			name: "nil Sp",
-			model: &models.System{
-				Authentication: &models.SystemAuthentication{
-					SAML: &models.SystemAuthenticationSAML{
-						Enabled: true,
-						Idp:     &models.SystemIdpSAML{EntityID: "entity-1"},
-						Sp:      nil,
-					},
-				},
-			},
-			check: func(t *testing.T, result *System) {
-				assert.Equal(t, "entity-1", result.Authentication.SAML.Idp.EntityID)
-				assert.False(t, result.Authentication.SAML.Sp.SignAuthRequests)
-				assert.Equal(t, "", result.Authentication.SAML.Sp.Certificate)
+				assert.False(t, result.Authentication.Local.Enabled)
 			},
 		},
 	}
@@ -182,7 +96,7 @@ func TestSystemToModel(t *testing.T) {
 			},
 		},
 		{
-			name: "zero-value authentication sub-structs",
+			name: "zero-value authentication",
 			entity: &System{
 				Setup: true,
 			},
@@ -191,65 +105,14 @@ func TestSystemToModel(t *testing.T) {
 				require.NotNil(t, result.Authentication)
 				require.NotNil(t, result.Authentication.Local)
 				assert.False(t, result.Authentication.Local.Enabled)
-				require.NotNil(t, result.Authentication.SAML)
-				assert.False(t, result.Authentication.SAML.Enabled)
-				require.NotNil(t, result.Authentication.SAML.Idp)
-				assert.Equal(t, "", result.Authentication.SAML.Idp.EntityID)
-				require.NotNil(t, result.Authentication.SAML.Idp.Binding)
-				assert.Equal(t, "", result.Authentication.SAML.Idp.Binding.Post)
-				require.NotNil(t, result.Authentication.SAML.Sp)
-				assert.False(t, result.Authentication.SAML.Sp.SignAuthRequests)
 			},
 		},
 		{
-			name: "only SAML enabled",
-			entity: &System{
-				Setup: true,
-				Authentication: SystemAuthentication{
-					Local: SystemAuthenticationLocal{Enabled: false},
-					SAML: SystemAuthenticationSAML{
-						Enabled: true,
-						Idp: SystemIdpSAML{
-							EntityID: "https://idp.example.com",
-						},
-					},
-				},
-			},
-			check: func(t *testing.T, result *models.System) {
-				assert.True(t, result.Setup)
-				require.NotNil(t, result.Authentication)
-				require.NotNil(t, result.Authentication.Local)
-				assert.False(t, result.Authentication.Local.Enabled)
-				require.NotNil(t, result.Authentication.SAML)
-				assert.True(t, result.Authentication.SAML.Enabled)
-				assert.Equal(t, "https://idp.example.com", result.Authentication.SAML.Idp.EntityID)
-				assert.False(t, result.Authentication.SAML.Sp.SignAuthRequests)
-			},
-		},
-		{
-			name: "full fields",
+			name: "local enabled",
 			entity: &System{
 				Setup: true,
 				Authentication: SystemAuthentication{
 					Local: SystemAuthenticationLocal{Enabled: true},
-					SAML: SystemAuthenticationSAML{
-						Enabled: true,
-						Idp: SystemIdpSAML{
-							EntityID:     "https://idp.example.com",
-							Certificates: []string{"cert1"},
-							Mappings:     map[string]string{"email": "user.email"},
-							Binding: SystemAuthenticationBinding{
-								Post:      "https://idp.example.com/post",
-								Redirect:  "https://idp.example.com/redirect",
-								Preferred: "post",
-							},
-						},
-						Sp: SystemSpSAML{
-							SignAuthRequests: true,
-							Certificate:      "sp-cert",
-							PrivateKey:       "sp-key",
-						},
-					},
 				},
 			},
 			check: func(t *testing.T, result *models.System) {
@@ -257,14 +120,21 @@ func TestSystemToModel(t *testing.T) {
 				require.NotNil(t, result.Authentication)
 				require.NotNil(t, result.Authentication.Local)
 				assert.True(t, result.Authentication.Local.Enabled)
-				require.NotNil(t, result.Authentication.SAML)
-				assert.True(t, result.Authentication.SAML.Enabled)
-				require.NotNil(t, result.Authentication.SAML.Idp)
-				assert.Equal(t, "https://idp.example.com", result.Authentication.SAML.Idp.EntityID)
-				require.NotNil(t, result.Authentication.SAML.Idp.Binding)
-				assert.Equal(t, "https://idp.example.com/post", result.Authentication.SAML.Idp.Binding.Post)
-				require.NotNil(t, result.Authentication.SAML.Sp)
-				assert.True(t, result.Authentication.SAML.Sp.SignAuthRequests)
+			},
+		},
+		{
+			name: "local disabled",
+			entity: &System{
+				Setup: false,
+				Authentication: SystemAuthentication{
+					Local: SystemAuthenticationLocal{Enabled: false},
+				},
+			},
+			check: func(t *testing.T, result *models.System) {
+				assert.False(t, result.Setup)
+				require.NotNil(t, result.Authentication)
+				require.NotNil(t, result.Authentication.Local)
+				assert.False(t, result.Authentication.Local.Enabled)
 			},
 		},
 	}

--- a/api/store/pg/system.go
+++ b/api/store/pg/system.go
@@ -22,11 +22,6 @@ func (pg *Pg) SystemGet(ctx context.Context) (*models.System, error) {
 					Local: &models.SystemAuthenticationLocal{
 						Enabled: true,
 					},
-					SAML: &models.SystemAuthenticationSAML{
-						Enabled: false,
-						Idp:     &models.SystemIdpSAML{Binding: &models.SystemAuthenticationBinding{}},
-						Sp:      &models.SystemSpSAML{},
-					},
 				},
 			}
 

--- a/api/store/storetest/system_tests.go
+++ b/api/store/storetest/system_tests.go
@@ -24,11 +24,6 @@ func (s *Suite) TestSystemGet(t *testing.T) {
 				Local: &models.SystemAuthenticationLocal{
 					Enabled: true,
 				},
-				SAML: &models.SystemAuthenticationSAML{
-					Enabled: false,
-					Idp:     &models.SystemIdpSAML{Binding: &models.SystemAuthenticationBinding{}},
-					Sp:      &models.SystemSpSAML{},
-				},
 			},
 		}
 
@@ -60,11 +55,6 @@ func (s *Suite) TestSystemSet(t *testing.T) {
 				Local: &models.SystemAuthenticationLocal{
 					Enabled: true,
 				},
-				SAML: &models.SystemAuthenticationSAML{
-					Enabled: false,
-					Idp:     &models.SystemIdpSAML{Binding: &models.SystemAuthenticationBinding{}},
-					Sp:      &models.SystemSpSAML{},
-				},
 			},
 		}
 
@@ -87,11 +77,6 @@ func (s *Suite) TestSystemSet(t *testing.T) {
 				Local: &models.SystemAuthenticationLocal{
 					Enabled: true,
 				},
-				SAML: &models.SystemAuthenticationSAML{
-					Enabled: false,
-					Idp:     &models.SystemIdpSAML{Binding: &models.SystemAuthenticationBinding{}},
-					Sp:      &models.SystemSpSAML{},
-				},
 			},
 		}
 
@@ -104,11 +89,6 @@ func (s *Suite) TestSystemSet(t *testing.T) {
 			Authentication: &models.SystemAuthentication{
 				Local: &models.SystemAuthenticationLocal{
 					Enabled: false,
-				},
-				SAML: &models.SystemAuthenticationSAML{
-					Enabled: true,
-					Idp:     &models.SystemIdpSAML{Binding: &models.SystemAuthenticationBinding{}},
-					Sp:      &models.SystemSpSAML{},
 				},
 			},
 		}
@@ -131,11 +111,6 @@ func (s *Suite) TestSystemSet(t *testing.T) {
 			Authentication: &models.SystemAuthentication{
 				Local: &models.SystemAuthenticationLocal{
 					Enabled: true,
-				},
-				SAML: &models.SystemAuthenticationSAML{
-					Enabled: false,
-					Idp:     &models.SystemIdpSAML{Binding: &models.SystemAuthenticationBinding{}},
-					Sp:      &models.SystemSpSAML{},
 				},
 			},
 		}

--- a/pkg/models/system.go
+++ b/pkg/models/system.go
@@ -2,89 +2,16 @@ package models
 
 type System struct {
 	Setup bool `json:"setup"`
-	// Authentication manages the settings for available authentication methods, such as manual
-	// username/password authentication and SAML authentication. Each authentication method
-	// can be individually enabled or disabled.
+	// Authentication manages the settings for available authentication methods.
 	Authentication *SystemAuthentication `json:"authentication" bson:"authentication"`
 }
 
 type SystemAuthentication struct {
 	Local *SystemAuthenticationLocal `json:"local" bson:"local"`
-	SAML  *SystemAuthenticationSAML  `json:"saml" bson:"saml"`
 }
 
 type SystemAuthenticationLocal struct {
 	// Enabled indicates whether manual authentication using a username and password is enabled or
 	// not.
 	Enabled bool `json:"enabled" bool:"enabled"`
-}
-
-type SystemAuthenticationSAML struct {
-	// Enabled indicates whether SAML authentication is enabled.
-	Enabled bool           `json:"enabled" bson:"enabled"`
-	Idp     *SystemIdpSAML `json:"idp" bson:"idp"`
-	Sp      *SystemSpSAML  `json:"sp" bson:"sp"`
-}
-
-type SystemAuthenticationBinding struct {
-	Post     string `json:"post" bson:"post"`
-	Redirect string `json:"redirect" bson:"redirect"`
-	// PreferredBinding defines the preferred SAML binding method.
-	Preferred string `json:"preferred" bson:"preferred"`
-}
-
-type SystemIdpSAML struct {
-	EntityID string                       `json:"entity_id" bson:"entity_id"`
-	Binding  *SystemAuthenticationBinding `json:"binding" bson:"binding"`
-	// Certificates is a list of X.509 certificates provided by the IdP. These certificates are used
-	// by the SP to validate the digital signatures of SAML assertions issued by the IdP.
-	Certificates []string `json:"certificates" bson:"certificates"`
-	// Mappings defines how IdP SAML attributes map to ShellHub attributes.
-	//
-	// Example:
-	// 	{
-	//		"external_id": "user_id",
-	// 		"email": "emailaddress",
-	// 		"name": "displayName"
-	// 	}
-	Mappings map[string]string `json:"mappings" bson:"mappings"`
-}
-
-type SystemSpSAML struct {
-	// SignRequests indicates whether ShellHub should sign authentication requests.
-	// If enabled, an X509 certificate is used to sign the request, and the IdP must authenticate
-	// the request using the corresponding public certificate. Enabling this option disables
-	// the "IdP-initiated" authentication pipeline.
-	SignAuthRequests bool `json:"sign_auth_requests" bson:"sign_auth_requests"`
-	// Certificate is an X509 certificate that the IdP uses to verify the authenticity of the
-	// authentication request signed by ShellHub. This certificate corresponds to the private key
-	// in the [SystemSpSAML.PrivateKey] and it is only populated when [SystemSpSAML.SignAuthRequests]
-	// is true.
-	Certificate string `json:"certificate" bson:"certificate"`
-	// PrivateKey is an encrypted private key used by ShellHub to sign authentication requests.
-	// The IdP verifies the signature using the [SystemSpSAML.Certificate]. It is only populated
-	// when [SystemSpSAML.SignAuthRequests] is true.
-	PrivateKey string `json:"-" bson:"private_key"`
-}
-
-type SAMLBinding struct {
-	URL     string
-	Binding string
-}
-
-const (
-	SAMLBindingPost     = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-	SAMLBindingRedirect = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-)
-
-func (s *SystemIdpSAML) GetBinding() SAMLBinding {
-	if s.Binding.Preferred == "post" {
-		return SAMLBinding{URL: s.Binding.Post, Binding: SAMLBindingPost}
-	} else if s.Binding.Preferred == "redirect" {
-		return SAMLBinding{URL: s.Binding.Redirect, Binding: SAMLBindingRedirect}
-	} else if s.Binding.Post != "" {
-		return SAMLBinding{URL: s.Binding.Post, Binding: SAMLBindingPost}
-	} else {
-		return SAMLBinding{URL: s.Binding.Redirect, Binding: SAMLBindingRedirect}
-	}
 }


### PR DESCRIPTION
## Summary

- Remove all SAML system types (`SystemAuthenticationSAML`, `SystemIdpSAML`,
  `SystemSpSAML`, `SAMLBinding`, etc.) from core `pkg/models`, PG entity,
  responses, services, and store layers
- Core `SystemAuthentication` now only carries `Local` auth config
- User-level SAML enums (`UserOriginSAML`, `UserAuthMethodSAML`) remain
  in core since the user model is shared
- PG schema columns are untouched — cloud owns them
- Companion PR: shellhub-io/cloud#TBD