### PR TITLE
fix(ui-react): fix sidebar behavior when terminal is open

### DIFF
--- a/ui-react/apps/console/src/components/layout/AdminLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminLayout.tsx
@@ -35,7 +35,7 @@ export default function AdminLayout() {
           </SidebarMobileDrawer>
         )}
         <div className="flex-1 flex flex-col min-w-0">
-          <AdminAppBar onMenuToggle={isDesktop ? undefined : handlers.openDrawer} />
+          <AdminAppBar onMenuToggle={isDesktop ? undefined : handlers.toggleDrawer} />
           <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 sm:p-8 relative">
             <div className="grid-bg scanline absolute inset-0 -z-10" />
             <div

--- a/ui-react/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AppLayout.tsx
@@ -18,6 +18,8 @@ export default function AppLayout() {
   const { isOpen, pinned, isDesktop, drawerOpen, handlers } = useSidebarLayout();
 
   const showSidebar = namespaces.length > 0;
+  const sidebarOffset =
+    showSidebar && isDesktop ? (isOpen ? 220 : 60) : 0;
 
   return (
     <div
@@ -62,7 +64,7 @@ export default function AppLayout() {
           </main>
         </div>
       </div>
-      <TerminalManager />
+      <TerminalManager sidebarOffset={sidebarOffset} />
       <WelcomeWizardTrigger />
     </div>
   );

--- a/ui-react/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AppLayout.tsx
@@ -50,7 +50,7 @@ export default function AppLayout() {
           </SidebarMobileDrawer>
         )}
         <div className="flex-1 flex flex-col min-w-0">
-          <AppBar onMenuToggle={showSidebar && !isDesktop ? handlers.openDrawer : undefined} />
+          <AppBar onMenuToggle={showSidebar && !isDesktop ? handlers.toggleDrawer : undefined} />
           <main className="flex-1 flex flex-col p-8 relative min-h-0">
             <div className="grid-bg scanline absolute inset-0 -z-10" />
             <div

--- a/ui-react/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui-react/apps/console/src/components/layout/SidebarShell.tsx
@@ -82,7 +82,7 @@ export function SidebarMobileDrawer({
       role="dialog"
       aria-modal={open}
       aria-label="Navigation menu"
-      className={`fixed inset-0 z-40 ${open ? "" : "pointer-events-none"}`}
+      className={`fixed inset-0 z-50 ${open ? "" : "pointer-events-none"}`}
       onKeyDown={onKeyDown}
       {...(!open && { inert: "" })}
     >

--- a/ui-react/apps/console/src/components/terminal/TerminalManager.tsx
+++ b/ui-react/apps/console/src/components/terminal/TerminalManager.tsx
@@ -8,7 +8,11 @@ import { buildSshid } from "../../utils/sshid";
 import TerminalInstance from "./TerminalInstance";
 import TerminalTaskbar from "./TerminalTaskbar";
 
-export default function TerminalManager() {
+export default function TerminalManager({
+  sidebarOffset,
+}: {
+  sidebarOffset: number;
+}) {
   const sessions = useTerminalStore((s) => s.sessions);
   const minimizeAll = useTerminalStore((s) => s.minimizeAll);
   const reconnectTarget = useTerminalStore((s) => s.reconnectTarget);
@@ -66,10 +70,10 @@ export default function TerminalManager() {
         return (
           <div
             key={s.id}
+            style={{ left: isFullscreen ? 0 : sidebarOffset }}
             className={[
               "fixed top-14 bottom-0 right-0 z-40 flex flex-col bg-background",
               "transition-[opacity,transform,left] duration-200 ease-out",
-              isFullscreen ? "left-0" : "left-[220px]",
               isVisible
                 ? "opacity-100 translate-y-0"
                 : "opacity-0 translate-y-3 pointer-events-none",
@@ -80,7 +84,7 @@ export default function TerminalManager() {
         );
       })}
 
-      <TerminalTaskbar />
+      <TerminalTaskbar sidebarOffset={sidebarOffset} />
     </>
   );
 }

--- a/ui-react/apps/console/src/components/terminal/TerminalTaskbar.tsx
+++ b/ui-react/apps/console/src/components/terminal/TerminalTaskbar.tsx
@@ -1,14 +1,21 @@
 import { XMarkIcon, CommandLineIcon } from "@heroicons/react/24/outline";
 import { useTerminalStore } from "../../stores/terminalStore";
 
-export default function TerminalTaskbar() {
+export default function TerminalTaskbar({
+  sidebarOffset,
+}: {
+  sidebarOffset: number;
+}) {
   const { sessions, restore, close } = useTerminalStore();
   const minimized = sessions.filter((s) => s.state === "minimized");
 
   if (minimized.length === 0) return null;
 
   return (
-    <div className="fixed bottom-0 left-[220px] right-0 z-30 h-11 flex items-center gap-1.5 px-3 bg-surface border-t border-border animate-slide-up">
+    <div
+      style={{ left: sidebarOffset }}
+      className="fixed bottom-0 right-0 z-30 h-11 flex items-center gap-1.5 px-3 bg-surface border-t border-border animate-slide-up transition-[left] duration-200 ease-out"
+    >
       {minimized.map((s) => {
         const isConnected = s.connectionStatus === "connected";
 

--- a/ui-react/apps/console/src/hooks/useSidebarLayout.ts
+++ b/ui-react/apps/console/src/hooks/useSidebarLayout.ts
@@ -1,11 +1,9 @@
 import {
   useState,
-  useCallback,
   useRef,
   useEffect,
   useSyncExternalStore,
 } from "react";
-import { useLocation } from "react-router-dom";
 
 const lgQuery = "(min-width: 1024px)";
 
@@ -28,8 +26,7 @@ function getIsDesktopServer() {
 export function useSidebarLayout() {
   const [expanded, setExpanded] = useState(false);
   const [pinned, setPinned] = useState(false);
-  const [drawerPathname, setDrawerPathname] = useState<string | null>(null);
-  const { pathname } = useLocation();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const isDesktop = useSyncExternalStore(
     subscribeToMediaQuery,
@@ -38,46 +35,28 @@ export function useSidebarLayout() {
   );
 
   const hoverTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const [prevIsDesktop, setPrevIsDesktop] = useState(isDesktop);
-
-  // Reset transient state when crossing the desktop/mobile breakpoint
-  if (prevIsDesktop !== isDesktop) {
-    setPrevIsDesktop(isDesktop);
-    setExpanded(false);
-    setDrawerPathname(null);
-  }
 
   const isOpen = expanded || pinned;
-  const drawerOpen = drawerPathname === pathname;
+
+  const openDrawer = () => setDrawerOpen(true);
+  const closeDrawer = () => setDrawerOpen(false);
 
   // Clean up hover timer on unmount
-  useEffect(() => {
-    return () => clearTimeout(hoverTimer.current);
-  }, []);
+  useEffect(() => () => clearTimeout(hoverTimer.current), []);
 
-  const handleExpand = useCallback(() => {
+  const handleExpand = () => {
     clearTimeout(hoverTimer.current);
     hoverTimer.current = setTimeout(() => setExpanded(true), 75);
-  }, []);
+  };
 
-  const handleCollapse = useCallback(() => {
+  const handleCollapse = () => {
     clearTimeout(hoverTimer.current);
     hoverTimer.current = setTimeout(() => setExpanded(false), 150);
-  }, []);
+  };
 
-  const handleToggle = useCallback(() => {
-    setPinned((prev) => !prev);
-  }, []);
+  const handleToggle = () => { setPinned((prev) => !prev); };
 
-  const openDrawer = useCallback(() => setDrawerPathname(pathname), [pathname]);
-  const closeDrawer = useCallback(() => setDrawerPathname(null), []);
-
-  const handleDrawerKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Escape") closeDrawer();
-    },
-    [closeDrawer],
-  );
+  const handleDrawerKeyDown = (e: React.KeyboardEvent) => { if (e.key === "Escape") closeDrawer(); };
 
   return {
     expanded,

--- a/ui-react/apps/console/src/hooks/useSidebarLayout.ts
+++ b/ui-react/apps/console/src/hooks/useSidebarLayout.ts
@@ -40,6 +40,7 @@ export function useSidebarLayout() {
 
   const openDrawer = () => setDrawerOpen(true);
   const closeDrawer = () => setDrawerOpen(false);
+  const toggleDrawer = () => setDrawerOpen((prev) => !prev);
 
   // Clean up hover timer on unmount
   useEffect(() => () => clearTimeout(hoverTimer.current), []);
@@ -72,6 +73,7 @@ export function useSidebarLayout() {
       onToggle: handleToggle,
       openDrawer,
       closeDrawer,
+      toggleDrawer,
       onDrawerKeyDown: handleDrawerKeyDown,
     },
   };


### PR DESCRIPTION
## What 

Fix the sidebar behavior on desktop and mobile when a web terminal instance is open.

## Why

The sidebar was presenting two strange behaviors when the terminal was open:
1. On desktop, the sidebar occupied 220px (expanded state width) even when collapsed, adding a blank space between the collapsed sidebar and the terminal window.
2. On mobile. the sidebar was opening below the terminal, being unclickable.

The fixes:

1. Compute the sidebar offset and pass to the terminal components in order to adapt the `left` space style based on it.
2. Increase the sidebar `z-index`, making it appear above the terminal and be usable.

## Testing

- On desktop, open a terminal instance and ensure the sidebar and terminal behave correctly in collapsed, expanded, and terminal fullscreen states.
- On mobile, ensure the sidebar opens, closes, and is clickable when a terminal instance is open.
