### PR TITLE
refactor(cli): move input validation to cmd layer and improve UX

### DIFF
--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"errors"
+)
+
+var (
+	ErrInvalidInput     = errors.New("invalid input")
+	ErrInvalidUsername  = errors.New("username must be between 3 and 32 characters and can only contain lowercase letters, numbers, and -_.@")
+	ErrInvalidPassword  = errors.New("password must be between 5 and 32 characters")
+	ErrInvalidEmail     = errors.New("email is invalid")
+	ErrInvalidNamespace = errors.New("namespace name is invalid")
+	ErrInvalidType      = errors.New("namespace type must be either 'personal' or 'team'")
+	ErrInvalidTenantID  = errors.New("tenant ID must be a valid UUID")
+)

--- a/cli/cmd/namespace.go
+++ b/cli/cmd/namespace.go
@@ -50,14 +50,18 @@ The owner must be a valid username within the system. If a tenant ID is provided
 			}
 
 			input := inputs.NamespaceCreate{
-				Namespace: args[0],
-				Owner:     args[1],
+				Namespace: strings.ToLower(args[0]),
+				Owner:     strings.ToLower(args[1]),
 				TenantID:  "",
-				Type:      namespaceType,
+				Type:      strings.ToLower(namespaceType),
 			}
 
 			if len(args) == 3 {
 				input.TenantID = args[2]
+			}
+
+			if err := validateInput(input); err != nil {
+				return err
 			}
 
 			namespace, err := service.NamespaceCreate(cmd.Context(), &input)
@@ -89,7 +93,11 @@ func namespaceDelete(service services.Services) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input := inputs.NamespaceDelete{
-				Namespace: args[0],
+				Namespace: strings.ToLower(args[0]),
+			}
+
+			if err := validateInput(input); err != nil {
+				return err
 			}
 
 			if err := service.NamespaceDelete(cmd.Context(), &input); err != nil {
@@ -231,7 +239,7 @@ cli namespace inspect --tenant-id $(cli namespace ls -q tenant-id | sed -n '2p')
 				resolver = services.NamespaceResolverTenantID
 				value = tenantID
 			} else {
-				value = args[0]
+				value = strings.ToLower(args[0])
 			}
 
 			ns, err := service.NamespaceResolve(cmd.Context(), resolver, value)
@@ -348,9 +356,13 @@ and the role indicates the permissions that the member will have within that nam
 			}
 
 			input := inputs.MemberAdd{
-				Username:  args[0],
-				Namespace: args[1],
+				Username:  strings.ToLower(args[0]),
+				Namespace: strings.ToLower(args[1]),
 				Role:      role,
+			}
+
+			if err := validateInput(input); err != nil {
+				return err
 			}
 
 			namespace, err := service.NamespaceAddMember(cmd.Context(), &input)
@@ -379,8 +391,12 @@ The username identifies the member to be removed, and the namespace specifies wh
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input := inputs.MemberRemove{
-				Username:  args[0],
-				Namespace: args[1],
+				Username:  strings.ToLower(args[0]),
+				Namespace: strings.ToLower(args[1]),
+			}
+
+			if err := validateInput(input); err != nil {
+				return err
 			}
 
 			namespace, err := service.NamespaceRemoveMember(cmd.Context(), &input)

