### PR TITLE
fix(ui-react): fix connection announcement overflow in admin namespace details

### DIFF
--- a/ui-react/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -185,8 +185,10 @@ export default function NamespaceDetails() {
             {namespace.settings?.connection_announcement && (
               <div>
                 <dt className={LABEL}>Connection Announcement</dt>
-                <dd className="text-sm text-text-primary mt-0.5">
-                  {namespace.settings.connection_announcement}
+                <dd className="mt-1.5 overflow-x-auto rounded-lg bg-surface border border-border p-3">
+                  <pre className="text-xs font-mono text-text-primary whitespace-pre">
+                    {namespace.settings.connection_announcement}
+                  </pre>
                 </dd>
               </div>
             )}


### PR DESCRIPTION
## What

The connection announcement text in the admin namespace detail page now renders in a monospace `<pre>` block with horizontal scroll, preventing layout breakage at intermediate viewport widths.

## Why

Long unbreakable strings (e.g., `*****` separator lines, ASCII art) overflowed the settings card container between desktop and mobile breakpoints.

## Changes

- **NamespaceDetails**: wrapped connection announcement in a scrollable `<pre>` container with monospace font, matching the editing experience and preserving ASCII art formatting