### PR TITLE
fix(ui-react): fix lint error in `ContainerTagsPopover` test

### DIFF
--- a/ui-react/apps/console/src/pages/containers/__tests__/ContainerTagsPopover.test.tsx
+++ b/ui-react/apps/console/src/pages/containers/__tests__/ContainerTagsPopover.test.tsx
@@ -52,7 +52,7 @@ function makeContainer(
     created_at: "2024-01-01T00:00:00Z",
     last_seen: "2024-01-01T00:00:00Z",
     ...overrides,
-  } as NormalizedContainer;
+  };
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## What
Fix a linting error in `ContainerTagsPopover.test.tsx`

## Why
The error originated when the containers change and the `typescript-eslint` package update were merged, creating a new error.

## Testing

- Inside of the `ui-react` container, go to `apps/console` and run `npm run lint`. Check if no more errors appear.
