### PR TITLE
refactor(ui-react): introduce NumericInput wrapper across number fields

### DIFF
--- a/ui-react/apps/console/src/components/common/NumericInput.tsx
+++ b/ui-react/apps/console/src/components/common/NumericInput.tsx
@@ -1,0 +1,34 @@
+import { InputHTMLAttributes } from "react";
+
+interface NumericInputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "onChange" | "value" | "type" | "inputMode" | "defaultValue"
+> {
+  value: string;
+  onChange: (value: string) => void;
+  allowNegative?: boolean;
+}
+
+export default function NumericInput({
+  value,
+  onChange,
+  allowNegative = false,
+  ...rest
+}: NumericInputProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    const regex = allowNegative ? /^-?\d*$/ : /^\d*$/;
+
+    if (regex.test(newValue)) onChange(newValue);
+  };
+
+  return (
+    <input
+      type="text"
+      inputMode="numeric"
+      value={value}
+      onChange={handleChange}
+      {...rest}
+    />
+  );
+}

--- a/ui-react/apps/console/src/pages/AddDevice.tsx
+++ b/ui-react/apps/console/src/pages/AddDevice.tsx
@@ -20,6 +20,8 @@ import {
 } from "@heroicons/react/24/outline";
 import { DockerIcon } from "../components/icons";
 import CopyButton from "../components/common/CopyButton";
+import { INPUT } from "../utils/styles";
+import NumericInput from "@/components/common/NumericInput";
 
 /* ─── Types ─── */
 type Method
@@ -121,8 +123,6 @@ const METHODS: MethodInfo[] = [
   },
 ];
 
-import { INPUT } from "../utils/styles";
-
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
 
