### PR TITLE
feat(ui): improve connect-via-terminal UX in ConnectDrawer

### DIFF
--- a/ui-react/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui-react/apps/console/src/components/ConnectDrawer.tsx
@@ -219,18 +219,46 @@ export default function ConnectDrawer({
           <div className="bg-card border border-border rounded-lg p-3.5">
             <p className={LABEL}>Connect via terminal</p>
             <div className="flex items-center gap-2">
-              <code className="text-xs font-mono text-accent-cyan flex-1 truncate">
-                ssh
-                {" "}
-                {sshid}
+              <code className="text-xs font-mono flex-1 truncate">
+                <span className="text-accent-cyan">ssh </span>
+                {state.username.trim() ? (
+                  <span className="text-accent-cyan">
+                    {state.username.trim()}
+                    @
+                    {sshid}
+                  </span>
+                ) : (
+                  <>
+                    <span className="text-text-muted italic">&lt;username&gt;</span>
+                    <span className="text-accent-cyan">
+                      @
+                      {sshid}
+                    </span>
+                  </>
+                )}
               </code>
-              <CopyButton text={`ssh ${sshid}`} />
+              <CopyButton
+                text={
+                  state.username.trim()
+                    ? `ssh ${state.username.trim()}@${sshid}`
+                    : `ssh <username>@${sshid}`
+                }
+              />
             </div>
+            {state.username.trim() ? (
+              <p className="text-2xs text-accent-green mt-2">
+                Command ready — copy and run in your terminal.
+              </p>
+            ) : (
+              <p className="text-2xs text-text-muted mt-2">
+                Enter your device OS username below to complete this command.
+              </p>
+            )}
           </div>
 
           <div className="flex items-center gap-3">
             <div className="flex-1 h-px bg-border" />
-            <span className="text-2xs text-text-muted font-mono uppercase tracking-wider">
+            <span className="text-2xs text-text-secondary font-medium uppercase tracking-wider">
               or connect via web
             </span>
             <div className="flex-1 h-px bg-border" />


### PR DESCRIPTION
## What

The "Connect via terminal" section in the device connect drawer previously
showed \`ssh <sshid>\` — omitting the required OS username prefix. Users,
especially those whose ShellHub namespace matches their name, would attempt
to connect without a username and fail silently.

## Why

The SSHID format is \`<namespace>.<device>@<server>\`, which looks like it
already contains a username. This caused users to copy and run the command
as-is, only to get an SSH authentication error because the actual device OS
username was never included.

## Changes

- **Command display**: renders \`ssh <username>@<sshid>\` instead of
  \`ssh <sshid>\`. When the username field is empty, \`<username>\` is shown as
  a muted italic placeholder; once filled it updates live in cyan alongside
  the rest of the command.

- **Contextual hint**: replaces the static description with a two-state hint
  — empty username prompts the user to fill it in below; filled username
  shows "Command ready — copy and run in your terminal." in green.

- **Copy button**: copies the complete, ready-to-use command when a username
  is present, or the template string when it is not.

- **Divider emphasis**: "or connect via web" stepped up from \`text-muted\` to
  \`text-secondary\` + \`font-medium\` to better separate the two connection
  paths.