### PR TITLE
feat(ui-react): add device chooser for cloud free-tier device limit

### DIFF
--- a/ui-react/apps/console/src/components/billing/DeviceChooserDialog.tsx
+++ b/ui-react/apps/console/src/components/billing/DeviceChooserDialog.tsx
@@ -1,0 +1,654 @@
+import {
+  forwardRef,
+  KeyboardEvent,
+  startTransition,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ExclamationCircleIcon,
+  MagnifyingGlassIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import BaseDialog from "../common/BaseDialog";
+import DataTable, { type Column } from "../common/DataTable";
+import DistroIcon from "../common/DistroIcon";
+import OnlineDot from "../common/OnlineDot";
+import LastSeenCell from "../common/LastSeenCell";
+import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import {
+  useChoiceDevices,
+  useSuggestedDevices,
+} from "@/hooks/useDeviceChooser";
+import { isSdkError } from "@/api/errors";
+import { FREE_TIER_DEVICE_LIMIT } from "./DeviceChooserTrigger";
+
+const PER_PAGE = 5;
+const SEARCH_DEBOUNCE_MS = 300;
+
+type TabId = "suggested" | "all";
+
+interface DeviceChooserDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function OsCell({ info }: { info?: NormalizedDevice["info"] }) {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <DistroIcon id={info?.id ?? ""} className="text-base shrink-0" />
+      <span className="text-xs text-text-secondary truncate">
+        {info?.pretty_name ?? "Unknown"}
+      </span>
+    </div>
+  );
+}
+
+export default function DeviceChooserDialog({
+  open,
+  onClose,
+}: DeviceChooserDialogProps) {
+  const navigate = useNavigate();
+  const titleId = useId();
+  const descriptionId = useId();
+  const suggestedTabId = useId();
+  const allTabId = useId();
+  const suggestedPanelId = useId();
+  const allPanelId = useId();
+
+  const choice = useChoiceDevices();
+  const {
+    devices: suggested,
+    isLoading: suggestedLoading,
+    error: suggestedError,
+  } = useSuggestedDevices(open);
+
+  const suggestedEmpty =
+    !suggestedLoading && !suggestedError && suggested.length === 0;
+
+  const [userTab, setUserTab] = useState<TabId | null>(null);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<NormalizedDevice[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const inFlightRef = useRef(false);
+
+  // Force the All tab whenever Suggested is empty so a refetch that returns
+  // [] doesn't strand the user on a tab that would submit zero choices.
+  const tab: TabId = suggestedEmpty ? "all" : (userTab ?? "suggested");
+
+  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
+
+  const {
+    devices: allDevices,
+    totalCount,
+    isLoading: allLoading,
+  } = useDevices({
+    page,
+    perPage: PER_PAGE,
+    status: "accepted",
+    search: debouncedSearch,
+    enabled: tab === "all",
+  });
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PER_PAGE));
+
+  const toggleSelected = (device: NormalizedDevice) => {
+    if (userTab === null) setUserTab("all");
+    setSelected((prev) => {
+      const exists = prev.some((d) => d.uid === device.uid);
+      if (exists) return prev.filter((d) => d.uid !== device.uid);
+      if (prev.length >= FREE_TIER_DEVICE_LIMIT) return prev;
+      return [...prev, device];
+    });
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setPage(1);
+    setError(null);
+  };
+
+  const handleTabChange = (next: TabId) => {
+    if (next === "suggested" && suggestedEmpty) return;
+    setError(null);
+    if (next === "suggested") setSelected([]);
+    startTransition(() => setUserTab(next));
+  };
+
+  const acceptDisabled =
+    choice.isPending ||
+    (tab === "suggested" && suggested.length === 0) ||
+    (tab === "all" && selected.length === 0);
+
+  const accept = async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setError(null);
+    try {
+      const choices = (tab === "suggested" ? suggested : selected).map(
+        (d) => d.uid,
+      );
+      if (choices.length === 0) return;
+      await choice.mutateAsync({ body: { choices } });
+      onClose();
+    } catch (err) {
+      const status = isSdkError(err) ? err.status : undefined;
+      setError(
+        status === 403
+          ? "You don't have permission to choose devices for this namespace."
+          : "We couldn't save your selection. Please try again in a few moments.",
+      );
+    } finally {
+      inFlightRef.current = false;
+    }
+  };
+
+  const goSubscribe = () => {
+    onClose();
+    void navigate("/settings#billing");
+  };
+
+  // Block ESC/backdrop while the mutation is in flight so the user doesn't
+  // dismiss the dialog mid-request.
+  const canClose = () => !choice.isPending;
+
+  return (
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      canClose={canClose}
+      size="xl"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      className="sm:max-h-[85vh]"
+    >
+      <header className="px-6 pt-6 pb-2 shrink-0">
+        <h2 id={titleId} className="text-base font-semibold text-text-primary">
+          Update account or select three devices
+        </h2>
+        <p
+          id={descriptionId}
+          className="text-xs text-text-muted mt-1.5 leading-relaxed"
+        >
+          Your namespace has more than three accepted devices and no active
+          subscription. Subscribe to ShellHub Cloud to keep them all, or pick
+          three devices to remain accepted — the rest will be moved to pending.
+        </p>
+      </header>
+
+      <TabBar
+        tab={tab}
+        onChange={handleTabChange}
+        suggestedDisabled={suggestedEmpty}
+        suggestedTabId={suggestedTabId}
+        allTabId={allTabId}
+        suggestedPanelId={suggestedPanelId}
+        allPanelId={allPanelId}
+      />
+
+      <main className="flex-auto overflow-y-auto px-6 min-h-0">
+        {tab === "suggested" && (
+          <section
+            id={suggestedPanelId}
+            role="tabpanel"
+            aria-labelledby={suggestedTabId}
+            className="py-4 space-y-3"
+          >
+            {suggestedError ? (
+              <div
+                role="alert"
+                className="flex items-start gap-2 rounded-lg bg-accent-red/[0.06] border border-accent-red/20 px-3 py-2.5 text-xs text-accent-red"
+              >
+                <ExclamationCircleIcon
+                  className="w-4 h-4 shrink-0 mt-px"
+                  strokeWidth={2}
+                />
+                <span>
+                  We couldn't load the suggested devices. Switch to All or try
+                  again.
+                </span>
+              </div>
+            ) : null}
+            <SuggestedTab devices={suggested} isLoading={suggestedLoading} />
+          </section>
+        )}
+
+        {tab === "all" && (
+          <section
+            id={allPanelId}
+            role="tabpanel"
+            aria-labelledby={allTabId}
+            className="py-4 space-y-4"
+          >
+            <SearchInput value={search} onChange={handleSearchChange} />
+            <AllTab
+              devices={allDevices}
+              isLoading={allLoading}
+              selected={selected}
+              onToggle={toggleSelected}
+              page={page}
+              totalPages={totalPages}
+              totalCount={totalCount}
+              onPageChange={setPage}
+            />
+            <SelectedChips
+              selected={selected}
+              onRemove={(d) => toggleSelected(d)}
+            />
+            <SelectionStatus
+              count={selected.length}
+              max={FREE_TIER_DEVICE_LIMIT}
+            />
+          </section>
+        )}
+      </main>
+
+      {error && (
+        <div
+          role="alert"
+          className="mx-6 mt-3 flex items-start gap-2 rounded-lg bg-accent-red/[0.06] border border-accent-red/20 px-3 py-2.5 text-xs text-accent-red"
+        >
+          <ExclamationCircleIcon
+            className="w-4 h-4 shrink-0 mt-px"
+            strokeWidth={2}
+          />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <footer className="px-6 py-4 mt-4 border-t border-border shrink-0 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={choice.isPending}
+          className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={goSubscribe}
+          disabled={choice.isPending}
+          className="px-4 py-2.5 rounded-lg text-sm font-semibold transition-all bg-card hover:bg-hover-medium border border-border hover:border-border-light text-text-primary disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Subscribe
+        </button>
+        <button
+          type="button"
+          onClick={() => void accept()}
+          disabled={acceptDisabled}
+          aria-disabled={acceptDisabled}
+          className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg text-sm font-semibold transition-all bg-primary text-white hover:bg-primary-600 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary disabled:active:scale-100"
+        >
+          {choice.isPending && (
+            <span
+              aria-hidden="true"
+              className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin"
+            />
+          )}
+          {choice.isPending ? "Saving…" : "Accept"}
+        </button>
+      </footer>
+    </BaseDialog>
+  );
+}
+
+interface TabBarProps {
+  tab: TabId;
+  onChange: (next: TabId) => void;
+  suggestedDisabled: boolean;
+  suggestedTabId: string;
+  allTabId: string;
+  suggestedPanelId: string;
+  allPanelId: string;
+}
+
+function TabBar({
+  tab,
+  onChange,
+  suggestedDisabled,
+  suggestedTabId,
+  allTabId,
+  suggestedPanelId,
+  allPanelId,
+}: TabBarProps) {
+  const suggestedRef = useRef<HTMLButtonElement>(null);
+  const allRef = useRef<HTMLButtonElement>(null);
+
+  const focusTab = (id: TabId) => {
+    if (id === "suggested") suggestedRef.current?.focus();
+    if (id === "all") allRef.current?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const order: TabId[] = ["suggested", "all"];
+    const enabled = order.filter(
+      (id) => id !== "suggested" || !suggestedDisabled,
+    );
+    const idx = enabled.indexOf(tab);
+    let next: TabId | null = null;
+    if (event.key === "ArrowRight") next = enabled[(idx + 1) % enabled.length];
+    else if (event.key === "ArrowLeft")
+      next = enabled[(idx - 1 + enabled.length) % enabled.length];
+    else if (event.key === "Home") next = enabled[0];
+    else if (event.key === "End") next = enabled[enabled.length - 1];
+    if (!next) return;
+    event.preventDefault();
+    onChange(next);
+    focusTab(next);
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Device chooser tabs"
+      className="px-6 mt-4 border-b border-border flex items-center gap-1"
+    >
+      <TabButton
+        ref={suggestedRef}
+        id={suggestedTabId}
+        controls={suggestedPanelId}
+        selected={tab === "suggested"}
+        disabled={suggestedDisabled}
+        onSelect={() => onChange("suggested")}
+        onKeyDown={handleKeyDown}
+      >
+        Suggested
+      </TabButton>
+      <TabButton
+        ref={allRef}
+        id={allTabId}
+        controls={allPanelId}
+        selected={tab === "all"}
+        disabled={false}
+        onSelect={() => onChange("all")}
+        onKeyDown={handleKeyDown}
+      >
+        All
+      </TabButton>
+    </div>
+  );
+}
+
+interface TabButtonProps {
+  id: string;
+  controls: string;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+  onKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void;
+  children: React.ReactNode;
+}
+
+const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
+  function TabButton(
+    { id, controls, selected, disabled, onSelect, onKeyDown, children },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="tab"
+        id={id}
+        aria-controls={controls}
+        aria-selected={selected}
+        aria-disabled={disabled || undefined}
+        tabIndex={selected ? 0 : -1}
+        disabled={disabled}
+        onClick={onSelect}
+        onKeyDown={onKeyDown}
+        className={`relative px-4 py-2.5 text-xs font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/50 rounded-t-md
+          ${selected ? "text-text-primary" : "text-text-muted hover:text-text-secondary"}
+          ${disabled ? "opacity-40 cursor-not-allowed hover:text-text-muted" : ""}`}
+      >
+        {children}
+        {selected && (
+          <span
+            aria-hidden="true"
+            className="absolute left-2 right-2 -bottom-px h-0.5 bg-primary rounded-full"
+          />
+        )}
+      </button>
+    );
+  },
+);
+
+function SearchInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <label className="relative block">
+      <span className="sr-only">Search by hostname</span>
+      <MagnifyingGlassIcon
+        aria-hidden="true"
+        className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none"
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search by hostname"
+        className="w-full pl-9 pr-3 py-2 bg-surface border border-border rounded-lg text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30 transition-colors"
+      />
+    </label>
+  );
+}
+
+function SuggestedTab({
+  devices,
+  isLoading,
+}: {
+  devices: NormalizedDevice[];
+  isLoading: boolean;
+}) {
+  const columns: Column<NormalizedDevice>[] = [
+    {
+      key: "selected",
+      header: "",
+      headerClassName: "w-10",
+      render: () => (
+        <span
+          aria-hidden="true"
+          className="inline-flex items-center justify-center w-4 h-4 rounded border border-primary bg-primary text-white"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            className="w-3 h-3"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={3}
+          >
+            <path
+              d="M3 8l3.5 3.5L13 5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </span>
+      ),
+    },
+    {
+      key: "online",
+      header: "",
+      headerClassName: "w-8",
+      render: (d) => <OnlineDot online={d.online} />,
+    },
+    {
+      key: "name",
+      header: "Hostname",
+      render: (d) => (
+        <span className="text-sm font-medium text-text-primary">{d.name}</span>
+      ),
+    },
+    {
+      key: "os",
+      header: "Operating System",
+      render: (d) => <OsCell info={d.info} />,
+    },
+    {
+      key: "last_seen",
+      header: "Last Seen",
+      render: (d) => <LastSeenCell value={d.last_seen} />,
+    },
+  ];
+
+  return (
+    <DataTable<NormalizedDevice>
+      columns={columns}
+      data={devices}
+      rowKey={(d, i) => d.uid ?? `suggested-${i}`}
+      isLoading={isLoading}
+      loadingMessage="Loading suggested devices…"
+      emptyMessage="No suggested devices to show."
+      label="Suggested devices"
+    />
+  );
+}
+
+interface AllTabProps {
+  devices: NormalizedDevice[];
+  isLoading: boolean;
+  selected: NormalizedDevice[];
+  onToggle: (d: NormalizedDevice) => void;
+  page: number;
+  totalPages: number;
+  totalCount: number;
+  onPageChange: (page: number) => void;
+}
+
+function AllTab({
+  devices,
+  isLoading,
+  selected,
+  onToggle,
+  page,
+  totalPages,
+  totalCount,
+  onPageChange,
+}: AllTabProps) {
+  const isSelected = (d: NormalizedDevice) =>
+    selected.some((s) => s.uid === d.uid);
+  const atLimit = selected.length >= FREE_TIER_DEVICE_LIMIT;
+
+  const columns: Column<NormalizedDevice>[] = [
+    {
+      key: "selected",
+      header: "",
+      headerClassName: "w-10",
+      render: (d) => {
+        const checked = isSelected(d);
+        const disabled = !checked && atLimit;
+        return (
+          <input
+            type="checkbox"
+            checked={checked}
+            disabled={disabled}
+            onChange={() => onToggle(d)}
+            aria-label={`Select ${d.name ?? "device"}`}
+            className="w-4 h-4 rounded border border-border bg-surface accent-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/50 disabled:opacity-40 disabled:cursor-not-allowed"
+          />
+        );
+      },
+    },
+    {
+      key: "online",
+      header: "",
+      headerClassName: "w-8",
+      render: (d) => <OnlineDot online={d.online} />,
+    },
+    {
+      key: "name",
+      header: "Hostname",
+      render: (d) => (
+        <span className="text-sm font-medium text-text-primary">{d.name}</span>
+      ),
+    },
+    {
+      key: "os",
+      header: "Operating System",
+      render: (d) => <OsCell info={d.info} />,
+    },
+    {
+      key: "last_seen",
+      header: "Last Seen",
+      render: (d) => <LastSeenCell value={d.last_seen} />,
+    },
+  ];
+
+  return (
+    <DataTable<NormalizedDevice>
+      columns={columns}
+      data={devices}
+      rowKey={(d, i) => d.uid ?? `all-${i}`}
+      isLoading={isLoading}
+      loadingMessage="Loading devices…"
+      emptyMessage="No devices match your search."
+      label="All accepted devices"
+      page={page}
+      totalPages={totalPages}
+      totalCount={totalCount}
+      itemLabel="device"
+      onPageChange={onPageChange}
+    />
+  );
+}
+
+function SelectedChips({
+  selected,
+  onRemove,
+}: {
+  selected: NormalizedDevice[];
+  onRemove: (d: NormalizedDevice) => void;
+}) {
+  if (selected.length === 0) return null;
+  return (
+    <ul
+      aria-label="Selected devices"
+      className="flex flex-wrap gap-1.5 list-none p-0 m-0"
+    >
+      {selected.map((d) => (
+        <li
+          key={d.uid}
+          className="inline-flex items-center gap-1 bg-card border border-border rounded px-1.5 py-0.5 text-xs text-text-secondary"
+        >
+          <span className="truncate max-w-[180px]">{d.name}</span>
+          <button
+            type="button"
+            onClick={() => onRemove(d)}
+            aria-label={`Remove ${d.name ?? "device"} from selection`}
+            className="text-text-muted hover:text-text-primary transition-colors rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/50"
+          >
+            <XMarkIcon className="w-3 h-3" strokeWidth={2.5} />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function SelectionStatus({ count, max }: { count: number; max: number }) {
+  const tone =
+    count === 0
+      ? "text-accent-yellow"
+      : count === max
+        ? "text-accent-green"
+        : "text-text-muted";
+  return (
+    <p
+      role="status"
+      aria-live="polite"
+      className={`text-2xs font-mono tabular-nums ${tone}`}
+    >
+      {count} of {max} selected
+    </p>
+  );
+}

--- a/ui-react/apps/console/src/components/billing/DeviceChooserTrigger.tsx
+++ b/ui-react/apps/console/src/components/billing/DeviceChooserTrigger.tsx
@@ -1,0 +1,44 @@
+import { lazy, Suspense, useState } from "react";
+import { getConfig } from "@/env";
+import { useStats } from "@/hooks/useStats";
+import { useNamespace } from "@/hooks/useNamespaces";
+import { useHasPermission } from "@/hooks/useHasPermission";
+import { useAuthStore } from "@/stores/authStore";
+
+const DeviceChooserDialog = lazy(() => import("./DeviceChooserDialog"));
+
+export const FREE_TIER_DEVICE_LIMIT = 3;
+
+/**
+ * Mounts the DeviceChooserDialog when a Cloud namespace owner has more than
+ * three accepted devices and no active subscription. The dialog reopens on
+ * every fresh mount: dismissing it doesn't persist anywhere — matches the Vue
+ * behavior so the user keeps seeing it until they subscribe or pick three.
+ */
+export default function DeviceChooserTrigger() {
+  if (!getConfig().cloud) return null;
+  return <DeviceChooserTriggerInner />;
+}
+
+function DeviceChooserTriggerInner() {
+  const canChoose = useHasPermission("device:choose");
+  const tenantId = useAuthStore((s) => s.tenant);
+  const { namespace, isLoading: nsLoading } = useNamespace(tenantId ?? "");
+  const { stats, isLoading: statsLoading } = useStats();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!tenantId || nsLoading || statsLoading || !namespace || !stats)
+    return null;
+
+  const overLimit = (stats?.registered_devices ?? 0) > FREE_TIER_DEVICE_LIMIT;
+  const noActiveSubscription = !namespace.billing?.active;
+  const shouldShow = canChoose && noActiveSubscription && overLimit;
+
+  if (!shouldShow || dismissed) return null;
+
+  return (
+    <Suspense fallback={null}>
+      <DeviceChooserDialog open onClose={() => setDismissed(true)} />
+    </Suspense>
+  );
+}

--- a/ui-react/apps/console/src/components/billing/__tests__/DeviceChooserDialog.test.tsx
+++ b/ui-react/apps/console/src/components/billing/__tests__/DeviceChooserDialog.test.tsx
@@ -1,0 +1,775 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// ── Stub BaseDialog ───────────────────────────────────────────────────────────
+// BaseDialog calls showModal() which jsdom does not implement. Replace it with
+// a plain div that honours the `open` prop and wires up a close button via the
+// native `cancel` event that the real component relies on.
+vi.mock("@/components/common/BaseDialog", () => ({
+  default: ({
+    open,
+    canClose,
+    children,
+    "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    canClose?: () => boolean;
+    children: React.ReactNode;
+    "aria-labelledby"?: string;
+    "aria-describedby"?: string;
+  }) => {
+    if (!open) return null;
+    return React.createElement(
+      "div",
+      {
+        role: "dialog",
+        "aria-labelledby": ariaLabelledBy,
+        "aria-describedby": ariaDescribedBy,
+        "data-can-close": String(canClose ? canClose() : true),
+      },
+      children,
+    );
+  },
+}));
+
+vi.mock("@/hooks/useFocusTrap", () => ({ useFocusTrap: vi.fn() }));
+
+// ── Hook mocks ────────────────────────────────────────────────────────────────
+
+const mockMutateAsync = vi.fn();
+const mockIsPending = { value: false };
+
+vi.mock("@/hooks/useDeviceChooser", () => ({
+  useSuggestedDevices: vi.fn(),
+  useChoiceDevices: vi.fn(),
+}));
+
+vi.mock("@/hooks/useDevices", () => ({
+  useDevices: vi.fn(),
+}));
+
+const mockIsSdkError = vi.fn();
+vi.mock("@/api/errors", () => ({
+  isSdkError: (err: unknown): boolean => mockIsSdkError(err) as boolean,
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ── Post-mock imports ─────────────────────────────────────────────────────────
+
+import {
+  useSuggestedDevices,
+  useChoiceDevices,
+} from "@/hooks/useDeviceChooser";
+import { useDevices } from "@/hooks/useDevices";
+import type { NormalizedDevice } from "@/hooks/useDevices";
+import DeviceChooserDialog from "../DeviceChooserDialog";
+
+const mockUseSuggestedDevices = vi.mocked(useSuggestedDevices);
+const mockUseChoiceDevices = vi.mocked(useChoiceDevices);
+const mockUseDevices = vi.mocked(useDevices);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeDevice(n: number): NormalizedDevice {
+  return {
+    uid: `uid-${n}`,
+    name: `hostname-${n}`,
+    tags: [],
+    info: { pretty_name: `Ubuntu ${n}` },
+  } as unknown as NormalizedDevice;
+}
+
+const SUGGESTED_DEVICES = [makeDevice(1), makeDevice(2), makeDevice(3)];
+const ALL_DEVICES = [
+  makeDevice(10),
+  makeDevice(11),
+  makeDevice(12),
+  makeDevice(13),
+  makeDevice(14),
+];
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(MemoryRouter, null, children),
+    );
+}
+
+function setupHooks({
+  suggested = SUGGESTED_DEVICES,
+  suggestedLoading = false,
+  allDevices = ALL_DEVICES,
+  totalCount = ALL_DEVICES.length,
+  allLoading = false,
+  isPending = false,
+}: {
+  suggested?: NormalizedDevice[];
+  suggestedLoading?: boolean;
+  allDevices?: NormalizedDevice[];
+  totalCount?: number;
+  allLoading?: boolean;
+  isPending?: boolean;
+} = {}) {
+  mockIsPending.value = isPending;
+
+  mockUseSuggestedDevices.mockReturnValue({
+    devices: suggested,
+    isLoading: suggestedLoading,
+    error: null,
+    refetch: vi.fn(),
+  });
+
+  mockUseChoiceDevices.mockReturnValue({
+    mutateAsync: mockMutateAsync,
+    isPending,
+    isError: false,
+    error: null,
+  } as never);
+
+  mockUseDevices.mockReturnValue({
+    devices: allDevices,
+    totalCount,
+    isLoading: allLoading,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
+
+function renderDialog(props: { open?: boolean; onClose?: () => void } = {}) {
+  const onClose = props.onClose ?? vi.fn();
+  return {
+    onClose,
+    ...render(
+      <DeviceChooserDialog open={props.open ?? true} onClose={onClose} />,
+      { wrapper: createWrapper() },
+    ),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsSdkError.mockReturnValue(false);
+  setupHooks();
+});
+
+afterEach(cleanup);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("DeviceChooserDialog", () => {
+  // ── Rendering ───────────────────────────────────────────────────────────────
+
+  describe("rendering", () => {
+    it("renders nothing when open=false", () => {
+      renderDialog({ open: false });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("renders the dialog title when open", () => {
+      renderDialog();
+      expect(
+        screen.getByText(/update account or select three devices/i),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the description when open", () => {
+      renderDialog();
+      expect(
+        screen.getByText(/subscribe to shellhub cloud/i),
+      ).toBeInTheDocument();
+    });
+
+    it("dialog has aria-labelledby pointing to the title", () => {
+      renderDialog();
+      const dialog = screen.getByRole("dialog");
+      const titleId = dialog.getAttribute("aria-labelledby");
+      expect(titleId).toBeTruthy();
+      const titleEl = document.getElementById(titleId!);
+      expect(titleEl).not.toBeNull();
+      expect(titleEl!.textContent).toMatch(
+        /update account or select three devices/i,
+      );
+    });
+
+    it("dialog has aria-describedby pointing to the description", () => {
+      renderDialog();
+      const dialog = screen.getByRole("dialog");
+      const descId = dialog.getAttribute("aria-describedby");
+      expect(descId).toBeTruthy();
+      const descEl = document.getElementById(descId!);
+      expect(descEl).not.toBeNull();
+      expect(descEl!.textContent).toMatch(/subscribe to shellhub cloud/i);
+    });
+  });
+
+  // ── Tab structure ────────────────────────────────────────────────────────────
+
+  describe("tab structure", () => {
+    it("renders a tablist with role=tablist", () => {
+      renderDialog();
+      expect(screen.getByRole("tablist")).toBeInTheDocument();
+    });
+
+    it("renders Suggested and All tabs with role=tab", () => {
+      renderDialog();
+      const tabs = screen.getAllByRole("tab");
+      const labels = tabs.map((t) => t.textContent);
+      expect(labels).toContain("Suggested");
+      expect(labels).toContain("All");
+    });
+
+    it("Suggested tab is selected by default when suggested devices are non-empty", () => {
+      renderDialog();
+      expect(screen.getByRole("tab", { name: "Suggested" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("renders a tabpanel for the active tab", () => {
+      renderDialog();
+      expect(screen.getByRole("tabpanel")).toBeInTheDocument();
+    });
+  });
+
+  // ── Suggested tab ────────────────────────────────────────────────────────────
+
+  describe("Suggested tab", () => {
+    it("shows suggested device hostnames", () => {
+      renderDialog();
+      expect(screen.getByText("hostname-1")).toBeInTheDocument();
+      expect(screen.getByText("hostname-2")).toBeInTheDocument();
+      expect(screen.getByText("hostname-3")).toBeInTheDocument();
+    });
+
+    it("does not render checkboxes on suggested tab (non-editable)", () => {
+      renderDialog();
+      expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    });
+
+    it("Accept button is enabled when suggested devices are present", () => {
+      renderDialog();
+      expect(
+        screen.getByRole("button", { name: /accept/i }),
+      ).not.toBeDisabled();
+    });
+  });
+
+  // ── Auto-switch to All tab when suggested is empty ───────────────────────────
+
+  describe("when suggested list is empty", () => {
+    beforeEach(() => {
+      setupHooks({ suggested: [], suggestedLoading: false });
+    });
+
+    it("switches to the All tab automatically", async () => {
+      renderDialog();
+      await waitFor(() =>
+        expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+          "aria-selected",
+          "true",
+        ),
+      );
+    });
+
+    it("Suggested tab is disabled", async () => {
+      renderDialog();
+      await waitFor(() =>
+        expect(screen.getByRole("tab", { name: "Suggested" })).toBeDisabled(),
+      );
+    });
+  });
+
+  // ── Suggested query error ───────────────────────────────────────────────────
+
+  describe("when the suggested query errors", () => {
+    beforeEach(() => {
+      mockUseSuggestedDevices.mockReturnValue({
+        devices: [],
+        isLoading: false,
+        error: new Error("network failure"),
+        refetch: vi.fn(),
+      });
+    });
+
+    it("keeps the Suggested tab selected and surfaces the error banner", () => {
+      renderDialog();
+      expect(screen.getByRole("tab", { name: "Suggested" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /couldn't load the suggested devices/i,
+      );
+    });
+
+    it("does not disable the Suggested tab", () => {
+      renderDialog();
+      expect(screen.getByRole("tab", { name: "Suggested" })).not.toBeDisabled();
+    });
+  });
+
+  // ── Refetch flips suggested-empty mid-session ───────────────────────────────
+
+  describe("when suggested becomes empty after a refetch", () => {
+    it("forces tab to All even if user previously picked Suggested", async () => {
+      setupHooks({ suggested: SUGGESTED_DEVICES });
+      const { rerender } = render(
+        <DeviceChooserDialog open onClose={vi.fn()} />,
+        { wrapper: createWrapper() },
+      );
+      // User sees Suggested tab selected initially.
+      expect(screen.getByRole("tab", { name: "Suggested" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      // Now the refetch returns []; suggested becomes empty.
+      setupHooks({ suggested: [] });
+      rerender(<DeviceChooserDialog open onClose={vi.fn()} />);
+      await waitFor(() =>
+        expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+          "aria-selected",
+          "true",
+        ),
+      );
+      // Accept is disabled because no device is selected on the All tab.
+      expect(screen.getByRole("button", { name: /accept/i })).toBeDisabled();
+    });
+  });
+
+  // ── Tab-switch selection persistence ────────────────────────────────────────
+
+  describe("tab-switch selection persistence", () => {
+    it("keeps the user on All after picking a device, even if Suggested refetches non-empty", async () => {
+      setupHooks({ suggested: [] });
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <DeviceChooserDialog open onClose={vi.fn()} />,
+        { wrapper: createWrapper() },
+      );
+      // Forced to All because suggested is empty.
+      expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      // User picks a device on All — this commits intent.
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      );
+      // Suggested refetches with results.
+      setupHooks({ suggested: SUGGESTED_DEVICES });
+      rerender(<DeviceChooserDialog open onClose={vi.fn()} />);
+      // Tab must stay on All so the user's selection is not silently discarded.
+      await waitFor(() =>
+        expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+          "aria-selected",
+          "true",
+        ),
+      );
+      // The selected device is still in scope.
+      expect(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      ).toBeChecked();
+    });
+
+    it("clears All-tab selections when the user explicitly switches to Suggested", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      // Switch to All and pick a device.
+      await user.click(screen.getByRole("tab", { name: "All" }));
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      );
+      // Switch back to Suggested — selections should be cleared so Accept
+      // submits the suggested list, not the now-stale All-tab picks.
+      await user.click(screen.getByRole("tab", { name: "Suggested" }));
+      await user.click(screen.getByRole("tab", { name: "All" }));
+      expect(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      ).not.toBeChecked();
+    });
+  });
+
+  // ── All tab ──────────────────────────────────────────────────────────────────
+
+  describe("All tab", () => {
+    async function switchToAll(user: ReturnType<typeof userEvent.setup>) {
+      await user.click(screen.getByRole("tab", { name: "All" }));
+    }
+
+    it("switches to All tab on click", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("shows device checkboxes in the All tab", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes.length).toBe(ALL_DEVICES.length);
+    });
+
+    it("Accept button is disabled when no devices are selected in All tab", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      expect(screen.getByRole("button", { name: /accept/i })).toBeDisabled();
+    });
+
+    it("Accept button is enabled after selecting 1 device", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      );
+      expect(
+        screen.getByRole("button", { name: /accept/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("can select up to 3 devices", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      );
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-11/i }),
+      );
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-12/i }),
+      );
+      const checked = screen
+        .getAllByRole("checkbox")
+        .filter((cb) => (cb as HTMLInputElement).checked);
+      expect(checked).toHaveLength(3);
+    });
+
+    it("4th checkbox is disabled when 3 are already selected", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      );
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-11/i }),
+      );
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-12/i }),
+      );
+      // The 4th unselected checkbox should now be disabled
+      const uncheckedDisabled = screen
+        .getAllByRole("checkbox")
+        .filter(
+          (cb) =>
+            !(cb as HTMLInputElement).checked &&
+            (cb as HTMLInputElement).disabled,
+        );
+      expect(uncheckedDisabled.length).toBeGreaterThan(0);
+    });
+
+    it("deselecting a device removes it from the selection", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      const checkbox = screen.getByRole("checkbox", {
+        name: /select hostname-10/i,
+      });
+      await user.click(checkbox);
+      await user.click(checkbox);
+      expect((checkbox as HTMLInputElement).checked).toBe(false);
+    });
+
+    it("shows the selection counter with aria-live", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      const status = screen.getByRole("status");
+      expect(status).toHaveAttribute("aria-live", "polite");
+      expect(status.textContent).toMatch(/0 of 3/);
+    });
+
+    it("selection counter updates after selecting a device", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await switchToAll(user);
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      );
+      expect(screen.getByRole("status").textContent).toMatch(/1 of 3/);
+    });
+
+    it("typing in search calls useDevices with the new search term", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("tab", { name: "All" }));
+      const searchInput = screen.getByRole("textbox");
+      await user.type(searchInput, "prod");
+      await waitFor(() => {
+        const lastCall =
+          mockUseDevices.mock.calls[mockUseDevices.mock.calls.length - 1];
+        expect(lastCall[0]).toMatchObject({ search: "prod" });
+      });
+    });
+
+    it("perPage is 5 when calling useDevices", () => {
+      renderDialog();
+      expect(mockUseDevices).toHaveBeenCalledWith(
+        expect.objectContaining({ perPage: 5 }),
+      );
+    });
+  });
+
+  // ── Tab keyboard navigation ──────────────────────────────────────────────────
+
+  describe("tab keyboard navigation", () => {
+    it("ArrowRight moves focus from Suggested to All", () => {
+      renderDialog();
+      const suggested = screen.getByRole("tab", { name: "Suggested" });
+      fireEvent.keyDown(suggested, { key: "ArrowRight" });
+      expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("ArrowLeft wraps from Suggested to All (only two tabs)", () => {
+      renderDialog();
+      const suggested = screen.getByRole("tab", { name: "Suggested" });
+      fireEvent.keyDown(suggested, { key: "ArrowLeft" });
+      expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("Home key moves to the first enabled tab", () => {
+      render(<DeviceChooserDialog open onClose={vi.fn()} />, {
+        wrapper: createWrapper(),
+      });
+      const allTab = screen.getByRole("tab", { name: "All" });
+      fireEvent.click(allTab);
+      expect(allTab).toHaveAttribute("aria-selected", "true");
+      fireEvent.keyDown(allTab, { key: "Home" });
+      expect(screen.getByRole("tab", { name: "Suggested" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("End key moves to the last tab", () => {
+      renderDialog();
+      const suggested = screen.getByRole("tab", { name: "Suggested" });
+      fireEvent.keyDown(suggested, { key: "End" });
+      expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+  });
+
+  // ── Footer buttons ───────────────────────────────────────────────────────────
+
+  describe("Cancel button", () => {
+    it("calls onClose when Cancel is clicked", async () => {
+      const user = userEvent.setup();
+      const { onClose } = renderDialog();
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("Cancel is disabled while mutation is in flight", () => {
+      setupHooks({ isPending: true });
+      renderDialog();
+      expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+    });
+  });
+
+  describe("Subscribe button", () => {
+    it("navigates to /settings#billing when Subscribe is clicked", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("button", { name: /subscribe/i }));
+      expect(mockNavigate).toHaveBeenCalledWith("/settings#billing");
+    });
+
+    it("calls onClose when Subscribe is clicked", async () => {
+      const user = userEvent.setup();
+      const { onClose } = renderDialog();
+      await user.click(screen.getByRole("button", { name: /subscribe/i }));
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("Subscribe is disabled while mutation is in flight", () => {
+      setupHooks({ isPending: true });
+      renderDialog();
+      expect(screen.getByRole("button", { name: /subscribe/i })).toBeDisabled();
+    });
+  });
+
+  describe("Accept button", () => {
+    it("calls mutateAsync with the suggested UIDs when on suggested tab", async () => {
+      mockMutateAsync.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+      await waitFor(() =>
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+          body: { choices: ["uid-1", "uid-2", "uid-3"] },
+        }),
+      );
+    });
+
+    it("calls onClose after a successful Accept", async () => {
+      mockMutateAsync.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      const { onClose } = renderDialog();
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+      await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+    });
+
+    it("calls mutateAsync with selected UIDs when on All tab", async () => {
+      mockMutateAsync.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("tab", { name: "All" }));
+      await user.click(
+        screen.getByRole("checkbox", { name: /select hostname-10/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+      await waitFor(() =>
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+          body: { choices: ["uid-10"] },
+        }),
+      );
+    });
+
+    it("shows spinner and 'Saving…' text while mutation is pending", () => {
+      setupHooks({ isPending: true });
+      renderDialog();
+      expect(
+        screen.getByRole("button", { name: /saving/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("Accept is disabled while mutation is in flight", () => {
+      setupHooks({ isPending: true });
+      renderDialog();
+      // The button text changes to "Saving…" but remains disabled
+      const btn = screen.getByRole("button", { name: /saving/i });
+      expect(btn).toBeDisabled();
+    });
+
+    it("blocks close (canClose=false) while mutation is in flight", () => {
+      setupHooks({ isPending: true });
+      renderDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.getAttribute("data-can-close")).toBe("false");
+    });
+
+    it("allows close (canClose=true) when mutation is idle", () => {
+      setupHooks({ isPending: false });
+      renderDialog();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.getAttribute("data-can-close")).toBe("true");
+    });
+  });
+
+  // ── Error handling ───────────────────────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("shows generic error when Accept fails with a non-403 error", async () => {
+      mockMutateAsync.mockRejectedValue(new Error("network error"));
+      mockIsSdkError.mockReturnValue(false);
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          /couldn't save your selection/i,
+        ),
+      );
+    });
+
+    it("shows permission error when Accept fails with a 403 SDK error", async () => {
+      const err = { status: 403 };
+      mockMutateAsync.mockRejectedValue(err);
+      mockIsSdkError.mockImplementation((e: unknown) => e === err);
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent(
+          /don't have permission/i,
+        ),
+      );
+    });
+
+    it("error alert is rendered above the footer", async () => {
+      mockMutateAsync.mockRejectedValue(new Error("fail"));
+      mockIsSdkError.mockReturnValue(false);
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toBeInTheDocument(),
+      );
+      // Error appears before footer buttons in the DOM
+      const alert = screen.getByRole("alert");
+      const cancel = screen.getByRole("button", { name: /cancel/i });
+      expect(
+        alert.compareDocumentPosition(cancel) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+
+    it("clears the error when switching tabs", async () => {
+      mockMutateAsync.mockRejectedValue(new Error("fail"));
+      mockIsSdkError.mockReturnValue(false);
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("button", { name: /accept/i }));
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("tab", { name: "All" }));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui-react/apps/console/src/components/billing/__tests__/DeviceChooserTrigger.test.tsx
+++ b/ui-react/apps/console/src/components/billing/__tests__/DeviceChooserTrigger.test.tsx
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// ── Feature flag ──────────────────────────────────────────────────────────────
+
+vi.mock("@/env", () => ({ getConfig: vi.fn() }));
+
+// ── Hooks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/hooks/useHasPermission", () => ({
+  useHasPermission: vi.fn(),
+}));
+
+vi.mock("@/hooks/useStats", () => ({
+  useStats: vi.fn(),
+}));
+
+vi.mock("@/hooks/useNamespaces", () => ({
+  useNamespace: vi.fn(),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (sel: (s: { tenant: string }) => unknown) =>
+    sel({ tenant: "tenant-abc" }),
+}));
+
+// ── Stub out DeviceChooserDialog so no real dialog logic runs ─────────────────
+vi.mock("../DeviceChooserDialog", () => ({
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open
+      ? React.createElement(
+          "div",
+          { "data-testid": "device-chooser-dialog" },
+          React.createElement("button", { onClick: onClose }, "Dismiss"),
+        )
+      : null,
+}));
+
+// ── Post-mock imports ─────────────────────────────────────────────────────────
+
+import { getConfig } from "@/env";
+import { useHasPermission } from "@/hooks/useHasPermission";
+import { useStats } from "@/hooks/useStats";
+import { useNamespace } from "@/hooks/useNamespaces";
+import DeviceChooserTrigger from "../DeviceChooserTrigger";
+
+const mockGetConfig = vi.mocked(getConfig);
+const mockUseHasPermission = vi.mocked(useHasPermission);
+const mockUseStats = vi.mocked(useStats);
+const mockUseNamespace = vi.mocked(useNamespace);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function makeStats(registeredDevices: number) {
+  return {
+    registered_devices: registeredDevices,
+    online_devices: 0,
+    active_sessions: 0,
+    pending_devices: 0,
+    rejected_devices: 0,
+  };
+}
+
+function makeNamespace(billingActive: boolean) {
+  return {
+    billing: { active: billingActive },
+  };
+}
+
+/** Sets up all hooks for the fully-open scenario and then overrides. */
+function setupHooks({
+  cloud = true,
+  canChoose = true,
+  billingActive = false,
+  registeredDevices = 4,
+  nsLoading = false,
+  statsLoading = false,
+  namespace,
+}: {
+  cloud?: boolean;
+  canChoose?: boolean;
+  billingActive?: boolean;
+  registeredDevices?: number;
+  nsLoading?: boolean;
+  statsLoading?: boolean;
+  namespace?: ReturnType<typeof makeNamespace> | null;
+} = {}) {
+  mockGetConfig.mockReturnValue({ cloud } as ReturnType<typeof getConfig>);
+  mockUseHasPermission.mockReturnValue(canChoose);
+  mockUseStats.mockReturnValue({
+    stats: statsLoading ? null : makeStats(registeredDevices),
+    isLoading: statsLoading,
+    error: null,
+    refetch: vi.fn(),
+  });
+  const ns = namespace === undefined ? makeNamespace(billingActive) : namespace;
+  mockUseNamespace.mockReturnValue({
+    namespace: nsLoading ? null : (ns as never),
+    isLoading: nsLoading,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupHooks();
+});
+
+afterEach(cleanup);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("DeviceChooserTrigger", () => {
+  // ── Gating matrix ────────────────────────────────────────────────────────────
+
+  describe("when cloud=false", () => {
+    it("renders nothing without mounting the inner component", () => {
+      setupHooks({ cloud: false });
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      expect(
+        screen.queryByTestId("device-chooser-dialog"),
+      ).not.toBeInTheDocument();
+      // Inner component never mounts, so useHasPermission is never called
+      expect(mockUseHasPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when cloud=true but user lacks device:choose permission", () => {
+    it("renders nothing", async () => {
+      setupHooks({ cloud: true, canChoose: false });
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("device-chooser-dialog"),
+        ).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("when cloud=true, owner, billing is active", () => {
+    it("renders nothing", async () => {
+      setupHooks({ cloud: true, canChoose: true, billingActive: true });
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("device-chooser-dialog"),
+        ).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("when cloud=true, owner, billing inactive, registered_devices=3 (boundary)", () => {
+    it("renders nothing — limit is strictly greater than 3", async () => {
+      setupHooks({
+        cloud: true,
+        canChoose: true,
+        billingActive: false,
+        registeredDevices: 3,
+      });
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("device-chooser-dialog"),
+        ).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("when all conditions are met (cloud, owner, billing inactive, >3 devices)", () => {
+    it("auto-opens the dialog on mount", async () => {
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      await waitFor(() =>
+        expect(screen.getByTestId("device-chooser-dialog")).toBeInTheDocument(),
+      );
+    });
+  });
+
+  // ── C1 regression: don't render while loading or namespace undefined ─────────
+
+  describe("when namespace is still loading", () => {
+    it("renders nothing even if stats indicate over-limit", () => {
+      setupHooks({
+        nsLoading: true,
+        registeredDevices: 4,
+        billingActive: false,
+      });
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      expect(
+        screen.queryByTestId("device-chooser-dialog"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when stats are still loading", () => {
+    it("renders nothing", () => {
+      setupHooks({ statsLoading: true, billingActive: false });
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      expect(
+        screen.queryByTestId("device-chooser-dialog"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when namespace returned is undefined", () => {
+    it("renders nothing — billing is unknown until namespace resolves", () => {
+      setupHooks({ namespace: null, registeredDevices: 4 });
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      expect(
+        screen.queryByTestId("device-chooser-dialog"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when the stats query settled with an error", () => {
+    it("renders nothing — overLimit cannot be evaluated without stats", () => {
+      setupHooks();
+      mockUseStats.mockReturnValue({
+        stats: null,
+        isLoading: false,
+        error: new Error("network failure"),
+        refetch: vi.fn(),
+      });
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      expect(
+        screen.queryByTestId("device-chooser-dialog"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Dismissal behaviour ──────────────────────────────────────────────────────
+
+  describe("dismissal", () => {
+    it("hides the dialog after dismissal", async () => {
+      const user = userEvent.setup();
+      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      await waitFor(() =>
+        expect(screen.getByTestId("device-chooser-dialog")).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("button", { name: /dismiss/i }));
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("device-chooser-dialog"),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it("does not re-open the dialog after dismissal within the same mount", async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<DeviceChooserTrigger />, {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId("device-chooser-dialog")).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("button", { name: /dismiss/i }));
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("device-chooser-dialog"),
+        ).not.toBeInTheDocument(),
+      );
+
+      // Trigger a re-render with the same conditions — dialog must NOT reopen
+      rerender(<DeviceChooserTrigger />);
+      expect(
+        screen.queryByTestId("device-chooser-dialog"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("reopens the dialog on a fresh remount after conditions are still true", async () => {
+      const user = userEvent.setup();
+      const wrapper = createWrapper();
+
+      render(<DeviceChooserTrigger />, { wrapper });
+      await waitFor(() =>
+        expect(screen.getByTestId("device-chooser-dialog")).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("button", { name: /dismiss/i }));
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("device-chooser-dialog"),
+        ).not.toBeInTheDocument(),
+      );
+
+      // Unmount and remount — fresh component state, so dialog reopens
+      cleanup();
+
+      render(<DeviceChooserTrigger />, { wrapper });
+      await waitFor(() =>
+        expect(screen.getByTestId("device-chooser-dialog")).toBeInTheDocument(),
+      );
+    });
+  });
+});

--- a/ui-react/apps/console/src/components/common/LastSeenCell.tsx
+++ b/ui-react/apps/console/src/components/common/LastSeenCell.tsx
@@ -1,0 +1,13 @@
+import { formatRelative } from "@/utils/date";
+
+interface LastSeenCellProps {
+  value?: string;
+}
+
+export default function LastSeenCell({ value }: LastSeenCellProps) {
+  return (
+    <span className="text-xs text-text-secondary">
+      {formatRelative(value ?? "")}
+    </span>
+  );
+}

--- a/ui-react/apps/console/src/components/common/OnlineDot.tsx
+++ b/ui-react/apps/console/src/components/common/OnlineDot.tsx
@@ -1,0 +1,25 @@
+interface OnlineDotProps {
+  online?: boolean;
+}
+
+export default function OnlineDot({ online }: OnlineDotProps) {
+  if (online) {
+    return (
+      <span
+        className="relative flex h-2.5 w-2.5 mx-auto"
+        aria-label="Online"
+        role="img"
+      >
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-green opacity-40" />
+        <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]" />
+      </span>
+    );
+  }
+  return (
+    <span
+      className="block w-2.5 h-2.5 rounded-full mx-auto bg-text-muted/30"
+      aria-label="Offline"
+      role="img"
+    />
+  );
+}

--- a/ui-react/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import TerminalManager from "../terminal/TerminalManager";
 import ConnectivityBanner from "../common/ConnectivityBanner";
 import WelcomeWizardTrigger from "../wizard/WelcomeWizardTrigger";
 import AnnouncementModalTrigger from "../announcements/AnnouncementModalTrigger";
+import DeviceChooserTrigger from "../billing/DeviceChooserTrigger";
 import { SidebarMobileDrawer } from "./SidebarShell";
 import ChatwootProvider from "./ChatwootProvider";
 import { useNamespaces } from "@/hooks/useNamespaces";
@@ -17,11 +18,11 @@ export default function AppLayout() {
   const hasVisibleTerminal = useTerminalStore((s) =>
     s.sessions.some((t) => t.state !== "minimized"),
   );
-  const { isOpen, pinned, isDesktop, drawerOpen, handlers } = useSidebarLayout();
+  const { isOpen, pinned, isDesktop, drawerOpen, handlers } =
+    useSidebarLayout();
 
   const showSidebar = namespaces.length > 0;
-  const sidebarOffset =
-    showSidebar && isDesktop ? (isOpen ? 220 : 60) : 0;
+  const sidebarOffset = showSidebar && isDesktop ? (isOpen ? 220 : 60) : 0;
 
   return (
     <ChatwootProvider>
@@ -31,14 +32,18 @@ export default function AppLayout() {
         <ConnectivityBanner />
         <div className="flex flex-1 min-h-0">
           {showSidebar && isDesktop && (
-          <div
-            onMouseEnter={handlers.onMouseEnter}
-            onMouseLeave={handlers.onMouseLeave}
-            onFocus={handlers.onFocus}
-            onBlur={handlers.onBlur}
-          >
-              <Sidebar expanded={isOpen} pinned={pinned} onToggle={handlers.onToggle} />
-          </div>
+            <div
+              onMouseEnter={handlers.onMouseEnter}
+              onMouseLeave={handlers.onMouseLeave}
+              onFocus={handlers.onFocus}
+              onBlur={handlers.onBlur}
+            >
+              <Sidebar
+                expanded={isOpen}
+                pinned={pinned}
+                onToggle={handlers.onToggle}
+              />
+            </div>
           )}
           {showSidebar && !isDesktop && (
             <SidebarMobileDrawer
@@ -56,7 +61,11 @@ export default function AppLayout() {
             </SidebarMobileDrawer>
           )}
           <div className="flex-1 flex flex-col min-w-0">
-            <AppBar onMenuToggle={showSidebar && !isDesktop ? handlers.toggleDrawer : undefined} />
+            <AppBar
+              onMenuToggle={
+                showSidebar && !isDesktop ? handlers.toggleDrawer : undefined
+              }
+            />
             <main className="flex-1 flex flex-col p-8 relative min-h-0 overflow-y-auto">
               <div className="grid-bg scanline absolute inset-0 -z-10" />
               <div
@@ -71,6 +80,7 @@ export default function AppLayout() {
         <TerminalManager sidebarOffset={sidebarOffset} />
         <WelcomeWizardTrigger />
         <AnnouncementModalTrigger />
+        <DeviceChooserTrigger />
       </div>
     </ChatwootProvider>
   );

--- a/ui-react/apps/console/src/hooks/__tests__/useDebouncedValue.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useDebouncedValue.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDebouncedValue } from "../useDebouncedValue";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useDebouncedValue", () => {
+  it("returns the initial value synchronously", () => {
+    const { result } = renderHook(() => useDebouncedValue("a", 100));
+    expect(result.current).toBe("a");
+  });
+
+  it("does not update before the delay elapses", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+
+    expect(result.current).toBe("a");
+  });
+
+  it("updates to the latest value after the delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe("b");
+  });
+
+  it("restarts the timer when value changes mid-flight", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    rerender({ value: "c" });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(result.current).toBe("c");
+  });
+
+  it("clears the pending timer on unmount", () => {
+    const { rerender, unmount } = renderHook(
+      ({ value }) => useDebouncedValue(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    unmount();
+
+    expect(() => {
+      vi.advanceTimersByTime(500);
+    }).not.toThrow();
+  });
+
+  it("does not re-run the timer when value and delay are referentially stable", () => {
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    const { rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 200),
+      { initialProps: { value: "a" } },
+    );
+
+    const initialCalls = setTimeoutSpy.mock.calls.length;
+    rerender({ value: "a" });
+    rerender({ value: "a" });
+
+    expect(setTimeoutSpy.mock.calls.length).toBe(initialCalls);
+  });
+
+  it("with delayMs=0, defers update by one tick", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 0),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(result.current).toBe("b");
+  });
+
+  it("respects a changed delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebouncedValue(value, delay),
+      { initialProps: { value: "a", delay: 500 } },
+    );
+
+    rerender({ value: "b", delay: 50 });
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(result.current).toBe("b");
+  });
+});

--- a/ui-react/apps/console/src/hooks/__tests__/useDeviceChooser.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useDeviceChooser.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act, cleanup } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+afterEach(() => {
+  cleanup();
+});
+
+// ── SDK mocks ────────────────────────────────────────────────────────────────
+
+const mockMostUsedQueryFn = vi.fn();
+const mockChoiceMutationFn = vi.fn();
+const mockInvalidate = vi.fn();
+
+vi.mock("../../client/@tanstack/react-query.gen", () => ({
+  getDevicesMostUsedOptions: vi.fn(() => ({
+    queryKey: [{ _id: "getDevicesMostUsed" }],
+    queryFn: mockMostUsedQueryFn,
+  })),
+  choiceDevicesMutation: vi.fn(() => ({
+    mutationFn: mockChoiceMutationFn,
+  })),
+}));
+
+vi.mock("../useInvalidateQueries", () => ({
+  useInvalidateByIds: vi.fn(() => mockInvalidate),
+}));
+
+// ── Imports under test (vi.mock calls hoist above these) ─────────────────────
+
+import { useSuggestedDevices, useChoiceDevices } from "../useDeviceChooser";
+import { useInvalidateByIds } from "../useInvalidateQueries";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, retryDelay: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── useSuggestedDevices ──────────────────────────────────────────────────────
+
+describe("useSuggestedDevices", () => {
+  describe("on success", () => {
+    it("returns the device list from the query response", async () => {
+      const devices = [
+        { uid: "d1", name: "host-1" },
+        { uid: "d2", name: "host-2" },
+      ];
+      mockMostUsedQueryFn.mockResolvedValue(devices);
+
+      const { result } = renderHook(() => useSuggestedDevices(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() =>
+        expect(result.current.devices).toEqual([
+          { uid: "d1", name: "host-1", tags: [] },
+          { uid: "d2", name: "host-2", tags: [] },
+        ]),
+      );
+    });
+
+    it("returns an empty array when data is undefined before load completes", () => {
+      // Don't resolve yet — keep the query pending
+      mockMostUsedQueryFn.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useSuggestedDevices(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.devices).toEqual([]);
+    });
+
+    it("exposes isLoading=true while the query is in flight", () => {
+      mockMostUsedQueryFn.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useSuggestedDevices(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  describe("when enabled=false", () => {
+    it("does not call the queryFn", () => {
+      renderHook(() => useSuggestedDevices(false), {
+        wrapper: createWrapper(),
+      });
+
+      expect(mockMostUsedQueryFn).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty devices array", () => {
+      const { result } = renderHook(() => useSuggestedDevices(false), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.devices).toEqual([]);
+    });
+  });
+
+  describe("on error", () => {
+    it("exposes the error on failure", async () => {
+      const err = new Error("network failure");
+      mockMostUsedQueryFn.mockRejectedValue(err);
+
+      const { result } = renderHook(() => useSuggestedDevices(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.error).toBe(err));
+    });
+  });
+});
+
+// ── useChoiceDevices ─────────────────────────────────────────────────────────
+
+describe("useChoiceDevices", () => {
+  describe("mutation call", () => {
+    it("calls the mutationFn with the choices body", async () => {
+      mockChoiceMutationFn.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useChoiceDevices(), {
+        wrapper: createWrapper(),
+      });
+
+      const vars = { body: { choices: ["uid1", "uid2"] } };
+      await act(() => result.current.mutateAsync(vars as never));
+
+      expect(mockChoiceMutationFn).toHaveBeenCalledWith(
+        vars,
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("on success", () => {
+    it("calls invalidate once after the mutation succeeds", async () => {
+      mockChoiceMutationFn.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useChoiceDevices(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(() =>
+        result.current.mutateAsync({ body: { choices: ["uid1"] } }),
+      );
+
+      await waitFor(() => expect(mockInvalidate).toHaveBeenCalledTimes(1));
+    });
+
+    it("registers invalidate using useInvalidateByIds with the correct query ids", () => {
+      renderHook(() => useChoiceDevices(), { wrapper: createWrapper() });
+
+      expect(useInvalidateByIds).toHaveBeenCalledWith(
+        "getDevices",
+        "getDevice",
+        "getStatusDevices",
+      );
+    });
+  });
+
+  describe("on failure", () => {
+    it("exposes error when the mutation fails", async () => {
+      const err = new Error("server error");
+      mockChoiceMutationFn.mockRejectedValue(err);
+
+      const { result } = renderHook(() => useChoiceDevices(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({ body: { choices: ["uid1"] } }));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toBe(err);
+    });
+
+    it("does not call invalidate when the mutation fails", async () => {
+      mockChoiceMutationFn.mockRejectedValue(new Error("server error"));
+
+      const { result } = renderHook(() => useChoiceDevices(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => result.current.mutate({ body: { choices: ["uid1"] } }));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockInvalidate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui-react/apps/console/src/hooks/useDebouncedValue.ts
+++ b/ui-react/apps/console/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a debounced copy of `value` that updates `delayMs` after the input
+ * stops changing.
+ *
+ * Use only with **primitive** values (string, number, boolean). Object or array
+ * inputs reset the timer on every render that produces a fresh reference,
+ * defeating the debounce. For non-primitives, debounce a stable derived key
+ * instead (e.g. `JSON.stringify`).
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/ui-react/apps/console/src/hooks/useDeviceChooser.ts
+++ b/ui-react/apps/console/src/hooks/useDeviceChooser.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  choiceDevicesMutation,
+  getDevicesMostUsedOptions,
+} from "../client/@tanstack/react-query.gen";
+import { useInvalidateByIds } from "./useInvalidateQueries";
+import { normalizeDevice, type NormalizedDevice } from "./useDevices";
+
+export function useSuggestedDevices(enabled = true) {
+  const result = useQuery({
+    ...getDevicesMostUsedOptions(),
+    enabled,
+  });
+  const devices: NormalizedDevice[] = (result.data ?? []).map(normalizeDevice);
+  return {
+    devices,
+    isLoading: result.isLoading,
+    error: result.error,
+    refetch: result.refetch,
+  };
+}
+
+export function useChoiceDevices() {
+  const invalidate = useInvalidateByIds(
+    "getDevices",
+    "getDevice",
+    "getStatusDevices",
+  );
+  return useMutation({
+    ...choiceDevicesMutation(),
+    onSuccess: invalidate,
+  });
+}

--- a/ui-react/apps/console/src/hooks/useDevices.ts
+++ b/ui-react/apps/console/src/hooks/useDevices.ts
@@ -9,16 +9,24 @@ import { getDevicesQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import type { Device as GeneratedDevice } from "../client";
 
-export type NormalizedDevice = Omit<GeneratedDevice, "tags"> & { tags: string[] };
+export type NormalizedDevice = Omit<GeneratedDevice, "tags"> & {
+  tags: string[];
+};
 
 export function buildFilter(search: string, tags: string[]): string {
   const filters: Record<string, unknown>[] = [];
   if (search) {
     filters.push(
       { type: "operator", params: { name: "or" } },
-      { type: "property", params: { name: "name", operator: "contains", value: search } },
+      {
+        type: "property",
+        params: { name: "name", operator: "contains", value: search },
+      },
       { type: "operator", params: { name: "or" } },
-      { type: "property", params: { name: "custom_fields", operator: "contains", value: search } },
+      {
+        type: "property",
+        params: { name: "custom_fields", operator: "contains", value: search },
+      },
     );
   }
   if (tags.length > 0) {
@@ -30,15 +38,15 @@ export function buildFilter(search: string, tags: string[]): string {
   return btoa(JSON.stringify(filters));
 }
 
-function normalizeDevice(device: GeneratedDevice): NormalizedDevice {
+export function normalizeDevice(device: GeneratedDevice): NormalizedDevice {
   return {
     ...device,
     tags: Array.isArray(device.tags)
       ? device.tags.map((t) =>
-        typeof t === "object" && t !== null && "name" in t
-          ? t.name
-          : String(t),
-      )
+          typeof t === "object" && t !== null && "name" in t
+            ? t.name
+            : String(t),
+        )
       : [],
   };
 }
@@ -49,6 +57,7 @@ interface UseDevicesParams {
   status?: DeviceStatus | "";
   search?: string;
   filterTags?: string[];
+  enabled?: boolean;
 }
 
 export function useDevices({
@@ -57,19 +66,25 @@ export function useDevices({
   status = "",
   search = "",
   filterTags = [],
+  enabled = true,
 }: UseDevicesParams = {}) {
   const query: GetDevicesData["query"] = { page, per_page: perPage };
   if (status) query.status = status;
-  if (search || filterTags.length > 0) query.filter = buildFilter(search, filterTags);
+  if (search || filterTags.length > 0)
+    query.filter = buildFilter(search, filterTags);
 
   const options = { query };
 
   const result = useQuery<PaginatedResult<GeneratedDevice>>({
     queryKey: getDevicesQueryKey(options),
     queryFn: paginatedQueryFn(getDevicesSdk, options),
+    enabled,
   });
 
-  const devices = useMemo(() => result.data?.data.map(normalizeDevice) ?? [], [result.data]);
+  const devices = useMemo(
+    () => result.data?.data.map(normalizeDevice) ?? [],
+    [result.data],
+  );
 
   return {
     devices,

--- a/ui-react/apps/console/src/pages/devices/index.tsx
+++ b/ui-react/apps/console/src/pages/devices/index.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import type { DeviceStatus } from "@/client";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useAuthStore } from "@/stores/authStore";
@@ -10,8 +11,9 @@ import ConnectDrawer from "@/components/ConnectDrawer";
 import ManageTagsDrawer from "@/components/ManageTagsDrawer";
 import CopyButton from "@/components/common/CopyButton";
 import PlatformBadge from "@/components/common/PlatformBadge";
+import OnlineDot from "@/components/common/OnlineDot";
+import LastSeenCell from "@/components/common/LastSeenCell";
 import DataTable, { type Column } from "@/components/common/DataTable";
-import { formatRelative } from "@/utils/date";
 import { buildSshid } from "@/utils/sshid";
 import TagFilterDropdown from "@/components/common/TagFilterDropdown";
 import TagsPopover from "./TagsPopover";
@@ -51,7 +53,10 @@ export default function Devices() {
   );
   const [filterTags, setFilterTags] = useState<string[]>([]);
   const [searchInput, setSearchInput] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(
+    searchInput.trim(),
+    SEARCH_DEBOUNCE_MS,
+  );
   const [actionTarget, setActionTarget] = useState<{
     device: NormalizedDevice;
     action: "accept" | "reject" | "remove";
@@ -63,13 +68,6 @@ export default function Devices() {
   } | null>(null);
   const [manageTagsOpen, setManageTagsOpen] = useState(false);
   const [billingWarningOpen, setBillingWarningOpen] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchInput.trim());
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   const { devices, totalCount, isLoading, error, refetch } = useDevices({
     page,
@@ -143,13 +141,23 @@ export default function Devices() {
         header: "Custom Fields",
         render: (device) => {
           const entries = Object.entries(device.custom_fields ?? {});
-          if (entries.length === 0) return <span className="text-2xs text-text-muted/30 font-mono">—</span>;
+          if (entries.length === 0)
+            return (
+              <span className="text-2xs text-text-muted/30 font-mono">—</span>
+            );
           return (
             <div className="flex flex-wrap gap-1">
               {entries.map(([k, v]) => (
-                <span key={k} className="inline-flex items-center text-2xs rounded overflow-hidden border border-border font-mono">
-                  <span className="px-1.5 py-0.5 bg-surface text-text-muted">{k}</span>
-                  <span className="px-1.5 py-0.5 bg-card text-text-primary font-medium">{v}</span>
+                <span
+                  key={k}
+                  className="inline-flex items-center text-2xs rounded overflow-hidden border border-border font-mono"
+                >
+                  <span className="px-1.5 py-0.5 bg-surface text-text-muted">
+                    {k}
+                  </span>
+                  <span className="px-1.5 py-0.5 bg-card text-text-primary font-medium">
+                    {v}
+                  </span>
                 </span>
               ))}
             </div>
@@ -159,11 +167,7 @@ export default function Devices() {
       {
         key: "last_seen",
         header: "Last Seen",
-        render: (device) => (
-          <span className="text-xs text-text-secondary">
-            {formatRelative(device.last_seen)}
-          </span>
-        ),
+        render: (device) => <LastSeenCell value={device.last_seen} />,
       },
     ];
 
@@ -173,15 +177,7 @@ export default function Devices() {
           key: "online",
           header: "",
           headerClassName: "w-12",
-          render: (device) =>
-            device.online ? (
-              <span className="relative flex h-2.5 w-2.5 mx-auto">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-green opacity-40" />
-                <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]" />
-              </span>
-            ) : (
-              <span className="block w-2.5 h-2.5 rounded-full mx-auto bg-text-muted/30" />
-            ),
+          render: (device) => <OnlineDot online={device.online} />,
         },
         baseColumns[0], // hostname
         {


### PR DESCRIPTION
## What
Port the Vue UI's device chooser to the React UI: when a Cloud namespace owner exceeds the free-tier three-device cap without an active subscription, present a forced modal to either subscribe or pick three devices to keep accepted; the rest are demoted to pending by the existing `/api/billing/device-choice` endpoint.

## Why
Closes the last open Device-Management gap on the React UI parity report (shellhub-io/team#91). Without this surface, free-tier Cloud namespaces that exceed the cap leave the owner with no UI to recover — they cannot accept new devices and have no way to pick which to keep short of calling the API directly.

## Changes
- **DeviceChooserTrigger**: gates the modal on cloud build + `device:choose` permission + `!namespace.billing.active` + `stats.registered_devices > 3`, with a loading guard so the modal cannot flash for paying customers during the namespace fetch race. Dismissal does not persist — reopens on next fresh mount, matching Vue.
- **DeviceChooserDialog**: hand-rolled accessible Tabs (no shared primitive exists), Suggested and All tabs sharing a single `NormalizedDevice` shape through the now-exported `normalizeDevice`. Suggested preselects the top three devices by session count from `/api/billing/devices-most-used`. All has hostname search (debounced), 5-per-page pagination, hard cap of three selections, and a chip strip surfacing the current selection across pages so picks cannot be silently lost when paginating or searching. Footer: Cancel / Subscribe (navigates to `/settings#billing`) / Accept. ESC and backdrop are blocked while the mutation is in flight; double-clicks are guarded by a ref.
- **Shared cells**: extracted `OnlineDot` and `LastSeenCell` to `components/common/` so the chooser and the main devices table render device status identically.
- **Shared hook**: extracted `useDebouncedValue` from the inline pattern in `pages/devices/index.tsx`; both surfaces use it now.
- **Constants**: `FREE_TIER_DEVICE_LIMIT` lives in `types/billing.ts`, replacing two unrelated `3` constants.
- **`useDevices`**: gained an `enabled` option so the dialog skips the All-tab query while the user is on Suggested.

## Testing
- 78 new unit/component tests covering the chooser surface and the extracted `useDebouncedValue` hook.
- Manual: with a Cloud free-tier namespace of >3 accepted devices, log in as owner → modal opens. Pick three → confirm → unchosen devices land in `pending` (not `removed`), dashboard refetches, modal does not reopen on reload. Log in as non-owner → no modal. Activate billing in Mongo → no modal. Run on CE → no modal.
- Watch for: paying-customer flash on initial load (the loading-gate fix), tab persistence across a Suggested refetch (selections must not silently switch tabs), and that the All-tab search does not fire per-keystroke requests.