### PR TITLE
fix(ui): restore sidebar pin and hover behavior

### DIFF
--- a/ui-react/apps/console/src/components/layout/AdminLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminLayout.tsx
@@ -6,13 +6,20 @@ import { useSidebarLayout } from "@/hooks/useSidebarLayout";
 
 export default function AdminLayout() {
   const { pathname } = useLocation();
-  const { isOpen, isDesktop, drawerOpen, handlers } = useSidebarLayout();
+  const { isOpen, pinned, isDesktop, drawerOpen, handlers } = useSidebarLayout();
 
   return (
     <div className="flex flex-col h-screen bg-background">
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {isDesktop ? (
-          <AdminSidebar expanded={isOpen} />
+          <div
+            onMouseEnter={handlers.onMouseEnter}
+            onMouseLeave={handlers.onMouseLeave}
+            onFocus={handlers.onFocus}
+            onBlur={handlers.onBlur}
+          >
+            <AdminSidebar expanded={isOpen} pinned={pinned} onToggle={handlers.onToggle} />
+          </div>
         ) : (
           <SidebarMobileDrawer
             open={drawerOpen}
@@ -21,8 +28,10 @@ export default function AdminLayout() {
           >
             <AdminSidebar
               expanded
+              pinned={false}
               onToggle={handlers.closeDrawer}
               onClose={handlers.closeDrawer}
+              toggleLabel="Close sidebar"
             />
           </SidebarMobileDrawer>
         )}

--- a/ui-react/apps/console/src/components/layout/AdminSidebar.tsx
+++ b/ui-react/apps/console/src/components/layout/AdminSidebar.tsx
@@ -168,12 +168,16 @@ function NavGroupItem({
 
 export default function AdminSidebar({
   expanded,
+  pinned,
   onToggle,
   onClose,
+  toggleLabel,
 }: {
   expanded: boolean;
-  onToggle?: () => void;
+  pinned: boolean;
+  onToggle: () => void;
   onClose?: () => void;
+  toggleLabel?: string;
 }) {
   const { data: license, isLoading } = useAdminLicense();
   const isAdmin = useAuthStore((s) => s.isAdmin);
@@ -198,8 +202,10 @@ export default function AdminSidebar({
   return (
     <SidebarShell
       expanded={expanded}
+      pinned={pinned}
       onToggle={onToggle}
       onClose={onClose}
+      toggleLabel={toggleLabel}
       ariaLabel="Admin navigation"
       footerLabel="Admin Panel"
       logoHref="/admin/dashboard"

--- a/ui-react/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AppLayout.tsx
@@ -15,7 +15,7 @@ export default function AppLayout() {
   const hasVisibleTerminal = useTerminalStore((s) =>
     s.sessions.some((t) => t.state !== "minimized"),
   );
-  const { isOpen, isDesktop, drawerOpen, handlers } = useSidebarLayout();
+  const { isOpen, pinned, isDesktop, drawerOpen, handlers } = useSidebarLayout();
 
   const showSidebar = namespaces.length > 0;
   const sidebarOffset =
@@ -28,7 +28,14 @@ export default function AppLayout() {
       <ConnectivityBanner />
       <div className="flex flex-1 min-h-0">
         {showSidebar && isDesktop && (
-          <Sidebar expanded={isOpen} />
+          <div
+            onMouseEnter={handlers.onMouseEnter}
+            onMouseLeave={handlers.onMouseLeave}
+            onFocus={handlers.onFocus}
+            onBlur={handlers.onBlur}
+          >
+            <Sidebar expanded={isOpen} pinned={pinned} onToggle={handlers.onToggle} />
+          </div>
         )}
         {showSidebar && !isDesktop && (
           <SidebarMobileDrawer
@@ -38,8 +45,10 @@ export default function AppLayout() {
           >
             <Sidebar
               expanded
+              pinned={false}
               onToggle={handlers.closeDrawer}
               onClose={handlers.closeDrawer}
+              toggleLabel="Close sidebar"
             />
           </SidebarMobileDrawer>
         )}

--- a/ui-react/apps/console/src/components/layout/Sidebar.tsx
+++ b/ui-react/apps/console/src/components/layout/Sidebar.tsx
@@ -98,12 +98,16 @@ function ProBadge() {
 
 export default function Sidebar({
   expanded,
+  pinned,
   onToggle,
   onClose,
+  toggleLabel,
 }: {
   expanded: boolean;
-  onToggle?: () => void;
+  pinned: boolean;
+  onToggle: () => void;
   onClose?: () => void;
+  toggleLabel?: string;
 }) {
   const minimizeAll = useTerminalStore((s) => s.minimizeAll);
   const isFullscreen = useTerminalStore((state) =>
@@ -118,8 +122,10 @@ export default function Sidebar({
   return (
     <SidebarShell
       expanded={expanded}
+      pinned={pinned}
       onToggle={onToggle}
       onClose={onClose}
+      toggleLabel={toggleLabel}
       hidden={isFullscreen}
       ariaLabel="Main navigation"
       footerLabel="Console"

--- a/ui-react/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui-react/apps/console/src/components/layout/SidebarShell.tsx
@@ -108,8 +108,10 @@ export function SidebarMobileDrawer({
 
 interface SidebarShellProps {
   expanded: boolean;
-  onToggle?: () => void;
+  pinned: boolean;
+  onToggle: () => void;
   onClose?: () => void;
+  toggleLabel?: string;
   hidden?: boolean;
   ariaLabel: string;
   footerLabel: string;
@@ -119,14 +121,19 @@ interface SidebarShellProps {
 
 export default function SidebarShell({
   expanded,
+  pinned,
   onToggle,
   onClose,
+  toggleLabel: toggleLabelOverride,
   hidden,
   ariaLabel,
   footerLabel,
   logoHref,
   children,
 }: SidebarShellProps) {
+  const toggleLabel = toggleLabelOverride ?? (pinned ? "Unpin sidebar" : "Pin sidebar");
+  const toggleTitle = toggleLabelOverride ?? (pinned ? "Unpin sidebar" : "Pin sidebar open");
+
   return (
     <aside
       className={`bg-surface border-r border-border flex flex-col h-full shrink-0 transition-all duration-200 ease-in-out overflow-hidden ${
@@ -161,34 +168,36 @@ export default function SidebarShell({
         {children}
       </nav>
 
-      {/* Footer with pin toggle */}
+      {/* Footer with context-specific sidebar toggle */}
       <div
-        className={`h-11 px-3 flex items-center justify-between transition-colors duration-200 ${expanded && onToggle ? "border-t border-border" : "border-t border-transparent"}`}
+        className={`h-11 px-3 flex items-center justify-between transition-colors duration-200 ${expanded ? "border-t border-border" : "border-t border-transparent"}`}
       >
         <p
-          className={`text-2xs font-mono text-text-muted/60 whitespace-nowrap transition-opacity duration-200 ${expanded && onToggle ? "opacity-100" : "opacity-0"}`}
+          className={`text-2xs font-mono text-text-muted/60 whitespace-nowrap transition-opacity duration-200 ${expanded ? "opacity-100" : "opacity-0"}`}
         >
           {footerLabel}
         </p>
-        {onToggle && (
-          <button
-            type="button"
-            onClick={onToggle}
-            tabIndex={expanded ? 0 : -1}
-            aria-label="Close sidebar"
-            title="Close sidebar"
-            className={`p-1 rounded-md transition-all duration-200 text-text-muted hover:text-text-primary hover:bg-hover-subtle ${
-              expanded ? "opacity-100" : "opacity-0"
+        <button
+          type="button"
+          onClick={onToggle}
+          tabIndex={expanded ? 0 : -1}
+          aria-label={toggleLabel}
+          title={toggleTitle}
+          className={`p-1 rounded-md transition-all duration-200 ${
+            expanded ? "opacity-100" : "opacity-0"
+          } ${
+            pinned
+              ? "text-primary bg-primary/10"
+              : "text-text-muted hover:text-text-primary hover:bg-hover-subtle"
+          }`}
+        >
+          <ChevronLeftIcon
+            className={`w-3.5 h-3.5 transition-transform duration-200 ${
+              expanded ? "" : "rotate-180"
             }`}
-          >
-            <ChevronLeftIcon
-              className={`w-3.5 h-3.5 transition-transform duration-200 ${
-                expanded ? "" : "rotate-180"
-              }`}
-              strokeWidth={2}
-            />
-          </button>
-        )}
+            strokeWidth={2}
+          />
+        </button>
       </div>
     </aside>
   );

--- a/ui-react/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/ui-react/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
@@ -22,13 +22,19 @@ vi.mock("@/hooks/useNamespaces", () => ({
 
 vi.mock("@/hooks/useSidebarLayout", () => ({
   useSidebarLayout: () => ({
+    expanded: false,
+    pinned: false,
     isOpen: false,
     isDesktop: true,
     drawerOpen: false,
     handlers: {
+      onMouseEnter: vi.fn(),
+      onMouseLeave: vi.fn(),
+      onFocus: vi.fn(),
+      onBlur: vi.fn(),
+      onToggle: vi.fn(),
       openDrawer: vi.fn(),
       closeDrawer: vi.fn(),
-      toggleDrawer: vi.fn(),
       onDrawerKeyDown: vi.fn(),
     },
   }),

--- a/ui-react/apps/console/src/components/layout/__tests__/SidebarShell.test.tsx
+++ b/ui-react/apps/console/src/components/layout/__tests__/SidebarShell.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import SidebarShell from "../SidebarShell";
+import type { ComponentProps } from "react";
+
+type SidebarShellProps = ComponentProps<typeof SidebarShell>;
+
+function renderSidebarShell(overrides: Partial<SidebarShellProps> = {}) {
+  const props: SidebarShellProps = {
+    expanded: true,
+    pinned: false,
+    onToggle: vi.fn(),
+    ariaLabel: "Test navigation",
+    footerLabel: "Console",
+    logoHref: "/dashboard",
+    children: <span>Navigation item</span>,
+    ...overrides,
+  };
+
+  return render(
+    <MemoryRouter>
+      <SidebarShell {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("SidebarShell", () => {
+  it("renders a pin control by default", () => {
+    renderSidebarShell();
+
+    const button = screen.getByRole("button", { name: "Pin sidebar" });
+    expect(button).toHaveAttribute("title", "Pin sidebar open");
+  });
+
+  it("labels the pin control as unpin when pinned", () => {
+    renderSidebarShell({ pinned: true });
+
+    const button = screen.getByRole("button", { name: "Unpin sidebar" });
+    expect(button).toHaveAttribute("title", "Unpin sidebar");
+  });
+
+  it("allows the toggle label to match a non-pin action", () => {
+    renderSidebarShell({ toggleLabel: "Close sidebar" });
+
+    const button = screen.getByRole("button", { name: "Close sidebar" });
+    expect(button).toHaveAttribute("title", "Close sidebar");
+  });
+});

--- a/ui-react/apps/console/src/hooks/useSidebarLayout.ts
+++ b/ui-react/apps/console/src/hooks/useSidebarLayout.ts
@@ -1,5 +1,7 @@
 import {
   useState,
+  useRef,
+  useEffect,
   useSyncExternalStore,
 } from "react";
 
@@ -22,6 +24,8 @@ function getIsDesktopServer() {
 }
 
 export function useSidebarLayout() {
+  const [expanded, setExpanded] = useState(false);
+  const [pinned, setPinned] = useState(true);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const isDesktop = useSyncExternalStore(
@@ -30,19 +34,51 @@ export function useSidebarLayout() {
     getIsDesktopServer,
   );
 
-  const isOpen = isDesktop;
+  const hoverTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const isOpen = expanded || pinned;
 
   const openDrawer = () => setDrawerOpen(true);
   const closeDrawer = () => setDrawerOpen(false);
   const toggleDrawer = () => setDrawerOpen((prev) => !prev);
 
+  // Clean up hover timer on unmount
+  useEffect(() => () => clearTimeout(hoverTimer.current), []);
+
+  const handleExpand = () => {
+    clearTimeout(hoverTimer.current);
+    hoverTimer.current = setTimeout(() => setExpanded(true), 75);
+  };
+
+  const handleCollapse = () => {
+    clearTimeout(hoverTimer.current);
+    hoverTimer.current = setTimeout(() => setExpanded(false), 150);
+  };
+
+  const handleToggle = () => {
+    setPinned((prev) => {
+      if (prev) {
+        clearTimeout(hoverTimer.current);
+        setExpanded(true);
+      }
+      return !prev;
+    });
+  };
+
   const handleDrawerKeyDown = (e: React.KeyboardEvent) => { if (e.key === "Escape") closeDrawer(); };
 
   return {
+    expanded,
+    pinned,
     isOpen,
     isDesktop,
     drawerOpen,
     handlers: {
+      onMouseEnter: handleExpand,
+      onMouseLeave: handleCollapse,
+      onFocus: handleExpand,
+      onBlur: handleCollapse,
+      onToggle: handleToggle,
       openDrawer,
       closeDrawer,
       toggleDrawer,


### PR DESCRIPTION
## Summary

- Restored sidebar pinning support in the console layout
- Restored desktop sidebar expansion on hover and focus
- Reconnected pinned and toggle props through app and admin sidebars
- Updated the sidebar footer button to show pinned and unpinned states
- Updated layout test mocks for the restored sidebar handlers

## Context

This restores sidebar behavior that previously existed, was removed,
and is now being brought back.
