### PR TITLE
fix(cli): fix namespace inspect device counts

### DIFF
--- a/cli/cmd/namespace.go
+++ b/cli/cmd/namespace.go
@@ -252,24 +252,23 @@ cli namespace inspect --tenant-id $(cli namespace ls -q tenant-id | sed -n '2p')
 				return fmt.Errorf("owner %s not found", ns.Owner)
 			}
 
-			totalDevices := ns.DevicesAcceptedCount +
-				ns.DevicesPendingCount +
-				ns.DevicesRejectedCount +
-				ns.DevicesRemovedCount
+			counts, err := service.NamespaceDeviceCounts(cmd.Context(), ns.TenantID)
+			if err != nil {
+				return err
+			}
 
 			fmt.Fprintf(out, `Namespace:
-  Name:        %s
-  Type:        %s
-  Owner:       %s
-  Tenant ID:   %s
-  Created At:  %s
+  Name         %s
+  Type         %s
+  Owner        %s
+  Tenant ID    %s
+  Created At   %s
 
 Devices:
-  Accepted:    %d
-  Pending:     %d
-  Rejected:    %d
-  Removed:     %d
-  Total:       %d
+  Accepted     %d
+  Online       %d
+  Pending      %d
+  Rejected     %d
 
 Members: %d
 `,
@@ -278,11 +277,10 @@ Members: %d
 				owner.Username,
 				ns.TenantID,
 				ns.CreatedAt.Format("2006-01-02"),
-				ns.DevicesAcceptedCount,
-				ns.DevicesPendingCount,
-				ns.DevicesRejectedCount,
-				ns.DevicesRemovedCount,
-				totalDevices,
+				counts.RegisteredDevices,
+				counts.OnlineDevices,
+				counts.PendingDevices,
+				counts.RejectedDevices,
 				len(ns.Members),
 			)
 
@@ -296,9 +294,9 @@ Members: %d
 
 			fmt.Fprintln(out, "\nLimits:")
 			if ns.MaxDevices == -1 {
-				fmt.Fprintln(out, "  Max Devices: unlimited")
+				fmt.Fprintln(out, "  Max Devices  unlimited")
 			} else {
-				fmt.Fprintf(out, "  Max Devices: %d\n", ns.MaxDevices)
+				fmt.Fprintf(out, "  Max Devices  %d\n", ns.MaxDevices)
 			}
 
 			return nil

--- a/cli/services/namespaces.go
+++ b/cli/services/namespaces.go
@@ -178,3 +178,8 @@ func (s *service) NamespaceResolve(ctx context.Context, resolver NamespaceResolv
 
 	return namespace, nil
 }
+
+// NamespaceDeviceCounts returns the actual device counts for a namespace.
+func (s *service) NamespaceDeviceCounts(ctx context.Context, tenantID string) (*models.Stats, error) {
+	return s.store.GetStats(ctx, tenantID)
+}

--- a/cli/services/services.go
+++ b/cli/services/services.go
@@ -49,6 +49,8 @@ type Services interface {
 	NamespaceAddMember(ctx context.Context, input *inputs.MemberAdd) (*models.Namespace, error)
 	// NamespaceRemoveMember removes a member from a namespace.
 	NamespaceRemoveMember(ctx context.Context, input *inputs.MemberRemove) (*models.Namespace, error)
+	// NamespaceDeviceCounts returns the actual device counts for a namespace.
+	NamespaceDeviceCounts(ctx context.Context, tenantID string) (*models.Stats, error)
 }
 
 // service is an internal struct that implements the Services interface.


### PR DESCRIPTION
## What changed?

Replaced the device count display in `namespace inspect` with
real-time counts from `store.GetStats`. Added online device count
and removed the total field to align with the UI.

## Why

The namespace document stores denormalized device counters that can
drift from reality, e.g. showing `Pending: -1` when the actual
count is 2. Querying counts directly from the store guarantees
accurate values.

## How to test

1. Start the environment with `./bin/docker-compose up -d`
2. Run `cli namespace inspect <namespace>` on a namespace with
   known device counts
3. Verify the counts match what the UI shows on the namespace
   dashboard