### PR TITLE
chore(deps): migrate dependabot from ui to ui-react

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,11 +33,11 @@ updates:
     - dependency-name: "golang"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
 - package-ecosystem: docker
-  directory: "/ui"
+  directory: "/ui-react"
   schedule:
     interval: weekly
   commit-message:
-    prefix: "docker: ui"
+    prefix: "docker: ui-react"
   ignore:
     - dependency-name: "node"
       update-types: ["version-update:semver-major"]
@@ -61,11 +61,11 @@ updates:
     - dependency-name: "golang"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
 - package-ecosystem: npm
-  directory: "/ui"
+  directory: "/ui-react"
   schedule:
     interval: weekly
   commit-message:
-    prefix: "ui"
+    prefix: "ui-react"
   versioning-strategy: lockfile-only
 - package-ecosystem: gomod
   directory: "/agent"


### PR DESCRIPTION
## What
Updated Dependabot to track `ui-react/` instead of `ui/` for both Docker and npm ecosystems.

## Why
`ui/` is the legacy Vue frontend, no longer under active development. `ui-react/` is the current frontend and needs weekly dependency updates going forward.

## Changes
- **docker**: changed directory from `/ui` to `/ui-react`; updated commit prefix to `docker: ui-react`
- **npm**: changed directory from `/ui` to `/ui-react`; updated commit prefix to `ui-react`

Existing ignore rules (node semver-major + `>=25` for Docker, lockfile-only strategy for npm) are preserved unchanged.