### PR TITLE
fix(cli): improve namespace inspect member list display

### DIFF
--- a/cli/cmd/namespace.go
+++ b/cli/cmd/namespace.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/shellhub-io/shellhub/cli/pkg/inputs"
@@ -271,7 +273,7 @@ Devices:
   Removed:     %d
   Total:       %d
 
-Members: %d
+Members (%d):
 `,
 				ns.Name,
 				ns.Type,
@@ -286,13 +288,19 @@ Members: %d
 				len(ns.Members),
 			)
 
+			slices.SortFunc(ns.Members, func(a, b models.Member) int {
+				return strings.Compare(userMap[a.ID].Email, userMap[b.ID].Email)
+			})
+
+			w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 			for _, m := range ns.Members {
 				user, ok := userMap[m.ID]
 				if !ok {
 					return fmt.Errorf("member %s not found", m.ID)
 				}
-				fmt.Fprintf(out, "  %-12s (%s)\n", user.Username, m.Role)
+				fmt.Fprintf(w, "  %s\t%s\n", user.Email, m.Role)
 			}
+			w.Flush()
 
 			fmt.Fprintln(out, "\nLimits:")
 			if ns.MaxDevices == -1 {


### PR DESCRIPTION
## What changed?

Improved the member list display in `namespace inspect`:

- Members are now sorted alphabetically by email, matching the UI
- Replaced hardcoded `%-12s` padding with `tabwriter` for proper
  alignment with emails of any length
- Changed `Members: N` to `Members (N):` for consistency with the
  other section headers

## Why

With real client data, members with long emails or usernames caused
the role column to misalign. The ordering was also inconsistent with
the UI, which sorts members alphabetically by email.

## How to test

1. Start the environment with `./bin/docker-compose up -d`
2. Run `cli namespace inspect <namespace>` on a namespace with
   multiple members
3. Verify members appear sorted alphabetically by email
4. Verify the role column is aligned regardless of email length