### PR TITLE
fix(cli): ensure first user created via CLI is admin

### DIFF
--- a/cli/services/users.go
+++ b/cli/services/users.go
@@ -52,6 +52,11 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 		return nil, ErrUserPasswordInvalid
 	}
 
+	system, err := s.store.SystemGet(ctx)
+	if err != nil {
+		system = &models.System{Setup: true}
+	}
+
 	user := &models.User{
 		Origin:        models.UserOriginLocal,
 		UserData:      userData,
@@ -62,16 +67,11 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 		Preferences: models.UserPreferences{
 			AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
 		},
-		Admin: input.Admin,
+		Admin: input.Admin || !system.Setup,
 	}
 
 	if _, err := s.store.UserCreate(ctx, user); err != nil {
 		return nil, ErrCreateNewUser
-	}
-
-	system, err := s.store.SystemGet(ctx)
-	if err != nil {
-		system = &models.System{}
 	}
 
 	system.Setup = true

--- a/cli/services/users_test.go
+++ b/cli/services/users_test.go
@@ -147,9 +147,12 @@ func TestUserCreate(t *testing.T) {
 					Preferences: models.UserPreferences{
 						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
 					},
-					Admin: false,
+					Admin: true,
 				}
 				mock.On("UserCreate", ctx, user).Return("", errors.New("error")).Once()
+				mock.On("SystemGet", ctx).
+					Return(&models.System{Setup: false}, nil).
+					Once()
 			},
 			expected: Expected{nil, ErrCreateNewUser},
 		},
@@ -185,13 +188,87 @@ func TestUserCreate(t *testing.T) {
 					Preferences: models.UserPreferences{
 						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
 					},
-					Admin: false,
+					Admin: true,
 				}
 
 				mock.On("UserCreate", ctx, user).Return("000000000000000000000000", nil).Once()
 
 				mock.On("SystemGet", ctx).Return(&models.System{Setup: false}, nil).Once()
 				mock.On("SystemSet", ctx, &models.System{Setup: true}).Return(nil).Once()
+			},
+			expected: Expected{&models.User{
+				Origin: models.UserOriginLocal,
+				UserData: models.UserData{
+					Name:     "john_doe",
+					Email:    "john.doe@test.com",
+					Username: "john_doe",
+				},
+				Password: models.UserPassword{
+					Plain: "secret",
+					Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+				},
+				Status:        models.UserStatusConfirmed,
+				CreatedAt:     clock.Now(),
+				MaxNamespaces: MaxNumberNamespacesCommunity,
+				Preferences: models.UserPreferences{
+					AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+				},
+				Admin: true,
+			}, nil},
+		},
+		{
+			description: "creates a non-admin user when system is already set up",
+			username:    "john_doe",
+			email:       "john.doe@test.com",
+			password:    "secret",
+			requiredMocks: func() {
+				mock.
+					On("UserConflicts", ctx, &models.UserConflicts{
+						Username: "john_doe",
+						Email:    "john.doe@test.com",
+					}).
+					Return([]string{}, false, nil).
+					Once()
+
+				hashMock.
+					On("Do", "secret").
+					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
+					Once()
+
+				mock.
+					On("SystemGet", ctx).
+					Return(&models.System{Setup: true}, nil).
+					Once()
+
+				user := &models.User{
+					Origin: models.UserOriginLocal,
+					UserData: models.UserData{
+						Name:     "john_doe",
+						Email:    "john.doe@test.com",
+						Username: "john_doe",
+					},
+					Password: models.UserPassword{
+						Plain: "secret",
+						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+					},
+					Status:        models.UserStatusConfirmed,
+					CreatedAt:     clock.Now(),
+					MaxNamespaces: MaxNumberNamespacesCommunity,
+					Preferences: models.UserPreferences{
+						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+					Admin: false,
+				}
+
+				mock.
+					On("UserCreate", ctx, user).
+					Return("000000000000000000000000", nil).
+					Once()
+
+				mock.
+					On("SystemSet", ctx, &models.System{Setup: true}).
+					Return(nil).
+					Once()
 			},
 			expected: Expected{&models.User{
 				Origin: models.UserOriginLocal,


### PR DESCRIPTION
## What changed
The CLI now ensures that the first user created is automatically granted admin privileges, even when the --admin flag is not used.

## Why
Previously, admin privileges were only assigned when the --admin flag was explicitly provided. This created an inconsistency with the API setup endpoint, which automatically promotes the first user to admin.

This change aligns the CLI behavior with the API and prevents misconfiguration during initial system setup.

## How to test
1. Start the environment with `make start`
2. Remove the database volume to ensure a clean state
3. Run `./bin/cli user create <username> <password> <email>`
4. Run `./bin/cli user list`
5. Verify that the created user has the role "admin"

Fixes #6153