### PR TITLE
fix(openapi): add missing bin path to air config

### DIFF
--- a/openapi/.air.toml
+++ b/openapi/.air.toml
@@ -3,5 +3,6 @@ tmp_dir = "/tmp/air"
 
 [build]
 cmd = "go build -gcflags=\"all=-N -l\" -o /tmp/air/main ."
+bin = "/tmp/air/main"
 exclude_regex = ["_test.go"]
 include_ext = ["html", "go", "yml", "yaml"]


### PR DESCRIPTION
Missing `bin` field in air config made it look for the binary
at the wrong path, breaking the openapi dev container on startup.