### PR TITLE
feat: add MCP server with OAuth 2.1 authentication

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/labstack/echo/v4 v4.15.2
 	github.com/labstack/gommon v0.5.0
 	github.com/lib/pq v1.12.3
+	github.com/mark3labs/mcp-go v0.50.0
 	github.com/moby/moby/api v1.54.2
 	github.com/pkg/errors v0.9.1
 	github.com/shellhub-io/mongotest v0.0.0-20230928124937-e33b07010742
@@ -74,6 +75,7 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -125,7 +127,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sethvargo/go-envconfig v0.9.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
-	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/therootcompany/xz v1.0.1 // indirect
@@ -144,6 +146,7 @@ require (
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -94,6 +94,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -181,6 +183,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -256,6 +260,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mark3labs/mcp-go v0.50.0 h1:kfxh8ejrBCABy5pez+rUYpsSLUKV2Yg38xBtrGRuo4U=
+github.com/mark3labs/mcp-go v0.50.0/go.mod h1:Zg9cB2HdwdMMVgY0xtTzq3KvYIOJQDsaut+jWjwDaQY=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
@@ -363,8 +369,9 @@ github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfx
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
-github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
@@ -440,6 +447,8 @@ github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3k
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=

--- a/api/pkg/gateway/gateway.go
+++ b/api/pkg/gateway/gateway.go
@@ -12,14 +12,16 @@ import (
 
 func TenantFromContext(ctx context.Context) *models.Tenant {
 	if c, ok := ctx.Value("ctx").(*Context); ok {
-		tenant := c.Tenant()
-		if tenant == nil {
-			if value, ok := ctx.Value("tenant").(string); ok {
-				tenant = &models.Tenant{value}
-			}
+		if tenant := c.Tenant(); tenant != nil {
+			return tenant
 		}
+	}
 
-		return tenant
+	// Fallback for callers that don't pass an Echo gateway Context (e.g. the
+	// MCP transport, internal jobs). Setting the "tenant" string key on the
+	// context is enough to scope service-level queries by namespace.
+	if value, ok := ctx.Value("tenant").(string); ok && value != "" {
+		return &models.Tenant{value}
 	}
 
 	return nil
@@ -27,14 +29,13 @@ func TenantFromContext(ctx context.Context) *models.Tenant {
 
 func UsernameFromContext(ctx context.Context) *models.Username {
 	if c, ok := ctx.Value("ctx").(*Context); ok {
-		username := c.Username()
-		if username == nil {
-			if value, ok := ctx.Value("username").(string); ok {
-				username = &models.Username{value}
-			}
+		if username := c.Username(); username != nil {
+			return username
 		}
+	}
 
-		return username
+	if value, ok := ctx.Value("username").(string); ok && value != "" {
+		return &models.Username{value}
 	}
 
 	return nil
@@ -42,14 +43,13 @@ func UsernameFromContext(ctx context.Context) *models.Username {
 
 func IDFromContext(ctx context.Context) *models.ID {
 	if c, ok := ctx.Value("ctx").(*Context); ok {
-		ID := c.ID()
-		if ID == nil {
-			if value, ok := ctx.Value("ID").(string); ok {
-				ID = &models.ID{value}
-			}
+		if id := c.ID(); id != nil {
+			return id
 		}
+	}
 
-		return ID
+	if value, ok := ctx.Value("ID").(string); ok && value != "" {
+		return &models.ID{value}
 	}
 
 	return nil

--- a/api/routes/mcp.go
+++ b/api/routes/mcp.go
@@ -1,0 +1,444 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/shellhub-io/shellhub/api/services"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/errors"
+	"github.com/shellhub-io/shellhub/pkg/models"
+)
+
+type mcpContextKey string
+
+const (
+	mcpKeyTenantID mcpContextKey = "mcp_tenant_id"
+	mcpKeyRole     mcpContextKey = "mcp_role"
+)
+
+// SetupMCPRoutes mounts the MCP Streamable HTTP server at /mcp.
+func SetupMCPRoutes(router *echo.Echo, service services.Service) {
+	s := buildMCPServer(service)
+
+	httpCtxFn := func(ctx context.Context, r *http.Request) context.Context {
+		tenantID := r.Header.Get("X-Tenant-ID")
+		role := authorizer.RoleFromString(r.Header.Get("X-Role"))
+
+		if tenantID == "" || role == authorizer.RoleInvalid {
+			return ctx
+		}
+
+		ctx = context.WithValue(ctx, mcpKeyTenantID, tenantID)
+		ctx = context.WithValue(ctx, mcpKeyRole, role)
+
+		// Mirror tenant into the key gateway.TenantFromContext looks up so
+		// service methods (GetDevice, GetSession, …) automatically scope
+		// queries to this namespace.
+		ctx = context.WithValue(ctx, "tenant", tenantID) //nolint:staticcheck // SA1029: matches gateway.TenantFromContext key
+
+		return ctx
+	}
+
+	streamable := mcpserver.NewStreamableHTTPServer(s,
+		mcpserver.WithHTTPContextFunc(httpCtxFn),
+	)
+
+	router.Any("/mcp", echo.WrapHandler(streamable))
+	router.Any("/mcp/*", echo.WrapHandler(streamable))
+}
+
+func buildMCPServer(svc services.Service) *mcpserver.MCPServer {
+	s := mcpserver.NewMCPServer("shellhub", "1.0.0",
+		mcpserver.WithToolCapabilities(true),
+	)
+
+	addDeviceTools(s, svc)
+	addSessionTools(s, svc)
+	addNamespaceTools(s, svc)
+
+	return s
+}
+
+// --- helpers ---
+
+func mcpForbidden() *mcp.CallToolResult {
+	return mcp.NewToolResultError("forbidden: insufficient permissions")
+}
+
+// mcpServiceError maps known service errors to fixed user-facing messages,
+// hiding internal store details from MCP clients.
+func mcpServiceError(err error) *mcp.CallToolResult {
+	switch {
+	case errors.Is(err, services.ErrDeviceNotFound):
+		return mcp.NewToolResultError("device not found")
+	case errors.Is(err, services.ErrSessionNotFound):
+		return mcp.NewToolResultError("session not found")
+	case errors.Is(err, services.ErrNamespaceNotFound):
+		return mcp.NewToolResultError("namespace not found")
+	default:
+		return mcp.NewToolResultError("internal error")
+	}
+}
+
+func mcpUnauth() *mcp.CallToolResult {
+	return mcp.NewToolResultError("unauthorized: missing or invalid token")
+}
+
+func roleFromCtx(ctx context.Context) (authorizer.Role, bool) {
+	r, ok := ctx.Value(mcpKeyRole).(authorizer.Role)
+
+	return r, ok
+}
+
+func tenantFromCtx(ctx context.Context) string {
+	v, _ := ctx.Value(mcpKeyTenantID).(string)
+
+	return v
+}
+
+func intArg(args map[string]any, key string, def int) int {
+	v, _ := args[key].(float64)
+	if v <= 0 {
+		return def
+	}
+
+	return int(v)
+}
+
+func toJSON(v any) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+
+	return string(b)
+}
+
+// --- Device tools ---
+
+func addDeviceTools(s *mcpserver.MCPServer, svc services.Service) {
+	s.AddTool(
+		mcp.NewTool("shellhub_list_devices",
+			mcp.WithDescription("List devices in the ShellHub namespace. Filter by status and paginate results."),
+			mcp.WithString("status", mcp.Description("Device status filter: accepted, pending, rejected, removed, unused.")),
+			mcp.WithInteger("page", mcp.Description("Page number (1-based). Default: 1.")),
+			mcp.WithInteger("per_page", mcp.Description("Results per page (max 100). Default: 20.")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			role, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+			if !role.HasPermission(authorizer.DeviceDetails) {
+				return mcpForbidden(), nil
+			}
+
+			args := req.GetArguments()
+			status, _ := args["status"].(string)
+			page := intArg(args, "page", 1)
+			perPage := intArg(args, "per_page", 20)
+
+			r := &requests.DeviceList{
+				TenantID:     tenantFromCtx(ctx),
+				DeviceStatus: models.DeviceStatus(status),
+				Paginator:    query.Paginator{Page: page, PerPage: perPage},
+			}
+			r.Paginator.Normalize()
+
+			devices, count, err := svc.ListDevices(ctx, r)
+			if err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(toJSON(map[string]any{
+				"total":   count,
+				"devices": devices,
+			})), nil
+		},
+	)
+
+	s.AddTool(
+		mcp.NewTool("shellhub_get_device",
+			mcp.WithDescription("Get details of a ShellHub device by its UID."),
+			mcp.WithString("uid", mcp.Required(), mcp.Description("Device UID.")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			role, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+			if !role.HasPermission(authorizer.DeviceDetails) {
+				return mcpForbidden(), nil
+			}
+
+			args := req.GetArguments()
+			uid, _ := args["uid"].(string)
+			device, err := svc.GetDevice(ctx, models.UID(uid))
+			if err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(toJSON(device)), nil
+		},
+	)
+
+	s.AddTool(
+		mcp.NewTool("shellhub_update_device_status",
+			mcp.WithDescription("Accept or reject a device. status must be 'accepted' or 'rejected'."),
+			mcp.WithString("uid", mcp.Required(), mcp.Description("Device UID.")),
+			mcp.WithString("status", mcp.Required(), mcp.Description("New status: accepted or rejected.")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			role, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+
+			args := req.GetArguments()
+			uid, _ := args["uid"].(string)
+			status, _ := args["status"].(string)
+
+			switch status {
+			case "accepted":
+				if !role.HasPermission(authorizer.DeviceAccept) {
+					return mcpForbidden(), nil
+				}
+			case "rejected":
+				if !role.HasPermission(authorizer.DeviceReject) {
+					return mcpForbidden(), nil
+				}
+			default:
+				return mcp.NewToolResultError("status must be 'accepted' or 'rejected'"), nil
+			}
+
+			r := &requests.DeviceUpdateStatus{
+				TenantID: tenantFromCtx(ctx),
+				UID:      uid,
+				Status:   status,
+			}
+
+			if err := svc.UpdateDeviceStatus(ctx, r); err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(fmt.Sprintf("device %s status updated to %s", uid, status)), nil
+		},
+	)
+
+	s.AddTool(
+		mcp.NewTool("shellhub_delete_device",
+			mcp.WithDescription("Permanently delete a ShellHub device. This action is irreversible."),
+			mcp.WithString("uid", mcp.Required(), mcp.Description("Device UID.")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			role, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+			if !role.HasPermission(authorizer.DeviceRemove) {
+				return mcpForbidden(), nil
+			}
+
+			args := req.GetArguments()
+			uid, _ := args["uid"].(string)
+			tenant := tenantFromCtx(ctx)
+
+			if err := svc.DeleteDevice(ctx, models.UID(uid), tenant); err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(fmt.Sprintf("device %s deleted", uid)), nil
+		},
+	)
+
+	s.AddTool(
+		mcp.NewTool("shellhub_rename_device",
+			mcp.WithDescription("Rename a ShellHub device."),
+			mcp.WithString("uid", mcp.Required(), mcp.Description("Device UID.")),
+			mcp.WithString("name", mcp.Required(), mcp.Description("New device name (hostname format).")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			role, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+			if !role.HasPermission(authorizer.DeviceRename) {
+				return mcpForbidden(), nil
+			}
+
+			args := req.GetArguments()
+			uid, _ := args["uid"].(string)
+			name, _ := args["name"].(string)
+			tenant := tenantFromCtx(ctx)
+
+			if err := svc.RenameDevice(ctx, models.UID(uid), name, tenant); err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(fmt.Sprintf("device %s renamed to %s", uid, name)), nil
+		},
+	)
+
+	s.AddTool(
+		mcp.NewTool("shellhub_get_stats",
+			mcp.WithDescription("Get ShellHub instance statistics: registered/online/pending/rejected devices and active sessions."),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			_, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+
+			tenant := tenantFromCtx(ctx)
+			if tenant == "" {
+				return mcpForbidden(), nil
+			}
+
+			r := &requests.GetStats{TenantID: tenant}
+			stats, err := svc.GetStats(ctx, r)
+			if err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(toJSON(stats)), nil
+		},
+	)
+}
+
+// --- Session tools ---
+
+func addSessionTools(s *mcpserver.MCPServer, svc services.Service) {
+	s.AddTool(
+		mcp.NewTool("shellhub_list_sessions",
+			mcp.WithDescription("List SSH sessions in the namespace. Returns active and historical sessions."),
+			mcp.WithInteger("page", mcp.Description("Page number (1-based). Default: 1.")),
+			mcp.WithInteger("per_page", mcp.Description("Results per page (max 100). Default: 20.")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			role, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+			if !role.HasPermission(authorizer.SessionDetails) {
+				return mcpForbidden(), nil
+			}
+
+			args := req.GetArguments()
+			page := intArg(args, "page", 1)
+			perPage := intArg(args, "per_page", 20)
+
+			r := &requests.ListSessions{
+				TenantID:  tenantFromCtx(ctx),
+				Paginator: query.Paginator{Page: page, PerPage: perPage},
+			}
+			r.Paginator.Normalize()
+
+			sessions, count, err := svc.ListSessions(ctx, r)
+			if err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(toJSON(map[string]any{
+				"total":    count,
+				"sessions": sessions,
+			})), nil
+		},
+	)
+
+	s.AddTool(
+		mcp.NewTool("shellhub_get_session",
+			mcp.WithDescription("Get details of a specific SSH session by its UID."),
+			mcp.WithString("uid", mcp.Required(), mcp.Description("Session UID.")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			role, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+			if !role.HasPermission(authorizer.SessionDetails) {
+				return mcpForbidden(), nil
+			}
+
+			args := req.GetArguments()
+			uid, _ := args["uid"].(string)
+			session, err := svc.GetSession(ctx, models.UID(uid))
+			if err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(toJSON(session)), nil
+		},
+	)
+}
+
+// --- Namespace tools ---
+
+func addNamespaceTools(s *mcpserver.MCPServer, svc services.Service) {
+	s.AddTool(
+		mcp.NewTool("shellhub_list_namespaces",
+			mcp.WithDescription("List ShellHub namespaces accessible to the authenticated user."),
+			mcp.WithInteger("page", mcp.Description("Page number (1-based). Default: 1.")),
+			mcp.WithInteger("per_page", mcp.Description("Results per page. Default: 20.")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			_, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+
+			args := req.GetArguments()
+			page := intArg(args, "page", 1)
+			perPage := intArg(args, "per_page", 20)
+
+			r := &requests.NamespaceList{
+				TenantID:  tenantFromCtx(ctx),
+				Paginator: query.Paginator{Page: page, PerPage: perPage},
+			}
+			r.Paginator.Normalize()
+
+			namespaces, count, err := svc.ListNamespaces(ctx, r)
+			if err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(toJSON(map[string]any{
+				"total":      count,
+				"namespaces": namespaces,
+			})), nil
+		},
+	)
+
+	s.AddTool(
+		mcp.NewTool("shellhub_get_namespace",
+			mcp.WithDescription("Get details and settings of a ShellHub namespace by its tenant ID."),
+			mcp.WithString("tenant_id", mcp.Required(), mcp.Description("Namespace tenant ID (UUID).")),
+		),
+		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			_, ok := roleFromCtx(ctx)
+			if !ok {
+				return mcpUnauth(), nil
+			}
+
+			args := req.GetArguments()
+			tenantID, _ := args["tenant_id"].(string)
+
+			// GetNamespace performs no membership check — only fetch the
+			// namespace the caller already belongs to.
+			if tenantID != tenantFromCtx(ctx) {
+				return mcpForbidden(), nil
+			}
+
+			namespace, err := svc.GetNamespace(ctx, tenantID)
+			if err != nil {
+				return mcpServiceError(err), nil
+			}
+
+			return mcp.NewToolResultText(toJSON(namespace)), nil
+		},
+	)
+}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -195,6 +195,9 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 		publicAPI.POST(SetupEndpoint, gateway.Handler(handler.Setup))
 	}
 
+	// MCP server (Model Context Protocol) for AI assistants.
+	SetupMCPRoutes(router, service)
+
 	// Apply route extensions (enterprise/cloud features)
 	if err := applyExtensions(router, service); err != nil {
 		logrus.WithError(err).Error("failed to apply route extensions")

--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -139,6 +139,28 @@ server {
         root /etc/letsencrypt;
     }
 
+    location ^~ /mcp {
+        set $upstream {{ $cfg.APIBackend }};
+        limit_req zone=api_limit{{ if $api_burst }} {{ $api_burst }}{{ end }} {{ $api_delay }};
+
+        auth_request /auth;
+        auth_request_set $tenant_id $upstream_http_x_tenant_id;
+        auth_request_set $api_key $upstream_http_x_api_key;
+        auth_request_set $role $upstream_http_x_role;
+        error_page 500 =401 /auth;
+        proxy_http_version 1.1;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $x_forwarded_port;
+        proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
+        proxy_set_header X-Api-Key $api_key;
+        proxy_set_header X-Role $role;
+        proxy_set_header X-Tenant-ID $tenant_id;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_pass http://$upstream;
+    }
+
     location /api {
         set $upstream {{ $cfg.APIBackend }};
         limit_req zone=api_limit{{ if $api_burst }} {{ $api_burst }}{{ end }} {{ $api_delay }};


### PR DESCRIPTION
## Summary

ShellHub now exposes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server so AI assistants (Claude Desktop, Claude Code, Cursor, etc.) can manage devices, sessions, and namespaces directly.

The MCP server runs inside the \`api\` service — no extra binary or sidecar needed. Authentication uses the **namespace API key** already supported by ShellHub — no new auth infrastructure required.

https://github.com/user-attachments/assets/6be395c6-4a24-4ea4-94ef-56aeded2dfdcf

## How to connect

**1. Generate an API key** in the ShellHub UI under *Namespace → Settings → API Keys*.

**2. Configure your MCP client:**

```json
// Claude Code / Claude Desktop (~/.claude.json or MCP settings)
{
  "mcpServers": {
    "shellhub": {
      "url": "https://<shellhub-host>/mcp",
      "headers": { "X-API-Key": "<your-api-key>" }
    }
  }
}
```

Or with the MCP Inspector to explore interactively:

```bash
npx @modelcontextprotocol/inspector https://<shellhub-host>/mcp
```

## How it works

Requests to \`/mcp\` flow through the standard ShellHub nginx \`auth_request\` path that already handles API key validation for \`/api\` routes. nginx validates the \`X-API-Key\` header, attaches \`X-Tenant-ID\` and \`X-Role\` to the upstream request, and the MCP handler reads those headers to scope all tool calls to the caller's namespace.

## Tool reference

All tools require a valid API key. Permission levels: \`observer\` < \`operator\` < \`administrator\` < \`owner\`.

### Device tools

#### \`shellhub_list_devices\`

List devices in the namespace.

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`status\` | string | no | Filter: \`accepted\`, \`pending\`, \`rejected\`, \`removed\`, \`unused\` |
| \`page\` | integer | no | Page number (1-based, default: 1) |
| \`per_page\` | integer | no | Results per page (default: 20, max: 100) |

**Minimum permission:** \`observer\`

**Output:** \`{ "total": N, "devices": [...] }\`

#### \`shellhub_get_device\`

Get full details of a single device.

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`uid\` | string | yes | Device UID |

**Minimum permission:** \`observer\`

#### \`shellhub_update_device_status\`

Accept or reject a pending device.

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`uid\` | string | yes | Device UID |
| \`status\` | string | yes | \`accepted\` or \`rejected\` |

**Minimum permission:** \`operator\`

#### \`shellhub_delete_device\`

Permanently delete a device. Irreversible.

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`uid\` | string | yes | Device UID |

**Minimum permission:** \`administrator\`

#### \`shellhub_rename_device\`

Rename a device.

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`uid\` | string | yes | Device UID |
| \`name\` | string | yes | New name (hostname format) |

**Minimum permission:** \`operator\`

#### \`shellhub_get_stats\`

Get namespace statistics (registered/online/pending/rejected devices, active sessions).

**Minimum permission:** any authenticated API key

### Session tools

#### \`shellhub_list_sessions\`

List SSH sessions (active and historical).

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`page\` | integer | no | Page (default: 1) |
| \`per_page\` | integer | no | Per page (default: 20, max: 100) |

**Minimum permission:** \`observer\`

#### \`shellhub_get_session\`

Get details of a specific session.

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`uid\` | string | yes | Session UID |

**Minimum permission:** \`observer\`

### Namespace tools

#### \`shellhub_list_namespaces\`

List namespaces accessible to the API key's namespace.

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`page\` | integer | no | Page (default: 1) |
| \`per_page\` | integer | no | Per page (default: 20) |

**Minimum permission:** any authenticated API key

#### \`shellhub_get_namespace\`

Get namespace details including settings (session recording, device auto-accept, etc.).

| Input | Type | Required | Description |
|-------|------|----------|-------------|
| \`tenant_id\` | string | yes | Namespace tenant ID (UUID) |

**Minimum permission:** any authenticated API key

## Troubleshooting

**401 on \`/mcp\`** — API key missing, expired, or invalid. Regenerate from namespace settings.

**\`forbidden: insufficient permissions\`** — the API key's role lacks the required permission. Use a key with a higher role.

**\`device is offline\`** — device is not connected to ShellHub. Check device agent status.

## Test plan

- [x] \`GET /mcp\` with no \`X-API-Key\` returns 401
- [x] \`GET /mcp\` with valid API key returns MCP capabilities and tool list
- [x] Calling \`shellhub_list_devices\`, \`shellhub_get_namespace\`, etc. returns expected data scoped to the key's namespace
- [x] Permission errors surface as \`forbidden: insufficient permissions\` for under-privileged key roles
- [x] An API key from namespace A cannot access data from namespace B