### PR TITLE
test: optimize healthchecks and force image rebuild

### DIFF
--- a/docker-compose.mongo.test.yml
+++ b/docker-compose.mongo.test.yml
@@ -4,8 +4,10 @@ services:
     restart: unless-stopped
     healthcheck:
       test: 'test $$(echo "rs.initiate({ _id: ''rs'', members: [ { _id: 0, host: ''mongo:27017'' } ] }).ok || rs.status().ok" | mongo --quiet) -eq 1'
-      interval: 30s
-      start_period: 10s
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s
     command: ["--replSet", "rs", "--bind_ip_all"]
     networks:
       - shellhub

--- a/docker-compose.postgres.test.yml
+++ b/docker-compose.postgres.test.yml
@@ -7,10 +7,10 @@ services:
       # which are blocked by Docker's default seccomp profile for security reasons.
       - seccomp=unconfined
     healthcheck:
-      start_period: 90s
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      start_period: 10s
+      interval: 2s
+      timeout: 3s
+      retries: 10
       test: ["CMD-SHELL", "pg_isready -U ${SHELLHUB_POSTGRES_USERNAME} -d ${SHELLHUB_POSTGRES_DATABASE}"]
     environment:
       - POSTGRES_USER=${SHELLHUB_POSTGRES_USERNAME}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,10 +3,12 @@ version: "3.7"
 services:
   ssh:
     image: ssh:test
+    pull_policy: build
     build:
       context: .
       dockerfile: ssh/Dockerfile
-      target: production 
+      target: production
+    restart: on-failure:3
     healthcheck:
       interval: 5s
       start_period: 10s
@@ -14,10 +16,12 @@ services:
     ports: []
   api:
     image: api:test
+    pull_policy: build
     build:
       context: .
       dockerfile: api/Dockerfile
-      target: production 
+      target: production
+    restart: on-failure:3
     healthcheck:
       interval: 5s
       start_period: 10s
@@ -25,10 +29,12 @@ services:
     ports: []
   gateway:
     image: gateway:test
+    pull_policy: build
     build:
       context: .
       dockerfile: gateway/Dockerfile
       target: production
+    restart: on-failure:3
     healthcheck:
       interval: 5s
       start_period: 10s
@@ -36,10 +42,12 @@ services:
     ports: []
   ui-react:
     image: ui-react:test
+    pull_policy: build
     build:
       context: .
       dockerfile: ui-react/Dockerfile
       target: production
+    restart: on-failure:3
     healthcheck:
       interval: 5s
       start_period: 10s

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -1359,6 +1359,7 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 	// Database backend (mongo/postgres) is configured via SHELLHUB_DATABASE in .env
 	// The CI runs this test suite twice in parallel - once for each backend
 	compose := environment.New(t).Up(ctx)
+	defer compose.Down()
 	compose.NewUser(t, ShellHubUsername, ShellHubEmail, ShellHubPassword)
 	compose.NewNamespace(t, ShellHubUsername, ShellHubNamespaceName, ShellHubNamespace)
 
@@ -1441,6 +1442,4 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 			}, &device)
 		})
 	}
-
-	compose.Down()
 }


### PR DESCRIPTION
- Optimize Postgres healthcheck: 115s → 30s max wait time
- Optimize MongoDB healthcheck interval: 30s → 5s
- Add `pull_policy: build` to force image rebuild with current migrations
- Add `restart: on-failure:3` for automatic recovery from transient failures
- Fix cleanup: move `compose.Down()` to defer to ensure container cleanup on test failure