### PR TITLE
chore: bump version to v0.24.0-rc.1

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # This is in order to avoid conflict with upstream code when updating to a newer version
 
 # ShellHub version. 
-SHELLHUB_VERSION=v0.23.0
+SHELLHUB_VERSION=v0.24.0-rc.1
 
 # The default log level for ShellHub.
 # VALUES: https://pkg.go.dev/github.com/sirupsen/logrus#Level
@@ -34,7 +34,7 @@ SHELLHUB_PROXY=false
 # Enable automatic HTTPS with Let's Encrypt.
 SHELLHUB_AUTO_SSL=false
 
-SHELLHUB_DATABASE=migrate
+SHELLHUB_DATABASE=postgres
 
 SHELLHUB_POSTGRES_HOST=postgres
 SHELLHUB_POSTGRES_PORT=5432


### PR DESCRIPTION
Bump version to v0.24.0-rc.1 and switch default database from migrate to postgres.