### PR TITLE
fix(ui-react): resolve prettier and eslint formatting conflicts

### DIFF
--- a/ui-react/.prettierrc.json
+++ b/ui-react/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "printWidth": 80
+}

--- a/ui-react/eslint.config.js
+++ b/ui-react/eslint.config.js
@@ -50,13 +50,20 @@ export default defineConfig([
       "@stylistic/multiline-ternary": "off",
       "@stylistic/jsx-one-expression-per-line": "off",
       "@stylistic/quotes": ["error", "double", { avoidEscape: true }],
-      "@stylistic/indent": ["error", 2],
       "@stylistic/semi": ["error", "always"],
       "@stylistic/brace-style": ["error", "1tbs", { allowSingleLine: true }],
       "@stylistic/max-statements-per-line": "off",
       "@stylistic/member-delimiter-style": "off",
       "@stylistic/arrow-parens": ["error", "always"],
       "@stylistic/quote-props": ["error", "as-needed"],
+
+      // Disabled — Prettier controls these and cannot be configured to match
+      "@stylistic/indent": "off",
+      "@stylistic/indent-binary-ops": "off",
+      "@stylistic/jsx-indent-props": "off",
+      "@stylistic/operator-linebreak": "off",
+      "@stylistic/jsx-wrap-multilines": "off",
+      "@stylistic/jsx-curly-newline": "off",
     },
   },
 


### PR DESCRIPTION
## What
Aligned Prettier and ESLint `@stylistic` configuration so running Prettier no longer produces ESLint errors.

## Why
A Claude Code hook runs `prettier --write` on every file edit, and the Stop hook runs `eslint --fix`. Without alignment, the two tools fought — Prettier would format a file, ESLint would revert parts of it, and the next Prettier run would change it back. This caused spurious lint failures on operator placement, indentation, and JSX wrapping.

## Changes
- **`.prettierrc.json` (new)**: Explicit Prettier config matching the existing `@stylistic` rules — double quotes, semicolons, 2-space tabs, always arrow parens, bracket spacing. Previously Prettier ran with defaults, which happened to agree on most settings but left the contract implicit.
- **`eslint.config.js`**: Disabled 6 `@stylistic` rules that Prettier overrides unconditionally and cannot be configured to match: `indent`, `indent-binary-ops`, `jsx-indent-props`, `operator-linebreak`, `jsx-wrap-multilines`, `jsx-curly-newline`. Prettier uses a width-based formatting algorithm for these, not AST-depth rules, so no ESLint configuration can make them agree.

## Testing
Format any large `.tsx` file with Prettier, then lint it — should produce zero stylistic errors:
```sh
./bin/docker-compose exec ui-react sh -c 'npx prettier --write apps/console/src/pages/WebEndpoints.tsx && npx eslint apps/console/src/pages/WebEndpoints.tsx'
```