### PR TITLE
fix(ui-react): make sidebar pinned by default on larger screens

### DIFF
--- a/ui-react/apps/console/src/hooks/useSidebarLayout.ts
+++ b/ui-react/apps/console/src/hooks/useSidebarLayout.ts
@@ -25,7 +25,7 @@ function getIsDesktopServer() {
 
 export function useSidebarLayout() {
   const [expanded, setExpanded] = useState(false);
-  const [pinned, setPinned] = useState(false);
+  const [pinned, setPinned] = useState(true);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const isDesktop = useSyncExternalStore(


### PR DESCRIPTION
## What

Modify the `useSidebarHook.ts` logic to always start as pinned after refresh. Now, on desktop, the sidebar starts pinned (expanded), and the user can unpin it via a button in the sidebar's footer. The behavior on mobile stays unchanged.

## Why 

In larger screens, it's best to have the expanded sidebar by default, being easier to use. The concern is the additional space occupied, but since we're talking about large screens, this shouldn't be a problem. If the users want, they can always unpin it, going to the rail (collapsed) state, which opens on hover.
