### PR TITLE
feat(cli): add type column to namespace list output

### DIFF
--- a/cli/cmd/namespace.go
+++ b/cli/cmd/namespace.go
@@ -169,10 +169,10 @@ cli namespace ls -q tenant-id`,
 
 			// non-quiet output
 			w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tTENANT ID")
+			fmt.Fprintln(w, "NAME\tTENANT ID\tTYPE")
 
 			for _, ns := range namespaces {
-				fmt.Fprintf(w, "%s\t%s\n", ns.Name, ns.TenantID)
+				fmt.Fprintf(w, "%s\t%s\t%s\n", ns.Name, ns.TenantID, ns.Type)
 			}
 			w.Flush()
 

--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -121,13 +121,14 @@ func userDelete(service services.Services) *cobra.Command {
 
 func userList(service services.Services) *cobra.Command {
 	return &cobra.Command{
-		Use:   "list",
-		Short: "List all users",
-		Long:  "List all users in the system",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all users",
+		Long:    "List all users in the system",
 		Example: `cli user list
-cli user list | head -n 5
-cli user list | tail -n 5
-cli user list | grep admin`,
+cli user ls | head -n 5
+cli user ls | tail -n 5
+cli user ls | grep admin`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			users, err := service.UserList(cmd.Context())
 			if err != nil {


### PR DESCRIPTION
## What changed?

Added a TYPE column to the `namespace ls` table output. Also added
the `ls` alias to the `user list` command for consistency.

## Why

Users need to quickly identify and categorize namespaces (e.g. team
vs personal) at a glance without having to inspect each one. The
`ls` alias on `user list` was missing despite being available on
`namespace list`.

## Notes

`-q type` was intentionally not added. Quiet mode is designed for
command substitution targeting a specific namespace (e.g. piping
into `inspect`), which requires a unique identifier. Since type is
shared across many namespaces, it doesn't serve that purpose.

## How to test

- Run `./bin/cli namespace list` or `./bin/cli namespace ls` to
  verify the TYPE column appears in the table output
- Run `./bin/cli user list` or `./bin/cli user ls` to verify the
  alias works

Closes #6190