### PR TITLE
fix(api): decode percent-encoded public key fingerprint path param

### DIFF
--- a/api/routes/middleware/params.go
+++ b/api/routes/middleware/params.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"net/url"
+
+	"github.com/labstack/echo/v4"
+)
+
+// DecodeParam URL-decodes the named path parameter in place before the handler runs.
+//
+// Echo's router does not unescape path parameters, so a percent-encoded segment
+// reaches handlers still escaped (e.g. a public key fingerprint whose colons are
+// sent as %3A). If the value is not valid percent-encoding it is left unchanged.
+func DecodeParam(param string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			for i, name := range c.ParamNames() {
+				if name != param {
+					continue
+				}
+
+				values := c.ParamValues()
+				if i >= len(values) {
+					break
+				}
+
+				if decoded, err := url.PathUnescape(values[i]); err == nil {
+					values[i] = decoded
+					c.SetParamValues(values...)
+				}
+
+				break
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/api/routes/middleware/params_test.go
+++ b/api/routes/middleware/params_test.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeParam(t *testing.T) {
+	cases := []struct {
+		description string
+		paramNames  []string
+		paramValues []string
+		target      string
+		expected    string
+	}{
+		{
+			description: "decodes a percent-encoded value",
+			paramNames:  []string{"fingerprint"},
+			paramValues: []string{"0f%3A8c%3Aae%3Af4"},
+			target:      "fingerprint",
+			expected:    "0f:8c:ae:f4",
+		},
+		{
+			description: "leaves an already decoded value unchanged",
+			paramNames:  []string{"fingerprint"},
+			paramValues: []string{"0f:8c:ae:f4"},
+			target:      "fingerprint",
+			expected:    "0f:8c:ae:f4",
+		},
+		{
+			description: "leaves an invalid percent-encoding unchanged",
+			paramNames:  []string{"fingerprint"},
+			paramValues: []string{"0f%zz8c"},
+			target:      "fingerprint",
+			expected:    "0f%zz8c",
+		},
+		{
+			description: "only decodes the named param",
+			paramNames:  []string{"tenant", "fingerprint"},
+			paramValues: []string{"a%3Ab", "0f%3A8c"},
+			target:      "fingerprint",
+			expected:    "0f:8c",
+		},
+		{
+			description: "is a no-op when the named param is absent",
+			paramNames:  []string{"tenant"},
+			paramValues: []string{"a%3Ab"},
+			target:      "fingerprint",
+			expected:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames(tc.paramNames...)
+			c.SetParamValues(tc.paramValues...)
+
+			next := func(echo.Context) error { return nil }
+			_ = DecodeParam(tc.target)(next)(c)
+
+			assert.Equal(t, tc.expected, c.Param(tc.target))
+		})
+	}
+}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -110,9 +110,9 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	internalAPI.POST(KeepAliveSessionURL, gateway.Handler(handler.KeepAliveSession))
 	internalAPI.PATCH(UpdateSessionURL, gateway.Handler(handler.UpdateSession))
 
-	internalAPI.GET(GetPublicKeyURL, gateway.Handler(handler.GetPublicKey))
+	internalAPI.GET(GetPublicKeyURL, gateway.Handler(handler.GetPublicKey), routesmiddleware.DecodeParam(ParamPublicKeyFingerprint))
 	internalAPI.POST(CreatePrivateKeyURL, gateway.Handler(handler.CreatePrivateKey))
-	internalAPI.POST(EvaluateKeyURL, gateway.Handler(handler.EvaluateKey))
+	internalAPI.POST(EvaluateKeyURL, gateway.Handler(handler.EvaluateKey), routesmiddleware.DecodeParam(ParamPublicKeyFingerprint))
 	internalAPI.GET(EventsSessionsURL, gateway.Handler(handler.EventSession))
 
 	// Internal namespace lookup used by other services (ssh, cloud) to resolve
@@ -175,8 +175,8 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 
 	publicAPI.POST(CreatePublicKeyURL, gateway.Handler(handler.CreatePublicKey), routesmiddleware.RequiresPermission(authorizer.PublicKeyCreate))
 	publicAPI.GET(GetPublicKeysURL, gateway.Handler(handler.GetPublicKeys))
-	publicAPI.PUT(UpdatePublicKeyURL, gateway.Handler(handler.UpdatePublicKey), routesmiddleware.RequiresPermission(authorizer.PublicKeyEdit))
-	publicAPI.DELETE(DeletePublicKeyURL, gateway.Handler(handler.DeletePublicKey), routesmiddleware.RequiresPermission(authorizer.PublicKeyRemove))
+	publicAPI.PUT(UpdatePublicKeyURL, gateway.Handler(handler.UpdatePublicKey), routesmiddleware.DecodeParam(ParamPublicKeyFingerprint), routesmiddleware.RequiresPermission(authorizer.PublicKeyEdit))
+	publicAPI.DELETE(DeletePublicKeyURL, gateway.Handler(handler.DeletePublicKey), routesmiddleware.DecodeParam(ParamPublicKeyFingerprint), routesmiddleware.RequiresPermission(authorizer.PublicKeyRemove))
 
 	publicAPI.POST(CreateNamespaceURL, gateway.Handler(handler.CreateNamespace))
 	publicAPI.GET(GetNamespaceURL, gateway.Handler(handler.GetNamespace), routesmiddleware.RequiresTenant(ParamNamespaceTenant))

--- a/api/routes/sshkeys.go
+++ b/api/routes/sshkeys.go
@@ -2,7 +2,6 @@ package routes
 
 import (
 	"net/http"
-	"net/url"
 	"strconv"
 
 	"github.com/shellhub-io/shellhub/api/pkg/gateway"
@@ -125,10 +124,6 @@ func (h *Handler) DeletePublicKey(c gateway.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return err
 	}
-
-	// NOTE: This is a temporary workaround.
-	// TODO: Investigate why echo is not decoding the Fingerprint.
-	req.Fingerprint, _ = url.QueryUnescape(req.Fingerprint)
 
 	if err := c.Validate(&req); err != nil {
 		return err


### PR DESCRIPTION
## What

Public key endpoints that take a `:fingerprint` path parameter now decode percent-encoded values before looking the key up, fixing a `404` on edit, delete, get, and key evaluation when clients encode the fingerprint's colons as `%3A`.

## Why

Echo's router does not URL-unescape path parameters. A fingerprint such as `0f:8c:...` is sent by HTTP clients with its colons encoded as `%3A`, and Go's `net/url` sets `URL.RawPath` for that non-canonical encoding. Echo routes on `RawPath` and stores the captured segment verbatim, so `c.Param("fingerprint")` returned the still-escaped string. The store query then matched nothing and returned `404 public key not found`.

The legacy Vue UI masked this because it sends the entire public key object as the request body; the body's decoded `fingerprint` field overwrote the bad path-bound value during `c.Bind` (the embedded `FingerprintParam` field has no `json:"-"` tag). The new React UI sends only `{name, username, filter}` per the OpenAPI spec, which exposed the latent bug.

`DeletePublicKey` already carried a per-handler `url.QueryUnescape` workaround with a TODO to investigate the root cause.

## Changes

- **api/routes/middleware**: added `DecodeParam`, a middleware that URL-decodes a named path parameter in place. Invalid encodings and already-decoded values are left untouched, so it is safe to apply unconditionally.
- **api/routes**: applied `DecodeParam(ParamPublicKeyFingerprint)` to the four `:fingerprint` routes (get, update, delete, evaluate), centralizing the fix instead of repeating it per handler.
- **api/routes**: removed the temporary `url.QueryUnescape` workaround and its TODO from `DeletePublicKey`, now covered by the middleware.

## Testing

Edit a public key in the React UI and confirm a `200`. Table-driven tests in `params_test.go` cover encoded, already-decoded, invalid-encoding, multi-param, and absent-param cases.