### PR TITLE
fix(ui-react): fix License page upload input on Chromium

### DIFF
--- a/ui-react/apps/console/src/components/common/LicenseGuard.tsx
+++ b/ui-react/apps/console/src/components/common/LicenseGuard.tsx
@@ -21,8 +21,10 @@ export default function LicenseGuard() {
     );
   }
 
+  const installedLicense = license && "grace_period" in license ? license : null;
+
   // Expired, missing, or error -> redirect to license page
-  if (isError || !license || license.expired) {
+  if (isError || !installedLicense || installedLicense.expired) {
     return <Navigate to="/admin/license" replace />;
   }
 

--- a/ui-react/apps/console/src/components/layout/AdminSidebar.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminSidebar.tsx
@@ -182,7 +182,8 @@ export default function AdminSidebar({
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
   const { pathname } = useLocation();
 
-  const isExpired = !isLoading && (!license || license.expired);
+  const installedLicense = license && "grace_period" in license ? license : null;
+  const isExpired = !isLoading && (!installedLicense || installedLicense.expired);
   const showRestrictedNav = !isAdmin || isLoading || isExpired;
   const isDisabled = !isAdmin;
 

--- a/ui-react/apps/console/src/hooks/useAdminLicense.ts
+++ b/ui-react/apps/console/src/hooks/useAdminLicense.ts
@@ -1,22 +1,34 @@
 import { useQuery } from "@tanstack/react-query";
 import {
-  getLicenseOptions,
   getLicenseQueryKey,
 } from "../client/@tanstack/react-query.gen";
+import { getLicense } from "../client";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
+import type { GetLicenseResponse } from "../client/types.gen";
 
 export { getLicenseQueryKey };
+
+type LicenseData = GetLicenseResponse | null;
 
 export function useAdminLicense() {
   const isAdmin = useAuthStore((s) => s.isAdmin);
 
-  return useQuery({
-    ...getLicenseOptions(),
+  return useQuery<LicenseData>({
+    queryKey: getLicenseQueryKey(),
+    queryFn: async ({ signal }) => {
+      try {
+        const { data } = await getLicense({ signal, throwOnError: true });
+        return data;
+      } catch (err) {
+        // 400 means no license stored; normalize to "no license" instead of error state.
+        if (isSdkError(err) && err.status === 400) return null;
+        throw err;
+      }
+    },
     enabled: isAdmin,
     staleTime: 5 * 60 * 1000, // 5 minutes
-    // 400 means no license stored — deterministic, no point retrying.
-    retry: (count, err) => isSdkError(err) && err.status === 400 ? false : count < 1,
+    retry: (count) => count < 1,
     // Prevent refetch when the OS file picker closes and returns focus to the window.
     refetchOnWindowFocus: false,
   });

--- a/ui-react/apps/console/src/pages/admin/License.tsx
+++ b/ui-react/apps/console/src/pages/admin/License.tsx
@@ -16,7 +16,6 @@ import PageHeader from "../../components/common/PageHeader";
 import CopyButton from "../../components/common/CopyButton";
 import { useAdminLicense } from "../../hooks/useAdminLicense";
 import { useUploadLicense } from "../../hooks/useUploadLicense";
-import { isSdkError } from "../../api/errors";
 import {
   formatLicenseTimestamp,
   formatDeviceCount,
@@ -365,16 +364,8 @@ function LicenseUpload() {
 
 /* ─── Page ─── */
 
-// The API returns 200 {} when license bytes are stored but unreadable.
-// It returns 400 when no license has been stored at all.
-// Both cases mean "not installed" — the generated type marks all fields as
-// required, but the runtime response can be an empty object.
-function isLicenseInstalled(data: GetLicenseResponse): boolean {
-  return "grace_period" in data;
-}
-
 export default function AdminLicense() {
-  const { data, isLoading, isError, error } = useAdminLicense();
+  const { data, isLoading, isError } = useAdminLicense();
 
   if (isLoading) {
     return (
@@ -388,10 +379,7 @@ export default function AdminLicense() {
     );
   }
 
-  // 400 = no license stored — show the upload form, not a generic error.
-  const isNoLicense = isError && isSdkError(error) && error.status === 400;
-
-  if (isError && !isNoLicense) {
+  if (isError) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center" role="alert">
@@ -403,7 +391,7 @@ export default function AdminLicense() {
     );
   }
 
-  const installed = !isNoLicense && data !== undefined && isLicenseInstalled(data);
+  const installedLicense = data && "grace_period" in data ? data : null;
 
   return (
     <div>
@@ -415,15 +403,15 @@ export default function AdminLicense() {
       />
 
       <div className="space-y-6 animate-fade-in">
-        <LicenseStatusAlert license={installed ? data : null} />
+        <LicenseStatusAlert license={installedLicense} />
 
-        {installed && (
+        {installedLicense && (
           <div className="bg-card border border-border rounded-xl p-6 space-y-6">
-            <LicenseDetails license={data} />
+            <LicenseDetails license={installedLicense} />
             <hr className="border-border" />
-            <LicenseOwner customer={data.customer} />
+            <LicenseOwner customer={installedLicense.customer} />
             <hr className="border-border" />
-            <LicenseFeatures features={data.features} />
+            <LicenseFeatures features={installedLicense.features} />
           </div>
         )}
 

--- a/ui-react/apps/console/src/pages/admin/__tests__/License.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/__tests__/License.test.tsx
@@ -45,7 +45,7 @@ function setupHooks({
   error,
   isPending = false,
 }: {
-  data?: object;
+  data?: object | null;
   isLoading?: boolean;
   isError?: boolean;
   error?: object;
@@ -88,8 +88,8 @@ describe("AdminLicense", () => {
       expect(screen.getByText("Failed to load license information")).toBeInTheDocument();
     });
 
-    it("shows no-license info alert and upload section when API returns 400", () => {
-      setupHooks({ isError: true, error: { status: 400 } });
+    it("shows no-license info alert and upload section when license data is null", () => {
+      setupHooks({ data: null });
       renderPage();
       expect(screen.getByText("You do not have an installed license")).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /choose a \.dat file/i })).toBeInTheDocument();

--- a/ui-react/apps/console/src/utils/license.ts
+++ b/ui-react/apps/console/src/utils/license.ts
@@ -18,7 +18,7 @@ type Features = GetLicenseResponse["features"];
 
 type DisplayFeature
   = { name: string; label: string; type: "boolean"; value: boolean }
-    | { name: string; label: string; type: "number"; value: number };
+  | { name: string; label: string; type: "number"; value: number };
 
 // "login_link" and "reports" are excluded to match the Vue admin UI.
 export function getDisplayFeatures(features: Features): DisplayFeature[] {


### PR DESCRIPTION
## What

Fix a Chromium-based behavior in the admin UI's License page, where the file input triggered a re-render when a file was selected due to a duplicated `useAdminLicense` hook call in the sidebar, which was triggered due to a focus event when the file picker was closed and re-rendered the page once the request completed

## Why

That re-render cleared the file input state, making it impossible to upload the license file on Chromium-based browsers via file picker.

## Testing

- Open the admin console in a clean state, without license, and check if the file input works in Chromium-based browsers via file picker or drag-and-drop, not re-rendering after selecting the file.
- Upload the license and check if the sidebar behaves correctly, hiding other nav items when there's no license or an expired one, and showing all entries when a valid license is uploaded.
