### PR TITLE
fix(api): add id tiebreaker to paginated queries

### DIFF
--- a/api/services/api-key.go
+++ b/api/services/api-key.go
@@ -94,6 +94,12 @@ func (s *service) CreateAPIKey(ctx context.Context, req *requests.CreateAPIKey) 
 }
 
 func (s *service) ListAPIKeys(ctx context.Context, req *requests.ListAPIKey) ([]models.APIKey, int, error) {
+	if req.Sorter.By == "" {
+		req.Sorter.By = "created_at"
+	}
+
+	req.Sorter.Tiebreak = "key_digest"
+
 	return s.store.APIKeyList(
 		ctx,
 		s.store.Options().InNamespace(req.TenantID),

--- a/api/services/api-key_test.go
+++ b/api/services/api-key_test.go
@@ -428,7 +428,7 @@ func TestListAPIKey(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "expires_in", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "expires_in", Order: query.OrderAsc, Tiebreak: "key_digest"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -459,7 +459,7 @@ func TestListAPIKey(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "expires_in", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "expires_in", Order: query.OrderAsc, Tiebreak: "key_digest"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.

--- a/api/services/device.go
+++ b/api/services/device.go
@@ -71,6 +71,8 @@ func (s *service) ListDevices(ctx context.Context, req *requests.DeviceList) ([]
 		req.Sorter.By = "last_seen"
 	}
 
+	req.Sorter.Tiebreak = "id"
+
 	opts = append(opts, s.store.Options().Match(&req.Filters), s.store.Options().Sort(&req.Sorter), s.store.Options().Paginate(&req.Paginator))
 
 	if req.DeviceStatus == models.DeviceStatusRemoved {

--- a/api/services/device_test.go
+++ b/api/services/device_test.go
@@ -57,7 +57,7 @@ func TestListDevices(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -94,7 +94,7 @@ func TestListDevices(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -169,7 +169,7 @@ func TestListDevices_status_removed(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -210,7 +210,7 @@ func TestListDevices_status_removed(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -289,7 +289,7 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -330,7 +330,7 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -383,7 +383,7 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -436,7 +436,7 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -489,7 +489,7 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.

--- a/api/services/session.go
+++ b/api/services/session.go
@@ -28,7 +28,7 @@ func (s *service) ListSessions(ctx context.Context, req *requests.ListSessions) 
 		opts = append(opts, s.store.Options().InNamespace(req.TenantID))
 	}
 
-	opts = append(opts, s.store.Options().Sort(&query.Sorter{By: "started_at", Order: query.OrderDesc}))
+	opts = append(opts, s.store.Options().Sort(&query.Sorter{By: "started_at", Order: query.OrderDesc, Tiebreak: "id"}))
 	opts = append(opts, s.store.Options().Paginate(&req.Paginator))
 
 	return s.store.SessionList(ctx, opts...)

--- a/api/services/session_test.go
+++ b/api/services/session_test.go
@@ -50,7 +50,7 @@ func TestListSessions(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc}).
+					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -83,7 +83,7 @@ func TestListSessions(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc}).
+					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.

--- a/api/services/tags.go
+++ b/api/services/tags.go
@@ -103,6 +103,8 @@ func (s *service) ListTags(ctx context.Context, req *requests.ListTags) ([]model
 		req.Sorter.Order = query.OrderDesc
 	}
 
+	req.Sorter.Tiebreak = "id"
+
 	opts := []store.QueryOption{
 		s.store.Options().InNamespace(req.TenantID),
 		s.store.Options().Match(&req.Filters),

--- a/api/services/tags_test.go
+++ b/api/services/tags_test.go
@@ -450,7 +450,7 @@ func TestService_ListTags(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderDesc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderDesc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -491,7 +491,7 @@ func TestService_ListTags(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
-					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderDesc}).
+					On("Sort", &query.Sorter{By: "created_at", Order: query.OrderDesc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
 				queryOptionsMock.

--- a/api/services/task.go
+++ b/api/services/task.go
@@ -81,8 +81,9 @@ func (s *service) deviceCleanup() store.TransactionCb {
 		}
 
 		sorter := &query.Sorter{
-			By:    "removed_at",
-			Order: query.OrderAsc,
+			By:       "removed_at",
+			Order:    query.OrderAsc,
+			Tiebreak: "id",
 		}
 
 		_, totalCount, err := s.store.DeviceList(ctx, store.DeviceAcceptableAsFalse, s.store.Options().Match(filter))

--- a/api/services/task_test.go
+++ b/api/services/task_test.go
@@ -146,7 +146,7 @@ func TestService_DeviceCleanup(t *testing.T) {
 	storeMock.On("Options").Return(queryOptionsMock)
 
 	thirtyDaysAgo := time.Now().AddDate(0, 0, -30)
-	sorter := query.Sorter{By: "removed_at", Order: query.OrderAsc}
+	sorter := query.Sorter{By: "removed_at", Order: query.OrderAsc, Tiebreak: "id"}
 
 	cases := []struct {
 		description   string

--- a/api/store/pg/query-options.go
+++ b/api/store/pg/query-options.go
@@ -47,7 +47,11 @@ func (*queryOptions) Sort(sorter *query.Sorter) store.QueryOption {
 			return ErrQueryNotFound
 		}
 
-		wrapper.query = wrapper.query.OrderExpr("? ?", bun.Ident(sorter.By), bun.Safe(strings.ToUpper(sorter.Order)))
+		if sorter.Tiebreak != "" {
+			wrapper.query = wrapper.query.OrderExpr("? ?, ? DESC", bun.Ident(sorter.By), bun.Safe(strings.ToUpper(sorter.Order)), bun.Ident(sorter.Tiebreak))
+		} else {
+			wrapper.query = wrapper.query.OrderExpr("? ?", bun.Ident(sorter.By), bun.Safe(strings.ToUpper(sorter.Order)))
+		}
 
 		return nil
 	}

--- a/pkg/api/query/sorter.go
+++ b/pkg/api/query/sorter.go
@@ -7,8 +7,9 @@ const (
 
 // Sorter represents the sorting order in a query.
 type Sorter struct {
-	By    string `query:"sort_by"`
-	Order string `query:"order_by" validate:"omitempty,oneof=asc desc"`
+	By       string `query:"sort_by"`
+	Order    string `query:"order_by" validate:"omitempty,oneof=asc desc"`
+	Tiebreak string // stable secondary sort column, set by service layer
 }
 
 // NewOrder creates and returns a new Sort instance with the default descending order.


### PR DESCRIPTION
## Problem

Paginated queries return rows in non-deterministic order when the primary sort column has duplicate values (e.g. multiple devices with the same `last_seen`), causing items to shift between pages.

## Fix

Add `id DESC` as a secondary sort key to all paginated queries in `Sort()`.

Fixes #6124