### PR TITLE
refactor(api): remove RSA signature gate from initial setup flow

### DIFF
--- a/api/routes/setup.go
+++ b/api/routes/setup.go
@@ -8,26 +8,17 @@ import (
 )
 
 const (
-	SetupEndpoint  = "/setup"
-	SetupSignQuery = "sign"
+	SetupEndpoint = "/setup"
 )
 
 func (h *Handler) Setup(c gateway.Context) error {
-	sign := c.QueryParam(SetupSignQuery)
-	if sign == "" {
-		return c.NoContent(http.StatusBadRequest)
-	}
-
 	var req requests.Setup
+
 	if err := c.Bind(&req); err != nil {
 		return err
 	}
 
 	if err := c.Validate(&req); err != nil {
-		return err
-	}
-
-	if err := h.service.SetupVerify(c.Ctx(), sign); err != nil {
 		return err
 	}
 

--- a/api/services/setup.go
+++ b/api/services/setup.go
@@ -2,14 +2,6 @@ package services
 
 import (
 	"context"
-	"crypto"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/x509"
-	"encoding/hex"
-	"encoding/pem"
-	"os"
 
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
@@ -22,7 +14,6 @@ const PrivateKeyPath = "/var/run/secrets/api_private_key"
 
 type SetupService interface {
 	Setup(ctx context.Context, req requests.Setup) error
-	SetupVerify(ctx context.Context, sign string) error
 }
 
 func (s *service) Setup(ctx context.Context, req requests.Setup) error {
@@ -103,40 +94,6 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) error {
 	system.Setup = true
 	if err := s.store.SystemSet(ctx, system); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (s *service) SetupVerify(_ context.Context, sign string) error {
-	privKeyData, err := os.ReadFile(PrivateKeyPath)
-	if err != nil {
-		return err
-	}
-
-	privKeyPem, _ := pem.Decode(privKeyData)
-	privKey, err := x509.ParsePKCS8PrivateKey(privKeyPem.Bytes)
-	if err != nil {
-		return err
-	}
-
-	const msgString = "shellhub"
-
-	msgHash := sha256.New()
-	_, err = msgHash.Write([]byte(msgString))
-	if err != nil {
-		return err
-	}
-
-	signed, err := rsa.SignPKCS1v15(rand.Reader, privKey.(*rsa.PrivateKey), crypto.SHA256, msgHash.Sum(nil))
-	if err != nil {
-		return err
-	}
-
-	sumSigned := sha256.Sum256(signed)
-
-	if sign != hex.EncodeToString(sumSigned[:]) {
-		return NewErrSetupForbidden(nil)
 	}
 
 	return nil

--- a/bin/setup
+++ b/bin/setup
@@ -2,6 +2,27 @@
 
 . "$(dirname "$0")/utils"
 
+open_url() {
+  url="$1"
+
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 &
+    return
+  fi
+
+  if command -v open >/dev/null 2>&1; then
+    open "$url"
+    return
+  fi
+
+  if command -v x-www-browser >/dev/null 2>&1; then
+    x-www-browser "$url" >/dev/null 2>&1 &
+    return
+  fi
+
+  echo "🚀 Open this URL in your browser to complete setup: $url"
+}
+
 echo "🌟 Welcome to the ShellHub Setup Script"
 echo ""
 
@@ -12,17 +33,14 @@ if curl -s http://localhost/info | grep -q '"setup":true'; then
   exit 0
 fi
 
-echo "📋 This script will generate a valid URL to set up your ShellHub instance."
+echo "📋 This script will open the setup URL for your ShellHub instance."
 echo "❗ Important: The ShellHub instance cannot be on localhost. Please ensure you provide a valid public IP address or hostname."
 echo ""
 
-KEY="api_private_key"
+URL="http://localhost/setup"
 
-SIGNATURE=$(echo -n "shellhub" | openssl dgst -sha256 -sign "$KEY" | sha256sum | cut -d' ' -f1)
-URL="http://localhost/setup?sign=$(printf '%s' "$SIGNATURE")"
+echo "🔗 Generated Setup URL: $URL"
+open_url "$URL"
 
-echo "🔗 Generated Setup URL:"
-echo "$URL"
 echo ""
-echo "🚀 You can use this URL to complete the setup of your ShellHub instance."
 echo "✅ Please ensure your ShellHub server is running and accessible from an external address."

--- a/cli/services/users.go
+++ b/cli/services/users.go
@@ -52,6 +52,11 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 		return nil, ErrUserPasswordInvalid
 	}
 
+	system, err := s.store.SystemGet(ctx)
+	if err != nil {
+		system = &models.System{Setup: true}
+	}
+
 	user := &models.User{
 		Origin:        models.UserOriginLocal,
 		UserData:      userData,
@@ -62,16 +67,11 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 		Preferences: models.UserPreferences{
 			AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
 		},
-		Admin: input.Admin,
+		Admin: input.Admin || !system.Setup,
 	}
 
 	if _, err := s.store.UserCreate(ctx, user); err != nil {
 		return nil, ErrCreateNewUser
-	}
-
-	system, err := s.store.SystemGet(ctx)
-	if err != nil {
-		system = &models.System{}
 	}
 
 	system.Setup = true

--- a/cli/services/users_test.go
+++ b/cli/services/users_test.go
@@ -147,9 +147,12 @@ func TestUserCreate(t *testing.T) {
 					Preferences: models.UserPreferences{
 						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
 					},
-					Admin: false,
+					Admin: true,
 				}
 				mock.On("UserCreate", ctx, user).Return("", errors.New("error")).Once()
+				mock.On("SystemGet", ctx).
+					Return(&models.System{Setup: false}, nil).
+					Once()
 			},
 			expected: Expected{nil, ErrCreateNewUser},
 		},
@@ -185,13 +188,87 @@ func TestUserCreate(t *testing.T) {
 					Preferences: models.UserPreferences{
 						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
 					},
-					Admin: false,
+					Admin: true,
 				}
 
 				mock.On("UserCreate", ctx, user).Return("000000000000000000000000", nil).Once()
 
 				mock.On("SystemGet", ctx).Return(&models.System{Setup: false}, nil).Once()
 				mock.On("SystemSet", ctx, &models.System{Setup: true}).Return(nil).Once()
+			},
+			expected: Expected{&models.User{
+				Origin: models.UserOriginLocal,
+				UserData: models.UserData{
+					Name:     "john_doe",
+					Email:    "john.doe@test.com",
+					Username: "john_doe",
+				},
+				Password: models.UserPassword{
+					Plain: "secret",
+					Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+				},
+				Status:        models.UserStatusConfirmed,
+				CreatedAt:     clock.Now(),
+				MaxNamespaces: MaxNumberNamespacesCommunity,
+				Preferences: models.UserPreferences{
+					AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+				},
+				Admin: true,
+			}, nil},
+		},
+		{
+			description: "creates a non-admin user when system is already set up",
+			username:    "john_doe",
+			email:       "john.doe@test.com",
+			password:    "secret",
+			requiredMocks: func() {
+				mock.
+					On("UserConflicts", ctx, &models.UserConflicts{
+						Username: "john_doe",
+						Email:    "john.doe@test.com",
+					}).
+					Return([]string{}, false, nil).
+					Once()
+
+				hashMock.
+					On("Do", "secret").
+					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
+					Once()
+
+				mock.
+					On("SystemGet", ctx).
+					Return(&models.System{Setup: true}, nil).
+					Once()
+
+				user := &models.User{
+					Origin: models.UserOriginLocal,
+					UserData: models.UserData{
+						Name:     "john_doe",
+						Email:    "john.doe@test.com",
+						Username: "john_doe",
+					},
+					Password: models.UserPassword{
+						Plain: "secret",
+						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+					},
+					Status:        models.UserStatusConfirmed,
+					CreatedAt:     clock.Now(),
+					MaxNamespaces: MaxNumberNamespacesCommunity,
+					Preferences: models.UserPreferences{
+						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+					Admin: false,
+				}
+
+				mock.
+					On("UserCreate", ctx, user).
+					Return("000000000000000000000000", nil).
+					Once()
+
+				mock.
+					On("SystemSet", ctx, &models.System{Setup: true}).
+					Return(nil).
+					Once()
 			},
 			expected: Expected{&models.User{
 				Origin: models.UserOriginLocal,


### PR DESCRIPTION
## What changed

Removed the RSA-based signature requirement from the setup flow and simplified the initial setup process.
The `/setup` endpoint no longer requires a `sign` query parameter and no longer performs cryptographic validation.
The setup script was updated to remove signature generation and now directly opens (or prints) the setup URL.

Cleanup was performed across:

- setup HTTP handler
- setup service interface and implementation
- CLI setup script

## Why

The previous setup flow introduced unnecessary complexity for a one-time initialization process.

Most self-hosted systems use a first-user-wins model where initialization is controlled by a persistent system state instead of cryptographic verification.

## How to test

1. Reset the environment
  `docker compose down -v`
2. Start the stack
  `make start`
3. Verify initial state
  `curl http://localhost/info | jq`
  Expected: setup: false
4. Create the first admin user via CLI
5.Verify setup is completed
  `curl http://localhost/info | jq`
  Expected: setup: true
  
Fixes: #6154 
