### PR TITLE
feat(ui-react): handle token query param on Login page for admin login-as-user

### DIFF
--- a/ui-react/apps/console/src/api/fetchInterceptors.ts
+++ b/ui-react/apps/console/src/api/fetchInterceptors.ts
@@ -41,8 +41,13 @@ client.interceptors.request.use((request) => {
   const token = useAuthStore.getState().token;
   if (token) {
     if (isTokenExpired(token)) {
-      useAuthStore.getState().logout();
-      window.location.href = "/login";
+      const isTokenLogin = new URLSearchParams(window.location.search).has(
+        "token",
+      );
+      if (!isTokenLogin) {
+        useAuthStore.getState().logout();
+        window.location.href = "/login";
+      }
       throw new Error("Token expired");
     }
     request.headers.set("Authorization", `Bearer ${token}`);
@@ -64,7 +69,10 @@ client.interceptors.response.use((response) => {
       useAuthStore.getState().setMfaToken(mfaToken);
     } else {
       const isLoginRequest = response.url.includes("/api/login");
-      if (!isLoginRequest) {
+      const isTokenLogin = new URLSearchParams(window.location.search).has(
+        "token",
+      );
+      if (!isLoginRequest && !isTokenLogin) {
         useAuthStore.getState().logout();
         window.location.href = "/login";
       }

--- a/ui-react/apps/console/src/pages/Login.tsx
+++ b/ui-react/apps/console/src/pages/Login.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, FormEvent } from "react";
 import { isSdkError } from "../api/errors";
-import { useNavigate, Link, useLocation } from "react-router-dom";
+import {
+  useNavigate,
+  Link,
+  useLocation,
+  useSearchParams,
+} from "react-router-dom";
 import {
   ExclamationCircleIcon,
   CheckCircleIcon,
@@ -62,7 +67,12 @@ export default function Login() {
   const isCloud = getConfig().cloud;
   const location = useLocation();
   const rawState = location.state as Record<string, unknown> | null;
-  const notice = typeof rawState?.notice === "string" ? rawState.notice : undefined;
+  const notice
+    = typeof rawState?.notice === "string" ? rawState.notice : undefined;
+
+  const [searchParams] = useSearchParams();
+  const queryToken = searchParams.get("token");
+  const [tokenLoading, setTokenLoading] = useState(!!queryToken);
 
   useEffect(() => {
     if (notice) {
@@ -79,6 +89,20 @@ export default function Login() {
   const { display: countdownDisplay, expired: lockoutExpired }
     = useLoginCountdown(lockoutEndEpoch);
 
+  useEffect(() => {
+    if (!queryToken) return;
+
+    const { logout, loginWithToken } = useAuthStore.getState();
+    logout();
+
+    loginWithToken(queryToken)
+      .then(() => navigate("/dashboard"))
+      .catch(() => {
+        setTokenLoading(false);
+        setError("Failed to authenticate with the provided token.");
+      });
+  }, [queryToken, navigate]);
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -91,9 +115,10 @@ export default function Login() {
       const redirect = getSafeRedirect(params);
 
       if (state.mfaToken) {
-        const mfaPath = redirect !== "/dashboard"
-          ? `/mfa-login?redirect=${encodeURIComponent(redirect)}`
-          : "/mfa-login";
+        const mfaPath
+          = redirect !== "/dashboard"
+            ? `/mfa-login?redirect=${encodeURIComponent(redirect)}`
+            : "/mfa-login";
         void navigate(mfaPath);
       } else {
         void navigate(redirect);
@@ -106,15 +131,21 @@ export default function Login() {
 
       switch (err.status) {
         case 401:
-          setError("Invalid login credentials. Your password is incorrect or this account doesn't exist.");
+          setError(
+            "Invalid login credentials. Your password is incorrect or this account doesn't exist.",
+          );
           break;
         case 403:
-          void navigate(`/confirm-account?username=${encodeURIComponent(username)}`);
+          void navigate(
+            `/confirm-account?username=${encodeURIComponent(username)}`,
+          );
           break;
         case 429: {
           const epoch = Number(err.headers.get("x-account-lockout"));
           setLockoutEndEpoch(isNaN(epoch) ? null : epoch);
-          setError("Too many failed login attempts. Please wait before trying again.");
+          setError(
+            "Too many failed login attempts. Please wait before trying again.",
+          );
           break;
         }
         default:
@@ -123,6 +154,14 @@ export default function Login() {
     }
     // Else: error is already set in store
   };
+
+  if (tokenLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <span className="w-6 h-6 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+      </div>
+    );
+  }
 
   return (
     <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
@@ -157,18 +196,30 @@ export default function Login() {
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
           {lockoutExpired && (
             <div className="flex items-center gap-2 bg-accent-green/8 border border-accent-green/20 text-accent-green px-3.5 py-2.5 rounded-md text-xs font-mono animate-slide-down">
-              <CheckCircleIcon className="w-3.5 h-3.5 shrink-0" strokeWidth={2} />
+              <CheckCircleIcon
+                className="w-3.5 h-3.5 shrink-0"
+                strokeWidth={2}
+              />
               Your timeout has finished. Please try to log back in.
             </div>
           )}
           {notice && (
-            <div role="alert" className="flex items-center gap-2 bg-accent-green/8 border border-accent-green/20 text-accent-green px-3.5 py-2.5 rounded-md text-xs font-mono animate-slide-down">
-              <CheckCircleIcon className="w-3.5 h-3.5 shrink-0" strokeWidth={2} />
+            <div
+              role="alert"
+              className="flex items-center gap-2 bg-accent-green/8 border border-accent-green/20 text-accent-green px-3.5 py-2.5 rounded-md text-xs font-mono animate-slide-down"
+            >
+              <CheckCircleIcon
+                className="w-3.5 h-3.5 shrink-0"
+                strokeWidth={2}
+              />
               {notice}
             </div>
           )}
           {error && !lockoutExpired && (
-            <div role="alert" className="flex items-center gap-2 bg-accent-red/8 border border-accent-red/20 text-accent-red px-3.5 py-2.5 rounded-md text-xs font-mono animate-slide-down">
+            <div
+              role="alert"
+              className="flex items-center gap-2 bg-accent-red/8 border border-accent-red/20 text-accent-red px-3.5 py-2.5 rounded-md text-xs font-mono animate-slide-down"
+            >
               <ExclamationCircleIcon
                 className="w-3.5 h-3.5 shrink-0"
                 strokeWidth={2}
@@ -176,12 +227,7 @@ export default function Login() {
               <span>
                 {error}
                 {countdownDisplay && (
-                  <span className="font-semibold">
-                    {" "}
-                    (
-                    {countdownDisplay}
-                    )
-                  </span>
+                  <span className="font-semibold"> ({countdownDisplay})</span>
                 )}
               </span>
             </div>
@@ -240,16 +286,14 @@ export default function Login() {
             disabled={loading}
             className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
           >
-            {loading
-              ? (
-                <span className="flex items-center justify-center gap-2">
-                  <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  <span className="font-mono text-xs">Authenticating...</span>
-                </span>
-              )
-              : (
-                "Sign In"
-              )}
+            {loading ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                <span className="font-mono text-xs">Authenticating...</span>
+              </span>
+            ) : (
+              "Sign In"
+            )}
           </button>
         </form>
       </div>

--- a/ui-react/apps/console/src/stores/authStore.ts
+++ b/ui-react/apps/console/src/stores/authStore.ts
@@ -32,6 +32,7 @@ interface AuthState {
   mfaResetUserId: string | null;
   mfaResetIdentifier: string | null;
   login: (username: string, password: string) => Promise<void>;
+  loginWithToken: (token: string) => Promise<void>;
   logout: () => void;
   fetchUser: () => Promise<void>;
   setSession: (data: { token: string; tenant: string; role?: Role }) => void;
@@ -124,6 +125,26 @@ export const useAuthStore = create<AuthState>()(
           }
           set({ loading: false });
           throw err;
+        }
+      },
+
+      loginWithToken: async (token: string) => {
+        set({ loading: true, token });
+        try {
+          const { data } = await getUserInfo({ throwOnError: true });
+          set({
+            user: data.user,
+            userId: data.id,
+            email: data.email,
+            tenant: data.tenant,
+            name: data.name,
+            isAdmin: data.admin ?? false,
+            mfaEnabled: data.mfa || false,
+            loading: false,
+          });
+        } catch {
+          set({ ...initialState });
+          throw new Error("Token login failed");
         }
       },
 


### PR DESCRIPTION
## What

The admin "Login as User" action opens `/login?token=<JWT>` in a new tab, but the React Login page ignores the `token` param — the user sees the normal login form instead of being authenticated.

## Why

Blocks the admin user management feature. The `useLoginAsUser` hook and backend endpoint already work; only the Login page consumer was missing.

Closes shellhub-io/team#95

## Changes

- **authStore**: Added `loginWithToken(token)` — sets the token in the store (so the existing request interceptor attaches `Authorization: Bearer`), calls `getUserInfo` to populate session data, resets to `initialState` on failure
- **Login.tsx**: On mount, reads `?token=` via `useSearchParams`. If present, clears any prior session, calls `loginWithToken`, and redirects to `/dashboard`. Shows a loading spinner while in flight; falls back to the login form with an error message on failure
- **fetchInterceptors.ts**: Both request and response interceptors now skip the hard redirect to `/login` when the current page has a `?token=` param, so `loginWithToken`'s error handling can actually run instead of being preempted

## Testing

1. Log in as admin → Settings > Users → click "Login as User" on any row → new tab should authenticate as that user and land on `/dashboard`
2. Navigate to `/login?token=invalid` → should show error message, not silently reload
3. Normal username/password login still works