### PR TITLE
docs(api): remove status field from namespace member schema

### DIFF
--- a/openapi/spec/components/schemas/namespace.yaml
+++ b/openapi/spec/components/schemas/namespace.yaml
@@ -17,26 +17,11 @@ properties:
         added_at:
           type: string
           format: date-time
-          description: The time when the member was invited.
+          description: The time when the member was added.
           example: 2024-09-03T23:17:50.51Z
-        expires_at:
-          type: string
-          format: date-time
-          description: |
-            **NOTE: ONLY USED IN CLOUD INSTANCE.**
-
-            The time when the invite expires. If the member is not in
-            `pending` status, this will be set to the zero UTC time.
-          example: 0001-01-01T00:00:00Z
         role:
           $ref: namespaceMemberRole.yaml
           default: owner
-        status:
-          type: string
-          enum:
-            - accepted
-            - pending
-          default: accepted
         email:
           type: string
           description: Member's email.
@@ -84,12 +69,10 @@ properties:
     description: |
       this field, on majority of cases is default 'personal', if the running
       instance of shellhub is cloud, the default value is 'team'.
-
       This field requires a valid input of either 'personal' or 'team'. the default
       will match the current Shellhub instance type. When a "type" field value is
       specified, it will override the default, but must be either 'personal' or 'team'.
       Any other input will be rejected.
-
     example: team
 required:
   - name

--- a/openapi/spec/paths/api@namespaces@{tenant}@members.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@members.yaml
@@ -34,15 +34,14 @@ post:
   operationId: addNamespaceMember
   summary: Invite member
   description: |
-    Invites a member to a namespace.
+    Adds a member to a namespace.
 
-    In enterprise and community instances, the member will automatically accept
-    the invite and will have an `accepted` status.
+    In enterprise and community instances, the member is added directly
+    to the namespace without any invitation step.
 
-    In cloud instances, the member will have a `pending` status until they
-    accept the invite via an email sent to them. The invite is valid for **7 days**.
-    If the member was previously invited and the invite is no longer valid, the same route
-    will resend the invite.
+    In cloud instances, an invitation email is sent to the member. 
+    The invite is valid for **7 days**. If the member was previously invited
+    and the invite is no longer valid, the same route will resend the invite.
   tags:
     - community
     - members


### PR DESCRIPTION
## What changed?

Removed the `status` field from the member object in
`openapi/spec/components/schemas/namespace.yaml`.

## Why

Pending invitations are now stored in a separate collection and
accessible via `GET /api/namespaces/{tenant}/invitations`. The
namespace endpoint only returns accepted members, making the `status`
field on the member object obsolete and inconsistent with the actual
API behavior.

## How to test

1. `GET /api/namespaces/{tenant}` and confirm members have no `status`
   field in the response, matching the updated spec.