### PR TITLE
fix(docker): use api-enterprise image in enterprise compose

### DIFF
--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: registry.infra.ossystems.io/shellhub/api-cloud:${SHELLHUB_VERSION}
+    image: registry.infra.ossystems.io/shellhub/api-enterprise:${SHELLHUB_VERSION}
     restart: unless-stopped
     environment:
       # Database and Cache connections


### PR DESCRIPTION
## Summary
- `docker-compose.enterprise.yml` was pulling `registry.infra.ossystems.io/shellhub/api-cloud`, but the published image is `api-enterprise` (see `.github/workflows/docker-publish.yml`).
- Updated the `api` service image to match what release publishes.