### PR TITLE
fix(dev): replace binutils-gold with CGO_ENABLED=0 in dev images

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -58,9 +58,9 @@ FROM base AS development
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
-RUN apk add --update openssl build-base binutils-gold openssh-client util-linux setpriv
-RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
+RUN apk add --update openssl openssh-client util-linux setpriv
+RUN CGO_ENABLED=0 go install github.com/air-verse/air@v1.62 && \
+    CGO_ENABLED=0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -75,11 +75,11 @@ ARG GOPROXY
 ARG MJML_VERSION
 ENV GOPROXY=${GOPROXY}
 
-RUN apk add --update openssl build-base binutils-gold docker-cli npm
+RUN apk add --update openssl docker-cli npm
 RUN npm install -g mjml@${MJML_VERSION}
-RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
-    go install github.com/vektra/mockery/v2/...@v2.53.2
+RUN CGO_ENABLED=0 go install github.com/air-verse/air@v1.62 && \
+    CGO_ENABLED=0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
+    CGO_ENABLED=0 go install github.com/vektra/mockery/v2/...@v2.53.2
 
 COPY ./api/entrypoint-dev.sh /entrypoint.sh
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -32,9 +32,9 @@ RUN go build
 # development stage
 FROM builder AS development
 
-RUN apk add --update openssl build-base binutils-gold docker-cli
-RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
+RUN apk add --update openssl docker-cli
+RUN CGO_ENABLED=0 go install github.com/air-verse/air@v1.62 && \
+    CGO_ENABLED=0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -39,10 +39,10 @@ RUN mkdir /etc/shellhub-gateway
 RUN mkdir -p /var/run/openresty /etc/letsencrypt && \
     curl -sSL https://ssl-config.mozilla.org/ffdhe2048.txt -o /etc/shellhub-gateway/dhparam.pem
 
-RUN apk add --update openssl build-base binutils-gold
-RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
-    go install github.com/vektra/mockery/v2/...@v2.20.0
+RUN apk add --update openssl
+RUN CGO_ENABLED=0 go install github.com/air-verse/air@v1.62 && \
+    CGO_ENABLED=0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
+    CGO_ENABLED=0 go install github.com/vektra/mockery/v2/...@v2.20.0
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 

--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.25.8-alpine3.22 AS base
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
-RUN apk add --no-cache openssl build-base binutils-gold nodejs npm openjdk11-jre git
+RUN apk add --no-cache openssl nodejs npm openjdk11-jre git
 
 RUN npm install -g @openapitools/openapi-generator-cli
 
@@ -13,9 +13,9 @@ RUN npm install -g @stoplight/prism-cli@4.6.1
 
 RUN npm install -g prettier@2.8.7
 
-RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
-    go install github.com/vektra/mockery/v2/...@v2.53.2
+RUN CGO_ENABLED=0 go install github.com/air-verse/air@v1.62 && \
+    CGO_ENABLED=0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
+    CGO_ENABLED=0 go install github.com/vektra/mockery/v2/...@v2.53.2
 
 FROM base AS development
 

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -39,10 +39,10 @@ FROM base AS development
 ARG GOPROXY
 ENV GOPROXY ${GOPROXY}
 
-RUN apk add --update openssl build-base binutils-gold
-RUN go install github.com/air-verse/air@v1.62 && \
-    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
-    go install github.com/vektra/mockery/v2/...@v2.20.0
+RUN apk add --update openssl
+RUN CGO_ENABLED=0 go install github.com/air-verse/air@v1.62 && \
+    CGO_ENABLED=0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 && \
+    CGO_ENABLED=0 go install github.com/vektra/mockery/v2/...@v2.20.0
 
 WORKDIR $GOPATH/src/github.com/shellhub-io/shellhub
 


### PR DESCRIPTION
Closes #6285.

## Summary
- `binutils-gold` was added in #6248 to fix `cannot find 'ld'` on linux/arm64 alpine when installing dev tools (air, golangci-lint, mockery).
- The real trigger is Go's `net`/`os/user` compiling with cgo by default, not the tools themselves — they are pure Go.
- Drop `binutils-gold` (and `build-base` where it was added only to support the cgo link step) and use `CGO_ENABLED=0` inline on each `go install`.

`CGO_ENABLED=0` is set inline only on the dev tool installs. App builds (via `air`, or the production `builder` stage) are unaffected.

Verified on linux/arm64 (emulated):
- agent dev image builds without `binutils-gold` / `build-base`
- `air -v` and `golangci-lint --version` run inside the arm64 image
- `go build -tags docker` of the agent succeeds inside the dev image and the resulting binary runs (`agent --help`)