### PR TITLE
chore(infra): annotate compose services with profiles

### DIFF
--- a/bin/utils
+++ b/bin/utils
@@ -72,5 +72,13 @@ case "$SHELLHUB_DATABASE" in
         ;;
 esac
 
+PROFILES=""
+[ "$SHELLHUB_ENV" = "development" ] && PROFILES="$PROFILES,agent"
+case "$SHELLHUB_DATABASE" in
+    mongo|postgres) PROFILES="$PROFILES,$SHELLHUB_DATABASE" ;;
+    migrate)        PROFILES="$PROFILES,mongo,postgres" ;;
+esac
+export COMPOSE_PROFILES="${PROFILES#,}"
+
 [ -f "$EXTRA_COMPOSE_FILE" ] && COMPOSE_FILE="${COMPOSE_FILE}:${EXTRA_COMPOSE_FILE}"
 export COMPOSE_FILE

--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -1,5 +1,6 @@
 services:
   agent:
+    profiles: [agent]
     image: agent
     restart: unless-stopped
     build:

--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -1,5 +1,6 @@
 services:
   mongo:
+    profiles: [mongo]
     image: mongo:4.4.29
     restart: unless-stopped
     healthcheck:
@@ -13,3 +14,4 @@ services:
     depends_on:
       mongo:
         condition: service_healthy
+        required: false

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,5 +1,6 @@
 services:
   postgres:
+    profiles: [postgres]
     image: postgres:18.0
     command: postgres -c io_method=io_uring
     restart: unless-stopped
@@ -23,3 +24,4 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        required: false


### PR DESCRIPTION
## What changed?

Added `profiles:` annotations to `docker-compose.agent.yml`,
`docker-compose.mongo.yml`, and `docker-compose.postgres.yml`.
Exports `COMPOSE_PROFILES` in `bin/utils` to activate them.

## Why

Part of the compose wrapper refactor (shellhub-io/team/issues/111). This is the first
incremental step: profiles must be in place before the wrapper replacement lands in the next PR.

## How to test

1. Start the environment: `./bin/docker-compose up -d`
2. Confirm postgres is running and mongo is absent:
   `docker compose ps`
3. Stop the environment: `./bin/docker-compose down`
4. Set `SHELLHUB_DATABASE=mongo` in `.env.override`
5. Start again: `./bin/docker-compose up -d`
6. Confirm mongo is running and postgres is absent:
   `docker compose ps`
7. Set `SHELLHUB_ENV=development` in `.env.override`, restart,
   confirm agent is running: `docker compose ps`
8. Verify profiles are correctly annotated:
   `./bin/docker-compose config | grep -A2 'profiles:'`