### PR TITLE
fix(ci): generate release notes from docker-publish draft

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -163,4 +163,5 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           draft: true
+          generate_release_notes: true
           files: sbom-*.cdx.json


### PR DESCRIPTION
## Summary

\`build-agent.yml\` and \`docker-publish.yml\` both run on tag push and race to create the GitHub release draft. Whichever workflow's \`softprops/action-gh-release\` step finishes first wins; the other one reuses the existing draft.

Aligning both workflows means the result is identical regardless of ordering.