--- a/cli/cmd/namespace_test.go
+++ b/cli/cmd/namespace_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamespaceCreateCmd(t *testing.T) {
+	cases := []struct {
+		description string
+		args        []string
+		expectedErr bool
+	}{
+		{
+			description: "fails when namespace is empty",
+			args:        []string{"", "john_doe"},
+			expectedErr: true,
+		},
+		{
+			description: "fails when namespace has invalid characters",
+			args:        []string{"invalid_namespace", "john_doe"},
+			expectedErr: true,
+		},
+		{
+			description: "fails when owner username is invalid",
+			args:        []string{"namespace", ""},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			cmd := NamespaceCommands(nil)
+			cmd.SetArgs(append([]string{"create"}, tc.args...))
+			err := cmd.Execute()
+
+			assert.Equal(t, tc.expectedErr, err != nil)
+		})
+	}
+}
+
+func TestNamespaceDeleteCmd(t *testing.T) {
+	cases := []struct {
+		description string
+		args        []string
+		expectedErr bool
+	}{
+		{
+			description: "fails when namespace is empty",
+			args:        []string{""},
+			expectedErr: true,
+		},
+		{
+			description: "fails when namespace has invalid characters",
+			args:        []string{"invalid_namespace"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			cmd := NamespaceCommands(nil)
+			cmd.SetArgs(append([]string{"delete"}, tc.args...))
+			err := cmd.Execute()
+
+			assert.Equal(t, tc.expectedErr, err != nil)
+		})
+	}
+}
+
+func TestMemberAddCmd(t *testing.T) {
+	cases := []struct {
+		description string
+		args        []string
+		expectedErr bool
+	}{
+		{
+			description: "fails when username is invalid",
+			args:        []string{"", "namespace", "observer"},
+			expectedErr: true,
+		},
+		{
+			description: "fails when role is invalid",
+			args:        []string{"john_doe", "namespace", "invalidrole"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			cmd := NamespaceCommands(nil)
+			cmd.SetArgs(append([]string{"member", "add"}, tc.args...))
+			err := cmd.Execute()
+
+			assert.Equal(t, tc.expectedErr, err != nil)
+		})
+	}
+}
+
+func TestMemberRemoveCmd(t *testing.T) {
+	cases := []struct {
+		description string
+		args        []string
+		expectedErr bool
+	}{
+		{
+			description: "fails when username is invalid",
+			args:        []string{"", "namespace"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			cmd := NamespaceCommands(nil)
+			cmd.SetArgs(append([]string{"member", "remove"}, tc.args...))
+			err := cmd.Execute()
+
+			assert.Equal(t, tc.expectedErr, err != nil)
+		})
+	}
+}

