### PR TITLE
fix(openapi): remove orphan connector path references

### DIFF
--- a/openapi/spec/cloud-openapi.yaml
+++ b/openapi/spec/cloud-openapi.yaml
@@ -106,12 +106,6 @@ paths:
     $ref: paths/api@user@mfa@reset@{user-id}.yaml
   /api/user:
     $ref: paths/api@user.yaml
-  /api/connector:
-    $ref: paths/api@connector.yaml
-  /api/connector/{uid}:
-    $ref: paths/api@connector@{uid}.yaml
-  /api/connector/{uid}/info:
-    $ref: paths/api@connector@{uid}@info.yaml
   /api/namespaces/{tenant}/invitations/links:
     $ref: paths/api@namespaces@{tenant}@invitations@links.yaml
   /api/namespaces/{tenant}/members/{id}/accept-invite:


### PR DESCRIPTION
## Summary
- Remove three connector path references (`/api/connector`, `/api/connector/{uid}`, `/api/connector/{uid}/info`) from `cloud-openapi.yaml`
- The referenced spec files (`paths/api@connector*.yaml`) never existed
- No connector API implementation exists in the cloud repository