### PR TITLE
feat(ui-react): add admin sessions list and detail pages

### DIFF
--- a/ui-react/apps/console/src/App.tsx
+++ b/ui-react/apps/console/src/App.tsx
@@ -39,6 +39,8 @@ const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const UpdatePassword = lazy(() => import("./pages/UpdatePassword"));
 const SecureVault = lazy(() => import("./pages/secure-vault"));
 const AdminDashboard = lazy(() => import("./pages/admin/Dashboard"));
+const AdminSessions = lazy(() => import("./pages/admin/Sessions"));
+const AdminSessionDetails = lazy(() => import("./pages/admin/SessionDetails"));
 const AdminLicense = lazy(() => import("./pages/admin/License"));
 const AdminUnauthorized = lazy(() => import("./pages/admin/Unauthorized"));
 const AdminUsers = lazy(() => import("./pages/admin/users"));
@@ -159,6 +161,14 @@ export default function App() {
                         />
                       </>
                     )}
+                    <Route
+                      path="/admin/sessions"
+                      element={<AdminSessions />}
+                    />
+                    <Route
+                      path="/admin/sessions/:uid"
+                      element={<AdminSessionDetails />}
+                    />
                   </Route>
                 </Route>
               </Route>

--- a/ui-react/apps/console/src/hooks/__tests__/useAdminSessionsList.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useAdminSessionsList.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: vi.fn(),
+}));
+
+vi.mock("@/api/pagination", () => ({
+  paginatedQueryFn: vi.fn(),
+}));
+
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
+  getSessionsAdminQueryKey: vi.fn(() => ["sessions-admin"]),
+}));
+
+vi.mock("@/client", () => ({
+  getSessionsAdmin: vi.fn(),
+}));
+
+import { useAuthStore } from "@/stores/authStore";
+import { paginatedQueryFn } from "@/api/pagination";
+import { useAdminSessionsList } from "../useAdminSessionsList";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retryDelay: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const mockSession = {
+  uid: "session-1",
+  device_uid: "device-1",
+  username: "root",
+  ip_address: "192.168.0.1",
+  started_at: "2024-01-01T00:00:00Z",
+  last_seen: "2024-01-01T01:00:00Z",
+  active: true,
+  authenticated: true,
+};
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAdminSessionsList", () => {
+  describe("when user is not an admin", () => {
+    it("returns empty sessions and zero totalCount without fetching", () => {
+      vi.mocked(useAuthStore).mockReturnValue(false);
+      // paginatedQueryFn should not be called (query is disabled)
+      vi.mocked(paginatedQueryFn).mockReturnValue(() => Promise.resolve({ data: [], totalCount: 0 }));
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      expect(result.current.sessions).toEqual([]);
+      expect(result.current.totalCount).toBe(0);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("when user is an admin", () => {
+    beforeEach(() => {
+      vi.mocked(useAuthStore).mockReturnValue(true);
+    });
+
+    it("returns sessions and totalCount on success", async () => {
+      vi.mocked(paginatedQueryFn).mockReturnValue(() =>
+        Promise.resolve({ data: [mockSession], totalCount: 1 }),
+      );
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.sessions).toHaveLength(1));
+
+      expect(result.current.sessions[0]).toMatchObject({ uid: "session-1" });
+      expect(result.current.totalCount).toBe(1);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("returns empty arrays when the API returns no sessions", async () => {
+      vi.mocked(paginatedQueryFn).mockReturnValue(() =>
+        Promise.resolve({ data: [], totalCount: 0 }),
+      );
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.sessions).toEqual([]);
+      expect(result.current.totalCount).toBe(0);
+    });
+
+    it("is loading while the query is in-flight", () => {
+      vi.mocked(paginatedQueryFn).mockReturnValue(
+        () => new Promise(() => { /* never resolves */ }),
+      );
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  describe("error transformation", () => {
+    beforeEach(() => {
+      vi.mocked(useAuthStore).mockReturnValue(true);
+    });
+
+    it("maps a 403 SdkError to a permission-denied message", async () => {
+      const sdkError = Object.assign(new Error(), { status: 403, headers: new Headers() });
+      vi.mocked(paginatedQueryFn).mockReturnValue(() => Promise.reject(sdkError));
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.error).not.toBeNull());
+      expect(result.current.error?.message).toBe("You don't have permission to view sessions.");
+    });
+
+    it("maps a 500 SdkError to a server-error message", async () => {
+      const sdkError = Object.assign(new Error(), { status: 500, headers: new Headers() });
+      vi.mocked(paginatedQueryFn).mockReturnValue(() => Promise.reject(sdkError));
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.error).not.toBeNull());
+      expect(result.current.error?.message).toBe("Server error. Please try again later.");
+    });
+
+    it("includes the status code for unrecognised SDK errors", async () => {
+      const sdkError = Object.assign(new Error(), { status: 422, headers: new Headers() });
+      vi.mocked(paginatedQueryFn).mockReturnValue(() => Promise.reject(sdkError));
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.error).not.toBeNull());
+      expect(result.current.error?.message).toBe("Failed to load sessions (422).");
+    });
+
+    it("preserves the message of a plain Error", async () => {
+      vi.mocked(paginatedQueryFn).mockReturnValue(() =>
+        Promise.reject(new Error("Network timeout")),
+      );
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.error).not.toBeNull());
+      expect(result.current.error?.message).toBe("Network timeout");
+    });
+
+    it("returns a generic message for unknown non-Error throws", async () => {
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+      vi.mocked(paginatedQueryFn).mockReturnValue(() => Promise.reject("oops"));
+
+      const { result } = renderHook(
+        () => useAdminSessionsList(1, 10),
+        { wrapper: makeWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.error).not.toBeNull());
+      expect(result.current.error?.message).toBe("Failed to load sessions.");
+    });
+  });
+});

