### PR TITLE
fix(ui-react): clip horizontal overflow on admin layout main area

### DIFF
--- a/ui-react/apps/console/src/components/layout/AdminLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminLayout.tsx
@@ -105,7 +105,7 @@ export default function AdminLayout() {
         )}
         <div className="flex-1 flex flex-col min-w-0">
           <AdminAppBar onMenuToggle={isDesktop ? undefined : openDrawer} />
-          <main className="flex-1 overflow-y-auto p-4 sm:p-8 relative">
+          <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 sm:p-8 relative">
             <div className="grid-bg scanline absolute inset-0 -z-10" />
             <div
               key={pathname}


### PR DESCRIPTION
## What

Eliminates the horizontal scrollbar that appeared on all admin pages at viewports narrower than 640px.

## Why

`<main>` had `overflow-y-auto` without an explicit `overflow-x`. Per CSS spec, when one axis is set to `auto` or `scroll`, the other defaults to `auto` rather than `visible` — so any content slightly wider than the viewport produced a horizontal scrollbar.

## Testing

1. Open any admin page (dashboard, license) at a viewport width below 640px
2. Confirm no horizontal scrollbar appears
3. Confirm vertical scrolling still works normally