### PR TITLE
refactor(ui-react): split useCopy hook into its own file

### DIFF
--- a/ui-react/apps/console/src/components/common/ClipboardProvider.tsx
+++ b/ui-react/apps/console/src/components/common/ClipboardProvider.tsx
@@ -1,26 +1,7 @@
-import {
-  createContext,
-  ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { ReactNode, useCallback, useId, useMemo, useState } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { ClipboardContext } from "@/hooks/useCopy";
 import BaseDialog from "./BaseDialog";
-
-// ─── Context ──────────────────────────────────────────────────────────────────
-
-interface ClipboardContextValue {
-  triggerWarning: () => void;
-}
-
-const ClipboardContext = createContext<ClipboardContextValue | null>(null);
-
-// ─── Provider ─────────────────────────────────────────────────────────────────
 
 /**
  * Mounts a single clipboard-warning dialog for the whole app.
@@ -80,60 +61,4 @@ export function ClipboardProvider({ children }: { children: ReactNode }) {
       </BaseDialog>
     </ClipboardContext.Provider>
   );
-}
-
-// ─── Hook ─────────────────────────────────────────────────────────────────────
-
-export interface UseCopyResult {
-  /** Call with the text to copy. Shows the warning dialog when clipboard access
-   *  is unavailable (insecure context or API error). */
-  copy: (text: string) => void;
-  /** True for 1500 ms after a successful copy. Use for inline visual feedback. */
-  copied: boolean;
-}
-
-/**
- * Safe clipboard copy with automatic insecure-context handling.
- *
- * Must be used within `<ClipboardProvider>`.
- *
- * ```tsx
- * const { copy, copied } = useCopy();
- * <button onClick={() => copy(deviceId)}>{copied ? "Copied!" : "Copy"}</button>
- * ```
- */
-export function useCopy(): UseCopyResult {
-  const ctx = useContext(ClipboardContext);
-  if (!ctx) throw new Error("useCopy must be used within <ClipboardProvider>");
-
-  const { triggerWarning } = ctx;
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const copy = useCallback(
-    (text: string) => {
-      if (!globalThis.isSecureContext) {
-        triggerWarning();
-        return;
-      }
-
-      navigator.clipboard.writeText(text).then(
-        () => {
-          if (timerRef.current) clearTimeout(timerRef.current);
-          setCopied(true);
-          timerRef.current = setTimeout(() => setCopied(false), 1500);
-        },
-        () => triggerWarning(),
-      );
-    },
-    [triggerWarning],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, []);
-
-  return { copy, copied };
 }

--- a/ui-react/apps/console/src/components/common/CopyButton.tsx
+++ b/ui-react/apps/console/src/components/common/CopyButton.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outline";
-import { useCopy } from "./ClipboardProvider";
+import { useCopy } from "@/hooks/useCopy";
 
 const sizes = {
   sm: { button: "p-1 rounded", icon: "w-3.5 h-3.5" },

--- a/ui-react/apps/console/src/components/common/CopyWarning.tsx
+++ b/ui-react/apps/console/src/components/common/CopyWarning.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, ReactNode, useCallback, useEffect, useImperativeHandle, useRef } from "react";
-import { useCopy } from "./ClipboardProvider";
+import { useCopy } from "@/hooks/useCopy";
 
 export interface CopyWarningRenderProps {
   /** Triggers a clipboard copy. Shows the warning dialog if clipboard access

--- a/ui-react/apps/console/src/components/common/__tests__/ClipboardProvider.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/ClipboardProvider.test.tsx
@@ -7,7 +7,8 @@ vi.mock("@/hooks/useFocusTrap", () => ({
   useFocusTrap: vi.fn(),
 }));
 
-import { ClipboardProvider, useCopy } from "../ClipboardProvider";
+import { ClipboardProvider } from "../ClipboardProvider";
+import { useCopy } from "@/hooks/useCopy";
 
 // ─── clipboard setup ──────────────────────────────────────────────────────────
 

--- a/ui-react/apps/console/src/hooks/useCopy.ts
+++ b/ui-react/apps/console/src/hooks/useCopy.ts
@@ -1,0 +1,72 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+export interface ClipboardContextValue {
+  triggerWarning: () => void;
+}
+
+export const ClipboardContext = createContext<ClipboardContextValue | null>(null);
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+interface UseCopyResult {
+  /** Call with the text to copy. Shows the warning dialog when clipboard access
+   *  is unavailable (insecure context or API error). */
+  copy: (text: string) => void;
+  /** True for 1500 ms after a successful copy. Use for inline visual feedback. */
+  copied: boolean;
+}
+
+/**
+ * Safe clipboard copy with automatic insecure-context handling.
+ *
+ * Must be used within `<ClipboardProvider>`.
+ *
+ * ```tsx
+ * const { copy, copied } = useCopy();
+ * <button onClick={() => copy(deviceId)}>{copied ? "Copied!" : "Copy"}</button>
+ * ```
+ */
+export function useCopy(): UseCopyResult {
+  const ctx = useContext(ClipboardContext);
+  if (!ctx) throw new Error("useCopy must be used within <ClipboardProvider>");
+
+  const { triggerWarning } = ctx;
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const copy = useCallback(
+    (text: string) => {
+      if (!globalThis.isSecureContext) {
+        triggerWarning();
+        return;
+      }
+
+      navigator.clipboard.writeText(text).then(
+        () => {
+          if (timerRef.current) clearTimeout(timerRef.current);
+          setCopied(true);
+          timerRef.current = setTimeout(() => setCopied(false), 1500);
+        },
+        () => triggerWarning(),
+      );
+    },
+    [triggerWarning],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return { copy, copied };
+}


### PR DESCRIPTION
## What
Move the `useCopy` hook and its `ClipboardContext` out of
`ClipboardProvider.tsx` into a dedicated `hooks/useCopy.ts` module.

## Why
`ClipboardProvider.tsx` exported a component, a hook, and an interface
from the same file, tripping `react-refresh/only-export-components`:

    warning  Fast refresh only works when a file only exports components

Beyond the lint noise, the mixed exports broke HMR for the provider —
editing it triggered a full reload instead of a fast refresh.

## Changes
- **hooks/useCopy.ts**: new home for `ClipboardContext`, its value type,
  and the `useCopy` hook. The context is exported so the provider can
  consume it.
- **ClipboardProvider.tsx**: now a component-only module that imports
  `ClipboardContext` from `@/hooks/useCopy`.
- **CopyButton / CopyWarning / ClipboardProvider.test**: import
  `useCopy` from `@/hooks/useCopy` instead of the provider file.

## Testing
- `npm run lint` — no `react-refresh` warning on `ClipboardProvider.tsx`
- `npx vitest run src/components/common/__tests__/ClipboardProvider.test.tsx src/components/common/__tests__/CopyWarning.test.tsx` — 33 tests pass