### PR TITLE
fix(api): sync public key tags on update

### DIFF
--- a/api/store/pg/public-key.go
+++ b/api/store/pg/public-key.go
@@ -66,26 +66,50 @@ func (pg *Pg) PublicKeyList(ctx context.Context, opts ...store.QueryOption) ([]m
 }
 
 func (pg *Pg) PublicKeyUpdate(ctx context.Context, publicKey *models.PublicKey) error {
-	db := pg.GetConnection(ctx)
+	return pg.WithTransaction(ctx, func(ctx context.Context) error {
+		db := pg.GetConnection(ctx)
 
-	a := entity.PublicKeyFromModel(publicKey)
-	a.UpdatedAt = clock.Now()
+		a := entity.PublicKeyFromModel(publicKey)
+		a.UpdatedAt = clock.Now()
 
-	// Filter by both fingerprint and namespace_id to match MongoDB behavior
-	r, err := db.NewUpdate().
-		Model(a).
-		Where("fingerprint = ?", publicKey.Fingerprint).
-		Where("namespace_id = ?", publicKey.TenantID).
-		Exec(ctx)
-	if err != nil {
-		return fromSQLError(err)
-	}
+		// Filter by both fingerprint and namespace_id to match MongoDB behavior
+		r, err := db.NewUpdate().
+			Model(a).
+			Where("fingerprint = ?", publicKey.Fingerprint).
+			Where("namespace_id = ?", publicKey.TenantID).
+			Exec(ctx)
+		if err != nil {
+			return fromSQLError(err)
+		}
 
-	if rowsAffected, err := r.RowsAffected(); err != nil || rowsAffected == 0 {
-		return store.ErrNoDocuments
-	}
+		if rowsAffected, err := r.RowsAffected(); err != nil || rowsAffected == 0 {
+			return store.ErrNoDocuments
+		}
 
-	return nil
+		// Sync the many-to-many tag relationships: drop the existing junction
+		// entries and re-insert the current set so removed tags don't linger.
+		if _, err := db.NewDelete().
+			Model((*entity.PublicKeyTag)(nil)).
+			Where("public_key_fingerprint = ?", a.Fingerprint).
+			Where("public_key_namespace_id = ?", a.NamespaceID).
+			Exec(ctx); err != nil {
+			return fromSQLError(err)
+		}
+
+		for _, tag := range a.Tags {
+			pkTag := entity.NewPublicKeyTag(tag.ID, a.Fingerprint, a.NamespaceID)
+			pkTag.CreatedAt = a.UpdatedAt
+
+			if _, err := db.NewInsert().
+				Model(pkTag).
+				On("CONFLICT (public_key_fingerprint, public_key_namespace_id, tag_id) DO NOTHING").
+				Exec(ctx); err != nil {
+				return fromSQLError(err)
+			}
+		}
+
+		return nil
+	})
 }
 
 func (pg *Pg) PublicKeyResolve(ctx context.Context, resolver store.PublicKeyResolver, value string, opts ...store.QueryOption) (*models.PublicKey, error) {


### PR DESCRIPTION
## What

Fixes public key updates silently keeping stale tag filters. Editing a key to remove or replace its tags now correctly drops the old tag relationships.

## Why

`PublicKeyUpdate` in the Postgres store only updated the `public_keys` row. Tags are a many-to-many relationship stored in the `public_key_tags` junction table, which was never touched on update — only on create. As a result, removed tags persisted and reappeared on the next read.

Observed reproduction:
- Create a public key with a tags filter.
- Edit it to use a hostname filter instead → key ends up with hostname `AND` tags (invalid state).
- Edit it to clear all filters → hostname resets, but tags remain.

The hostname field reset correctly because it is a plain column on `public_keys`; only the junction-table relationships were orphaned.

## Changes

- **api/store/pg**: `PublicKeyUpdate` now re-syncs the `public_key_tags` junction table — it deletes the existing entries for the key and re-inserts the current set, mirroring the tag-handling already done in `PublicKeyCreate`.
- **api/store/pg**: The row update and junction-table sync are wrapped in `WithTransaction` so a partial failure cannot leave the key with mismatched filters.

## Testing

Verify with a key that has a tags filter: edit it to a hostname filter and confirm the tags are gone, then edit it to clear all filters and confirm both hostname resets to `.*` and the tags array is empty.