--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/shellhub-io/shellhub/cli/pkg/inputs"
@@ -42,10 +43,15 @@ The username must be unique, and the password must meet the system's security re
 cli user create john_doe Secret123!- john.doe@test.com --admin`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input := inputs.UserCreate{
-				Username: args[0],
+				// Normalize username and email to lowercase to avoid case-sensitive duplicates.
+				Username: strings.ToLower(args[0]),
 				Password: args[1],
-				Email:    args[2],
+				Email:    strings.ToLower(args[2]),
 				Admin:    admin,
+			}
+
+			if err := validateInput(input); err != nil {
+				return err
 			}
 
 			user, err := service.UserCreate(cmd.Context(), &input)
@@ -75,8 +81,12 @@ func userResetPassword(service services.Services) *cobra.Command {
 		Example: `cli user password john_doe Secret123!-`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input := inputs.UserUpdate{
-				Username: args[0],
+				Username: strings.ToLower(args[0]),
 				Password: args[1],
+			}
+
+			if err := validateInput(input); err != nil {
+				return err
 			}
 
 			if err := service.UserUpdate(cmd.Context(), &input); err != nil {
@@ -100,7 +110,11 @@ func userDelete(service services.Services) *cobra.Command {
 		Example: `cli user delete john_doe`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			input := inputs.UserDelete{
-				Username: args[0],
+				Username: strings.ToLower(args[0]),
+			}
+
+			if err := validateInput(input); err != nil {
+				return err
 			}
 
 			if err := service.UserDelete(cmd.Context(), &input); err != nil {

--- a/cli/cmd/user_test.go
+++ b/cli/cmd/user_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserCreateCmd(t *testing.T) {
+	cases := []struct {
+		description string
+		args        []string
+		expectedErr bool
+	}{
+		{
+			description: "fails when email is invalid",
+			args:        []string{"john_doe", "secret", "invalidmail.com"},
+			expectedErr: true,
+		},
+		{
+			description: "fails when username is invalid",
+			args:        []string{"", "secret", "john.doe@test.com"},
+			expectedErr: true,
+		},
+		{
+			description: "fails when password is invalid",
+			args:        []string{"john_doe", "ab", "john.doe@test.com"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			cmd := UserCommands(nil)
+			cmd.SetArgs(append([]string{"create"}, tc.args...))
+			err := cmd.Execute()
+
+			assert.Equal(t, tc.expectedErr, err != nil)
+		})
+	}
+}
+
+func TestUserResetPasswordCmd(t *testing.T) {
+	cases := []struct {
+		description string
+		args        []string
+		expectedErr bool
+	}{
+		{
+			description: "fails when username is invalid",
+			args:        []string{"", "secret"},
+			expectedErr: true,
+		},
+		{
+			description: "fails when password is invalid",
+			args:        []string{"john_doe", "ab"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			cmd := UserCommands(nil)
+			cmd.SetArgs(append([]string{"password"}, tc.args...))
+			err := cmd.Execute()
+
+			assert.Equal(t, tc.expectedErr, err != nil)
+		})
+	}
+}
+
+func TestUserDeleteCmd(t *testing.T) {
+	cases := []struct {
+		description string
+		args        []string
+		expectedErr bool
+	}{
+		{
+			description: "fails when username is invalid",
+			args:        []string{""},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			cmd := UserCommands(nil)
+			cmd.SetArgs(append([]string{"delete"}, tc.args...))
+			err := cmd.Execute()
+
+			assert.Equal(t, tc.expectedErr, err != nil)
+		})
+	}
+}

--- a/cli/cmd/validate.go
+++ b/cli/cmd/validate.go
@@ -1,0 +1,41 @@
+package cmd
+
+import "github.com/shellhub-io/shellhub/pkg/validator"
+
+// validateInput validates the provided input struct against its validation tags.
+// It returns an error if any field fails validation.
+func validateInput(input any) error {
+	v := validator.New()
+	ok, fields, err := v.StructWithFields(input)
+	if !ok || err != nil {
+		return mapValidationError(fields)
+	}
+
+	return nil
+}
+
+// mapValidationError maps a validation fields map returned by the validator to a
+// human-readable sentinel error based on the first failing field.
+func mapValidationError(fields map[string]any) error {
+	for _, field := range []string{"Username", "Owner", "Password", "Email", "Namespace", "TenantID", "Type"} {
+		if _, ok := fields[field]; !ok {
+			continue
+		}
+		switch field {
+		case "Username", "Owner":
+			return ErrInvalidUsername
+		case "Password":
+			return ErrInvalidPassword
+		case "Email":
+			return ErrInvalidEmail
+		case "Namespace":
+			return ErrInvalidNamespace
+		case "Type":
+			return ErrInvalidType
+		case "TenantID":
+			return ErrInvalidTenantID
+		}
+	}
+
+	return ErrInvalidInput
+}

--- a/cli/pkg/inputs/member.go
+++ b/cli/pkg/inputs/member.go
@@ -5,12 +5,12 @@ import "github.com/shellhub-io/shellhub/pkg/api/authorizer"
 // MemberAdd is a struct for handling input when adding a member.
 type MemberAdd struct {
 	Username  string `validate:"required,username"`
-	Namespace string
+	Namespace string `validate:"required,hostname_rfc1123,excludes=.,lowercase"`
 	Role      authorizer.Role
 }
 
 // MemberRemove is a struct for handling input when removing a member.
 type MemberRemove struct {
 	Username  string `validate:"required,username"`
-	Namespace string
+	Namespace string `validate:"required,hostname_rfc1123,excludes=.,lowercase"`
 }

--- a/cli/pkg/inputs/user.go
+++ b/cli/pkg/inputs/user.go
@@ -11,7 +11,7 @@ type UserCreate struct {
 // UserUpdate defines the structure for inputs when updating a user.
 type UserUpdate struct {
 	Username string `validate:"required,username"`
-	Password string
+	Password string `validate:"required,password"`
 }
 
 // UserDelete defines the structure for inputs when deleting a user.

--- a/cli/services/errors.go
+++ b/cli/services/errors.go
@@ -5,7 +5,6 @@ import (
 )
 
 var (
-	ErrInvalidFormat               = errors.New("invalid format")
 	ErrCreateNewUser               = errors.New("failed to create a new user")
 	ErrDuplicateNamespace          = errors.New("namespace already exists")
 	ErrUserNotFound                = errors.New("user not found")
@@ -14,12 +13,10 @@ var (
 	ErrFailedDeleteNamespace       = errors.New("failed to delete the namespace")
 	ErrFailedUpdateUser            = errors.New("failed to reset the password for the user")
 	ErrFailedNamespaceRemoveMember = errors.New("failed to remove member from the namespace")
-	ErrUserDataInvalid             = errors.New("user data is invalid")
 	ErrUserPasswordInvalid         = errors.New("user password is invalid")
 	ErrUserEmailExists             = errors.New("user email already exists")
 	ErrUserNameExists              = errors.New("user name already exists")
 	ErrUserNameAndEmailExists      = errors.New("user name and email already exists")
-	ErrNamespaceInvalid            = errors.New("namespace is invalid")
 	ErrFailedNamespaceAddMember    = errors.New("could not add this member to this namespace")
 	ErrUserUnhandledDuplicate      = errors.New("unhandled duplicated field for the user")
 	ErrFailedListNamespaces        = errors.New("failed to list namespaces")

--- a/cli/services/namespaces.go
+++ b/cli/services/namespaces.go
@@ -32,10 +32,6 @@ func (s *service) NamespaceCreate(ctx context.Context, input *inputs.NamespaceCr
 		input.TenantID = uuid.Generate()
 	}
 
-	if ok, err := s.validator.Struct(input); !ok || err != nil {
-		return nil, ErrNamespaceInvalid
-	}
-
 	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Owner))
 	if err != nil {
 		return nil, ErrUserNotFound
@@ -80,10 +76,6 @@ func (s *service) NamespaceCreate(ctx context.Context, input *inputs.NamespaceCr
 
 // NamespaceAddMember adds a new member with a specified role to a namespace.
 func (s *service) NamespaceAddMember(ctx context.Context, input *inputs.MemberAdd) (*models.Namespace, error) {
-	if ok, err := s.validator.Struct(input); !ok || err != nil {
-		return nil, ErrInvalidFormat
-	}
-
 	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Username))
 	if err != nil {
 		return nil, ErrUserNotFound
@@ -107,10 +99,6 @@ func (s *service) NamespaceAddMember(ctx context.Context, input *inputs.MemberAd
 
 // NamespaceRemoveMember removes a member from a namespace.
 func (s *service) NamespaceRemoveMember(ctx context.Context, input *inputs.MemberRemove) (*models.Namespace, error) {
-	if ok, err := s.validator.Struct(input); !ok || err != nil {
-		return nil, ErrInvalidFormat
-	}
-
 	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Username))
 	if err != nil {
 		return nil, ErrUserNotFound
@@ -135,10 +123,6 @@ func (s *service) NamespaceRemoveMember(ctx context.Context, input *inputs.Membe
 
 // NamespaceDelete deletes a namespace based on the provided namespace name.
 func (s *service) NamespaceDelete(ctx context.Context, input *inputs.NamespaceDelete) error {
-	if ok, err := s.validator.Struct(input); !ok || err != nil {
-		return ErrNamespaceInvalid
-	}
-
 	ns, err := s.store.NamespaceResolve(ctx, store.NamespaceNameResolver, strings.ToLower(input.Namespace))
 	if err != nil {
 		return ErrNamespaceNotFound

--- a/cli/services/namespaces_test.go
+++ b/cli/services/namespaces_test.go
@@ -42,30 +42,6 @@ func TestNamespaceCreate(t *testing.T) {
 		expected      Expected
 	}{
 		{
-			description:   "fails when namespace is not valid",
-			namespace:     "",
-			username:      "john_doe",
-			tenant:        "00000000-0000-4000-0000-000000000000",
-			typeNamespace: "",
-			requiredMocks: func() {
-				envMock := &env_mocks.Backend{}
-				envs.DefaultBackend = envMock
-			},
-			expected: Expected{nil, ErrNamespaceInvalid},
-		},
-		{
-			description:   "fails when namespace is not valid due name",
-			namespace:     "invalid_namespace",
-			username:      "john_doe",
-			tenant:        "00000000-0000-4000-0000-000000000000",
-			typeNamespace: "",
-			requiredMocks: func() {
-				envMock := &env_mocks.Backend{}
-				envs.DefaultBackend = envMock
-			},
-			expected: Expected{nil, ErrNamespaceInvalid},
-		},
-		{
 			description:   "fails when could not find a user",
 			namespace:     "namespace",
 			username:      "john_doe",

--- a/cli/services/services.go
+++ b/cli/services/services.go
@@ -6,7 +6,6 @@ import (
 	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/cli/pkg/inputs"
 	"github.com/shellhub-io/shellhub/pkg/models"
-	"github.com/shellhub-io/shellhub/pkg/validator"
 )
 
 const (
@@ -54,13 +53,11 @@ type Services interface {
 }
 
 // service is an internal struct that implements the Services interface.
-// It contains a store, which provides a mechanism to interact with the data store.
 type service struct {
-	store     store.Store
-	validator *validator.Validator
+	store store.Store
 }
 
 // NewService creates and returns a new instance of the service with the provided store.
 func NewService(store store.Store) Services {
-	return &service{store, validator.New()}
+	return &service{store}
 }

--- a/cli/services/users.go
+++ b/cli/services/users.go
@@ -14,16 +14,10 @@ import (
 // UserCreate adds a new user based on the provided user's data. This method validates data and
 // checks for conflicts.
 func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*models.User, error) {
-	// TODO: convert username and email to lower case.
 	userData := models.UserData{
 		Name:     input.Username,
 		Email:    input.Email,
 		Username: input.Username,
-	}
-
-	// TODO: validate this at cmd layer
-	if ok, err := s.validator.Struct(userData); !ok || err != nil {
-		return nil, ErrUserDataInvalid
 	}
 
 	if conflicts, has, _ := s.store.UserConflicts(ctx, &models.UserConflicts{Email: userData.Email, Username: userData.Username}); has {
@@ -44,11 +38,6 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 
 	password, err := models.HashUserPassword(input.Password)
 	if err != nil {
-		return nil, ErrUserPasswordInvalid
-	}
-
-	// TODO: validate this at cmd layer
-	if ok, err := s.validator.Struct(password); !ok || err != nil {
 		return nil, ErrUserPasswordInvalid
 	}
 
@@ -82,10 +71,6 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 
 // UserDelete removes a user and cleans up related data based on the provided username.
 func (s *service) UserDelete(ctx context.Context, input *inputs.UserDelete) error {
-	if ok, err := s.validator.Struct(input); !ok || err != nil {
-		return ErrUserDataInvalid
-	}
-
 	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Username))
 	if err != nil {
 		return ErrUserNotFound
@@ -121,10 +106,6 @@ func (s *service) UserDelete(ctx context.Context, input *inputs.UserDelete) erro
 
 // UserUpdate updates a user's data based on the provided username.
 func (s *service) UserUpdate(ctx context.Context, input *inputs.UserUpdate) error {
-	if ok, err := s.validator.Struct(input); !ok || err != nil {
-		return ErrUserDataInvalid
-	}
-
 	user, err := s.store.UserResolve(ctx, store.UserUsernameResolver, strings.ToLower(input.Username))
 	if err != nil {
 		return ErrUserNotFound
@@ -132,11 +113,6 @@ func (s *service) UserUpdate(ctx context.Context, input *inputs.UserUpdate) erro
 
 	password, err := models.HashUserPassword(input.Password)
 	if err != nil {
-		return ErrUserPasswordInvalid
-	}
-
-	// TODO: validate this at cmd layer
-	if ok, err := s.validator.Struct(password); !ok || err != nil {
 		return ErrUserPasswordInvalid
 	}
 

--- a/cli/services/users_test.go
+++ b/cli/services/users_test.go
@@ -42,24 +42,6 @@ func TestUserCreate(t *testing.T) {
 		expected      Expected
 	}{
 		{
-			description: "fails when email is invalid",
-			username:    "john_doe",
-			email:       "invalidmail.com",
-			password:    "secret",
-			requiredMocks: func() {
-			},
-			expected: Expected{nil, ErrUserDataInvalid},
-		},
-		{
-			description: "fails when username is invalid",
-			username:    "",
-			email:       "john.doe@test.com",
-			password:    "secret",
-			requiredMocks: func() {
-			},
-			expected: Expected{nil, ErrUserDataInvalid},
-		},
-		{
 			description: "fails when email is duplicated",
 			username:    "john_doe",
 			email:       "john.doe@test.com",


### PR DESCRIPTION
## What changed?

- Validation of all user and namespace inputs moved from the service
  layer to the cmd layer, where CLI input sanitization belongs.
- Username and email are normalized to lowercase in `UserCreate`
  before validation, so `TpoSe` is accepted and stored as `tpose`.
- Missing `validate` tags added to `UserUpdate.Password`,
  `MemberAdd.Namespace`, and `MemberRemove.Namespace`.
- A `validateInput` helper introduced in `cmd/validate.go` uses
  `StructWithFields` to map failing fields to specific sentinel errors
  defined in `cmd/errors.go`, replacing the generic
  `"invalid structure"` message with clear, field-specific feedback.
- The `validator` field removed from the `service` struct since it is
  no longer used in the service layer.
- Three unused sentinel errors removed from `services/errors.go`:
  `ErrInvalidFormat`, `ErrNamespaceInvalid`, `ErrUserDataInvalid`.
- Service-layer validation test cases removed from `users_test.go`
  and `namespaces_test.go`. New cmd-layer validation tests added in
  `cmd/user_test.go` and `cmd/namespace_test.go`.

## Why

The service layer should focus on business logic - conflict checks,
hashing, persistence. Validating raw CLI input there couples concerns
that don't belong together. Moving validation to the cmd layer also
enables proper user-facing error messages, since the service layer had
no way to produce field-specific feedback.

## How to test

1. Start the environment with `./bin/docker-compose up -d`
2. Run the automated tests:
   `./bin/docker-compose exec -T cli go test ./... -v`
3. Verify human-readable errors for invalid input:
   - `./bin/cli user create TpoSe ab notanemail` - should fail with
     a specific error per field
   - `./bin/cli user create TpoSe secret123 tpose@gmail.com` - should
     succeed, stored as `tpose`