### PR TITLE
refactor(ui-react): share defaultConfig across env mocks in tests

### DIFF
--- a/ui-react/apps/console/src/components/announcements/__tests__/AnnouncementModalTrigger.test.tsx
+++ b/ui-react/apps/console/src/components/announcements/__tests__/AnnouncementModalTrigger.test.tsx
@@ -5,7 +5,10 @@ import type { Announcement } from "@/client";
 
 // ── Dependency mocks ──────────────────────────────────────────────────────────
 
-vi.mock("@/env", () => ({ getConfig: vi.fn() }));
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
 
 vi.mock("@/hooks/useLatestAnnouncement", () => ({
   useLatestAnnouncement: vi.fn(),
@@ -31,7 +34,7 @@ vi.mock("../AnnouncementModal", () => ({
     ) : null,
 }));
 
-import { getConfig } from "@/env";
+import { getConfig, defaultConfig } from "@/env";
 import { useLatestAnnouncement } from "@/hooks/useLatestAnnouncement";
 import AnnouncementModalTrigger from "../AnnouncementModalTrigger";
 
@@ -61,9 +64,7 @@ beforeEach(() => {
   localStorage.clear();
 
   // Default: feature enabled, no announcement available
-  mockGetConfig.mockReturnValue({ announcements: true } as ReturnType<
-    typeof getConfig
-  >);
+  mockGetConfig.mockReturnValue({ ...defaultConfig, announcements: true });
   mockUseLatestAnnouncement.mockReturnValue({
     announcement: null,
     isLoading: false,
@@ -77,9 +78,7 @@ afterEach(cleanup);
 describe("AnnouncementModalTrigger", () => {
   describe("when announcements feature flag is disabled", () => {
     it("renders nothing without calling any hooks", () => {
-      mockGetConfig.mockReturnValue({ announcements: false } as ReturnType<
-        typeof getConfig
-      >);
+      mockGetConfig.mockReturnValue({ ...defaultConfig, announcements: false });
 
       render(<AnnouncementModalTrigger />);
 

--- a/ui-react/apps/console/src/components/common/__tests__/CreateNamespaceDialog.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/CreateNamespaceDialog.test.tsx
@@ -14,9 +14,10 @@ vi.mock("@/hooks/useFocusTrap", () => ({
   useFocusTrap: vi.fn(),
 }));
 
-vi.mock("@/env", () => ({
-  getConfig: vi.fn(),
-}));
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
 
 vi.mock("@/hooks/useNamespaceMutations", () => ({
   useCreateNamespace: vi.fn(),
@@ -28,7 +29,7 @@ Object.defineProperty(navigator, "clipboard", {
   configurable: true,
 });
 
-import { getConfig } from "@/env";
+import { getConfig, defaultConfig } from "@/env";
 import { useCreateNamespace } from "@/hooks/useNamespaceMutations";
 import { ClipboardProvider } from "../ClipboardProvider";
 import CreateNamespaceDialog from "../CreateNamespaceDialog";
@@ -38,17 +39,7 @@ const mockUseCreateNamespace = vi.mocked(useCreateNamespace);
 
 beforeEach(() => {
   // Default to CE (no cloud/enterprise features)
-  mockGetConfig.mockReturnValue({
-    cloud: false,
-    enterprise: false,
-    version: "",
-    onboardingUrl: "",
-    announcements: false,
-    webEndpoints: false,
-    stripePublishableKey: "",
-    chatwootWebsiteToken: "",
-    chatwootBaseUrl: "",
-  });
+  mockGetConfig.mockReturnValue({ ...defaultConfig });
   mockUseCreateNamespace.mockReturnValue({
     mutateAsync: vi.fn(),
     isPending: false,
@@ -217,17 +208,7 @@ describe("CreateNamespaceDialog", () => {
 
 describe("CreateNamespaceDialog (cloud/enterprise)", () => {
   beforeEach(() => {
-    mockGetConfig.mockReturnValue({
-      cloud: false,
-      enterprise: true,
-      version: "",
-      onboardingUrl: "",
-      announcements: false,
-      webEndpoints: false,
-      stripePublishableKey: "",
-      chatwootWebsiteToken: "",
-      chatwootBaseUrl: "",
-    });
+    mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
   });
 
   it("renders the creation form instead of CLI instructions", () => {
@@ -385,29 +366,5 @@ describe("CreateNamespaceDialog (cloud/enterprise)", () => {
     await user.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
-  });
-});
-
-describe("CreateNamespaceDialog (cloud: true, enterprise: false)", () => {
-  beforeEach(() => {
-    mockGetConfig.mockReturnValue({
-      cloud: true,
-      enterprise: false,
-      version: "",
-      onboardingUrl: "",
-      announcements: false,
-      webEndpoints: false,
-      stripePublishableKey: "",
-      chatwootWebsiteToken: "",
-      chatwootBaseUrl: "",
-    });
-  });
-
-  it("renders the creation form (cloud branch of isCloud)", () => {
-    renderDialog(true);
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
-    expect(
-      screen.queryByText(/Community Edition uses the CLI/i),
-    ).not.toBeInTheDocument();
   });
 });

--- a/ui-react/apps/console/src/components/common/__tests__/SignUpGuard.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/SignUpGuard.test.tsx
@@ -6,14 +6,21 @@ import { render, screen, cleanup } from "@testing-library/react";
 afterEach(cleanup);
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
-vi.mock("@/env", () => ({ getConfig: vi.fn() }));
-import { getConfig } from "@/env";
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
+import { getConfig, defaultConfig } from "@/env";
 import SignUpGuard from "../SignUpGuard";
 
 const mockedGetConfig = vi.mocked(getConfig);
 
 function renderWithRouter(cloud: boolean) {
-  mockedGetConfig.mockReturnValue({ cloud } as ReturnType<typeof getConfig>);
+  mockedGetConfig.mockReturnValue({
+    ...defaultConfig,
+    cloud,
+    enterprise: cloud,
+  });
   return render(
     <MemoryRouter initialEntries={["/sign-up"]}>
       <Routes>

--- a/ui-react/apps/console/src/components/layout/__tests__/InvitationsMenu.test.tsx
+++ b/ui-react/apps/console/src/components/layout/__tests__/InvitationsMenu.test.tsx
@@ -11,8 +11,9 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useAuthStore } from "../../../stores/authStore";
-import type { MembershipInvitation } from "../../../client";
+import { useAuthStore } from "@/stores/authStore";
+import type { MembershipInvitation } from "@/client";
+import { defaultConfig } from "@/env";
 import InvitationsMenu from "../InvitationsMenu";
 
 /* ------------------------------------------------------------------ */
@@ -20,7 +21,7 @@ import InvitationsMenu from "../InvitationsMenu";
 /* ------------------------------------------------------------------ */
 
 // Stub ConfirmDialog — jsdom lacks HTMLDialogElement.showModal()
-vi.mock("../../../components/common/ConfirmDialog", () => ({
+vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
     onClose,
@@ -57,10 +58,12 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-// Cloud mode on by default — tests that need it off override in their own beforeEach
-vi.mock("../../../env", () => ({
-  getConfig: vi.fn(() => ({ cloud: true })),
-}));
+const mockGetConfig = vi.fn();
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: (): unknown => mockGetConfig() };
+});
 
 const mockUserInvitations = vi.fn<
   () => {
@@ -70,7 +73,7 @@ const mockUserInvitations = vi.fn<
   }
 >();
 
-vi.mock("../../../hooks/useInvitations", () => ({
+vi.mock("@/hooks/useInvitations", () => ({
   useUserInvitations: () => mockUserInvitations(),
 }));
 
@@ -78,7 +81,7 @@ const mockAcceptMutateAsync = vi.fn();
 const mockDeclineMutateAsync = vi.fn();
 const mockSwitchNamespaceMutateAsync = vi.fn();
 
-vi.mock("../../../hooks/useInvitationMutations", () => ({
+vi.mock("@/hooks/useInvitationMutations", () => ({
   useAcceptInvite: () => ({
     mutateAsync: mockAcceptMutateAsync,
     isPending: false,
@@ -89,7 +92,7 @@ vi.mock("../../../hooks/useInvitationMutations", () => ({
   }),
 }));
 
-vi.mock("../../../hooks/useNamespaceMutations", () => ({
+vi.mock("@/hooks/useNamespaceMutations", () => ({
   useSwitchNamespace: () => ({
     mutateAsync: mockSwitchNamespaceMutateAsync,
     isPending: false,
@@ -148,6 +151,12 @@ afterEach(cleanup);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Cloud mode on by default — tests that need it off override in-test.
+  mockGetConfig.mockReturnValue({
+    ...defaultConfig,
+    cloud: true,
+    enterprise: true,
+  });
   useAuthStore.setState({
     token: "test-token",
     user: "alice",
@@ -174,35 +183,11 @@ beforeEach(() => {
 
 describe("InvitationsMenu", () => {
   describe("cloud gating", () => {
-    it("returns null in non-cloud mode", async () => {
-      const { getConfig } = await import("../../../env");
-      vi.mocked(getConfig).mockReturnValue({
-        cloud: false,
-        version: "",
-        enterprise: false,
-        announcements: false,
-        webEndpoints: false,
-        onboardingUrl: "",
-        stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-      });
+    it("returns null in non-cloud mode", () => {
+      mockGetConfig.mockReturnValue({ ...defaultConfig });
 
       const { container } = renderMenu();
       expect(container).toBeEmptyDOMElement();
-
-      // Restore cloud mode for subsequent tests
-      vi.mocked(getConfig).mockReturnValue({
-        cloud: true,
-        version: "",
-        enterprise: false,
-        announcements: false,
-        webEndpoints: false,
-        onboardingUrl: "",
-        stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-      });
     });
 
     it("returns null when there is no auth token", () => {

--- a/ui-react/apps/console/src/env.ts
+++ b/ui-react/apps/console/src/env.ts
@@ -10,7 +10,12 @@ export interface ClientConfig {
   chatwootBaseUrl: string;
 }
 
-const defaultConfig: ClientConfig = {
+/**
+ * Fallback used by `loadConfig` before `/config.json` resolves, and exported
+ * for tests to spread as a known-good baseline. Production code should call
+ * `getConfig()` so runtime overrides apply — never read this directly.
+ */
+export const defaultConfig: ClientConfig = {
   version: "",
   enterprise: false,
   cloud: false,

--- a/ui-react/apps/console/src/hooks/__tests__/useChatwoot.test.tsx
+++ b/ui-react/apps/console/src/hooks/__tests__/useChatwoot.test.tsx
@@ -1,13 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { defaultConfig } from "@/env";
 
 // ─── Module mocks (must come before any import of the module under test) ──────
 
 const mockGetConfig = vi.fn();
 
-vi.mock("@/env", () => ({
-  getConfig: (): unknown => mockGetConfig(),
-}));
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return {
+    ...actual,
+    getConfig: (): unknown => mockGetConfig(),
+  };
+});
 
 const mockUseAuthStore = vi.fn();
 
@@ -30,21 +35,6 @@ vi.mock("@/hooks/useSupportIdentifier", () => ({
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function makeConfig(
-  overrides: Partial<{
-    cloud: boolean;
-    chatwootWebsiteToken: string;
-    chatwootBaseUrl: string;
-  }> = {},
-) {
-  return {
-    cloud: false,
-    chatwootWebsiteToken: "",
-    chatwootBaseUrl: "",
-    ...overrides,
-  };
-}
 
 /** Simulate the Zustand selector pattern for authStore */
 function setupAuthStore(values: {
@@ -129,7 +119,7 @@ afterEach(() => {
 describe("useChatwoot", () => {
   describe("status: non-cloud", () => {
     it("returns status 'non-cloud' when cloud=false", async () => {
-      mockGetConfig.mockReturnValue(makeConfig({ cloud: false }));
+      mockGetConfig.mockReturnValue({ ...defaultConfig });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -141,7 +131,7 @@ describe("useChatwoot", () => {
     });
 
     it("does not inject a script when cloud=false", async () => {
-      mockGetConfig.mockReturnValue(makeConfig({ cloud: false }));
+      mockGetConfig.mockReturnValue({ ...defaultConfig });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -155,13 +145,13 @@ describe("useChatwoot", () => {
 
   describe("status: unavailable", () => {
     it("returns 'unavailable' when cloud=true but chatwootWebsiteToken is missing", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -173,13 +163,13 @@ describe("useChatwoot", () => {
     });
 
     it("returns 'unavailable' when cloud=true but chatwootBaseUrl is missing", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -193,13 +183,13 @@ describe("useChatwoot", () => {
 
   describe("status: loading (namespace not resolved)", () => {
     it("returns 'loading' when namespace is null", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace(null);
       setupIdentifier(null, false);
@@ -213,13 +203,13 @@ describe("useChatwoot", () => {
 
   describe("status: no-subscription", () => {
     it("returns 'no-subscription' when namespace loaded but billing.active !== true", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: false } });
       setupIdentifier(null, false);
@@ -231,13 +221,13 @@ describe("useChatwoot", () => {
     });
 
     it("returns 'no-subscription' when namespace has no billing object", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns" });
       setupIdentifier(null, false);
@@ -251,13 +241,13 @@ describe("useChatwoot", () => {
 
   describe("status: loading (identifier fetching)", () => {
     it("returns 'loading' while support identifier is being fetched", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier(null, true); // isLoading=true
@@ -269,13 +259,13 @@ describe("useChatwoot", () => {
     });
 
     it("returns 'loading' when identifier has not arrived yet (isLoading=false but identifier=null)", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier(null, false);
@@ -289,13 +279,13 @@ describe("useChatwoot", () => {
 
   describe("status: ready", () => {
     it("returns 'ready' after the chatwoot:ready event fires with window.$chatwoot set", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -314,13 +304,13 @@ describe("useChatwoot", () => {
   describe("script injection", () => {
     it("injects a script with the correct src when prerequisites are met", async () => {
       const baseURL = "https://chat.example.com";
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: baseURL,
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: baseURL,
+      });
       setupAuthStore({ userId: "user-1" });
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -336,13 +326,13 @@ describe("useChatwoot", () => {
     });
 
     it("does not inject a second script when the hook renders twice (StrictMode safety)", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({ userId: "user-1" });
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -360,13 +350,13 @@ describe("useChatwoot", () => {
 
   describe("window.chatwootSettings", () => {
     it("sets chatwootSettings with the correct values before script injection", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({ userId: "user-1" });
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -389,13 +379,13 @@ describe("useChatwoot", () => {
 
   describe("setUser after widget ready", () => {
     it("calls setUser with identifier_hash when widget reports ready", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       const userId = "user-1";
       const email = "user@example.com";
       const name = "Test User";
@@ -420,13 +410,13 @@ describe("useChatwoot", () => {
     });
 
     it("does not call setUser again when re-rendered with the same identity", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({
         userId: "user-1",
         email: "user@example.com",
@@ -456,13 +446,13 @@ describe("useChatwoot", () => {
 
   describe("setConversationCustomAttributes", () => {
     it("calls setConversationCustomAttributes with namespace data on chatwoot:on-message", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({ userId: "user-1", tenant: "tenant-abc" });
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -492,13 +482,13 @@ describe("useChatwoot", () => {
 
   describe("openWidget", () => {
     it("calls window.$chatwoot.toggle('open') when status is ready", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -520,13 +510,13 @@ describe("useChatwoot", () => {
     });
 
     it("does not call toggle when status is not ready (loading)", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace(null); // loading state
       setupIdentifier(null, true);
@@ -555,13 +545,13 @@ describe("useChatwoot", () => {
 
   describe("status: unavailable (identifier endpoint errors)", () => {
     it("flips to 'unavailable' when /support returns an error (e.g. backend identity key missing)", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifierError();
@@ -579,13 +569,13 @@ describe("useChatwoot", () => {
     it("flips to 'unavailable' when chatwoot:ready never fires after script load", async () => {
       vi.useFakeTimers();
       try {
-        mockGetConfig.mockReturnValue(
-          makeConfig({
-            cloud: true,
-            chatwootWebsiteToken: "token-abc",
-            chatwootBaseUrl: "https://chat.example.com",
-          }),
-        );
+        mockGetConfig.mockReturnValue({
+          ...defaultConfig,
+          cloud: true,
+          enterprise: true,
+          chatwootWebsiteToken: "token-abc",
+          chatwootBaseUrl: "https://chat.example.com",
+        });
         setupAuthStore({});
         setupNamespace({ name: "my-ns", billing: { active: true } });
         setupIdentifier("abc123");
@@ -621,13 +611,13 @@ describe("useChatwoot", () => {
 
   describe("status: unavailable (script load error)", () => {
     it("flips to 'unavailable' when the SDK script fails to load (script.onerror)", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -655,13 +645,13 @@ describe("useChatwoot", () => {
 
   describe("teardown via runtime helper", () => {
     it("tearDownChatwoot('logout') removes the script tag and clears window globals", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -685,13 +675,13 @@ describe("useChatwoot", () => {
     });
 
     it("after teardown, a re-mount cleanly re-injects the script", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -711,13 +701,13 @@ describe("useChatwoot", () => {
     });
 
     it("removes SDK-injected DOM (chat bubble holders, iframe) on teardown", async () => {
-      mockGetConfig.mockReturnValue(
-        makeConfig({
-          cloud: true,
-          chatwootWebsiteToken: "token-abc",
-          chatwootBaseUrl: "https://chat.example.com",
-        }),
-      );
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        cloud: true,
+        enterprise: true,
+        chatwootWebsiteToken: "token-abc",
+        chatwootBaseUrl: "https://chat.example.com",
+      });
       setupAuthStore({});
       setupNamespace({ name: "my-ns", billing: { active: true } });
       setupIdentifier("abc123");
@@ -748,13 +738,13 @@ describe("useChatwoot", () => {
     it("clears bootstrapFailed when a fresh injection proceeds (recovers from prior watchdog timeout)", async () => {
       vi.useFakeTimers();
       try {
-        mockGetConfig.mockReturnValue(
-          makeConfig({
-            cloud: true,
-            chatwootWebsiteToken: "token-abc",
-            chatwootBaseUrl: "https://chat.example.com",
-          }),
-        );
+        mockGetConfig.mockReturnValue({
+          ...defaultConfig,
+          cloud: true,
+          enterprise: true,
+          chatwootWebsiteToken: "token-abc",
+          chatwootBaseUrl: "https://chat.example.com",
+        });
         setupAuthStore({});
         setupNamespace({ name: "my-ns", billing: { active: true } });
         setupIdentifier("abc123");

--- a/ui-react/apps/console/src/hooks/__tests__/useLatestAnnouncement.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useLatestAnnouncement.test.ts
@@ -7,7 +7,10 @@ import type { Announcement } from "@/client";
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
 
-vi.mock("@/env", () => ({ getConfig: vi.fn() }));
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
 
 // Mock the generated query-option factories so we control what queryFn runs
 vi.mock("@/client/@tanstack/react-query.gen", () => ({
@@ -15,7 +18,7 @@ vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getAnnouncementOptions: vi.fn(),
 }));
 
-import { getConfig } from "@/env";
+import { getConfig, defaultConfig } from "@/env";
 import {
   listAnnouncementsOptions,
   getAnnouncementOptions,
@@ -68,9 +71,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 
   // Default: feature enabled
-  mockGetConfig.mockReturnValue({ announcements: true } as ReturnType<
-    typeof getConfig
-  >);
+  mockGetConfig.mockReturnValue({ ...defaultConfig, announcements: true });
 
   // Default: both option factories return never-resolving promises (loading state)
   mockListAnnouncementsOptions.mockReturnValue(
@@ -86,9 +87,7 @@ beforeEach(() => {
 describe("useLatestAnnouncement", () => {
   describe("when announcements feature flag is disabled", () => {
     beforeEach(() => {
-      mockGetConfig.mockReturnValue({ announcements: false } as ReturnType<
-        typeof getConfig
-      >);
+      mockGetConfig.mockReturnValue({ ...defaultConfig, announcements: false });
     });
 
     it("returns null announcement immediately", () => {

--- a/ui-react/apps/console/src/pages/__tests__/Login.test.tsx
+++ b/ui-react/apps/console/src/pages/__tests__/Login.test.tsx
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { useAuthStore } from "../../stores/authStore";
-import type { UserAuth, Info } from "../../client";
+import { useAuthStore } from "@/stores/authStore";
+import type { UserAuth, Info } from "@/client";
 import Login from "../Login";
 
 /* ------------------------------------------------------------------ */
@@ -31,8 +31,8 @@ vi.mock("@/client", () => ({
   getSamlAuthUrl: vi.fn(),
 }));
 
-vi.mock("../../env", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../env")>();
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
   return { ...actual, getConfig: vi.fn(() => actual.getConfig()) };
 });
 
@@ -40,8 +40,8 @@ import {
   login as loginSdk,
   getInfo as getInfoSdk,
   getSamlAuthUrl as getSamlAuthUrlSdk,
-} from "../../client";
-import { getConfig } from "../../env";
+} from "@/client";
+import { getConfig, defaultConfig } from "@/env";
 
 const mockedLogin = vi.mocked(loginSdk);
 const mockedGetInfo = vi.mocked(getInfoSdk);
@@ -135,17 +135,7 @@ beforeEach(() => {
     mockSdkResponse(mockInfo({ authentication: { local: true, saml: false } })),
   );
   // Default: community edition (no enterprise/cloud flags).
-  mockedGetConfig.mockReturnValue({
-    version: "",
-    enterprise: false,
-    cloud: false,
-    announcements: false,
-    webEndpoints: false,
-    onboardingUrl: "",
-    stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-  });
+  mockedGetConfig.mockReturnValue({ ...defaultConfig });
   useAuthStore.setState({
     token: null,
     user: null,
@@ -358,17 +348,7 @@ describe("Login", () => {
 
   describe("SSO / SAML button", () => {
     it("does not show SSO button when not enterprise", async () => {
-      mockedGetConfig.mockReturnValue({
-        version: "",
-        enterprise: false,
-        cloud: false,
-        announcements: false,
-        webEndpoints: false,
-        onboardingUrl: "",
-        stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-      });
+      mockedGetConfig.mockReturnValue({ ...defaultConfig });
       mockedGetInfo.mockResolvedValue(
         mockSdkResponse(
           mockInfo({ authentication: { local: true, saml: true } }),
@@ -383,17 +363,7 @@ describe("Login", () => {
     });
 
     it("does not show SSO button when enterprise but saml is false", async () => {
-      mockedGetConfig.mockReturnValue({
-        version: "",
-        enterprise: true,
-        cloud: false,
-        announcements: false,
-        webEndpoints: false,
-        onboardingUrl: "",
-        stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-      });
+      mockedGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
       mockedGetInfo.mockResolvedValue(
         mockSdkResponse(
           mockInfo({ authentication: { local: true, saml: false } }),
@@ -409,17 +379,7 @@ describe("Login", () => {
     });
 
     it("shows SSO button when enterprise and saml is true", async () => {
-      mockedGetConfig.mockReturnValue({
-        version: "",
-        enterprise: true,
-        cloud: false,
-        announcements: false,
-        webEndpoints: false,
-        onboardingUrl: "",
-        stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-      });
+      mockedGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
       mockedGetInfo.mockResolvedValue(
         mockSdkResponse(
           mockInfo({ authentication: { local: true, saml: true } }),
@@ -441,17 +401,7 @@ describe("Login", () => {
       });
 
       try {
-        mockedGetConfig.mockReturnValue({
-          version: "",
-          enterprise: true,
-          cloud: false,
-          announcements: false,
-          webEndpoints: false,
-          onboardingUrl: "",
-          stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-        });
+        mockedGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
         mockedGetInfo.mockResolvedValue(
           mockSdkResponse(
             mockInfo({ authentication: { local: true, saml: true } }),
@@ -480,17 +430,7 @@ describe("Login", () => {
     });
 
     it("shows error when SSO URL fetch fails", async () => {
-      mockedGetConfig.mockReturnValue({
-        version: "",
-        enterprise: true,
-        cloud: false,
-        announcements: false,
-        webEndpoints: false,
-        onboardingUrl: "",
-        stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-      });
+      mockedGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
       mockedGetInfo.mockResolvedValue(
         mockSdkResponse(
           mockInfo({ authentication: { local: true, saml: true } }),
@@ -511,17 +451,7 @@ describe("Login", () => {
     });
 
     it("hides the form entirely and shows SSO as the only option when local auth is disabled", async () => {
-      mockedGetConfig.mockReturnValue({
-        version: "",
-        enterprise: true,
-        cloud: false,
-        announcements: false,
-        webEndpoints: false,
-        onboardingUrl: "",
-        stripePublishableKey: "",
-          chatwootWebsiteToken: "",
-          chatwootBaseUrl: "",
-      });
+      mockedGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
       mockedGetInfo.mockResolvedValue(
         mockSdkResponse(
           mockInfo({ authentication: { local: false, saml: true } }),


### PR DESCRIPTION
## What

Test files no longer inline the full `ClientConfig` shape at every `getConfig()` mock site. They spread a shared `defaultConfig` instead.

## Why

Every time a field landed on `ClientConfig` (most recently `chatwootWebsiteToken` and `chatwootBaseUrl`), six-plus inline literals had to be updated, and a missed one was silently masked by `mockReturnValue`'s permissive typing. The `defaultConfig` constant already existed in `env.ts` as the loader's pre-fetch fallback — it just wasn't exported.

A second issue surfaced while touching these files: several tests set `cloud: true, enterprise: false`, which describes a configuration that cannot exist in production (cloud is built on top of enterprise). Tests now pair the two flags so feature-gate code that conditions on `enterprise` doesn't get exercised under an impossible config.

## Changes

- **`env.ts`**: export the existing `defaultConfig`. Added a JSDoc warning that production code should call `getConfig()` so runtime overrides apply, not import the constant directly.
- **Mock factories**: switched `vi.mock(\"@/env\", ...)` to the `importOriginal` pattern across the touched files so the real `defaultConfig` flows through to test code via top-level imports. Two shapes survive intentionally: `Login.test.tsx` keeps its existing pattern that delegates to the real cached `getConfig()`; the rest use a hoisted `mockGetConfig` set per `beforeEach`.
- **`cloud` / `enterprise` pairing**: every `cloud: true` is now accompanied by `enterprise: true` (23 sites in `useChatwoot.test.tsx` alone). `SignUpGuard.test.tsx` ties the two together via `enterprise: cloud` to keep the invariant under both branches.
- **`useChatwoot.test.tsx`**: dropped the local `makeConfig` helper that duplicated this functionality with a smaller field surface.
- **`CreateNamespaceDialog.test.tsx`**: deleted the redundant `(cloud: true, enterprise: false)` describe block. The component branches on `cloud || enterprise`, and the `(cloud/enterprise)` block already exercises that path with `enterprise: true`.
- **Imports**: normalized `../../` cross-directory imports in the touched files to the `@/` alias per the codebase rule.
- Dropped the dead `as ReturnType<typeof getConfig>` casts from the announcement tests now that the spread produces a properly-typed `ClientConfig`.

## Testing

Test, lint, and build all pass (1792 tests). The refactor's value can be confirmed by adding a dummy required field to `ClientConfig` and running `npm run build`: only `defaultConfig` itself should fail to type-check; no test file should.