### PR TITLE
fix(ci): update claude-code-action to v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.gate.outputs.proceed == 'true'
         timeout-minutes: 30
-        uses: anthropics/claude-code-action@v1.0.88
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Update `anthropics/claude-code-action` from pinned `v1.0.88` to `v1` (floating tag)

## Why

The pinned v1.0.88 fails on fork PRs with `fatal: couldn't find remote ref <branch>` because it fetches branches by name from origin. Fork branches don't exist on origin.

This was fixed in [anthropics/claude-code-action#963](https://github.com/anthropics/claude-code-action/pull/963) (merged 2026-04-15, available from v1.0.89+). Using `v1` ensures we always get the latest fixes.

Triggered by: shellhub-io/shellhub#6248