### PR TITLE
chore(ui-react): remove deprecated `baseUrl` from ui-react's `tsconfig.json`

### DIFF
--- a/ui-react/apps/console/tsconfig.json
+++ b/ui-react/apps/console/tsconfig.json
@@ -15,11 +15,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["./src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## What

Remove deprecated `baseUrl` from React UI's `tsconfig.json`.

## Why

`baseUrl` became deprecated in TS 6 and will be removed in TS 7: https://github.com/microsoft/TypeScript/pull/62509
