### PR TITLE
fix(ssh): restore TLS-to-backend in web endpoint proxy

### DIFF
--- a/ssh/http/handlers.go
+++ b/ssh/http/handlers.go
@@ -1,6 +1,9 @@
 package http
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -125,15 +128,52 @@ func (h *Handlers) HandleHTTPProxy(c echo.Context) error {
 	defer logger.Trace("web endpoint connection doned")
 
 	req := c.Request()
-	req.Host = strings.Join([]string{address, h.Config.WebEndpointsDomain}, ".")
-	req.URL, err = url.Parse(path)
+	req.URL, err = url.Parse(fmt.Sprintf("http://%s:%d%s", endpoint.Host, endpoint.Port, path))
 	if err != nil {
 		logger.WithError(err).Error("failed to parse the path")
 
-		return c.JSON(http.StatusInternalServerError, NewMessageFromError(ErrDeviceTunnelReadResponse))
+		return c.JSON(http.StatusInternalServerError, NewMessageFromError(ErrDeviceTunnelParsePath))
 	}
 
-	if err := req.Write(conn); err != nil {
+	req.Host = strings.Join([]string{address, h.Config.WebEndpointsDomain}, ".")
+
+	// NOTE: When the endpoint is configured with TLS-to-backend, wrap the raw
+	// tunnel connection with a TLS client so the proxied HTTP request reaches
+	// the device as a TLS handshake plus encrypted payload. The SNI and the
+	// outgoing Host header are both set to endpoint.TLS.Domain so the backend
+	// can select the right virtual host and certificate. tls.Verify toggles
+	// system-CA validation.
+	transportConn := conn
+	if endpoint.TLS.Enabled {
+		cfg := &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			ServerName: endpoint.TLS.Domain,
+		}
+
+		if endpoint.TLS.Verify {
+			roots, err := x509.SystemCertPool()
+			if err != nil {
+				logger.WithError(err).Error("failed to load system CA pool")
+
+				return c.JSON(http.StatusInternalServerError, NewMessageFromError(ErrDeviceTunnelConnect))
+			}
+			cfg.RootCAs = roots
+		} else {
+			cfg.InsecureSkipVerify = true //nolint:gosec // intentional: user opted out of cert verification via TLS.Verify=false
+		}
+
+		tlsConn := tls.Client(conn, cfg)
+		if err := tlsConn.Handshake(); err != nil {
+			logger.WithError(err).Error("tls handshake to device failed")
+
+			return c.JSON(http.StatusInternalServerError, NewMessageFromError(ErrDeviceTunnelConnect))
+		}
+
+		transportConn = tlsConn
+		req.Host = endpoint.TLS.Domain
+	}
+
+	if err := req.Write(transportConn); err != nil {
 		logger.WithError(err).Error("failed to write the request to the agent")
 
 		return c.JSON(http.StatusInternalServerError, NewMessageFromError(ErrDeviceTunnelWriteRequest))
@@ -166,7 +206,7 @@ func (h *Handlers) HandleHTTPProxy(c echo.Context) error {
 	go func() {
 		defer wg.Done()
 
-		if _, err := io.Copy(conn, out); err != nil {
+		if _, err := io.Copy(transportConn, out); err != nil {
 			logger.WithError(err).Debug("in and out done returned a error")
 		}
 
@@ -176,7 +216,7 @@ func (h *Handlers) HandleHTTPProxy(c echo.Context) error {
 	go func() {
 		defer wg.Done()
 
-		if _, err := io.Copy(out, conn); err != nil {
+		if _, err := io.Copy(out, transportConn); err != nil {
 			logger.WithError(err).Debug("out and in done returned a error")
 		}
 


### PR DESCRIPTION
Closes #6316.

## What

Reintroduces the TLS-to-backend block in `ssh/http/handlers.go::HandleHTTPProxy` that was silently lost when `ssh/pkg/tunnel/tunnel.go` was deleted during the agent V2 multistream refactor. Until this lands, the `tls.enabled` / `tls.verify` / `tls.domain` fields captured by the UI and persisted by the API have no effect at runtime.

## Behavior change

- When `endpoint.TLS.Enabled` is true, the proxy now wraps the raw tunnel `net.Conn` returned by `Dialer.DialTo` with `tls.Client`. SNI and the outgoing `Host` header are set to `endpoint.TLS.Domain`. `endpoint.TLS.Verify` toggles `RootCAs = SystemCertPool()` vs `InsecureSkipVerify`.
- `req.URL` is now reconstructed as `http://<host>:<port>/<path>` so `req.Write` produces a complete request line. Scheme stays `http://` because `tls.Client` wraps the conn; the wire is TLS regardless of the URL scheme.
- Backend-side TLS minimum is `tls.VersionTLS13`.
- When TLS is disabled, behavior is unchanged: `Host` stays as `<address>.<endpoints_domain>`, no TLS wrap.

## Verification

Reproduced and validated end-to-end against a local stack with a Python backend serving HTTP on 9080 and HTTPS on 9443. Both backends respond `200` only when `Host: app.local`, otherwise `302 Location: https://app.local/...`.

| Endpoint | Target | TLS Domain | Before this PR | After this PR |
|---|---|---|---|---|
| A | `127.0.0.1:9080` (HTTP) | n/a | `302 -> https://app.local` (canonical redirect, expected) | unchanged: `302 -> https://app.local` |
| B | `127.0.0.1:9443` (HTTPS), `tls.enabled=true`, `tls.domain=app.local` | `app.local` | `504 Gateway Time-out` (proxy wrote cleartext to TLS socket) | `200 OK`, backend logs `Host: app.local` |

Backend log after the fix on scenario B:

```
[HTTPS:9443] GET /foo (Host='app.local')
    Host: app.local
    ...
-> 200 (Host matched 'app.local')
```

## Out of scope (separate issues)

- shellhub-io/shellhub#6319 (allow Host override independent of TLS so HTTP-plain backends that validate canonical hostname also work)
- shellhub-io/cloud#2368 (web endpoint routes only registered in cloud branch, not enterprise-only)
- shellhub-io/cloud#2369 (`SHELLHUB_WEB_ENDPOINTS` not propagated to containers in dev mode)