--- a/ui-react/apps/console/src/hooks/useAdminSessionDetail.ts
+++ b/ui-react/apps/console/src/hooks/useAdminSessionDetail.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSessionAdminOptions } from "../client/@tanstack/react-query.gen";
+import { useAuthStore } from "../stores/authStore";
+import { isSdkError } from "../api/errors";
+
+export function useAdminSessionDetail(uid: string) {
+  const isAdmin = useAuthStore((s) => s.isAdmin);
+
+  const result = useQuery({
+    ...getSessionAdminOptions({ path: { uid } }),
+    enabled: isAdmin && !!uid,
+    staleTime: 60 * 1000,
+    retry: (count, err) => isSdkError(err) && err.status === 401 ? false : count < 1,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    session: result.data ?? null,
+    isLoading: result.isLoading,
+    error: result.error,
+  };
+}

--- a/ui-react/apps/console/src/hooks/useAdminSessionsList.ts
+++ b/ui-react/apps/console/src/hooks/useAdminSessionsList.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSessionsAdmin, type GetSessionsAdminData, type Session } from "../client";
+import { getSessionsAdminQueryKey } from "../client/@tanstack/react-query.gen";
+import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
+import { useAuthStore } from "../stores/authStore";
+import { isSdkError } from "../api/errors";
+
+function toDisplayError(err: unknown): Error {
+  if (isSdkError(err)) {
+    if (err.status === 403) return new Error("You don't have permission to view sessions.");
+    if (err.status >= 500) return new Error("Server error. Please try again later.");
+    return new Error(`Failed to load sessions (${err.status}).`);
+  }
+  if (err instanceof Error) return err;
+  return new Error("Failed to load sessions.");
+}
+
+export function useAdminSessionsList(page: number, perPage: number) {
+  const isAdmin = useAuthStore((s) => s.isAdmin);
+  const options = { query: { page, per_page: perPage } } satisfies { query: GetSessionsAdminData["query"] };
+
+  const result = useQuery<PaginatedResult<Session>>({
+    queryKey: getSessionsAdminQueryKey(options),
+    queryFn: paginatedQueryFn(getSessionsAdmin, options),
+    enabled: isAdmin,
+    staleTime: 60 * 1000,
+    retry: (count, err) => isSdkError(err) && err.status === 401 ? false : count < 1,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    sessions: result.data?.data ?? [],
+    totalCount: result.data?.totalCount ?? 0,
+    isLoading: result.isLoading,
+    error: result.error ? toDisplayError(result.error) : null,
+  };
+}

--- a/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
@@ -1,0 +1,155 @@
+import { useParams, Link } from "react-router-dom";
+import {
+  CommandLineIcon,
+  ExclamationCircleIcon,
+  CheckCircleIcon,
+  MinusCircleIcon,
+} from "@heroicons/react/24/outline";
+import { useAdminSessionDetail } from "../../hooks/useAdminSessionDetail";
+import PageHeader from "../../components/common/PageHeader";
+import { formatDateFull } from "../../utils/date";
+import { sessionType } from "../../utils/session";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="py-3 border-b border-border/50 last:border-0">
+      <p className="text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-1">
+        {label}
+      </p>
+      <div className="text-sm text-text-primary">{children}</div>
+    </div>
+  );
+}
+
+function BoolField({ value, falseColor = "text-accent-red" }: { value: boolean; falseColor?: string }) {
+  return (
+    <span className={`flex items-center gap-1.5 text-sm ${value ? "text-accent-green" : falseColor}`}>
+      {value
+        ? <CheckCircleIcon className="w-4 h-4" strokeWidth={2} />
+        : <MinusCircleIcon className="w-4 h-4" strokeWidth={2} />}
+      {value ? "Yes" : "No"}
+    </span>
+  );
+}
+
+export default function AdminSessionDetails() {
+  const { uid = "" } = useParams<{ uid: string }>();
+  const { session, isLoading, error } = useAdminSessionDetail(uid);
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center" role="status" aria-label="Loading session">
+        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (error || !session) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center" role="alert">
+          <ExclamationCircleIcon className="w-10 h-10 text-accent-red mx-auto mb-3" />
+          <p className="text-sm font-medium text-text-primary">Session not found</p>
+          <p className="text-2xs text-text-muted mt-1">
+            {error?.message ?? "The session may have been removed or the ID is invalid."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const type = sessionType(session);
+
+  return (
+    <div>
+      <PageHeader
+        icon={<CommandLineIcon className="w-6 h-6" />}
+        overline="Admin · Sessions"
+        title="Session Details"
+        description="Detailed information about the selected session."
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className={`w-2 h-2 rounded-full inline-block shrink-0 ${
+              session.active
+                ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
+                : "bg-text-muted/40"
+            }`}
+          />
+          <code className="text-xs font-mono text-text-muted">{session.uid}</code>
+        </div>
+      </PageHeader>
+
+      <div className="bg-card border border-border rounded-lg overflow-hidden animate-fade-in">
+        <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
+          <div className="px-6 py-2">
+            <Field label="UID">
+              <code className="text-xs font-mono text-text-secondary break-all">{session.uid}</code>
+            </Field>
+
+            {session.device && (
+              <Field label="Device">
+                <Link
+                  to={`/admin/devices/${session.device.uid}`}
+                  className="text-primary hover:underline text-sm"
+                >
+                  {session.device.name || session.device.uid}
+                </Link>
+              </Field>
+            )}
+
+            <Field label="Username">
+              <code className="text-xs font-mono">{session.username}</code>
+            </Field>
+
+            <Field label="IP Address">
+              <code className="text-xs font-mono text-text-muted bg-surface px-1.5 py-0.5 rounded">
+                {session.ip_address}
+              </code>
+            </Field>
+
+            <Field label="Type">
+              {type
+                ? (
+                  <span className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}>
+                    {type.label}
+                  </span>
+                )
+                : <span className="text-text-secondary capitalize">{session.type}</span>}
+            </Field>
+
+            <Field label="Terminal">
+              <span className="text-text-secondary">
+                {session.term === "none" || !session.term ? "—" : session.term}
+              </span>
+            </Field>
+          </div>
+
+          <div className="px-6 py-2">
+            {session.device?.namespace && (
+              <Field label="Namespace">
+                <span className="text-text-secondary">{session.device.namespace}</span>
+              </Field>
+            )}
+
+            <Field label="Authenticated">
+              <BoolField value={session.authenticated} falseColor="text-accent-red" />
+            </Field>
+
+            <Field label="Recorded">
+              <BoolField value={session.recorded} falseColor="text-text-secondary" />
+            </Field>
+
+            <Field label="Started At">
+              <span className="text-text-secondary">{formatDateFull(session.started_at)}</span>
+            </Field>
+
+            <Field label="Last Seen">
+              <span className="text-text-secondary">{formatDateFull(session.last_seen)}</span>
+            </Field>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui-react/apps/console/src/pages/admin/Sessions.tsx
+++ b/ui-react/apps/console/src/pages/admin/Sessions.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  CommandLineIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  ShieldCheckIcon,
+  ShieldExclamationIcon,
+} from "@heroicons/react/24/outline";
+import { useAdminSessionsList } from "../../hooks/useAdminSessionsList";
+import PageHeader from "../../components/common/PageHeader";
+import Pagination from "../../components/common/Pagination";
+import DeviceChip from "../../components/common/DeviceChip";
+import { formatDateFull } from "../../utils/date";
+import { TH } from "../../utils/styles";
+
+const PER_PAGE = 10;
+const COL_SPAN = 8;
+
+export default function AdminSessions() {
+  const [page, setPage] = useState(1);
+  const { sessions, totalCount, isLoading, error } = useAdminSessionsList(page, PER_PAGE);
+  const navigate = useNavigate();
+
+  const totalPages = Math.ceil(totalCount / PER_PAGE);
+
+  return (
+    <div>
+      <PageHeader
+        icon={<CommandLineIcon className="w-6 h-6" />}
+        overline="Admin"
+        title="Sessions"
+        description="Track live and historical sessions happening across every namespace."
+      />
+
+      {error && (
+        <div role="alert" className="flex items-center gap-2 bg-accent-red/8 border border-accent-red/20 text-accent-red px-3.5 py-2.5 rounded-md text-xs font-mono mb-4 animate-slide-down">
+          <ExclamationCircleIcon className="w-3.5 h-3.5 shrink-0" strokeWidth={2} />
+          {error.message}
+        </div>
+      )}
+
+      <div className="bg-card border border-border rounded-lg overflow-hidden animate-fade-in">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-border bg-surface/50">
+              <th className={`${TH} w-14`}>Active</th>
+              <th className={TH}>ID</th>
+              <th className={TH}>Device</th>
+              <th className={TH}>Username</th>
+              <th className={`${TH} w-14`}>Auth</th>
+              <th className={TH}>IP Address</th>
+              <th className={TH}>Started</th>
+              <th className={TH}>Last Seen</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/60">
+            {isLoading
+              ? (
+                <tr>
+                  <td colSpan={COL_SPAN} className="px-4 py-12 text-center">
+                    <div className="flex items-center justify-center gap-3">
+                      <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                      <span className="text-xs font-mono text-text-muted">Loading sessions…</span>
+                    </div>
+                  </td>
+                </tr>
+              )
+              : sessions.length === 0
+                ? (
+                  <tr>
+                    <td colSpan={COL_SPAN} className="px-4 py-12 text-center">
+                      <p className="text-xs font-mono text-text-muted">No sessions found</p>
+                    </td>
+                  </tr>
+                )
+                : sessions.map((session) => {
+                  const suspicious = !session.authenticated;
+                  return (
+                    <tr
+                      key={session.uid}
+                      onClick={() => void navigate(`/admin/sessions/${session.uid}`)}
+                      className={`transition-colors cursor-pointer ${
+                        suspicious
+                          ? "bg-accent-red/[0.03] hover:bg-accent-red/[0.06] border-l-2 border-l-accent-red/50"
+                          : "hover:bg-hover-subtle border-l-2 border-l-transparent"
+                      }`}
+                    >
+                      <td className="px-4 py-3.5">
+                        <span
+                          className={`w-2 h-2 rounded-full inline-block ${
+                            session.active
+                              ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
+                              : "bg-text-muted/40"
+                          }`}
+                        />
+                      </td>
+                      <td className="px-4 py-3.5">
+                        <code
+                          className="text-xs font-mono text-text-muted bg-surface px-1.5 py-0.5 rounded"
+                          title={session.uid}
+                        >
+                          {session.uid.substring(0, 10)}
+                        </code>
+                      </td>
+                      <td className="px-4 py-3.5">
+                        {session.device
+                          ? (
+                            <DeviceChip
+                              disableLink
+                              name={session.device.name}
+                              online={session.device.online}
+                              osId={session.device.info?.id}
+                            />
+                          )
+                          : (
+                            <span className="text-xs font-mono text-text-primary">
+                              {(session.device_uid ?? "").substring(0, 8)}
+                            </span>
+                          )}
+                      </td>
+                      <td className="px-4 py-3.5">
+                        <div className="flex items-center gap-1.5">
+                          {suspicious && (
+                            <ExclamationTriangleIcon
+                              className="w-3.5 h-3.5 text-accent-red/70 shrink-0"
+                              strokeWidth={2}
+                              title="Not authenticated"
+                            />
+                          )}
+                          <code
+                            className={`text-xs font-mono ${
+                              suspicious ? "text-accent-red/60" : "text-text-secondary"
+                            }`}
+                          >
+                            {session.username}
+                          </code>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3.5">
+                        {session.authenticated
+                          ? (
+                            <ShieldCheckIcon
+                              className="w-4 h-4 text-accent-green"
+                              strokeWidth={2}
+                              title="Authenticated"
+                            />
+                          )
+                          : (
+                            <ShieldExclamationIcon
+                              className="w-4 h-4 text-accent-red"
+                              strokeWidth={2}
+                              title="Not authenticated"
+                            />
+                          )}
+                      </td>
+                      <td className="px-4 py-3.5">
+                        <code className="text-xs font-mono text-text-muted bg-surface px-1.5 py-0.5 rounded">
+                          {session.ip_address}
+                        </code>
+                      </td>
+                      <td className="px-4 py-3.5">
+                        <span className="text-xs text-text-secondary">
+                          {formatDateFull(session.started_at)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5">
+                        <span className="text-xs text-text-secondary">
+                          {formatDateFull(session.last_seen)}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+          </tbody>
+        </table>
+      </div>
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        totalCount={totalCount}
+        itemLabel="session"
+        onPageChange={setPage}
+      />
+    </div>
+  );
+}

--- a/ui-react/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("../../../hooks/useAdminSessionsList", () => ({
+  useAdminSessionsList: vi.fn(),
+}));
+
+import { useAdminSessionsList } from "../../../hooks/useAdminSessionsList";
+import AdminSessions from "../Sessions";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeSession(overrides: Record<string, any> = {}) {
+  return {
+    uid: "session-1",
+    device_uid: "device-1",
+    device: { uid: "device-1", name: "web-server-01", online: true, info: { id: "ubuntu" } },
+    username: "root",
+    ip_address: "192.168.0.1",
+    started_at: "2024-01-01T00:00:00Z",
+    last_seen: "2024-01-01T01:00:00Z",
+    active: false,
+    authenticated: true,
+    ...overrides,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setupHook(overrides: Record<string, any> = {}) {
+  vi.mocked(useAdminSessionsList).mockReturnValue({
+    sessions: [],
+    totalCount: 0,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  } as ReturnType<typeof useAdminSessionsList>);
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminSessions />
+    </MemoryRouter>,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupHook();
+});
+
+describe("AdminSessions", () => {
+  describe("loading state", () => {
+    it("shows a loading spinner while fetching", () => {
+      setupHook({ isLoading: true });
+      renderPage();
+      expect(screen.getByText(/loading sessions/i)).toBeInTheDocument();
+    });
+
+    it("does not render session rows while loading", () => {
+      setupHook({ isLoading: true });
+      renderPage();
+      expect(screen.queryByText("root")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows 'No sessions found' when there are no sessions", () => {
+      renderPage();
+      expect(screen.getByText("No sessions found")).toBeInTheDocument();
+    });
+  });
+
+  describe("error state", () => {
+    it("renders the error banner with role='alert'", () => {
+      setupHook({ error: new Error("Server error. Please try again later.") });
+      renderPage();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("displays the error message in the banner", () => {
+      setupHook({ error: new Error("You don't have permission to view sessions.") });
+      renderPage();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "You don't have permission to view sessions.",
+      );
+    });
+
+    it("does not show the error banner when there is no error", () => {
+      renderPage();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("session rows", () => {
+    it("renders one row per session", () => {
+      setupHook({
+        sessions: [
+          makeSession({ uid: "session-1", username: "root" }),
+          makeSession({ uid: "session-2", username: "admin" }),
+        ],
+        totalCount: 2,
+      });
+      renderPage();
+      expect(screen.getByText("root")).toBeInTheDocument();
+      expect(screen.getByText("admin")).toBeInTheDocument();
+    });
+
+    it("renders the device name via DeviceChip", () => {
+      setupHook({ sessions: [makeSession()], totalCount: 1 });
+      renderPage();
+      expect(screen.getByText("web-server-01")).toBeInTheDocument();
+    });
+
+    it("renders the truncated session uid", () => {
+      setupHook({ sessions: [makeSession({ uid: "abcdef1234567890" })], totalCount: 1 });
+      renderPage();
+      expect(screen.getByText("abcdef1234")).toBeInTheDocument();
+    });
+
+    it("renders the IP address", () => {
+      setupHook({ sessions: [makeSession({ ip_address: "10.0.0.1" })], totalCount: 1 });
+      renderPage();
+      expect(screen.getByText("10.0.0.1")).toBeInTheDocument();
+    });
+
+    it("navigates to session detail when a row is clicked", async () => {
+      const user = userEvent.setup();
+      setupHook({ sessions: [makeSession({ uid: "session-abc" })], totalCount: 1 });
+      renderPage();
+
+      await user.click(screen.getByText("root"));
+
+      expect(mockNavigate).toHaveBeenCalledWith("/admin/sessions/session-abc");
+    });
+  });
+
+  describe("active indicator", () => {
+    it("renders a green dot for active sessions", () => {
+      setupHook({ sessions: [makeSession({ active: true })], totalCount: 1 });
+      renderPage();
+      const dot = document.querySelector(".bg-accent-green");
+      expect(dot).toBeInTheDocument();
+    });
+
+    it("renders a muted dot for inactive sessions", () => {
+      setupHook({ sessions: [makeSession({ active: false })], totalCount: 1 });
+      renderPage();
+      const dot = document.querySelector(".bg-text-muted\\/40");
+      expect(dot).toBeInTheDocument();
+    });
+  });
+
+  describe("authentication indicator", () => {
+    it("renders the 'Authenticated' shield for authenticated sessions", () => {
+      setupHook({ sessions: [makeSession({ authenticated: true })], totalCount: 1 });
+      renderPage();
+      expect(screen.getByTitle("Authenticated")).toBeInTheDocument();
+    });
+
+    it("renders the 'Not authenticated' shield for unauthenticated sessions", () => {
+      setupHook({ sessions: [makeSession({ authenticated: false })], totalCount: 1 });
+      renderPage();
+      expect(screen.getAllByTitle("Not authenticated").length).toBeGreaterThan(0);
+    });
+
+    it("shows the warning icon in the username cell for unauthenticated sessions", () => {
+      setupHook({ sessions: [makeSession({ authenticated: false })], totalCount: 1 });
+      renderPage();
+      // ExclamationTriangleIcon has title "Not authenticated"
+      expect(screen.getAllByTitle("Not authenticated").length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("device fallback", () => {
+    it("shows the truncated device_uid when device object is missing", () => {
+      setupHook({
+        sessions: [makeSession({ device: null, device_uid: "abcd1234efgh" })],
+        totalCount: 1,
+      });
+      renderPage();
+      expect(screen.getByText("abcd1234")).toBeInTheDocument();
+    });
+  });
+
+  describe("pagination", () => {
+    it("renders pagination when totalCount > perPage", () => {
+      setupHook({
+        sessions: Array.from({ length: 10 }, (_, i) =>
+          makeSession({ uid: `session-${i}`, username: `user-${i}` }),
+        ),
+        totalCount: 25,
+      });
+      renderPage();
+      // Pagination renders page info
+      expect(screen.getByText(/25/)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds paginated admin sessions list and per-session detail pages to the
React console, accessible at `/admin/sessions` and
`/admin/sessions/:uid`.

## Why

The admin console lacked visibility into sessions across all namespaces.
The Vue admin already exposed this data; this brings parity to the React
console.

## Changes

- **`pages/admin/Sessions`**: table with active indicator, auth shield,
  device chip, IP, and timestamps; clicking a row navigates to the
  detail page; error banner uses `role="alert"` for accessibility
- **`pages/admin/SessionDetails`**: per-session detail view
- **`hooks/useAdminSessionsList`**: React Query hook wrapping
  `getSessionsAdmin`; transforms `SdkHttpError` (which carries
  `status`/`headers` but no `message`) into a human-readable `Error`
  before surfacing it — without this, `error.message` was `undefined`
  at runtime despite TypeScript typing it as `Error | null`
- **`hooks/useAdminSessionDetail`**: hook for the detail page
- **`App.tsx`**: registers the two new routes inside the admin guard

## Testing

27 new unit tests covering the hook (disabled when non-admin, success
mapping, all error-transformation branches) and the page (loading,
empty, error banner, row rendering, navigation, auth indicators, device
fallback, pagination).

```
npx vitest run src/hooks/__tests__/useAdminSessionsList.test.ts \
              src/pages/admin/__tests__/Sessions.test.tsx
```