### PR TITLE
ci: add SBOM generation to release workflows

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -98,6 +98,49 @@ jobs:
           path: rootfs/*.tar.gz
 
 
+  sbom:
+    if: "contains(github.ref, 'refs/tags/v')"
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Set release version
+        run: echo RELEASE_VERSION=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Generate SBOM for agent image
+        uses: anchore/sbom-action@v0
+        with:
+          image: shellhubio/agent:${{ env.RELEASE_VERSION }}
+          format: cyclonedx-json
+          output-file: sbom-agent-${{ env.RELEASE_VERSION }}.cdx.json
+          artifact-name: ""
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-agent
+          path: sbom-agent-*.cdx.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Attach SBOM to agent image
+        run: |
+          cosign attach sbom \
+            --sbom sbom-agent-${{ env.RELEASE_VERSION }}.cdx.json \
+            --type cyclonedx \
+            shellhubio/agent:${{ env.RELEASE_VERSION }}
+
   build-binaries:
     if: "contains(github.ref, 'refs/tags/v')"
     needs: build
@@ -158,6 +201,9 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v6
 
+      - name: Set release version
+        run: echo RELEASE_VERSION=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
+
       - name: export agent tarball
         run: |
           cd ./agent && go mod vendor && cd .. && tar czf shellhub-agent.tar.gz agent
@@ -168,10 +214,26 @@ jobs:
           name: shellhub-agent
           path: shellhub-agent.tar.gz
 
+      - name: Generate source SBOM from Go modules
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./agent
+          format: cyclonedx-json
+          output-file: sbom-agent-source-${{ env.RELEASE_VERSION }}.cdx.json
+          artifact-name: ""
+
+      - name: Upload source SBOM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-agent-source
+          path: sbom-agent-source-*.cdx.json
+
   draft:
     if: "contains(github.ref, 'refs/tags/v')"
-    needs: [build-binaries, vendored-tarball]
+    needs: [build-binaries, vendored-tarball, sbom]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: download rootfs artifacts
         uses: actions/download-artifact@v8
@@ -186,6 +248,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: shellhub-agent
+      - name: download agent SBOM
+        uses: actions/download-artifact@v8
+        with:
+          name: sbom-agent
+      - name: download agent source SBOM
+        uses: actions/download-artifact@v8
+        with:
+          name: sbom-agent-source
       - name: release draft
         uses: softprops/action-gh-release@v2
         with:
@@ -195,3 +265,4 @@ jobs:
             rootfs-*.tar.gz
             shellhub-agent-*.gz
             shellhub-agent.tar.gz
+            sbom-*.cdx.json

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 jobs:
   build:
     name: Build and publish '${{ matrix.project }}' to Docker Registry
@@ -36,6 +41,38 @@ jobs:
           tags: shellhubio/${{ matrix.project }}:latest,shellhubio/${{ matrix.project }}:${{ env.RELEASE_VERSION }}
           push: true
           file: ${{ matrix.project }}/Dockerfile
+
+      - name: Generate SBOM for '${{ matrix.project }}' image
+        uses: anchore/sbom-action@v0
+        with:
+          image: shellhubio/${{ matrix.project }}:${{ env.RELEASE_VERSION }}
+          format: cyclonedx-json
+          output-file: sbom-${{ matrix.project }}-${{ env.RELEASE_VERSION }}.cdx.json
+          artifact-name: ""
+
+      - name: Generate SBOM for '${{ matrix.project }}' source
+        uses: anchore/sbom-action@v0
+        with:
+          path: ${{ matrix.project }}
+          format: cyclonedx-json
+          output-file: sbom-${{ matrix.project }}-source-${{ env.RELEASE_VERSION }}.cdx.json
+          artifact-name: ""
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-${{ matrix.project }}
+          path: sbom-${{ matrix.project }}-*.cdx.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Attach SBOM to '${{ matrix.project }}' image
+        run: |
+          cosign attach sbom \
+            --sbom sbom-${{ matrix.project }}-${{ env.RELEASE_VERSION }}.cdx.json \
+            --type cyclonedx \
+            shellhubio/${{ matrix.project }}:${{ env.RELEASE_VERSION }}
 
   publish-enterprise:
     name: Build and publish 'api-enterprise' to Docker Registry
@@ -84,3 +121,46 @@ jobs:
           file: shellhub/api/Dockerfile
           build-args: EDITION=enterprise
           build-contexts: cloud-src=./cloud
+
+      - name: Generate SBOM for api-enterprise image
+        uses: anchore/sbom-action@v0
+        with:
+          image: registry.infra.ossystems.io/shellhub/api-enterprise:${{ env.RELEASE_VERSION }}
+          format: cyclonedx-json
+          output-file: sbom-api-enterprise-${{ env.RELEASE_VERSION }}.cdx.json
+          artifact-name: ""
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-api-enterprise
+          path: sbom-api-enterprise-*.cdx.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Attach SBOM to api-enterprise image
+        run: |
+          cosign attach sbom \
+            --sbom sbom-api-enterprise-${{ env.RELEASE_VERSION }}.cdx.json \
+            --type cyclonedx \
+            registry.infra.ossystems.io/shellhub/api-enterprise:${{ env.RELEASE_VERSION }}
+
+  release-sboms:
+    name: Attach SBOMs to GitHub Release
+    needs: [build, publish-enterprise]
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Download all SBOM artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: sbom-*
+          merge-multiple: true
+
+      - name: Attach SBOMs to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          draft: true
+          files: sbom-*.cdx.json


### PR DESCRIPTION
## What

Every tagged release now generates CycloneDX SBOMs for all published Docker images and source code, attaches them to the GitHub release, and embeds them as OCI referrers on the container images.

## Why

EU Cyber Resilience Act (Art. 13(1)) requires a machine-readable SBOM identifying top-level dependencies with each release. ShellHub had no SBOM generation.

Closes shellhub-io/team#97

## Changes

- **docker-publish.yml**: Each community service (api, ssh, gateway, ui, ui-react, cli) now gets two SBOMs — one from the container image (Go modules, Alpine packages) and one from the source directory (catches npm dependencies bundled away in production nginx images). SBOMs are attached as OCI referrers via cosign and collected into the GitHub release by a new `release-sboms` job. Same pattern applied to the enterprise API image.
- **build-agent.yml**: New `sbom` job scans the pushed multi-arch agent image and attaches the SBOM as an OCI referrer. The `vendored-tarball` job generates an additional source-level SBOM from Go modules. Both are included in the draft release.
- **Permissions**: Both workflows gained `contents: write`, `packages: write`, and `id-token: write` at workflow level for release attachment, OCI push, and future cosign keyless signing.

## Testing

- Validated locally with `syft` (via `nix shell nixpkgs#syft`) against dev images: API detected 99 Go modules + 26 Alpine packages, UI-React detected 1284 npm packages, agent detected 243 Go modules + 58 Alpine packages, agent source scan found 66 Go modules.
- Full end-to-end verification requires a tagged release push — confirm SBOMs appear as GitHub release assets and via `cosign tree shellhubio/<service>:<tag>`.