### PR TITLE
fix(openapi): align tag name pattern with backend validation

### DIFF
--- a/openapi/spec/paths/api@devices@{uid}@tags@{name}.yaml
+++ b/openapi/spec/paths/api@devices@{uid}@tags@{name}.yaml
@@ -14,7 +14,7 @@ post:
       description: Tag name to associate
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path
@@ -47,7 +47,7 @@ delete:
       description: Tag name to remove
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path

--- a/openapi/spec/paths/api@namespaces@{tenant}@containers@{uid}@tags@{name}.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@containers@{uid}@tags@{name}.yaml
@@ -14,7 +14,7 @@ post:
       description: Tag name to associate
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path
@@ -47,7 +47,7 @@ delete:
       description: Tag name to remove
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path

--- a/openapi/spec/paths/api@namespaces@{tenant}@devices@{uid}@tags@{name}.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@devices@{uid}@tags@{name}.yaml
@@ -16,7 +16,7 @@ post:
       description: Tag name to associate
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path
@@ -51,7 +51,7 @@ delete:
       description: Tag name to remove
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path

--- a/openapi/spec/paths/api@namespaces@{tenant}@tags@{name}.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@tags@{name}.yaml
@@ -15,7 +15,7 @@ patch:
       description: Current tag name
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path
@@ -32,7 +32,7 @@ patch:
               type: string
               minLength: 3
               maxLength: 255
-              pattern: ^[a-zA-Z0-9-_]+$
+              pattern: ^[a-zA-Z0-9]+$
               example: dev
               description: New tag name
   responses:
@@ -71,7 +71,7 @@ delete:
       description: Tag name to delete
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path

--- a/openapi/spec/paths/api@tags@{name}.yaml
+++ b/openapi/spec/paths/api@tags@{name}.yaml
@@ -13,7 +13,7 @@ patch:
       description: Current tag name
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path
@@ -30,7 +30,7 @@ patch:
               type: string
               minLength: 3
               maxLength: 255
-              pattern: ^[a-zA-Z0-9-_]+$
+              pattern: ^[a-zA-Z0-9]+$
               example: dev
               description: New tag name
   responses:
@@ -67,7 +67,7 @@ delete:
       description: Tag name to delete
       schema:
         type: string
-        pattern: ^[a-zA-Z0-9-_]+$
+        pattern: ^[a-zA-Z0-9]+$
         example: prod
       required: true
       in: path


### PR DESCRIPTION
## What

Corrected the tag name regex pattern in OpenAPI path specs to match what the backend actually enforces.

## Why

The specs documented `^[a-zA-Z0-9-_]+$`, implying hyphens and underscores are valid tag name characters. The backend uses the `alphanum` validator, which only accepts `[a-zA-Z0-9]`. The mismatch meant the spec was promising behavior the API does not deliver.

Closes #6215

## Changes

- **openapi**: replaced `^[a-zA-Z0-9-_]+$` with `^[a-zA-Z0-9]+$` in all five affected path spec files covering tag push/pull on devices and containers, tag update, and tag delete — both the current and deprecated endpoint variants