### PR TITLE
fix(agent): set WantReply to true on keepalive requests

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -168,9 +168,12 @@ loop:
 		select {
 		case <-ticker.C:
 			if conn, ok := session.Context().Value(gliderssh.ContextKeyConn).(gossh.Conn); ok {
-				if _, _, err := conn.SendRequest("keepalive", true, nil); err != nil {
+				ok, _, err := conn.SendRequest("keepalive", true, nil)
+				if err != nil {
 					log.Error(err)
 				}
+
+				log.WithField("reply", ok).Info("keepalive sent with WantReply=true")
 			}
 		case <-session.Context().Done():
 			log.Debug("Stopping keep alive loop after session closed")

--- a/ssh/server/channels/session.go
+++ b/ssh/server/channels/session.go
@@ -177,6 +177,8 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 							if err := req.Reply(true, nil); err != nil {
 								logger.WithError(err).Error("failed to reply to keepalive request from agent")
 							}
+
+							logger.Info("replied to keepalive request from agent")
 						}
 
 						if _, err := client.Channel.SendRequest(KeepAliveRequestType, req.WantReply, req.Payload); err != nil {


### PR DESCRIPTION
## Summary

The agent sends SSH keepalive global requests every 30s with
`WantReply` set to `false`. This means the server never sends
a response back, making the traffic unidirectional on the
underlying WebSocket connection.

Intermediaries like load balancers (GCP External Proxy Network
Load Balancer) and reverse proxies (nginx) detect this
half-idle connection and close it, killing the SSH session.

Setting `WantReply` to `true` forces the server to reply,
creating bidirectional traffic that keeps the connection alive
through all intermediaries.

This matches the behavior of OpenSSH, where both client
([clientloop.c](https://github.com/openssh/openssh-portable/blob/master/clientloop.c#L499-L503))
and server
([serverloop.c](https://github.com/openssh/openssh-portable/blob/master/serverloop.c#L131-L134))
send `keepalive@openssh.com` requests with `want_reply = 1`.

Fixes #5946