### PR TITLE
fix(api): handle BSON types in session event migration and fix session store

### DIFF
--- a/api/store/migrate/deep_validate_session_events.go
+++ b/api/store/migrate/deep_validate_session_events.go
@@ -171,7 +171,7 @@ func convertSessionEventData(data any) string {
 		return ""
 	}
 
-	b, err := json.Marshal(data)
+	b, err := json.Marshal(bsonToJSON(data))
 	if err != nil {
 		return ""
 	}

--- a/api/store/migrate/sessions.go
+++ b/api/store/migrate/sessions.go
@@ -63,10 +63,38 @@ func convertSession(doc mongoSession) *entity.Session {
 	return e
 }
 
+// bsonToJSON converts BSON types (bson.D, bson.A) into standard Go types
+// (map, slice) so that json.Marshal produces the expected JSON format.
+//
+// Without this, json.Marshal(bson.D{{"key","val"}}) produces
+// [{"Key":"key","Value":"val"}] instead of {"key":"val"}, because bson.D
+// is []bson.E and bson.E has exported Key/Value fields with no custom
+// MarshalJSON in the v1 driver.
+func bsonToJSON(v any) any {
+	switch val := v.(type) {
+	case bson.D:
+		m := make(map[string]any, len(val))
+		for _, e := range val {
+			m[e.Key] = bsonToJSON(e.Value)
+		}
+
+		return m
+	case bson.A:
+		a := make([]any, len(val))
+		for i, e := range val {
+			a[i] = bsonToJSON(e)
+		}
+
+		return a
+	default:
+		return v
+	}
+}
+
 func convertSessionEvent(doc mongoSessionEvent) *entity.SessionEvent {
 	var data string
 	if doc.Data != nil {
-		if dataBytes, err := json.Marshal(doc.Data); err == nil {
+		if dataBytes, err := json.Marshal(bsonToJSON(doc.Data)); err == nil {
 			data = string(dataBytes)
 		}
 	}

--- a/api/store/pg/entity/session.go
+++ b/api/store/pg/entity/session.go
@@ -48,8 +48,6 @@ func SessionFromModel(model *models.Session) *Session {
 		sessionType = "shell"
 	}
 
-	now := clock.Now()
-
 	session := &Session{
 		ID:            model.UID,
 		NamespaceID:   model.TenantID,
@@ -65,8 +63,7 @@ func SessionFromModel(model *models.Session) *Session {
 		Term:          model.Term,
 		Longitude:     model.Position.Longitude,
 		Latitude:      model.Position.Latitude,
-		CreatedAt:     now,
-		UpdatedAt:     now,
+		UpdatedAt:     clock.Now(),
 	}
 
 	return session

--- a/api/store/pg/entity/session_test.go
+++ b/api/store/pg/entity/session_test.go
@@ -57,7 +57,7 @@ func TestSessionFromModel(t *testing.T) {
 				assert.Equal(t, "xterm-256color", result.Term)
 				assert.InDelta(t, 1.23, result.Longitude, 0.001)
 				assert.InDelta(t, 4.56, result.Latitude, 0.001)
-				assert.Equal(t, now, result.CreatedAt)
+				assert.True(t, result.CreatedAt.IsZero())
 				assert.Equal(t, now, result.UpdatedAt)
 			},
 		},

--- a/api/store/pg/session.go
+++ b/api/store/pg/session.go
@@ -99,6 +99,7 @@ func (pg *Pg) SessionCreate(ctx context.Context, session models.Session) (string
 	session.TenantID = device.TenantID
 
 	e := entity.SessionFromModel(&session)
+	e.CreatedAt = clock.Now()
 	if _, err := db.NewInsert().Model(e).Exec(ctx); err != nil {
 		return "", fromSQLError(err)
 	}
@@ -110,7 +111,15 @@ func (pg *Pg) SessionUpdate(ctx context.Context, session *models.Session) error 
 	db := pg.GetConnection(ctx)
 
 	e := entity.SessionFromModel(session)
-	result, err := db.NewUpdate().Model(e).OmitZero().Where("id = ?", e.ID).Exec(ctx)
+	result, err := db.NewUpdate().
+		Model(e).
+		OmitZero().
+		ExcludeColumn("closed", "authenticated", "recorded").
+		Set("closed = ?", e.Closed).
+		Set("authenticated = ?", e.Authenticated).
+		Set("recorded = ?", e.Recorded).
+		Where("id = ?", e.ID).
+		Exec(ctx)
 	if err != nil {
 		return fromSQLError(err)
 	}


### PR DESCRIPTION
## What
Session events migrated from MongoDB to PostgreSQL contained
malformed JSON, and the session PG store had two bugs that
caused incorrect timestamps and silently dropped boolean
updates.

## Why
The mongo-go v1 driver decodes untyped fields as bson.D/bson.A.
json.Marshal on bson.D produces [{"Key":"k","Value":"v"}]
instead of {"k":"v"} because bson.E has exported fields with
no custom MarshalJSON. This broke session record playback
(asciinema) after migration — the API returned 500 trying to
unmarshal an array into models.SSHPty.

## Changes
- **migrate/sessions.go**: added bsonToJSON helper that
  recursively converts bson.D → map and bson.A → slice before
  json.Marshal, producing correct JSON in migrated session
  event data
- **migrate/deep_validate_session_events.go**: applied the
  same bsonToJSON conversion in the validator so it compares
  normalized data instead of reporting false mismatches
- **pg/entity/session.go**: removed CreatedAt assignment from
  SessionFromModel — it was stamping current time on every
  call, including updates, overwriting the original creation
  timestamp
- **pg/session.go (SessionCreate)**: CreatedAt is now set
  only at insert time
- **pg/session.go (SessionUpdate)**: boolean fields (closed,
  authenticated, recorded) are now set explicitly instead of
  relying on OmitZero, which silently dropped false values