### PR TITLE
fix(gateway): raise WebSocket timeouts and enable TCP keepalive

### DIFF
--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -417,6 +417,9 @@ server {
         proxy_set_header X-Request-ID $request_id;
         proxy_http_version 1.1;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        proxy_socket_keepalive on;
         proxy_redirect off;
     }
 
@@ -435,6 +438,9 @@ server {
         proxy_set_header X-Request-ID $request_id;
         proxy_http_version 1.1;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        proxy_socket_keepalive on;
         proxy_redirect off;
     }
 
@@ -458,6 +464,9 @@ server {
         proxy_set_header X-Request-ID $request_id;
         proxy_http_version 1.1;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        proxy_socket_keepalive on;
         proxy_redirect off;
     }
 
@@ -767,6 +776,9 @@ server {
         {{ end -}}
         proxy_http_version 1.1;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        proxy_socket_keepalive on;
         proxy_redirect off;
     }
 


### PR DESCRIPTION
## Problem

The WebSocket locations in the gateway (`/ssh/connection`, `/ssh/revdial`, `/agent/connection` and `/ws`) had no `proxy_read_timeout` or `proxy_send_timeout` configured, so nginx fell back to the default 60s. Any idle WebSocket was killed by the gateway after one minute, even when no external load balancer sat in front of ShellHub.

This made the agent SSH keepalive only effective when its interval was shorter than 60s. Operators that set a higher interval (e.g. 300s) still had idle sessions forcefully closed by the gateway itself, as reported in shellhub-io/shellhub#5946.

## Fix

Raise both timeouts to `1h` on the long-lived WebSocket locations and enable `proxy_socket_keepalive` so the kernel can detect half-open upstream connections (peer crashed without sending FIN) instead of holding zombie sockets until the timeout fires.

Fixes: shellhub-io/shellhub#5946