### PR TITLE
chore(api): watch shellhub/pkg in air for live reload

### DIFF
--- a/api/.air.toml
+++ b/api/.air.toml
@@ -6,5 +6,5 @@ cmd = "go build -o /tmp/air/main github.com/shellhub-io/shellhub/api"
 bin = "/tmp/air/main"
 args_bin = ["server"]
 exclude_regex = ["_test.go"]
-include_dir = ["shellhub/api", "shellhub/openapi", "cloud"]
+include_dir = ["shellhub/api", "shellhub/openapi", "shellhub/pkg", "cloud"]
 include_ext = ["go", "tpl", "tmpl", "html", "yaml", "yml", "json"]


### PR DESCRIPTION
## Summary
- Add `shellhub/pkg` to `include_dir` in `api/.air.toml` so changes to shared packages trigger the API live reload during development.