### PR TITLE
fix(openapi): add missing fields to admin user endpoints

### DIFF
--- a/openapi/spec/components/schemas/userAdminResponse.yaml
+++ b/openapi/spec/components/schemas/userAdminResponse.yaml
@@ -6,11 +6,18 @@ properties:
     description: User's integer of owned namespaces.
     type: integer
     minimum: 0
-  confirmed:
-    description: User's confirmation.
-    type: boolean
+  status:
+    description: User's account status.
+    type: string
+    enum: [confirmed, not-confirmed]
   admin:
     description: User's admin status.
+    type: boolean
+  max_namespaces:
+    description: Maximum number of namespaces the user can own.
+    type: integer
+  email_marketing:
+    description: Whether the user has opted in to marketing emails.
     type: boolean
   created_at:
     description: User's creating date.
@@ -33,6 +40,7 @@ properties:
     maxLength: 64
 required:
   - id
+  - status
   - admin
   - created_at
   - last_login

--- a/openapi/spec/paths/admin@api@users.yaml
+++ b/openapi/spec/paths/admin@api@users.yaml
@@ -62,7 +62,7 @@ get:
               value:
                 - id: 507f1f77bcf86cd799439011
                   namespaces: 0
-                  confirmed: false
+                  status: not-confirmed
                   admin: false
                   created_at: 2020-05-01T00:00:00.000Z
                   last_login: 2020-05-01T00:00:00.000Z
@@ -74,7 +74,7 @@ get:
               value:
                 - id: 507f1f77bcf86cd799439011
                   namespaces: 0
-                  confirmed: true
+                  status: confirmed
                   admin: false
                   created_at: 2020-05-01T00:00:00.000Z
                   last_login: 2020-05-01T00:00:00.000Z
@@ -84,7 +84,7 @@ get:
                   password: 50d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
                 - id: 507f191e810c19729de860ea
                   namespaces: 2
-                  confirmed: false
+                  status: not-confirmed
                   admin: true
                   created_at: 2012-01-02T00:00:00.000Z
                   last_login: 2012-01-02T00:00:00.000Z

--- a/openapi/spec/paths/admin@api@users@{id}.yaml
+++ b/openapi/spec/paths/admin@api@users@{id}.yaml
@@ -90,9 +90,12 @@ get:
               id:
                 $ref: ../components/schemas/userID.yaml
               status:
-                description: User's status
+                description: User's account status
                 type: string
-                enum: [confirmed, pending]
+                enum: [confirmed, not-confirmed]
+              admin:
+                description: Whether the user has admin privileges
+                type: boolean
               max_namespaces:
                 description: Maximum number of namespaces the user can own
                 type: integer
@@ -143,6 +146,7 @@ get:
             required:
               - id
               - status
+              - admin
               - max_namespaces
               - created_at
               - last_login
@@ -157,6 +161,7 @@ get:
               value:
                 id: '68ada99d2f96ee43fd86306a'
                 status: 'confirmed'
+                admin: true
                 max_namespaces: 0
                 created_at: '2025-08-26T12:33:33.19Z'
                 last_login: '2025-10-27T13:10:59.458Z'
@@ -170,10 +175,11 @@ get:
                 preferences:
                   auth_methods:
                     - 'local'
-            user_pending:
+            user_not_confirmed:
               value:
                 id: '507f1f77bcf86cd799439012'
-                status: 'pending'
+                status: 'not-confirmed'
+                admin: false
                 max_namespaces: 5
                 created_at: '2025-01-15T10:00:00.000Z'
                 last_login: '2025-01-20T15:30:00.000Z'


### PR DESCRIPTION
## What
Aligned the OpenAPI spec for admin user endpoints with what the Go backend actually returns.

## Why
The generated TypeScript SDK was missing fields that the backend sends, forcing the React UI to use type casts and intersection types as workarounds. The `status` enum also listed `pending` instead of the real `not-confirmed` value.
Closes #6088

## Changes
- **UserAdminResponse** (`userAdminResponse.yaml`): replaced stale `confirmed: boolean` with `status: string` (enum: confirmed, not-confirmed). Added `max_namespaces: integer` and `email_marketing: boolean`. Made `status` required.
- **GET /admin/api/users/{id}** (`admin@api@users@{id}.yaml`): added `admin: boolean` (required). Fixed `status` enum from `[confirmed, pending]` to `[confirmed, not-confirmed]` to match the Go `UserStatus` constants.
- **Examples**: updated both list and detail endpoint examples to reflect the new fields.

`email_marketing` was intentionally left out of the detail endpoint — the cloud `UserGet` response struct doesn't include it. The list endpoint returns `[]models.User` directly, which does include the field.