### PR TITLE
feat: add device custom fields

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -58,7 +58,7 @@ FROM base AS development
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
-RUN apk add --update openssl openssh-client util-linux setpriv
+RUN apk add --update openssl build-base binutils-gold openssh-client util-linux setpriv
 RUN go install github.com/air-verse/air@v1.62 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -75,7 +75,7 @@ ARG GOPROXY
 ARG MJML_VERSION
 ENV GOPROXY=${GOPROXY}
 
-RUN apk add --update openssl build-base docker-cli npm
+RUN apk add --update openssl build-base binutils-gold docker-cli npm
 RUN npm install -g mjml@${MJML_VERSION}
 RUN go install github.com/air-verse/air@v1.62 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \

--- a/api/services/device.go
+++ b/api/services/device.go
@@ -30,6 +30,7 @@ var DeviceFilterFields = query.NewFieldConstraints(map[string][]string{
 	"info.platform": {"contains", "eq", "ne"},
 	"tags.name":     {"contains", "eq"},
 	"online":        {"bool", "eq"},
+	"custom_fields": {"contains"},
 })
 
 // DeviceSortFields is the set of field names accepted in the sort_by query
@@ -378,6 +379,10 @@ func (s *service) UpdateDevice(ctx context.Context, req *requests.DeviceUpdate) 
 
 	if req.Name != "" && !strings.EqualFold(req.Name, device.Name) {
 		device.Name = strings.ToLower(req.Name)
+	}
+
+	if req.CustomFields != nil {
+		device.CustomFields = *req.CustomFields
 	}
 
 	if err := s.store.DeviceUpdate(ctx, device); err != nil { // nolint:revive

--- a/api/services/device_test.go
+++ b/api/services/device_test.go
@@ -2411,6 +2411,123 @@ func TestDeviceUpdate(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			description: "success when setting custom fields",
+			req: &requests.DeviceUpdate{
+				UID:          "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e",
+				TenantID:     "00000000-0000-0000-0000-000000000000",
+				Name:         "existingname",
+				CustomFields: &map[string]string{"env": "production", "owner": "team-a"},
+			},
+			requiredMocks: func(ctx context.Context) {
+				device := &models.Device{
+					UID:            "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e",
+					Name:           "existingname",
+					DisconnectedAt: &now,
+				}
+				updatedDevice := &models.Device{
+					UID:            "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e",
+					Name:           "existingname",
+					DisconnectedAt: &now,
+					CustomFields:   map[string]string{"env": "production", "owner": "team-a"},
+				}
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-0000-0000-000000000000").
+					Return(nil).
+					Once()
+				storeMock.
+					On("DeviceResolve", ctx, store.DeviceUIDResolver, "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e", mock.AnythingOfType("store.QueryOption")).
+					Return(device, nil).
+					Once()
+				// Distinct clears Name when req.Name == device.Name
+				storeMock.
+					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: ""}).
+					Return([]string{}, false, nil).
+					Once()
+				storeMock.
+					On("DeviceUpdate", ctx, updatedDevice).
+					Return(nil).
+					Once()
+			},
+			expected: nil,
+		},
+		{
+			description: "success when clearing custom fields with empty map",
+			req: &requests.DeviceUpdate{
+				UID:          "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e",
+				TenantID:     "00000000-0000-0000-0000-000000000000",
+				Name:         "existingname",
+				CustomFields: &map[string]string{},
+			},
+			requiredMocks: func(ctx context.Context) {
+				device := &models.Device{
+					UID:            "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e",
+					Name:           "existingname",
+					DisconnectedAt: &now,
+					CustomFields:   map[string]string{"env": "production"},
+				}
+				updatedDevice := &models.Device{
+					UID:            "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e",
+					Name:           "existingname",
+					DisconnectedAt: &now,
+					CustomFields:   map[string]string{},
+				}
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-0000-0000-000000000000").
+					Return(nil).
+					Once()
+				storeMock.
+					On("DeviceResolve", ctx, store.DeviceUIDResolver, "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e", mock.AnythingOfType("store.QueryOption")).
+					Return(device, nil).
+					Once()
+				// Distinct clears Name when req.Name == device.Name
+				storeMock.
+					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: ""}).
+					Return([]string{}, false, nil).
+					Once()
+				storeMock.
+					On("DeviceUpdate", ctx, updatedDevice).
+					Return(nil).
+					Once()
+			},
+			expected: nil,
+		},
+		{
+			description: "does not modify custom fields when CustomFields is nil",
+			req: &requests.DeviceUpdate{
+				UID:          "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e",
+				TenantID:     "00000000-0000-0000-0000-000000000000",
+				Name:         "existingname",
+				CustomFields: nil,
+			},
+			requiredMocks: func(ctx context.Context) {
+				device := &models.Device{
+					UID:            "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e",
+					Name:           "existingname",
+					DisconnectedAt: &now,
+					CustomFields:   map[string]string{"env": "production"},
+				}
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-0000-0000-000000000000").
+					Return(nil).
+					Once()
+				storeMock.
+					On("DeviceResolve", ctx, store.DeviceUIDResolver, "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e", mock.AnythingOfType("store.QueryOption")).
+					Return(device, nil).
+					Once()
+				// Distinct clears Name when req.Name == device.Name
+				storeMock.
+					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: ""}).
+					Return([]string{}, false, nil).
+					Once()
+				// device passed unchanged — CustomFields still has "env":"production"
+				storeMock.
+					On("DeviceUpdate", ctx, device).
+					Return(nil).
+					Once()
+			},
+			expected: nil,
+		},
 	}
 
 	service := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache(), clientMock)

