### PR TITLE
chore: bump shellhub version to v0.23.0-rc.3

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # This is in order to avoid conflict with upstream code when updating to a newer version
 
 # ShellHub version. 
-SHELLHUB_VERSION=v0.23.0-rc.2
+SHELLHUB_VERSION=v0.23.0-rc.3
 
 # The default log level for ShellHub.
 # VALUES: https://pkg.go.dev/github.com/sirupsen/logrus#Level


### PR DESCRIPTION
Bump ShellHub version to v0.23.0-rc.3.