### PR TITLE
feat(api): expose SAML status in system info and add hook extension point

### DIFF
--- a/api/pkg/responses/system.go
+++ b/api/pkg/responses/system.go
@@ -9,6 +9,7 @@ type SystemInfo struct {
 
 type SystemAuthenticationInfo struct {
 	Local bool `json:"local"`
+	SAML  bool `json:"saml"`
 }
 
 type SystemEndpointsInfo struct {

--- a/api/services/system.go
+++ b/api/services/system.go
@@ -45,6 +45,10 @@ func (s *service) GetSystemInfo(ctx context.Context, req *requests.GetSystemInfo
 		resp.Endpoints.API = req.Host
 	}
 
+	if err := fireGetSystemInfo(ctx, resp); err != nil {
+		return nil, err
+	}
+
 	return resp, nil
 }
 

--- a/api/services/system_hooks.go
+++ b/api/services/system_hooks.go
@@ -1,0 +1,38 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shellhub-io/shellhub/api/pkg/responses"
+)
+
+// SystemInfoHookFn is called after GetSystemInfo builds its response, allowing
+// enterprise/cloud packages to augment the response (e.g. add SAML status).
+// Hooks run synchronously; a returned error aborts the request.
+type SystemInfoHookFn func(ctx context.Context, info *responses.SystemInfo) error
+
+var systemInfoHooks []SystemInfoHookFn
+
+// OnGetSystemInfo registers a hook that fires after GetSystemInfo builds its
+// response. Must be called during package init, before the server starts
+// handling requests. Cloud/enterprise packages use this to inject additional
+// authentication capabilities (e.g. SAML enabled status) into the /info response.
+func OnGetSystemInfo(fn SystemInfoHookFn) {
+	if fn == nil {
+		panic("services: OnGetSystemInfo called with nil hook")
+	}
+
+	systemInfoHooks = append(systemInfoHooks, fn)
+}
+
+// fireGetSystemInfo dispatches all registered system info hooks sequentially.
+func fireGetSystemInfo(ctx context.Context, info *responses.SystemInfo) error {
+	for _, fn := range systemInfoHooks {
+		if err := fn(ctx, info); err != nil {
+			return fmt.Errorf("system info hook failed: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/api/services/system_hooks_test.go
+++ b/api/services/system_hooks_test.go
@@ -1,0 +1,107 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/pkg/responses"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOnGetSystemInfo(t *testing.T) {
+	saved := systemInfoHooks
+	t.Cleanup(func() { systemInfoHooks = saved })
+
+	t.Run("nil hook panics", func(t *testing.T) {
+		systemInfoHooks = nil
+		assert.PanicsWithValue(t, "services: OnGetSystemInfo called with nil hook", func() {
+			OnGetSystemInfo(nil)
+		})
+	})
+
+	t.Run("registers hook", func(t *testing.T) {
+		systemInfoHooks = nil
+
+		called := false
+		OnGetSystemInfo(func(_ context.Context, _ *responses.SystemInfo) error {
+			called = true
+
+			return nil
+		})
+
+		assert.Len(t, systemInfoHooks, 1)
+
+		err := systemInfoHooks[0](context.Background(), &responses.SystemInfo{})
+		assert.NoError(t, err)
+		assert.True(t, called)
+	})
+}
+
+func TestFireGetSystemInfo(t *testing.T) {
+	saved := systemInfoHooks
+	t.Cleanup(func() { systemInfoHooks = saved })
+
+	ctx := context.Background()
+	info := &responses.SystemInfo{
+		Authentication: &responses.SystemAuthenticationInfo{Local: true},
+	}
+
+	t.Run("no hooks registered", func(t *testing.T) {
+		systemInfoHooks = nil
+		assert.NoError(t, fireGetSystemInfo(ctx, info))
+	})
+
+	t.Run("single hook receives correct args and can mutate info", func(t *testing.T) {
+		systemInfoHooks = nil
+
+		OnGetSystemInfo(func(gotCtx context.Context, gotInfo *responses.SystemInfo) error {
+			assert.Equal(t, ctx, gotCtx)
+			assert.Equal(t, info, gotInfo)
+			gotInfo.Authentication.SAML = true
+
+			return nil
+		})
+
+		assert.NoError(t, fireGetSystemInfo(ctx, info))
+		assert.True(t, info.Authentication.SAML)
+	})
+
+	t.Run("error aborts remaining hooks", func(t *testing.T) {
+		systemInfoHooks = nil
+		hookErr := errors.New("hook failed")
+
+		OnGetSystemInfo(func(context.Context, *responses.SystemInfo) error {
+			return hookErr
+		})
+
+		secondCalled := false
+		OnGetSystemInfo(func(context.Context, *responses.SystemInfo) error {
+			secondCalled = true
+
+			return nil
+		})
+
+		assert.ErrorIs(t, fireGetSystemInfo(ctx, info), hookErr)
+		assert.False(t, secondCalled)
+	})
+
+	t.Run("multiple hooks run in order", func(t *testing.T) {
+		systemInfoHooks = nil
+
+		var order []int
+		OnGetSystemInfo(func(context.Context, *responses.SystemInfo) error {
+			order = append(order, 1)
+
+			return nil
+		})
+		OnGetSystemInfo(func(context.Context, *responses.SystemInfo) error {
+			order = append(order, 2)
+
+			return nil
+		})
+
+		assert.NoError(t, fireGetSystemInfo(ctx, info))
+		assert.Equal(t, []int{1, 2}, order)
+	})
+}

--- a/api/services/system_test.go
+++ b/api/services/system_test.go
@@ -1,0 +1,237 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/pkg/responses"
+	"github.com/shellhub-io/shellhub/api/store/mocks"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	storecache "github.com/shellhub-io/shellhub/pkg/cache"
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	envmocks "github.com/shellhub-io/shellhub/pkg/envs/mocks"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	gomock "github.com/stretchr/testify/mock"
+)
+
+func TestGetSystemInfo(t *testing.T) {
+	// Save and restore global hooks so tests don't leak.
+	savedHooks := systemInfoHooks
+	t.Cleanup(func() { systemInfoHooks = savedHooks })
+
+	// Use a local env mock to avoid interference with the shared package-level envMock.
+	localEnvMock := new(envmocks.Backend)
+	savedEnvBackend := envs.DefaultBackend
+	envs.DefaultBackend = localEnvMock
+	t.Cleanup(func() { envs.DefaultBackend = savedEnvBackend })
+
+	storeMock := &mocks.Store{}
+	s := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache(), clientMock)
+
+	ctx := context.Background()
+
+	cases := []struct {
+		description    string
+		req            *requests.GetSystemInfo
+		setupMocks     func()
+		setupHooks     func()
+		expectedResult *responses.SystemInfo
+		expectedErrMsg string
+	}{
+		{
+			description: "store error propagates",
+			req:         &requests.GetSystemInfo{Host: "localhost"},
+			setupMocks: func() {
+				storeMock.On("SystemGet", gomock.Anything).
+					Return(nil, errors.New("db error")).Once()
+			},
+			setupHooks:     func() {},
+			expectedResult: nil,
+			expectedErrMsg: "db error",
+		},
+		{
+			description: "returns local auth enabled, saml false when no hooks",
+			req:         &requests.GetSystemInfo{Host: "192.168.1.1"},
+			setupMocks: func() {
+				localEnvMock.On("Get", "SHELLHUB_SSH_PORT").Return("22").Once()
+				localEnvMock.On("Get", "SHELLHUB_VERSION").Return("v1.0.0").Once()
+				storeMock.On("SystemGet", gomock.Anything).Return(&models.System{
+					Setup: true,
+					Authentication: &models.SystemAuthentication{
+						Local: &models.SystemAuthenticationLocal{Enabled: true},
+					},
+				}, nil).Once()
+			},
+			setupHooks: func() {},
+			expectedResult: &responses.SystemInfo{
+				Version: "v1.0.0",
+				Setup:   true,
+				Endpoints: &responses.SystemEndpointsInfo{
+					API: "192.168.1.1",
+					SSH: "192.168.1.1:22",
+				},
+				Authentication: &responses.SystemAuthenticationInfo{
+					Local: true,
+					SAML:  false,
+				},
+			},
+		},
+		{
+			description: "returns local auth disabled, saml false when no hooks",
+			req:         &requests.GetSystemInfo{Host: "example.com"},
+			setupMocks: func() {
+				localEnvMock.On("Get", "SHELLHUB_SSH_PORT").Return("2222").Once()
+				localEnvMock.On("Get", "SHELLHUB_VERSION").Return("v1.0.0").Once()
+				storeMock.On("SystemGet", gomock.Anything).Return(&models.System{
+					Setup: false,
+					Authentication: &models.SystemAuthentication{
+						Local: &models.SystemAuthenticationLocal{Enabled: false},
+					},
+				}, nil).Once()
+			},
+			setupHooks: func() {},
+			expectedResult: &responses.SystemInfo{
+				Version: "v1.0.0",
+				Setup:   false,
+				Endpoints: &responses.SystemEndpointsInfo{
+					API: "example.com",
+					SSH: "example.com:2222",
+				},
+				Authentication: &responses.SystemAuthenticationInfo{
+					Local: false,
+					SAML:  false,
+				},
+			},
+		},
+		{
+			description: "hook sets saml true when enterprise has saml enabled",
+			req:         &requests.GetSystemInfo{Host: "192.168.1.1"},
+			setupMocks: func() {
+				localEnvMock.On("Get", "SHELLHUB_SSH_PORT").Return("22").Once()
+				localEnvMock.On("Get", "SHELLHUB_VERSION").Return("v1.0.0").Once()
+				storeMock.On("SystemGet", gomock.Anything).Return(&models.System{
+					Setup: true,
+					Authentication: &models.SystemAuthentication{
+						Local: &models.SystemAuthenticationLocal{Enabled: true},
+					},
+				}, nil).Once()
+			},
+			setupHooks: func() {
+				OnGetSystemInfo(func(_ context.Context, info *responses.SystemInfo) error {
+					info.Authentication.SAML = true
+
+					return nil
+				})
+			},
+			expectedResult: &responses.SystemInfo{
+				Version: "v1.0.0",
+				Setup:   true,
+				Endpoints: &responses.SystemEndpointsInfo{
+					API: "192.168.1.1",
+					SSH: "192.168.1.1:22",
+				},
+				Authentication: &responses.SystemAuthenticationInfo{
+					Local: true,
+					SAML:  true,
+				},
+			},
+		},
+		{
+			description: "hook error is returned",
+			req:         &requests.GetSystemInfo{Host: "192.168.1.1"},
+			setupMocks: func() {
+				localEnvMock.On("Get", "SHELLHUB_SSH_PORT").Return("22").Once()
+				localEnvMock.On("Get", "SHELLHUB_VERSION").Return("v1.0.0").Once()
+				storeMock.On("SystemGet", gomock.Anything).Return(&models.System{
+					Setup: false,
+					Authentication: &models.SystemAuthentication{
+						Local: &models.SystemAuthenticationLocal{Enabled: false},
+					},
+				}, nil).Once()
+			},
+			setupHooks: func() {
+				OnGetSystemInfo(func(_ context.Context, _ *responses.SystemInfo) error {
+					return errors.New("hook error")
+				})
+			},
+			expectedResult: nil,
+			expectedErrMsg: "system info hook failed: hook error",
+		},
+		{
+			description: "port in request overrides host port in api endpoint",
+			req:         &requests.GetSystemInfo{Host: "example.com", Port: 8080},
+			setupMocks: func() {
+				localEnvMock.On("Get", "SHELLHUB_SSH_PORT").Return("22").Once()
+				localEnvMock.On("Get", "SHELLHUB_VERSION").Return("v1.0.0").Once()
+				storeMock.On("SystemGet", gomock.Anything).Return(&models.System{
+					Setup: false,
+					Authentication: &models.SystemAuthentication{
+						Local: &models.SystemAuthenticationLocal{Enabled: false},
+					},
+				}, nil).Once()
+			},
+			setupHooks: func() {},
+			expectedResult: &responses.SystemInfo{
+				Version: "v1.0.0",
+				Setup:   false,
+				Endpoints: &responses.SystemEndpointsInfo{
+					API: "example.com:8080",
+					SSH: "example.com:22",
+				},
+				Authentication: &responses.SystemAuthenticationInfo{
+					Local: false,
+					SAML:  false,
+				},
+			},
+		},
+		{
+			description: "host with port is stripped for ssh endpoint",
+			req:         &requests.GetSystemInfo{Host: "example.com:443"},
+			setupMocks: func() {
+				localEnvMock.On("Get", "SHELLHUB_SSH_PORT").Return("22").Once()
+				localEnvMock.On("Get", "SHELLHUB_VERSION").Return("v1.0.0").Once()
+				storeMock.On("SystemGet", gomock.Anything).Return(&models.System{
+					Setup: false,
+					Authentication: &models.SystemAuthentication{
+						Local: &models.SystemAuthenticationLocal{Enabled: false},
+					},
+				}, nil).Once()
+			},
+			setupHooks: func() {},
+			expectedResult: &responses.SystemInfo{
+				Version: "v1.0.0",
+				Setup:   false,
+				Endpoints: &responses.SystemEndpointsInfo{
+					API: "example.com:443",
+					SSH: "example.com:22",
+				},
+				Authentication: &responses.SystemAuthenticationInfo{
+					Local: false,
+					SAML:  false,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			systemInfoHooks = nil
+			tc.setupHooks()
+			tc.setupMocks()
+
+			result, err := s.GetSystemInfo(ctx, tc.req)
+			assert.Equal(t, tc.expectedResult, result)
+
+			if tc.expectedErrMsg != "" {
+				assert.EqualError(t, err, tc.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+	storeMock.AssertExpectations(t)
+	localEnvMock.AssertExpectations(t)
+}


### PR DESCRIPTION
## What
Adds a `saml` boolean to the `/info` response and introduces a hook-registration mechanism that lets enterprise/cloud packages inject authentication capability flags (starting with SAML) into that response without touching CE code.

## Why
The frontend needs to know at login time whether SAML SSO is available on this instance. Rather than gating on an env var in CE, the hook pattern keeps the extension seam clean: cloud registers `OnGetSystemInfo` at init and sets `saml: true` when its SAML feature is enabled.

## Changes
- **`responses/system.go`**: added `SAML bool \`json:"saml"\`` to `SystemAuthenticationInfo`
- **`services/system_hooks.go`**: `SystemInfoHookFn` type, package-level `systemInfoHooks` slice, `OnGetSystemInfo` registration (panics on nil), `fireGetSystemInfo` dispatcher — errors abort the request and wrap with context
- **`services/system.go`**: calls `fireGetSystemInfo` after building the response, before returning

## Testing
`go test ./api/services/...` covers: nil-hook panic, hook registration, single/multiple hook ordering, error short-circuits second hook, full `GetSystemInfo` flow with mocked store and env including hook mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)