### PR TITLE
feat(agent): default transport to yamux (v2)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -109,8 +109,8 @@ type Config struct {
 
 	// TransportVersion specifies the version of the agent transport protocol to use.
 	// Version 1 uses HTTP-based revdial, version 2 uses yamux multiplexing with multistream.
-	// Supported values are 1 and 2. Default is 1.
-	TransportVersion int `env:"TRANSPORT_VERSION,default=1"`
+	// Supported values are 1 and 2. Default is 2.
+	TransportVersion int `env:"TRANSPORT_VERSION,default=2"`
 }
 
 func LoadConfigFromEnv() (*Config, map[string]interface{}, error) {

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -62,7 +62,7 @@ func NewAgentContainer(ctx context.Context, port string, opts ...NewAgentContain
 		"SHELLHUB_LOG_FORMAT":         "json",
 		"SHELLHUB_KEEPALIVE_INTERVAL": "1",
 		"SHELLHUB_LOG_LEVEL":          "trace",
-		"SHELLHUB_TRANSPORT_VERSION":  "1", // Default to v1 for compatibility
+		"SHELLHUB_TRANSPORT_VERSION":  "2",
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
## Summary

- Flip the agent's default `TRANSPORT_VERSION` from `1` to `2` so new agents negotiate the yamux-multiplexed transport out of the box.
- The SSH server already exposes `/agent/connection` for v2 and keeps `/ssh/connection` around, so agents still running older binaries continue to work on v1.
- Align the integration test helper default with v2 (cosmetic, since every caller already overrides via `NewAgentContainerWithConnectionVersion`).