### PR TITLE
fix(store): remove MFA from core entity and discard unknown columns

### DIFF
--- a/api/store/pg/entity/user.go
+++ b/api/store/pg/entity/user.go
@@ -22,7 +22,6 @@ type User struct {
 	Email          string          `bun:"email"`
 	PasswordDigest string          `bun:"password_digest"`
 	Preferences    UserPreferences `bun:"embed:"`
-	MFA            UserMFA         `bun:"-"`
 	Admin          bool            `bun:"admin"`
 	Namespaces     int             `bun:"namespaces,scanonly"`
 }
@@ -33,12 +32,6 @@ type UserPreferences struct {
 	SecurityEmail      string   `bun:"security_email,nullzero"`
 	MaxNamespaces      int      `bun:"namespace_ownership_limit"`
 	EmailMarketing     bool     `bun:"email_marketing"`
-}
-
-type UserMFA struct {
-	Enabled       bool     `bun:"enabled"`
-	Secret        string   `bun:"secret,nullzero"`
-	RecoveryCodes []string `bun:"recovery_codes,nullzero,array"`
 }
 
 func UserFromModel(model *models.User) *User {
@@ -79,11 +72,6 @@ func UserFromModel(model *models.User) *User {
 			MaxNamespaces:      model.MaxNamespaces,
 			EmailMarketing:     model.EmailMarketing,
 		},
-		MFA: UserMFA{
-			Enabled:       model.MFA.Enabled,
-			Secret:        model.MFA.Secret,
-			RecoveryCodes: model.MFA.RecoveryCodes,
-		},
 	}
 }
 
@@ -111,11 +99,6 @@ func UserToModel(entity *User) *models.User {
 		},
 		Password: models.UserPassword{
 			Hash: entity.PasswordDigest,
-		},
-		MFA: models.UserMFA{
-			Enabled:       entity.MFA.Enabled,
-			Secret:        entity.MFA.Secret,
-			RecoveryCodes: entity.MFA.RecoveryCodes,
 		},
 		Preferences: models.UserPreferences{
 			PreferredNamespace: entity.Preferences.PreferredNamespace,

--- a/api/store/pg/entity/user_test.go
+++ b/api/store/pg/entity/user_test.go
@@ -66,11 +66,6 @@ func TestUserFromModel(t *testing.T) {
 					MaxNamespaces:      5,
 					EmailMarketing:     true,
 				},
-				MFA: UserMFA{
-					Enabled:       true,
-					Secret:        "mfa-secret",
-					RecoveryCodes: []string{"code1", "code2"},
-				},
 			},
 		},
 		{
@@ -126,9 +121,6 @@ func TestUserFromModel(t *testing.T) {
 			assert.Equal(t, tt.expected.Preferences.SecurityEmail, result.Preferences.SecurityEmail)
 			assert.Equal(t, tt.expected.Preferences.MaxNamespaces, result.Preferences.MaxNamespaces)
 			assert.Equal(t, tt.expected.Preferences.EmailMarketing, result.Preferences.EmailMarketing)
-			assert.Equal(t, tt.expected.MFA.Enabled, result.MFA.Enabled)
-			assert.Equal(t, tt.expected.MFA.Secret, result.MFA.Secret)
-			assert.Equal(t, tt.expected.MFA.RecoveryCodes, result.MFA.RecoveryCodes)
 			assert.True(t, result.UpdatedAt.IsZero(), "UpdatedAt should be zero")
 		})
 	}
@@ -163,11 +155,6 @@ func TestUserToModel(t *testing.T) {
 					MaxNamespaces:      5,
 					EmailMarketing:     true,
 				},
-				MFA: UserMFA{
-					Enabled:       true,
-					Secret:        "mfa-secret",
-					RecoveryCodes: []string{"code1", "code2"},
-				},
 			},
 			expected: &models.User{
 				ID:             "user-id-1",
@@ -187,11 +174,6 @@ func TestUserToModel(t *testing.T) {
 				},
 				Password: models.UserPassword{
 					Hash: "hashed-password-123",
-				},
-				MFA: models.UserMFA{
-					Enabled:       true,
-					Secret:        "mfa-secret",
-					RecoveryCodes: []string{"code1", "code2"},
 				},
 				Preferences: models.UserPreferences{
 					PreferredNamespace: "ns-id-1",
@@ -215,7 +197,6 @@ func TestUserToModel(t *testing.T) {
 				Status:   models.UserStatusNotConfirmed,
 				UserData: models.UserData{},
 				Password: models.UserPassword{},
-				MFA:      models.UserMFA{},
 				Preferences: models.UserPreferences{
 					AuthMethods: []models.UserAuthMethod{},
 				},

--- a/api/store/pg/pg.go
+++ b/api/store/pg/pg.go
@@ -38,7 +38,7 @@ func New(ctx context.Context, uri string, opts ...options.Option) (store.Store, 
 		return nil, err
 	}
 
-	pg := &Pg{driver: bun.NewDB(stdlib.OpenDBFromPool(pool), pgdialect.New()), options: &queryOptions{}}
+	pg := &Pg{driver: bun.NewDB(stdlib.OpenDBFromPool(pool), pgdialect.New(), bun.WithDiscardUnknownColumns()), options: &queryOptions{}}
 	if err := pg.driver.Ping(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Remove `UserMFA` struct and MFA field from core pg entity (MFA is cloud-only)
- Remove MFA conversion code from `UserFromModel`/`UserToModel`
- Add `bun.WithDiscardUnknownColumns()` so cloud-added columns (e.g. `mfa_enabled`) are silently ignored by core code (fixes CLI scan error)