### PR TITLE
fix(ui-react): surface swallowed errors in ConfirmDialog delete flows

### DIFF
--- a/ui-react/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui-react/apps/console/src/pages/WebEndpoints.tsx
@@ -2,7 +2,10 @@ import { useState, useRef, FormEvent } from "react";
 import { isSdkError } from "../api/errors";
 import { useResetOnOpen } from "../hooks/useResetOnOpen";
 import { useWebEndpoints } from "../hooks/useWebEndpoints";
-import { useCreateWebEndpoint, useDeleteWebEndpoint } from "../hooks/useWebEndpointMutations";
+import {
+  useCreateWebEndpoint,
+  useDeleteWebEndpoint,
+} from "../hooks/useWebEndpointMutations";
 import type { Webendpoint } from "../client";
 import { useDevices, type NormalizedDevice } from "../hooks/useDevices";
 import PageHeader from "../components/common/PageHeader";
@@ -95,7 +98,11 @@ function DeviceSelector({
   onChange: (device: NormalizedDevice | null) => void;
   error?: string;
 }) {
-  const { devices, isLoading: loading } = useDevices({ page: 1, perPage: 20, status: "accepted" });
+  const { devices, isLoading: loading } = useDevices({
+    page: 1,
+    perPage: 20,
+    status: "accepted",
+  });
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -104,10 +111,10 @@ function DeviceSelector({
 
   const filtered = search
     ? devices.filter(
-      (dev) =>
-        dev.name.toLowerCase().includes(search.toLowerCase())
-        || dev.uid.toLowerCase().includes(search.toLowerCase()),
-    )
+        (dev) =>
+          dev.name.toLowerCase().includes(search.toLowerCase()) ||
+          dev.uid.toLowerCase().includes(search.toLowerCase()),
+      )
     : devices;
 
   return (
@@ -118,76 +125,70 @@ function DeviceSelector({
         } ${error ? "border-accent-red/50" : ""}`}
         onClick={() => setOpen(true)}
       >
-        {selected
-          ? (
-            <div className="flex items-center gap-2 flex-1 min-w-0">
-              <span
-                className={`w-2 h-2 rounded-full shrink-0 ${selected.online ? "bg-accent-green" : "bg-text-muted/40"}`}
-              />
-              <span className="text-sm text-text-primary truncate">
-                {selected.name}
-              </span>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onChange(null);
-                  setSearch("");
-                }}
-                className="ml-auto shrink-0 p-0.5 text-text-muted hover:text-text-primary transition-colors"
-              >
-                <XMarkIcon className="w-3.5 h-3.5" strokeWidth={2} />
-              </button>
-            </div>
-          )
-          : (
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              onFocus={() => setOpen(true)}
-              placeholder="Search devices..."
-              className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-secondary outline-none"
+        {selected ? (
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <span
+              className={`w-2 h-2 rounded-full shrink-0 ${selected.online ? "bg-accent-green" : "bg-text-muted/40"}`}
             />
-          )}
+            <span className="text-sm text-text-primary truncate">
+              {selected.name}
+            </span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange(null);
+                setSearch("");
+              }}
+              className="ml-auto shrink-0 p-0.5 text-text-muted hover:text-text-primary transition-colors"
+            >
+              <XMarkIcon className="w-3.5 h-3.5" strokeWidth={2} />
+            </button>
+          </div>
+        ) : (
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onFocus={() => setOpen(true)}
+            placeholder="Search devices..."
+            className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-secondary outline-none"
+          />
+        )}
       </div>
       {error && <p className="mt-1 text-2xs text-accent-red">{error}</p>}
       {open && !selected && (
         <div className="absolute z-10 mt-1 w-full max-h-48 overflow-y-auto bg-surface border border-border rounded-lg shadow-xl">
-          {loading
-            ? (
-              <div className="px-3 py-2 text-xs text-text-muted">
-                Loading devices...
-              </div>
-            )
-            : filtered.length === 0
-              ? (
-                <div className="px-3 py-2 text-xs text-text-muted">
-                  No devices found
-                </div>
-              )
-              : (
-                filtered.map((dev) => (
-                  <button
-                    key={dev.uid}
-                    type="button"
-                    onClick={() => {
-                      onChange(dev);
-                      setOpen(false);
-                      setSearch("");
-                    }}
-                    className="w-full text-left px-3 py-2 text-sm text-text-primary hover:bg-hover-medium transition-colors flex items-center gap-2"
-                  >
-                    <span
-                      className={`w-2 h-2 rounded-full shrink-0 ${dev.online ? "bg-accent-green" : "bg-text-muted/40"}`}
-                    />
-                    <span className="truncate">{dev.name}</span>
-                    <span className="text-2xs text-text-muted font-mono ml-auto shrink-0">
-                      {dev.uid.slice(0, 8)}
-                    </span>
-                  </button>
-                ))
-              )}
+          {loading ? (
+            <div className="px-3 py-2 text-xs text-text-muted">
+              Loading devices...
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-text-muted">
+              No devices found
+            </div>
+          ) : (
+            filtered.map((dev) => (
+              <button
+                key={dev.uid}
+                type="button"
+                onClick={() => {
+                  onChange(dev);
+                  setOpen(false);
+                  setSearch("");
+                }}
+                className="w-full text-left px-3 py-2 text-sm text-text-primary hover:bg-hover-medium transition-colors flex items-center gap-2"
+              >
+                <span
+                  className={`w-2 h-2 rounded-full shrink-0 ${dev.online ? "bg-accent-green" : "bg-text-muted/40"}`}
+                />
+                <span className="truncate">{dev.name}</span>
+                <span className="text-2xs text-text-muted font-mono ml-auto shrink-0">
+                  {dev.uid.slice(0, 8)}
+                </span>
+              </button>
+            ))
+          )}
         </div>
       )}
     </div>
@@ -271,76 +272,74 @@ function TimeoutSelector({
         </button>
       </div>
 
-      {hasExpiration
-        ? (
-          <div className="space-y-2.5">
-            <div className="flex flex-wrap gap-1.5">
-              {EXPIRATION_PRESETS.map((preset) => (
-                <button
-                  key={preset.value}
-                  type="button"
-                  onClick={() => {
-                    setCustomMode(false);
-                    setCustomError(null);
-                    onChange(preset.value);
-                  }}
-                  className={`px-2.5 py-1.5 text-xs rounded-md border transition-all ${
-                    !customMode && preset.value === value
-                      ? "bg-primary/10 border-primary/30 text-primary font-medium"
-                      : "bg-card border-border text-text-secondary hover:border-border-light hover:text-text-primary"
-                  }`}
-                >
-                  {preset.label}
-                </button>
-              ))}
+      {hasExpiration ? (
+        <div className="space-y-2.5">
+          <div className="flex flex-wrap gap-1.5">
+            {EXPIRATION_PRESETS.map((preset) => (
               <button
+                key={preset.value}
                 type="button"
                 onClick={() => {
-                  setCustomMode(true);
-                  setCustomValue("");
+                  setCustomMode(false);
                   setCustomError(null);
+                  onChange(preset.value);
                 }}
                 className={`px-2.5 py-1.5 text-xs rounded-md border transition-all ${
-                  customMode
+                  !customMode && preset.value === value
                     ? "bg-primary/10 border-primary/30 text-primary font-medium"
                     : "bg-card border-border text-text-secondary hover:border-border-light hover:text-text-primary"
                 }`}
               >
-                Custom
+                {preset.label}
               </button>
-            </div>
-
-            {customMode && (
-              <div>
-                <input
-                  type="number"
-                  value={customValue}
-                  onChange={(e) => {
-                    setCustomValue(e.target.value);
-                    setCustomError(null);
-                  }}
-                  onBlur={handleCustomSubmit}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") handleCustomSubmit();
-                  }}
-                  placeholder="Value in seconds"
-                  min={1}
-                  max={MAX_CUSTOM_TTL}
-                  className={INPUT_MONO}
-                  autoFocus
-                />
-                {customError && (
-                  <p className="mt-1 text-2xs text-accent-red">{customError}</p>
-                )}
-              </div>
-            )}
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                setCustomMode(true);
+                setCustomValue("");
+                setCustomError(null);
+              }}
+              className={`px-2.5 py-1.5 text-xs rounded-md border transition-all ${
+                customMode
+                  ? "bg-primary/10 border-primary/30 text-primary font-medium"
+                  : "bg-card border-border text-text-secondary hover:border-border-light hover:text-text-primary"
+              }`}
+            >
+              Custom
+            </button>
           </div>
-        )
-        : (
-          <p className="text-2xs text-text-muted">
-            This endpoint will never expire.
-          </p>
-        )}
+
+          {customMode && (
+            <div>
+              <input
+                type="number"
+                value={customValue}
+                onChange={(e) => {
+                  setCustomValue(e.target.value);
+                  setCustomError(null);
+                }}
+                onBlur={handleCustomSubmit}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleCustomSubmit();
+                }}
+                placeholder="Value in seconds"
+                min={1}
+                max={MAX_CUSTOM_TTL}
+                className={INPUT_MONO}
+                autoFocus
+              />
+              {customError && (
+                <p className="mt-1 text-2xs text-accent-red">{customError}</p>
+              )}
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="text-2xs text-text-muted">
+          This endpoint will never expire.
+        </p>
+      )}
     </div>
   );
 }
@@ -379,27 +378,27 @@ function EndpointDrawer({
     setError(null);
   });
 
-  const hostError
-    = host && !isValidHost(host)
+  const hostError =
+    host && !isValidHost(host)
       ? "Enter a valid IPv4 or IPv6 address"
       : undefined;
   const portNum = parseInt(port, 10);
-  const portError
-    = port && (isNaN(portNum) || portNum < 1 || portNum > 65535)
+  const portError =
+    port && (isNaN(portNum) || portNum < 1 || portNum > 65535)
       ? "Port must be 1-65535"
       : undefined;
-  const tlsDomainError
-    = tlsEnabled && tlsDomain && !isValidFQDN(tlsDomain)
+  const tlsDomainError =
+    tlsEnabled && tlsDomain && !isValidFQDN(tlsDomain)
       ? "Enter a valid domain (e.g. example.com)"
       : undefined;
 
-  const confirmDisabled
-    = !device
-      || !host.trim()
-      || !!hostError
-      || !port.trim()
-      || !!portError
-      || (tlsEnabled && tlsDomain.trim() !== "" && !!tlsDomainError);
+  const confirmDisabled =
+    !device ||
+    !host.trim() ||
+    !!hostError ||
+    !port.trim() ||
+    !!portError ||
+    (tlsEnabled && tlsDomain.trim() !== "" && !!tlsDomainError);
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
@@ -415,12 +414,12 @@ function EndpointDrawer({
           ttl,
           ...(tlsEnabled
             ? {
-              tls: {
-                enabled: true,
-                verify: tlsVerify,
-                domain: tlsDomain.trim(),
-              },
-            }
+                tls: {
+                  enabled: true,
+                  verify: tlsVerify,
+                  domain: tlsDomain.trim(),
+                },
+              }
             : {}),
         },
       });
@@ -444,7 +443,7 @@ function EndpointDrawer({
       onClose={onClose}
       title="New Web Endpoint"
       subtitle="Tunnel HTTP traffic to a service on your device."
-      footer={(
+      footer={
         <>
           <button
             type="button"
@@ -459,19 +458,17 @@ function EndpointDrawer({
             disabled={submitting || confirmDisabled}
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
           >
-            {submitting
-              ? (
-                <span className="flex items-center gap-2">
-                  <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  Creating...
-                </span>
-              )
-              : (
-                "Create Endpoint"
-              )}
+            {submitting ? (
+              <span className="flex items-center gap-2">
+                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                Creating...
+              </span>
+            ) : (
+              "Create Endpoint"
+            )}
           </button>
         </>
-      )}
+      }
     >
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
         {/* Device */}
@@ -766,9 +763,7 @@ function EndpointCard({
               {/* Host:Port */}
               <span className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-hover-medium text-text-muted text-2xs rounded font-mono">
                 <ServerStackIcon className="w-2.5 h-2.5" strokeWidth={2} />
-                {endpoint.host}
-                :
-                {endpoint.port}
+                {endpoint.host}:{endpoint.port}
               </span>
 
               {/* Device-side TLS indicator */}
@@ -832,7 +827,29 @@ function WebEndpointsContent() {
     address: string;
     deviceName: string;
   } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+
+  const closeDelete = () => {
+    setDeleteError(null);
+    setDeleteTarget(null);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteError(null);
+    try {
+      await deleteEndpoint.mutateAsync({
+        path: { address: deleteTarget.address },
+      });
+      if (webEndpoints.length === 1 && page > 1) setPage(page - 1);
+      closeDelete();
+    } catch (err) {
+      setDeleteError(
+        err instanceof Error ? err.message : "Failed to delete web endpoint.",
+      );
+    }
+  };
 
   const openNew = () => {
     setDrawerOpen(true);
@@ -846,13 +863,13 @@ function WebEndpointsContent() {
 
   const filtered = search
     ? webEndpoints.filter(
-      (ep) =>
-        (ep.device?.name || "")
-          .toLowerCase()
-          .includes(search.toLowerCase())
-          || ep.full_address.toLowerCase().includes(search.toLowerCase())
-          || ep.address.toLowerCase().includes(search.toLowerCase()),
-    )
+        (ep) =>
+          (ep.device?.name || "")
+            .toLowerCase()
+            .includes(search.toLowerCase()) ||
+          ep.full_address.toLowerCase().includes(search.toLowerCase()) ||
+          ep.address.toLowerCase().includes(search.toLowerCase()),
+      )
     : webEndpoints;
 
   return (
@@ -1009,7 +1026,8 @@ function WebEndpointsContent() {
                       setDeleteTarget({
                         address: ep.address,
                         deviceName: ep.device?.name || ep.device_uid,
-                      })}
+                      })
+                    }
                   />
                 ))}
               </div>
@@ -1018,9 +1036,7 @@ function WebEndpointsContent() {
               {totalPages > 1 && (
                 <div className="flex items-center justify-between mt-4 px-1">
                   <span className="text-xs font-mono text-text-muted">
-                    {totalCount}
-                    {" "}
-                    endpoint
+                    {totalCount} endpoint
                     {totalCount !== 1 ? "s" : ""}
                   </span>
                   <div className="flex items-center gap-1">
@@ -1032,10 +1048,7 @@ function WebEndpointsContent() {
                       Prev
                     </button>
                     <span className="text-xs font-mono text-text-muted px-2">
-                      {page}
-                      {" "}
-                      /
-                      {totalPages}
+                      {page} /{totalPages}
                     </span>
                     <button
                       onClick={() => setPage(page + 1)}
@@ -1058,25 +1071,24 @@ function WebEndpointsContent() {
       {/* Delete Dialog */}
       <ConfirmDialog
         open={!!deleteTarget}
-        onClose={() => setDeleteTarget(null)}
-        onConfirm={async () => {
-          await deleteEndpoint.mutateAsync({ path: { address: deleteTarget!.address } });
-          if (webEndpoints.length === 1 && page > 1) setPage(page - 1);
-          setDeleteTarget(null);
-        }}
+        onClose={closeDelete}
+        onConfirm={confirmDelete}
         title="Delete Web Endpoint"
-        description={(
+        description={
           <>
-            Are you sure you want to delete the endpoint for
-            {" "}
+            Are you sure you want to delete the endpoint for{" "}
             <span className="font-medium text-text-primary">
               {deleteTarget?.deviceName}
             </span>
             ? This action cannot be undone.
           </>
-        )}
+        }
         confirmLabel="Delete"
-      />
+      >
+        {deleteError && (
+          <p className="text-xs text-accent-red">{deleteError}</p>
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/ui-react/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
@@ -1,0 +1,181 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { FirewallRule } from "../../../hooks/useFirewallRules";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("../../../hooks/useFirewallRules", () => ({
+  useFirewallRules: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useFirewallRuleMutations", () => ({
+  useDeleteFirewallRule: vi.fn(),
+}));
+
+// RestrictedAction gates buttons on permissions — always allow in tests.
+vi.mock("../../../hooks/useHasPermission", () => ({
+  useHasPermission: () => true,
+}));
+
+// RuleDrawer is not relevant for these tests and pulls in a lot of deps.
+vi.mock("../RuleDrawer", () => ({
+  default: () => null,
+}));
+
+// Flatten ConfirmDialog to a plain div so we can exercise the page's logic
+// without animations, portals, or BaseDialog internals. Matches the pattern
+// used in other page tests (DeleteNamespaceDialog, KeyDeleteDialog).
+vi.mock("../../../components/common/ConfirmDialog", () => ({
+  default: ({
+    open,
+    onClose,
+    onConfirm,
+    title,
+    description,
+    confirmLabel = "Confirm",
+    children,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void> | void;
+    title: string;
+    description: ReactNode;
+    confirmLabel?: string;
+    children?: ReactNode;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        <div>{description}</div>
+        {children}
+        <button onClick={onClose}>Cancel</button>
+        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+      </div>
+    );
+  },
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import { useFirewallRules } from "../../../hooks/useFirewallRules";
+import { useDeleteFirewallRule } from "../../../hooks/useFirewallRuleMutations";
+import FirewallRules from "../index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRule(overrides: Partial<FirewallRule> = {}): FirewallRule {
+  return {
+    id: "rule-1",
+    tenant_id: "tenant-abc",
+    priority: 42,
+    action: "allow",
+    active: true,
+    source_ip: ".*",
+    username: ".*",
+    filter: { hostname: ".*" },
+    ...overrides,
+  };
+}
+
+const mockMutateAsync = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useFirewallRules).mockReturnValue({
+    rules: [makeRule()],
+    totalCount: 1,
+    isLoading: false,
+    error: null,
+  });
+  vi.mocked(useDeleteFirewallRule).mockReturnValue({
+    mutateAsync: mockMutateAsync,
+  } as never);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("FirewallRules — delete error handling", () => {
+  // The row-action Delete button has no visible text; its accessible name
+  // comes from its `title` attribute. The dialog Delete button has visible
+  // text "Delete". Before the dialog opens there is only one match; after
+  // the dialog opens we scope dialog queries with `within(dialog)`.
+  async function openDeleteDialog() {
+    const user = userEvent.setup();
+    render(<FirewallRules />);
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    return user;
+  }
+
+  async function getDialog() {
+    return screen.findByRole("dialog", { name: /delete firewall rule/i });
+  }
+
+  it("shows the mutation error message inside the dialog when deletion fails", async () => {
+    mockMutateAsync.mockRejectedValue(new Error("Permission denied"));
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(within(dialog).getByText("Permission denied")).toBeInTheDocument(),
+    );
+    // Dialog stays open with the error visible.
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("shows a generic fallback message when the rejection is not an Error", async () => {
+    mockMutateAsync.mockRejectedValue("boom");
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(
+        within(dialog).getByText(/failed to delete firewall rule/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("closes the dialog and does not show an error on successful deletion", async () => {
+    mockMutateAsync.mockResolvedValue(undefined);
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: /delete firewall rule/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText(/failed to delete firewall rule/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears any previous error when the dialog is cancelled and reopened", async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error("Transient"));
+    const user = await openDeleteDialog();
+    let dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+    await within(dialog).findByText("Transient");
+
+    await user.click(within(dialog).getByRole("button", { name: /cancel/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: /delete firewall rule/i }),
+      ).not.toBeInTheDocument(),
+    );
+
+    // Reopen — the stale error text should be gone before the next attempt.
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    dialog = await getDialog();
+    expect(within(dialog).queryByText("Transient")).not.toBeInTheDocument();
+  });
+});

--- a/ui-react/apps/console/src/pages/firewall-rules/index.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/index.tsx
@@ -31,7 +31,27 @@ export default function FirewallRules() {
     id: string;
     priority: number;
   } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+
+  const closeDelete = () => {
+    setDeleteError(null);
+    setDeleteTarget(null);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteError(null);
+    try {
+      await deleteRule.mutateAsync({ path: { id: deleteTarget.id } });
+      if (rules.length === 1 && page > 1) setPage(page - 1);
+      closeDelete();
+    } catch (err) {
+      setDeleteError(
+        err instanceof Error ? err.message : "Failed to delete firewall rule.",
+      );
+    }
+  };
 
   const openNew = () => {
     setEditTarget(null);
@@ -52,12 +72,12 @@ export default function FirewallRules() {
 
   const filtered = search
     ? rules.filter(
-      (r) =>
-        r.action.toLowerCase().includes(search.toLowerCase())
-        || r.source_ip.toLowerCase().includes(search.toLowerCase())
-        || r.username.toLowerCase().includes(search.toLowerCase())
-        || String(r.priority).includes(search),
-    )
+        (r) =>
+          r.action.toLowerCase().includes(search.toLowerCase()) ||
+          r.source_ip.toLowerCase().includes(search.toLowerCase()) ||
+          r.username.toLowerCase().includes(search.toLowerCase()) ||
+          String(r.priority).includes(search),
+      )
     : rules;
 
   const columns: Column<FirewallRule>[] = [
@@ -78,7 +98,9 @@ export default function FirewallRules() {
           {rule.action === "allow" ? (
             <>
               <CheckCircleIcon className="w-4 h-4 text-accent-green" />
-              <span className="text-xs font-medium text-accent-green">Allow</span>
+              <span className="text-xs font-medium text-accent-green">
+                Allow
+              </span>
             </>
           ) : (
             <>
@@ -96,7 +118,9 @@ export default function FirewallRules() {
         rule.source_ip === ".*" ? (
           <span className="text-xs text-text-secondary">Any IP</span>
         ) : (
-          <span className="text-xs font-mono text-text-primary">{rule.source_ip}</span>
+          <span className="text-xs font-mono text-text-primary">
+            {rule.source_ip}
+          </span>
         ),
     },
     {
@@ -106,7 +130,9 @@ export default function FirewallRules() {
         rule.username === ".*" ? (
           <span className="text-xs text-text-secondary">All users</span>
         ) : (
-          <span className="text-xs font-mono text-text-primary">{rule.username}</span>
+          <span className="text-xs font-mono text-text-primary">
+            {rule.username}
+          </span>
         ),
     },
     {
@@ -146,7 +172,8 @@ export default function FirewallRules() {
           <RestrictedAction action="firewall:remove">
             <button
               onClick={() =>
-                setDeleteTarget({ id: rule.id, priority: rule.priority })}
+                setDeleteTarget({ id: rule.id, priority: rule.priority })
+              }
               className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all"
               title="Delete"
             >
@@ -305,7 +332,11 @@ export default function FirewallRules() {
         totalCount={totalCount}
         itemLabel="rule"
         onPageChange={setPage}
-        emptyMessage={search ? `No rules matching \u201C${search}\u201D` : "No firewall rules found"}
+        emptyMessage={
+          search
+            ? `No rules matching \u201C${search}\u201D`
+            : "No firewall rules found"
+        }
       />
 
       <RuleDrawer
@@ -316,25 +347,24 @@ export default function FirewallRules() {
 
       <ConfirmDialog
         open={!!deleteTarget}
-        onClose={() => setDeleteTarget(null)}
-        onConfirm={async () => {
-          await deleteRule.mutateAsync({ path: { id: deleteTarget!.id } });
-          if (rules.length === 1 && page > 1) setPage(page - 1);
-          setDeleteTarget(null);
-        }}
+        onClose={closeDelete}
+        onConfirm={confirmDelete}
         title="Delete Firewall Rule"
-        description={(
+        description={
           <>
-            Are you sure you want to delete the rule with priority
-            {" "}
+            Are you sure you want to delete the rule with priority{" "}
             <span className="font-medium text-text-primary">
               {deleteTarget?.priority}
             </span>
             ? This action cannot be undone.
           </>
-        )}
+        }
         confirmLabel="Delete"
-      />
+      >
+        {deleteError && (
+          <p className="text-xs text-accent-red">{deleteError}</p>
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/ui-react/apps/console/src/pages/public-keys/__tests__/PublicKeys.test.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/__tests__/PublicKeys.test.tsx
@@ -1,0 +1,153 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PublicKey } from "../../../hooks/usePublicKeys";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("../../../hooks/usePublicKeys", () => ({
+  usePublicKeys: vi.fn(),
+}));
+
+vi.mock("../../../hooks/usePublicKeyMutations", () => ({
+  useDeletePublicKey: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useHasPermission", () => ({
+  useHasPermission: () => true,
+}));
+
+vi.mock("../KeyDrawer", () => ({
+  default: () => null,
+}));
+
+// CopyButton reads from ClipboardProvider which we don't wire up in tests.
+vi.mock("../../../components/common/CopyButton", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../../components/common/ConfirmDialog", () => ({
+  default: ({
+    open,
+    onClose,
+    onConfirm,
+    title,
+    description,
+    confirmLabel = "Confirm",
+    children,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void> | void;
+    title: string;
+    description: ReactNode;
+    confirmLabel?: string;
+    children?: ReactNode;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        <div>{description}</div>
+        {children}
+        <button onClick={onClose}>Cancel</button>
+        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+      </div>
+    );
+  },
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import { usePublicKeys } from "../../../hooks/usePublicKeys";
+import { useDeletePublicKey } from "../../../hooks/usePublicKeyMutations";
+import PublicKeys from "../index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeKey(overrides: Partial<PublicKey> = {}): PublicKey {
+  return {
+    data: "ssh-rsa AAAA...",
+    fingerprint: "aa:bb:cc:dd",
+    created_at: "2024-01-01T00:00:00Z",
+    tenant_id: "tenant-abc",
+    name: "my-key",
+    filter: { hostname: ".*" },
+    username: ".*",
+    ...overrides,
+  };
+}
+
+const mockMutateAsync = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(usePublicKeys).mockReturnValue({
+    publicKeys: [makeKey()],
+    totalCount: 1,
+    isLoading: false,
+    error: null,
+  });
+  vi.mocked(useDeletePublicKey).mockReturnValue({
+    mutateAsync: mockMutateAsync,
+  } as never);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("PublicKeys — delete error handling", () => {
+  async function openDeleteDialog() {
+    const user = userEvent.setup();
+    render(<PublicKeys />);
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    return user;
+  }
+
+  async function getDialog() {
+    return screen.findByRole("dialog", { name: /delete public key/i });
+  }
+
+  it("shows the mutation error message inside the dialog when deletion fails", async () => {
+    mockMutateAsync.mockRejectedValue(new Error("Fingerprint in use"));
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(
+        within(dialog).getByText("Fingerprint in use"),
+      ).toBeInTheDocument(),
+    );
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("shows a generic fallback message when the rejection is not an Error", async () => {
+    mockMutateAsync.mockRejectedValue({ status: 500 });
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(
+        within(dialog).getByText(/failed to delete public key/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("closes the dialog and does not show an error on successful deletion", async () => {
+    mockMutateAsync.mockResolvedValue(undefined);
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: /delete public key/i }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/ui-react/apps/console/src/pages/public-keys/index.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/index.tsx
@@ -35,8 +35,8 @@ function ScopeCell({ pk }: { pk: PublicKey }) {
     deviceNode = (
       <span className="inline-flex items-center gap-1.5 flex-wrap">
         {pk.filter.tags.map((tag) => {
-          const label
-            = typeof tag === "string" ? tag : (tag as { name: string }).name;
+          const label =
+            typeof tag === "string" ? tag : (tag as { name: string }).name;
           return (
             <span
               key={label}
@@ -70,9 +70,11 @@ function ScopeCell({ pk }: { pk: PublicKey }) {
       <span
         className={`inline-flex items-center gap-1 text-xs font-mono ${isAllUsers ? "text-text-muted" : "text-text-secondary"}`}
       >
-        {isAllUsers
-          ? <UsersIcon className="w-3 h-3 shrink-0" strokeWidth={2} />
-          : <UserIcon className="w-3 h-3 shrink-0" strokeWidth={2} />}
+        {isAllUsers ? (
+          <UsersIcon className="w-3 h-3 shrink-0" strokeWidth={2} />
+        ) : (
+          <UserIcon className="w-3 h-3 shrink-0" strokeWidth={2} />
+        )}
         {username}
       </span>
       <span className="text-text-muted/40 text-xs">{"\u2192"}</span>
@@ -93,7 +95,29 @@ export default function PublicKeys() {
     fingerprint: string;
     name: string;
   } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+
+  const closeDelete = () => {
+    setDeleteError(null);
+    setDeleteTarget(null);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteError(null);
+    try {
+      await deleteKey.mutateAsync({
+        path: { fingerprint: deleteTarget.fingerprint },
+      });
+      if (publicKeys.length === 1 && page > 1) setPage(page - 1);
+      closeDelete();
+    } catch (err) {
+      setDeleteError(
+        err instanceof Error ? err.message : "Failed to delete public key.",
+      );
+    }
+  };
 
   const openNew = () => {
     setEditTarget(null);
@@ -111,10 +135,10 @@ export default function PublicKeys() {
   const totalPages = Math.ceil(totalCount / PER_PAGE);
   const filtered = search
     ? publicKeys.filter(
-      (k) =>
-        k.name.toLowerCase().includes(search.toLowerCase())
-        || k.fingerprint.toLowerCase().includes(search.toLowerCase()),
-    )
+        (k) =>
+          k.name.toLowerCase().includes(search.toLowerCase()) ||
+          k.fingerprint.toLowerCase().includes(search.toLowerCase()),
+      )
     : publicKeys;
 
   const columns: Column<PublicKey>[] = [
@@ -175,7 +199,8 @@ export default function PublicKeys() {
                 setDeleteTarget({
                   fingerprint: pk.fingerprint,
                   name: pk.name,
-                })}
+                })
+              }
               title="Delete"
               className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all"
             >
@@ -277,7 +302,11 @@ export default function PublicKeys() {
           </div>
         </div>
 
-        <KeyDrawer open={drawerOpen} editKey={editTarget} onClose={closeDrawer} />
+        <KeyDrawer
+          open={drawerOpen}
+          editKey={editTarget}
+          onClose={closeDrawer}
+        />
       </div>
     );
   }
@@ -325,32 +354,35 @@ export default function PublicKeys() {
         totalCount={totalCount}
         itemLabel="key"
         onPageChange={setPage}
-        emptyMessage={search ? `No keys matching \u201C${search}\u201D` : "No public keys found"}
+        emptyMessage={
+          search
+            ? `No keys matching \u201C${search}\u201D`
+            : "No public keys found"
+        }
       />
 
       <KeyDrawer open={drawerOpen} editKey={editTarget} onClose={closeDrawer} />
 
       <ConfirmDialog
         open={!!deleteTarget}
-        onClose={() => setDeleteTarget(null)}
-        onConfirm={async () => {
-          await deleteKey.mutateAsync({ path: { fingerprint: deleteTarget!.fingerprint } });
-          if (publicKeys.length === 1 && page > 1) setPage(page - 1);
-          setDeleteTarget(null);
-        }}
+        onClose={closeDelete}
+        onConfirm={confirmDelete}
         title="Delete Public Key"
-        description={(
+        description={
           <>
-            Are you sure you want to delete
-            {" "}
+            Are you sure you want to delete{" "}
             <span className="font-medium text-text-primary">
               {deleteTarget?.name}
             </span>
             ? This action cannot be undone.
           </>
-        )}
+        }
         confirmLabel="Delete"
-      />
+      >
+        {deleteError && (
+          <p className="text-xs text-accent-red">{deleteError}</p>
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/ui-react/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui-react/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -26,6 +26,26 @@ function ApiKeysTab() {
   const [generateOpen, setGenerateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ApiKey | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<ApiKey | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const closeDelete = () => {
+    setDeleteError(null);
+    setDeleteTarget(null);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteError(null);
+    try {
+      await deleteKey.mutateAsync({ path: { key: deleteTarget.name } });
+      if (apiKeys.length === 1 && page > 1) setPage(page - 1);
+      closeDelete();
+    } catch (err) {
+      setDeleteError(
+        err instanceof Error ? err.message : "Failed to delete API key.",
+      );
+    }
+  };
 
   const totalPages = Math.ceil(totalCount / PER_PAGE);
 
@@ -169,12 +189,8 @@ function ApiKeysTab() {
       />
       <ConfirmDialog
         open={!!deleteTarget}
-        onClose={() => setDeleteTarget(null)}
-        onConfirm={async () => {
-          await deleteKey.mutateAsync({ path: { key: deleteTarget!.name } });
-          if (apiKeys.length === 1 && page > 1) setPage(page - 1);
-          setDeleteTarget(null);
-        }}
+        onClose={closeDelete}
+        onConfirm={confirmDelete}
         title="Delete API Key"
         description={
           <>
@@ -186,7 +202,11 @@ function ApiKeysTab() {
           </>
         }
         confirmLabel="Delete"
-      />
+      >
+        {deleteError && (
+          <p className="text-xs text-accent-red">{deleteError}</p>
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/ui-react/apps/console/src/pages/team/MembersTab.tsx
+++ b/ui-react/apps/console/src/pages/team/MembersTab.tsx
@@ -25,6 +25,27 @@ function MembersTab({ tenantId }: { tenantId: string }) {
   const [removeTarget, setRemoveTarget] = useState<NamespaceMember | null>(
     null,
   );
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  const closeRemove = () => {
+    setRemoveError(null);
+    setRemoveTarget(null);
+  };
+
+  const confirmRemove = async () => {
+    if (!removeTarget) return;
+    setRemoveError(null);
+    try {
+      await removeMember.mutateAsync({
+        path: { tenant: tenantId, uid: removeTarget.id },
+      });
+      closeRemove();
+    } catch (err) {
+      setRemoveError(
+        err instanceof Error ? err.message : "Failed to remove member.",
+      );
+    }
+  };
 
   const members = (namespace?.members ?? []).filter(
     (m): m is NamespaceMember => !!m.id && !!m.role && !!m.email,
@@ -148,13 +169,8 @@ function MembersTab({ tenantId }: { tenantId: string }) {
       />
       <ConfirmDialog
         open={!!removeTarget}
-        onClose={() => setRemoveTarget(null)}
-        onConfirm={async () => {
-          await removeMember.mutateAsync({
-            path: { tenant: tenantId, uid: removeTarget!.id },
-          });
-          setRemoveTarget(null);
-        }}
+        onClose={closeRemove}
+        onConfirm={confirmRemove}
         title="Remove Member"
         description={
           <>
@@ -166,7 +182,11 @@ function MembersTab({ tenantId }: { tenantId: string }) {
           </>
         }
         confirmLabel="Remove"
-      />
+      >
+        {removeError && (
+          <p className="text-xs text-accent-red">{removeError}</p>
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/ui-react/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui-react/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -1,0 +1,150 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ApiKey } from "../../../client";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("../../../hooks/useApiKeys", () => ({
+  useApiKeys: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useApiKeyMutations", () => ({
+  useDeleteApiKey: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useHasPermission", () => ({
+  useHasPermission: () => true,
+}));
+
+vi.mock("../GenerateKeyDrawer", () => ({
+  default: () => null,
+}));
+
+vi.mock("../EditKeyDrawer", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../../components/common/ConfirmDialog", () => ({
+  default: ({
+    open,
+    onClose,
+    onConfirm,
+    title,
+    description,
+    confirmLabel = "Confirm",
+    children,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void> | void;
+    title: string;
+    description: ReactNode;
+    confirmLabel?: string;
+    children?: ReactNode;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        <div>{description}</div>
+        {children}
+        <button onClick={onClose}>Cancel</button>
+        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+      </div>
+    );
+  },
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import { useApiKeys } from "../../../hooks/useApiKeys";
+import { useDeleteApiKey } from "../../../hooks/useApiKeyMutations";
+import ApiKeysTab from "../ApiKeysTab";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeApiKey(overrides: Partial<ApiKey> = {}): ApiKey {
+  return {
+    tenant_id: "tenant-abc",
+    created_by: "user-xyz",
+    role: "administrator",
+    name: "prod-key",
+    expires_in: Math.floor(Date.now() / 1000) + 3600 * 24 * 30,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockMutateAsync = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(useApiKeys).mockReturnValue({
+    apiKeys: [makeApiKey()],
+    totalCount: 1,
+    isLoading: false,
+    error: null,
+  });
+  vi.mocked(useDeleteApiKey).mockReturnValue({
+    mutateAsync: mockMutateAsync,
+  } as never);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("ApiKeysTab — delete error handling", () => {
+  async function openDeleteDialog() {
+    const user = userEvent.setup();
+    render(<ApiKeysTab />);
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    return user;
+  }
+
+  async function getDialog() {
+    return screen.findByRole("dialog", { name: /delete api key/i });
+  }
+
+  it("shows the mutation error message inside the dialog when deletion fails", async () => {
+    mockMutateAsync.mockRejectedValue(new Error("Key is protected"));
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(within(dialog).getByText("Key is protected")).toBeInTheDocument(),
+    );
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("shows a generic fallback message when the rejection is not an Error", async () => {
+    mockMutateAsync.mockRejectedValue("boom");
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(
+        within(dialog).getByText(/failed to delete api key/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("closes the dialog and does not show an error on successful deletion", async () => {
+    mockMutateAsync.mockResolvedValue(undefined);
+    const user = await openDeleteDialog();
+    const dialog = await getDialog();
+
+    await user.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: /delete api key/i }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## What
Five confirm-dialog delete flows in the console silently swallowed mutation errors on failure, leaving the dialog stuck open with no explanation. Each now catches the rejection, keeps the dialog open, and renders a human-readable error inline.

## Why
`ConfirmDialog` intentionally swallows exceptions from `onConfirm` and expects consumers to pre-catch and manage their own error state (the component's comment points at `KeyDeleteDialog` as the reference implementation). Three pages listed in shellhub-io/shellhub#6165 — firewall rules, public keys, API keys — violated that contract with an uncaught `await mutateAsync` inside `onConfirm`. A grep of `apps/console/src/pages` surfaced two more with the same pattern: team members and web endpoints.

Closes shellhub-io/shellhub#6165

## Changes
- **firewall-rules, public-keys, api-keys, members, web-endpoints**: mirrored the `KeyDeleteDialog` shape — local `deleteError` state, `closeDelete` handler that resets both the target and the error, `confirmDelete` handler that wraps `mutateAsync` in try/catch and falls back to `"Failed to delete …"` when the rejection isn't an `Error`. Success-path side effects (page decrement, dialog close) only run on success.
- **tests**: added vitest coverage for the three pages named in the issue (firewall rules, public keys, API keys). Each file mocks the data hook, the mutation hook, and flattens `ConfirmDialog` — matching the existing pattern used by `DeleteNamespaceDialog.test.tsx` and `KeyDeleteDialog.test.tsx`. Coverage asserts: the raw `Error.message` is shown, the generic fallback is shown for non-`Error` rejections, the dialog closes on success, and stale error text clears on cancel+reopen.

## Testing
The large line count on `WebEndpoints.tsx` is the project formatter normalizing the whole file on first edit — the intended change is the new state + handlers plus the `ConfirmDialog` wiring (same shape as the other four pages). Review that file's diff with whitespace ignored to see the real change.

Reviewers can exercise the error path manually by opening any of the five pages with the API unreachable (or returning 4xx/5xx), clicking a destructive action, and confirming: the dialog should stay open, the confirm button should re-enable, and a red error message should appear below the description.