### PR TITLE
fix(ui): call correct endpoint to close SSH sessions

### DIFF
--- a/ui-react/apps/admin/src/api/sessions.ts
+++ b/ui-react/apps/admin/src/api/sessions.ts
@@ -17,6 +17,9 @@ export async function getSession(uid: string): Promise<Session> {
   return response.data;
 }
 
-export async function closeSession(uid: string): Promise<void> {
-  await apiClient.post(`/api/sessions/${uid}/finish`);
+export async function closeSession(
+  uid: string,
+  deviceUid: string,
+): Promise<void> {
+  await apiClient.post(`/api/sessions/${uid}/close`, { device: deviceUid });
 }

--- a/ui-react/apps/admin/src/pages/SessionDetails.tsx
+++ b/ui-react/apps/admin/src/pages/SessionDetails.tsx
@@ -52,13 +52,11 @@ function buildTimeline(session: Session): TLEvent[] {
 
   events.push({
     id: "auth",
-    icon: session.authenticated
-      ? (
-        <ShieldCheckIcon className="w-3.5 h-3.5" strokeWidth={2} />
-      )
-      : (
-        <ShieldExclamationIcon className="w-3.5 h-3.5" strokeWidth={2} />
-      ),
+    icon: session.authenticated ? (
+      <ShieldCheckIcon className="w-3.5 h-3.5" strokeWidth={2} />
+    ) : (
+      <ShieldExclamationIcon className="w-3.5 h-3.5" strokeWidth={2} />
+    ),
     title: session.authenticated ? "Authenticated" : "Authentication failed",
     detail: `as ${session.username}`,
     status: session.authenticated ? "success" : "error",
@@ -136,11 +134,9 @@ function buildTimeline(session: Session): TLEvent[] {
 
   events.push({
     id: "end",
-    icon: session.active
-      ? null
-      : (
-        <CheckCircleIcon className="w-3.5 h-3.5" strokeWidth={2} />
-      ),
+    icon: session.active ? null : (
+      <CheckCircleIcon className="w-3.5 h-3.5" strokeWidth={2} />
+    ),
     title: session.active ? "Session active" : "Session closed",
     detail: session.active
       ? `started ${formatRelative(session.started_at)}`
@@ -206,16 +202,14 @@ function TimelineNode({ event, isLast }: { event: TLEvent; isLast: boolean }) {
         <div
           className={`w-6 h-6 rounded-full border flex items-center justify-center ${NODE_COLORS[event.status]}`}
         >
-          {event.status === "active" && event.icon === null
-            ? (
-              <span className="relative flex w-2 h-2">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-green opacity-60" />
-                <span className="relative inline-flex rounded-full w-2 h-2 bg-accent-green" />
-              </span>
-            )
-            : (
-              event.icon
-            )}
+          {event.status === "active" && event.icon === null ? (
+            <span className="relative flex w-2 h-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-green opacity-60" />
+              <span className="relative inline-flex rounded-full w-2 h-2 bg-accent-green" />
+            </span>
+          ) : (
+            event.icon
+          )}
         </div>
         {!isLast && (
           <div className="w-px flex-1 bg-border/60 my-1 min-h-[20px]" />
@@ -302,11 +296,11 @@ export default function SessionDetails() {
   }, [uid, fetchOne]);
 
   const handleClose = async () => {
-    if (!uid) return;
+    if (!uid || !session) return;
     setClosing(true);
     setCloseError(null);
     try {
-      await close(uid);
+      await close(uid, session.device_uid);
       setShowClose(false);
     } catch {
       setCloseError("Failed to close session. Check your permissions.");
@@ -523,14 +517,11 @@ export default function SessionDetails() {
               </div>
             </div>
             <p className="text-sm text-text-muted mb-6">
-              Are you sure you want to close the session for
-              {" "}
+              Are you sure you want to close the session for{" "}
               <span className="font-medium text-text-primary">
                 {session.username}
-              </span>
-              {" "}
-              on
-              {" "}
+              </span>{" "}
+              on{" "}
               <span className="font-medium text-text-primary">
                 {session.device?.name ?? session.device_uid.substring(0, 8)}
               </span>

--- a/ui-react/apps/admin/src/pages/Sessions.tsx
+++ b/ui-react/apps/admin/src/pages/Sessions.tsx
@@ -95,134 +95,128 @@ export default function Sessions() {
             </tr>
           </thead>
           <tbody className="divide-y divide-border/60">
-            {loading
-              ? (
-                <tr>
-                  <td colSpan={COL_SPAN} className="px-4 py-12 text-center">
-                    <div className="flex items-center justify-center gap-3">
-                      <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-                      <span className="text-xs font-mono text-text-muted">
-                        Loading sessions…
+            {loading ? (
+              <tr>
+                <td colSpan={COL_SPAN} className="px-4 py-12 text-center">
+                  <div className="flex items-center justify-center gap-3">
+                    <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                    <span className="text-xs font-mono text-text-muted">
+                      Loading sessions…
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            ) : sessions.length === 0 ? (
+              <tr>
+                <td colSpan={COL_SPAN} className="px-4 py-12 text-center">
+                  <p className="text-xs font-mono text-text-muted">
+                    No sessions found
+                  </p>
+                </td>
+              </tr>
+            ) : (
+              sessions.map((session) => {
+                const type = sessionType(session);
+                const suspicious = !session.authenticated;
+                return (
+                  <tr
+                    key={session.uid}
+                    onClick={() => void navigate(`/sessions/${session.uid}`)}
+                    className={`transition-colors group cursor-pointer relative ${
+                      suspicious
+                        ? "bg-accent-red/[0.03] hover:bg-accent-red/[0.06] border-l-2 border-l-accent-red/50"
+                        : "hover:bg-hover-subtle border-l-2 border-l-transparent"
+                    }`}
+                  >
+                    <td className="px-4 py-3.5">
+                      <span
+                        className={`w-2 h-2 rounded-full inline-block ${
+                          session.active
+                            ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
+                            : "bg-text-muted/40"
+                        }`}
+                      />
+                    </td>
+                    <td className="px-4 py-3.5">
+                      {session.device?.uid ? (
+                        <DeviceChip
+                          uid={session.device.uid}
+                          name={
+                            session.device.name
+                            ?? session.device_uid.substring(0, 8)
+                          }
+                          online={session.device.online}
+                          osId={session.device.info?.id}
+                          onClick={(e) => e.stopPropagation()}
+                        />
+                      ) : (
+                        <span className="text-xs font-mono text-text-primary">
+                          {session.device?.name
+                            ?? session.device_uid.substring(0, 8)}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3.5">
+                      <div className="flex items-center gap-1.5">
+                        {suspicious && (
+                          <ExclamationTriangleIcon
+                            className="w-3.5 h-3.5 text-accent-red/70 shrink-0"
+                            strokeWidth={2}
+                            title="Not authenticated"
+                          />
+                        )}
+                        <code
+                          className={`text-xs font-mono ${
+                            suspicious
+                              ? "text-accent-red/60"
+                              : "text-text-secondary"
+                          }`}
+                        >
+                          {session.username}
+                        </code>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3.5">
+                      <code className="text-xs font-mono text-text-muted bg-surface px-1.5 py-0.5 rounded">
+                        {session.ip_address}
+                      </code>
+                    </td>
+                    <td className="px-4 py-3.5">
+                      {type ? (
+                        <span
+                          className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}
+                        >
+                          {type.label}
+                        </span>
+                      ) : (
+                        <span className="text-2xs text-text-muted">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3.5">
+                      <span className="text-xs text-text-secondary">
+                        {formatDate(session.started_at)}
                       </span>
-                    </div>
-                  </td>
-                </tr>
-              )
-              : sessions.length === 0
-                ? (
-                  <tr>
-                    <td colSpan={COL_SPAN} className="px-4 py-12 text-center">
-                      <p className="text-xs font-mono text-text-muted">
-                        No sessions found
-                      </p>
+                    </td>
+                    <td className="px-4 py-3.5">
+                      <span className="text-xs font-mono text-text-secondary tabular-nums">
+                        {formatDuration(
+                          session.started_at,
+                          session.last_seen,
+                          session.active,
+                        )}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3.5 text-right">
+                      {session.active && (
+                        <CloseButton
+                          onClose={() => close(session.uid, session.device_uid)}
+                        />
+                      )}
                     </td>
                   </tr>
-                )
-                : (
-                  sessions.map((session) => {
-                    const type = sessionType(session);
-                    const suspicious = !session.authenticated;
-                    return (
-                      <tr
-                        key={session.uid}
-                        onClick={() => void navigate(`/sessions/${session.uid}`)}
-                        className={`transition-colors group cursor-pointer relative ${
-                          suspicious
-                            ? "bg-accent-red/[0.03] hover:bg-accent-red/[0.06] border-l-2 border-l-accent-red/50"
-                            : "hover:bg-hover-subtle border-l-2 border-l-transparent"
-                        }`}
-                      >
-                        <td className="px-4 py-3.5">
-                          <span
-                            className={`w-2 h-2 rounded-full inline-block ${
-                              session.active
-                                ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
-                                : "bg-text-muted/40"
-                            }`}
-                          />
-                        </td>
-                        <td className="px-4 py-3.5">
-                          {session.device?.uid
-                            ? (
-                              <DeviceChip
-                                uid={session.device.uid}
-                                name={
-                                  session.device.name
-                                  ?? session.device_uid.substring(0, 8)
-                                }
-                                online={session.device.online}
-                                osId={session.device.info?.id}
-                                onClick={(e) => e.stopPropagation()}
-                              />
-                            )
-                            : (
-                              <span className="text-xs font-mono text-text-primary">
-                                {session.device?.name
-                                  ?? session.device_uid.substring(0, 8)}
-                              </span>
-                            )}
-                        </td>
-                        <td className="px-4 py-3.5">
-                          <div className="flex items-center gap-1.5">
-                            {suspicious && (
-                              <ExclamationTriangleIcon
-                                className="w-3.5 h-3.5 text-accent-red/70 shrink-0"
-                                strokeWidth={2}
-                                title="Not authenticated"
-                              />
-                            )}
-                            <code
-                              className={`text-xs font-mono ${
-                                suspicious
-                                  ? "text-accent-red/60"
-                                  : "text-text-secondary"
-                              }`}
-                            >
-                              {session.username}
-                            </code>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3.5">
-                          <code className="text-xs font-mono text-text-muted bg-surface px-1.5 py-0.5 rounded">
-                            {session.ip_address}
-                          </code>
-                        </td>
-                        <td className="px-4 py-3.5">
-                          {type
-                            ? (
-                              <span
-                                className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}
-                              >
-                                {type.label}
-                              </span>
-                            )
-                            : (
-                              <span className="text-2xs text-text-muted">—</span>
-                            )}
-                        </td>
-                        <td className="px-4 py-3.5">
-                          <span className="text-xs text-text-secondary">
-                            {formatDate(session.started_at)}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3.5">
-                          <span className="text-xs font-mono text-text-secondary tabular-nums">
-                            {formatDuration(
-                              session.started_at,
-                              session.last_seen,
-                              session.active,
-                            )}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3.5 text-right">
-                          {session.active && (
-                            <CloseButton onClose={() => close(session.uid)} />
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })
-                )}
+                );
+              })
+            )}
           </tbody>
         </table>
       </div>

--- a/ui-react/apps/admin/src/stores/sessionsStore.ts
+++ b/ui-react/apps/admin/src/stores/sessionsStore.ts
@@ -12,7 +12,7 @@ interface SessionsState {
   perPage: number;
   fetch: (page?: number, perPage?: number) => Promise<void>;
   fetchOne: (uid: string) => Promise<void>;
-  close: (uid: string) => Promise<void>;
+  close: (uid: string, deviceUid: string) => Promise<void>;
   setPage: (page: number) => void;
 }
 
@@ -47,8 +47,8 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
     }
   },
 
-  close: async (uid: string) => {
-    await closeSession(uid);
+  close: async (uid: string, deviceUid: string) => {
+    await closeSession(uid, deviceUid);
     const current = get().session;
     if (current?.uid === uid) {
       set({ session: { ...current, active: false } });


### PR DESCRIPTION
## Summary

- The v2 React UI was calling `POST /api/sessions/{uid}/finish` (an internal-only endpoint) instead of `POST /api/sessions/{uid}/close` (handled by the SSH service)
- Pass `device_uid` in the request body as required by the close endpoint
- Update store and page components to thread the `device_uid` parameter through

Fixes: #6021

## Test plan

- [ ] Start a dev environment and establish an SSH session
- [ ] Open the v2 UI sessions page and click close on an active session — should succeed
- [ ] Verify the session list shows the session as inactive
- [ ] Test closing from the session detail page as well