### PR TITLE
feat(ssh): use tls.domain as Host override even when TLS is disabled

### DIFF
--- a/ssh/http/handlers.go
+++ b/ssh/http/handlers.go
@@ -137,12 +137,20 @@ func (h *Handlers) HandleHTTPProxy(c echo.Context) error {
 
 	req.Host = strings.Join([]string{address, h.Config.WebEndpointsDomain}, ".")
 
+	// NOTE: endpoint.TLS.Domain doubles as a Host-override hint and (when TLS
+	// is enabled) as the SNI used during the handshake. When non-empty, it
+	// rewrites the outgoing Host header so backends that validate Host or
+	// auto-redirect to a canonical hostname can be reached, even when the
+	// proxy-to-backend leg stays cleartext HTTP.
+	if endpoint.TLS.Domain != "" {
+		req.Host = endpoint.TLS.Domain
+	}
+
 	// NOTE: When the endpoint is configured with TLS-to-backend, wrap the raw
 	// tunnel connection with a TLS client so the proxied HTTP request reaches
-	// the device as a TLS handshake plus encrypted payload. The SNI and the
-	// outgoing Host header are both set to endpoint.TLS.Domain so the backend
-	// can select the right virtual host and certificate. tls.Verify toggles
-	// system-CA validation.
+	// the device as a TLS handshake plus encrypted payload. SNI is set to
+	// endpoint.TLS.Domain so the backend can select the right virtual host
+	// and certificate. tls.Verify toggles system-CA validation.
 	transportConn := conn
 	if endpoint.TLS.Enabled {
 		cfg := &tls.Config{
@@ -170,7 +178,6 @@ func (h *Handlers) HandleHTTPProxy(c echo.Context) error {
 		}
 
 		transportConn = tlsConn
-		req.Host = endpoint.TLS.Domain
 	}
 
 	if err := req.Write(transportConn); err != nil {


### PR DESCRIPTION
Closes #6319.

## What

Decouples the Host rewrite from `endpoint.TLS.Enabled` in `ssh/http/handlers.go::HandleHTTPProxy`. When `endpoint.TLS.Domain` is non-empty, the outgoing Host header is set to that value regardless of whether TLS-to-backend is enabled. When TLS is enabled, the same value is used as SNI, as before.

## Why

Today the proxy only overrides Host inside the TLS branch. Backends served on plain HTTP that validate Host or auto-redirect to a canonical hostname (very common with internal admin panels and corporate apps) cannot be reached through a Web Endpoint, because they receive `Host: <address>.<endpoints_domain>` and respond with a `302` to their internal canonical hostname, which is not publicly resolvable. The `tls.domain` field already captures the value such backends expect; treating it as a Host hint independent of TLS makes that case work.

## Behavior matrix

| `tls.enabled` | `tls.domain` | Host sent to backend | Wire to backend |
|---|---|---|---|
| `true`  | non-empty | `tls.domain` (unchanged) | TLS with SNI=`tls.domain` (unchanged) |
| `false` | non-empty | `tls.domain` **(new)** | plain HTTP |
| `false` | empty | `<address>.<endpoints_domain>` (unchanged) | plain HTTP |
| `true`  | empty | rejected by service-layer validation (unchanged) | n/a |

## Verification

Validated end-to-end against a local stack with a Python backend on `127.0.0.1:9080` (plain HTTP) that returns `200` only when `Host: app.local`, otherwise `302 Location: https://app.local/...`. Three endpoints created via `POST /api/web-endpoints`:

| Scenario | `tls.enabled` | `tls.domain` | Result before this PR | Result after this PR |
|---|---|---|---|---|
| C | `false` | `app.local` | `302 Location: https://app.local` (host override never ran) | `200 OK`, backend logs `Host: app.local` |
| B (HTTPS 9443, regression check) | `true` | `app.local` | `200 OK` (already fixed by #6320) | `200 OK` (preserved) |
| D | `false` | empty | `302 Location: https://app.local` (default Host caused canonical redirect) | unchanged: `302 Location: https://app.local` |

## Notes

- The UI currently hides the `TLS Domain` field unless the `Enable TLS` toggle is on, and the create payload only includes `tls.domain` when `tls.enabled=true`. A UI/UX follow-up issue is filed separately to allow setting `tls.domain` independent of TLS, including renaming the field to reflect its expanded role.