### PR TITLE
fix(console): validate add member email

### DIFF
--- a/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
@@ -7,6 +7,8 @@ import { LABEL, INPUT } from "@/utils/styles";
 import { RoleSelector } from "./constants";
 import { type AssignableRole } from "./helpers";
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 /* --- Add Member Drawer --- */
 
 function AddMemberDrawer({
@@ -22,23 +24,32 @@ function AddMemberDrawer({
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<AssignableRole>("operator");
   const [submitting, setSubmitting] = useState(false);
+  const [emailError, setEmailError] = useState("");
   const [error, setError] = useState("");
 
   useResetOnOpen(open, () => {
     setEmail("");
     setRole("operator");
+    setEmailError("");
     setError("");
   });
 
+  const trimmedEmail = email.trim();
+  const emailValid = EMAIL_REGEX.test(trimmedEmail);
+
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
-    if (!email.trim()) return;
+    if (!emailValid) {
+      setEmailError("Enter a valid email address.");
+      return;
+    }
     setSubmitting(true);
+    setEmailError("");
     setError("");
     try {
       await addMember.mutateAsync({
         path: { tenant: tenantId },
-        body: { email: email.trim(), role },
+        body: { email: trimmedEmail, role },
       });
       onClose();
     } catch {
@@ -64,7 +75,7 @@ function AddMemberDrawer({
           </button>
           <button
             onClick={() => void handleSubmit()}
-            disabled={!email.trim() || submitting}
+            disabled={!emailValid || submitting}
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting
@@ -81,18 +92,37 @@ function AddMemberDrawer({
     >
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
         <div>
-          <label className={LABEL}>Email</label>
+          <label className={LABEL} htmlFor="add-member-email">
+            Email
+          </label>
           <input
+            id="add-member-email"
             type="email"
             value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              if (emailError) setEmailError("");
+            }}
             placeholder="user@example.com"
             autoFocus={open}
-            className={INPUT}
+            className={`${INPUT} ${emailError ? "border-accent-red/60 focus:border-accent-red/60 focus:ring-accent-red/20" : ""}`}
+            aria-invalid={!!emailError}
+            aria-describedby={
+              emailError ? "add-member-email-error" : undefined
+            }
           />
-          <p className="text-2xs text-text-muted mt-1.5">
-            Must have an existing ShellHub account
-          </p>
+          {emailError ? (
+            <p
+              id="add-member-email-error"
+              className="mt-1.5 text-2xs text-accent-red"
+            >
+              {emailError}
+            </p>
+          ) : (
+            <p className="text-2xs text-text-muted mt-1.5">
+              Must have an existing ShellHub account
+            </p>
+          )}
         </div>
         <div>
           <label className={LABEL}>Role</label>

--- a/ui-react/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import AddMemberDrawer from "../AddMemberDrawer";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const mockAddMemberMutateAsync = vi.fn();
+
+vi.mock("../../../hooks/useMemberMutations", () => ({
+  useAddMember: () => ({
+    mutateAsync: mockAddMemberMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../../../components/common/Drawer", () => ({
+  default: ({
+    open,
+    onClose,
+    title,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) => {
+    if (!open) return null;
+    return (
+      <div role="dialog" aria-label={title}>
+        <h2>{title}</h2>
+        <button onClick={onClose}>Close</button>
+        {children}
+        {footer ?? null}
+      </div>
+    );
+  },
+}));
+
+vi.mock("../../../utils/styles", () => ({
+  LABEL: "label",
+  INPUT: "input",
+}));
+
+/* ------------------------------------------------------------------ */
+/* Setup                                                               */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAddMemberMutateAsync.mockResolvedValue({});
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("AddMemberDrawer", () => {
+  it("blocks invalid emails and shows an inline validation error", async () => {
+    const user = userEvent.setup();
+    render(<AddMemberDrawer open onClose={vi.fn()} tenantId="t1" />);
+
+    const input = screen.getByPlaceholderText(/user@example.com/i);
+    await user.type(input, "foo");
+    expect(screen.getByRole("button", { name: /add member/i })).toBeDisabled();
+
+    const form = input.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    expect(mockAddMemberMutateAsync).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/enter a valid email address/i),
+    ).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("submits trimmed valid email addresses", async () => {
+    const user = userEvent.setup();
+    render(<AddMemberDrawer open onClose={vi.fn()} tenantId="t1" />);
+
+    fireEvent.change(screen.getByPlaceholderText(/user@example.com/i), {
+      target: { value: "  alice@example.com  " },
+    });
+    await user.click(screen.getByRole("button", { name: /add member/i }));
+
+    await waitFor(() =>
+      expect(mockAddMemberMutateAsync).toHaveBeenCalledWith({
+        path: { tenant: "t1" },
+        body: { email: "alice@example.com", role: "operator" },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

  Fixes #6296.

  Adds client-side email validation to the Add Member drawer so invalid email strings are blocked before the API request is sent.

  ## Changes

  - Added the same email validation regex used by `InvitationDrawer`
  - Shows an inline `Enter a valid email address.` message for invalid input
  - Disables the Add Member button until the trimmed email is valid
  - Sends the trimmed email value to the add-member API
  - Added regression tests for invalid email blocking and trimmed valid submission

  ## Testing

  - `AddMemberDrawer.test.tsx` passes
  - `eslint src` passes via local ESLint binary
  - `tsc -b` passes
  - Vite production build passes

  Note: the full Vitest suite has unrelated existing failures in MFA/public-key/secure-vault tests; the new focused AddMemberDrawer tests pass.