### PR TITLE
fix(ci): temporarily pin `claude-code-action` to 1.0.88

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.gate.outputs.proceed == 'true'
         timeout-minutes: 30
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.88
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Pin `claude-code-action` version to 1.0.88 to avoid a regression in the latest version.

## Why 
The action's latest version introduced a bug where the action crashes with ENOENT when any sensitive path is a symlink, as stated in https://github.com/anthropics/claude-code-action/issues/1187.

---

This commit will be reverted once that action's regression is fixed.