### PR TITLE
fix(ui-react): clear query cache on logout to drop stale user data

### DIFF
--- a/ui-react/apps/console/src/api/queryClient.ts
+++ b/ui-react/apps/console/src/api/queryClient.ts
@@ -1,0 +1,14 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 3,
+      staleTime: 30_000,
+      refetchOnWindowFocus: true,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+});

--- a/ui-react/apps/console/src/main.tsx
+++ b/ui-react/apps/console/src/main.tsx
@@ -1,29 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import ErrorBoundary from "./components/common/ErrorBoundary";
 import { ClipboardProvider } from "./components/common/ClipboardProvider";
 import { loadConfig } from "./env";
+import { queryClient } from "./api/queryClient";
 import "./api/fetchInterceptors";
 import "@xterm/xterm/css/xterm.css";
 import "font-logos/assets/font-logos.css";
 import "./index.css";
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 3,
-      staleTime: 30_000,
-      refetchOnWindowFocus: true,
-    },
-    mutations: {
-      retry: 0,
-    },
-  },
-});
 
 void loadConfig().then(() => {
   ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/ui-react/apps/console/src/stores/authStore.ts
+++ b/ui-react/apps/console/src/stores/authStore.ts
@@ -11,6 +11,7 @@ import {
   requestResetMfa,
   resetMfa,
 } from "../client";
+import { queryClient } from "../api/queryClient";
 import { useVaultStore } from "./vaultStore";
 
 interface AuthState {
@@ -152,6 +153,9 @@ export const useAuthStore = create<AuthState>()(
         useVaultStore.getState().lock();
         set(initialState);
         localStorage.removeItem("shellhub-session");
+        // Drop every cached query so the next user doesn't briefly see the
+        // previous user's namespaces, devices, role, etc. before refetches land.
+        queryClient.clear();
       },
 
       fetchUser: async () => {


### PR DESCRIPTION
## What
Logging out now wipes the TanStack Query cache, so switching from one
user to another in the same tab no longer bleeds the previous user's
namespaces, role, or devices into the new session.

## Why
`authStore.logout()` reset Zustand state and cleared `shellhub-session`
from `localStorage`, but left every React Query entry behind. Because
query keys like `getNamespaces({page:1,per_page:100})` and
`getNamespace({tenant})` aren't scoped to the authenticated user, the
cached values survived logout and were served to the next user until a
refetch landed (well inside the 30s `staleTime`).

Observed symptoms:
- User A (namespace `dev`) → logout → login as user B (no namespaces):
  `NamespaceSelector` kept showing `dev`.
- User B → logout → login as user A: A briefly landed on the "create
  your first namespace" screen because the empty list from B was still
  cached.

A hard refresh masked the bug because it tore down the `QueryClient`.

## Changes
- **ui-react/apps/console/src/api/queryClient.ts**: new module owning
  the singleton `QueryClient` so non-React code can reach it without
  prop-drilling or `useQueryClient()`.
- **ui-react/apps/console/src/main.tsx**: imports the singleton instead
  of constructing it locally; `QueryClientProvider` still wraps the app.
- **ui-react/apps/console/src/stores/authStore.ts**: `logout()` calls
  `queryClient.clear()` after resetting state and removing the
  persisted session. Covers every logout path — UserMenu, AdminAppBar,
  CommandPalette, AcceptInvite, Login, Unauthorized, the 401
  interceptors in `fetchInterceptors`/`interceptors`, and `deleteUser`
  — since all of them funnel through `useAuthStore.logout()`.

## Testing
- Log in as user A with at least one namespace, log out, immediately
  log in as a user B with no namespaces. The namespace selector should
  show "No namespace" and the app should land on the create-namespace
  flow — not A's namespace.
- Reverse the order (B → A) and confirm A lands on their dashboard
  with the correct namespace, not on the create-namespace screen.
- Confirm the 401 auto-logout path still works: expire a token
  server-side, trigger any authenticated request, and verify the user
  is bounced to `/login` with no residual data visible on the next
  session.