### PR TITLE
feat(ui-react): add team invitations feature

### DIFF
--- a/ui-react/apps/console/src/App.tsx
+++ b/ui-react/apps/console/src/App.tsx
@@ -37,6 +37,7 @@ const BannerEdit = lazy(() => import("./pages/BannerEdit"));
 const Profile = lazy(() => import("./pages/Profile"));
 const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const UpdatePassword = lazy(() => import("./pages/UpdatePassword"));
+const AcceptInvite = lazy(() => import("./pages/AcceptInvite"));
 const SecureVault = lazy(() => import("./pages/secure-vault"));
 const AdminDashboard = lazy(() => import("./pages/admin/Dashboard"));
 const AdminSessions = lazy(() => import("./pages/admin/Sessions"));
@@ -94,6 +95,7 @@ export default function App() {
                 <>
                   <Route path="/forgot-password" element={<ForgotPassword />} />
                   <Route path="/update-password" element={<UpdatePassword />} />
+                  <Route path="/accept-invite" element={<AcceptInvite />} />
                 </>
               )}
             </Route>

--- a/ui-react/apps/console/src/components/auth/AccountCreated.tsx
+++ b/ui-react/apps/console/src/components/auth/AccountCreated.tsx
@@ -1,37 +1,43 @@
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import {
-  ArrowRightIcon,
-  CheckCircleIcon,
-} from "@heroicons/react/24/outline";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ArrowRightIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import { useAuthStore } from "@/stores/authStore";
 import { useSignUpStore } from "@/stores/signUpStore";
 
 export default function AccountCreated() {
   const navigate = useNavigate();
+  const location = useLocation();
   const signUpToken = useSignUpStore((s) => s.signUpToken);
   const signUpTenant = useSignUpStore((s) => s.signUpTenant);
   const setSession = useAuthStore((s) => s.setSession);
+
+  // Preserve the sign-up URL's query string (tenant-id, user-id, sig, email)
+  // so /accept-invite can complete the invitation flow it started.
+  const acceptInviteTarget = `/accept-invite${location.search}`;
 
   useEffect(() => {
     if (!signUpToken || !signUpTenant) return;
 
     setSession({ token: signUpToken, tenant: signUpTenant });
 
-    // TODO: replace "/accept-invite" with the real route once it is added to App.tsx.
-    const timer = setTimeout(() => { void navigate("/accept-invite"); }, 5000);
+    const timer = setTimeout(() => {
+      void navigate(acceptInviteTarget);
+    }, 5000);
     return () => clearTimeout(timer);
-  }, [signUpToken, signUpTenant, setSession, navigate]);
+  }, [signUpToken, signUpTenant, setSession, navigate, acceptInviteTarget]);
 
   const handleRedirect = () => {
-    void navigate("/accept-invite"); // TODO: update when accept-invite route is added
+    void navigate(acceptInviteTarget);
   };
 
   return (
     <div className="w-full max-w-sm mx-auto animate-fade-in">
       <div className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm text-center">
         <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-green/10 border border-accent-green/20 mb-5">
-          <CheckCircleIcon className="w-7 h-7 text-accent-green" strokeWidth={1.5} />
+          <CheckCircleIcon
+            className="w-7 h-7 text-accent-green"
+            strokeWidth={1.5}
+          />
         </div>
 
         <h2 className="text-lg font-semibold text-text-primary mb-3">
@@ -40,8 +46,8 @@ export default function AccountCreated() {
 
         <p className="text-sm text-text-secondary leading-relaxed mb-6">
           Thank you for registering an account on ShellHub. You will be
-          redirected in 5 seconds. If you weren&apos;t redirected, please
-          click the button below.
+          redirected in 5 seconds. If you weren&apos;t redirected, please click
+          the button below.
         </p>
 
         <button

--- a/ui-react/apps/console/src/components/common/ConfirmDialog.tsx
+++ b/ui-react/apps/console/src/components/common/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useId, useState } from "react";
+import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import BaseDialog from "./BaseDialog";
 
@@ -40,11 +41,19 @@ interface ConfirmDialogProps {
   /** Optional content rendered between the description and the button row.
    *  Used by dialogs that embed extra form fields or warning messages. */
   children?: ReactNode;
+
+  /** Optional error banner rendered above the footer. Use this to surface
+   *  mutation failures inline — the dialog does NOT close on error, so the
+   *  user can retry or cancel. */
+  errorMessage?: string | null;
 }
 
 // Text color is included per-variant so that `warning`'s dark text is not
 // overridden by a standalone `text-white` on the button element.
-const VARIANT_CLASSES: Record<"primary" | "danger" | "success" | "warning", string> = {
+const VARIANT_CLASSES: Record<
+  "primary" | "danger" | "success" | "warning",
+  string
+> = {
   danger: "bg-accent-red/90 hover:bg-accent-red text-white",
   primary: "bg-primary hover:bg-primary-600 text-white",
   success: "bg-accent-green/90 hover:bg-accent-green text-white",
@@ -62,6 +71,7 @@ export default function ConfirmDialog({
   variant = "danger",
   confirmDisabled,
   children,
+  errorMessage,
 }: ConfirmDialogProps) {
   const [confirming, setConfirming] = useState(false);
   // useId produces a stable, unique id per component instance, satisfying
@@ -96,10 +106,7 @@ export default function ConfirmDialog({
     >
       {/* Header */}
       <div className="p-6 pb-0">
-        <h2
-          id={titleId}
-          className="text-base font-semibold text-text-primary"
-        >
+        <h2 id={titleId} className="text-base font-semibold text-text-primary">
           {title}
         </h2>
       </div>
@@ -107,11 +114,26 @@ export default function ConfirmDialog({
       {/* Body */}
       <div className="px-6 pt-2 pb-6">
         {description != null && (
-          <div id={descriptionId} className={`text-sm text-text-muted ${children ? "mb-4" : "mb-6"}`}>
+          <div
+            id={descriptionId}
+            className={`text-sm text-text-muted ${children || errorMessage ? "mb-4" : "mb-6"}`}
+          >
             {description}
           </div>
         )}
         {children}
+        {errorMessage && (
+          <div
+            role="alert"
+            className={`${children ? "mt-4" : ""} flex items-start gap-2 bg-accent-red/[0.06] border border-accent-red/20 rounded-lg px-3 py-2.5 text-xs text-accent-red`}
+          >
+            <ExclamationCircleIcon
+              className="w-4 h-4 shrink-0 mt-px"
+              strokeWidth={2}
+            />
+            <span>{errorMessage}</span>
+          </div>
+        )}
       </div>
 
       {/* Footer */}

--- a/ui-react/apps/console/src/components/layout/AppBar.tsx
+++ b/ui-react/apps/console/src/components/layout/AppBar.tsx
@@ -8,6 +8,7 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
 import NamespaceSelector from "./NamespaceSelector";
 
 import UserMenu from "./UserMenu";
+import InvitationsMenu from "./InvitationsMenu";
 import { TerminalInfo, TerminalActions } from "../terminal/TerminalControls";
 
 interface AppBarProps {
@@ -113,6 +114,7 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
           {displayed && <TerminalActions session={displayed} />}
         </div>
 
+        <InvitationsMenu />
         <UserMenu />
       </div>
     </header>

--- a/ui-react/apps/console/src/components/layout/InvitationsMenu.tsx
+++ b/ui-react/apps/console/src/components/layout/InvitationsMenu.tsx
@@ -1,0 +1,297 @@
+import { useState, useRef } from "react";
+import { Link } from "react-router-dom";
+import {
+  EnvelopeIcon,
+  InboxIcon,
+  CheckIcon,
+  XMarkIcon,
+  ArrowRightIcon,
+} from "@heroicons/react/24/outline";
+import { getConfig } from "@/env";
+import { useAuthStore } from "@/stores/authStore";
+import { useClickOutside } from "@/hooks/useClickOutside";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { useUserInvitations } from "@/hooks/useInvitations";
+import {
+  useAcceptInvite,
+  useDeclineInvite,
+} from "@/hooks/useInvitationMutations";
+import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
+import type { MembershipInvitation } from "@/client";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
+import { formatRelative } from "@/utils/date";
+import { RoleBadge } from "@/pages/team/constants";
+import { isInvitationExpired } from "@/utils/invitations";
+
+function InvitationCard({
+  invitation,
+  onAccept,
+  onDecline,
+}: {
+  invitation: MembershipInvitation;
+  onAccept: (inv: MembershipInvitation) => void;
+  onDecline: (inv: MembershipInvitation) => void;
+}) {
+  const expired = isInvitationExpired(invitation.expires_at);
+  return (
+    <li className="px-3.5 py-3 border-b border-border/60 last:border-b-0">
+      <div className="flex items-start justify-between gap-2 mb-1.5">
+        <p className="text-sm font-semibold text-text-primary truncate">
+          {invitation.namespace.name}
+        </p>
+        <RoleBadge role={invitation.role} />
+      </div>
+      <p className="text-2xs text-text-muted font-mono truncate">
+        Invited by {invitation.invited_by}
+      </p>
+      <p className="text-2xs text-text-muted mt-0.5">
+        {expired ? (
+          <span className="text-accent-red font-medium">Expired</span>
+        ) : invitation.expires_at ? (
+          <>Expires {formatRelative(invitation.expires_at)}</>
+        ) : (
+          <>No expiration</>
+        )}
+      </p>
+      <div className="flex items-center gap-1.5 mt-2.5">
+        <button
+          onClick={() => onAccept(invitation)}
+          disabled={expired}
+          className="flex-1 inline-flex items-center justify-center gap-1 px-2.5 py-1.5 bg-primary/10 hover:bg-primary/20 border border-primary/20 text-primary rounded-md text-2xs font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-colors"
+        >
+          <CheckIcon className="w-3 h-3" strokeWidth={2.5} />
+          Accept
+        </button>
+        <button
+          onClick={() => onDecline(invitation)}
+          className="flex-1 inline-flex items-center justify-center gap-1 px-2.5 py-1.5 bg-hover-subtle hover:bg-hover-medium border border-border text-text-secondary hover:text-text-primary rounded-md text-2xs font-semibold transition-colors"
+        >
+          <XMarkIcon className="w-3 h-3" strokeWidth={2.5} />
+          Decline
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export default function InvitationsMenu() {
+  const isCloud = getConfig().cloud;
+  const token = useAuthStore((s) => s.token);
+
+  const [open, setOpen] = useState(false);
+  const [acceptTarget, setAcceptTarget] = useState<MembershipInvitation | null>(
+    null,
+  );
+  const [declineTarget, setDeclineTarget] =
+    useState<MembershipInvitation | null>(null);
+  const [acceptError, setAcceptError] = useState<string | null>(null);
+  const [declineError, setDeclineError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(containerRef, () => setOpen(false));
+  useEscapeKey(() => setOpen(false), open);
+
+  const enabled = isCloud && !!token;
+  const { invitations, totalCount, isLoading } = useUserInvitations({
+    status: "pending",
+    perPage: 10,
+    enabled,
+  });
+  const acceptInvite = useAcceptInvite();
+  const declineInvite = useDeclineInvite();
+  const switchNamespace = useSwitchNamespace();
+
+  if (!enabled) return null;
+
+  // Badge and header reflect the *total* pending count, not the page we
+  // happen to have fetched — otherwise the badge caps at perPage and lies
+  // to users with lots of invitations.
+  const count = totalCount;
+  const hasMore = invitations.length < totalCount;
+
+  const handleAccept = async () => {
+    if (!acceptTarget) return;
+    const tenant = acceptTarget.namespace.tenant_id;
+    setAcceptError(null);
+    try {
+      await acceptInvite.mutateAsync({ path: { tenant } });
+      // useSwitchNamespace mints a fresh namespace-scoped token, stores
+      // { token, tenant, role } via setSession, and hard-navigates to
+      // /dashboard so NamespaceGuard re-initializes with a clean slate.
+      await switchNamespace.mutateAsync({
+        tenantId: tenant,
+        redirectTo: "/dashboard",
+      });
+      setAcceptTarget(null);
+      setOpen(false);
+    } catch {
+      setAcceptError("Failed to accept the invitation. Please try again.");
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!declineTarget) return;
+    setDeclineError(null);
+    try {
+      await declineInvite.mutateAsync({
+        path: { tenant: declineTarget.namespace.tenant_id },
+      });
+      setDeclineTarget(null);
+    } catch {
+      setDeclineError("Failed to decline the invitation. Please try again.");
+    }
+  };
+
+  return (
+    <>
+      <div ref={containerRef} className="relative">
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          className="relative flex items-center justify-center h-8 w-8 rounded-lg border border-transparent hover:border-border hover:bg-hover-subtle transition-all duration-150"
+          aria-label={`Pending invitations${count > 0 ? ` (${count})` : ""}`}
+          aria-haspopup="menu"
+          aria-expanded={open}
+        >
+          <EnvelopeIcon
+            className="w-4 h-4 text-text-secondary"
+            strokeWidth={1.8}
+          />
+          {count > 0 && (
+            <span
+              aria-hidden="true"
+              className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] px-1 rounded-full bg-accent-red text-white text-[9px] font-mono font-bold flex items-center justify-center border border-surface"
+            >
+              {count > 9 ? "9+" : count}
+            </span>
+          )}
+        </button>
+
+        {open && (
+          <div
+            role="menu"
+            aria-label="Pending invitations"
+            className="absolute top-full right-0 mt-1.5 w-80 bg-surface border border-border rounded-lg shadow-2xl shadow-black/40 z-50 overflow-hidden animate-slide-down"
+          >
+            <div className="flex items-center justify-between px-3.5 py-3 border-b border-border">
+              <div>
+                <p className="text-sm font-semibold text-text-primary">
+                  Invitations
+                </p>
+                <p className="text-2xs text-text-muted mt-0.5">
+                  {count > 0
+                    ? `${count} pending invitation${count !== 1 ? "s" : ""}`
+                    : "No pending invitations"}
+                </p>
+              </div>
+              <span className="inline-flex items-center justify-center w-7 h-7 rounded-md bg-primary/10 border border-primary/20">
+                <InboxIcon
+                  className="w-3.5 h-3.5 text-primary"
+                  strokeWidth={2}
+                />
+              </span>
+            </div>
+
+            <div className="max-h-[360px] overflow-y-auto">
+              {isLoading ? (
+                <div
+                  className="flex items-center justify-center gap-2 py-8"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                  <span className="text-2xs font-mono text-text-muted">
+                    Loading...
+                  </span>
+                </div>
+              ) : count === 0 ? (
+                <div className="px-3.5 py-10 text-center">
+                  <InboxIcon
+                    className="w-8 h-8 text-text-muted/30 mx-auto mb-2"
+                    strokeWidth={1}
+                  />
+                  <p className="text-xs text-text-muted">
+                    You&apos;re all caught up
+                  </p>
+                  <p className="text-2xs text-text-muted/60 mt-0.5">
+                    New invitations will appear here
+                  </p>
+                </div>
+              ) : (
+                <ul className="divide-y divide-border/60">
+                  {invitations.map((inv) => (
+                    <InvitationCard
+                      key={`${inv.namespace.tenant_id}-${inv.user.id}`}
+                      invitation={inv}
+                      onAccept={setAcceptTarget}
+                      onDecline={setDeclineTarget}
+                    />
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {hasMore && (
+              <Link
+                to="/team"
+                onClick={() => setOpen(false)}
+                className="flex items-center justify-center gap-1.5 px-3.5 py-2.5 border-t border-border text-2xs font-semibold text-primary hover:bg-primary/5 transition-colors"
+              >
+                View all {totalCount} invitations
+                <ArrowRightIcon className="w-3 h-3" strokeWidth={2.5} />
+              </Link>
+            )}
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={!!acceptTarget}
+        onClose={() => {
+          setAcceptTarget(null);
+          setAcceptError(null);
+        }}
+        onConfirm={handleAccept}
+        title="Accept Invitation"
+        description={
+          acceptTarget ? (
+            <>
+              Accept the invitation to join{" "}
+              <span className="font-medium text-text-primary">
+                {acceptTarget.namespace.name}
+              </span>
+              ? You will be switched to this namespace after accepting.
+            </>
+          ) : null
+        }
+        confirmLabel="Accept"
+        variant="primary"
+        errorMessage={acceptError}
+      />
+
+      <ConfirmDialog
+        open={!!declineTarget}
+        onClose={() => {
+          setDeclineTarget(null);
+          setDeclineError(null);
+        }}
+        onConfirm={handleDecline}
+        title="Decline Invitation"
+        description={
+          declineTarget ? (
+            <>
+              Decline the invitation to join{" "}
+              <span className="font-medium text-text-primary">
+                {declineTarget.namespace.name}
+              </span>
+              ? The owner can send a new invitation later.
+            </>
+          ) : null
+        }
+        confirmLabel="Decline"
+        variant="danger"
+        errorMessage={declineError}
+      />
+    </>
+  );
+}

--- a/ui-react/apps/console/src/components/layout/__tests__/InvitationsMenu.test.tsx
+++ b/ui-react/apps/console/src/components/layout/__tests__/InvitationsMenu.test.tsx
@@ -1,0 +1,506 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  waitFor,
+  fireEvent,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAuthStore } from "../../../stores/authStore";
+import type { MembershipInvitation } from "../../../client";
+import InvitationsMenu from "../InvitationsMenu";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+// Stub ConfirmDialog — jsdom lacks HTMLDialogElement.showModal()
+vi.mock("../../../components/common/ConfirmDialog", () => ({
+  default: ({
+    open,
+    onClose,
+    onConfirm,
+    title,
+    confirmLabel = "Confirm",
+    cancelLabel = "Cancel",
+    errorMessage,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void> | void;
+    title: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    errorMessage?: string | null;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog">
+        <h2>{title}</h2>
+        {errorMessage ? <div role="alert">{errorMessage}</div> : null}
+        <button onClick={onClose}>{cancelLabel}</button>
+        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+      </div>
+    );
+  },
+}));
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// Cloud mode on by default — tests that need it off override in their own beforeEach
+vi.mock("../../../env", () => ({
+  getConfig: vi.fn(() => ({ cloud: true })),
+}));
+
+const mockUserInvitations = vi.fn<
+  () => {
+    invitations: MembershipInvitation[];
+    totalCount: number;
+    isLoading: boolean;
+  }
+>();
+
+vi.mock("../../../hooks/useInvitations", () => ({
+  useUserInvitations: () => mockUserInvitations(),
+}));
+
+const mockAcceptMutateAsync = vi.fn();
+const mockDeclineMutateAsync = vi.fn();
+const mockSwitchNamespaceMutateAsync = vi.fn();
+
+vi.mock("../../../hooks/useInvitationMutations", () => ({
+  useAcceptInvite: () => ({
+    mutateAsync: mockAcceptMutateAsync,
+    isPending: false,
+  }),
+  useDeclineInvite: () => ({
+    mutateAsync: mockDeclineMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../../../hooks/useNamespaceMutations", () => ({
+  useSwitchNamespace: () => ({
+    mutateAsync: mockSwitchNamespaceMutateAsync,
+    isPending: false,
+  }),
+}));
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function makeInvitation(
+  overrides: Partial<MembershipInvitation> = {},
+): MembershipInvitation {
+  return {
+    namespace: { tenant_id: "t1", name: "my-namespace" },
+    user: { id: "u1", email: "alice@example.com" },
+    invited_by: "owner@example.com",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    expires_at: "2099-01-08T00:00:00Z",
+    status: "pending",
+    status_updated_at: "2024-01-01T00:00:00Z",
+    role: "operator",
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderMenu() {
+  return render(<InvitationsMenu />, {
+    wrapper: createWrapper(),
+  });
+}
+
+async function openMenu() {
+  await userEvent.click(
+    screen.getByRole("button", { name: /pending invitations/i }),
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup / teardown                                                    */
+/* ------------------------------------------------------------------ */
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useAuthStore.setState({
+    token: "test-token",
+    user: "alice",
+    userId: "user-1",
+    email: "alice@example.com",
+    tenant: "t1",
+    role: "owner",
+    name: "Alice",
+    loading: false,
+  });
+  mockUserInvitations.mockReturnValue({
+    invitations: [],
+    totalCount: 0,
+    isLoading: false,
+  });
+  mockAcceptMutateAsync.mockResolvedValue(undefined);
+  mockDeclineMutateAsync.mockResolvedValue(undefined);
+  mockSwitchNamespaceMutateAsync.mockResolvedValue(undefined);
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("InvitationsMenu", () => {
+  describe("cloud gating", () => {
+    it("returns null in non-cloud mode", async () => {
+      const { getConfig } = await import("../../../env");
+      vi.mocked(getConfig).mockReturnValue({
+        cloud: false,
+        version: "",
+        enterprise: false,
+        announcements: false,
+        onboardingUrl: "",
+      });
+
+      const { container } = renderMenu();
+      expect(container).toBeEmptyDOMElement();
+
+      // Restore cloud mode for subsequent tests
+      vi.mocked(getConfig).mockReturnValue({
+        cloud: true,
+        version: "",
+        enterprise: false,
+        announcements: false,
+        onboardingUrl: "",
+      });
+    });
+
+    it("returns null when there is no auth token", () => {
+      useAuthStore.setState({ token: null });
+      const { container } = renderMenu();
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("trigger button", () => {
+    it("renders the envelope button in cloud+authenticated mode", () => {
+      renderMenu();
+      expect(
+        screen.getByRole("button", { name: /pending invitations/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows no badge when there are zero pending invitations", () => {
+      renderMenu();
+      // aria-hidden badge is absent
+      expect(screen.queryByText(/[0-9]+/)).not.toBeInTheDocument();
+    });
+
+    it("shows badge count when there are pending invitations", () => {
+      mockUserInvitations.mockReturnValue({
+        invitations: [
+          makeInvitation(),
+          makeInvitation({ user: { id: "u2", email: "bob@example.com" } }),
+        ],
+        totalCount: 2,
+        isLoading: false,
+      });
+      renderMenu();
+      expect(screen.getByText("2")).toBeInTheDocument();
+    });
+
+    it("shows '9+' badge when there are more than 9 pending invitations", () => {
+      mockUserInvitations.mockReturnValue({
+        invitations: Array.from({ length: 10 }, (_, i) =>
+          makeInvitation({
+            user: { id: `u${i}`, email: `user${i}@example.com` },
+          }),
+        ),
+        totalCount: 10,
+        isLoading: false,
+      });
+      renderMenu();
+      expect(screen.getByText("9+")).toBeInTheDocument();
+    });
+
+    it("includes count in aria-label when invitations are present", () => {
+      mockUserInvitations.mockReturnValue({
+        invitations: [makeInvitation()],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      expect(
+        screen.getByRole("button", { name: /pending invitations \(1\)/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("dropdown open/close", () => {
+    it("shows the dropdown menu after clicking the trigger", async () => {
+      renderMenu();
+      await openMenu();
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+
+    it("hides the dropdown after a second click on the trigger", async () => {
+      const user = userEvent.setup();
+      renderMenu();
+      await user.click(
+        screen.getByRole("button", { name: /pending invitations/i }),
+      );
+      await user.click(
+        screen.getByRole("button", { name: /pending invitations/i }),
+      );
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    it("dismisses on Escape key", async () => {
+      renderMenu();
+      await openMenu();
+      // The escape handler is on the container element — use fireEvent
+      fireEvent.keyDown(document, { key: "Escape" });
+      await waitFor(() =>
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument(),
+      );
+    });
+
+    it("dismisses on click outside", async () => {
+      renderMenu();
+      await openMenu();
+      // Click outside the container
+      fireEvent.mouseDown(document.body);
+      await waitFor(() =>
+        expect(screen.queryByRole("menu")).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("dropdown content", () => {
+    it("shows loading state when invitations are loading", async () => {
+      mockUserInvitations.mockReturnValue({
+        invitations: [],
+        totalCount: 0,
+        isLoading: true,
+      });
+      renderMenu();
+      await openMenu();
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("shows empty state when there are no pending invitations", async () => {
+      renderMenu();
+      await openMenu();
+      expect(screen.getByText(/you're all caught up/i)).toBeInTheDocument();
+    });
+
+    it("renders invitation cards when invitations exist", async () => {
+      mockUserInvitations.mockReturnValue({
+        invitations: [makeInvitation()],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+      expect(screen.getByText("my-namespace")).toBeInTheDocument();
+    });
+
+    it("shows Accept and Decline buttons for each invitation card", async () => {
+      mockUserInvitations.mockReturnValue({
+        invitations: [makeInvitation()],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+      expect(
+        screen.getByRole("button", { name: /accept/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /decline/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("disables Accept button for expired invitations", async () => {
+      mockUserInvitations.mockReturnValue({
+        invitations: [makeInvitation({ expires_at: "2020-01-01T00:00:00Z" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+      expect(screen.getByRole("button", { name: /accept/i })).toBeDisabled();
+    });
+
+    it("shows Expired text for expired invitations", async () => {
+      mockUserInvitations.mockReturnValue({
+        invitations: [makeInvitation({ expires_at: "2020-01-01T00:00:00Z" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+      expect(screen.getByText("Expired")).toBeInTheDocument();
+    });
+  });
+
+  describe("accept flow", () => {
+    it("shows Accept confirmation dialog after clicking Accept", async () => {
+      const user = userEvent.setup();
+      mockUserInvitations.mockReturnValue({
+        invitations: [makeInvitation()],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+
+      await user.click(screen.getByRole("button", { name: /^accept$/i }));
+
+      expect(
+        screen.getByRole("heading", { name: /accept invitation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls acceptInvite and then useSwitchNamespace with the invitation's tenant", async () => {
+      const user = userEvent.setup();
+      mockUserInvitations.mockReturnValue({
+        invitations: [
+          makeInvitation({
+            namespace: { tenant_id: "t1", name: "my-namespace" },
+          }),
+        ],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+
+      await user.click(screen.getByRole("button", { name: /^accept$/i }));
+
+      // Click the confirm button inside the dialog (not the card button)
+      const dialog = screen.getByRole("dialog");
+      await user.click(
+        within(dialog).getByRole("button", { name: /^accept$/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockAcceptMutateAsync).toHaveBeenCalledWith({
+          path: { tenant: "t1" },
+        }),
+      );
+      // useSwitchNamespace is what actually switches the active namespace and
+      // hard-navigates to /dashboard — the menu no longer calls setSession or
+      // useNavigate itself for the accept flow.
+      await waitFor(() =>
+        expect(mockSwitchNamespaceMutateAsync).toHaveBeenCalledWith({
+          tenantId: "t1",
+          redirectTo: "/dashboard",
+        }),
+      );
+    });
+
+    it("does not switch namespace when acceptInvite fails", async () => {
+      mockAcceptMutateAsync.mockRejectedValue(new Error("server error"));
+      const user = userEvent.setup();
+      mockUserInvitations.mockReturnValue({
+        invitations: [
+          makeInvitation({
+            namespace: { tenant_id: "t1", name: "my-namespace" },
+          }),
+        ],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+
+      await user.click(screen.getByRole("button", { name: /^accept$/i }));
+
+      const dialog = screen.getByRole("dialog");
+      await user.click(
+        within(dialog).getByRole("button", { name: /^accept$/i }),
+      );
+
+      await waitFor(() => expect(mockAcceptMutateAsync).toHaveBeenCalled());
+      expect(mockSwitchNamespaceMutateAsync).not.toHaveBeenCalled();
+      // Error banner appears inline in the dialog.
+      await waitFor(() =>
+        expect(within(dialog).getByRole("alert")).toHaveTextContent(
+          /failed to accept the invitation/i,
+        ),
+      );
+    });
+  });
+
+  describe("decline flow", () => {
+    it("shows Decline confirmation dialog after clicking Decline", async () => {
+      const user = userEvent.setup();
+      mockUserInvitations.mockReturnValue({
+        invitations: [makeInvitation()],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+
+      await user.click(screen.getByRole("button", { name: /decline/i }));
+
+      expect(
+        screen.getByRole("heading", { name: /decline invitation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls declineInvite mutation on confirm", async () => {
+      const user = userEvent.setup();
+      mockUserInvitations.mockReturnValue({
+        invitations: [
+          makeInvitation({
+            namespace: { tenant_id: "t1", name: "my-namespace" },
+          }),
+        ],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderMenu();
+      await openMenu();
+
+      // Click Decline on the invitation card
+      await user.click(screen.getByRole("button", { name: /decline/i }));
+
+      // Confirm inside the dialog
+      const dialog = screen.getByRole("dialog");
+      await user.click(
+        within(dialog).getByRole("button", { name: /^decline$/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockDeclineMutateAsync).toHaveBeenCalledWith({
+          path: { tenant: "t1" },
+        }),
+      );
+    });
+  });
+});

--- a/ui-react/apps/console/src/hooks/__tests__/useInvitationMutations.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useInvitationMutations.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  useAcceptInvite,
+  useDeclineInvite,
+  useGenerateInvitationLink,
+  useCancelMembershipInvitation,
+  useUpdateMembershipInvitation,
+} from "../useInvitationMutations";
+
+const mockAcceptFn = vi.fn();
+const mockDeclineFn = vi.fn();
+const mockGenerateLinkFn = vi.fn();
+const mockCancelFn = vi.fn();
+const mockUpdateFn = vi.fn();
+const mockInvalidate = vi.fn();
+
+vi.mock("../../client/@tanstack/react-query.gen", () => ({
+  acceptInviteMutation: vi.fn(() => ({ mutationFn: mockAcceptFn })),
+  declineInviteMutation: vi.fn(() => ({ mutationFn: mockDeclineFn })),
+  generateInvitationLinkMutation: vi.fn(() => ({
+    mutationFn: mockGenerateLinkFn,
+  })),
+  cancelMembershipInvitationMutation: vi.fn(() => ({
+    mutationFn: mockCancelFn,
+  })),
+  updateMembershipInvitationMutation: vi.fn(() => ({
+    mutationFn: mockUpdateFn,
+  })),
+}));
+
+vi.mock("../useInvalidateQueries", () => ({
+  useInvalidateByIds: vi.fn(() => mockInvalidate),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAcceptInvite", () => {
+  describe("mutation call", () => {
+    it("calls acceptInvite with the provided path", async () => {
+      mockAcceptFn.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useAcceptInvite(), {
+        wrapper: createWrapper(),
+      });
+
+      const vars = { path: { tenant: "t1" } };
+      await act(() => result.current.mutateAsync(vars as never));
+
+      expect(mockAcceptFn).toHaveBeenCalledWith(vars, expect.anything());
+    });
+  });
+
+  describe("on success", () => {
+    it("calls invalidate after successful mutation", async () => {
+      mockAcceptFn.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useAcceptInvite(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(() => result.current.mutateAsync({} as never));
+
+      await waitFor(() => expect(mockInvalidate).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("on failure", () => {
+    it("exposes error when mutation fails", async () => {
+      const error = new Error("accept failed");
+      mockAcceptFn.mockRejectedValue(error);
+      const { result } = renderHook(() => useAcceptInvite(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toBe(error);
+    });
+
+    it("does not call invalidate when mutation fails", async () => {
+      mockAcceptFn.mockRejectedValue(new Error("accept failed"));
+      const { result } = renderHook(() => useAcceptInvite(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockInvalidate).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useDeclineInvite", () => {
+  describe("mutation call", () => {
+    it("calls declineInvite with the provided path", async () => {
+      mockDeclineFn.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useDeclineInvite(), {
+        wrapper: createWrapper(),
+      });
+
+      const vars = { path: { tenant: "t1" } };
+      await act(() => result.current.mutateAsync(vars as never));
+
+      expect(mockDeclineFn).toHaveBeenCalledWith(vars, expect.anything());
+    });
+  });
+
+  describe("on success", () => {
+    it("calls invalidate after successful mutation", async () => {
+      mockDeclineFn.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useDeclineInvite(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(() => result.current.mutateAsync({} as never));
+
+      await waitFor(() => expect(mockInvalidate).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("on failure", () => {
+    it("exposes error when mutation fails", async () => {
+      const error = new Error("decline failed");
+      mockDeclineFn.mockRejectedValue(error);
+      const { result } = renderHook(() => useDeclineInvite(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toBe(error);
+    });
+
+    it("does not call invalidate when mutation fails", async () => {
+      mockDeclineFn.mockRejectedValue(new Error("decline failed"));
+      const { result } = renderHook(() => useDeclineInvite(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockInvalidate).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useGenerateInvitationLink", () => {
+  describe("mutation call", () => {
+    it("calls generateInvitationLink with path and body", async () => {
+      mockGenerateLinkFn.mockResolvedValue({ link: "https://example.com/invite/abc" });
+      const { result } = renderHook(() => useGenerateInvitationLink(), {
+        wrapper: createWrapper(),
+      });
+
+      const vars = {
+        path: { tenant: "t1" },
+        body: { email: "bob@example.com", role: "operator" },
+      };
+      await act(() => result.current.mutateAsync(vars as never));
+
+      expect(mockGenerateLinkFn).toHaveBeenCalledWith(vars, expect.anything());
+    });
+
+    it("returns the generated link from the mutation", async () => {
+      const link = "https://example.com/invite/xyz";
+      mockGenerateLinkFn.mockResolvedValue({ link });
+      const { result } = renderHook(() => useGenerateInvitationLink(), {
+        wrapper: createWrapper(),
+      });
+
+      const data = await act(() => result.current.mutateAsync({} as never));
+
+      expect(data).toEqual({ link });
+    });
+  });
+
+  describe("on success", () => {
+    it("calls invalidate after successful mutation", async () => {
+      mockGenerateLinkFn.mockResolvedValue({ link: "https://example.com/invite/abc" });
+      const { result } = renderHook(() => useGenerateInvitationLink(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(() => result.current.mutateAsync({} as never));
+
+      await waitFor(() => expect(mockInvalidate).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("on failure", () => {
+    it("exposes error when mutation fails", async () => {
+      const error = new Error("generate link failed");
+      mockGenerateLinkFn.mockRejectedValue(error);
+      const { result } = renderHook(() => useGenerateInvitationLink(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toBe(error);
+    });
+
+    it("does not call invalidate when mutation fails", async () => {
+      mockGenerateLinkFn.mockRejectedValue(new Error("generate link failed"));
+      const { result } = renderHook(() => useGenerateInvitationLink(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockInvalidate).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useCancelMembershipInvitation", () => {
+  describe("mutation call", () => {
+    it("calls cancelMembershipInvitation with path", async () => {
+      mockCancelFn.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useCancelMembershipInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      const vars = { path: { tenant: "t1", "user-id": "u1" } };
+      await act(() => result.current.mutateAsync(vars as never));
+
+      expect(mockCancelFn).toHaveBeenCalledWith(vars, expect.anything());
+    });
+  });
+
+  describe("on success", () => {
+    it("calls invalidate after successful mutation", async () => {
+      mockCancelFn.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useCancelMembershipInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(() => result.current.mutateAsync({} as never));
+
+      await waitFor(() => expect(mockInvalidate).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("on failure", () => {
+    it("exposes error when mutation fails", async () => {
+      const error = new Error("cancel failed");
+      mockCancelFn.mockRejectedValue(error);
+      const { result } = renderHook(() => useCancelMembershipInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toBe(error);
+    });
+
+    it("does not call invalidate when mutation fails", async () => {
+      mockCancelFn.mockRejectedValue(new Error("cancel failed"));
+      const { result } = renderHook(() => useCancelMembershipInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockInvalidate).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useUpdateMembershipInvitation", () => {
+  describe("mutation call", () => {
+    it("calls updateMembershipInvitation with path and body", async () => {
+      mockUpdateFn.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useUpdateMembershipInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      const vars = {
+        path: { tenant: "t1", "user-id": "u1" },
+        body: { role: "administrator" },
+      };
+      await act(() => result.current.mutateAsync(vars as never));
+
+      expect(mockUpdateFn).toHaveBeenCalledWith(vars, expect.anything());
+    });
+  });
+
+  describe("on success", () => {
+    it("calls invalidate after successful mutation", async () => {
+      mockUpdateFn.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useUpdateMembershipInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(() => result.current.mutateAsync({} as never));
+
+      await waitFor(() => expect(mockInvalidate).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("on failure", () => {
+    it("exposes error when mutation fails", async () => {
+      const error = new Error("update failed");
+      mockUpdateFn.mockRejectedValue(error);
+      const { result } = renderHook(() => useUpdateMembershipInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toBe(error);
+    });
+
+    it("does not call invalidate when mutation fails", async () => {
+      mockUpdateFn.mockRejectedValue(new Error("update failed"));
+      const { result } = renderHook(() => useUpdateMembershipInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({} as never));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockInvalidate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui-react/apps/console/src/hooks/__tests__/useInvitations.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useInvitations.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUserInvitations, useNamespaceInvitations } from "../useInvitations";
+import type { MembershipInvitation } from "../../client";
+
+vi.mock("../../client", () => ({
+  getMembershipInvitationList: vi.fn(),
+  getNamespaceMembershipInvitationList: vi.fn(),
+}));
+
+vi.mock("../../client/@tanstack/react-query.gen", () => ({
+  getMembershipInvitationListQueryKey: vi.fn(
+    (opts: unknown) => [{ _id: "getMembershipInvitationList" }, opts],
+  ),
+  getNamespaceMembershipInvitationListQueryKey: vi.fn(
+    (opts: unknown) => [{ _id: "getNamespaceMembershipInvitationList" }, opts],
+  ),
+}));
+
+vi.mock("../../api/pagination", () => ({
+  paginatedQueryFn: vi.fn(
+    (_sdkFn: unknown, opts: { query: Record<string, unknown> }) => {
+      return () => mockFetchFn(opts) as unknown;
+    },
+  ),
+}));
+
+const mockFetchFn = vi.fn();
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, retryDelay: 0 },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function makeInvitation(
+  overrides: Partial<MembershipInvitation> = {},
+): MembershipInvitation {
+  return {
+    namespace: { tenant_id: "t1", name: "my-ns" },
+    user: { id: "u1", email: "alice@example.com" },
+    invited_by: "owner@example.com",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    expires_at: "2024-01-08T00:00:00Z",
+    status: "pending",
+    status_updated_at: "2024-01-01T00:00:00Z",
+    role: "operator",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useUserInvitations", () => {
+  describe("returns", () => {
+    it("returns invitations from the paginated result", async () => {
+      const inv = makeInvitation({ status: "pending" });
+      mockFetchFn.mockResolvedValue({ data: [inv], totalCount: 1 });
+
+      const { result } = renderHook(() => useUserInvitations(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.invitations).toHaveLength(1);
+      expect(result.current.invitations[0].user.email).toBe("alice@example.com");
+    });
+
+    it("returns totalCount from the paginated result", async () => {
+      mockFetchFn.mockResolvedValue({ data: [], totalCount: 42 });
+
+      const { result } = renderHook(() => useUserInvitations(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.totalCount).toBe(42);
+    });
+
+    it("defaults invitations to empty array while loading", () => {
+      mockFetchFn.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useUserInvitations(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.invitations).toEqual([]);
+    });
+
+    it("defaults totalCount to 0 while loading", () => {
+      mockFetchFn.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useUserInvitations(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.totalCount).toBe(0);
+    });
+
+    it("returns isLoading true initially", () => {
+      mockFetchFn.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useUserInvitations(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("exposes error when query fails", async () => {
+      const networkError = new Error("network failure");
+      mockFetchFn.mockRejectedValue(networkError);
+
+      const { result } = renderHook(() => useUserInvitations(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+      expect(result.current.error).toBe(networkError);
+    });
+  });
+
+  describe("pagination defaults", () => {
+    it("uses page 1 and perPage 10 as defaults", async () => {
+      mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
+
+      renderHook(() => useUserInvitations(), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(mockFetchFn).toHaveBeenCalled());
+      const [opts] = mockFetchFn.mock.calls[0] as [
+        { query: Record<string, unknown> },
+      ];
+      expect(opts.query.page).toBe(1);
+      expect(opts.query.per_page).toBe(10);
+    });
+
+    it("forwards custom page and perPage", async () => {
+      mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
+
+      renderHook(() => useUserInvitations({ page: 2, perPage: 25 }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(mockFetchFn).toHaveBeenCalled());
+      const [opts] = mockFetchFn.mock.calls[0] as [
+        { query: Record<string, unknown> },
+      ];
+      expect(opts.query.page).toBe(2);
+      expect(opts.query.per_page).toBe(25);
+    });
+  });
+
+  describe("enabled flag", () => {
+    it("does not fetch when enabled is false", () => {
+      mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
+
+      renderHook(() => useUserInvitations({ enabled: false }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(mockFetchFn).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useNamespaceInvitations", () => {
+  describe("returns", () => {
+    it("returns invitations for the given tenant", async () => {
+      const inv = makeInvitation({ status: "pending" });
+      mockFetchFn.mockResolvedValue({ data: [inv], totalCount: 1 });
+
+      const { result } = renderHook(
+        () => useNamespaceInvitations({ tenantId: "t1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.invitations).toHaveLength(1);
+    });
+
+    it("returns totalCount from the paginated result", async () => {
+      mockFetchFn.mockResolvedValue({ data: [], totalCount: 7 });
+
+      const { result } = renderHook(
+        () => useNamespaceInvitations({ tenantId: "t1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.totalCount).toBe(7);
+    });
+
+    it("defaults invitations to empty array while loading", () => {
+      mockFetchFn.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(
+        () => useNamespaceInvitations({ tenantId: "t1" }),
+        { wrapper: createWrapper() },
+      );
+
+      expect(result.current.invitations).toEqual([]);
+    });
+
+    it("exposes error when query fails", async () => {
+      const err = new Error("fetch failed");
+      mockFetchFn.mockRejectedValue(err);
+
+      const { result } = renderHook(
+        () => useNamespaceInvitations({ tenantId: "t1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+      expect(result.current.error).toBe(err);
+    });
+  });
+
+  describe("enabled flag", () => {
+    it("does not fetch when enabled is false", () => {
+      mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
+
+      renderHook(() => useNamespaceInvitations({ tenantId: "t1", enabled: false }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(mockFetchFn).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when tenantId is empty", () => {
+      mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
+
+      renderHook(() => useNamespaceInvitations({ tenantId: "" }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(mockFetchFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pagination", () => {
+    it("uses page 1 and perPage 10 as defaults", async () => {
+      mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
+
+      renderHook(() => useNamespaceInvitations({ tenantId: "t1" }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(mockFetchFn).toHaveBeenCalled());
+      const [opts] = mockFetchFn.mock.calls[0] as [
+        { query: Record<string, unknown> },
+      ];
+      expect(opts.query.page).toBe(1);
+      expect(opts.query.per_page).toBe(10);
+    });
+  });
+});

--- a/ui-react/apps/console/src/hooks/useInvitationMutations.ts
+++ b/ui-react/apps/console/src/hooks/useInvitationMutations.ts
@@ -1,0 +1,62 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  acceptInviteMutation,
+  addNamespaceMemberMutation,
+  declineInviteMutation,
+  generateInvitationLinkMutation,
+  cancelMembershipInvitationMutation,
+  updateMembershipInvitationMutation,
+} from "@/client/@tanstack/react-query.gen";
+import { useInvalidateByIds } from "./useInvalidateQueries";
+
+export function useAcceptInvite() {
+  const invalidate = useInvalidateByIds(
+    "getMembershipInvitationList",
+    "getNamespace",
+    "getNamespaces",
+  );
+  return useMutation({
+    ...acceptInviteMutation(),
+    onSuccess: invalidate,
+  });
+}
+
+export function useDeclineInvite() {
+  const invalidate = useInvalidateByIds("getMembershipInvitationList");
+  return useMutation({
+    ...declineInviteMutation(),
+    onSuccess: invalidate,
+  });
+}
+
+export function useSendInvitationEmail() {
+  const invalidate = useInvalidateByIds("getNamespaceMembershipInvitationList");
+  return useMutation({
+    ...addNamespaceMemberMutation(),
+    onSuccess: invalidate,
+  });
+}
+
+export function useGenerateInvitationLink() {
+  const invalidate = useInvalidateByIds("getNamespaceMembershipInvitationList");
+  return useMutation({
+    ...generateInvitationLinkMutation(),
+    onSuccess: invalidate,
+  });
+}
+
+export function useCancelMembershipInvitation() {
+  const invalidate = useInvalidateByIds("getNamespaceMembershipInvitationList");
+  return useMutation({
+    ...cancelMembershipInvitationMutation(),
+    onSuccess: invalidate,
+  });
+}
+
+export function useUpdateMembershipInvitation() {
+  const invalidate = useInvalidateByIds("getNamespaceMembershipInvitationList");
+  return useMutation({
+    ...updateMembershipInvitationMutation(),
+    onSuccess: invalidate,
+  });
+}

--- a/ui-react/apps/console/src/hooks/useInvitations.ts
+++ b/ui-react/apps/console/src/hooks/useInvitations.ts
@@ -1,0 +1,93 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getMembershipInvitationList,
+  getNamespaceMembershipInvitationList,
+  type GetMembershipInvitationListData,
+  type GetNamespaceMembershipInvitationListData,
+  type MembershipInvitation,
+} from "@/client";
+import {
+  getMembershipInvitationListQueryKey,
+  getNamespaceMembershipInvitationListQueryKey,
+} from "@/client/@tanstack/react-query.gen";
+import { paginatedQueryFn, type PaginatedResult } from "@/api/pagination";
+import {
+  invitationStatusFilter,
+  type InvitationStatus,
+} from "@/utils/invitations";
+
+interface UseUserInvitationsParams {
+  status?: InvitationStatus;
+  page?: number;
+  perPage?: number;
+  enabled?: boolean;
+}
+
+export function useUserInvitations({
+  status = "pending",
+  page = 1,
+  perPage = 10,
+  enabled = true,
+}: UseUserInvitationsParams = {}) {
+  const options = {
+    query: {
+      filter: invitationStatusFilter(status),
+      page,
+      per_page: perPage,
+    },
+  } satisfies { query: GetMembershipInvitationListData["query"] };
+
+  const result = useQuery<PaginatedResult<MembershipInvitation>>({
+    queryKey: getMembershipInvitationListQueryKey(options),
+    queryFn: paginatedQueryFn(getMembershipInvitationList, options),
+    enabled,
+  });
+
+  return {
+    invitations: result.data?.data ?? [],
+    totalCount: result.data?.totalCount ?? 0,
+    isLoading: result.isLoading,
+    error: result.error,
+  };
+}
+
+interface UseNamespaceInvitationsParams {
+  tenantId: string;
+  status?: InvitationStatus;
+  page?: number;
+  perPage?: number;
+  enabled?: boolean;
+}
+
+export function useNamespaceInvitations({
+  tenantId,
+  status = "pending",
+  page = 1,
+  perPage = 10,
+  enabled = true,
+}: UseNamespaceInvitationsParams) {
+  const options = {
+    path: { tenant: tenantId },
+    query: {
+      filter: invitationStatusFilter(status),
+      page,
+      per_page: perPage,
+    },
+  } satisfies {
+    path: GetNamespaceMembershipInvitationListData["path"];
+    query: GetNamespaceMembershipInvitationListData["query"];
+  };
+
+  const result = useQuery<PaginatedResult<MembershipInvitation>>({
+    queryKey: getNamespaceMembershipInvitationListQueryKey(options),
+    queryFn: paginatedQueryFn(getNamespaceMembershipInvitationList, options),
+    enabled: enabled && !!tenantId,
+  });
+
+  return {
+    invitations: result.data?.data ?? [],
+    totalCount: result.data?.totalCount ?? 0,
+    isLoading: result.isLoading,
+    error: result.error,
+  };
+}

--- a/ui-react/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui-react/apps/console/src/pages/AcceptInvite.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import {
+  EnvelopeOpenIcon,
+  ExclamationTriangleIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  ArrowRightIcon,
+  UserCircleIcon,
+} from "@heroicons/react/24/outline";
+import { lookupUserStatus } from "@/client";
+import { useAuthStore } from "@/stores/authStore";
+import {
+  useAcceptInvite,
+  useDeclineInvite,
+} from "@/hooks/useInvitationMutations";
+import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
+
+type Branch =
+  | { kind: "loading" }
+  | { kind: "missing-params" }
+  | { kind: "error"; message: string }
+  | { kind: "wrong-user" }
+  | { kind: "ready" };
+
+export default function AcceptInvite() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const authToken = useAuthStore((s) => s.token);
+  const authUserId = useAuthStore((s) => s.userId);
+  const authEmail = useAuthStore((s) => s.email);
+  const logout = useAuthStore((s) => s.logout);
+
+  const tenant = searchParams.get("tenant-id") ?? "";
+  const userId = searchParams.get("user-id") ?? "";
+  const sig = searchParams.get("sig") ?? "";
+  const email = searchParams.get("email") ?? "";
+
+  const acceptInvite = useAcceptInvite();
+  const declineInvite = useDeclineInvite();
+  const switchNamespace = useSwitchNamespace();
+
+  const [branch, setBranch] = useState<Branch>({ kind: "loading" });
+  const [confirmKind, setConfirmKind] = useState<"accept" | "decline" | null>(
+    null,
+  );
+  const [actionError, setActionError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function resolve() {
+      if (!tenant || !userId || !sig) {
+        if (!cancelled) setBranch({ kind: "missing-params" });
+        return;
+      }
+
+      if (authToken) {
+        if (authUserId === userId) {
+          if (!cancelled) setBranch({ kind: "ready" });
+        } else if (!cancelled) {
+          setBranch({ kind: "wrong-user" });
+        }
+        return;
+      }
+
+      try {
+        const { data } = await lookupUserStatus({
+          path: { tenant, id: userId },
+          query: { sig },
+          throwOnError: true,
+        });
+        if (cancelled) return;
+
+        const status = data.status;
+
+        if (status === "invited") {
+          // Forward every invitation param so the post-signup redirect back
+          // to /accept-invite lands with the full context intact. Dropping
+          // tenant-id or user-id here strands the user on the "Invalid
+          // Invitation" card after they finish creating their account.
+          const signUpQuery = new URLSearchParams();
+          if (email) signUpQuery.set("email", email);
+          if (sig) signUpQuery.set("sig", sig);
+          if (tenant) signUpQuery.set("tenant-id", tenant);
+          if (userId) signUpQuery.set("user-id", userId);
+          void navigate(`/sign-up?${signUpQuery.toString()}`);
+          return;
+        }
+
+        if (status === "not-confirmed" || status === "confirmed") {
+          const redirectTarget = `/accept-invite?${searchParams.toString()}`;
+          void navigate(
+            `/login?redirect=${encodeURIComponent(redirectTarget)}`,
+          );
+          return;
+        }
+
+        if (!cancelled) {
+          setBranch({
+            kind: "error",
+            message: "We couldn't verify this invitation. Please try again.",
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setBranch({
+            kind: "error",
+            message:
+              "This invitation is invalid or has expired. Please ask the sender for a new one.",
+          });
+        }
+      }
+    }
+
+    void resolve();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    tenant,
+    userId,
+    sig,
+    email,
+    authToken,
+    authUserId,
+    searchParams,
+    navigate,
+  ]);
+
+  const handleAccept = async () => {
+    if (!tenant || !authToken) return;
+    setActionError("");
+    try {
+      await acceptInvite.mutateAsync({ path: { tenant } });
+      // switchNamespace mints a fresh namespace-scoped token, stores
+      // { token, tenant, role } via setSession, and hard-navigates so
+      // NamespaceGuard re-initializes with a clean slate. We intentionally
+      // don't call navigate("/dashboard") below — useSwitchNamespace owns
+      // the redirect.
+      await switchNamespace.mutateAsync({
+        tenantId: tenant,
+        redirectTo: "/dashboard",
+      });
+      setConfirmKind(null);
+    } catch {
+      setActionError("Failed to accept the invitation. Please try again.");
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!tenant) return;
+    setActionError("");
+    try {
+      await declineInvite.mutateAsync({ path: { tenant } });
+      setConfirmKind(null);
+      void navigate("/dashboard");
+    } catch {
+      setActionError("Failed to decline the invitation. Please try again.");
+    }
+  };
+
+  const handleSignOut = () => {
+    logout();
+    void navigate(
+      `/login?redirect=${encodeURIComponent(`/accept-invite?${searchParams.toString()}`)}`,
+    );
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto animate-fade-in">
+      <div className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm">
+        {branch.kind === "loading" && (
+          <div
+            className="flex flex-col items-center gap-3 py-6"
+            role="status"
+            aria-live="polite"
+          >
+            <span className="w-8 h-8 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+            <p className="text-sm text-text-muted">Checking invitation...</p>
+          </div>
+        )}
+
+        {branch.kind === "missing-params" && (
+          <InvitationMessage
+            tone="error"
+            icon={
+              <XCircleIcon
+                className="w-7 h-7 text-accent-red"
+                strokeWidth={1.5}
+              />
+            }
+            title="Invalid Invitation"
+            description="This invitation link is missing required parameters. Please use the link from the original email."
+            action={
+              <Link
+                to="/login"
+                className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all"
+              >
+                Back to Login
+                <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
+              </Link>
+            }
+          />
+        )}
+
+        {branch.kind === "error" && (
+          <InvitationMessage
+            tone="error"
+            icon={
+              <ExclamationTriangleIcon
+                className="w-7 h-7 text-accent-red"
+                strokeWidth={1.5}
+              />
+            }
+            title="Invitation Unavailable"
+            description={branch.message}
+            action={
+              <Link
+                to="/login"
+                className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all"
+              >
+                Back to Login
+                <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
+              </Link>
+            }
+          />
+        )}
+
+        {branch.kind === "wrong-user" && (
+          <InvitationMessage
+            tone="warning"
+            icon={
+              <UserCircleIcon
+                className="w-7 h-7 text-accent-yellow"
+                strokeWidth={1.5}
+              />
+            }
+            title="Different Account Signed In"
+            description={
+              <>
+                You&apos;re signed in as{" "}
+                <span className="font-medium text-text-primary font-mono">
+                  {authEmail ?? "another account"}
+                </span>
+                . Sign out and use the account this invitation was sent to.
+              </>
+            }
+            action={
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all"
+              >
+                Sign Out
+                <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
+              </button>
+            }
+          />
+        )}
+
+        {branch.kind === "ready" && (
+          <div className="text-center">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 border border-primary/20 mb-5">
+              <EnvelopeOpenIcon
+                className="w-7 h-7 text-primary"
+                strokeWidth={1.5}
+              />
+            </div>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              Namespace Invitation
+            </h2>
+            <p className="text-sm text-text-secondary leading-relaxed mb-6">
+              Accepting this invitation will add you to the namespace. You will
+              be automatically switched to it after accepting.
+            </p>
+            <div className="flex items-center justify-center gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmKind("decline")}
+                className="px-5 py-2.5 text-sm font-semibold text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
+              >
+                Decline
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmKind("accept")}
+                className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all"
+              >
+                <CheckCircleIcon className="w-4 h-4" strokeWidth={2} />
+                Accept
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmKind === "accept"}
+        onClose={() => {
+          setConfirmKind(null);
+          setActionError("");
+        }}
+        onConfirm={handleAccept}
+        title="Accept Invitation"
+        description="You will be added to the namespace and switched to it immediately."
+        confirmLabel="Accept"
+        variant="primary"
+        errorMessage={confirmKind === "accept" ? actionError || null : null}
+      />
+
+      <ConfirmDialog
+        open={confirmKind === "decline"}
+        onClose={() => {
+          setConfirmKind(null);
+          setActionError("");
+        }}
+        onConfirm={handleDecline}
+        title="Decline Invitation"
+        description="The invitation will be marked as rejected. You can ask the sender to invite you again later."
+        confirmLabel="Decline"
+        variant="danger"
+        errorMessage={confirmKind === "decline" ? actionError || null : null}
+      />
+    </div>
+  );
+}
+
+function InvitationMessage({
+  tone,
+  icon,
+  title,
+  description,
+  action,
+}: {
+  tone: "error" | "warning";
+  icon: React.ReactNode;
+  title: string;
+  description: React.ReactNode;
+  action: React.ReactNode;
+}) {
+  const ringClass =
+    tone === "error"
+      ? "bg-accent-red/10 border-accent-red/20"
+      : "bg-accent-yellow/10 border-accent-yellow/20";
+  return (
+    <div className="text-center">
+      <div
+        className={`inline-flex items-center justify-center w-14 h-14 rounded-full border mb-5 ${ringClass}`}
+      >
+        {icon}
+      </div>
+      <h2 className="text-lg font-semibold text-text-primary mb-3">{title}</h2>
+      <p className="text-sm text-text-secondary leading-relaxed mb-6">
+        {description}
+      </p>
+      {action}
+    </div>
+  );
+}

--- a/ui-react/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
+++ b/ui-react/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
@@ -1,0 +1,533 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAuthStore } from "../../stores/authStore";
+import AcceptInvite from "../AcceptInvite";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+// Stub ConfirmDialog — jsdom lacks HTMLDialogElement.showModal()
+vi.mock("../../components/common/ConfirmDialog", () => ({
+  default: ({
+    open,
+    onClose,
+    onConfirm,
+    title,
+    confirmLabel = "Confirm",
+    cancelLabel = "Cancel",
+    errorMessage,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void> | void;
+    title: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    errorMessage?: string | null;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog">
+        <h2>{title}</h2>
+        {errorMessage ? <div role="alert">{errorMessage}</div> : null}
+        <button onClick={onClose}>{cancelLabel}</button>
+        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+      </div>
+    );
+  },
+}));
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockLookupUserStatus = vi.fn();
+
+vi.mock("../../client", () => ({
+  lookupUserStatus: (...args: unknown[]): unknown =>
+    mockLookupUserStatus(...args),
+}));
+
+const mockAcceptMutateAsync = vi.fn();
+const mockDeclineMutateAsync = vi.fn();
+const mockSwitchNamespaceMutateAsync = vi.fn();
+
+vi.mock("../../hooks/useInvitationMutations", () => ({
+  useAcceptInvite: () => ({
+    mutateAsync: mockAcceptMutateAsync,
+    isPending: false,
+  }),
+  useDeclineInvite: () => ({
+    mutateAsync: mockDeclineMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../../hooks/useNamespaceMutations", () => ({
+  useSwitchNamespace: () => ({
+    mutateAsync: mockSwitchNamespaceMutateAsync,
+    isPending: false,
+  }),
+}));
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+const VALID_PARAMS =
+  "tenant-id=t1&user-id=u1&sig=abc123&email=alice@example.com";
+
+function createWrapper(initialSearch = "") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter
+      initialEntries={[
+        `/accept-invite${initialSearch ? "?" + initialSearch : ""}`,
+      ]}
+    >
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderPage(search = VALID_PARAMS) {
+  return render(<AcceptInvite />, {
+    wrapper: createWrapper(search),
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup / teardown                                                    */
+/* ------------------------------------------------------------------ */
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: unauthenticated
+  useAuthStore.setState({
+    token: null,
+    user: null,
+    userId: null,
+    email: null,
+    tenant: null,
+    role: null,
+    name: null,
+    loading: false,
+  });
+  mockAcceptMutateAsync.mockResolvedValue(undefined);
+  mockDeclineMutateAsync.mockResolvedValue(undefined);
+  mockSwitchNamespaceMutateAsync.mockResolvedValue(undefined);
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("AcceptInvite", () => {
+  describe("branch: missing-params", () => {
+    it("renders the Invalid Invitation heading when query params are missing", async () => {
+      renderPage("");
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /invalid invitation/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("renders a Back to Login link", async () => {
+      renderPage("");
+      await waitFor(() =>
+        expect(
+          screen.getByRole("link", { name: /back to login/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("branch: ready (authenticated as the correct user)", () => {
+    beforeEach(() => {
+      useAuthStore.setState({
+        token: "jwt-token",
+        userId: "u1",
+        email: "alice@example.com",
+        user: "alice",
+        tenant: "t1",
+        role: "owner",
+        name: "Alice",
+        loading: false,
+      });
+    });
+
+    it("renders the Namespace Invitation heading", async () => {
+      renderPage(VALID_PARAMS);
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /namespace invitation/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("renders Accept and Decline buttons", async () => {
+      renderPage(VALID_PARAMS);
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /accept/i }),
+        ).toBeInTheDocument(),
+      );
+      expect(
+        screen.getByRole("button", { name: /decline/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show a loading spinner once ready", async () => {
+      renderPage(VALID_PARAMS);
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /namespace invitation/i }),
+        ).toBeInTheDocument(),
+      );
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    describe("accept flow", () => {
+      it("shows Accept confirmation dialog when Accept button is clicked", async () => {
+        const user = userEvent.setup();
+        renderPage(VALID_PARAMS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /^accept$/i }),
+          ).toBeInTheDocument(),
+        );
+        await user.click(screen.getByRole("button", { name: /^accept$/i }));
+
+        expect(
+          screen.getByRole("heading", { name: /accept invitation/i }),
+        ).toBeInTheDocument();
+      });
+
+      it("calls acceptInvite mutation with the tenant from query params", async () => {
+        const user = userEvent.setup();
+        renderPage(VALID_PARAMS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /^accept$/i }),
+          ).toBeInTheDocument(),
+        );
+        // Open dialog
+        await user.click(screen.getByRole("button", { name: /^accept$/i }));
+        // Confirm inside dialog
+        const dialog = screen.getByRole("dialog");
+        await user.click(
+          within(dialog).getByRole("button", { name: /^accept$/i }),
+        );
+
+        await waitFor(() =>
+          expect(mockAcceptMutateAsync).toHaveBeenCalledWith({
+            path: { tenant: "t1" },
+          }),
+        );
+      });
+
+      it("switches namespace via useSwitchNamespace after acceptInvite succeeds", async () => {
+        const user = userEvent.setup();
+        renderPage(VALID_PARAMS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /^accept$/i }),
+          ).toBeInTheDocument(),
+        );
+        await user.click(screen.getByRole("button", { name: /^accept$/i }));
+        const dialog = screen.getByRole("dialog");
+        await user.click(
+          within(dialog).getByRole("button", { name: /^accept$/i }),
+        );
+
+        // acceptInvite runs first, then switchNamespace mints a fresh
+        // namespace-scoped token and hard-navigates to /dashboard.
+        await waitFor(() =>
+          expect(mockAcceptMutateAsync).toHaveBeenCalledWith({
+            path: { tenant: "t1" },
+          }),
+        );
+        await waitFor(() =>
+          expect(mockSwitchNamespaceMutateAsync).toHaveBeenCalledWith({
+            tenantId: "t1",
+            redirectTo: "/dashboard",
+          }),
+        );
+      });
+
+      it("does not switch namespace when acceptInvite fails", async () => {
+        mockAcceptMutateAsync.mockRejectedValue(new Error("server error"));
+        const user = userEvent.setup();
+        renderPage(VALID_PARAMS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /^accept$/i }),
+          ).toBeInTheDocument(),
+        );
+        await user.click(screen.getByRole("button", { name: /^accept$/i }));
+        const dialog = screen.getByRole("dialog");
+        await user.click(
+          within(dialog).getByRole("button", { name: /^accept$/i }),
+        );
+
+        await waitFor(() => expect(mockAcceptMutateAsync).toHaveBeenCalled());
+        expect(mockSwitchNamespaceMutateAsync).not.toHaveBeenCalled();
+      });
+
+      it("shows action error when acceptInvite mutation fails", async () => {
+        mockAcceptMutateAsync.mockRejectedValue(new Error("server error"));
+        const user = userEvent.setup();
+        renderPage(VALID_PARAMS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /^accept$/i }),
+          ).toBeInTheDocument(),
+        );
+        await user.click(screen.getByRole("button", { name: /^accept$/i }));
+        const dialog = screen.getByRole("dialog");
+        await user.click(
+          within(dialog).getByRole("button", { name: /^accept$/i }),
+        );
+
+        await waitFor(() =>
+          expect(
+            screen.getByText(/failed to accept the invitation/i),
+          ).toBeInTheDocument(),
+        );
+      });
+    });
+
+    describe("decline flow", () => {
+      it("shows Decline confirmation dialog when Decline button is clicked", async () => {
+        const user = userEvent.setup();
+        renderPage(VALID_PARAMS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /decline/i }),
+          ).toBeInTheDocument(),
+        );
+        await user.click(screen.getByRole("button", { name: /decline/i }));
+
+        expect(
+          screen.getByRole("heading", { name: /decline invitation/i }),
+        ).toBeInTheDocument();
+      });
+
+      it("calls declineInvite mutation and navigates to /dashboard after confirm", async () => {
+        const user = userEvent.setup();
+        renderPage(VALID_PARAMS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /decline/i }),
+          ).toBeInTheDocument(),
+        );
+        await user.click(screen.getByRole("button", { name: /decline/i }));
+        const dialog = screen.getByRole("dialog");
+        await user.click(
+          within(dialog).getByRole("button", { name: /^decline$/i }),
+        );
+
+        await waitFor(() =>
+          expect(mockDeclineMutateAsync).toHaveBeenCalledWith({
+            path: { tenant: "t1" },
+          }),
+        );
+        await waitFor(() =>
+          expect(mockNavigate).toHaveBeenCalledWith("/dashboard"),
+        );
+      });
+
+      it("shows action error when declineInvite mutation fails", async () => {
+        mockDeclineMutateAsync.mockRejectedValue(new Error("server error"));
+        const user = userEvent.setup();
+        renderPage(VALID_PARAMS);
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /decline/i }),
+          ).toBeInTheDocument(),
+        );
+        await user.click(screen.getByRole("button", { name: /decline/i }));
+        const dialog = screen.getByRole("dialog");
+        await user.click(
+          within(dialog).getByRole("button", { name: /^decline$/i }),
+        );
+
+        await waitFor(() =>
+          expect(
+            screen.getByText(/failed to decline the invitation/i),
+          ).toBeInTheDocument(),
+        );
+      });
+    });
+  });
+
+  describe("branch: wrong-user (authenticated as different user)", () => {
+    beforeEach(() => {
+      useAuthStore.setState({
+        token: "jwt-token",
+        userId: "other-user-id", // Mismatch with user-id=u1 in params
+        email: "other@example.com",
+        user: "other",
+        tenant: "t2",
+        role: "owner",
+        name: "Other",
+        loading: false,
+      });
+    });
+
+    it("renders the Different Account Signed In heading", async () => {
+      renderPage(VALID_PARAMS);
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /different account signed in/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("renders a Sign Out button", async () => {
+      renderPage(VALID_PARAMS);
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /sign out/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("calls logout and navigates to login with redirect on Sign Out", async () => {
+      const logout = vi.fn();
+      useAuthStore.setState({ logout } as never);
+      const user = userEvent.setup();
+      renderPage(VALID_PARAMS);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /sign out/i }),
+        ).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("button", { name: /sign out/i }));
+
+      expect(logout).toHaveBeenCalledTimes(1);
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(
+          expect.stringContaining("/login"),
+        ),
+      );
+    });
+  });
+
+  describe("branch: unauthenticated — lookupUserStatus invited → navigate to /sign-up", () => {
+    it("navigates to /sign-up with email and sig when status is 'invited'", async () => {
+      mockLookupUserStatus.mockResolvedValue({
+        data: { status: "invited" },
+        response: new Response(),
+      });
+      renderPage(VALID_PARAMS);
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(
+          expect.stringMatching(/^\/sign-up\?/),
+        ),
+      );
+      const call = mockNavigate.mock.calls[0][0] as string;
+      expect(call).toContain("email=alice%40example.com");
+      expect(call).toContain("sig=abc123");
+    });
+  });
+
+  describe("branch: unauthenticated — lookupUserStatus confirmed → navigate to /login", () => {
+    it("navigates to /login with redirect param when status is 'confirmed'", async () => {
+      mockLookupUserStatus.mockResolvedValue({
+        data: { status: "confirmed" },
+        response: new Response(),
+      });
+      renderPage(VALID_PARAMS);
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(
+          expect.stringMatching(/^\/login\?/),
+        ),
+      );
+      const call = mockNavigate.mock.calls[0][0] as string;
+      expect(call).toContain("redirect=");
+      expect(decodeURIComponent(call)).toContain("accept-invite");
+    });
+  });
+
+  describe("branch: unauthenticated — lookupUserStatus not-confirmed → navigate to /login", () => {
+    it("navigates to /login when status is 'not-confirmed'", async () => {
+      mockLookupUserStatus.mockResolvedValue({
+        data: { status: "not-confirmed" },
+        response: new Response(),
+      });
+      renderPage(VALID_PARAMS);
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(
+          expect.stringMatching(/^\/login\?redirect=/),
+        ),
+      );
+    });
+  });
+
+  describe("branch: error (lookupUserStatus rejects)", () => {
+    it("renders the Invitation Unavailable heading when lookupUserStatus throws", async () => {
+      mockLookupUserStatus.mockRejectedValue(new Error("network failure"));
+      renderPage(VALID_PARAMS);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /invitation unavailable/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("renders a Back to Login link in the error state", async () => {
+      mockLookupUserStatus.mockRejectedValue(new Error("network failure"));
+      renderPage(VALID_PARAMS);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("link", { name: /back to login/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("initial loading state", () => {
+    it("shows the checking invitation spinner initially when params are present and unauthenticated", async () => {
+      // Delay resolution so we can observe the loading state
+      mockLookupUserStatus.mockReturnValue(new Promise(() => {}));
+      renderPage(VALID_PARAMS);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText(/checking invitation/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
@@ -2,10 +2,10 @@ import { useState, FormEvent } from "react";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { PlusIcon } from "@heroicons/react/24/outline";
 import { useAddMember } from "@/hooks/useMemberMutations";
-import type { NamespaceMemberRole } from "@/client";
 import Drawer from "@/components/common/Drawer";
 import { LABEL, INPUT } from "@/utils/styles";
 import { RoleSelector } from "./constants";
+import { type AssignableRole } from "./helpers";
 
 /* --- Add Member Drawer --- */
 
@@ -20,7 +20,7 @@ function AddMemberDrawer({
 }) {
   const addMember = useAddMember();
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState("operator");
+  const [role, setRole] = useState<AssignableRole>("operator");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
 
@@ -36,7 +36,10 @@ function AddMemberDrawer({
     setSubmitting(true);
     setError("");
     try {
-      await addMember.mutateAsync({ path: { tenant: tenantId }, body: { email: email.trim(), role: role as NamespaceMemberRole } });
+      await addMember.mutateAsync({
+        path: { tenant: tenantId },
+        body: { email: email.trim(), role },
+      });
       onClose();
     } catch {
       setError("Failed to add member. Check the email and try again.");

--- a/ui-react/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui-react/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -1,21 +1,20 @@
 import { useState } from "react";
+import {
+  KeyIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from "@heroicons/react/24/outline";
 import { useApiKeys } from "@/hooks/useApiKeys";
 import { useDeleteApiKey } from "@/hooks/useApiKeyMutations";
 import { type ApiKey } from "@/client";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import DataTable, { type Column } from "@/components/common/DataTable";
-import { RoleBadge } from "./constants";
+import RestrictedAction from "@/components/common/RestrictedAction";
+import { ExpiredBadge, RoleBadge } from "./constants";
 import { isExpired } from "./helpers";
 import { formatExpiry, formatDateShort } from "@/utils/date";
 import GenerateKeyDrawer from "./GenerateKeyDrawer";
 import EditKeyDrawer from "./EditKeyDrawer";
-import {
-  KeyIcon,
-  ExclamationCircleIcon,
-  PencilSquareIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline";
-import RestrictedAction from "@/components/common/RestrictedAction";
 
 const PER_PAGE = 10;
 
@@ -60,15 +59,7 @@ function ApiKeysTab() {
             <span className="text-sm font-medium text-text-primary">
               {key.name}
             </span>
-            {expired && (
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs font-mono font-semibold text-accent-red bg-accent-red/10 border border-accent-red/20 rounded">
-                <ExclamationCircleIcon
-                  className="w-2.5 h-2.5"
-                  strokeWidth={2}
-                />
-                Expired
-              </span>
-            )}
+            {expired && <ExpiredBadge />}
           </div>
         );
       },

--- a/ui-react/apps/console/src/pages/team/EditInvitationDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/EditInvitationDrawer.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useUpdateMembershipInvitation } from "@/hooks/useInvitationMutations";
+import type { MembershipInvitation } from "@/client";
+import Drawer from "@/components/common/Drawer";
+import { LABEL } from "@/utils/styles";
+import { RoleSelector } from "./constants";
+import { isAssignableRole, type AssignableRole } from "./helpers";
+
+function EditInvitationDrawer({
+  open,
+  onClose,
+  tenantId,
+  invitation,
+}: {
+  open: boolean;
+  onClose: () => void;
+  tenantId: string;
+  invitation: MembershipInvitation | null;
+}) {
+  const updateInvitation = useUpdateMembershipInvitation();
+  const [role, setRole] = useState<AssignableRole>("operator");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useResetOnOpen(open, () => {
+    // The backend may return any NamespaceMemberRole (including "owner"),
+    // but only assignable roles can be chosen via RoleSelector. Fall back to
+    // "operator" for any non-assignable role — in practice "owner" never
+    // reaches the edit drawer, but the guard keeps types sound.
+    setRole(
+      isAssignableRole(invitation?.role) ? invitation.role : "operator",
+    );
+    setSubmitting(false);
+    setError("");
+  });
+
+  const handleSubmit = async () => {
+    if (!invitation) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      await updateInvitation.mutateAsync({
+        path: { tenant: tenantId, "user-id": invitation.user.id },
+        body: { role },
+      });
+      onClose();
+    } catch {
+      setError("Failed to update invitation role. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title="Update Invitation Role"
+      subtitle={
+        invitation ? (
+          <span className="font-mono">{invitation.user.email}</span>
+        ) : undefined
+      }
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleSubmit()}
+            disabled={role === invitation?.role || submitting}
+            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+          >
+            Save Changes
+          </button>
+        </>
+      }
+    >
+      <label className={LABEL}>Role</label>
+      <RoleSelector value={role} onChange={setRole} />
+      {error && (
+        <div
+          role="alert"
+          className="mt-4 flex items-start gap-2 bg-accent-red/[0.06] border border-accent-red/20 rounded-lg px-3 py-2.5 text-xs text-accent-red"
+        >
+          <InformationCircleIcon className="w-4 h-4 shrink-0 mt-px" />
+          <span>{error}</span>
+        </div>
+      )}
+    </Drawer>
+  );
+}
+
+export default EditInvitationDrawer;

--- a/ui-react/apps/console/src/pages/team/EditKeyDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/EditKeyDrawer.tsx
@@ -6,6 +6,7 @@ import { type ApiKey } from "@/client";
 import Drawer from "@/components/common/Drawer";
 import { LABEL, INPUT } from "@/utils/styles";
 import { RoleSelector } from "./constants";
+import { isAssignableRole, type AssignableRole } from "./helpers";
 
 /* ─── Edit API Key Drawer ─── */
 
@@ -20,13 +21,13 @@ function EditKeyDrawer({
 }) {
   const updateKey = useUpdateApiKey();
   const [name, setName] = useState("");
-  const [role, setRole] = useState("administrator");
+  const [role, setRole] = useState<AssignableRole>("administrator");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useResetOnOpen(open, () => {
     setName(apiKey?.name ?? "");
-    setRole(apiKey?.role ?? "administrator");
+    setRole(isAssignableRole(apiKey?.role) ? apiKey.role : "administrator");
     setSubmitting(false);
     setError(null);
   });

--- a/ui-react/apps/console/src/pages/team/EditMemberDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/EditMemberDrawer.tsx
@@ -2,10 +2,10 @@ import { useState } from "react";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { useUpdateMemberRole } from "@/hooks/useMemberMutations";
 import { type NamespaceMember } from "@/hooks/useNamespaces";
-import type { NamespaceMemberRole } from "@/client";
 import Drawer from "@/components/common/Drawer";
 import { LABEL } from "@/utils/styles";
 import { RoleSelector } from "./constants";
+import { isAssignableRole, type AssignableRole } from "./helpers";
 
 /* ─── Edit Member Drawer ─── */
 
@@ -21,11 +21,11 @@ function EditMemberDrawer({
   member: NamespaceMember | null;
 }) {
   const updateRole = useUpdateMemberRole();
-  const [role, setRole] = useState("operator");
+  const [role, setRole] = useState<AssignableRole>("operator");
   const [submitting, setSubmitting] = useState(false);
 
   useResetOnOpen(open, () => {
-    setRole(member?.role ?? "operator");
+    setRole(isAssignableRole(member?.role) ? member.role : "operator");
     setSubmitting(false);
   });
 
@@ -33,7 +33,10 @@ function EditMemberDrawer({
     if (!member) return;
     setSubmitting(true);
     try {
-      await updateRole.mutateAsync({ path: { tenant: tenantId, uid: member.id }, body: { role: role as NamespaceMemberRole } });
+      await updateRole.mutateAsync({
+        path: { tenant: tenantId, uid: member.id },
+        body: { role },
+      });
       onClose();
     } catch {
       /* */

--- a/ui-react/apps/console/src/pages/team/GenerateKeyDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/GenerateKeyDrawer.tsx
@@ -8,7 +8,7 @@ import CopyButton from "@/components/common/CopyButton";
 import Drawer from "@/components/common/Drawer";
 import { LABEL, INPUT } from "@/utils/styles";
 import { RoleSelector } from "./constants";
-import { EXPIRY_OPTIONS } from "./helpers";
+import { EXPIRY_OPTIONS, type AssignableRole } from "./helpers";
 
 function validateName(value: string): string {
   if (value.length < 3) return "Name must be at least 3 characters.";
@@ -28,7 +28,7 @@ function GenerateKeyDrawer({
 }) {
   const createKey = useCreateApiKey();
   const [name, setName] = useState("");
-  const [role, setRole] = useState("administrator");
+  const [role, setRole] = useState<AssignableRole>("administrator");
   const [expiresIn, setExpiresIn] = useState<ApiKeyCreate["expires_at"]>(30);
   const [submitting, setSubmitting] = useState(false);
   const [nameError, setNameError] = useState("");

--- a/ui-react/apps/console/src/pages/team/InvitationDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/InvitationDrawer.tsx
@@ -1,0 +1,269 @@
+import { useRef, useState, FormEvent } from "react";
+import { isSdkError } from "@/api/errors";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import {
+  EnvelopeIcon,
+  LinkIcon,
+  CheckCircleIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline";
+import {
+  useGenerateInvitationLink,
+  useSendInvitationEmail,
+} from "@/hooks/useInvitationMutations";
+import Drawer from "@/components/common/Drawer";
+import CopyButton from "@/components/common/CopyButton";
+import { LABEL, INPUT } from "@/utils/styles";
+import { RoleSelector } from "./constants";
+import { type AssignableRole } from "./helpers";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface InvitationDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  tenantId: string;
+  /** Fires when the drawer is closed *after* a successful invitation was
+   *  created during this session. Typically used to navigate the user to the
+   *  Invitations tab so they can see their freshly-created pending record. */
+  onInvitationSent?: () => void;
+}
+
+function InvitationDrawer({
+  open,
+  onClose,
+  tenantId,
+  onInvitationSent,
+}: InvitationDrawerProps) {
+  const sendEmail = useSendInvitationEmail();
+  const generateLink = useGenerateInvitationLink();
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<AssignableRole>("operator");
+  const [wantLink, setWantLink] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [emailError, setEmailError] = useState("");
+  const [error, setError] = useState("");
+  const [generatedLink, setGeneratedLink] = useState("");
+
+  // Ref (not state) so flipping it doesn't trigger re-renders and so the
+  // onInvitationSent callback reads the latest value at close time.
+  const sentRef = useRef(false);
+
+  useResetOnOpen(open, () => {
+    setEmail("");
+    setRole("operator");
+    setWantLink(false);
+    setSubmitting(false);
+    setEmailError("");
+    setError("");
+    setGeneratedLink("");
+    sentRef.current = false;
+  });
+
+  const handleClose = () => {
+    if (sentRef.current) onInvitationSent?.();
+    onClose();
+  };
+
+  const trimmedEmail = email.trim();
+  const emailValid = EMAIL_REGEX.test(trimmedEmail);
+
+  const handleSubmit = async (e?: FormEvent) => {
+    e?.preventDefault();
+    if (!emailValid) {
+      setEmailError("Enter a valid email address.");
+      return;
+    }
+    setSubmitting(true);
+    setEmailError("");
+    setError("");
+    try {
+      const body = { email: trimmedEmail, role };
+      let link = "";
+      if (wantLink) {
+        const result = await generateLink.mutateAsync({
+          path: { tenant: tenantId },
+          body,
+        });
+        link = result.link ?? "";
+      } else {
+        await sendEmail.mutateAsync({ path: { tenant: tenantId }, body });
+      }
+      sentRef.current = true;
+      if (wantLink) setGeneratedLink(link);
+      else handleClose();
+    } catch (err) {
+      if (isSdkError(err)) {
+        switch (err.status) {
+          case 400:
+            setEmailError("Invalid email or role.");
+            break;
+          case 403:
+            setError("You don't have permission to invite members.");
+            break;
+          case 404:
+            setEmailError("No account exists for this email.");
+            break;
+          case 409:
+            setEmailError(
+              "This user is already a member or has a pending invitation.",
+            );
+            break;
+          default:
+            setError("Failed to send invitation. Please try again.");
+        }
+      } else {
+        setError("Failed to send invitation. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const done = !!generatedLink;
+
+  return (
+    <Drawer
+      open={open}
+      onClose={handleClose}
+      title={done ? "Invitation Link" : "Invite Member"}
+      subtitle={
+        done ? <span className="font-mono">{trimmedEmail}</span> : undefined
+      }
+      footer={
+        done ? (
+          <button
+            onClick={handleClose}
+            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+          >
+            Done
+          </button>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={handleClose}
+              className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => void handleSubmit()}
+              disabled={!emailValid || submitting}
+              className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
+            >
+              {submitting ? (
+                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              ) : wantLink ? (
+                <LinkIcon className="w-4 h-4" strokeWidth={2} />
+              ) : (
+                <EnvelopeIcon className="w-4 h-4" strokeWidth={2} />
+              )}
+              {wantLink ? "Generate Link" : "Send Invite"}
+            </button>
+          </>
+        )
+      }
+    >
+      {done ? (
+        <div className="space-y-5">
+          <div className="flex items-start gap-3 bg-accent-green/[0.06] border border-accent-green/20 rounded-xl px-4 py-3.5">
+            <CheckCircleIcon className="w-5 h-5 text-accent-green shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-medium text-text-primary">
+                Invitation Ready
+              </p>
+              <p className="text-2xs text-text-muted mt-0.5 leading-relaxed">
+                Share this link with the recipient. It is only valid for{" "}
+                <span className="font-mono text-text-secondary">
+                  {trimmedEmail}
+                </span>{" "}
+                and has a limited lifetime.
+              </p>
+            </div>
+          </div>
+          <div>
+            <label className={LABEL}>Invitation link</label>
+            <div className="flex items-center gap-2 bg-card border border-border rounded-lg px-3.5 py-2.5">
+              <code className="flex-1 text-xs font-mono text-accent-cyan break-all select-all">
+                {generatedLink}
+              </code>
+              <CopyButton text={generatedLink} size="md" />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
+          <div>
+            <label className={LABEL} htmlFor="invitation-email">
+              Email
+            </label>
+            <input
+              id="invitation-email"
+              type="email"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                if (emailError) setEmailError("");
+              }}
+              placeholder="user@example.com"
+              autoFocus={open}
+              className={`${INPUT} ${emailError ? "border-accent-red/60 focus:border-accent-red/60 focus:ring-accent-red/20" : ""}`}
+              aria-invalid={!!emailError}
+              aria-describedby={
+                emailError ? "invitation-email-error" : undefined
+              }
+            />
+            {emailError ? (
+              <p
+                id="invitation-email-error"
+                className="mt-1.5 text-2xs text-accent-red"
+              >
+                {emailError}
+              </p>
+            ) : (
+              <p className="mt-1.5 text-2xs text-text-muted">
+                If no account matches this email, we'll send a sign-up link.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className={LABEL}>Role</label>
+            <RoleSelector value={role} onChange={setRole} />
+          </div>
+
+          <label className="flex items-start gap-2.5 px-3 py-2.5 bg-card border border-border rounded-lg cursor-pointer hover:border-border-light transition-colors">
+            <input
+              type="checkbox"
+              checked={wantLink}
+              onChange={(e) => setWantLink(e.target.checked)}
+              className="mt-0.5 h-3.5 w-3.5 rounded border-border bg-background text-primary focus:ring-1 focus:ring-primary/30 cursor-pointer"
+            />
+            <span className="flex-1">
+              <span className="block text-xs font-medium text-text-secondary">
+                Get the invite link instead of sending an email
+              </span>
+              <span className="block text-2xs text-text-muted mt-0.5">
+                Useful when you want to share the invitation through another
+                channel.
+              </span>
+            </span>
+          </label>
+
+          {error && (
+            <div
+              role="alert"
+              className="flex items-start gap-2 bg-accent-red/[0.06] border border-accent-red/20 rounded-lg px-3 py-2.5 text-xs text-accent-red"
+            >
+              <InformationCircleIcon className="w-4 h-4 shrink-0 mt-px" />
+              <span>{error}</span>
+            </div>
+          )}
+        </form>
+      )}
+    </Drawer>
+  );
+}
+
+export default InvitationDrawer;

--- a/ui-react/apps/console/src/pages/team/InvitationsTab.tsx
+++ b/ui-react/apps/console/src/pages/team/InvitationsTab.tsx
@@ -1,0 +1,455 @@
+import { useState } from "react";
+import {
+  EnvelopeOpenIcon,
+  PencilSquareIcon,
+  ArrowPathIcon,
+  TrashIcon,
+  UserPlusIcon,
+  ChevronDownIcon,
+} from "@heroicons/react/24/outline";
+import type { MembershipInvitation } from "@/client";
+import { isSdkError } from "@/api/errors";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
+import DataTable, { type Column } from "@/components/common/DataTable";
+import RestrictedAction from "@/components/common/RestrictedAction";
+import { formatDateShort } from "@/utils/date";
+import { useNamespaceInvitations } from "@/hooks/useInvitations";
+import {
+  useCancelMembershipInvitation,
+  useGenerateInvitationLink,
+} from "@/hooks/useInvitationMutations";
+import {
+  isInvitationExpired,
+  type InvitationStatus,
+} from "@/utils/invitations";
+import { ExpiredBadge, RoleBadge } from "./constants";
+import InvitationDrawer from "./InvitationDrawer";
+import EditInvitationDrawer from "./EditInvitationDrawer";
+
+const PER_PAGE = 10;
+
+type StatusOption = { value: InvitationStatus; label: string };
+
+const STATUS_OPTIONS: StatusOption[] = [
+  { value: "pending", label: "Pending" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+  { value: "cancelled", label: "Cancelled" },
+];
+
+const STATUS_STYLES: Record<
+  InvitationStatus,
+  { bg: string; text: string; border: string; label: string }
+> = {
+  pending: {
+    bg: "bg-accent-yellow/10",
+    text: "text-accent-yellow",
+    border: "border-accent-yellow/20",
+    label: "Pending",
+  },
+  accepted: {
+    bg: "bg-accent-green/10",
+    text: "text-accent-green",
+    border: "border-accent-green/20",
+    label: "Accepted",
+  },
+  rejected: {
+    bg: "bg-accent-red/10",
+    text: "text-accent-red",
+    border: "border-accent-red/20",
+    label: "Rejected",
+  },
+  cancelled: {
+    bg: "bg-hover-medium",
+    text: "text-text-muted",
+    border: "border-border",
+    label: "Cancelled",
+  },
+};
+
+function StatusBadge({ status }: { status: InvitationStatus }) {
+  const style = STATUS_STYLES[status];
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${style.bg} ${style.text} ${style.border}`}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+function rightColumnHeader(status: InvitationStatus): string {
+  switch (status) {
+    case "accepted":
+      return "Accepted";
+    case "rejected":
+      return "Rejected";
+    case "cancelled":
+      return "Cancelled";
+    case "pending":
+      return "Expires";
+  }
+}
+
+function resendEnabled(inv: MembershipInvitation): boolean {
+  if (inv.status === "cancelled") return true;
+  if (inv.status === "pending" && isInvitationExpired(inv.expires_at))
+    return true;
+  return false;
+}
+
+function cancelErrorMessage(err: unknown): string {
+  if (isSdkError(err)) {
+    switch (err.status) {
+      case 403:
+        return "You don't have permission to cancel invitations.";
+      case 404:
+        return "This invitation no longer exists.";
+    }
+  }
+  return "Failed to cancel the invitation. Please try again.";
+}
+
+function resendErrorMessage(err: unknown): string {
+  if (isSdkError(err)) {
+    switch (err.status) {
+      case 403:
+        return "You don't have permission to resend invitations.";
+      case 404:
+        return "This invitation no longer exists.";
+      case 409:
+        return "This user is already a member or has a pending invitation.";
+    }
+  }
+  return "Failed to resend the invitation. Please try again.";
+}
+
+function InvitationsTab({ tenantId }: { tenantId: string }) {
+  const [status, setStatus] = useState<InvitationStatus>("pending");
+  const [page, setPage] = useState(1);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<MembershipInvitation | null>(
+    null,
+  );
+  const [cancelTarget, setCancelTarget] = useState<MembershipInvitation | null>(
+    null,
+  );
+  const [resendTarget, setResendTarget] = useState<MembershipInvitation | null>(
+    null,
+  );
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  const [resendError, setResendError] = useState<string | null>(null);
+
+  const { invitations, totalCount, isLoading } = useNamespaceInvitations({
+    tenantId,
+    status,
+    page,
+    perPage: PER_PAGE,
+  });
+
+  const cancelInvitation = useCancelMembershipInvitation();
+  const resendInvitation = useGenerateInvitationLink();
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PER_PAGE));
+
+  const handleStatusChange = (next: InvitationStatus) => {
+    setStatus(next);
+    setPage(1);
+  };
+
+  const rightHeader = rightColumnHeader(status);
+
+  const columns: Column<MembershipInvitation>[] = [
+    {
+      key: "email",
+      header: "Email",
+      render: (inv) => (
+        <span className="text-sm font-medium text-text-primary">
+          {inv.user.email}
+        </span>
+      ),
+    },
+    {
+      key: "role",
+      header: "Role",
+      render: (inv) => <RoleBadge role={inv.role} />,
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (inv) => {
+        const expired =
+          inv.status === "pending" && isInvitationExpired(inv.expires_at);
+        return (
+          <div className="flex items-center gap-1.5">
+            <StatusBadge status={inv.status} />
+            {expired && <ExpiredBadge />}
+          </div>
+        );
+      },
+    },
+    {
+      key: "created",
+      header: "Created",
+      render: (inv) => (
+        <span className="text-xs text-text-secondary">
+          {formatDateShort(inv.created_at)}
+        </span>
+      ),
+    },
+    {
+      key: "timestamp",
+      header: rightHeader,
+      render: (inv) => {
+        if (inv.status === "pending") {
+          if (!inv.expires_at) {
+            return <span className="text-xs text-text-muted">Never</span>;
+          }
+          const expired = isInvitationExpired(inv.expires_at);
+          return (
+            <span
+              className={`text-xs ${expired ? "text-accent-red" : "text-text-secondary"}`}
+            >
+              {formatDateShort(inv.expires_at)}
+            </span>
+          );
+        }
+        return (
+          <span className="text-xs text-text-secondary">
+            {formatDateShort(inv.status_updated_at)}
+          </span>
+        );
+      },
+    },
+    {
+      key: "actions",
+      header: "Actions",
+      headerClassName: "text-right",
+      render: (inv) => {
+        const canEdit = inv.status === "pending";
+        const canCancel = inv.status === "pending";
+        const canResend = resendEnabled(inv);
+        return (
+          <div className="flex items-center justify-end gap-1">
+            <RestrictedAction action="namespace:editInvitation">
+              <button
+                onClick={() => canEdit && setEditTarget(inv)}
+                disabled={!canEdit}
+                className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium disabled:opacity-dim disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-muted transition-colors"
+                title={
+                  canEdit
+                    ? "Edit role"
+                    : "Only pending invitations can be edited"
+                }
+                aria-label="Edit invitation role"
+              >
+                <PencilSquareIcon className="w-4 h-4" />
+              </button>
+            </RestrictedAction>
+            <RestrictedAction action="namespace:addMember">
+              <button
+                onClick={() => canResend && setResendTarget(inv)}
+                disabled={!canResend}
+                className="p-1.5 rounded-md text-text-muted hover:text-primary hover:bg-primary/5 disabled:opacity-dim disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-muted transition-colors"
+                title={
+                  canResend
+                    ? "Resend invitation"
+                    : "Only cancelled or expired invitations can be resent"
+                }
+                aria-label="Resend invitation"
+              >
+                <ArrowPathIcon className="w-4 h-4" />
+              </button>
+            </RestrictedAction>
+            <RestrictedAction action="namespace:cancelInvitation">
+              <button
+                onClick={() => canCancel && setCancelTarget(inv)}
+                disabled={!canCancel}
+                className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/5 disabled:opacity-dim disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-text-muted transition-colors"
+                title={
+                  canCancel
+                    ? "Cancel invitation"
+                    : "Only pending invitations can be cancelled"
+                }
+                aria-label="Cancel invitation"
+              >
+                <TrashIcon className="w-4 h-4" />
+              </button>
+            </RestrictedAction>
+          </div>
+        );
+      },
+    },
+  ];
+
+  return (
+    <div className="animate-fade-in">
+      <div className="flex items-center justify-between mb-5 gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <p className="text-sm text-text-muted">
+            {totalCount} invitation
+            {totalCount !== 1 ? "s" : ""}
+          </p>
+          <div className="relative">
+            <select
+              value={status}
+              onChange={(e) =>
+                handleStatusChange(e.target.value as InvitationStatus)
+              }
+              className="appearance-none pl-3 pr-8 h-8 bg-card border border-border rounded-md text-xs font-medium text-text-secondary hover:border-border-light focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all cursor-pointer"
+              aria-label="Filter invitations by status"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <ChevronDownIcon
+              className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-muted"
+              strokeWidth={2.5}
+            />
+          </div>
+        </div>
+        <RestrictedAction action="namespace:addMember">
+          <button
+            onClick={() => setInviteOpen(true)}
+            className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+          >
+            <UserPlusIcon className="w-4 h-4" strokeWidth={2} />
+            Invite Member
+          </button>
+        </RestrictedAction>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={invitations}
+        rowKey={(inv) => `${inv.status}-${inv.user.id}`}
+        isLoading={isLoading}
+        loadingMessage="Loading invitations..."
+        page={page}
+        totalPages={totalPages}
+        totalCount={totalCount}
+        itemLabel="invitation"
+        onPageChange={setPage}
+        rowClassName={(inv) =>
+          inv.status === "pending" && isInvitationExpired(inv.expires_at)
+            ? "bg-accent-red/[0.03] border-l-2 border-l-accent-red/50"
+            : "border-l-2 border-l-transparent"
+        }
+        emptyState={
+          <div className="text-center">
+            <EnvelopeOpenIcon
+              className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
+              strokeWidth={1}
+            />
+            <p className="text-sm text-text-muted">
+              No {STATUS_STYLES[status].label.toLowerCase()} invitations
+            </p>
+            <p className="text-2xs text-text-muted/60 mt-1">
+              {status === "pending"
+                ? "Invite teammates to collaborate in this namespace"
+                : "Switch filters to see other invitations"}
+            </p>
+          </div>
+        }
+      />
+
+      <InvitationDrawer
+        open={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+        tenantId={tenantId}
+      />
+
+      <EditInvitationDrawer
+        open={!!editTarget}
+        onClose={() => setEditTarget(null)}
+        tenantId={tenantId}
+        invitation={editTarget}
+      />
+
+      <ConfirmDialog
+        open={!!cancelTarget}
+        onClose={() => {
+          setCancelTarget(null);
+          setCancelError(null);
+        }}
+        onConfirm={async () => {
+          if (!cancelTarget) return;
+          setCancelError(null);
+          // Drop one page *before* awaiting so the refetch targeted by
+          // useInvalidateByIds hits the correct page after the row disappears.
+          const shouldStepBack = invitations.length === 1 && page > 1;
+          if (shouldStepBack) setPage(page - 1);
+          try {
+            await cancelInvitation.mutateAsync({
+              path: {
+                tenant: tenantId,
+                "user-id": cancelTarget.user.id,
+              },
+            });
+            setCancelTarget(null);
+          } catch (err) {
+            if (shouldStepBack) setPage(page);
+            setCancelError(cancelErrorMessage(err));
+          }
+        }}
+        title="Cancel Invitation"
+        description={
+          <>
+            Cancel the invitation sent to{" "}
+            <span className="font-medium text-text-primary">
+              {cancelTarget?.user.email}
+            </span>
+            ? They will no longer be able to join via the existing link.
+          </>
+        }
+        confirmLabel="Cancel Invitation"
+        cancelLabel="Keep"
+        variant="danger"
+        errorMessage={cancelError}
+      />
+
+      <ConfirmDialog
+        open={!!resendTarget}
+        onClose={() => {
+          setResendTarget(null);
+          setResendError(null);
+        }}
+        onConfirm={async () => {
+          if (!resendTarget) return;
+          setResendError(null);
+          try {
+            await resendInvitation.mutateAsync({
+              path: { tenant: tenantId },
+              body: {
+                email: resendTarget.user.email,
+                role: resendTarget.role,
+              },
+            });
+            setResendTarget(null);
+          } catch (err) {
+            setResendError(resendErrorMessage(err));
+          }
+        }}
+        title="Resend Invitation"
+        description={
+          <>
+            Send a fresh invitation to{" "}
+            <span className="font-medium text-text-primary">
+              {resendTarget?.user.email}
+            </span>
+            ? A new email will be dispatched and any previous link will become
+            invalid.
+          </>
+        }
+        confirmLabel="Resend"
+        variant="primary"
+        errorMessage={resendError}
+      />
+    </div>
+  );
+}
+
+export default InvitationsTab;

--- a/ui-react/apps/console/src/pages/team/MembersTab.tsx
+++ b/ui-react/apps/console/src/pages/team/MembersTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import {
   PlusIcon,
   UserGroupIcon,
@@ -10,16 +10,30 @@ import { useNamespace, type NamespaceMember } from "@/hooks/useNamespaces";
 import { useRemoveMember } from "@/hooks/useMemberMutations";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import { getConfig } from "@/env";
 import { RoleBadge } from "./constants";
 import { initials } from "./helpers";
 import AddMemberDrawer from "./AddMemberDrawer";
 import EditMemberDrawer from "./EditMemberDrawer";
 import RestrictedAction from "@/components/common/RestrictedAction";
 
-function MembersTab({ tenantId }: { tenantId: string }) {
+// Cloud-only drawer — lazy so its transitive deps (CopyButton, isSdkError,
+// etc.) don't ship to the community bundle.
+const InvitationDrawer = lazy(() => import("./InvitationDrawer"));
+
+interface MembersTabProps {
+  tenantId: string;
+  /** Called after an invitation is successfully sent (cloud mode only).
+   *  Typically used by the Team page to switch the user to the Invitations
+   *  tab so they can see the newly-created pending invitation. */
+  onInvitationSent?: () => void;
+}
+
+function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
   const { namespace, isLoading: membersLoading } = useNamespace(tenantId);
   const removeMember = useRemoveMember();
   const currentUserEmail = useAuthStore((s) => s.email);
+  const isCloud = getConfig().cloud;
   const [addOpen, setAddOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<NamespaceMember | null>(null);
   const [removeTarget, setRemoveTarget] = useState<NamespaceMember | null>(
@@ -156,11 +170,22 @@ function MembersTab({ tenantId }: { tenantId: string }) {
         }
       />
 
-      <AddMemberDrawer
-        open={addOpen}
-        onClose={() => setAddOpen(false)}
-        tenantId={tenantId}
-      />
+      {isCloud ? (
+        <Suspense fallback={null}>
+          <InvitationDrawer
+            open={addOpen}
+            onClose={() => setAddOpen(false)}
+            tenantId={tenantId}
+            onInvitationSent={onInvitationSent}
+          />
+        </Suspense>
+      ) : (
+        <AddMemberDrawer
+          open={addOpen}
+          onClose={() => setAddOpen(false)}
+          tenantId={tenantId}
+        />
+      )}
       <EditMemberDrawer
         open={!!editTarget}
         onClose={() => setEditTarget(null)}

--- a/ui-react/apps/console/src/pages/team/__tests__/EditInvitationDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/team/__tests__/EditInvitationDrawer.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { MembershipInvitation } from "../../../client";
+import EditInvitationDrawer from "../EditInvitationDrawer";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const mockUpdateMutateAsync = vi.fn();
+
+vi.mock("../../../hooks/useInvitationMutations", () => ({
+  useUpdateMembershipInvitation: () => ({
+    mutateAsync: mockUpdateMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../../../components/common/Drawer", () => ({
+  default: ({
+    open,
+    onClose,
+    title,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        <button onClick={onClose}>Close</button>
+        {children}
+        {footer ?? null}
+      </div>
+    );
+  },
+}));
+
+vi.mock("../../../utils/styles", () => ({
+  LABEL: "label",
+  INPUT: "input",
+}));
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function makeInvitation(
+  overrides: Partial<MembershipInvitation> = {},
+): MembershipInvitation {
+  return {
+    namespace: { tenant_id: "t1", name: "my-ns" },
+    user: { id: "u1", email: "alice@example.com" },
+    invited_by: "owner@example.com",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    expires_at: "2099-01-08T00:00:00Z",
+    status: "pending",
+    status_updated_at: "2024-01-01T00:00:00Z",
+    role: "operator",
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderDrawer({
+  open = true,
+  onClose = vi.fn(),
+  tenantId = "t1",
+  invitation = makeInvitation(),
+}: {
+  open?: boolean;
+  onClose?: () => void;
+  tenantId?: string;
+  invitation?: MembershipInvitation | null;
+} = {}) {
+  return render(
+    <EditInvitationDrawer
+      open={open}
+      onClose={onClose}
+      tenantId={tenantId}
+      invitation={invitation}
+    />,
+    { wrapper: createWrapper() },
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup                                                               */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdateMutateAsync.mockResolvedValue(undefined);
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("EditInvitationDrawer", () => {
+  describe("rendering", () => {
+    it("renders nothing when closed", () => {
+      const { container } = renderDrawer({ open: false });
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders the Update Invitation Role heading when open", () => {
+      renderDrawer();
+      expect(
+        screen.getByRole("heading", { name: /update invitation role/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the role selector", () => {
+      renderDrawer();
+      // RoleSelector renders buttons for each role
+      expect(
+        screen.getByRole("button", { name: /operator/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("pre-fills role with the invitation's current role", () => {
+      renderDrawer({ invitation: makeInvitation({ role: "administrator" }) });
+      // The administrator button should be visually selected (ring-1 class is applied via aria — tested via DOM)
+      // We test the behaviour: clicking Save Changes should send the pre-filled role
+      // The actual visual selection is controlled via className — we just verify it renders
+      expect(
+        screen.getByRole("button", { name: /administrator/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("disables Save Changes when the role has not changed", () => {
+      renderDrawer({ invitation: makeInvitation({ role: "operator" }) });
+      expect(
+        screen.getByRole("button", { name: /save changes/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe("saving", () => {
+    it("enables Save Changes after a different role is selected", async () => {
+      const user = userEvent.setup();
+      renderDrawer({ invitation: makeInvitation({ role: "operator" }) });
+
+      await user.click(screen.getByRole("button", { name: /administrator/i }));
+
+      expect(
+        screen.getByRole("button", { name: /save changes/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("calls updateMembershipInvitation with correct path and body", async () => {
+      const user = userEvent.setup();
+      const inv = makeInvitation({
+        role: "operator",
+        user: { id: "u1", email: "alice@example.com" },
+      });
+      renderDrawer({ invitation: inv, tenantId: "t1" });
+
+      await user.click(screen.getByRole("button", { name: /administrator/i }));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() =>
+        expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+          path: { tenant: "t1", "user-id": "u1" },
+          body: { role: "administrator" },
+        }),
+      );
+    });
+
+    it("calls onClose after successful save", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      const inv = makeInvitation({ role: "operator" });
+      renderDrawer({ invitation: inv, onClose });
+
+      await user.click(screen.getByRole("button", { name: /administrator/i }));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("error handling", () => {
+    it("shows error message when mutation fails", async () => {
+      mockUpdateMutateAsync.mockRejectedValue(new Error("update failed"));
+      const user = userEvent.setup();
+      const inv = makeInvitation({ role: "operator" });
+      renderDrawer({ invitation: inv });
+
+      await user.click(screen.getByRole("button", { name: /administrator/i }));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/failed to update invitation role/i),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("does not call onClose when mutation fails", async () => {
+      mockUpdateMutateAsync.mockRejectedValue(new Error("update failed"));
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      const inv = makeInvitation({ role: "operator" });
+      renderDrawer({ invitation: inv, onClose });
+
+      await user.click(screen.getByRole("button", { name: /administrator/i }));
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/failed to update invitation role/i),
+        ).toBeInTheDocument(),
+      );
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui-react/apps/console/src/pages/team/__tests__/InvitationDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/team/__tests__/InvitationDrawer.test.tsx
@@ -1,0 +1,440 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import InvitationDrawer from "../InvitationDrawer";
+import type { SdkHttpError } from "../../../api/errors";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const mockSendEmailMutateAsync = vi.fn();
+const mockGenerateLinkMutateAsync = vi.fn();
+
+vi.mock("../../../hooks/useInvitationMutations", () => ({
+  useSendInvitationEmail: () => ({
+    mutateAsync: mockSendEmailMutateAsync,
+    isPending: false,
+  }),
+  useGenerateInvitationLink: () => ({
+    mutateAsync: mockGenerateLinkMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../../../components/common/Drawer", () => ({
+  default: ({
+    open,
+    onClose,
+    title,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        <button onClick={onClose}>Close</button>
+        {children}
+        {footer ?? null}
+      </div>
+    );
+  },
+}));
+
+vi.mock("../../../components/common/CopyButton", () => ({
+  default: ({ text }: { text: string }) => (
+    <button aria-label="Copy" data-copy={text}>
+      Copy
+    </button>
+  ),
+}));
+
+vi.mock("../../../utils/styles", () => ({
+  LABEL: "label",
+  INPUT: "input",
+}));
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderDrawer(open = true, onClose = vi.fn(), tenantId = "t1") {
+  return render(
+    <InvitationDrawer open={open} onClose={onClose} tenantId={tenantId} />,
+    { wrapper: createWrapper() },
+  );
+}
+
+function makeSdkError(status: number): SdkHttpError {
+  return Object.assign(new Error("request failed"), {
+    status,
+    headers: new Headers(),
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup                                                               */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSendEmailMutateAsync.mockResolvedValue({});
+  mockGenerateLinkMutateAsync.mockResolvedValue({ link: null });
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("InvitationDrawer", () => {
+  describe("rendering", () => {
+    it("renders the Invite Member title when open", () => {
+      renderDrawer();
+      expect(
+        screen.getByRole("heading", { name: /invite member/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders nothing when closed", () => {
+      const { container } = renderDrawer(false);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders the email input", () => {
+      renderDrawer();
+      expect(
+        screen.getByPlaceholderText(/user@example.com/i),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the 'get invite link' checkbox unchecked by default", () => {
+      renderDrawer();
+      const checkbox = screen.getByRole("checkbox", {
+        name: /get the invite link/i,
+      });
+      expect(checkbox).not.toBeChecked();
+    });
+
+    it("shows 'Send Invite' button text when checkbox is unchecked", () => {
+      renderDrawer();
+      expect(
+        screen.getByRole("button", { name: /send invite/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows 'Generate Link' button text when checkbox is checked", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+      await user.click(
+        screen.getByRole("checkbox", { name: /get the invite link/i }),
+      );
+      expect(
+        screen.getByRole("button", { name: /generate link/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("form validation", () => {
+    it("marks email input as aria-invalid after typing and clearing an invalid value", async () => {
+      // The handleSubmit path sets emailError which sets aria-invalid.
+      // The submit button is disabled when email is invalid, so we use a direct
+      // approach: type a valid email, then clear it — the error state is set
+      // when the user tries to submit an empty email via footer button click
+      // is not possible (disabled). Instead verify that the email error helper
+      // text is displayed inline when the submission is attempted via the
+      // formAction callback by checking the aria-invalid initial state.
+      const user = userEvent.setup();
+      renderDrawer();
+      const input = screen.getByPlaceholderText(/user@example.com/i);
+      // Initially no error
+      expect(input).toHaveAttribute("aria-invalid", "false");
+      // After typing invalid email — button is disabled but no error yet
+      await user.type(input, "not-an-email");
+      expect(input).toHaveAttribute("aria-invalid", "false");
+    });
+
+    it("does not call the mutation when email is invalid (Enter submit)", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+      await user.type(screen.getByPlaceholderText(/user@example.com/i), "bad");
+      await user.keyboard("{Enter}");
+      expect(mockSendEmailMutateAsync).not.toHaveBeenCalled();
+      expect(mockGenerateLinkMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it("disables the submit button when email field is empty", () => {
+      renderDrawer();
+      expect(
+        screen.getByRole("button", { name: /send invite/i }),
+      ).toBeDisabled();
+    });
+
+    it("disables the submit button when email is invalid (non-empty)", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "not-an-email",
+      );
+      expect(
+        screen.getByRole("button", { name: /send invite/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe("successful invite — email mode (checkbox off)", () => {
+    it("calls sendEmail mutation with correct args", async () => {
+      const user = userEvent.setup();
+      renderDrawer(true, vi.fn(), "t1");
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      await waitFor(() =>
+        expect(mockSendEmailMutateAsync).toHaveBeenCalledWith({
+          path: { tenant: "t1" },
+          body: { email: "alice@example.com", role: "operator" },
+        }),
+      );
+      expect(mockGenerateLinkMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it("calls onClose after successful send when wantLink is false", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      renderDrawer(true, onClose, "t1");
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("successful invite — link mode (checkbox on)", () => {
+    it("shows the invitation link after successful generation", async () => {
+      const generatedLink = "https://shellhub.example.com/invite/abc123";
+      mockGenerateLinkMutateAsync.mockResolvedValue({ link: generatedLink });
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(
+        screen.getByRole("checkbox", { name: /get the invite link/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /generate link/i }));
+
+      await waitFor(() =>
+        expect(screen.getByText(generatedLink)).toBeInTheDocument(),
+      );
+    });
+
+    it("shows the copy button after link generation", async () => {
+      mockGenerateLinkMutateAsync.mockResolvedValue({
+        link: "https://shellhub.example.com/invite/abc123",
+      });
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(
+        screen.getByRole("checkbox", { name: /get the invite link/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /generate link/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /copy/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("shows 'Invitation Link' title after link is generated", async () => {
+      mockGenerateLinkMutateAsync.mockResolvedValue({
+        link: "https://shellhub.example.com/invite/abc123",
+      });
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(
+        screen.getByRole("checkbox", { name: /get the invite link/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /generate link/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /invitation link/i }),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("does not call onClose when wantLink is true after success", async () => {
+      mockGenerateLinkMutateAsync.mockResolvedValue({
+        link: "https://shellhub.example.com/invite/abc123",
+      });
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      renderDrawer(true, onClose, "t1");
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(
+        screen.getByRole("checkbox", { name: /get the invite link/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /generate link/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /invitation link/i }),
+        ).toBeInTheDocument(),
+      );
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it("shows 400 error as invalid email/role message", async () => {
+      mockSendEmailMutateAsync.mockRejectedValue(makeSdkError(400));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      await waitFor(() =>
+        expect(screen.getByText(/invalid email or role/i)).toBeInTheDocument(),
+      );
+    });
+
+    it("shows 403 error as permission denied message", async () => {
+      mockSendEmailMutateAsync.mockRejectedValue(makeSdkError(403));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/don't have permission to invite/i),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("shows 404 error as no account message", async () => {
+      mockSendEmailMutateAsync.mockRejectedValue(makeSdkError(404));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/no account exists for this email/i),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("shows 409 error as already member message", async () => {
+      mockSendEmailMutateAsync.mockRejectedValue(makeSdkError(409));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/already a member or has a pending invitation/i),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("shows generic error for unexpected status codes", async () => {
+      mockSendEmailMutateAsync.mockRejectedValue(makeSdkError(500));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/failed to send invitation/i),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("shows generic error for non-SDK errors", async () => {
+      mockSendEmailMutateAsync.mockRejectedValue(new Error("network error"));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(
+        screen.getByPlaceholderText(/user@example.com/i),
+        "alice@example.com",
+      );
+      await user.click(screen.getByRole("button", { name: /send invite/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/failed to send invitation/i),
+        ).toBeInTheDocument(),
+      );
+    });
+  });
+});

--- a/ui-react/apps/console/src/pages/team/__tests__/InvitationsTab.test.tsx
+++ b/ui-react/apps/console/src/pages/team/__tests__/InvitationsTab.test.tsx
@@ -1,0 +1,516 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAuthStore } from "../../../stores/authStore";
+import type { MembershipInvitation } from "../../../client";
+import InvitationsTab from "../InvitationsTab";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const mockInvitations = vi.fn<
+  () => {
+    invitations: MembershipInvitation[];
+    totalCount: number;
+    isLoading: boolean;
+  }
+>();
+const mockCancelMutateAsync = vi.fn();
+const mockResendMutateAsync = vi.fn();
+
+vi.mock("../../../hooks/useInvitations", () => ({
+  useNamespaceInvitations: () => mockInvitations(),
+}));
+
+vi.mock("../../../hooks/useInvitationMutations", () => ({
+  useCancelMembershipInvitation: () => ({
+    mutateAsync: mockCancelMutateAsync,
+    isPending: false,
+  }),
+  useGenerateInvitationLink: () => ({
+    mutateAsync: mockResendMutateAsync,
+    isPending: false,
+  }),
+}));
+
+// Stub ConfirmDialog so jsdom's lack of HTMLDialogElement.showModal() doesn't crash
+vi.mock("../../../components/common/ConfirmDialog", () => ({
+  default: ({
+    open,
+    onClose,
+    onConfirm,
+    title,
+    confirmLabel = "Confirm",
+    cancelLabel = "Cancel",
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void> | void;
+    title: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog">
+        <h2>{title}</h2>
+        <button onClick={onClose}>{cancelLabel}</button>
+        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+      </div>
+    );
+  },
+}));
+
+// Stub drawers to keep tests focused on InvitationsTab logic
+vi.mock("../InvitationDrawer", () => ({
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="invitation-drawer">
+        <button onClick={onClose}>Close Invite Drawer</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("../EditInvitationDrawer", () => ({
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="edit-invitation-drawer">
+        <button onClick={onClose}>Close Edit Drawer</button>
+      </div>
+    ) : null,
+}));
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function makeInvitation(
+  overrides: Partial<MembershipInvitation> = {},
+): MembershipInvitation {
+  return {
+    namespace: { tenant_id: "t1", name: "my-ns" },
+    user: { id: "u1", email: "alice@example.com" },
+    invited_by: "owner@example.com",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    expires_at: "2099-01-08T00:00:00Z",
+    status: "pending",
+    status_updated_at: "2024-01-01T00:00:00Z",
+    role: "operator",
+    ...overrides,
+  };
+}
+
+function makeExpiredInvitation(
+  overrides: Partial<MembershipInvitation> = {},
+): MembershipInvitation {
+  return makeInvitation({
+    expires_at: "2020-01-01T00:00:00Z",
+    ...overrides,
+  });
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderTab(tenantId = "t1") {
+  return render(<InvitationsTab tenantId={tenantId} />, {
+    wrapper: createWrapper(),
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup                                                               */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default to owner so RestrictedAction does not block anything
+  useAuthStore.setState({ role: "owner" });
+  mockInvitations.mockReturnValue({
+    invitations: [],
+    totalCount: 0,
+    isLoading: false,
+  });
+  mockCancelMutateAsync.mockResolvedValue(undefined);
+  mockResendMutateAsync.mockResolvedValue(undefined);
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("InvitationsTab", () => {
+  describe("rendering", () => {
+    it("shows the invitation count from totalCount", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [],
+        totalCount: 5,
+        isLoading: false,
+      });
+      renderTab();
+      expect(screen.getByText(/5 invitation/i)).toBeInTheDocument();
+    });
+
+    it("uses singular 'invitation' when count is 1", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      // "1 invitation" without an 's'
+      expect(screen.getByText("1 invitation")).toBeInTheDocument();
+    });
+
+    it("renders the status filter dropdown with Pending selected by default", () => {
+      renderTab();
+      const select = screen.getByRole("combobox", {
+        name: /filter invitations by status/i,
+      });
+      expect(select).toHaveValue("pending");
+    });
+
+    it("renders all four status options in the dropdown", () => {
+      renderTab();
+      expect(
+        screen.getByRole("option", { name: /pending/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /accepted/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /rejected/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /cancelled/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the Invite Member button for owners", () => {
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /invite member/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows a row for each invitation", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [
+          makeInvitation({ user: { id: "u1", email: "alice@example.com" } }),
+          makeInvitation({ user: { id: "u2", email: "bob@example.com" } }),
+        ],
+        totalCount: 2,
+        isLoading: false,
+      });
+      renderTab();
+      expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+      expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+    });
+
+    it("shows loading message while fetching", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [],
+        totalCount: 0,
+        isLoading: true,
+      });
+      renderTab();
+      expect(screen.getByText(/loading invitations/i)).toBeInTheDocument();
+    });
+
+    it("shows empty state when there are no pending invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [],
+        totalCount: 0,
+        isLoading: false,
+      });
+      renderTab();
+      expect(screen.getByText(/no pending invitations/i)).toBeInTheDocument();
+    });
+
+    it("shows expired badge for pending invitation past expires_at", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeExpiredInvitation()],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(screen.getByText("Expired")).toBeInTheDocument();
+    });
+  });
+
+  describe("status filter", () => {
+    it("changes the displayed status when a new option is selected", async () => {
+      const user = userEvent.setup();
+      renderTab();
+
+      const select = screen.getByRole("combobox", {
+        name: /filter invitations by status/i,
+      });
+      await user.selectOptions(select, "accepted");
+
+      expect(select).toHaveValue("accepted");
+    });
+  });
+
+  describe("action buttons — enablement rules", () => {
+    it("Edit button is enabled for pending invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "pending" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /edit invitation role/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("Edit button is disabled for accepted invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "accepted" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /edit invitation role/i }),
+      ).toBeDisabled();
+    });
+
+    it("Cancel button is enabled for pending invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "pending" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /cancel invitation/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("Cancel button is disabled for cancelled invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "cancelled" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /cancel invitation/i }),
+      ).toBeDisabled();
+    });
+
+    it("Resend button is enabled for cancelled invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "cancelled" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /resend invitation/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("Resend button is enabled for expired pending invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeExpiredInvitation({ status: "pending" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /resend invitation/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("Resend button is disabled for non-expired pending invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "pending" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /resend invitation/i }),
+      ).toBeDisabled();
+    });
+
+    it("Resend button is disabled for accepted invitations", () => {
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "accepted" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+      expect(
+        screen.getByRole("button", { name: /resend invitation/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe("Invite Member drawer", () => {
+    it("opens InvitationDrawer when Invite Member is clicked", async () => {
+      const user = userEvent.setup();
+      renderTab();
+
+      await user.click(screen.getByRole("button", { name: /invite member/i }));
+
+      expect(screen.getByTestId("invitation-drawer")).toBeInTheDocument();
+    });
+
+    it("closes InvitationDrawer when the drawer's close action is triggered", async () => {
+      const user = userEvent.setup();
+      renderTab();
+
+      await user.click(screen.getByRole("button", { name: /invite member/i }));
+      await user.click(
+        screen.getByRole("button", { name: /close invite drawer/i }),
+      );
+
+      expect(screen.queryByTestId("invitation-drawer")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Edit invitation drawer", () => {
+    it("opens EditInvitationDrawer when Edit button is clicked on a pending invitation", async () => {
+      const user = userEvent.setup();
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "pending" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+
+      await user.click(
+        screen.getByRole("button", { name: /edit invitation role/i }),
+      );
+
+      expect(screen.getByTestId("edit-invitation-drawer")).toBeInTheDocument();
+    });
+  });
+
+  describe("Cancel invitation", () => {
+    it("opens confirmation dialog when Cancel button is clicked on a pending invitation", async () => {
+      const user = userEvent.setup();
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "pending" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+
+      await user.click(
+        screen.getByRole("button", { name: /cancel invitation/i }),
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /cancel invitation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls cancelMembershipInvitation mutation when confirmed", async () => {
+      const user = userEvent.setup();
+      const inv = makeInvitation({
+        status: "pending",
+        user: { id: "u1", email: "alice@example.com" },
+      });
+      mockInvitations.mockReturnValue({
+        invitations: [inv],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab("t1");
+
+      // Open dialog by clicking the table action button (aria-label)
+      await user.click(
+        screen.getByRole("button", { name: "Cancel invitation" }),
+      );
+
+      // Confirm inside the dialog — the confirm button renders with the confirmLabel prop
+      const dialog = screen.getByRole("dialog");
+      await user.click(
+        within(dialog).getByRole("button", { name: /cancel invitation/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockCancelMutateAsync).toHaveBeenCalledWith({
+          path: { tenant: "t1", "user-id": "u1" },
+        }),
+      );
+    });
+  });
+
+  describe("Resend invitation", () => {
+    it("opens confirmation dialog when Resend is clicked on a cancelled invitation", async () => {
+      const user = userEvent.setup();
+      mockInvitations.mockReturnValue({
+        invitations: [makeInvitation({ status: "cancelled" })],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab();
+
+      await user.click(
+        screen.getByRole("button", { name: /resend invitation/i }),
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /resend invitation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls generateInvitationLink mutation when confirmed", async () => {
+      const user = userEvent.setup();
+      const inv = makeInvitation({
+        status: "cancelled",
+        user: { id: "u1", email: "alice@example.com" },
+        role: "operator",
+      });
+      mockInvitations.mockReturnValue({
+        invitations: [inv],
+        totalCount: 1,
+        isLoading: false,
+      });
+      renderTab("t1");
+
+      await user.click(
+        screen.getByRole("button", { name: /resend invitation/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /^resend$/i }));
+
+      await waitFor(() =>
+        expect(mockResendMutateAsync).toHaveBeenCalledWith({
+          path: { tenant: "t1" },
+          body: { email: "alice@example.com", role: "operator" },
+        }),
+      );
+    });
+  });
+
+  describe("permission gating", () => {
+    it("restricts Invite Member button for non-owner roles", () => {
+      useAuthStore.setState({ role: "observer" });
+      renderTab();
+      // RestrictedAction wraps it in aria-disabled span
+      const wrapper = screen
+        .getByRole("button", { name: /invite member/i })
+        .closest("[aria-disabled='true']");
+      expect(wrapper).toBeInTheDocument();
+    });
+  });
+});

--- a/ui-react/apps/console/src/pages/team/constants.tsx
+++ b/ui-react/apps/console/src/pages/team/constants.tsx
@@ -1,4 +1,5 @@
-import { ROLES } from "./helpers";
+import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
+import { ROLES, type AssignableRole } from "./helpers";
 
 /* ─── Constants ─── */
 
@@ -43,6 +44,18 @@ const ROLE_META: Record<string, { icon: string; summary: string }> = {
   },
 };
 
+/* ─── Expired Badge ─── */
+
+/** Small destructive badge shown next to expired API keys or invitations. */
+export function ExpiredBadge() {
+  return (
+    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs font-mono font-semibold text-accent-red bg-accent-red/10 border border-accent-red/20 rounded">
+      <ExclamationCircleIcon className="w-2.5 h-2.5" strokeWidth={2} />
+      Expired
+    </span>
+  );
+}
+
 /* ─── Role Badge ─── */
 
 export function RoleBadge({ role }: { role: string }) {
@@ -62,8 +75,8 @@ export function RoleSelector({
   value,
   onChange,
 }: {
-  value: string;
-  onChange: (v: string) => void;
+  value: AssignableRole;
+  onChange: (v: AssignableRole) => void;
 }) {
   return (
     <div className="space-y-1.5">

--- a/ui-react/apps/console/src/pages/team/helpers.ts
+++ b/ui-react/apps/console/src/pages/team/helpers.ts
@@ -8,6 +8,20 @@ export const EXPIRY_OPTIONS = [
 
 export const ROLES = ["administrator", "operator", "observer"] as const;
 
+/** A role that can be assigned to an invitation, member, or API key.
+ *  Excludes "owner" — ownership is transferred, not assigned. */
+export type AssignableRole = (typeof ROLES)[number];
+
+/** Type guard for strings that happen to be valid AssignableRoles — used to
+ *  narrow arbitrary role strings from the backend (e.g. an existing member's
+ *  role) before feeding them into RoleSelector. */
+export function isAssignableRole(role: unknown): role is AssignableRole {
+  return (
+    typeof role === "string" &&
+    (ROLES as readonly string[]).includes(role)
+  );
+}
+
 export function isExpired(expiresIn: number): boolean {
   if (expiresIn <= 0) return false;
   return Date.now() > expiresIn * 1000;

--- a/ui-react/apps/console/src/pages/team/index.tsx
+++ b/ui-react/apps/console/src/pages/team/index.tsx
@@ -1,20 +1,34 @@
 import { useState } from "react";
 import { UserGroupIcon } from "@heroicons/react/24/outline";
 import { useAuthStore } from "@/stores/authStore";
+import { getConfig } from "@/env";
+import { hasPermission } from "@/utils/permission";
 import PageHeader from "@/components/common/PageHeader";
 import MembersTab from "./MembersTab";
 import ApiKeysTab from "./ApiKeysTab";
+import InvitationsTab from "./InvitationsTab";
 
 /* --- Page --- */
-
-const tabs = [
-  { label: "Members", value: "members" },
-  { label: "API Keys", value: "api-keys" },
-];
 
 export default function Team() {
   const [tab, setTab] = useState("members");
   const tenant = useAuthStore((s) => s.tenant);
+  const role = useAuthStore((s) => s.role);
+  const isCloud = getConfig().cloud;
+  // The invitations endpoint is administrator-only — operators and
+  // observers get a 403 on every read. Match the Vue UI (router meta
+  // `isHidden`) and hide the tab for anyone without that permission
+  // rather than rendering a tab that can only show an error state.
+  const canManageInvitations =
+    isCloud && hasPermission(role, "namespace:editInvitation");
+
+  const tabs = [
+    { label: "Members", value: "members" },
+    ...(canManageInvitations
+      ? [{ label: "Invitations", value: "invitations" }]
+      : []),
+    { label: "API Keys", value: "api-keys" },
+  ];
 
   return (
     <div>
@@ -22,7 +36,11 @@ export default function Team() {
         icon={<UserGroupIcon className="w-6 h-6" />}
         overline="Management"
         title="Team"
-        description="Manage namespace members and API keys"
+        description={
+          isCloud
+            ? "Manage namespace members, invitations, and API keys"
+            : "Manage namespace members and API keys"
+        }
       />
 
       {/* Tabs */}
@@ -43,7 +61,17 @@ export default function Team() {
       </div>
 
       {/* Tab content */}
-      {tab === "members" && tenant && <MembersTab tenantId={tenant} />}
+      {tab === "members" && tenant && (
+        <MembersTab
+          tenantId={tenant}
+          onInvitationSent={
+            canManageInvitations ? () => setTab("invitations") : undefined
+          }
+        />
+      )}
+      {tab === "invitations" && tenant && canManageInvitations && (
+        <InvitationsTab tenantId={tenant} />
+      )}
       {tab === "api-keys" && <ApiKeysTab />}
     </div>
   );

--- a/ui-react/apps/console/src/utils/__tests__/invitations.test.ts
+++ b/ui-react/apps/console/src/utils/__tests__/invitations.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { invitationStatusFilter, isInvitationExpired } from "../invitations";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("invitationStatusFilter", () => {
+  it("returns a non-empty base64 string", () => {
+    const result = invitationStatusFilter("pending");
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("decodes to valid JSON array", () => {
+    const result = invitationStatusFilter("pending");
+    const decoded = JSON.parse(atob(result)) as unknown[];
+    expect(Array.isArray(decoded)).toBe(true);
+    expect(decoded).toHaveLength(1);
+  });
+
+  it("encodes a property-type filter with name='status' and operator='eq'", () => {
+    const result = invitationStatusFilter("accepted");
+    const [filter] = JSON.parse(atob(result)) as Array<{
+      type: string;
+      params: { name: string; operator: string; value: string };
+    }>;
+    expect(filter.type).toBe("property");
+    expect(filter.params.name).toBe("status");
+    expect(filter.params.operator).toBe("eq");
+  });
+
+  it("encodes the given status as the filter value — pending", () => {
+    const result = invitationStatusFilter("pending");
+    const [filter] = JSON.parse(atob(result)) as Array<{
+      type: string;
+      params: { name: string; operator: string; value: string };
+    }>;
+    expect(filter.params.value).toBe("pending");
+  });
+
+  it("encodes the given status as the filter value — cancelled", () => {
+    const result = invitationStatusFilter("cancelled");
+    const [filter] = JSON.parse(atob(result)) as Array<{
+      type: string;
+      params: { name: string; operator: string; value: string };
+    }>;
+    expect(filter.params.value).toBe("cancelled");
+  });
+
+  it("produces different output for different statuses", () => {
+    expect(invitationStatusFilter("pending")).not.toBe(
+      invitationStatusFilter("accepted"),
+    );
+  });
+});
+
+describe("isInvitationExpired", () => {
+  it("returns false when expiresAt is null", () => {
+    expect(isInvitationExpired(null)).toBe(false);
+  });
+
+  it("returns true when expiresAt is in the past", () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+    expect(isInvitationExpired(pastDate)).toBe(true);
+  });
+
+  it("returns false when expiresAt is in the future", () => {
+    const futureDate = new Date(Date.now() + 60_000).toISOString();
+    expect(isInvitationExpired(futureDate)).toBe(false);
+  });
+
+  it("returns true when expiresAt is exactly at epoch 0 (far past)", () => {
+    expect(isInvitationExpired("1970-01-01T00:00:00.000Z")).toBe(true);
+  });
+
+  it("returns false when expiresAt is far in the future", () => {
+    expect(isInvitationExpired("2099-12-31T23:59:59.000Z")).toBe(false);
+  });
+});

--- a/ui-react/apps/console/src/utils/invitations.ts
+++ b/ui-react/apps/console/src/utils/invitations.ts
@@ -1,0 +1,22 @@
+import type { MembershipInvitation } from "@/client";
+
+export type InvitationStatus = MembershipInvitation["status"];
+
+/**
+ * Builds the base64-encoded filter query used by the backend's invitation list
+ * endpoints. Mirrors the encoding from the legacy Vue UI (ui/src/utils/invitations.ts).
+ */
+export function invitationStatusFilter(status: InvitationStatus): string {
+  const filter = [
+    {
+      type: "property",
+      params: { name: "status", operator: "eq", value: status },
+    },
+  ];
+  return btoa(JSON.stringify(filter));
+}
+
+export function isInvitationExpired(expiresAt: string | null): boolean {
+  if (!expiresAt) return false;
+  return new Date(expiresAt).getTime() < Date.now();
+}


### PR DESCRIPTION
## What
Ported the Vue UI team invitations feature to React: namespace-scoped invitation CRUD on the Team page, a pending invitations dropdown in the AppBar, and a public `/accept-invite` page integrated with the post-signup redirect flow.

## Why
Closes: shellhub-io/team#70

Team invitations are a core feature for onboarding members. This ports the existing Vue implementation to the React UI, maintaining feature parity while adapting to React patterns.

## Changes

- **AcceptInvite page**: New public page (`/accept-invite`) that accepts invitation tokens and chains the acceptance into `useSwitchNamespace` to mint a fresh namespace-scoped token, avoiding the stale-token trap of reusing the current session token. Integrated with the post-signup redirect flow in `AccountCreated`.

- **Invitation CRUD on Team page**: New `InvitationsTab` component displays pending and accepted invitations with status filtering. `InvitationDrawer` handles creating and resending invitations; `EditInvitationDrawer` handles updating roles and revoking invitations. In Cloud mode, the Members tab "Add Member" button opens the shared `InvitationDrawer`, matching Vue behavior where every new member goes through an invitation. Community mode keeps the direct add-member flow.

- **Pending invitations dropdown**: New `InvitationsMenu` component in the AppBar displays pending invitations count and a list of pending invites. Users can accept or decline directly from the dropdown.

- **Hooks and utilities**: Added `useInvitations` and `useInvitationMutations` hooks for querying and mutating invitations. Added `invitations.ts` utilities for formatting and validating invitation data.

- **ConfirmDialog enhancement**: Added `errorMessage` prop to surface mutation failures inline without closing the dialog, allowing users to retry or cancel.

- **Routing**: Added `/accept-invite` route to App.tsx.

## Testing
- Unit tests for `useInvitations` and `useInvitationMutations` hooks cover lifecycle and error handling.
- Component tests for `InvitationDrawer`, `EditInvitationDrawer`, and `InvitationsTab` validate form submission, error display, and state updates.
- `InvitationsMenu` tests verify dropdown rendering, invitation display, and accept/decline flows.
- `AcceptInvite` page tests cover token validation, successful acceptance, and error cases.
- Utility tests for invitation formatting and validation.