### PR TITLE
fix(cli): disable TTY allocation when stdout is not a terminal

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -4,9 +4,11 @@
 # The CLI service contains a set of commands to manage users, namespaces and members.
 
 . "$(dirname "$0")/utils"
-
 cd $(dirname $(readlink_f $0))/../
-
 exit_if_not_running
 
-exec docker compose exec cli /cli "$@"
+# If stdout is NOT a terminal (it's a pipe/file), use -T
+TTY_FLAG=""
+[ ! -t 1 ] && TTY_FLAG="-T"
+
+exec docker compose exec $TTY_FLAG cli /cli "$@"


### PR DESCRIPTION
# What changed

Added an interactive terminal check ([ -t 1 ]) to the ./bin/cli wrapper. The script now automatically detects if the output is being sent to a pipe and, in those cases, disables Docker's TTY allocation by using the -T flag.

# Why

By default, docker compose exec allocates a TTY. When the output is piped to tools like head or grep, it creates a race condition: head closes the pipe as soon as it receives the required lines, but Docker's TTY driver is still attempting to format and send the next chunk of data.

This abrupt interruption causes a "broken pipe" error (SIGPIPE) that leaves the user's terminal in an inconsistent state, resulting in the misaligned text and "leading spaces" reported by users. This change ensures a clean data stream for pipes while preserving the full interactive TTY experience for manual use.

# How to test

1. Start the environment with ./bin/docker-compose up -d
2. Run a list command while filtering the output: ./bin/cli user list | head -n 1
3. Verify that the table header appears perfectly left-aligned, without any extra leading spaces.