### PR TITLE
fix(api): place AND operator before connector filter in device list

### DIFF
--- a/api/routes/device.go
+++ b/api/routes/device.go
@@ -44,17 +44,17 @@ func (h *Handler) GetDeviceList(c gateway.Context) error {
 	if c.QueryParam("connector") != "" {
 		filter := []query.Filter{
 			{
+				Type: query.FilterTypeOperator,
+				Params: &query.FilterOperator{
+					Name: "and",
+				},
+			},
+			{
 				Type: query.FilterTypeProperty,
 				Params: &query.FilterProperty{
 					Name:     "info.platform",
 					Operator: "eq",
 					Value:    "connector",
-				},
-			},
-			{
-				Type: query.FilterTypeOperator,
-				Params: &query.FilterOperator{
-					Name: "and",
 				},
 			},
 		}
@@ -63,17 +63,17 @@ func (h *Handler) GetDeviceList(c gateway.Context) error {
 	} else {
 		filter := []query.Filter{
 			{
+				Type: query.FilterTypeOperator,
+				Params: &query.FilterOperator{
+					Name: "and",
+				},
+			},
+			{
 				Type: query.FilterTypeProperty,
 				Params: &query.FilterProperty{
 					Name:     "info.platform",
 					Operator: "ne",
 					Value:    "connector",
-				},
-			},
-			{
-				Type: query.FilterTypeOperator,
-				Params: &query.FilterOperator{
-					Name: "and",
 				},
 			},
 		}

--- a/api/routes/device_test.go
+++ b/api/routes/device_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -377,6 +378,93 @@ func TestGetDeviceList(t *testing.T) {
 
 			require.Equal(t, tc.expected.status, rec.Result().StatusCode)
 			require.Equal(t, tc.expected.devices, devices)
+		})
+	}
+}
+
+func TestGetDeviceListConnectorFilterOrder(t *testing.T) {
+	cases := []struct {
+		description string
+		connector   string
+		userFilter  []query.Filter
+	}{
+		{
+			description: "connector filter has AND before property when user filter is present",
+			connector:   "",
+			userFilter: []query.Filter{
+				{
+					Type:   query.FilterTypeProperty,
+					Params: &query.FilterProperty{Name: "name", Operator: "contains", Value: "foo"},
+				},
+			},
+		},
+		{
+			description: "connector=true filter has AND before property when user filter is present",
+			connector:   "true",
+			userFilter: []query.Filter{
+				{
+					Type:   query.FilterTypeProperty,
+					Params: &query.FilterProperty{Name: "name", Operator: "contains", Value: "foo"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			mock := new(mocks.Service)
+
+			var captured *requests.DeviceList
+			mock.
+				On("ListDevices", gomock.Anything, gomock.AnythingOfType("*requests.DeviceList")).
+				Run(func(args gomock.Arguments) {
+					captured = args.Get(1).(*requests.DeviceList)
+				}).
+				Return([]models.Device{}, 0, nil).
+				Once()
+
+			filterJSON, err := json.Marshal(tc.userFilter)
+			require.NoError(t, err)
+
+			filterB64 := base64.StdEncoding.EncodeToString(filterJSON)
+
+			urlVal := &url.Values{}
+			urlVal.Set("page", "1")
+			urlVal.Set("per_page", "10")
+			urlVal.Set("sort_by", "name")
+			urlVal.Set("order_by", "asc")
+			urlVal.Set("status", "accepted")
+			urlVal.Set("filter", filterB64)
+			if tc.connector != "" {
+				urlVal.Set("connector", tc.connector)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/devices?"+urlVal.Encode(), nil)
+			req.Header.Set("X-Role", authorizer.RoleOwner.String())
+			req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
+
+			rec := httptest.NewRecorder()
+			e := NewRouter(mock)
+			e.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+			require.NotNil(t, captured)
+
+			// The connector/platform filter is appended after the user
+			// filters. The AND operator MUST come before the platform
+			// property so it applies to it; otherwise the platform
+			// condition gets OR'd with user filters, returning all
+			// devices regardless of the user's filter.
+			data := captured.Filters.Data
+			require.GreaterOrEqual(t, len(data), 3)
+
+			lastTwo := data[len(data)-2:]
+			require.Equal(t, query.FilterTypeOperator, lastTwo[0].Type, "AND operator must precede the platform property filter")
+			require.Equal(t, query.FilterTypeProperty, lastTwo[1].Type, "platform property filter must follow the AND operator")
+
+			op, ok := lastTwo[0].Params.(*query.FilterOperator)
+			require.True(t, ok)
+			require.Equal(t, "and", op.Name)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- The connector/platform filter in the device list handler placed the AND operator after the property instead of before
- Since `Match` processes operators as prefix (applies to the next condition), the platform filter was OR'd with user filters
- This caused `WHERE (name ILIKE '%foo%') OR (platform <> 'connector')` instead of AND, returning all non-connector devices regardless of the user's search
- Added test that verifies operator ordering and fails without the fix