### PR TITLE
fix(ui-react): ignore empty change events on license file input

### DIFF
--- a/ui-react/apps/console/src/pages/admin/License.tsx
+++ b/ui-react/apps/console/src/pages/admin/License.tsx
@@ -198,7 +198,8 @@ function LicenseUpload() {
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    selectFile(e.target.files?.[0] ?? null);
+    const selected = e.target.files?.[0];
+    if (selected) selectFile(selected);
   };
 
   const handleDrop = (e: React.DragEvent) => {


### PR DESCRIPTION
## What

Prevents the license file picker from resetting the selected file immediately after selection.

## Why

The license upload drop zone triggers the hidden `<input type="file">` via programmatic `.click()`. In Chrome, this can fire a phantom `change` event with an empty `FileList` after the OS dialog closes, which the old code forwarded as `selectFile(null)` — clearing the file the user just picked. Drag and drop was unaffected because it bypasses the input entirely, and after a successful drag-and-drop cycle Chrome's internal state settled so subsequent picker clicks also worked.

## Testing

1. Open the admin license page in a fresh browser session (incognito or cleared storage)
2. Click "Choose a .dat file" and select any `.dat` file — it should appear and stay
3. Verify drag and drop still works
4. Verify the X clear button still removes the file