### PR TITLE
fix(ui-react): add explicit button types to prevent form conflicts

### DIFF
--- a/ui-react/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui-react/apps/console/src/components/ConnectDrawer.tsx
@@ -204,7 +204,7 @@ export default function ConnectDrawer({
             </button>
             <button
               type="submit"
-              onClick={handleConnect}
+              form={`connect-form-${deviceUid}`}
               disabled={!canConnect}
               className="px-5 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
@@ -214,7 +214,7 @@ export default function ConnectDrawer({
           </>
         )}
       >
-        <form onSubmit={handleConnect} className="space-y-5">
+        <form id={`connect-form-${deviceUid}`} onSubmit={handleConnect} className="space-y-5">
           {/* SSHID helper */}
           <div className="bg-card border border-border rounded-lg p-3.5">
             <p className={LABEL}>Connect via terminal</p>

--- a/ui-react/apps/console/src/components/common/CopyButton.tsx
+++ b/ui-react/apps/console/src/components/common/CopyButton.tsx
@@ -29,6 +29,7 @@ export default function CopyButton({
   if (showLabel) {
     return (
       <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation();
           handleCopy();
@@ -60,6 +61,7 @@ export default function CopyButton({
 
   return (
     <button
+      type="button"
       onClick={(e) => {
         e.stopPropagation();
         handleCopy();


### PR DESCRIPTION
## What

Pressing Enter in the ConnectDrawer form now submits the form instead of triggering the CopyButton's clipboard write.

## Why

Two HTML issues combined to break form submission:

1. CopyButton renders `<button>` without an explicit `type`, which defaults to `type="submit"`. When placed inside the ConnectDrawer form, it became the form's default button — so pressing Enter triggered a clipboard copy instead of connecting.
2. The Connect button lives in the Drawer's `footer` slot, which renders outside the `<form>` element. Despite having `type="submit"`, it had no form to submit — it relied on a redundant `onClick` handler, and Enter keypresses couldn't reach it.

## Changes

- **CopyButton**: Added `type="button"` to both render paths so it never acts as an implicit submit button in any form context.
- **ConnectDrawer**: Added `id="connect-form"` to the form and linked the Connect button via the HTML `form` attribute. Removed the redundant `onClick` — the button now submits the form natively, so both Enter and click go through `onSubmit`.

## Testing

Open the ConnectDrawer, fill in username and password, press Enter — should connect. Click the copy icon next to the SSHID — should copy without submitting the form.