### PR TITLE
fix(store): add namespace_id to sessions table

### DIFF
--- a/api/store/pg/entity/session.go
+++ b/api/store/pg/entity/session.go
@@ -15,6 +15,7 @@ type Session struct {
 	bun.BaseModel `bun:"table:sessions"`
 
 	ID            string    `bun:"id,pk"`
+	NamespaceID   string    `bun:"namespace_id"`
 	DeviceID      string    `bun:"device_id"`
 	Username      string    `bun:"username"`
 	IPAddress     string    `bun:"ip_address"`
@@ -36,7 +37,8 @@ type Session struct {
 	// EventSeats is a comma-separated list of unique seats as integers
 	EventSeats string `bun:"event_seats,scanonly"`
 
-	Device *Device `bun:"rel:belongs-to,join:device_id=id"`
+	Device    *Device    `bun:"rel:belongs-to,join:device_id=id"`
+	Namespace *Namespace `bun:"rel:belongs-to,join:namespace_id=id"`
 }
 
 func SessionFromModel(model *models.Session) *Session {
@@ -50,6 +52,7 @@ func SessionFromModel(model *models.Session) *Session {
 
 	session := &Session{
 		ID:            model.UID,
+		NamespaceID:   model.TenantID,
 		DeviceID:      string(model.DeviceUID),
 		Username:      model.Username,
 		IPAddress:     model.IPAddress,
@@ -72,6 +75,7 @@ func SessionFromModel(model *models.Session) *Session {
 func SessionToModel(entity *Session) *models.Session {
 	session := &models.Session{
 		UID:           strings.TrimSpace(entity.ID),
+		TenantID:      entity.NamespaceID,
 		DeviceUID:     models.UID(strings.TrimSpace(entity.DeviceID)),
 		Username:      entity.Username,
 		IPAddress:     entity.IPAddress,
@@ -95,7 +99,6 @@ func SessionToModel(entity *Session) *models.Session {
 
 	if entity.Device != nil {
 		session.Device = DeviceToModel(entity.Device)
-		session.TenantID = entity.Device.NamespaceID
 	}
 
 	return session
@@ -125,8 +128,8 @@ func ActiveSessionToModel(entity *ActiveSession) *models.ActiveSession {
 		LastSeen: entity.SeenAt,
 	}
 
-	if entity.Session != nil && entity.Session.Device != nil {
-		activeSession.TenantID = entity.Session.Device.NamespaceID
+	if entity.Session != nil {
+		activeSession.TenantID = entity.Session.NamespaceID
 	}
 
 	return activeSession

--- a/api/store/pg/entity/session_test.go
+++ b/api/store/pg/entity/session_test.go
@@ -96,6 +96,7 @@ func TestSessionToModel(t *testing.T) {
 			name: "full fields with Device",
 			entity: &Session{
 				ID:            "session-uid-1",
+				NamespaceID:   "ns-id-1",
 				DeviceID:      "device-uid-1",
 				Username:      "root",
 				IPAddress:     "192.168.1.1",
@@ -234,6 +235,7 @@ func TestActiveSessionToModel(t *testing.T) {
 				SessionID: "active-session-1",
 				SeenAt:    now,
 				Session: &Session{
+					NamespaceID: "ns-id-1",
 					Device: &Device{
 						NamespaceID: "ns-id-1",
 					},

--- a/api/store/pg/migrations/001_initial_schema.tx.up.sql
+++ b/api/store/pg/migrations/001_initial_schema.tx.up.sql
@@ -282,6 +282,7 @@ CREATE TABLE systems (
 
 CREATE TABLE sessions (
     id character varying(128) NOT NULL,
+    namespace_id uuid NOT NULL,
     device_id character varying NOT NULL,
     username character varying(64) NOT NULL,
     ip_address inet NOT NULL,
@@ -297,8 +298,13 @@ CREATE TABLE sessions (
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
     PRIMARY KEY (id),
+    FOREIGN KEY (namespace_id) REFERENCES namespaces(id),
     FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE
 );
+
+--bun:split
+
+CREATE INDEX sessions_namespace_id_idx ON sessions USING btree (namespace_id);
 
 --bun:split
 

--- a/api/store/pg/query-options.go
+++ b/api/store/pg/query-options.go
@@ -141,7 +141,12 @@ func (*queryOptions) InNamespace(namespaceID string) store.QueryOption {
 			return ErrQueryNotFound
 		}
 
-		wrapper.query = wrapper.query.Where("namespace_id = ?", namespaceID)
+		col := "namespace_id"
+		if alias, ok := ctx.Value(CtxTableAlias).(string); ok && alias != "" {
+			col = alias + ".namespace_id"
+		}
+
+		wrapper.query = wrapper.query.Where(col+" = ?", namespaceID)
 
 		return nil
 	}

--- a/api/store/pg/session.go
+++ b/api/store/pg/session.go
@@ -14,11 +14,13 @@ import (
 func (pg *Pg) SessionList(ctx context.Context, opts ...store.QueryOption) ([]models.Session, int, error) {
 	db := pg.GetConnection(ctx)
 
+	// Sessions and devices both have namespace_id; qualify the column to
+	// avoid ambiguity when SessionSelectQuery JOINs the devices table.
+	ctx = context.WithValue(ctx, CtxTableAlias, "session")
+
 	entities := make([]entity.Session, 0)
 	query := db.NewSelect().
-		Model(&entities).
-		Relation("Device").
-		Relation("Device.Namespace")
+		Model(&entities)
 
 	var err error
 	query, err = applyOptions(ctx, query, opts...)

--- a/api/store/pg/utils.go
+++ b/api/store/pg/utils.go
@@ -29,6 +29,12 @@ func fromSQLError(err error) error {
 	}
 }
 
+type ctxKey string
+
+// CtxTableAlias is the context key used to pass a table alias to query options
+// like InNamespace, avoiding column ambiguity in queries with JOINs.
+const CtxTableAlias ctxKey = "table_alias"
+
 // queryWrapper wraps a SelectQuery pointer to allow mutations
 type queryWrapper struct {
 	query *bun.SelectQuery

--- a/api/store/storetest/session_tests.go
+++ b/api/store/storetest/session_tests.go
@@ -2,6 +2,7 @@ package storetest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -48,6 +49,92 @@ func (s *Suite) TestSessionList(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 4, count)
 		assert.Len(t, sessions, 4)
+	})
+
+	t.Run("returns all sessions across tenants without filter", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenant1 := s.CreateNamespace(t)
+		tenant2 := s.CreateNamespace(t)
+
+		device1 := s.CreateDevice(t, WithTenantID(tenant1))
+		device2 := s.CreateDevice(t, WithTenantID(tenant2))
+
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionUser("user1"))
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionUser("user2"))
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionUser("user3"))
+
+		sessions, count, err := st.SessionList(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 3, count)
+		assert.Len(t, sessions, 3)
+	})
+
+	t.Run("succeeds when tenant filter applied", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenant1 := s.CreateNamespace(t)
+		tenant2 := s.CreateNamespace(t)
+
+		device1 := s.CreateDevice(t, WithTenantID(tenant1))
+		device2 := s.CreateDevice(t, WithTenantID(tenant2))
+
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionUser("user1"))
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionUser("user2"))
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionUser("user3"))
+
+		sessions, count, err := st.SessionList(ctx, st.Options().InNamespace(tenant1))
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+		assert.Len(t, sessions, 2)
+
+		for _, session := range sessions {
+			assert.Equal(t, tenant1, session.TenantID)
+		}
+	})
+
+	t.Run("returns no sessions from other tenant", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenant1 := s.CreateNamespace(t)
+		tenant2 := s.CreateNamespace(t)
+
+		device1 := s.CreateDevice(t, WithTenantID(tenant1))
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionUser("user1"))
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionUser("user2"))
+
+		sessions, count, err := st.SessionList(ctx, st.Options().InNamespace(tenant2))
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+		assert.Empty(t, sessions)
+	})
+
+	t.Run("succeeds with pagination", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenant := s.CreateNamespace(t)
+		device := s.CreateDevice(t, WithTenantID(tenant))
+
+		for i := 0; i < 5; i++ {
+			s.CreateSession(t, WithSessionDevice(device),
+				WithSessionUser(fmt.Sprintf("user%d", i)))
+		}
+
+		sessions, count, err := st.SessionList(ctx,
+			st.Options().InNamespace(tenant),
+			st.Options().Paginate(&query.Paginator{Page: 1, PerPage: 2}),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 5, count)
+		assert.Len(t, sessions, 2)
+
+		sessions, count, err = st.SessionList(ctx,
+			st.Options().InNamespace(tenant),
+			st.Options().Paginate(&query.Paginator{Page: 3, PerPage: 2}),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 5, count)
+		assert.Len(t, sessions, 1)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Add `namespace_id` column directly to the sessions table, removing
  the need to JOIN through devices for tenant-scoped queries
- Update session entity to map `namespace_id` ↔ `TenantID`
- Qualify `InNamespace` WHERE clause with a context-based table alias
  to avoid column ambiguity when `SessionSelectQuery` JOINs devices
- Add tenant isolation and pagination tests for `SessionList`