@@ -135,6 +135,7 @@ export default function AddDevice() {
   const [hostname, setHostname] = useState("");
   const [identity, setIdentity] = useState("");
   const [keepaliveInterval, setKeepaliveInterval] = useState("");
+  const keepaliveIntervalError = keepaliveInterval && parseInt(keepaliveInterval, 10) < 1 ? "Interval must be a positive number" : "";
 
   const selectedMethod = METHODS.find((m) => m.id === method)!;
   const baseMethods = METHODS.slice(0, INITIAL_VISIBLE);
@@ -154,7 +155,7 @@ export default function AddDevice() {
     parts.push(`SERVER_ADDRESS=${origin}`);
     if (hostname.trim()) parts.push(`PREFERRED_HOSTNAME=${hostname.trim()}`);
     if (identity.trim()) parts.push(`PREFERRED_IDENTITY=${identity.trim()}`);
-    if (keepaliveInterval.trim())
+    if (keepaliveInterval.trim() && !keepaliveIntervalError)
       parts.push(`KEEPALIVE_INTERVAL=${keepaliveInterval.trim()}`);
     parts.push("sh");
     return parts.join(" ");
@@ -416,18 +417,21 @@ export default function AddDevice() {
                     (optional)
                   </span>
                 </label>
-                <input
-                  type="number"
-                  min="1"
+                <NumericInput
                   value={keepaliveInterval}
-                  onChange={(e) => setKeepaliveInterval(e.target.value)}
+                  onChange={setKeepaliveInterval}
                   placeholder="30"
                   className={INPUT}
                 />
-                <p className="text-2xs text-text-muted/60 mt-1">
-                  Interval in seconds between keep-alive messages sent by the
-                  agent. Defaults to 30.
-                </p>
+                {!keepaliveIntervalError
+                ? <p className="text-2xs text-text-muted/60 mt-1">
+                    Interval in seconds between keep-alive messages sent by the
+                    agent. Defaults to 30.
+                  </p>
+                : <p className="text-2xs text-accent-red mt-1">
+                    {keepaliveIntervalError}
+                  </p>
+                }
               </div>
             </div>
           )}

--- a/ui-react/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui-react/apps/console/src/pages/WebEndpoints.tsx
@@ -1,19 +1,20 @@
 import { useState, useRef, useEffect, FormEvent } from "react";
-import { isSdkError } from "../api/errors";
-import { useResetOnOpen } from "../hooks/useResetOnOpen";
-import { useWebEndpoints } from "../hooks/useWebEndpoints";
+import { isSdkError } from "@/api/errors";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useWebEndpoints } from "@/hooks/useWebEndpoints";
 import {
   useCreateWebEndpoint,
   useDeleteWebEndpoint,
-} from "../hooks/useWebEndpointMutations";
-import type { Webendpoint } from "../client";
-import { useDevices, type NormalizedDevice } from "../hooks/useDevices";
-import PageHeader from "../components/common/PageHeader";
-import Drawer from "../components/common/Drawer";
-import ConfirmDialog from "../components/common/ConfirmDialog";
-import { formatDate } from "../utils/date";
-import { LABEL, INPUT_MONO } from "../utils/styles";
-import { useClickOutside } from "../hooks/useClickOutside";
+} from "@/hooks/useWebEndpointMutations";
+import type { Webendpoint } from "@/client";
+import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
+import PageHeader from "@/components/common/PageHeader";
+import Drawer from "@/components/common/Drawer";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
+import NumericInput from "@/components/common/NumericInput";
+import { formatDate } from "@/utils/date";
+import { LABEL, INPUT_MONO } from "@/utils/styles";
+import { useClickOutside } from "@/hooks/useClickOutside";
 import {
   XMarkIcon,
   ServerStackIcon,
@@ -27,7 +28,7 @@ import {
   PlusIcon,
   MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
-import RestrictedAction from "../components/common/RestrictedAction";
+import RestrictedAction from "@/components/common/RestrictedAction";
 
 /* ─── Constants ─── */
 
@@ -212,29 +213,30 @@ function TimeoutSelector({
   onChange,
   onErrorChange,
 }: {
-  value: number;
+  value: string;
   error: string | null;
-  onChange: (v: number) => void;
+  onChange: (v: string) => void;
   onErrorChange: (error: string | null) => void;
 }) {
-  const hasExpiration = value !== -1;
+  const hasExpiration = value !== "-1";
+  const numValue = parseInt(value, 10);
   const [isEditingCustom, setIsEditingCustom] = useState(false);
 
   const handleToggle = () => {
-    onChange(hasExpiration ? -1 : 3600);
+    onChange(hasExpiration ? "-1" : "3600");
     setIsEditingCustom(false);
     onErrorChange(null);
   };
 
   const handleCustomValueChange = (inputValue: string) => {
-    const numValue = parseInt(inputValue, 10);
+    onChange(inputValue);
 
-    let customError = null;
+    const numValue = parseInt(inputValue, 10);
+    let customError: string | null = null;
     if (isNaN(numValue) || numValue < 1) customError = "Must be at least 1 second";
     else if (numValue > MAX_CUSTOM_TTL) customError = `Maximum is ${MAX_CUSTOM_TTL}`;
 
     onErrorChange(customError);
-    if (!customError) onChange(numValue);
   };
 
   return (
@@ -262,10 +264,10 @@ function TimeoutSelector({
                 onClick={() => {
                   setIsEditingCustom(false);
                   onErrorChange(null);
-                  onChange(preset.value);
+                  onChange(String(preset.value));
                 }}
                 className={`px-2.5 py-1.5 text-xs rounded-md border transition-all ${
-                  !isEditingCustom && preset.value === value
+                  !isEditingCustom && preset.value === numValue
                     ? "bg-primary/10 border-primary/30 text-primary font-medium"
                     : "bg-card border-border text-text-secondary hover:border-border-light hover:text-text-primary"
                 }`}
@@ -291,13 +293,10 @@ function TimeoutSelector({
 
           {isEditingCustom && (
             <div>
-              <input
-                type="number"
-                defaultValue={value}
-                onChange={(e) => handleCustomValueChange(e.target.value)}
+              <NumericInput
+                value={value}
+                onChange={handleCustomValueChange}
                 placeholder="Value in seconds"
-                min={1}
-                max={MAX_CUSTOM_TTL}
                 className={INPUT_MONO}
                 autoFocus
               />
@@ -330,7 +329,7 @@ function EndpointDrawer({
   const [hostMode, setHostMode] = useState<"localhost" | "custom">("localhost");
   const [host, setHost] = useState("127.0.0.1");
   const [port, setPort] = useState("");
-  const [ttl, setTtl] = useState(-1);
+  const [ttl, setTtl] = useState("-1");
   const [ttlError, setTtlError] = useState<string | null>(null);
   const [tlsEnabled, setTlsEnabled] = useState(false);
   const [tlsVerify, setTlsVerify] = useState(false);
@@ -343,7 +342,7 @@ function EndpointDrawer({
     setHostMode("localhost");
     setHost("127.0.0.1");
     setPort("");
-    setTtl(-1);
+    setTtl("-1");
     setTtlError(null);
     setTlsEnabled(false);
     setTlsVerify(false);
@@ -386,7 +385,7 @@ function EndpointDrawer({
           uid: device.uid,
           host: host.trim(),
           port: portNum,
-          ttl,
+          ttl: parseInt(ttl, 10),
           ...(tlsEnabled
             ? {
                 tls: {
@@ -507,13 +506,10 @@ function EndpointDrawer({
                     className={`${INPUT_MONO} opacity-60 cursor-default`}
                     tabIndex={-1}
                   />
-                  <input
-                    type="number"
+                  <NumericInput
                     value={port}
-                    onChange={(e) => setPort(e.target.value)}
+                    onChange={setPort}
                     placeholder="Port"
-                    min={1}
-                    max={65535}
                     className={INPUT_MONO}
                   />
                   {portError && (
@@ -573,13 +569,10 @@ function EndpointDrawer({
                     className={INPUT_MONO}
                     autoFocus
                   />
-                  <input
-                    type="number"
+                  <NumericInput
                     value={port}
-                    onChange={(e) => setPort(e.target.value)}
+                    onChange={setPort}
                     placeholder="Port"
-                    min={1}
-                    max={65535}
                     className={INPUT_MONO}
                   />
                   {hostError && (
@@ -957,7 +950,11 @@ function WebEndpointsContent() {
                     onClick={openNew}
                     className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   >
-                    <PlusIcon className="w-4 h-4" strokeWidth={2} aria-hidden="true" />
+                    <PlusIcon
+                      className="w-4 h-4"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    />
                     Create your first endpoint
                   </button>
                 </RestrictedAction>
@@ -982,7 +979,11 @@ function WebEndpointsContent() {
                 onClick={openNew}
                 className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
-                <PlusIcon className="w-4 h-4" strokeWidth={2} aria-hidden="true" />
+                <PlusIcon
+                  className="w-4 h-4"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
                 New Endpoint
               </button>
             </RestrictedAction>

--- a/ui-react/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
@@ -5,6 +5,7 @@ import { isSdkError } from "@/api/errors";
 import Drawer from "@/components/common/Drawer";
 import { LABEL, INPUT } from "@/utils/styles";
 import type { Namespace } from "@/client";
+import NumericInput from "@/components/common/NumericInput";
 
 interface EditNamespaceDrawerProps {
   open: boolean;
@@ -20,20 +21,23 @@ export default function EditNamespaceDrawer({
   const editNamespace = useAdminEditNamespace();
 
   const [name, setName] = useState("");
-  const [maxDevices, setMaxDevices] = useState(-1);
+  const [maxDevices, setMaxDevices] = useState(() =>
+    String(namespace?.max_devices ?? -1),
+  );
   const [sessionRecord, setSessionRecord] = useState(false);
   const [deviceAutoAccept, setDeviceAutoAccept] = useState(false);
   const [error, setError] = useState("");
 
   useResetOnOpen(open, () => {
     setName(namespace?.name ?? "");
-    setMaxDevices(namespace?.max_devices ?? -1);
+    setMaxDevices(String(namespace?.max_devices ?? -1));
     setSessionRecord(namespace?.settings?.session_record ?? false);
     setDeviceAutoAccept(namespace?.settings?.device_auto_accept ?? false);
     setError("");
   });
 
-  const canSubmit = name.trim().length > 0;
+  const isMaxDevicesValid = parseInt(maxDevices, 10) >= -1;
+  const canSubmit = name.trim().length > 0 && isMaxDevicesValid;
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
@@ -47,12 +51,12 @@ export default function EditNamespaceDrawer({
         body: {
           ...namespace,
           name: name.trim(),
-          max_devices: maxDevices,
+          max_devices: parseInt(maxDevices, 10),
           settings: {
             connection_announcement:
               namespace.settings?.connection_announcement ?? "",
             session_record: sessionRecord,
-              device_auto_accept: deviceAutoAccept,
+            device_auto_accept: deviceAutoAccept,
           },
         },
       });
@@ -76,7 +80,7 @@ export default function EditNamespaceDrawer({
           <span className="font-mono">{namespace.name}</span>
         ) : undefined
       }
-      footer={(
+      footer={
         <>
           <button
             type="button"
@@ -99,7 +103,7 @@ export default function EditNamespaceDrawer({
             Save Changes
           </button>
         </>
-      )}
+      }
     >
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
         <div>
@@ -120,20 +124,22 @@ export default function EditNamespaceDrawer({
           <label className={LABEL} htmlFor="edit-ns-max-devices">
             Max Devices
           </label>
-          <input
+          <NumericInput
             id="edit-ns-max-devices"
-            type="number"
             value={maxDevices}
-            onChange={(e) => {
-              const parsed = parseInt(e.target.value, 10);
-              setMaxDevices(Number.isNaN(parsed) ? -1 : parsed);
-            }}
-            min={-1}
+            onChange={setMaxDevices}
+            allowNegative
             className={INPUT}
           />
-          <p className="text-2xs text-text-muted mt-1.5">
-            Use -1 for unlimited devices
-          </p>
+          {isMaxDevicesValid ? (
+            <p className="text-2xs text-text-muted mt-1.5">
+              Use -1 for unlimited devices
+            </p>
+          ) : (
+            <p className="text-2xs text-accent-red mt-1.5">
+              Max devices must be a number greater than or equal to -1
+            </p>
+          )}
         </div>
 
         <label className="flex items-center gap-2 cursor-pointer">

--- a/ui-react/apps/console/src/pages/admin/namespaces/__tests__/EditNamespaceDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/__tests__/EditNamespaceDrawer.test.tsx
@@ -113,7 +113,7 @@ describe("EditNamespaceDrawer", () => {
 
     it("pre-fills the Max Devices field with the namespace max_devices", () => {
       renderDrawer();
-      expect(screen.getByLabelText(/^max devices$/i)).toHaveValue(10);
+      expect(screen.getByLabelText(/^max devices$/i)).toHaveValue("10");
     });
 
     it("pre-fills Session Recording checkbox as checked when session_record is true", () => {
@@ -135,7 +135,7 @@ describe("EditNamespaceDrawer", () => {
       renderDrawer({
         namespace: { ...mockNamespace, max_devices: -1 },
       });
-      expect(screen.getByLabelText(/^max devices$/i)).toHaveValue(-1);
+      expect(screen.getByLabelText(/^max devices$/i)).toHaveValue("-1");
     });
   });
 
@@ -394,7 +394,7 @@ describe("EditNamespaceDrawer", () => {
 
     it("renders the drawer with max_devices of -1 when namespace is null", () => {
       renderDrawer({ namespace: null });
-      expect(screen.getByLabelText(/^max devices$/i)).toHaveValue(-1);
+      expect(screen.getByLabelText(/^max devices$/i)).toHaveValue("-1");
     });
 
     it("renders the Session Recording checkbox unchecked when namespace is null", () => {

--- a/ui-react/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
@@ -7,6 +7,7 @@ import Drawer from "@/components/common/Drawer";
 import { LABEL, INPUT } from "@/utils/styles";
 import PasswordInput from "./PasswordInput";
 import NamespaceLimitFields from "./NamespaceLimitFields";
+import { isMaxNamespacesValid } from "@/utils/validation";
 
 interface CreateUserDrawerProps {
   open: boolean;
@@ -26,7 +27,7 @@ export default function CreateUserDrawer({
   const [admin, setAdmin] = useState(false);
   const [limitEnabled, setLimitEnabled] = useState(false);
   const [limitDisabled, setLimitDisabled] = useState(false);
-  const [maxNamespaces, setMaxNamespaces] = useState(1);
+  const [maxNamespaces, setMaxNamespaces] = useState("1");
   const [error, setError] = useState("");
 
   useResetOnOpen(open, () => {
@@ -37,18 +38,22 @@ export default function CreateUserDrawer({
     setAdmin(false);
     setLimitEnabled(false);
     setLimitDisabled(false);
-    setMaxNamespaces(1);
+    setMaxNamespaces("1");
     setError("");
   });
 
   const computeMaxNamespaces = (): number | undefined => {
     if (!limitEnabled) return undefined;
     if (limitDisabled) return 0;
-    return maxNamespaces;
+    return parseInt(maxNamespaces, 10);
   };
 
-  const canSubmit
-    = name.trim() && username.trim() && email.trim() && password.trim();
+  const canSubmit =
+    name.trim() &&
+    username.trim() &&
+    email.trim() &&
+    password.trim() &&
+    isMaxNamespacesValid(limitEnabled, limitDisabled, maxNamespaces);
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
@@ -80,7 +85,7 @@ export default function CreateUserDrawer({
       open={open}
       onClose={onClose}
       title="Create User"
-      footer={(
+      footer={
         <>
           <button
             type="button"
@@ -105,7 +110,7 @@ export default function CreateUserDrawer({
             Create User
           </button>
         </>
-      )}
+      }
     >
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
         {/* Name */}

--- a/ui-react/apps/console/src/pages/admin/users/EditUserDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/EditUserDrawer.tsx
@@ -7,6 +7,7 @@ import Drawer from "@/components/common/Drawer";
 import { LABEL, INPUT } from "@/utils/styles";
 import PasswordInput from "./PasswordInput";
 import NamespaceLimitFields from "./NamespaceLimitFields";
+import { isMaxNamespacesValid } from "@/utils/validation";
 import type { UserStatus } from "./UserStatusChip";
 
 export interface EditableUser {
@@ -41,7 +42,7 @@ export default function EditUserDrawer({
   const [admin, setAdmin] = useState(false);
   const [limitEnabled, setLimitEnabled] = useState(false);
   const [limitDisabled, setLimitDisabled] = useState(false);
-  const [maxNamespaces, setMaxNamespaces] = useState(1);
+  const [maxNamespaces, setMaxNamespaces] = useState("1");
   const [error, setError] = useState("");
 
   useResetOnOpen(open, () => {
@@ -56,11 +57,11 @@ export default function EditUserDrawer({
     if (maxNs !== undefined && maxNs >= 0) {
       setLimitEnabled(true);
       setLimitDisabled(maxNs === 0);
-      setMaxNamespaces(maxNs || 1);
+      setMaxNamespaces(String(maxNs || 1));
     } else {
       setLimitEnabled(false);
       setLimitDisabled(false);
-      setMaxNamespaces(1);
+      setMaxNamespaces("1");
     }
 
     setError("");
@@ -76,10 +77,14 @@ export default function EditUserDrawer({
       return orig !== undefined && orig < 0 ? orig : undefined;
     }
     if (limitDisabled) return 0;
-    return maxNamespaces;
+    return parseInt(maxNamespaces, 10);
   };
 
-  const canSubmit = name.trim() && username.trim() && email.trim();
+  const canSubmit =
+    name.trim() &&
+    username.trim() &&
+    email.trim() &&
+    isMaxNamespacesValid(limitEnabled, limitDisabled, maxNamespaces);
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
@@ -116,7 +121,7 @@ export default function EditUserDrawer({
       subtitle={
         user ? <span className="font-mono">{user.username}</span> : undefined
       }
-      footer={(
+      footer={
         <>
           <button
             type="button"
@@ -139,7 +144,7 @@ export default function EditUserDrawer({
             Save Changes
           </button>
         </>
-      )}
+      }
     >
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
         {/* Name */}

--- a/ui-react/apps/console/src/pages/admin/users/NamespaceLimitFields.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/NamespaceLimitFields.tsx
@@ -1,4 +1,6 @@
+import NumericInput from "@/components/common/NumericInput";
 import { LABEL, INPUT } from "@/utils/styles";
+import { isMaxNamespacesValid } from "@/utils/validation";
 
 interface NamespaceLimitFieldsProps {
   idPrefix: string;
@@ -6,8 +8,8 @@ interface NamespaceLimitFieldsProps {
   onLimitEnabledChange: (v: boolean) => void;
   limitDisabled: boolean;
   onLimitDisabledChange: (v: boolean) => void;
-  maxNamespaces: number;
-  onMaxNamespacesChange: (v: number) => void;
+  maxNamespaces: string;
+  onMaxNamespacesChange: (v: string) => void;
 }
 
 export default function NamespaceLimitFields({
@@ -19,6 +21,12 @@ export default function NamespaceLimitFields({
   maxNamespaces,
   onMaxNamespacesChange,
 }: NamespaceLimitFieldsProps) {
+  const valid = isMaxNamespacesValid(
+    limitEnabled,
+    limitDisabled,
+    maxNamespaces,
+  );
+
   return (
     <div className="space-y-3">
       <label className="flex items-center gap-2 cursor-pointer">
@@ -50,15 +58,17 @@ export default function NamespaceLimitFields({
               <label className={LABEL} htmlFor={`${idPrefix}-max-ns`}>
                 Max namespaces
               </label>
-              <input
+              <NumericInput
                 id={`${idPrefix}-max-ns`}
-                type="number"
-                min={1}
                 value={maxNamespaces}
-                onChange={(e) =>
-                  onMaxNamespacesChange(parseInt(e.target.value, 10) || 1)}
+                onChange={onMaxNamespacesChange}
                 className={`${INPUT} w-32`}
               />
+              {!valid && (
+                <p className="text-2xs text-accent-red mt-1.5">
+                  Max namespaces must be a number greater than or equal to 1
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/ui-react/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
@@ -19,6 +19,7 @@ import {
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { DevicesIcon as DevicesIconComponent } from "@/components/icons";
+import NumericInput from "@/components/common/NumericInput";
 
 /* ─── Icons ─── */
 const UsersIcon = <UserGroupIcon className="w-4 h-4" />;
@@ -212,11 +213,9 @@ export default function RuleDrawer({
         {/* Priority */}
         <div>
           <label className={LABEL}>Priority</label>
-          <input
-            type="number"
-            min={1}
+          <NumericInput
             value={priority}
-            onChange={(e) => setPriority(e.target.value)}
+            onChange={setPriority}
             placeholder="e.g. 100"
             autoFocus={open}
             className={INPUT}

--- a/ui-react/apps/console/src/utils/validation.ts
+++ b/ui-react/apps/console/src/utils/validation.ts
@@ -3,3 +3,11 @@ export function validatePassword(value: string): string | null {
     return "Password must be 5–32 characters long";
   return null;
 }
+
+export function isMaxNamespacesValid(
+  limitEnabled: boolean,
+  limitDisabled: boolean,
+  maxNamespaces: string,
+): boolean {
+  return !limitEnabled || limitDisabled || parseInt(maxNamespaces, 10) >= 1;
+}


### PR DESCRIPTION
## What

Adds a `NumericInput` wrapper component and migrates the seven existing `<input type="number">` sites to it. The wrapper renders `<input type="text" inputMode="numeric">` and filters non-digit input via regex on every change event, eliminating the `<input type="number">` quirks that were leaking into the UI.

## Why

`<input type="number">` admits scientific notation (`e`/`E`), unintended sign keys, decimals, and exposes a native spinner. None of these were desired by any of the existing call sites — every one of them constrained values to positive integers (or `>= -1` with a sentinel). Browser-side `min`/`max` hints only fire on form submit, so users could type or paste invalid values and the parent state would reflect them mid-edit. The new wrapper rejects invalid input at the value-update step, covering paste and drag-drop as well as keystroke.

## Changes

- **NumericInput**: new wrapper at `@/components/common/NumericInput`. Accepts `value: string`, `onChange: (v: string) => void`, and an optional `allowNegative` flag. The regex (`^\d*$` or `^-?\d*$`) gates whether `onChange` propagates, so callers receive a string guaranteed to be digit-only.
- **WebEndpoints**: lifted `ttl` from `number` to `string` at the parent and parses on the way to the API, matching the wrapper's contract.
- **AddDevice**: replaced the `min="1"` browser hint with explicit inline validation that mirrors `RuleDrawer`'s priority pattern. The keepalive interval is dropped from the generated command when invalid, so the agent falls back to its own default.
- **NamespaceLimitFields + CreateUserDrawer + EditUserDrawer**: lifted `maxNamespaces` from `number` to `string`. Extracted `isMaxNamespacesValid` to `utils/validation.ts` so the component renders an inline error and both parent drawers gate `canSubmit` through the same predicate.
- **EditNamespaceDrawer**: lifted `maxDevices` to `string`, added an inline error when the value falls outside \`[-1, ∞)\`, lazy-initialized state from the namespace prop to avoid a one-frame error flash on open. Tests updated to assert string values.
- **RuleDrawer**: drop-in swap; existing `priorityError` covered all wrapper-permitted intermediate states.

## Testing

Spot-check each migrated input by typing `e`, `E`, `+`, `-`, `.`, and pasting `1e10` — none should be accepted. Submit should be blocked while the field is invalid (empty, `0`, lone `-`, out-of-range). For WebEndpoints, exercise the toggle, all preset buttons, and the Custom path; confirm that submitting with "No expiration" still works (the `-1` default state). For EditNamespaceDrawer, opening with an existing namespace must show its `max_devices` immediately without flashing the red error message.