### PR TITLE
fix(api): expose internal namespace lookup for SSH service

### DIFF
--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -115,6 +115,11 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	internalAPI.POST(EvaluateKeyURL, gateway.Handler(handler.EvaluateKey))
 	internalAPI.GET(EventsSessionsURL, gateway.Handler(handler.EventSession))
 
+	// Internal namespace lookup used by other services (ssh, cloud) to resolve
+	// a namespace by tenant without passing through the user-facing tenant
+	// guard on /api/namespaces/:tenant.
+	internalAPI.GET(GetNamespaceURL, gateway.Handler(handler.GetNamespace))
+
 	// Public routes for external access through API gateway
 	publicAPI := router.Group("/api")
 	publicAPI.GET(HealthCheckURL, gateway.Handler(handler.EvaluateHealth))

--- a/pkg/api/internalclient/namespace.go
+++ b/pkg/api/internalclient/namespace.go
@@ -26,7 +26,7 @@ func (c *client) NamespaceLookup(ctx context.Context, tenant string) (*models.Na
 		SetContext(ctx).
 		SetPathParam("tenant", tenant).
 		SetResult(namespace).
-		Get(c.config.APIBaseURL + "/api/namespaces/{tenant}")
+		Get(c.config.APIBaseURL + "/internal/namespaces/{tenant}")
 	if err := HasError(resp, err); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Add `GET /internal/namespaces/:tenant` bound to the same handler as the public route but without the tenant guard, and point `internalclient.NamespaceLookup` at it.

The SSH service calls `NamespaceLookup` directly on `api:8080` without passing through the nginx `/auth` subrequest, so the `RequiresTenant` guard added on `/api/namespaces/:tenant` in fe8e2bdf8 was turning every SSH connection into a 403.

Backported to `release/v0.21.6` as 9881a99c3.