### PR TITLE
fix(ui-react): fix WelcomeWizard invisible content on WebKit

### DIFF
--- a/ui-react/apps/console/src/components/wizard/WelcomeWizard.tsx
+++ b/ui-react/apps/console/src/components/wizard/WelcomeWizard.tsx
@@ -105,7 +105,7 @@ export default function WelcomeWizard({ open, onClose }: WelcomeWizardProps) {
       </div>
 
       {/* Scrollable content */}
-      <main className="flex-1 overflow-y-auto px-6 min-h-0">
+      <main className="flex-auto overflow-y-auto px-6 min-h-0">
         {step === 1 && <WizardStep1Welcome />}
         {step === 2 && (
           <WizardStep2Install onDeviceDetected={() => setStep(3)} />


### PR DESCRIPTION
## What

Fixed the WelcomeWizard content area being completely invisible on Safari
and other WebKit-based browsers.

## Why

`flex-1` resolves to `flex: 1 1 0`, setting `flex-basis: 0`. WebKit
collapses the main content area to zero height in this configuration,
rendering nothing inside the wizard. `flex-auto` (`flex: 1 1 auto`)
preserves the natural content size as the flex basis, which WebKit
handles correctly while maintaining the intended layout in all other
browsers.

## Testing

Verify on Safari (or any WebKit browser) that the WelcomeWizard renders
its content steps correctly on first login when no devices are registered.