### PR TITLE
fix(ui-react): replace crypto.randomUUID with insecure-context fallback

### DIFF
--- a/ui-react/apps/console/src/stores/terminalStore.ts
+++ b/ui-react/apps/console/src/stores/terminalStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { generateRandomUUID } from "@/utils/random-uuid";
 
 export type TerminalWindowState = "docked" | "minimized" | "fullscreen";
 export type ConnectionStatus = "connecting" | "connected" | "disconnected";
@@ -49,17 +50,12 @@ function demoteOthers(
   });
 }
 
-function generateId(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(8));
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-}
-
 export const useTerminalStore = create<TerminalState>((set) => ({
   sessions: [],
   reconnectTarget: null,
 
   open: (params) => {
-    const id = generateId();
+    const id = generateRandomUUID();
     set((state) => ({
       reconnectTarget: null,
       sessions: [

--- a/ui-react/apps/console/src/stores/vaultStore.ts
+++ b/ui-react/apps/console/src/stores/vaultStore.ts
@@ -12,6 +12,7 @@ import {
 import { getVaultBackend } from "@/utils/vault-backend-factory";
 import type { IVaultBackend } from "@/utils/vault-backend";
 import { useAuthStore } from "@/stores/authStore";
+import { generateRandomUUID } from "@/utils/random-uuid";
 
 function getBackend() {
   const { user, tenant } = useAuthStore.getState();
@@ -71,7 +72,7 @@ function checkDuplicates(
 function migrateLegacyKeys(legacy: LegacyPrivateKey[]): VaultKeyEntry[] {
   const now = new Date().toISOString();
   return legacy.map((entry) => ({
-    id: crypto.randomUUID(),
+    id: generateRandomUUID(),
     name: entry.name,
     data: entry.data,
     hasPassphrase: entry.hasPassphrase,
@@ -198,7 +199,7 @@ export const useVaultStore = create<VaultState>((set, get) => ({
     const now = new Date().toISOString();
     const newKey: VaultKeyEntry = {
       ...entry,
-      id: crypto.randomUUID(),
+      id: generateRandomUUID(),
       createdAt: now,
       updatedAt: now,
     };

--- a/ui-react/apps/console/src/utils/__tests__/random-uuid.test.ts
+++ b/ui-react/apps/console/src/utils/__tests__/random-uuid.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { generateRandomUUID } from "@/utils/random-uuid";
+
+const UUID_V4_REGEX
+  = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("randomUUID", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns a valid UUID v4", () => {
+    expect(generateRandomUUID()).toMatch(UUID_V4_REGEX);
+  });
+
+  it("returns unique values across calls", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => generateRandomUUID()));
+    expect(ids.size).toBe(50);
+  });
+
+  describe("when crypto.randomUUID is unavailable", () => {
+    it("falls back to a valid UUID v4", () => {
+      vi.stubGlobal("crypto", {
+        getRandomValues: crypto.getRandomValues.bind(crypto),
+      });
+
+      const uuid = generateRandomUUID();
+      expect(uuid).toMatch(UUID_V4_REGEX);
+    });
+
+    it("returns unique values across calls", () => {
+      vi.stubGlobal("crypto", {
+        getRandomValues: crypto.getRandomValues.bind(crypto),
+      });
+
+      const ids = new Set(Array.from({ length: 50 }, () => generateRandomUUID()));
+      expect(ids.size).toBe(50);
+    });
+  });
+});

--- a/ui-react/apps/console/src/utils/random-uuid.ts
+++ b/ui-react/apps/console/src/utils/random-uuid.ts
@@ -1,0 +1,17 @@
+/**
+ * UUID v4 generator with fallback for insecure contexts (plain HTTP).
+ *
+ * `crypto.randomUUID()` is secure-context-only and throws over plain HTTP.
+ * The fallback builds a compliant v4 UUID using `crypto.getRandomValues()`,
+ * which works in any context.
+ */
+export function generateRandomUUID(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+
+  return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) => {
+    const n = Number(c);
+    return (
+      n ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (n / 4)))
+    ).toString(16);
+  });
+}


### PR DESCRIPTION
## What

`crypto.randomUUID()` calls in the vault and terminal stores now go through a `generateRandomUUID()` utility that falls back to a manual UUID v4 implementation when the native API is unavailable.

## Why

`crypto.randomUUID()` is a secure-context-only Web API — it throws when ShellHub is accessed over plain HTTP on a non-localhost address (common in local network and dev setups). This broke vault key creation, legacy key migration, and terminal session opening.

Closes #6067

## Changes

- **`utils/random-uuid.ts`**: New utility that delegates to `crypto.randomUUID()` when available, otherwise builds a spec-compliant UUID v4 using `crypto.getRandomValues()` — which is the one Web Crypto API member that works in insecure contexts ([W3C spec](https://w3c.github.io/webcrypto/#Crypto-interface), [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues)).
- **`stores/vaultStore.ts`**: Replaced two direct `crypto.randomUUID()` calls (key migration and key creation) with `generateRandomUUID()`.
- **`stores/terminalStore.ts`**: Replaced `generateId()` (which used `crypto.getRandomValues()` to build a hex string) with `generateRandomUUID()` for consistency — both produce random session identifiers, UUIDs are more standard.

## Testing

Access the console over plain HTTP via LAN IP (not localhost). Open the vault, add a key, and open a terminal session — all should work without throwing.