### PR TITLE
refactor(ui-react): use `@` import alias

### DIFF
--- a/ui-react/apps/console/src/api/__tests__/interceptors.test.ts
+++ b/ui-react/apps/console/src/api/__tests__/interceptors.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import axios from "axios";
 import { setupInterceptors } from "../interceptors";
-import { useAuthStore } from "../../stores/authStore";
-import { useConnectivityStore } from "../../stores/connectivityStore";
+import { useAuthStore } from "@/stores/authStore";
+import { useConnectivityStore } from "@/stores/connectivityStore";
 
 /* --- helpers --- */
 

--- a/ui-react/apps/console/src/components/auth/AccountCreated.tsx
+++ b/ui-react/apps/console/src/components/auth/AccountCreated.tsx
@@ -4,8 +4,8 @@ import {
   ArrowRightIcon,
   CheckCircleIcon,
 } from "@heroicons/react/24/outline";
-import { useAuthStore } from "../../stores/authStore";
-import { useSignUpStore } from "../../stores/signUpStore";
+import { useAuthStore } from "@/stores/authStore";
+import { useSignUpStore } from "@/stores/signUpStore";
 
 export default function AccountCreated() {
   const navigate = useNavigate();

--- a/ui-react/apps/console/src/components/common/AdminRoute.tsx
+++ b/ui-react/apps/console/src/components/common/AdminRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Outlet, Navigate } from "react-router-dom";
-import { useAuthStore } from "../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 
 export default function AdminRoute() {
   const fetchUser = useAuthStore((s) => s.fetchUser);

--- a/ui-react/apps/console/src/components/common/ConfirmDialog.tsx
+++ b/ui-react/apps/console/src/components/common/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useId, useState } from "react";
-import { useResetOnOpen } from "../../hooks/useResetOnOpen";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import BaseDialog from "./BaseDialog";
 
 interface ConfirmDialogProps {

--- a/ui-react/apps/console/src/components/common/ConnectivityBanner.tsx
+++ b/ui-react/apps/console/src/components/common/ConnectivityBanner.tsx
@@ -1,4 +1,4 @@
-import { useConnectivityStore } from "../../stores/connectivityStore";
+import { useConnectivityStore } from "@/stores/connectivityStore";
 
 export default function ConnectivityBanner() {
   const apiReachable = useConnectivityStore((s) => s.apiReachable);

--- a/ui-react/apps/console/src/components/common/ConnectivityGuard.tsx
+++ b/ui-react/apps/console/src/components/common/ConnectivityGuard.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
-import { useConnectivityStore } from "../../stores/connectivityStore";
+import { useConnectivityStore } from "@/stores/connectivityStore";
 import AmbientBackground from "./AmbientBackground";
 
 function ApiUnavailablePage() {

--- a/ui-react/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui-react/apps/console/src/components/common/CreateNamespace.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FormEvent } from "react";
-import { useCreateNamespace, useSwitchNamespace } from "../../hooks/useNamespaceMutations";
-import { getNamespaces } from "../../client";
-import { getConfig } from "../../env";
+import { useCreateNamespace, useSwitchNamespace } from "@/hooks/useNamespaceMutations";
+import { getNamespaces } from "@/client";
+import { getConfig } from "@/env";
 import {
   ExclamationCircleIcon,
   CheckIcon,

--- a/ui-react/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui-react/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -7,8 +7,8 @@ import {
 } from "@heroicons/react/24/outline";
 import BaseDialog from "./BaseDialog";
 import CopyButton from "./CopyButton";
-import { getConfig } from "../../env";
-import { useCreateNamespace } from "../../hooks/useNamespaceMutations";
+import { getConfig } from "@/env";
+import { useCreateNamespace } from "@/hooks/useNamespaceMutations";
 
 const CLI_COMMAND = "./bin/cli namespace create <namespace> <owner>";
 

--- a/ui-react/apps/console/src/components/common/FeatureGate.tsx
+++ b/ui-react/apps/console/src/components/common/FeatureGate.tsx
@@ -3,7 +3,7 @@ import {
   LockClosedIcon,
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
-import { getConfig } from "../../env";
+import { getConfig } from "@/env";
 
 interface Highlight {
   icon: ReactNode;

--- a/ui-react/apps/console/src/components/common/LicenseGuard.tsx
+++ b/ui-react/apps/console/src/components/common/LicenseGuard.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Navigate } from "react-router-dom";
-import { useAdminLicense } from "../../hooks/useAdminLicense";
+import { useAdminLicense } from "@/hooks/useAdminLicense";
 
 export default function LicenseGuard() {
   const { data: license, isLoading, isError } = useAdminLicense();

--- a/ui-react/apps/console/src/components/common/NamespaceGuard.tsx
+++ b/ui-react/apps/console/src/components/common/NamespaceGuard.tsx
@@ -4,8 +4,8 @@ import {
   ExclamationTriangleIcon,
   ArrowPathIcon,
 } from "@heroicons/react/24/outline";
-import { useNamespaces, useInitRole } from "../../hooks/useNamespaces";
-import { useConnectivityStore } from "../../stores/connectivityStore";
+import { useNamespaces, useInitRole } from "@/hooks/useNamespaces";
+import { useConnectivityStore } from "@/stores/connectivityStore";
 import AmbientBackground from "./AmbientBackground";
 import CreateNamespace from "./CreateNamespace";
 import UserMenu from "../layout/UserMenu";

--- a/ui-react/apps/console/src/components/common/ProtectedRoute.tsx
+++ b/ui-react/apps/console/src/components/common/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Navigate } from "react-router-dom";
-import { useAuthStore } from "../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 
 export default function ProtectedRoute() {
   const token = useAuthStore((s) => s.token);

--- a/ui-react/apps/console/src/components/common/RestrictedAction.tsx
+++ b/ui-react/apps/console/src/components/common/RestrictedAction.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
-import { useHasPermission } from "../../hooks/useHasPermission";
-import type { Action } from "../../utils/permission";
+import { useHasPermission } from "@/hooks/useHasPermission";
+import type { Action } from "@/utils/permission";
 
 interface RestrictedActionProps {
   action: Action;

--- a/ui-react/apps/console/src/components/common/SetupGuard.tsx
+++ b/ui-react/apps/console/src/components/common/SetupGuard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Outlet, Navigate, useLocation } from "react-router-dom";
-import { getInfo } from "../../client";
-import { getConfig } from "../../env";
+import { getInfo } from "@/client";
+import { getConfig } from "@/env";
 
 export default function SetupGuard() {
   const isCloud = getConfig().cloud;

--- a/ui-react/apps/console/src/components/common/SignUpGuard.tsx
+++ b/ui-react/apps/console/src/components/common/SignUpGuard.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Navigate } from "react-router-dom";
-import { getConfig } from "../../env";
+import { getConfig } from "@/env";
 
 // Sign-up endpoints (/api/register, /api/user/resend_email, /api/user/validation_account)
 // are registered exclusively in cloud. This guard restricts the sign-up route to cloud only.

--- a/ui-react/apps/console/src/components/common/TagsSelector.tsx
+++ b/ui-react/apps/console/src/components/common/TagsSelector.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
-import { useTags } from "../../hooks/useTags";
-import { useClickOutside } from "../../hooks/useClickOutside";
+import { useTags } from "@/hooks/useTags";
+import { useClickOutside } from "@/hooks/useClickOutside";
 
 export default function TagsSelector({
   selected,

--- a/ui-react/apps/console/src/components/common/__tests__/AdminRoute.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/AdminRoute.test.tsx
@@ -1,20 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { useAuthStore } from "../../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 import AdminRoute from "../AdminRoute";
 
 // Mock the API client so fetchUser never makes a real HTTP request.
 // authStore.fetchUser calls getUserInfo from @/client (re-exported from ../client).
-vi.mock("../../../client", async (importOriginal) => {
-  const original = await importOriginal<typeof import("../../../client")>();
+vi.mock("@/client", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/client")>();
   return {
     ...original,
     getUserInfo: vi.fn(),
   };
 });
 
-import { getUserInfo } from "../../../client";
+import { getUserInfo } from "@/client";
 
 const mockGetUserInfo = vi.mocked(getUserInfo);
 

--- a/ui-react/apps/console/src/components/common/__tests__/NamespaceGuard.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/NamespaceGuard.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { useConnectivityStore } from "../../../stores/connectivityStore";
+import { useConnectivityStore } from "@/stores/connectivityStore";
 import NamespaceGuard from "../NamespaceGuard";
 
 const mockUseNamespaces = vi.fn<() => { namespaces: Array<{ tenant_id: string; name: string }>; isLoading: boolean; error: Error | null; refetch: () => void }>();
 
-vi.mock("../../../hooks/useNamespaces", () => ({
+vi.mock("@/hooks/useNamespaces", () => ({
   useNamespaces: () => mockUseNamespaces(),
   useInitRole: () => {},
 }));
@@ -15,7 +15,7 @@ vi.mock("../CreateNamespace", () => ({
   default: () => <div data-testid="create-namespace" />,
 }));
 
-vi.mock("../../layout/UserMenu", () => ({
+vi.mock("@/components/layout/UserMenu", () => ({
   default: () => <div data-testid="user-menu" />,
 }));
 

--- a/ui-react/apps/console/src/components/common/__tests__/ProtectedRoute.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/ProtectedRoute.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { useAuthStore } from "../../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 import ProtectedRoute from "../ProtectedRoute";
 
 beforeEach(() => {

--- a/ui-react/apps/console/src/components/common/__tests__/RestrictedAction.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/RestrictedAction.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useAuthStore } from "../../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 import RestrictedAction from "../RestrictedAction";
 
 beforeEach(() => {

--- a/ui-react/apps/console/src/components/common/__tests__/SignUpGuard.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/SignUpGuard.test.tsx
@@ -6,8 +6,8 @@ import { render, screen, cleanup } from "@testing-library/react";
 afterEach(cleanup);
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
-vi.mock("../../../env", () => ({ getConfig: vi.fn() }));
-import { getConfig } from "../../../env";
+vi.mock("@/env", () => ({ getConfig: vi.fn() }));
+import { getConfig } from "@/env";
 import SignUpGuard from "../SignUpGuard";
 
 const mockedGetConfig = vi.mocked(getConfig);

--- a/ui-react/apps/console/src/components/layout/AdminAppBar.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminAppBar.tsx
@@ -3,8 +3,8 @@ import {
   ArrowRightStartOnRectangleIcon,
   Bars3Icon,
 } from "@heroicons/react/24/outline";
-import { useAuthStore } from "../../stores/authStore";
-import { getInitials } from "../../utils/string";
+import { useAuthStore } from "@/stores/authStore";
+import { getInitials } from "@/utils/string";
 import NamespaceSelector from "./NamespaceSelector";
 
 interface AdminAppBarProps {

--- a/ui-react/apps/console/src/components/layout/AdminLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminLayout.tsx
@@ -2,7 +2,7 @@ import { Outlet, useLocation } from "react-router-dom";
 import AdminSidebar from "./AdminSidebar";
 import AdminAppBar from "./AdminAppBar";
 import { SidebarMobileDrawer } from "./SidebarShell";
-import { useSidebarLayout } from "../../hooks/useSidebarLayout";
+import { useSidebarLayout } from "@/hooks/useSidebarLayout";
 
 export default function AdminLayout() {
   const { pathname } = useLocation();

--- a/ui-react/apps/console/src/components/layout/AdminSidebar.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminSidebar.tsx
@@ -14,9 +14,9 @@ import {
   ChevronDownIcon,
 } from "@heroicons/react/24/outline";
 import type { ReactNode } from "react";
-import { getConfig } from "../../env";
-import { useAdminLicense } from "../../hooks/useAdminLicense";
-import { useAuthStore } from "../../stores/authStore";
+import { getConfig } from "@/env";
+import { useAdminLicense } from "@/hooks/useAdminLicense";
+import { useAuthStore } from "@/stores/authStore";
 import SidebarShell, { NavItemLink, navBase, navDisabled, navIcon } from "./SidebarShell";
 
 // ---- Types ----

--- a/ui-react/apps/console/src/components/layout/AppBar.tsx
+++ b/ui-react/apps/console/src/components/layout/AppBar.tsx
@@ -2,8 +2,8 @@ import { useCallback, useState } from "react";
 import {
   useTerminalStore,
   type TerminalSession,
-} from "../../stores/terminalStore";
-import { useTerminalThemeStore } from "../../stores/terminalThemeStore";
+} from "@/stores/terminalStore";
+import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 import { Bars3Icon } from "@heroicons/react/24/outline";
 import NamespaceSelector from "./NamespaceSelector";
 

--- a/ui-react/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AppLayout.tsx
@@ -5,9 +5,9 @@ import TerminalManager from "../terminal/TerminalManager";
 import ConnectivityBanner from "../common/ConnectivityBanner";
 import WelcomeWizardTrigger from "../wizard/WelcomeWizardTrigger";
 import { SidebarMobileDrawer } from "./SidebarShell";
-import { useNamespaces } from "../../hooks/useNamespaces";
-import { useTerminalStore } from "../../stores/terminalStore";
-import { useSidebarLayout } from "../../hooks/useSidebarLayout";
+import { useNamespaces } from "@/hooks/useNamespaces";
+import { useTerminalStore } from "@/stores/terminalStore";
+import { useSidebarLayout } from "@/hooks/useSidebarLayout";
 
 export default function AppLayout() {
   const { pathname } = useLocation();

--- a/ui-react/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui-react/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -4,11 +4,11 @@ import {
   PlusIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
-import { useNamespaces, useNamespace } from "../../hooks/useNamespaces";
-import { useSwitchNamespace } from "../../hooks/useNamespaceMutations";
-import { useAuthStore } from "../../stores/authStore";
-import { useClickOutside } from "../../hooks/useClickOutside";
-import { getInitials } from "../../utils/string";
+import { useNamespaces, useNamespace } from "@/hooks/useNamespaces";
+import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
+import { useAuthStore } from "@/stores/authStore";
+import { useClickOutside } from "@/hooks/useClickOutside";
+import { getInitials } from "@/utils/string";
 import { getConfig } from "@/env";
 import CreateNamespaceDialog from "../common/CreateNamespaceDialog";
 import { useNavigate } from "react-router-dom";

--- a/ui-react/apps/console/src/components/layout/PendingDevices.tsx
+++ b/ui-react/apps/console/src/components/layout/PendingDevices.tsx
@@ -7,9 +7,9 @@ import {
   CpuChipIcon,
   ArrowRightIcon,
 } from "@heroicons/react/24/outline";
-import { useDevices } from "../../hooks/useDevices";
-import { useAcceptDevice, useRejectDevice } from "../../hooks/useDeviceMutations";
-import { useClickOutside } from "../../hooks/useClickOutside";
+import { useDevices } from "@/hooks/useDevices";
+import { useAcceptDevice, useRejectDevice } from "@/hooks/useDeviceMutations";
+import { useClickOutside } from "@/hooks/useClickOutside";
 
 export default function PendingDevices() {
   const navigate = useNavigate();

--- a/ui-react/apps/console/src/components/layout/Sidebar.tsx
+++ b/ui-react/apps/console/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useCallback, type ReactNode } from "react";
-import { getConfig } from "../../env";
-import { useTerminalStore } from "../../stores/terminalStore";
+import { getConfig } from "@/env";
+import { useTerminalStore } from "@/stores/terminalStore";
 import {
   HomeIcon,
   KeyIcon,

--- a/ui-react/apps/console/src/components/layout/UserMenu.tsx
+++ b/ui-react/apps/console/src/components/layout/UserMenu.tsx
@@ -6,10 +6,10 @@ import {
   Cog6ToothIcon,
   ArrowRightStartOnRectangleIcon,
 } from "@heroicons/react/24/outline";
-import { useAuthStore } from "../../stores/authStore";
-import { useClickOutside } from "../../hooks/useClickOutside";
-import { useNamespaces } from "../../hooks/useNamespaces";
-import { getInitials } from "../../utils/string";
+import { useAuthStore } from "@/stores/authStore";
+import { useClickOutside } from "@/hooks/useClickOutside";
+import { useNamespaces } from "@/hooks/useNamespaces";
+import { getInitials } from "@/utils/string";
 
 export default function UserMenu() {
   const { user, logout } = useAuthStore();

--- a/ui-react/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/ui-react/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
@@ -14,12 +14,13 @@ const mockUseNamespaces =
     }
   >();
 
-vi.mock("../../../hooks/useNamespaces", () => ({
+vi.mock("@/hooks/useNamespaces", () => ({
   useNamespaces: () => mockUseNamespaces(),
+  useNamespace: () => ({ tenant_id: "t1", name: "ns1" }),
   useInitRole: () => {},
 }));
 
-vi.mock("../../../hooks/useSidebarLayout", () => ({
+vi.mock("@/hooks/useSidebarLayout", () => ({
   useSidebarLayout: () => ({
     expanded: false,
     pinned: false,
@@ -47,11 +48,11 @@ vi.mock("../AppBar", () => ({
   default: () => <div data-testid="app-bar" />,
 }));
 
-vi.mock("../../terminal/TerminalManager", () => ({
+vi.mock("@/terminal/TerminalManager", () => ({
   default: () => null,
 }));
 
-vi.mock("../../common/ConnectivityBanner", () => ({
+vi.mock("@/common/ConnectivityBanner", () => ({
   default: () => null,
 }));
 

--- a/ui-react/apps/console/src/components/layout/__tests__/UserMenu.test.tsx
+++ b/ui-react/apps/console/src/components/layout/__tests__/UserMenu.test.tsx
@@ -2,12 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { useAuthStore } from "../../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 import UserMenu from "../UserMenu";
 
 const mockUseNamespaces = vi.fn<() => { namespaces: Array<{ tenant_id: string; name: string }>; isLoading: boolean; error: Error | null; refetch: () => void }>();
 
-vi.mock("../../../hooks/useNamespaces", () => ({
+vi.mock("@/hooks/useNamespaces", () => ({
   useNamespaces: () => mockUseNamespaces(),
 }));
 

--- a/ui-react/apps/console/src/components/mfa/MfaDisableDialog.tsx
+++ b/ui-react/apps/console/src/components/mfa/MfaDisableDialog.tsx
@@ -1,8 +1,8 @@
 import { useState, FormEvent } from "react";
 import { ExclamationTriangleIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
-import { disableMfa } from "../../client";
-import { useOtpInput } from "../../hooks/useOtpInput";
-import { useAuthStore } from "../../stores/authStore";
+import { disableMfa } from "@/client";
+import { useOtpInput } from "@/hooks/useOtpInput";
+import { useAuthStore } from "@/stores/authStore";
 
 interface MfaDisableDialogProps {
   open: boolean;

--- a/ui-react/apps/console/src/components/mfa/MfaEnableDrawer.tsx
+++ b/ui-react/apps/console/src/components/mfa/MfaEnableDrawer.tsx
@@ -7,10 +7,10 @@ import {
 } from "@heroicons/react/24/outline";
 import Drawer from "../common/Drawer";
 import { QRCodeDisplay } from "./QRCodeDisplay";
-import { generateMfa, enableMfa, updateUser } from "../../client";
-import { isSdkError } from "../../api/errors";
-import { useOtpInput } from "../../hooks/useOtpInput";
-import { useRecoveryCodeActions } from "../../hooks/useRecoveryCodeActions";
+import { generateMfa, enableMfa, updateUser } from "@/client";
+import { isSdkError } from "@/api/errors";
+import { useOtpInput } from "@/hooks/useOtpInput";
+import { useRecoveryCodeActions } from "@/hooks/useRecoveryCodeActions";
 
 interface MfaEnableDrawerProps {
   open: boolean;

--- a/ui-react/apps/console/src/components/mfa/MfaRecoveryTimeoutModal.tsx
+++ b/ui-react/apps/console/src/components/mfa/MfaRecoveryTimeoutModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
-import { useCountdown } from "../../hooks/useCountdown";
+import { useCountdown } from "@/hooks/useCountdown";
 
 interface MfaRecoveryTimeoutModalProps {
   open: boolean;

--- a/ui-react/apps/console/src/components/mfa/__tests__/MfaDisableDialog.test.tsx
+++ b/ui-react/apps/console/src/components/mfa/__tests__/MfaDisableDialog.test.tsx
@@ -3,11 +3,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MfaDisableDialog from "../MfaDisableDialog";
 
-vi.mock("../../../client", () => ({
+vi.mock("@/client", () => ({
   disableMfa: vi.fn(),
 }));
 
-import { disableMfa } from "../../../client";
+import { disableMfa } from "@/client";
 
 const mockedDisableMfa = vi.mocked(disableMfa);
 

--- a/ui-react/apps/console/src/components/mfa/__tests__/MfaEnableDrawer.test.tsx
+++ b/ui-react/apps/console/src/components/mfa/__tests__/MfaEnableDrawer.test.tsx
@@ -5,14 +5,14 @@ import MfaEnableDrawer from "../MfaEnableDrawer";
 
 vi.mock("qrcode");
 
-vi.mock("../../../client", () => ({
+vi.mock("@/client", () => ({
   generateMfa: vi.fn(),
   enableMfa: vi.fn(),
   updateUser: vi.fn(),
 }));
 
-import { generateMfa, enableMfa, updateUser } from "../../../client";
-import type { MfaGenerate } from "../../../client";
+import { generateMfa, enableMfa, updateUser } from "@/client";
+import type { MfaGenerate } from "@/client";
 
 const mockedGenerateMfa = vi.mocked(generateMfa);
 const mockedEnableMfa = vi.mocked(enableMfa);

--- a/ui-react/apps/console/src/components/terminal/TerminalControls.tsx
+++ b/ui-react/apps/console/src/components/terminal/TerminalControls.tsx
@@ -5,8 +5,8 @@ import {
   Cog6ToothIcon,
   MinusIcon,
 } from "@heroicons/react/24/outline";
-import { useTerminalStore } from "../../stores/terminalStore";
-import type { TerminalSession } from "../../stores/terminalStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+import type { TerminalSession } from "@/stores/terminalStore";
 import TerminalSettingsDrawer from "./TerminalSettingsDrawer";
 
 /** Terminal info shown on the left side of the AppBar */

--- a/ui-react/apps/console/src/components/terminal/TerminalErrorBanner.tsx
+++ b/ui-react/apps/console/src/components/terminal/TerminalErrorBanner.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { ExclamationCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { useTerminalStore } from "../../stores/terminalStore";
+import { useTerminalStore } from "@/stores/terminalStore";
 import type { TerminalError } from "./terminalErrors";
 
 interface TerminalErrorBannerProps {

--- a/ui-react/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui-react/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -4,11 +4,11 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Buffer } from "buffer";
-import apiClient from "../../api/client";
-import { generateSignature } from "../../utils/ssh-keys";
-import type { TerminalSession } from "../../stores/terminalStore";
-import { useTerminalStore } from "../../stores/terminalStore";
-import { useTerminalThemeStore } from "../../stores/terminalThemeStore";
+import apiClient from "@/api/client";
+import { generateSignature } from "@/utils/ssh-keys";
+import type { TerminalSession } from "@/stores/terminalStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 import type { TerminalError } from "./terminalErrors";
 import TerminalErrorBanner from "./TerminalErrorBanner";
 import {

--- a/ui-react/apps/console/src/components/terminal/TerminalManager.tsx
+++ b/ui-react/apps/console/src/components/terminal/TerminalManager.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { useTerminalStore } from "../../stores/terminalStore";
-import { useNamespace } from "../../hooks/useNamespaces";
-import { useAuthStore } from "../../stores/authStore";
+import { useTerminalStore } from "@/stores/terminalStore";
+import { useNamespace } from "@/hooks/useNamespaces";
+import { useAuthStore } from "@/stores/authStore";
 import ConnectDrawer from "../ConnectDrawer";
-import { buildSshid } from "../../utils/sshid";
+import { buildSshid } from "@/utils/sshid";
 import TerminalInstance from "./TerminalInstance";
 import TerminalTaskbar from "./TerminalTaskbar";
 

--- a/ui-react/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
+++ b/ui-react/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
@@ -4,9 +4,9 @@ import {
   useTerminalThemeStore,
   TERMINAL_FONTS,
   type TerminalTheme,
-} from "../../stores/terminalThemeStore";
+} from "@/stores/terminalThemeStore";
 import Drawer from "../common/Drawer";
-import { getConfig } from "../../env";
+import { getConfig } from "@/env";
 
 interface Props {
   open: boolean;

--- a/ui-react/apps/console/src/components/terminal/TerminalTaskbar.tsx
+++ b/ui-react/apps/console/src/components/terminal/TerminalTaskbar.tsx
@@ -1,5 +1,5 @@
 import { XMarkIcon, CommandLineIcon } from "@heroicons/react/24/outline";
-import { useTerminalStore } from "../../stores/terminalStore";
+import { useTerminalStore } from "@/stores/terminalStore";
 
 export default function TerminalTaskbar({
   sidebarOffset,

--- a/ui-react/apps/console/src/components/terminal/terminalErrors.ts
+++ b/ui-react/apps/console/src/components/terminal/terminalErrors.ts
@@ -1,4 +1,4 @@
-import { getConfig } from "../../env";
+import { getConfig } from "@/env";
 
 interface ErrorEntry {
   message: string;
@@ -85,14 +85,14 @@ const errorMap: Record<string, ErrorEntry> = {
     ],
   },
   "connections using public keys are not permitted when the agent version is 0.5.x or earlier":
-    {
-      message: "This device does not support public key authentication.",
-      reconnect: true,
-      hints: [
-        "The ShellHub agent is v0.5.x or earlier. Update to v0.6.0+ for public key support, or reconnect using a password.",
-      ],
-      links: [{ label: "Device details", to: "/devices/$uid" }],
-    },
+  {
+    message: "This device does not support public key authentication.",
+    reconnect: true,
+    hints: [
+      "The ShellHub agent is v0.5.x or earlier. Update to v0.6.0+ for public key support, or reconnect using a password.",
+    ],
+    links: [{ label: "Device details", to: "/devices/$uid" }],
+  },
 };
 
 // Values match ssh/web/messages.go messageKind iota.

--- a/ui-react/apps/console/src/hooks/__tests__/useAdminFirewallRules.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useAdminFirewallRules.test.ts
@@ -6,15 +6,15 @@ import {
   useAdminFirewallRules,
   useAdminFirewallRule,
 } from "../useAdminFirewallRules";
-import { useAuthStore } from "../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 
 // Mock the SDK functions used by the generated options/queryFn helpers.
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   getFirewallRulesAdmin: vi.fn(),
   getFirewallRuleAdmin: vi.fn(),
 }));
 
-vi.mock("../../client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getFirewallRulesAdminQueryKey: vi.fn((opts: unknown) => [
     { _id: "getFirewallRulesAdmin" },
     opts,
@@ -25,7 +25,7 @@ vi.mock("../../client/@tanstack/react-query.gen", () => ({
   })),
 }));
 
-vi.mock("../../api/pagination", () => ({
+vi.mock("@/api/pagination", () => ({
   paginatedQueryFn: vi.fn(
     (_sdkFn: unknown, opts: { query: Record<string, unknown> }) => {
       return () => mockGetFirewallRulesAdminFn(opts) as unknown;
@@ -188,7 +188,7 @@ describe("useAdminFirewallRules", () => {
 
     it("defaults rules to empty array while loading", () => {
       // Never resolves — stays in loading state
-      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
+      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminFirewallRules(), {
         wrapper: createWrapper(),
@@ -198,7 +198,7 @@ describe("useAdminFirewallRules", () => {
     });
 
     it("defaults totalCount to 0 while loading", () => {
-      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
+      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminFirewallRules(), {
         wrapper: createWrapper(),
@@ -208,7 +208,7 @@ describe("useAdminFirewallRules", () => {
     });
 
     it("returns isLoading true initially", () => {
-      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
+      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminFirewallRules(), {
         wrapper: createWrapper(),
@@ -368,7 +368,7 @@ describe("useAdminFirewallRule", () => {
     });
 
     it("is loading initially when id is provided", () => {
-      mockGetFirewallRuleAdminFn.mockReturnValue(new Promise(() => {}));
+      mockGetFirewallRuleAdminFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminFirewallRule("rule-1"), {
         wrapper: createWrapper(),

--- a/ui-react/apps/console/src/hooks/__tests__/useAdminUserMutations.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useAdminUserMutations.test.ts
@@ -15,7 +15,7 @@ const mockDeleteFn = vi.fn();
 const mockResetPasswordFn = vi.fn();
 const mockInvalidate = vi.fn();
 
-vi.mock("../../client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
   createUserAdminMutation: vi.fn(() => ({ mutationFn: mockCreateFn })),
   adminUpdateUserMutation: vi.fn(() => ({ mutationFn: mockUpdateFn })),
   adminDeleteUserMutation: vi.fn(() => ({ mutationFn: mockDeleteFn })),

--- a/ui-react/apps/console/src/hooks/__tests__/useAdminUsers.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useAdminUsers.test.ts
@@ -3,15 +3,15 @@ import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAdminUsers, useAdminUser } from "../useAdminUsers";
-import { useAuthStore } from "../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 
 // Mock the SDK functions used by the generated options/queryFn helpers.
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   getUsers: vi.fn(),
   getUser: vi.fn(),
 }));
 
-vi.mock("../../client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getUsersQueryKey: vi.fn((opts: unknown) => [{ _id: "getUsers" }, opts]),
   getUserOptions: vi.fn((opts: unknown) => ({
     queryKey: [{ _id: "getUser" }, opts],
@@ -19,7 +19,7 @@ vi.mock("../../client/@tanstack/react-query.gen", () => ({
   })),
 }));
 
-vi.mock("../../api/pagination", () => ({
+vi.mock("@/api/pagination", () => ({
   paginatedQueryFn: vi.fn(
     (_sdkFn: unknown, opts: { query: Record<string, unknown> }) => {
       return () => mockGetUsersFn(opts) as unknown;
@@ -76,7 +76,7 @@ describe("useAdminUsers", () => {
 
     it("defaults users to empty array while loading", () => {
       // Never resolves — stays in loading state
-      mockGetUsersFn.mockReturnValue(new Promise(() => {}));
+      mockGetUsersFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminUsers(), {
         wrapper: createWrapper(),
@@ -86,7 +86,7 @@ describe("useAdminUsers", () => {
     });
 
     it("defaults totalCount to 0 while loading", () => {
-      mockGetUsersFn.mockReturnValue(new Promise(() => {}));
+      mockGetUsersFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminUsers(), {
         wrapper: createWrapper(),
@@ -96,7 +96,7 @@ describe("useAdminUsers", () => {
     });
 
     it("returns isLoading true initially", () => {
-      mockGetUsersFn.mockReturnValue(new Promise(() => {}));
+      mockGetUsersFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminUsers(), {
         wrapper: createWrapper(),
@@ -118,7 +118,7 @@ describe("useAdminUsers", () => {
     });
 
     it("exposes refetch function", () => {
-      mockGetUsersFn.mockReturnValue(new Promise(() => {}));
+      mockGetUsersFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminUsers(), {
         wrapper: createWrapper(),
@@ -237,7 +237,7 @@ describe("useAdminUser", () => {
     });
 
     it("is loading initially when id is provided", () => {
-      mockGetUserFn.mockReturnValue(new Promise(() => {}));
+      mockGetUserFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => useAdminUser("u1"), {
         wrapper: createWrapper(),

--- a/ui-react/apps/console/src/hooks/__tests__/useHasPermission.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useHasPermission.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { useAuthStore } from "../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 import { useHasPermission } from "../useHasPermission";
 
 beforeEach(() => {

--- a/ui-react/apps/console/src/hooks/__tests__/usePublicKeys.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/usePublicKeys.test.ts
@@ -3,17 +3,17 @@ import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { usePublicKeys } from "../usePublicKeys";
-import type { PublicKeyResponse } from "../../client";
+import type { PublicKeyResponse } from "@/client";
 
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   getPublicKeys: vi.fn(),
 }));
 
-vi.mock("../../client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getPublicKeysQueryKey: vi.fn((opts: unknown) => [{ _id: "getPublicKeys" }, opts]),
 }));
 
-vi.mock("../../api/pagination", () => ({
+vi.mock("@/api/pagination", () => ({
   paginatedQueryFn: vi.fn(
     (_sdkFn: unknown, opts: { query: Record<string, unknown> }) => {
       return () => mockGetPublicKeysFn(opts) as unknown;
@@ -147,7 +147,7 @@ describe("usePublicKeys", () => {
     });
 
     it("defaults publicKeys to empty array while loading", () => {
-      mockGetPublicKeysFn.mockReturnValue(new Promise(() => {}));
+      mockGetPublicKeysFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => usePublicKeys(), {
         wrapper: createWrapper(),
@@ -157,7 +157,7 @@ describe("usePublicKeys", () => {
     });
 
     it("defaults totalCount to 0 while loading", () => {
-      mockGetPublicKeysFn.mockReturnValue(new Promise(() => {}));
+      mockGetPublicKeysFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => usePublicKeys(), {
         wrapper: createWrapper(),
@@ -167,7 +167,7 @@ describe("usePublicKeys", () => {
     });
 
     it("returns isLoading true initially", () => {
-      mockGetPublicKeysFn.mockReturnValue(new Promise(() => {}));
+      mockGetPublicKeysFn.mockReturnValue(new Promise(() => { }));
 
       const { result } = renderHook(() => usePublicKeys(), {
         wrapper: createWrapper(),

--- a/ui-react/apps/console/src/hooks/__tests__/useResendEmail.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useResendEmail.test.ts
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useResendEmail, RESEND_COOLDOWN_S } from "../useResendEmail";
-import { useSignUpStore } from "../../stores/signUpStore";
+import { useSignUpStore } from "@/stores/signUpStore";
 
 const mockResendEmail = vi.fn();
 

--- a/ui-react/apps/console/src/hooks/__tests__/useSessionRecording.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useSessionRecording.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useSessionRecording } from "../useSessionRecording";
-import apiClient from "../../api/client";
+import apiClient from "@/api/client";
 
-vi.mock("../../api/client", () => ({
+vi.mock("@/api/client", () => ({
   default: {
     get: vi.fn(),
     delete: vi.fn(),

--- a/ui-react/apps/console/src/hooks/__tests__/useUploadLicense.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useUploadLicense.test.ts
@@ -9,7 +9,7 @@ afterEach(() => { cleanup(); });
 const mockMutationFn = vi.fn();
 const mockInvalidate = vi.fn();
 
-vi.mock("../../client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
   sendLicenseMutation: vi.fn(() => ({ mutationFn: mockMutationFn })),
 }));
 

--- a/ui-react/apps/console/src/pages/__tests__/ConfirmAccount.test.tsx
+++ b/ui-react/apps/console/src/pages/__tests__/ConfirmAccount.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { useSignUpStore } from "../../stores/signUpStore";
+import { useSignUpStore } from "@/stores/signUpStore";
 import ConfirmAccount from "../ConfirmAccount";
 
 /* ------------------------------------------------------------------ */
@@ -14,13 +14,13 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual };
 });
 
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   registerUser: vi.fn(),
   resendEmail: vi.fn(),
   getValidateAccount: vi.fn(),
 }));
 
-import { resendEmail as apiResendEmail } from "../../client";
+import { resendEmail as apiResendEmail } from "@/client";
 const mockedResendEmail = vi.mocked(apiResendEmail);
 
 type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };

--- a/ui-react/apps/console/src/pages/__tests__/Login.test.tsx
+++ b/ui-react/apps/console/src/pages/__tests__/Login.test.tsx
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { useAuthStore } from "../../stores/authStore";
-import type { UserAuth } from "../../client";
+import { useAuthStore } from "@/stores/authStore";
+import type { UserAuth } from "@/client";
 import Login from "../Login";
 
 /* ------------------------------------------------------------------ */
@@ -17,7 +17,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   login: vi.fn(),
   getUserInfo: vi.fn(),
   updateUser: vi.fn(),
@@ -29,7 +29,7 @@ vi.mock("../../client", () => ({
   resendEmail: vi.fn(),
 }));
 
-import { login as loginSdk } from "../../client";
+import { login as loginSdk } from "@/client";
 const mockedLogin = vi.mocked(loginSdk);
 
 type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };

--- a/ui-react/apps/console/src/pages/__tests__/MfaLogin.test.tsx
+++ b/ui-react/apps/console/src/pages/__tests__/MfaLogin.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { useAuthStore } from "../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 import MfaLogin from "../MfaLogin";
 
 beforeEach(() => {

--- a/ui-react/apps/console/src/pages/__tests__/MfaRecover.test.tsx
+++ b/ui-react/apps/console/src/pages/__tests__/MfaRecover.test.tsx
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { useAuthStore } from "../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 import MfaRecover from "../MfaRecover";
 
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   disableMfa: vi.fn(),
 }));
 
-import { disableMfa } from "../../client";
+import { disableMfa } from "@/client";
 const mockedDisableMfa = vi.mocked(disableMfa);
 
 type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };

--- a/ui-react/apps/console/src/pages/admin/License.tsx
+++ b/ui-react/apps/console/src/pages/admin/License.tsx
@@ -12,10 +12,10 @@ import {
   DocumentIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
-import PageHeader from "../../components/common/PageHeader";
-import CopyButton from "../../components/common/CopyButton";
-import { useAdminLicense } from "../../hooks/useAdminLicense";
-import { useUploadLicense } from "../../hooks/useUploadLicense";
+import PageHeader from "@/components/common/PageHeader";
+import CopyButton from "@/components/common/CopyButton";
+import { useAdminLicense } from "@/hooks/useAdminLicense";
+import { useUploadLicense } from "@/hooks/useUploadLicense";
 import {
   formatLicenseTimestamp,
   formatDeviceCount,
@@ -23,8 +23,8 @@ import {
   getDisplayFeatures,
   validateLicenseFile,
   getLicenseAlertConfig,
-} from "../../utils/license";
-import type { GetLicenseResponse } from "../../client/types.gen";
+} from "@/utils/license";
+import type { GetLicenseResponse } from "@/client/types.gen";
 
 type HeroIcon = ComponentType<SVGProps<SVGSVGElement>>;
 

--- a/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
@@ -5,10 +5,10 @@ import {
   CheckCircleIcon,
   MinusCircleIcon,
 } from "@heroicons/react/24/outline";
-import { useAdminSessionDetail } from "../../hooks/useAdminSessionDetail";
-import PageHeader from "../../components/common/PageHeader";
-import { formatDateFull } from "../../utils/date";
-import { sessionType } from "../../utils/session";
+import { useAdminSessionDetail } from "@/hooks/useAdminSessionDetail";
+import PageHeader from "@/components/common/PageHeader";
+import { formatDateFull } from "@/utils/date";
+import { sessionType } from "@/utils/session";
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (

--- a/ui-react/apps/console/src/pages/admin/Unauthorized.tsx
+++ b/ui-react/apps/console/src/pages/admin/Unauthorized.tsx
@@ -7,7 +7,7 @@ import {
   UserGroupIcon,
   CpuChipIcon,
 } from "@heroicons/react/24/outline";
-import { useAuthStore } from "../../stores/authStore";
+import { useAuthStore } from "@/stores/authStore";
 
 const highlights = [
   {

--- a/ui-react/apps/console/src/pages/admin/__tests__/Dashboard.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/__tests__/Dashboard.test.tsx
@@ -2,13 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import AdminDashboard from "../Dashboard";
-import { useAdminStats } from "../../../hooks/useAdminStats";
-import { useAdminSessions } from "../../../hooks/useAdminSessions";
+import { useAdminStats } from "@/hooks/useAdminStats";
+import { useAdminSessions } from "@/hooks/useAdminSessions";
 
-vi.mock("../../../hooks/useAdminStats", () => ({
+vi.mock("@/hooks/useAdminStats", () => ({
   useAdminStats: vi.fn(),
 }));
-vi.mock("../../../hooks/useAdminSessions", () => ({
+vi.mock("@/hooks/useAdminSessions", () => ({
   useAdminSessions: vi.fn(),
 }));
 

--- a/ui-react/apps/console/src/pages/admin/__tests__/License.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/__tests__/License.test.tsx
@@ -3,14 +3,14 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import AdminLicense from "../License";
-import { ClipboardProvider } from "../../../components/common/ClipboardProvider";
-import { useAdminLicense } from "../../../hooks/useAdminLicense";
-import { useUploadLicense } from "../../../hooks/useUploadLicense";
+import { ClipboardProvider } from "@/components/common/ClipboardProvider";
+import { useAdminLicense } from "@/hooks/useAdminLicense";
+import { useUploadLicense } from "@/hooks/useUploadLicense";
 
-vi.mock("../../../hooks/useAdminLicense", () => ({
+vi.mock("@/hooks/useAdminLicense", () => ({
   useAdminLicense: vi.fn(),
 }));
-vi.mock("../../../hooks/useUploadLicense", () => ({
+vi.mock("@/hooks/useUploadLicense", () => ({
   useUploadLicense: vi.fn(),
 }));
 

--- a/ui-react/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
@@ -14,11 +14,11 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-vi.mock("../../../hooks/useAdminSessionsList", () => ({
+vi.mock("@/hooks/useAdminSessionsList", () => ({
   useAdminSessionsList: vi.fn(),
 }));
 
-import { useAdminSessionsList } from "../../../hooks/useAdminSessionsList";
+import { useAdminSessionsList } from "@/hooks/useAdminSessionsList";
 import AdminSessions from "../Sessions";
 
 /* ------------------------------------------------------------------ */

--- a/ui-react/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import type { AnnouncementShort } from "../../../../client";
+import type { AnnouncementShort } from "@/client";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("../../../../hooks/useAdminAnnouncements", () => ({
+vi.mock("@/hooks/useAdminAnnouncements", () => ({
   useAdminAnnouncements: vi.fn(),
 }));
 
@@ -40,7 +40,7 @@ vi.mock("../DeleteAnnouncementDialog", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { useAdminAnnouncements } from "../../../../hooks/useAdminAnnouncements";
+import { useAdminAnnouncements } from "@/hooks/useAdminAnnouncements";
 import AdminAnnouncements from "../index";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/ui-react/apps/console/src/pages/admin/announcements/__tests__/DeleteAnnouncementDialog.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/__tests__/DeleteAnnouncementDialog.test.tsx
@@ -3,15 +3,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DeleteAnnouncementDialog from "../DeleteAnnouncementDialog";
-import { useAdminDeleteAnnouncement } from "../../../../hooks/useAdminAnnouncementMutations";
+import { useAdminDeleteAnnouncement } from "@/hooks/useAdminAnnouncementMutations";
 
-vi.mock("../../../../hooks/useAdminAnnouncementMutations", () => ({
+vi.mock("@/hooks/useAdminAnnouncementMutations", () => ({
   useAdminDeleteAnnouncement: vi.fn(),
 }));
 
 // Flatten ConfirmDialog to a plain div so we can test the component's logic
 // without dialog portals, animations, or BaseDialog internals.
-vi.mock("../../../../components/common/ConfirmDialog", () => ({
+vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
     onClose,

--- a/ui-react/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -8,12 +8,12 @@ import {
   TagIcon,
   KeyIcon,
 } from "@heroicons/react/24/outline";
-import { useAdminDevice } from "../../../hooks/useAdminDevices";
-import CopyButton from "../../../components/common/CopyButton";
-import DistroIcon from "../../../components/common/DistroIcon";
-import PlatformBadge from "../../../components/common/PlatformBadge";
+import { useAdminDevice } from "@/hooks/useAdminDevices";
+import CopyButton from "@/components/common/CopyButton";
+import DistroIcon from "@/components/common/DistroIcon";
+import PlatformBadge from "@/components/common/PlatformBadge";
 import DeviceStatusChip from "./DeviceStatusChip";
-import { formatDateFull, formatRelative } from "../../../utils/date";
+import { formatDateFull, formatRelative } from "@/utils/date";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";

--- a/ui-react/apps/console/src/pages/admin/devices/DeviceStatusChip.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/DeviceStatusChip.tsx
@@ -4,7 +4,7 @@ import {
   XCircleIcon,
   MinusCircleIcon,
 } from "@heroicons/react/24/outline";
-import type { DeviceStatus } from "../../../client";
+import type { DeviceStatus } from "@/client";
 
 const STATUS_CONFIG: Record<
   DeviceStatus,

--- a/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDeviceDetails.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDeviceDetails.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import type { NormalizedDevice } from "../../../../hooks/useAdminDevices";
+import type { NormalizedDevice } from "@/hooks/useAdminDevices";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("../../../../hooks/useAdminDevices", () => ({
+vi.mock("@/hooks/useAdminDevices", () => ({
   useAdminDevice: vi.fn(),
 }));
 
@@ -24,7 +24,7 @@ vi.mock("@/components/common/CopyButton", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { useAdminDevice } from "../../../../hooks/useAdminDevices";
+import { useAdminDevice } from "@/hooks/useAdminDevices";
 import AdminDeviceDetails from "../AdminDeviceDetails";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import type { NormalizedDevice } from "../../../../hooks/useAdminDevices";
+import type { NormalizedDevice } from "@/hooks/useAdminDevices";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("../../../../hooks/useAdminDevices", () => ({
+vi.mock("@/hooks/useAdminDevices", () => ({
   useAdminDevices: vi.fn(),
 }));
 
@@ -19,7 +19,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-import { useAdminDevices } from "../../../../hooks/useAdminDevices";
+import { useAdminDevices } from "@/hooks/useAdminDevices";
 import AdminDevices from "../index";
 
 const defaultHookState = {

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
@@ -7,9 +7,9 @@ import {
   CheckCircleIcon,
   NoSymbolIcon,
 } from "@heroicons/react/24/outline";
-import { useAdminFirewallRule } from "../../../hooks/useAdminFirewallRules";
-import CopyButton from "../../../components/common/CopyButton";
-import FilterBadge from "../../../components/common/FilterBadge";
+import { useAdminFirewallRule } from "@/hooks/useAdminFirewallRules";
+import CopyButton from "@/components/common/CopyButton";
+import FilterBadge from "@/components/common/FilterBadge";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRuleDetails.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRuleDetails.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import type { FirewallRule } from "../../../../hooks/useAdminFirewallRules";
+import type { FirewallRule } from "@/hooks/useAdminFirewallRules";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("../../../../hooks/useAdminFirewallRules", () => ({
+vi.mock("@/hooks/useAdminFirewallRules", () => ({
   useAdminFirewallRule: vi.fn(),
 }));
 
@@ -24,7 +24,7 @@ vi.mock("@/components/common/CopyButton", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { useAdminFirewallRule } from "../../../../hooks/useAdminFirewallRules";
+import { useAdminFirewallRule } from "@/hooks/useAdminFirewallRules";
 import AdminFirewallRuleDetails from "../AdminFirewallRuleDetails";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
@@ -2,11 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import type { FirewallRule } from "../../../../hooks/useAdminFirewallRules";
+import type { FirewallRule } from "@/hooks/useAdminFirewallRules";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("../../../../hooks/useAdminFirewallRules", () => ({
+vi.mock("@/hooks/useAdminFirewallRules", () => ({
   useAdminFirewallRules: vi.fn(),
 }));
 
@@ -19,7 +19,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { useAdminFirewallRules } from "../../../../hooks/useAdminFirewallRules";
+import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
 import AdminFirewallRules from "../index";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/ui-react/apps/console/src/pages/admin/namespaces/DeleteNamespaceDialog.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/DeleteNamespaceDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useAdminDeleteNamespace } from "../../../hooks/useAdminNamespaceMutations";
-import ConfirmDialog from "../../../components/common/ConfirmDialog";
+import { useAdminDeleteNamespace } from "@/hooks/useAdminNamespaceMutations";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
 
 interface DeleteNamespaceDialogProps {
   open: boolean;

--- a/ui-react/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
@@ -1,10 +1,10 @@
 import { useState, type FormEvent } from "react";
-import { useResetOnOpen } from "../../../hooks/useResetOnOpen";
-import { useAdminEditNamespace } from "../../../hooks/useAdminNamespaceMutations";
-import { isSdkError } from "../../../api/errors";
-import Drawer from "../../../components/common/Drawer";
-import { LABEL, INPUT } from "../../../utils/styles";
-import type { Namespace } from "../../../client";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useAdminEditNamespace } from "@/hooks/useAdminNamespaceMutations";
+import { isSdkError } from "@/api/errors";
+import Drawer from "@/components/common/Drawer";
+import { LABEL, INPUT } from "@/utils/styles";
+import type { Namespace } from "@/client";
 
 interface EditNamespaceDrawerProps {
   open: boolean;

--- a/ui-react/apps/console/src/pages/admin/namespaces/__tests__/DeleteNamespaceDialog.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/__tests__/DeleteNamespaceDialog.test.tsx
@@ -3,16 +3,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DeleteNamespaceDialog from "../DeleteNamespaceDialog";
-import { useAdminDeleteNamespace } from "../../../../hooks/useAdminNamespaceMutations";
+import { useAdminDeleteNamespace } from "@/hooks/useAdminNamespaceMutations";
 
-vi.mock("../../../../hooks/useAdminNamespaceMutations", () => ({
+vi.mock("@/hooks/useAdminNamespaceMutations", () => ({
   useAdminDeleteNamespace: vi.fn(),
 }));
 
 // ConfirmDialog manages open/close state and calls onConfirm on button click.
 // We flatten it to a plain div so we can exercise the component's logic without
 // the real dialog's animations, portals, or BaseDialog internals.
-vi.mock("../../../../components/common/ConfirmDialog", () => ({
+vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
     onClose,

--- a/ui-react/apps/console/src/pages/admin/namespaces/__tests__/EditNamespaceDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/__tests__/EditNamespaceDrawer.test.tsx
@@ -2,20 +2,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import EditNamespaceDrawer from "../EditNamespaceDrawer";
-import { useAdminEditNamespace } from "../../../../hooks/useAdminNamespaceMutations";
-import type { Namespace } from "../../../../client";
+import { useAdminEditNamespace } from "@/hooks/useAdminNamespaceMutations";
+import type { Namespace } from "@/client";
 
-vi.mock("../../../../hooks/useAdminNamespaceMutations", () => ({
+vi.mock("@/hooks/useAdminNamespaceMutations", () => ({
   useAdminEditNamespace: vi.fn(),
 }));
 
-vi.mock("../../../../utils/styles", () => ({
+vi.mock("@/utils/styles", () => ({
   LABEL: "label",
   INPUT: "input",
 }));
 
-vi.mock("../../../../components/common/Drawer", async () => ({
-  default: (await import("../../users/__tests__/mocks")).MockDrawer,
+vi.mock("@/components/common/Drawer", async () => ({
+  default: (await import("@/pages/admin/users/__tests__/mocks")).MockDrawer,
 }));
 
 const mockMutateAsync = vi.fn();

--- a/ui-react/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
@@ -1,10 +1,10 @@
 import { useState, type FormEvent } from "react";
 import { PlusIcon } from "@heroicons/react/24/outline";
-import { useResetOnOpen } from "../../../hooks/useResetOnOpen";
-import { useCreateUser } from "../../../hooks/useAdminUserMutations";
-import { isSdkError } from "../../../api/errors";
-import Drawer from "../../../components/common/Drawer";
-import { LABEL, INPUT } from "../../../utils/styles";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useCreateUser } from "@/hooks/useAdminUserMutations";
+import { isSdkError } from "@/api/errors";
+import Drawer from "@/components/common/Drawer";
+import { LABEL, INPUT } from "@/utils/styles";
 import PasswordInput from "./PasswordInput";
 import NamespaceLimitFields from "./NamespaceLimitFields";
 

--- a/ui-react/apps/console/src/pages/admin/users/DeleteUserDialog.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/DeleteUserDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useDeleteUser } from "../../../hooks/useAdminUserMutations";
-import ConfirmDialog from "../../../components/common/ConfirmDialog";
+import { useDeleteUser } from "@/hooks/useAdminUserMutations";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
 
 interface DeleteUserDialogProps {
   open: boolean;

--- a/ui-react/apps/console/src/pages/admin/users/EditUserDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/EditUserDrawer.tsx
@@ -1,10 +1,10 @@
 import { useState, type FormEvent } from "react";
-import { useResetOnOpen } from "../../../hooks/useResetOnOpen";
-import { useUpdateUser } from "../../../hooks/useAdminUserMutations";
-import { useAuthStore } from "../../../stores/authStore";
-import { isSdkError } from "../../../api/errors";
-import Drawer from "../../../components/common/Drawer";
-import { LABEL, INPUT } from "../../../utils/styles";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useUpdateUser } from "@/hooks/useAdminUserMutations";
+import { useAuthStore } from "@/stores/authStore";
+import { isSdkError } from "@/api/errors";
+import Drawer from "@/components/common/Drawer";
+import { LABEL, INPUT } from "@/utils/styles";
 import PasswordInput from "./PasswordInput";
 import NamespaceLimitFields from "./NamespaceLimitFields";
 import type { UserStatus } from "./UserStatusChip";

--- a/ui-react/apps/console/src/pages/admin/users/NamespaceLimitFields.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/NamespaceLimitFields.tsx
@@ -1,4 +1,4 @@
-import { LABEL, INPUT } from "../../../utils/styles";
+import { LABEL, INPUT } from "@/utils/styles";
 
 interface NamespaceLimitFieldsProps {
   idPrefix: string;

--- a/ui-react/apps/console/src/pages/admin/users/PasswordInput.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/PasswordInput.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline";
-import { LABEL, INPUT } from "../../../utils/styles";
+import { LABEL, INPUT } from "@/utils/styles";
 
 interface PasswordInputProps {
   id: string;

--- a/ui-react/apps/console/src/pages/admin/users/ResetPasswordDialog.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/ResetPasswordDialog.tsx
@@ -1,10 +1,10 @@
 import { useState, useId } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
-import { useResetOnOpen } from "../../../hooks/useResetOnOpen";
-import { useResetUserPassword } from "../../../hooks/useAdminUserMutations";
-import { isSdkError } from "../../../api/errors";
-import CopyButton from "../../../components/common/CopyButton";
-import BaseDialog from "../../../components/common/BaseDialog";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useResetUserPassword } from "@/hooks/useAdminUserMutations";
+import { isSdkError } from "@/api/errors";
+import CopyButton from "@/components/common/CopyButton";
+import BaseDialog from "@/components/common/BaseDialog";
 
 interface ResetPasswordDialogProps {
   open: boolean;

--- a/ui-react/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -10,14 +10,14 @@ import {
   ClockIcon,
   KeyIcon,
 } from "@heroicons/react/24/outline";
-import { useAdminUser } from "../../../hooks/useAdminUsers";
-import { useLoginAsUser } from "../../../hooks/useLoginAsUser";
-import CopyButton from "../../../components/common/CopyButton";
+import { useAdminUser } from "@/hooks/useAdminUsers";
+import { useLoginAsUser } from "@/hooks/useLoginAsUser";
+import CopyButton from "@/components/common/CopyButton";
 import UserStatusChip from "./UserStatusChip";
 import EditUserDrawer from "./EditUserDrawer";
 import ResetPasswordDialog from "./ResetPasswordDialog";
 import DeleteUserDialog from "./DeleteUserDialog";
-import { formatDateFull } from "../../../utils/date";
+import { formatDateFull } from "@/utils/date";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";

--- a/ui-react/apps/console/src/pages/admin/users/__tests__/CreateUserDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/__tests__/CreateUserDrawer.test.tsx
@@ -2,17 +2,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CreateUserDrawer from "../CreateUserDrawer";
-import { useCreateUser } from "../../../../hooks/useAdminUserMutations";
-vi.mock("../../../../hooks/useAdminUserMutations", () => ({
+import { useCreateUser } from "@/hooks/useAdminUserMutations";
+vi.mock("@/hooks/useAdminUserMutations", () => ({
   useCreateUser: vi.fn(),
 }));
 
-vi.mock("../../../../utils/styles", () => ({
+vi.mock("@/utils/styles", () => ({
   LABEL: "label",
   INPUT: "input",
 }));
 
-vi.mock("../../../../components/common/Drawer", async () => ({
+vi.mock("@/components/common/Drawer", async () => ({
   default: (await import("./mocks")).MockDrawer,
 }));
 

--- a/ui-react/apps/console/src/pages/admin/users/__tests__/EditUserDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/__tests__/EditUserDrawer.test.tsx
@@ -2,18 +2,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import EditUserDrawer, { type EditableUser } from "../EditUserDrawer";
-import { useUpdateUser } from "../../../../hooks/useAdminUserMutations";
-import { useAuthStore } from "../../../../stores/authStore";
-vi.mock("../../../../hooks/useAdminUserMutations", () => ({
+import { useUpdateUser } from "@/hooks/useAdminUserMutations";
+import { useAuthStore } from "@/stores/authStore";
+vi.mock("@/hooks/useAdminUserMutations", () => ({
   useUpdateUser: vi.fn(),
 }));
 
-vi.mock("../../../../utils/styles", () => ({
+vi.mock("@/utils/styles", () => ({
   LABEL: "label",
   INPUT: "input",
 }));
 
-vi.mock("../../../../components/common/Drawer", async () => ({
+vi.mock("@/components/common/Drawer", async () => ({
   default: (await import("./mocks")).MockDrawer,
 }));
 

--- a/ui-react/apps/console/src/pages/admin/users/__tests__/ResetPasswordDialog.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/__tests__/ResetPasswordDialog.test.tsx
@@ -3,14 +3,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ResetPasswordDialog from "../ResetPasswordDialog";
-import { useResetUserPassword } from "../../../../hooks/useAdminUserMutations";
+import { useResetUserPassword } from "@/hooks/useAdminUserMutations";
 
-vi.mock("../../../../hooks/useAdminUserMutations", () => ({
+vi.mock("@/hooks/useAdminUserMutations", () => ({
   useResetUserPassword: vi.fn(),
 }));
 
 // BaseDialog renders open/close state; we flatten it to a simple div for test isolation.
-vi.mock("../../../../components/common/BaseDialog", () => ({
+vi.mock("@/components/common/BaseDialog", () => ({
   default: ({
     open,
     onClose,
@@ -30,7 +30,7 @@ vi.mock("../../../../components/common/BaseDialog", () => ({
   },
 }));
 
-vi.mock("../../../../components/common/CopyButton", () => ({
+vi.mock("@/components/common/CopyButton", () => ({
   default: ({ text }: { text: string }) => (
     <button type="button" aria-label="Copy">
       {text}

--- a/ui-react/apps/console/src/pages/devices/DeviceActionDialog.tsx
+++ b/ui-react/apps/console/src/pages/devices/DeviceActionDialog.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { isSdkError } from "../../api/errors";
+import { isSdkError } from "@/api/errors";
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
-import { useAcceptDevice, useRejectDevice, useRemoveDevice } from "../../hooks/useDeviceMutations";
+import { useAcceptDevice, useRejectDevice, useRemoveDevice } from "@/hooks/useDeviceMutations";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 
 interface ActionDevice {

--- a/ui-react/apps/console/src/pages/devices/TagFilterDropdown.tsx
+++ b/ui-react/apps/console/src/pages/devices/TagFilterDropdown.tsx
@@ -6,8 +6,8 @@ import {
   CheckIcon,
   Cog6ToothIcon,
 } from "@heroicons/react/24/outline";
-import { useTags } from "../../hooks/useTags";
-import { useEscapeKey } from "../../hooks/useEscapeKey";
+import { useTags } from "@/hooks/useTags";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 function TagFilterDropdown({
   filterTags,

--- a/ui-react/apps/console/src/pages/devices/TagsPopover.tsx
+++ b/ui-react/apps/console/src/pages/devices/TagsPopover.tsx
@@ -6,11 +6,11 @@ import {
   PlusIcon,
   PencilIcon,
 } from "@heroicons/react/24/outline";
-import { useTags } from "../../hooks/useTags";
-import { useAddDeviceTag, useRemoveDeviceTag } from "../../hooks/useDeviceMutations";
-import type { NormalizedDevice } from "../../hooks/useDevices";
-import { useEscapeKey } from "../../hooks/useEscapeKey";
-import { useHasPermission } from "../../hooks/useHasPermission";
+import { useTags } from "@/hooks/useTags";
+import { useAddDeviceTag, useRemoveDeviceTag } from "@/hooks/useDeviceMutations";
+import type { NormalizedDevice } from "@/hooks/useDevices";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { useHasPermission } from "@/hooks/useHasPermission";
 
 /* ─── Tags Popover (portal-based, no table layout bugs) ─── */
 function TagsPopover({

--- a/ui-react/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
@@ -1,12 +1,12 @@
 import { useState, FormEvent } from "react";
-import { useResetOnOpen } from "../../hooks/useResetOnOpen";
-import { useCreateFirewallRule, useUpdateFirewallRule } from "../../hooks/useFirewallRuleMutations";
-import type { FirewallRule } from "../../hooks/useFirewallRules";
-import type { FirewallRulesRequest, Tag } from "../../client";
-import Drawer from "../../components/common/Drawer";
-import { LABEL, INPUT, INPUT_MONO } from "../../utils/styles";
-import RadioCard from "../../components/common/RadioCard";
-import TagsSelector from "../../components/common/TagsSelector";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useCreateFirewallRule, useUpdateFirewallRule } from "@/hooks/useFirewallRuleMutations";
+import type { FirewallRule } from "@/hooks/useFirewallRules";
+import type { FirewallRulesRequest, Tag } from "@/client";
+import Drawer from "@/components/common/Drawer";
+import { LABEL, INPUT, INPUT_MONO } from "@/utils/styles";
+import RadioCard from "@/components/common/RadioCard";
+import TagsSelector from "@/components/common/TagsSelector";
 import {
   UserGroupIcon,
   UserIcon as UserIconHero,
@@ -18,7 +18,7 @@ import {
   NoSymbolIcon,
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
-import { DevicesIcon as DevicesIconComponent } from "../../components/icons";
+import { DevicesIcon as DevicesIconComponent } from "@/components/icons";
 
 /* ─── Icons ─── */
 const UsersIcon = <UserGroupIcon className="w-4 h-4" />;

--- a/ui-react/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
@@ -2,20 +2,20 @@ import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { FirewallRule } from "../../../hooks/useFirewallRules";
+import type { FirewallRule } from "@/hooks/useFirewallRules";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("../../../hooks/useFirewallRules", () => ({
+vi.mock("@/hooks/useFirewallRules", () => ({
   useFirewallRules: vi.fn(),
 }));
 
-vi.mock("../../../hooks/useFirewallRuleMutations", () => ({
+vi.mock("@/hooks/useFirewallRuleMutations", () => ({
   useDeleteFirewallRule: vi.fn(),
 }));
 
 // RestrictedAction gates buttons on permissions — always allow in tests.
-vi.mock("../../../hooks/useHasPermission", () => ({
+vi.mock("@/hooks/useHasPermission", () => ({
   useHasPermission: () => true,
 }));
 
@@ -27,7 +27,7 @@ vi.mock("../RuleDrawer", () => ({
 // Flatten ConfirmDialog to a plain div so we can exercise the page's logic
 // without animations, portals, or BaseDialog internals. Matches the pattern
 // used in other page tests (DeleteNamespaceDialog, KeyDeleteDialog).
-vi.mock("../../../components/common/ConfirmDialog", () => ({
+vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
     onClose,
@@ -60,8 +60,8 @@ vi.mock("../../../components/common/ConfirmDialog", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { useFirewallRules } from "../../../hooks/useFirewallRules";
-import { useDeleteFirewallRule } from "../../../hooks/useFirewallRuleMutations";
+import { useFirewallRules } from "@/hooks/useFirewallRules";
+import { useDeleteFirewallRule } from "@/hooks/useFirewallRuleMutations";
 import FirewallRules from "../index";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/ui-react/apps/console/src/pages/profile/__tests__/EditProfileDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/profile/__tests__/EditProfileDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { useAuthStore } from "../../../stores/authStore";
-import { EditProfileDrawer } from "../../Profile";
+import { useAuthStore } from "@/stores/authStore";
+import { EditProfileDrawer } from "@/pages/Profile";
 
 const defaultProps = {
   open: true,

--- a/ui-react/apps/console/src/pages/public-keys/KeyDataInput.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/KeyDataInput.tsx
@@ -1,5 +1,5 @@
-import { isPublicKeyValid } from "../../utils/sshKeys";
-import KeyFileInput from "../../components/common/KeyFileInput";
+import { isPublicKeyValid } from "@/utils/sshKeys";
+import KeyFileInput from "@/components/common/KeyFileInput";
 
 function KeyDataInput({
   value,

--- a/ui-react/apps/console/src/pages/public-keys/KeyDrawer.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/KeyDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, FormEvent } from "react";
-import { isSdkError } from "../../api/errors";
-import { useResetOnOpen } from "../../hooks/useResetOnOpen";
+import { isSdkError } from "@/api/errors";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import {
   UserGroupIcon,
   UserIcon,
@@ -8,15 +8,15 @@ import {
   ExclamationCircleIcon,
   ClipboardDocumentListIcon,
 } from "@heroicons/react/24/outline";
-import { DevicesIcon } from "../../components/icons";
-import { useCreatePublicKey, useUpdatePublicKey } from "../../hooks/usePublicKeyMutations";
-import type { PublicKey } from "../../hooks/usePublicKeys";
-import type { PublicKeyRequest } from "../../client";
-import { isPublicKeyValid } from "../../utils/sshKeys";
-import RadioCard from "../../components/common/RadioCard";
-import TagsSelector from "../../components/common/TagsSelector";
-import Drawer from "../../components/common/Drawer";
-import { LABEL, INPUT, INPUT_MONO } from "../../utils/styles";
+import { DevicesIcon } from "@/components/icons";
+import { useCreatePublicKey, useUpdatePublicKey } from "@/hooks/usePublicKeyMutations";
+import type { PublicKey } from "@/hooks/usePublicKeys";
+import type { PublicKeyRequest } from "@/client";
+import { isPublicKeyValid } from "@/utils/sshKeys";
+import RadioCard from "@/components/common/RadioCard";
+import TagsSelector from "@/components/common/TagsSelector";
+import Drawer from "@/components/common/Drawer";
+import { LABEL, INPUT, INPUT_MONO } from "@/utils/styles";
 import KeyDataInput from "./KeyDataInput";
 
 /* --- Drawer --- */

--- a/ui-react/apps/console/src/pages/public-keys/__tests__/KeyDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/__tests__/KeyDrawer.test.tsx
@@ -2,22 +2,22 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useCreatePublicKey, useUpdatePublicKey } from "../../../hooks/usePublicKeyMutations";
+import { useCreatePublicKey, useUpdatePublicKey } from "@/hooks/usePublicKeyMutations";
 import KeyDrawer from "../KeyDrawer";
-import type { PublicKey } from "../../../hooks/usePublicKeys";
+import type { PublicKey } from "@/hooks/usePublicKeys";
 
-vi.mock("../../../hooks/usePublicKeyMutations", () => ({
+vi.mock("@/hooks/usePublicKeyMutations", () => ({
   useCreatePublicKey: vi.fn(),
   useUpdatePublicKey: vi.fn(),
 }));
 
-vi.mock("../../../utils/styles", () => ({
+vi.mock("@/utils/styles", () => ({
   LABEL: "label-class",
   INPUT: "input-class",
   INPUT_MONO: "input-mono-class",
 }));
 
-vi.mock("../../../components/common/Drawer", () => ({
+vi.mock("@/components/common/Drawer", () => ({
   default: ({
     open,
     onClose,
@@ -43,7 +43,7 @@ vi.mock("../../../components/common/Drawer", () => ({
   },
 }));
 
-vi.mock("../../../components/common/TagsSelector", () => ({
+vi.mock("@/components/common/TagsSelector", () => ({
   default: ({
     selected,
     onChange,
@@ -103,11 +103,11 @@ vi.mock("../KeyDataInput", () => ({
   ),
 }));
 
-vi.mock("../../../utils/sshKeys", () => ({
+vi.mock("@/utils/sshKeys", () => ({
   isPublicKeyValid: vi.fn(() => true),
 }));
 
-vi.mock("../../../components/icons", () => ({
+vi.mock("@/components/icons", () => ({
   DevicesIcon: () => <svg data-testid="devices-icon" />,
 }));
 

--- a/ui-react/apps/console/src/pages/public-keys/__tests__/PublicKeys.test.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/__tests__/PublicKeys.test.tsx
@@ -2,19 +2,19 @@ import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { PublicKey } from "../../../hooks/usePublicKeys";
+import type { PublicKey } from "@/hooks/usePublicKeys";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("../../../hooks/usePublicKeys", () => ({
+vi.mock("@/hooks/usePublicKeys", () => ({
   usePublicKeys: vi.fn(),
 }));
 
-vi.mock("../../../hooks/usePublicKeyMutations", () => ({
+vi.mock("@/hooks/usePublicKeyMutations", () => ({
   useDeletePublicKey: vi.fn(),
 }));
 
-vi.mock("../../../hooks/useHasPermission", () => ({
+vi.mock("@/hooks/useHasPermission", () => ({
   useHasPermission: () => true,
 }));
 
@@ -23,11 +23,11 @@ vi.mock("../KeyDrawer", () => ({
 }));
 
 // CopyButton reads from ClipboardProvider which we don't wire up in tests.
-vi.mock("../../../components/common/CopyButton", () => ({
+vi.mock("@/components/common/CopyButton", () => ({
   default: () => null,
 }));
 
-vi.mock("../../../components/common/ConfirmDialog", () => ({
+vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
     onClose,
@@ -60,8 +60,8 @@ vi.mock("../../../components/common/ConfirmDialog", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { usePublicKeys } from "../../../hooks/usePublicKeys";
-import { useDeletePublicKey } from "../../../hooks/usePublicKeyMutations";
+import { usePublicKeys } from "@/hooks/usePublicKeys";
+import { useDeletePublicKey } from "@/hooks/usePublicKeyMutations";
 import PublicKeys from "../index";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/ui-react/apps/console/src/pages/secure-vault/__tests__/KeyDeleteDialog.test.tsx
+++ b/ui-react/apps/console/src/pages/secure-vault/__tests__/KeyDeleteDialog.test.tsx
@@ -2,15 +2,15 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useVaultStore } from "../../../stores/vaultStore";
+import { useVaultStore } from "@/stores/vaultStore";
 import KeyDeleteDialog from "../KeyDeleteDialog";
-import type { VaultKeyEntry } from "../../../types/vault";
+import type { VaultKeyEntry } from "@/types/vault";
 
-vi.mock("../../../stores/vaultStore", () => ({
+vi.mock("@/stores/vaultStore", () => ({
   useVaultStore: vi.fn(),
 }));
 
-vi.mock("../../../components/common/ConfirmDialog", () => ({
+vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
     onClose,

--- a/ui-react/apps/console/src/pages/secure-vault/__tests__/KeyDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/secure-vault/__tests__/KeyDrawer.test.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useVaultStore, DuplicateKeyError } from "../../../stores/vaultStore";
+import { useVaultStore, DuplicateKeyError } from "@/stores/vaultStore";
 import KeyDrawer from "../KeyDrawer";
-import type { VaultKeyEntry } from "../../../types/vault";
+import type { VaultKeyEntry } from "@/types/vault";
 
-vi.mock("../../../stores/vaultStore", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../stores/vaultStore")>();
+vi.mock("@/stores/vaultStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/stores/vaultStore")>();
   return {
     ...actual,
     useVaultStore: vi.fn((selector?: (s: Record<string, unknown>) => unknown) => {
@@ -17,7 +17,7 @@ vi.mock("../../../stores/vaultStore", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../utils/ssh-keys", () => ({
+vi.mock("@/utils/ssh-keys", () => ({
   validatePrivateKey: vi.fn(),
   getFingerprint: vi.fn(),
   getAlgorithm: vi.fn(),
@@ -26,12 +26,12 @@ vi.mock("../../../utils/ssh-keys", () => ({
 // KeyFileInput internally uses a hook + file input. To keep tests focused on
 // KeyDrawer logic, we replace it with a simple textarea that forwards the same
 // onChange/value interface that KeyDrawer expects.
-vi.mock("../../../utils/styles", () => ({
+vi.mock("@/utils/styles", () => ({
   LABEL: "label-class",
   INPUT: "input-class",
 }));
 
-vi.mock("../../../components/common/Drawer", () => ({
+vi.mock("@/components/common/Drawer", () => ({
   default: ({
     open,
     onClose,
@@ -57,7 +57,7 @@ vi.mock("../../../components/common/Drawer", () => ({
   },
 }));
 
-vi.mock("../../../components/common/KeyFileInput", () => ({
+vi.mock("@/components/common/KeyFileInput", () => ({
   default: ({
     label,
     id,
@@ -87,7 +87,7 @@ vi.mock("../../../components/common/KeyFileInput", () => ({
   ),
 }));
 
-import { validatePrivateKey, getFingerprint, getAlgorithm } from "../../../utils/ssh-keys";
+import { validatePrivateKey, getFingerprint, getAlgorithm } from "@/utils/ssh-keys";
 
 const mockAddKey = vi.fn();
 const mockUpdateKey = vi.fn();

--- a/ui-react/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
+++ b/ui-react/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
@@ -2,15 +2,15 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useVaultStore } from "../../../stores/vaultStore";
+import { useVaultStore } from "@/stores/vaultStore";
 import SecureVault from "../index";
-import type { VaultKeyEntry } from "../../../types/vault";
+import type { VaultKeyEntry } from "@/types/vault";
 
-vi.mock("../../../utils/date", () => ({
+vi.mock("@/utils/date", () => ({
   formatDate: (d: string) => d,
 }));
 
-vi.mock("../../../components/common/PageHeader", () => ({
+vi.mock("@/components/common/PageHeader", () => ({
   default: ({
     title,
     children,
@@ -25,7 +25,7 @@ vi.mock("../../../components/common/PageHeader", () => ({
   ),
 }));
 
-vi.mock("../../../stores/vaultStore", () => ({
+vi.mock("@/stores/vaultStore", () => ({
   useVaultStore: vi.fn((selector?: (s: Record<string, unknown>) => unknown) => {
     const state = (useVaultStore as unknown as { _state: Record<string, unknown> })._state;
     return selector ? selector(state) : state;
@@ -33,7 +33,7 @@ vi.mock("../../../stores/vaultStore", () => ({
 }));
 
 // Mock heavy vault dialog/banner components to isolate page logic
-vi.mock("../../../components/vault/VaultSetupDialog", () => ({
+vi.mock("@/components/vault/VaultSetupDialog", () => ({
   default: ({
     open,
     onClose,
@@ -50,7 +50,7 @@ vi.mock("../../../components/vault/VaultSetupDialog", () => ({
       : null,
 }));
 
-vi.mock("../../../components/vault/VaultUnlockDialog", () => ({
+vi.mock("@/components/vault/VaultUnlockDialog", () => ({
   default: ({
     open,
     onClose,
@@ -67,7 +67,7 @@ vi.mock("../../../components/vault/VaultUnlockDialog", () => ({
       : null,
 }));
 
-vi.mock("../../../components/vault/VaultSettingsSection", () => ({
+vi.mock("@/components/vault/VaultSettingsSection", () => ({
   default: () => <div data-testid="vault-settings-section" />,
 }));
 
@@ -116,7 +116,7 @@ vi.mock("../KeyDeleteDialog", () => ({
 }));
 
 // CopyButton is used inside the key table — stub it out
-vi.mock("../../../components/common/CopyButton", () => ({
+vi.mock("@/components/common/CopyButton", () => ({
   default: ({ text }: { text: string }) => (
     <button aria-label={`Copy ${text}`}>Copy</button>
   ),

--- a/ui-react/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
+++ b/ui-react/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
@@ -1,5 +1,5 @@
 import { XMarkIcon } from "@heroicons/react/24/outline";
-import SessionPlayer from "../../components/sessions/SessionPlayer";
+import SessionPlayer from "@/components/sessions/SessionPlayer";
 
 interface SessionPlayerDialogProps {
   open: boolean;

--- a/ui-react/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
+++ b/ui-react/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
@@ -15,15 +15,15 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-vi.mock("../../../hooks/useSessions", () => ({
+vi.mock("@/hooks/useSessions", () => ({
   useSessions: vi.fn(),
 }));
 
-vi.mock("../../../hooks/useSessionMutations", () => ({
+vi.mock("@/hooks/useSessionMutations", () => ({
   useCloseSession: vi.fn(),
 }));
 
-vi.mock("../../../hooks/useSessionRecording", () => ({
+vi.mock("@/hooks/useSessionRecording", () => ({
   useSessionRecording: vi.fn(),
 }));
 
@@ -36,9 +36,9 @@ vi.mock("../SessionPlayerDialog", () => ({
     ) : null,
 }));
 
-import { useSessions } from "../../../hooks/useSessions";
-import { useCloseSession } from "../../../hooks/useSessionMutations";
-import { useSessionRecording } from "../../../hooks/useSessionRecording";
+import { useSessions } from "@/hooks/useSessions";
+import { useCloseSession } from "@/hooks/useSessionMutations";
+import { useSessionRecording } from "@/hooks/useSessionRecording";
 
 /* ------------------------------------------------------------------ */
 /* Helpers                                                             */

--- a/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
@@ -1,10 +1,10 @@
 import { useState, FormEvent } from "react";
-import { useResetOnOpen } from "../../hooks/useResetOnOpen";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { PlusIcon } from "@heroicons/react/24/outline";
-import { useAddMember } from "../../hooks/useMemberMutations";
-import type { NamespaceMemberRole } from "../../client";
-import Drawer from "../../components/common/Drawer";
-import { LABEL, INPUT } from "../../utils/styles";
+import { useAddMember } from "@/hooks/useMemberMutations";
+import type { NamespaceMemberRole } from "@/client";
+import Drawer from "@/components/common/Drawer";
+import { LABEL, INPUT } from "@/utils/styles";
 import { RoleSelector } from "./constants";
 
 /* --- Add Member Drawer --- */

--- a/ui-react/apps/console/src/pages/team/EditKeyDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/EditKeyDrawer.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
-import { useResetOnOpen } from "../../hooks/useResetOnOpen";
-import { useUpdateApiKey } from "../../hooks/useApiKeyMutations";
-import { type ApiKey } from "../../client";
-import Drawer from "../../components/common/Drawer";
-import { LABEL, INPUT } from "../../utils/styles";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useUpdateApiKey } from "@/hooks/useApiKeyMutations";
+import { type ApiKey } from "@/client";
+import Drawer from "@/components/common/Drawer";
+import { LABEL, INPUT } from "@/utils/styles";
 import { RoleSelector } from "./constants";
 
 /* ─── Edit API Key Drawer ─── */

--- a/ui-react/apps/console/src/pages/team/EditMemberDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/EditMemberDrawer.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { useResetOnOpen } from "../../hooks/useResetOnOpen";
-import { useUpdateMemberRole } from "../../hooks/useMemberMutations";
-import { type NamespaceMember } from "../../hooks/useNamespaces";
-import type { NamespaceMemberRole } from "../../client";
-import Drawer from "../../components/common/Drawer";
-import { LABEL } from "../../utils/styles";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useUpdateMemberRole } from "@/hooks/useMemberMutations";
+import { type NamespaceMember } from "@/hooks/useNamespaces";
+import type { NamespaceMemberRole } from "@/client";
+import Drawer from "@/components/common/Drawer";
+import { LABEL } from "@/utils/styles";
 import { RoleSelector } from "./constants";
 
 /* ─── Edit Member Drawer ─── */

--- a/ui-react/apps/console/src/pages/team/GenerateKeyDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/GenerateKeyDrawer.tsx
@@ -1,12 +1,12 @@
 import { useState, FormEvent } from "react";
-import { isSdkError } from "../../api/errors";
-import { useResetOnOpen } from "../../hooks/useResetOnOpen";
+import { isSdkError } from "@/api/errors";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { KeyIcon, CheckIcon } from "@heroicons/react/24/outline";
-import { useCreateApiKey } from "../../hooks/useApiKeyMutations";
-import { type ApiKeyCreate } from "../../client";
-import CopyButton from "../../components/common/CopyButton";
-import Drawer from "../../components/common/Drawer";
-import { LABEL, INPUT } from "../../utils/styles";
+import { useCreateApiKey } from "@/hooks/useApiKeyMutations";
+import { type ApiKeyCreate } from "@/client";
+import CopyButton from "@/components/common/CopyButton";
+import Drawer from "@/components/common/Drawer";
+import { LABEL, INPUT } from "@/utils/styles";
 import { RoleSelector } from "./constants";
 import { EXPIRY_OPTIONS } from "./helpers";
 

--- a/ui-react/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui-react/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -2,19 +2,19 @@ import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ApiKey } from "../../../client";
+import type { ApiKey } from "@/client";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("../../../hooks/useApiKeys", () => ({
+vi.mock("@/hooks/useApiKeys", () => ({
   useApiKeys: vi.fn(),
 }));
 
-vi.mock("../../../hooks/useApiKeyMutations", () => ({
+vi.mock("@/hooks/useApiKeyMutations", () => ({
   useDeleteApiKey: vi.fn(),
 }));
 
-vi.mock("../../../hooks/useHasPermission", () => ({
+vi.mock("@/hooks/useHasPermission", () => ({
   useHasPermission: () => true,
 }));
 
@@ -26,7 +26,7 @@ vi.mock("../EditKeyDrawer", () => ({
   default: () => null,
 }));
 
-vi.mock("../../../components/common/ConfirmDialog", () => ({
+vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
     onClose,
@@ -59,8 +59,8 @@ vi.mock("../../../components/common/ConfirmDialog", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { useApiKeys } from "../../../hooks/useApiKeys";
-import { useDeleteApiKey } from "../../../hooks/useApiKeyMutations";
+import { useApiKeys } from "@/hooks/useApiKeys";
+import { useDeleteApiKey } from "@/hooks/useApiKeyMutations";
 import ApiKeysTab from "../ApiKeysTab";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/ui-react/apps/console/src/pages/team/index.tsx
+++ b/ui-react/apps/console/src/pages/team/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { UserGroupIcon } from "@heroicons/react/24/outline";
-import { useAuthStore } from "../../stores/authStore";
-import PageHeader from "../../components/common/PageHeader";
+import { useAuthStore } from "@/stores/authStore";
+import PageHeader from "@/components/common/PageHeader";
 import MembersTab from "./MembersTab";
 import ApiKeysTab from "./ApiKeysTab";
 

--- a/ui-react/apps/console/src/stores/__tests__/authStore.test.ts
+++ b/ui-react/apps/console/src/stores/__tests__/authStore.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useAuthStore } from "../authStore";
-import type { UserAuth } from "../../client";
+import type { UserAuth } from "@/client";
 
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   login: vi.fn(),
   getUserInfo: vi.fn(),
   updateUser: vi.fn(),
@@ -18,7 +18,7 @@ import {
   getUserInfo,
   authMfa,
   mfaRecover,
-} from "../../client";
+} from "@/client";
 
 const mockedLogin = vi.mocked(loginSdk);
 const mockedGetUserInfo = vi.mocked(getUserInfo);

--- a/ui-react/apps/console/src/stores/__tests__/signUpStore.test.ts
+++ b/ui-react/apps/console/src/stores/__tests__/signUpStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useSignUpStore } from "../signUpStore";
 
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   registerUser: vi.fn(),
   resendEmail: vi.fn(),
   getValidateAccount: vi.fn(),
@@ -11,7 +11,7 @@ import {
   registerUser as apiRegisterUser,
   resendEmail as apiResendEmail,
   getValidateAccount as apiGetValidateAccount,
-} from "../../client";
+} from "@/client";
 
 const mockedRegisterUser = vi.mocked(apiRegisterUser);
 const mockedResendEmail = vi.mocked(apiResendEmail);
@@ -49,7 +49,7 @@ function createSdkError(status: number, body?: unknown) {
 
 describe("signUpStore", () => {
   describe("signUp", () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {}); // Suppress expected warn logs during tests
+    vi.spyOn(console, "warn").mockImplementation(() => { }); // Suppress expected warn logs during tests
 
     it("sets loading during request", async () => {
       let resolve: (v: SdkResponse<{ token: string; tenant: string }>) => void;

--- a/ui-react/apps/console/src/stores/__tests__/vaultStore.test.ts
+++ b/ui-react/apps/console/src/stores/__tests__/vaultStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { VaultMeta, VaultData, VaultKeyEntry } from "../../types/vault";
+import type { VaultMeta, VaultData, VaultKeyEntry } from "@/types/vault";
 
-vi.mock("../../utils/vault-crypto", () => ({
+vi.mock("@/utils/vault-crypto", () => ({
   createVaultMeta: vi.fn(),
   verifyPassword: vi.fn(),
   encrypt: vi.fn(),
@@ -11,7 +11,7 @@ vi.mock("../../utils/vault-crypto", () => ({
   clearSessionKey: vi.fn(),
 }));
 
-vi.mock("../../utils/vault-backend-factory", () => ({
+vi.mock("@/utils/vault-backend-factory", () => ({
   getVaultBackend: vi.fn(),
 }));
 
@@ -29,9 +29,9 @@ import {
   setSessionKey,
   getSessionKey,
   clearSessionKey,
-} from "../../utils/vault-crypto";
+} from "@/utils/vault-crypto";
 
-import { getVaultBackend } from "../../utils/vault-backend-factory";
+import { getVaultBackend } from "@/utils/vault-backend-factory";
 
 import { useVaultStore, DuplicateKeyError } from "../vaultStore";
 

--- a/ui-react/apps/console/src/utils/__tests__/vault-backend-local.test.ts
+++ b/ui-react/apps/console/src/utils/__tests__/vault-backend-local.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { LocalVaultBackend } from "../vault-backend-local";
-import type { VaultMeta, VaultData, LegacyPrivateKey } from "../../types/vault";
+import type { VaultMeta, VaultData, LegacyPrivateKey } from "@/types/vault";
 
 const VAULT_META_KEY = "shellhub-vault-meta";
 const VAULT_DATA_KEY = "shellhub-vault-data";

--- a/ui-react/apps/console/src/utils/__tests__/vault-crypto.test.ts
+++ b/ui-react/apps/console/src/utils/__tests__/vault-crypto.test.ts
@@ -9,7 +9,7 @@ import {
   getSessionKey,
   clearSessionKey,
 } from "../vault-crypto";
-import type { VaultMeta, VaultData } from "../../types/vault";
+import type { VaultMeta, VaultData } from "@/types/vault";
 
 /** Generate a random 16-byte salt synchronously using the test environment's
  *  Web Crypto (provided by jsdom / @vitest/browser). */


### PR DESCRIPTION
## What

Replace long relative paths with `@` alias.


## Why

Using the alias standardizes the imports for files in distant directories, preventing paths with two or more `../`, which are longer and harder to understand.
