### PR TITLE
fix(ui-react): use combined openapi spec for code generation

### DIFF
--- a/ui-react/apps/console/openapi-ts.config.ts
+++ b/ui-react/apps/console/openapi-ts.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@hey-api/openapi-ts";
 
 export default defineConfig({
   input:
-    process.env.OPENAPI_SPEC_PATH || "http://openapi:8080/openapi/openapi.json",
+    process.env.OPENAPI_SPEC_PATH || "../../../openapi/spec/openapi.yaml",
   output: "src/client",
   plugins: [
     "@hey-api/typescript",


### PR DESCRIPTION
## What

Fixes SDK code generation missing all admin API endpoints by switching the `openapi-ts` input from a runtime service URL to the combined spec file.

## Why

The previous default (`http://openapi:8080/openapi/openapi.json`) fetched from the `openapi` Docker service, which at startup bundles one of three specs depending on edition env vars. In dev, `SHELLHUB_ENTERPRISE=false` causes it to bundle `community-openapi.yaml`, which contains no admin paths. The enterprise and admin endpoints were silently excluded from generation every time `npm run generate` ran in a standard dev environment.

`openapi/spec/openapi.yaml` is the combined spec covering all editions (106 paths vs. 41 in community-only), and is already volume-mounted at `/openapi` inside the `ui-react` container. The relative path resolves correctly both inside the container (`/src/apps/console/` → `/openapi/spec/openapi.yaml`) and outside it (`ui-react/apps/console/` → `openapi/spec/openapi.yaml`), unlike the previous URL which was Docker-network-only. `OPENAPI_SPEC_PATH` continues to work as an override.