--- a/api/store/mongo/internal/filters.go
+++ b/api/store/mongo/internal/filters.go
@@ -144,3 +144,43 @@ func fromLt(value interface{}) (bson.M, error) {
 func fromNe(value interface{}) (bson.M, error) {
 	return bson.M{"$ne": value}, nil
 }
+
+// ParseCustomFieldsFilter builds a MongoDB $match condition that searches across all values
+// of the custom_fields document. Only "contains" with a string value is supported.
+func ParseCustomFieldsFilter(fp *query.FilterProperty) (bson.M, bool, error) {
+	if fp.Operator != "contains" {
+		return nil, false, nil
+	}
+
+	v, ok := fp.Value.(string)
+	if !ok {
+		return nil, false, errors.New("custom_fields contains filter requires a string value")
+	}
+
+	// Use $objectToArray to iterate over all values in the custom_fields map,
+	// then check if any value matches the regex.
+	condition := bson.M{
+		"$expr": bson.M{
+			"$gt": bson.A{
+				bson.M{
+					"$size": bson.M{
+						"$filter": bson.M{
+							"input": bson.M{"$objectToArray": bson.M{"$ifNull": bson.A{"$custom_fields", bson.M{}}}},
+							"as":    "cf",
+							"cond": bson.M{
+								"$regexMatch": bson.M{
+									"input":   "$$cf.v",
+									"regex":   v,
+									"options": "i",
+								},
+							},
+						},
+					},
+				},
+				0,
+			},
+		},
+	}
+
+	return condition, true, nil
+}

--- a/api/store/mongo/internal/filters_custom_fields_test.go
+++ b/api/store/mongo/internal/filters_custom_fields_test.go
@@ -1,0 +1,104 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestParseCustomFieldsFilter(t *testing.T) {
+	cases := []struct {
+		description string
+		fp          *query.FilterProperty
+		wantOk      bool
+		wantErr     bool
+		checkResult func(t *testing.T, result bson.M)
+	}{
+		{
+			description: "returns not-ok for unsupported operator eq",
+			fp:          &query.FilterProperty{Name: "custom_fields", Operator: "eq", Value: "prod"},
+			wantOk:      false,
+			wantErr:     false,
+			checkResult: func(t *testing.T, result bson.M) {
+				assert.Nil(t, result)
+			},
+		},
+		{
+			description: "returns error when value is not a string",
+			fp:          &query.FilterProperty{Name: "custom_fields", Operator: "contains", Value: 42},
+			wantOk:      false,
+			wantErr:     true,
+			checkResult: func(t *testing.T, result bson.M) {
+				assert.Nil(t, result)
+			},
+		},
+		{
+			description: "returns $expr condition for contains with string value",
+			fp:          &query.FilterProperty{Name: "custom_fields", Operator: "contains", Value: "production"},
+			wantOk:      true,
+			wantErr:     false,
+			checkResult: func(t *testing.T, result bson.M) {
+				require.NotNil(t, result)
+				// Top-level key must be $expr
+				exprRaw, ok := result["$expr"]
+				require.True(t, ok, "result must have $expr key")
+
+				expr, ok := exprRaw.(bson.M)
+				require.True(t, ok)
+
+				// $expr.$gt must exist
+				gtRaw, ok := expr["$gt"]
+				require.True(t, ok, "$expr must have $gt")
+
+				gt, ok := gtRaw.(bson.A)
+				require.True(t, ok)
+				require.Len(t, gt, 2)
+
+				// Second element of $gt must be 0 (threshold)
+				assert.Equal(t, 0, gt[1])
+
+				// First element is the $size expression
+				sizeExpr, ok := gt[0].(bson.M)
+				require.True(t, ok)
+				_, hasSz := sizeExpr["$size"]
+				assert.True(t, hasSz, "$gt[0] must be a $size expression")
+			},
+		},
+		{
+			description: "regex contains the search value",
+			fp:          &query.FilterProperty{Name: "custom_fields", Operator: "contains", Value: "team-a"},
+			wantOk:      true,
+			wantErr:     false,
+			checkResult: func(t *testing.T, result bson.M) {
+				require.NotNil(t, result)
+				// Walk down to the $regexMatch input
+				expr := result["$expr"].(bson.M)
+				gt := expr["$gt"].(bson.A)
+				sizeExpr := gt[0].(bson.M)
+				filterExpr := sizeExpr["$size"].(bson.M)
+				filterMap := filterExpr["$filter"].(bson.M)
+				cond := filterMap["cond"].(bson.M)
+				regexMatch := cond["$regexMatch"].(bson.M)
+
+				assert.Equal(t, "team-a", regexMatch["regex"])
+				assert.Equal(t, "i", regexMatch["options"])
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, ok, err := ParseCustomFieldsFilter(tc.fp)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			tc.checkResult(t, result)
+		})
+	}
+}

--- a/api/store/mongo/query-options.go
+++ b/api/store/mongo/query-options.go
@@ -132,6 +132,18 @@ func (*queryOptions) Match(filters *query.Filters) store.QueryOption {
 					return query.ErrFilterInvalid
 				}
 
+				if param.Name == "custom_fields" {
+					condition, ok, err := internal.ParseCustomFieldsFilter(param)
+					switch {
+					case err != nil:
+						return query.ErrFilterPropertyInvalid
+					case ok:
+						conditions = append(conditions, condition)
+					}
+
+					continue
+				}
+
 				property, ok, err := internal.ParseFilterProperty(param)
 				switch {
 				case err != nil:

--- a/api/store/pg/entity/device.go
+++ b/api/store/pg/entity/device.go
@@ -10,27 +10,28 @@ import (
 type Device struct {
 	bun.BaseModel `bun:"table:devices"`
 
-	ID              string     `bun:"id,pk"`
-	NamespaceID     string     `bun:"namespace_id,type:uuid"`
-	CreatedAt       time.Time  `bun:"created_at"`
-	UpdatedAt       time.Time  `bun:"updated_at"`
-	RemovedAt       *time.Time `bun:"removed_at"`
-	LastSeen        time.Time  `bun:"last_seen"`
-	DisconnectedAt  time.Time  `bun:"disconnected_at,nullzero"`
-	Online          bool       `bun:",scanonly"`
-	Acceptable      bool       `bun:",scanonly"`
-	Status          string     `bun:"status"`
-	StatusUpdatedAt time.Time  `bun:"status_updated_at"`
-	Name            string     `bun:"name"`
-	MAC             string     `bun:"mac"`
-	PublicKey       string     `bun:"public_key"`
-	Identifier      string     `bun:"identifier"`
-	PrettyName      string     `bun:"pretty_name"`
-	Version         string     `bun:"version"`
-	Arch            string     `bun:"arch"`
-	Platform        string     `bun:"platform"`
-	Longitude       float64    `bun:"longitude,type:numeric"`
-	Latitude        float64    `bun:"latitude,type:numeric"`
+	ID              string            `bun:"id,pk"`
+	NamespaceID     string            `bun:"namespace_id,type:uuid"`
+	CreatedAt       time.Time         `bun:"created_at"`
+	UpdatedAt       time.Time         `bun:"updated_at"`
+	RemovedAt       *time.Time        `bun:"removed_at"`
+	LastSeen        time.Time         `bun:"last_seen"`
+	DisconnectedAt  time.Time         `bun:"disconnected_at,nullzero"`
+	Online          bool              `bun:",scanonly"`
+	Acceptable      bool              `bun:",scanonly"`
+	Status          string            `bun:"status"`
+	StatusUpdatedAt time.Time         `bun:"status_updated_at"`
+	Name            string            `bun:"name"`
+	MAC             string            `bun:"mac"`
+	PublicKey       string            `bun:"public_key"`
+	Identifier      string            `bun:"identifier"`
+	PrettyName      string            `bun:"pretty_name"`
+	Version         string            `bun:"version"`
+	Arch            string            `bun:"arch"`
+	Platform        string            `bun:"platform"`
+	Longitude       float64           `bun:"longitude,type:numeric"`
+	Latitude        float64           `bun:"latitude,type:numeric"`
+	CustomFields    map[string]string `bun:"custom_fields,type:jsonb"`
 
 	Namespace *Namespace `bun:"rel:belongs-to,join:namespace_id=id"`
 	Tags      []*Tag     `bun:"m2m:device_tags,join:Device=Tag"`
@@ -54,6 +55,7 @@ func DeviceFromModel(model *models.Device) *Device {
 		StatusUpdatedAt: model.StatusUpdatedAt,
 		Name:            model.Name,
 		PublicKey:       model.PublicKey,
+		CustomFields:    model.CustomFields,
 		Tags:            []*Tag{},
 	}
 
@@ -112,6 +114,7 @@ func DeviceToModel(entity *Device) *models.Device {
 		Namespace:       "",
 		DisconnectedAt:  nil,
 		RemoteAddr:      "",
+		CustomFields:    entity.CustomFields,
 		Taggable: models.Taggable{
 			Tags: []models.Tag{},
 		},

--- a/api/store/pg/entity/device.go
+++ b/api/store/pg/entity/device.go
@@ -31,7 +31,7 @@ type Device struct {
 	Platform        string            `bun:"platform"`
 	Longitude       float64           `bun:"longitude,type:numeric"`
 	Latitude        float64           `bun:"latitude,type:numeric"`
-	CustomFields    map[string]string `bun:"custom_fields,type:jsonb"`
+	CustomFields    map[string]string `bun:"custom_fields,type:jsonb,nullzero,default:'{}'"`
 
 	Namespace *Namespace `bun:"rel:belongs-to,join:namespace_id=id"`
 	Tags      []*Tag     `bun:"m2m:device_tags,join:Device=Tag"`

--- a/api/store/pg/internal/filters.go
+++ b/api/store/pg/internal/filters.go
@@ -101,6 +101,11 @@ func ParseFilterProperty(fp *query.FilterProperty, tableAlias string) (string, [
 		return fromTagsFilter(fp.Operator, fp.Value)
 	}
 
+	// custom_fields is a JSONB column; search across all values.
+	if fp.Name == "custom_fields" {
+		return fromCustomFieldsFilter(fp.Operator, fp.Value)
+	}
+
 	var condition string
 	var args []any
 	var err error
@@ -279,4 +284,21 @@ func fromLt(column string, value any, tableAlias string) (string, []any, error) 
 // arguments array, and error if any.
 func fromNe(column string, value any, tableAlias string) (string, []any, error) {
 	return "? <> ?", []any{qualifyColumn(mapColumnFromLegacyMongo(column), tableAlias), value}, nil
+}
+
+// fromCustomFieldsFilter searches across all values of the custom_fields JSONB column.
+// Only "contains" is supported: it matches any value using ILIKE.
+func fromCustomFieldsFilter(operator string, value any) (string, []any, bool, error) {
+	if operator != "contains" {
+		return "", nil, false, nil
+	}
+
+	v, ok := value.(string)
+	if !ok {
+		return "", nil, false, ErrUnsupportedContainsType
+	}
+
+	const sql = `EXISTS (SELECT 1 FROM jsonb_each_text("device"."custom_fields") WHERE value ILIKE ?)`
+
+	return sql, []any{"%" + v + "%"}, true, nil
 }

--- a/api/store/pg/internal/filters_custom_fields_test.go
+++ b/api/store/pg/internal/filters_custom_fields_test.go
@@ -1,0 +1,128 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromCustomFieldsFilter(t *testing.T) {
+	cases := []struct {
+		description string
+		operator    string
+		value       any
+		wantSQL     string
+		wantArgs    []any
+		wantOk      bool
+		wantErr     error
+	}{
+		{
+			description: "returns SQL for contains with string value",
+			operator:    "contains",
+			value:       "production",
+			wantSQL:     `EXISTS (SELECT 1 FROM jsonb_each_text("device"."custom_fields") WHERE value ILIKE ?)`,
+			wantArgs:    []any{"%production%"},
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "wraps value with %% wildcards",
+			operator:    "contains",
+			value:       "team",
+			wantSQL:     `EXISTS (SELECT 1 FROM jsonb_each_text("device"."custom_fields") WHERE value ILIKE ?)`,
+			wantArgs:    []any{"%team%"},
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "returns not-ok for unsupported operator eq",
+			operator:    "eq",
+			value:       "production",
+			wantSQL:     "",
+			wantArgs:    nil,
+			wantOk:      false,
+			wantErr:     nil,
+		},
+		{
+			description: "returns not-ok for unsupported operator ne",
+			operator:    "ne",
+			value:       "production",
+			wantSQL:     "",
+			wantArgs:    nil,
+			wantOk:      false,
+			wantErr:     nil,
+		},
+		{
+			description: "returns error when value is not a string",
+			operator:    "contains",
+			value:       42,
+			wantSQL:     "",
+			wantArgs:    nil,
+			wantOk:      false,
+			wantErr:     ErrUnsupportedContainsType,
+		},
+		{
+			description: "returns error when value is a slice",
+			operator:    "contains",
+			value:       []any{"a", "b"},
+			wantSQL:     "",
+			wantArgs:    nil,
+			wantOk:      false,
+			wantErr:     ErrUnsupportedContainsType,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			sql, args, ok, err := fromCustomFieldsFilter(tc.operator, tc.value)
+			assert.Equal(t, tc.wantOk, ok)
+			assert.Equal(t, tc.wantSQL, sql)
+			assert.Equal(t, tc.wantArgs, args)
+			assert.Equal(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestParseFilterProperty_CustomFields(t *testing.T) {
+	cases := []struct {
+		description string
+		fp          *query.FilterProperty
+		wantSQL     string
+		wantArgs    []any
+		wantOk      bool
+		wantErr     bool
+	}{
+		{
+			description: "routes custom_fields contains to JSONB subquery",
+			fp:          &query.FilterProperty{Name: "custom_fields", Operator: "contains", Value: "prod"},
+			wantSQL:     `EXISTS (SELECT 1 FROM jsonb_each_text("device"."custom_fields") WHERE value ILIKE ?)`,
+			wantArgs:    []any{"%prod%"},
+			wantOk:      true,
+			wantErr:     false,
+		},
+		{
+			description: "returns error for custom_fields contains with non-string value",
+			fp:          &query.FilterProperty{Name: "custom_fields", Operator: "contains", Value: 123},
+			wantSQL:     "",
+			wantArgs:    nil,
+			wantOk:      false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			sql, args, ok, err := ParseFilterProperty(tc.fp, "device")
+			assert.Equal(t, tc.wantOk, ok)
+			assert.Equal(t, tc.wantSQL, sql)
+			assert.Equal(t, tc.wantArgs, args)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/api/store/pg/migrations/002_device_custom_fields.tx.down.sql
+++ b/api/store/pg/migrations/002_device_custom_fields.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices DROP COLUMN IF EXISTS custom_fields;

--- a/api/store/pg/migrations/002_device_custom_fields.tx.up.sql
+++ b/api/store/pg/migrations/002_device_custom_fields.tx.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices ADD COLUMN IF NOT EXISTS custom_fields jsonb NOT NULL DEFAULT '{}';

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -32,7 +32,7 @@ RUN go build
 # development stage
 FROM builder AS development
 
-RUN apk add --update openssl build-base docker-cli
+RUN apk add --update openssl build-base binutils-gold docker-cli
 RUN go install github.com/air-verse/air@v1.62 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir /etc/shellhub-gateway
 RUN mkdir -p /var/run/openresty /etc/letsencrypt && \
     curl -sSL https://ssl-config.mozilla.org/ffdhe2048.txt -o /etc/shellhub-gateway/dhparam.pem
 
-RUN apk add --update openssl build-base
+RUN apk add --update openssl build-base binutils-gold
 RUN go install github.com/air-verse/air@v1.62 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
     go install github.com/vektra/mockery/v2/...@v2.20.0

--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.25.8-alpine3.22 AS base
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
-RUN apk add --no-cache openssl build-base nodejs npm openjdk11-jre git
+RUN apk add --no-cache openssl build-base binutils-gold nodejs npm openjdk11-jre git
 
 RUN npm install -g @openapitools/openapi-generator-cli
 

--- a/openapi/spec/components/schemas/device.yaml
+++ b/openapi/spec/components/schemas/device.yaml
@@ -60,6 +60,14 @@ properties:
         example: -52.322474
   tags:
     $ref: deviceTags.yaml
+  custom_fields:
+    description: User-defined key-value metadata for the device.
+    type: object
+    additionalProperties:
+      type: string
+    example:
+      env: production
+      owner: team-a
   public_url:
     $ref: devicePublicURL.yaml
   acceptable:

--- a/openapi/spec/paths/api@devices@{uid}.yaml
+++ b/openapi/spec/paths/api@devices@{uid}.yaml
@@ -62,6 +62,14 @@ put:
               $ref: ../components/schemas/deviceName.yaml
             public_url:
               $ref: ../components/schemas/devicePublicURL.yaml
+            custom_fields:
+              description: User-defined key-value metadata. Replaces all existing custom fields.
+              type: object
+              additionalProperties:
+                type: string
+              example:
+                env: production
+                owner: team-a
           required:
             - name
   responses:

--- a/pkg/api/requests/device.go
+++ b/pkg/api/requests/device.go
@@ -17,7 +17,7 @@ type DeviceUpdate struct {
 	TenantID     string             `header:"X-Tenant-ID"`
 	UID          string             `param:"uid" validate:"required"`
 	Name         string             `json:"name" validate:"device_name,omitempty"`
-	CustomFields *map[string]string `json:"custom_fields" validate:"omitempty"`
+	CustomFields *map[string]string `json:"custom_fields" validate:"omitempty,max=20,dive,keys,min=1,max=64,endkeys,max=256"`
 }
 
 // DeviceParam is a structure to represent and validate a device UID as path param.

--- a/pkg/api/requests/device.go
+++ b/pkg/api/requests/device.go
@@ -14,9 +14,10 @@ type DeviceList struct {
 }
 
 type DeviceUpdate struct {
-	TenantID string `header:"X-Tenant-ID"`
-	UID      string `param:"uid" validate:"required"`
-	Name     string `json:"name" validate:"device_name,omitempty"`
+	TenantID     string             `header:"X-Tenant-ID"`
+	UID          string             `param:"uid" validate:"required"`
+	Name         string             `json:"name" validate:"device_name,omitempty"`
+	CustomFields *map[string]string `json:"custom_fields" validate:"omitempty"`
 }
 
 // DeviceParam is a structure to represent and validate a device UID as path param.

--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -49,6 +49,8 @@ type Device struct {
 	Position        *DevicePosition `json:"position" bson:"position"`
 	Acceptable      bool            `json:"acceptable" bson:"acceptable,omitempty"`
 
+	CustomFields map[string]string `json:"custom_fields,omitempty" bson:"custom_fields,omitempty"`
+
 	Taggable `json:",inline" bson:",inline"`
 }
 

--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -49,7 +49,7 @@ type Device struct {
 	Position        *DevicePosition `json:"position" bson:"position"`
 	Acceptable      bool            `json:"acceptable" bson:"acceptable,omitempty"`
 
-	CustomFields map[string]string `json:"custom_fields,omitempty" bson:"custom_fields,omitempty"`
+	CustomFields map[string]string `json:"custom_fields,omitempty" bson:"custom_fields"`
 
 	Taggable `json:",inline" bson:",inline"`
 }

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -39,7 +39,7 @@ FROM base AS development
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
-RUN apk add --update openssl
+RUN apk add --update openssl build-base binutils-gold
 RUN go install github.com/air-verse/air@v1.62 && \
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
     go install github.com/vektra/mockery/v2/...@v2.20.0

--- a/ui-react/apps/console/src/hooks/__tests__/useDevices.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useDevices.test.ts
@@ -3,10 +3,13 @@ import { buildFilter } from "../useDevices";
 
 describe("buildFilter", () => {
   describe("search only", () => {
-    it("encodes a name filter", () => {
+    it("encodes a name OR custom_fields filter", () => {
       const result = JSON.parse(atob(buildFilter("my-device", [])));
       expect(result).toEqual([
+        { type: "operator", params: { name: "or" } },
         { type: "property", params: { name: "name", operator: "contains", value: "my-device" } },
+        { type: "operator", params: { name: "or" } },
+        { type: "property", params: { name: "custom_fields", operator: "contains", value: "my-device" } },
       ]);
     });
   });
@@ -24,7 +27,10 @@ describe("buildFilter", () => {
     it("encodes both filters in the same array", () => {
       const result = JSON.parse(atob(buildFilter("srv", ["prod"])));
       expect(result).toEqual([
+        { type: "operator", params: { name: "or" } },
         { type: "property", params: { name: "name", operator: "contains", value: "srv" } },
+        { type: "operator", params: { name: "or" } },
+        { type: "property", params: { name: "custom_fields", operator: "contains", value: "srv" } },
         { type: "property", params: { name: "tags.name", operator: "contains", value: ["prod"] } },
       ]);
     });

--- a/ui-react/apps/console/src/hooks/useDeviceMutations.ts
+++ b/ui-react/apps/console/src/hooks/useDeviceMutations.ts
@@ -42,6 +42,14 @@ export function useRenameDevice() {
   });
 }
 
+export function useUpdateDeviceCustomFields() {
+  const invalidate = useInvalidateByIds("getDevices", "getDevice");
+  return useMutation({
+    ...updateDeviceMutation(),
+    onSuccess: invalidate,
+  });
+}
+
 export function useAddDeviceTag() {
   const invalidate = useInvalidateByIds("getDevices", "getDevice", "getStatusDevices", "getTags");
   return useMutation({

--- a/ui-react/apps/console/src/hooks/useDevices.ts
+++ b/ui-react/apps/console/src/hooks/useDevices.ts
@@ -14,10 +14,12 @@ export type NormalizedDevice = Omit<GeneratedDevice, "tags"> & { tags: string[] 
 export function buildFilter(search: string, tags: string[]): string {
   const filters: Record<string, unknown>[] = [];
   if (search) {
-    filters.push({
-      type: "property",
-      params: { name: "name", operator: "contains", value: search },
-    });
+    filters.push(
+      { type: "operator", params: { name: "or" } },
+      { type: "property", params: { name: "name", operator: "contains", value: search } },
+      { type: "operator", params: { name: "or" } },
+      { type: "property", params: { name: "custom_fields", operator: "contains", value: search } },
+    );
   }
   if (tags.length > 0) {
     filters.push({

--- a/ui-react/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/DeviceDetails.tsx
@@ -25,6 +25,7 @@ import {
   useAddDeviceTag,
   useRemoveDeviceTag,
   useRemoveDevice,
+  useUpdateDeviceCustomFields,
 } from "../hooks/useDeviceMutations";
 import { useNamespace } from "../hooks/useNamespaces";
 import { useAuthStore } from "../stores/authStore";
@@ -267,6 +268,129 @@ function RenameSection({
         </button>
       </div>
       {error && <p className="text-2xs text-accent-red mt-1">{error}</p>}
+    </div>
+  );
+}
+
+/* ─── Custom Fields Section ─── */
+function CustomFieldsSection({
+  uid,
+  name,
+  customFields,
+}: {
+  uid: string;
+  name: string;
+  customFields: Record<string, string>;
+}) {
+  const mutation = useUpdateDeviceCustomFields();
+  const [keyInput, setKeyInput] = useState("");
+  const [valueInput, setValueInput] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmKey, setConfirmKey] = useState<string | null>(null);
+
+  const handleAdd = async () => {
+    const key = keyInput.trim();
+    const value = valueInput.trim();
+    if (!key || !value) return;
+    if (key in customFields) {
+      setError("This key already exists.");
+      return;
+    }
+    setError(null);
+    setAdding(true);
+    try {
+      await mutation.mutateAsync({
+        path: { uid },
+        body: { name, custom_fields: { ...customFields, [key]: value } },
+      });
+      setKeyInput("");
+      setValueInput("");
+    } catch {
+      setError("Failed to add custom field.");
+    }
+    setAdding(false);
+  };
+
+  const handleRemove = async (key: string) => {
+    const updated = { ...customFields };
+    delete updated[key];
+    try {
+      await mutation.mutateAsync({
+        path: { uid },
+        body: { name, custom_fields: updated },
+      });
+    } catch {
+      /* invalidation handles UI update */
+    }
+  };
+
+  return (
+    <div>
+      <h3 className={LABEL + " mb-3"}>Custom Fields</h3>
+      <dl className="space-y-2 mb-3">
+        {Object.entries(customFields).map(([key, value]) => (
+          <div key={key} className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-xs font-mono text-text-muted shrink-0">{key}:</span>
+              <span className="text-sm text-text-primary font-medium truncate">{value}</span>
+            </div>
+            {confirmKey === key
+              ? (
+                <div className="flex items-center gap-1 shrink-0">
+                  <span className="text-2xs text-text-muted">Remove?</span>
+                  <button
+                    onClick={() => { void handleRemove(key); setConfirmKey(null); }}
+                    className="px-1.5 py-0.5 rounded text-2xs font-semibold bg-accent-red/90 hover:bg-accent-red text-white transition-all"
+                  >
+                    Yes
+                  </button>
+                  <button
+                    onClick={() => setConfirmKey(null)}
+                    className="px-1.5 py-0.5 rounded text-2xs font-semibold text-text-muted hover:text-text-primary hover:bg-hover-subtle transition-all"
+                  >
+                    No
+                  </button>
+                </div>
+              )
+              : (
+                <button
+                  onClick={() => setConfirmKey(key)}
+                  className="shrink-0 p-1 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all"
+                >
+                  <XMarkIcon className="w-3 h-3" strokeWidth={2} />
+                </button>
+              )}
+          </div>
+        ))}
+      </dl>
+      <div className="flex items-center gap-1.5">
+        <input
+          type="text"
+          value={keyInput}
+          onChange={(e) => { setKeyInput(e.target.value); setError(null); }}
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAdd(); } }}
+          placeholder="key"
+          className="w-24 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
+        />
+        <span className="text-text-muted text-xs">:</span>
+        <input
+          type="text"
+          value={valueInput}
+          onChange={(e) => { setValueInput(e.target.value); setError(null); }}
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAdd(); } }}
+          placeholder="value"
+          className="w-32 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
+        />
+        <button
+          onClick={() => void handleAdd()}
+          disabled={adding || !keyInput.trim() || !valueInput.trim()}
+          className="p-1 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 disabled:opacity-soft transition-all"
+        >
+          <PlusIcon className="w-4 h-4" strokeWidth={2} />
+        </button>
+      </div>
+      {error && <p className="text-2xs text-accent-red mt-1.5">{error}</p>}
     </div>
   );
 }
@@ -588,9 +712,18 @@ export default function DeviceDetails() {
         </div>
       </div>
 
-      {/* Tags */}
-      <div className="bg-card border border-border rounded-xl p-5 mb-6">
-        <TagsSection uid={device.uid} tags={tags} />
+      {/* Tags + Custom Fields */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+        <div className="bg-card border border-border rounded-xl p-5">
+          <TagsSection uid={device.uid} tags={tags} />
+        </div>
+        <div className="bg-card border border-border rounded-xl p-5">
+          <CustomFieldsSection
+            uid={device.uid}
+            name={device.name}
+            customFields={device.custom_fields ?? {}}
+          />
+        </div>
       </div>
 
       {/* Delete Dialog */}

--- a/ui-react/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/DeviceDetails.tsx
@@ -275,14 +275,13 @@ function RenameSection({
 /* ─── Custom Fields Section ─── */
 function CustomFieldsSection({
   uid,
-  name,
   customFields,
 }: {
   uid: string;
-  name: string;
   customFields: Record<string, string>;
 }) {
   const mutation = useUpdateDeviceCustomFields();
+  const canEdit = useHasPermission("device:rename");
   const [keyInput, setKeyInput] = useState("");
   const [valueInput, setValueInput] = useState("");
   const [adding, setAdding] = useState(false);
@@ -302,7 +301,7 @@ function CustomFieldsSection({
     try {
       await mutation.mutateAsync({
         path: { uid },
-        body: { name, custom_fields: { ...customFields, [key]: value } },
+        body: { name: "", custom_fields: { ...customFields, [key]: value } },
       });
       setKeyInput("");
       setValueInput("");
@@ -318,7 +317,7 @@ function CustomFieldsSection({
     try {
       await mutation.mutateAsync({
         path: { uid },
-        body: { name, custom_fields: updated },
+        body: { name: "", custom_fields: updated },
       });
     } catch {
       /* invalidation handles UI update */
@@ -335,61 +334,65 @@ function CustomFieldsSection({
               <span className="text-xs font-mono text-text-muted shrink-0">{key}:</span>
               <span className="text-sm text-text-primary font-medium truncate">{value}</span>
             </div>
-            {confirmKey === key
-              ? (
-                <div className="flex items-center gap-1 shrink-0">
-                  <span className="text-2xs text-text-muted">Remove?</span>
+            {canEdit && (
+              confirmKey === key
+                ? (
+                  <div className="flex items-center gap-1 shrink-0">
+                    <span className="text-2xs text-text-muted">Remove?</span>
+                    <button
+                      onClick={() => { void handleRemove(key); setConfirmKey(null); }}
+                      className="px-1.5 py-0.5 rounded text-2xs font-semibold bg-accent-red/90 hover:bg-accent-red text-white transition-all"
+                    >
+                      Yes
+                    </button>
+                    <button
+                      onClick={() => setConfirmKey(null)}
+                      className="px-1.5 py-0.5 rounded text-2xs font-semibold text-text-muted hover:text-text-primary hover:bg-hover-subtle transition-all"
+                    >
+                      No
+                    </button>
+                  </div>
+                )
+                : (
                   <button
-                    onClick={() => { void handleRemove(key); setConfirmKey(null); }}
-                    className="px-1.5 py-0.5 rounded text-2xs font-semibold bg-accent-red/90 hover:bg-accent-red text-white transition-all"
+                    onClick={() => setConfirmKey(key)}
+                    className="shrink-0 p-1 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all"
                   >
-                    Yes
+                    <XMarkIcon className="w-3 h-3" strokeWidth={2} />
                   </button>
-                  <button
-                    onClick={() => setConfirmKey(null)}
-                    className="px-1.5 py-0.5 rounded text-2xs font-semibold text-text-muted hover:text-text-primary hover:bg-hover-subtle transition-all"
-                  >
-                    No
-                  </button>
-                </div>
-              )
-              : (
-                <button
-                  onClick={() => setConfirmKey(key)}
-                  className="shrink-0 p-1 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all"
-                >
-                  <XMarkIcon className="w-3 h-3" strokeWidth={2} />
-                </button>
-              )}
+                )
+            )}
           </div>
         ))}
       </dl>
-      <div className="flex items-center gap-1.5">
-        <input
-          type="text"
-          value={keyInput}
-          onChange={(e) => { setKeyInput(e.target.value); setError(null); }}
-          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAdd(); } }}
-          placeholder="key"
-          className="w-24 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
-        />
-        <span className="text-text-muted text-xs">:</span>
-        <input
-          type="text"
-          value={valueInput}
-          onChange={(e) => { setValueInput(e.target.value); setError(null); }}
-          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAdd(); } }}
-          placeholder="value"
-          className="w-32 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
-        />
-        <button
-          onClick={() => void handleAdd()}
-          disabled={adding || !keyInput.trim() || !valueInput.trim()}
-          className="p-1 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 disabled:opacity-soft transition-all"
-        >
-          <PlusIcon className="w-4 h-4" strokeWidth={2} />
-        </button>
-      </div>
+      {canEdit && (
+        <div className="flex items-center gap-1.5">
+          <input
+            type="text"
+            value={keyInput}
+            onChange={(e) => { setKeyInput(e.target.value); setError(null); }}
+            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAdd(); } }}
+            placeholder="key"
+            className="w-24 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
+          />
+          <span className="text-text-muted text-xs">:</span>
+          <input
+            type="text"
+            value={valueInput}
+            onChange={(e) => { setValueInput(e.target.value); setError(null); }}
+            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAdd(); } }}
+            placeholder="value"
+            className="w-32 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
+          />
+          <button
+            onClick={() => void handleAdd()}
+            disabled={adding || !keyInput.trim() || !valueInput.trim()}
+            className="p-1 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 disabled:opacity-soft transition-all"
+          >
+            <PlusIcon className="w-4 h-4" strokeWidth={2} />
+          </button>
+        </div>
+      )}
       {error && <p className="text-2xs text-accent-red mt-1.5">{error}</p>}
     </div>
   );
@@ -720,7 +723,6 @@ export default function DeviceDetails() {
         <div className="bg-card border border-border rounded-xl p-5">
           <CustomFieldsSection
             uid={device.uid}
-            name={device.name}
             customFields={device.custom_fields ?? {}}
           />
         </div>

--- a/ui-react/apps/console/src/pages/devices/__tests__/DeviceDetails.test.tsx
+++ b/ui-react/apps/console/src/pages/devices/__tests__/DeviceDetails.test.tsx
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import type { Device } from "@/client";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/hooks/useDevice", () => ({
+  useDevice: vi.fn(),
+}));
+
+const mockUpdateCustomFields = vi.fn();
+
+vi.mock("@/hooks/useDeviceMutations", () => ({
+  useRenameDevice: () => ({ mutateAsync: vi.fn() }),
+  useAddDeviceTag: () => ({ mutateAsync: vi.fn() }),
+  useRemoveDeviceTag: () => ({ mutateAsync: vi.fn() }),
+  useRemoveDevice: () => ({ mutateAsync: vi.fn() }),
+  useUpdateDeviceCustomFields: () => ({ mutateAsync: mockUpdateCustomFields }),
+}));
+
+vi.mock("@/hooks/useNamespaces", () => ({
+  useNamespace: () => ({ namespace: { name: "my-ns" } }),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (sel: (s: { tenant: string }) => unknown) =>
+    sel({ tenant: "tenant-1" }),
+}));
+
+vi.mock("@/stores/terminalStore", () => ({
+  useTerminalStore: (sel: (s: { sessions: []; restore: () => void }) => unknown) =>
+    sel({ sessions: [], restore: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useHasPermission", () => ({
+  useHasPermission: () => true,
+}));
+
+vi.mock("@/components/common/CopyButton", () => ({
+  default: ({ text }: { text: string }) => (
+    <button type="button" aria-label={`Copy ${text}`} />
+  ),
+}));
+
+vi.mock("@/components/common/PlatformBadge", () => ({
+  default: ({ platform }: { platform: string }) => <span>{platform}</span>,
+}));
+
+vi.mock("@/components/ConnectDrawer", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/components/common/RestrictedAction", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/pages/devices/DeviceActionDialog", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/utils/date", () => ({
+  formatRelative: () => "just now",
+  formatDateFull: () => "Jan 15, 2024",
+}));
+
+vi.mock("@/utils/sshid", () => ({
+  buildSshid: (ns: string, name: string) => `${ns}.${name}@localhost`,
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useParams: () => ({ uid: "test-uid" }),
+    useNavigate: () => vi.fn(),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  };
+});
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import { useDevice } from "@/hooks/useDevice";
+import DeviceDetails from "../../DeviceDetails";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeDevice(overrides: Partial<Device> = {}): Device {
+  return {
+    uid: "test-uid",
+    name: "my-device",
+    status: "accepted",
+    online: true,
+    tags: [],
+    last_seen: "2024-01-15T10:00:00.000Z",
+    created_at: "2023-06-01T08:00:00.000Z",
+    identity: { mac: "aa:bb:cc:dd:ee:ff" },
+    info: {
+      id: "ubuntu",
+      pretty_name: "Ubuntu 22.04 LTS",
+      arch: "x86_64",
+      platform: "linux",
+      version: "0.14.0",
+    },
+    remote_addr: "1.2.3.4",
+    custom_fields: {},
+    ...overrides,
+  } as Device;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <DeviceDetails />
+    </MemoryRouter>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("DeviceDetails", () => {
+  beforeEach(() => {
+    mockUpdateCustomFields.mockReset().mockResolvedValue({});
+    vi.mocked(useDevice).mockReturnValue({
+      device: null,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  describe("loading state", () => {
+    it("renders a spinner while loading", () => {
+      vi.mocked(useDevice).mockReturnValue({
+        device: null,
+        isLoading: true,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+      expect(document.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+  });
+
+  describe("device data", () => {
+    beforeEach(() => {
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice(),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+    });
+
+    it("renders the device name as a heading", () => {
+      renderPage();
+      expect(screen.getByRole("heading", { name: "my-device" })).toBeInTheDocument();
+    });
+
+    it("renders the MAC address", () => {
+      renderPage();
+      expect(screen.getByText("aa:bb:cc:dd:ee:ff")).toBeInTheDocument();
+    });
+
+    it("renders the operating system", () => {
+      renderPage();
+      expect(screen.getByText("Ubuntu 22.04 LTS")).toBeInTheDocument();
+    });
+
+    it('renders the "Custom Fields" section label', () => {
+      renderPage();
+      expect(screen.getByText("Custom Fields")).toBeInTheDocument();
+    });
+  });
+
+  describe("custom fields section", () => {
+    it("renders key-value pairs when custom fields are present", () => {
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice({ custom_fields: { env: "production", owner: "team-a" } }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+      expect(screen.getByText("env:")).toBeInTheDocument();
+      expect(screen.getByText("production")).toBeInTheDocument();
+      expect(screen.getByText("owner:")).toBeInTheDocument();
+      expect(screen.getByText("team-a")).toBeInTheDocument();
+    });
+
+    it("renders the add form inputs", () => {
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice({ custom_fields: {} }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+      expect(screen.getByPlaceholderText("key")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("value")).toBeInTheDocument();
+    });
+
+    it("shows delete confirmation when the remove button is clicked", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice({ custom_fields: { env: "production" } }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      // Find the field row by key text and click the adjacent remove button
+      const keyEl = screen.getByText("env:");
+      const fieldRow = keyEl.closest("div")!.parentElement!;
+      const xBtn = within(fieldRow).getByRole("button");
+      await user.click(xBtn);
+
+      expect(screen.getByText("Remove?")).toBeInTheDocument();
+      expect(screen.getByText("Yes")).toBeInTheDocument();
+      expect(screen.getByText("No")).toBeInTheDocument();
+    });
+
+    it("hides the confirmation when 'No' is clicked", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice({ custom_fields: { env: "production" } }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      const keyEl = screen.getByText("env:");
+      const fieldRow = keyEl.closest("div")!.parentElement!;
+      const xBtn = within(fieldRow).getByRole("button");
+      await user.click(xBtn);
+      await user.click(screen.getByText("No"));
+
+      expect(screen.queryByText("Remove?")).not.toBeInTheDocument();
+    });
+
+    it("calls mutation without the deleted key when 'Yes' is clicked", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice({ custom_fields: { env: "production", owner: "team-a" } }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      const keyEl = screen.getByText("env:");
+      const fieldRow = keyEl.closest("div")!.parentElement!;
+      const xBtn = within(fieldRow).getByRole("button");
+      await user.click(xBtn);
+      await user.click(screen.getByText("Yes"));
+
+      expect(mockUpdateCustomFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            custom_fields: { owner: "team-a" },
+          }),
+        }),
+      );
+    });
+
+    it("calls mutation with new field when add form is submitted via Enter key", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice({ custom_fields: {} }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      await user.type(screen.getByPlaceholderText("key"), "region");
+      await user.type(screen.getByPlaceholderText("value"), "us-east{Enter}");
+
+      expect(mockUpdateCustomFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            custom_fields: { region: "us-east" },
+          }),
+        }),
+      );
+    });
+
+    it("shows an error when trying to add a duplicate key", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice({ custom_fields: { env: "production" } }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      await user.type(screen.getByPlaceholderText("key"), "env");
+      await user.type(screen.getByPlaceholderText("value"), "staging{Enter}");
+
+      expect(screen.getByText("This key already exists.")).toBeInTheDocument();
+      expect(mockUpdateCustomFields).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui-react/apps/console/src/pages/devices/__tests__/Devices.test.tsx
+++ b/ui-react/apps/console/src/pages/devices/__tests__/Devices.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import type { NormalizedDevice } from "@/hooks/useDevices";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/hooks/useDevices", () => ({
+  useDevices: vi.fn(),
+  buildFilter: vi.fn(),
+}));
+
+vi.mock("@/hooks/useNamespaces", () => ({
+  useNamespace: () => ({ namespace: { name: "my-ns" } }),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (sel: (s: { tenant: string }) => unknown) =>
+    sel({ tenant: "tenant-1" }),
+}));
+
+vi.mock("@/stores/terminalStore", () => ({
+  useTerminalStore: (sel: (s: { sessions: [] }) => unknown) =>
+    sel({ sessions: [] }),
+}));
+
+vi.mock("@/hooks/useHasPermission", () => ({
+  useHasPermission: () => true,
+}));
+
+vi.mock("@/components/common/CopyButton", () => ({
+  default: ({ text }: { text: string }) => (
+    <button type="button" aria-label={`Copy ${text}`} />
+  ),
+}));
+
+vi.mock("@/components/common/PageHeader", () => ({
+  default: ({ title, children }: { title: string; children?: React.ReactNode }) => (
+    <div><h1>{title}</h1>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/common/DataTable", () => ({
+  default: ({
+    columns,
+    data,
+    isLoading,
+    loadingMessage,
+    onRowClick,
+    emptyState,
+  }: {
+    columns: { key: string; header: string; render: (row: unknown) => React.ReactNode }[];
+    data: unknown[];
+    isLoading: boolean;
+    loadingMessage: string;
+    onRowClick: (row: unknown) => void;
+    emptyState: React.ReactNode;
+  }) => {
+    if (isLoading) return <div>{loadingMessage}</div>;
+    if (data.length === 0) return <div>{emptyState}</div>;
+    return (
+      <table>
+        <thead>
+          <tr>{columns.map((c) => <th key={c.key}>{c.header}</th>)}</tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr key={i} onClick={() => onRowClick(row)}>
+              {columns.map((c) => <td key={c.key}>{c.render(row)}</td>)}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  },
+}));
+
+vi.mock("@/components/common/PlatformBadge", () => ({
+  default: ({ platform }: { platform: string }) => <span>{platform}</span>,
+}));
+
+vi.mock("@/utils/date", () => ({
+  formatRelative: () => "just now",
+  formatDateFull: () => "Jan 15, 2024",
+}));
+
+vi.mock("@/utils/sshid", () => ({
+  buildSshid: (ns: string, name: string) => `${ns}.${name}@localhost`,
+}));
+
+vi.mock("@/components/common/TagFilterDropdown", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/components/ManageTagsDrawer", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/components/ConnectDrawer", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("../TagsPopover", () => ({
+  default: ({ device }: { device: NormalizedDevice }) => (
+    <span>{device.tags.length > 0 ? device.tags.join(", ") : "No tags"}</span>
+  ),
+}));
+
+vi.mock("../DeviceActionDialog", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/components/common/RestrictedAction", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import React from "react";
+import { useDevices } from "@/hooks/useDevices";
+import Devices from "../index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const defaultHookState = {
+  devices: [] as NormalizedDevice[],
+  totalCount: 0,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+function makeDevice(overrides: Partial<NormalizedDevice> = {}): NormalizedDevice {
+  return {
+    uid: "device-uid-1",
+    name: "my-device",
+    status: "accepted",
+    online: true,
+    tags: [],
+    last_seen: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    identity: { mac: "aa:bb:cc:dd:ee:ff" },
+    info: {
+      id: "ubuntu",
+      pretty_name: "Ubuntu 22.04 LTS",
+      arch: "x86_64",
+      platform: "linux",
+      version: "0.14.0",
+    },
+    remote_addr: "1.2.3.4",
+    custom_fields: {},
+    ...overrides,
+  } as NormalizedDevice;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <Devices />
+    </MemoryRouter>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Devices list", () => {
+  beforeEach(() => {
+    vi.mocked(useDevices).mockReturnValue(defaultHookState);
+    mockNavigate.mockReset();
+  });
+
+  describe("rendering", () => {
+    it("renders the page heading", () => {
+      renderPage();
+      expect(screen.getByRole("heading", { name: "Devices" })).toBeInTheDocument();
+    });
+
+    it("renders all status filter tabs", () => {
+      renderPage();
+      expect(screen.getByRole("button", { name: "Accepted" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Pending" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Rejected" })).toBeInTheDocument();
+    });
+
+    it("renders the search input", () => {
+      renderPage();
+      expect(screen.getByPlaceholderText("Search devices...")).toBeInTheDocument();
+    });
+
+    it('renders the "Custom Fields" column header', () => {
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [makeDevice()],
+        totalCount: 1,
+      });
+      renderPage();
+      expect(screen.getByRole("columnheader", { name: "Custom Fields" })).toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it("renders the loading message", () => {
+      vi.mocked(useDevices).mockReturnValue({ ...defaultHookState, isLoading: true });
+      renderPage();
+      expect(screen.getByText("Loading devices...")).toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it('renders "No devices found" when list is empty', () => {
+      renderPage();
+      expect(screen.getByText("No devices found")).toBeInTheDocument();
+    });
+  });
+
+  describe("device rows", () => {
+    it("renders a row for each device", () => {
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [
+          makeDevice({ uid: "uid-1", name: "alpha" }),
+          makeDevice({ uid: "uid-2", name: "beta" }),
+        ],
+        totalCount: 2,
+      });
+      renderPage();
+      expect(screen.getByText("alpha")).toBeInTheDocument();
+      expect(screen.getByText("beta")).toBeInTheDocument();
+    });
+
+    it("navigates to device detail on row click", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [makeDevice({ uid: "uid-abc", name: "clickable" })],
+        totalCount: 1,
+      });
+      renderPage();
+      await user.click(screen.getByText("clickable"));
+      expect(mockNavigate).toHaveBeenCalledWith("/devices/uid-abc");
+    });
+  });
+
+  describe("custom fields column", () => {
+    it("renders '—' when device has no custom fields", () => {
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [makeDevice({ custom_fields: {} })],
+        totalCount: 1,
+      });
+      renderPage();
+      expect(screen.getByText("—")).toBeInTheDocument();
+    });
+
+    it("renders key and value badges for each custom field", () => {
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [makeDevice({ custom_fields: { env: "production", owner: "team-a" } })],
+        totalCount: 1,
+      });
+      renderPage();
+      expect(screen.getByText("env")).toBeInTheDocument();
+      expect(screen.getByText("production")).toBeInTheDocument();
+      expect(screen.getByText("owner")).toBeInTheDocument();
+      expect(screen.getByText("team-a")).toBeInTheDocument();
+    });
+
+    it("renders multiple custom field badges for multiple fields", () => {
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [makeDevice({ custom_fields: { a: "1", b: "2", c: "3" } })],
+        totalCount: 1,
+      });
+      renderPage();
+      expect(screen.getByText("a")).toBeInTheDocument();
+      expect(screen.getByText("1")).toBeInTheDocument();
+      expect(screen.getByText("b")).toBeInTheDocument();
+      expect(screen.getByText("2")).toBeInTheDocument();
+      expect(screen.getByText("c")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+  });
+
+  describe("error state", () => {
+    it("renders an error message when hook returns an error", () => {
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        error: new Error("Request failed"),
+      });
+      renderPage();
+      expect(screen.getByText("Request failed")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui-react/apps/console/src/pages/devices/index.tsx
+++ b/ui-react/apps/console/src/pages/devices/index.tsx
@@ -136,6 +136,24 @@ export default function Devices() {
         ),
       },
       {
+        key: "custom_fields",
+        header: "Custom Fields",
+        render: (device) => {
+          const entries = Object.entries(device.custom_fields ?? {});
+          if (entries.length === 0) return <span className="text-2xs text-text-muted/30 font-mono">—</span>;
+          return (
+            <div className="flex flex-wrap gap-1">
+              {entries.map(([k, v]) => (
+                <span key={k} className="inline-flex items-center text-2xs rounded overflow-hidden border border-border font-mono">
+                  <span className="px-1.5 py-0.5 bg-surface text-text-muted">{k}</span>
+                  <span className="px-1.5 py-0.5 bg-card text-text-primary font-medium">{v}</span>
+                </span>
+              ))}
+            </div>
+          );
+        },
+      },
+      {
         key: "last_seen",
         header: "Last Seen",
         render: (device) => (

--- a/ui/src/api/client/api.ts
+++ b/ui/src/api/client/api.ts
@@ -434,6 +434,10 @@ export interface Device {
      * Device\'s acceptable  The value \"acceptable\" is based on the number of devices removed and already accepted into a namespace. All devices are \"acceptable\" unless the \"namespace.max_devices\" is reached. This limit is set based on the sum up of accepted and removed devices into the namespace. When this limit is reached, only removed devices between 720 hours or 30 days are set to \"acceptable\". 
      */
     'acceptable'?: boolean;
+    /**
+     * User-defined key-value metadata for the device.
+     */
+    'custom_fields'?: { [key: string]: string };
 }
 
 

--- a/ui/src/interfaces/IDevice.ts
+++ b/ui/src/interfaces/IDevice.ts
@@ -36,6 +36,7 @@ export interface IDevice {
   remote_addr: string;
   position: Position;
   tags: Array<ITag>;
+  custom_fields?: Record<string, string>;
 }
 
 export interface IDeviceRename {

--- a/ui/src/views/DetailsDevice.vue
+++ b/ui/src/views/DetailsDevice.vue
@@ -182,6 +182,34 @@
           </div>
         </v-col>
       </v-row>
+
+      <template v-if="device.custom_fields && Object.keys(device.custom_fields).length">
+        <v-divider class="my-2" />
+        <div
+          class="py-3"
+          data-test="device-custom-fields"
+        >
+          <div class="item-title mb-2">
+            Custom Fields:
+          </div>
+          <v-row>
+            <v-col
+              v-for="(value, key) in device.custom_fields"
+              :key="key"
+              cols="12"
+              md="6"
+              class="my-0 py-0"
+            >
+              <div :data-test="`device-custom-field-${key}`">
+                <div class="item-title">
+                  {{ key }}:
+                </div>
+                <p>{{ value }}</p>
+              </div>
+            </v-col>
+          </v-row>
+        </div>
+      </template>
     </v-card-text>
   </v-card>
   <v-card


### PR DESCRIPTION
## Motivation

As device fleets grow, operators often need to attach context-specific metadata to individual devices — things like physical location, environment tags, asset identifiers, or team ownership. Without a dedicated mechanism, this information ends up scattered across external spreadsheets or encoded into hostnames, making it hard to query and maintain.

This feature introduces **custom fields**: a simple key-value map attached to each device. Operators can freely define any metadata they need, and that metadata becomes a first-class citizen in the dashboard — visible in the device list, searchable alongside the hostname, and fully manageable from the device detail page without touching the API directly.

https://github.com/user-attachments/assets/32f357be-424d-4068-ab8a-62263d059343

---

## Summary

- Add `custom_fields map[string]string` to the Device model, stored as JSONB in PostgreSQL and an embedded document in MongoDB
- Expose via the existing `PUT /devices/{uid}` endpoint — nil means no change, empty map clears all fields
- Search in the device list also queries custom field values (OR with hostname search)
- Display and manage custom fields in the device detail page (add, delete with confirmation)
- Add custom fields column in the devices list table

## Changes

| Scope | Description |
|---|---|
| `pkg` | Add `CustomFields` to `Device` model and `DeviceUpdate` request DTO |
| `api` | Service logic, MongoDB `$objectToArray` filter, PostgreSQL JSONB filter, migration 002 |
| `openapi` | Add `custom_fields` to device schema and PUT request body |
| `docker` | Add `binutils-gold` to Alpine images for ARM64 linker support (see note below) |
| `ui` (Vue) | Display custom fields on device detail page |
| `ui-react` | Custom fields column in list, management UI in detail page, search integration |
| `test(api)` | Unit tests for PG/Mongo filters and service UpdateDevice cases |
| `test(ui-react)` | Tests for devices list and device details custom fields behavior |

### Note: binutils-gold in Alpine Dockerfiles

During local development on an ARM64 machine (Apple Silicon), the Docker builds were failing with:

```
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find 'ld'
```

The root cause is that `golangci-lint` is compiled with `-fuse-ld=gold`, which requires the `gold` linker (`binutils-gold` package) to be present on the system. Alpine's default `binutils` does not include it. Adding `binutils-gold` to the Alpine images that install `golangci-lint` resolves the build failure on ARM64 hosts.

## Test plan

- [x] `go test ./api/services/... ./api/store/pg/internal/... ./api/store/mongo/internal/...`
- [x] `cd ui-react/apps/console && npx vitest run src/pages/devices/__tests__`
- [x] `PUT /devices/{uid}` with `{"name": "x", "custom_fields": {"env": "prod"}}` → 200
- [x] `GET /devices/{uid}` → response includes `custom_fields`
- [x] Search on `/devices` by custom field value returns matching devices
- [x] Device detail page shows custom fields with add/delete UI