### PR TITLE
fix(ui-react): allow sidebar to collapse and expand on desktop

### DIFF
--- a/ui-react/apps/console/src/components/layout/AdminLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminLayout.tsx
@@ -12,7 +12,7 @@ export default function AdminLayout() {
     <div className="flex flex-col h-screen bg-background">
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {isDesktop ? (
-          <AdminSidebar expanded={isOpen} />
+          <AdminSidebar expanded={isOpen} onToggle={handlers.toggleDesktop} />
         ) : (
           <SidebarMobileDrawer
             open={drawerOpen}

--- a/ui-react/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AppLayout.tsx
@@ -28,7 +28,7 @@ export default function AppLayout() {
       <ConnectivityBanner />
       <div className="flex flex-1 min-h-0">
         {showSidebar && isDesktop && (
-          <Sidebar expanded={isOpen} />
+          <Sidebar expanded={isOpen} onToggle={handlers.toggleDesktop} />
         )}
         {showSidebar && !isDesktop && (
           <SidebarMobileDrawer

--- a/ui-react/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui-react/apps/console/src/components/layout/SidebarShell.tsx
@@ -163,23 +163,20 @@ export default function SidebarShell({
 
       {/* Footer with pin toggle */}
       <div
-        className={`h-11 px-3 flex items-center justify-between transition-colors duration-200 ${expanded && onToggle ? "border-t border-border" : "border-t border-transparent"}`}
+        className={`h-11 px-3 flex items-center border-t border-border ${expanded && onToggle ? "justify-between" : "justify-center"}`}
       >
-        <p
-          className={`text-2xs font-mono text-text-muted/60 whitespace-nowrap transition-opacity duration-200 ${expanded && onToggle ? "opacity-100" : "opacity-0"}`}
-        >
-          {footerLabel}
-        </p>
+        {expanded && onToggle && (
+          <p className="text-2xs font-mono text-text-muted/60 whitespace-nowrap">
+            {footerLabel}
+          </p>
+        )}
         {onToggle && (
           <button
             type="button"
             onClick={onToggle}
-            tabIndex={expanded ? 0 : -1}
-            aria-label="Close sidebar"
-            title="Close sidebar"
-            className={`p-1 rounded-md transition-all duration-200 text-text-muted hover:text-text-primary hover:bg-hover-subtle ${
-              expanded ? "opacity-100" : "opacity-0"
-            }`}
+            aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
+            title={expanded ? "Collapse sidebar" : "Expand sidebar"}
+            className="p-1 rounded-md transition-all duration-200 text-text-muted hover:text-text-primary hover:bg-hover-subtle"
           >
             <ChevronLeftIcon
               className={`w-3.5 h-3.5 transition-transform duration-200 ${

--- a/ui-react/apps/console/src/hooks/useSidebarLayout.ts
+++ b/ui-react/apps/console/src/hooks/useSidebarLayout.ts
@@ -23,6 +23,7 @@ function getIsDesktopServer() {
 
 export function useSidebarLayout() {
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [desktopExpanded, setDesktopExpanded] = useState(true);
 
   const isDesktop = useSyncExternalStore(
     subscribeToMediaQuery,
@@ -30,11 +31,12 @@ export function useSidebarLayout() {
     getIsDesktopServer,
   );
 
-  const isOpen = isDesktop;
+  const isOpen = isDesktop ? desktopExpanded : false;
 
   const openDrawer = () => setDrawerOpen(true);
   const closeDrawer = () => setDrawerOpen(false);
   const toggleDrawer = () => setDrawerOpen((prev) => !prev);
+  const toggleDesktop = () => setDesktopExpanded((prev) => !prev);
 
   const handleDrawerKeyDown = (e: React.KeyboardEvent) => { if (e.key === "Escape") closeDrawer(); };
 
@@ -46,6 +48,7 @@ export function useSidebarLayout() {
       openDrawer,
       closeDrawer,
       toggleDrawer,
+      toggleDesktop,
       onDrawerKeyDown: handleDrawerKeyDown,
     },
   };


### PR DESCRIPTION
## What

Restored the ability to collapse and expand the sidebar on desktop/tablet screen sizes. The toggle button in the sidebar footer now works on all viewport sizes, not just mobile.

## Why

A previous refactor (`b726d1ec`) simplified `useSidebarLayout` by hardcoding `isOpen = isDesktop`, removing the desktop expand/collapse state and never passing `onToggle` to the desktop sidebar instances. This left the chevron button wired up in `SidebarShell` but unreachable.

## Changes

- **`useSidebarLayout`**: Added `desktopExpanded` state (defaults `true`) and a `toggleDesktop` handler. `isOpen` on desktop now reflects user preference instead of being hardcoded to `true`.
- **`AppLayout` / `AdminLayout`**: Pass `onToggle={handlers.toggleDesktop}` to the desktop sidebar, activating the footer button.
- **`SidebarShell` footer**: Fixed a layout bug where the invisible `<p>` label (opacity-0, whitespace-nowrap) still occupied flex space, pushing the chevron button outside the 60px collapsed sidebar and clipping it under `overflow-hidden`. Replaced the opacity trick with conditional rendering and switched the footer to `justify-center` when collapsed so the chevron is properly centered.