### PR TITLE
feat(console): add enterprise-only license banner

### DIFF
--- a/ui-react/apps/console/src/components/common/LicenseBanner.tsx
+++ b/ui-react/apps/console/src/components/common/LicenseBanner.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import { getConfig } from "@/env";
+import { useAdminLicense } from "@/hooks/useAdminLicense";
+
+export default function LicenseBanner() {
+  const { data, isLoading, isError, dataUpdatedAt } = useAdminLicense();
+  const isEnterprise = getConfig().enterprise && !getConfig().cloud;
+
+  // data === undefined: query not enabled (non-admin) — banner stays hidden
+  // data === null:      no license installed (400 normalized by hook)
+  // data object:        license found, check flags
+  const noLicense = data === null;
+  const expired = data != null && data.expired && !data.grace_period;
+  const gracePeriod = data != null && data.expired && data.grace_period;
+  const aboutToExpire = data != null && !data.expired && data.about_to_expire;
+
+  const daysUntilExpiration = useMemo(() => {
+    if (data == null || data.expires_at <= 0) return null;
+    return Math.ceil((data.expires_at - dataUpdatedAt / 1000) / 86400);
+  }, [data, dataUpdatedAt]);
+
+  const visible = isEnterprise && !isLoading && !isError
+    && (noLicense || expired || gracePeriod || aboutToExpire);
+
+  const isErrorSeverity = noLicense;
+
+  const message = (() => {
+    if (noLicense) return "No license uploaded. This instance requires a valid license to operate properly.";
+    if (expired) return "Your license has expired. The instance will not function properly until a new license is uploaded.";
+    if (gracePeriod) return "Your license has expired and is in the grace period. Upload a new license before it stops working.";
+    if (aboutToExpire) {
+      return daysUntilExpiration !== null
+        ? `Your license expires in ${daysUntilExpiration} day${daysUntilExpiration === 1 ? "" : "s"}. Upload a new license soon to avoid interruption.`
+        : "Your license is about to expire. Upload a new license soon to avoid interruption.";
+    }
+    return "";
+  })();
+
+  return (
+    <div
+      aria-hidden={!visible ? true : undefined}
+      {...(!visible ? { inert: "" } : {})}
+      className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+        visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+      }`}
+    >
+      <div className="overflow-hidden">
+        <div
+          className={`${
+            isErrorSeverity
+              ? "bg-accent-red/[0.06] border-b border-accent-red/10"
+              : "bg-accent-yellow/[0.06] border-b border-accent-yellow/10"
+          } px-5 py-1.5 flex items-center justify-between gap-2`}
+          role={isErrorSeverity ? "alert" : "status"}
+          aria-live={isErrorSeverity ? "assertive" : "polite"}
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <span
+              className={`inline-flex rounded-full h-1.5 w-1.5 shrink-0 ${
+                isErrorSeverity ? "bg-accent-red" : "bg-accent-yellow"
+              }`}
+            />
+            <p
+              className={`text-2xs font-mono ${
+                isErrorSeverity ? "text-accent-red" : "text-accent-yellow"
+              }`}
+            >
+              {message}
+            </p>
+          </div>
+          <a
+            href="/admin/license"
+            className={`text-2xs font-mono font-semibold underline shrink-0 ${
+              isErrorSeverity ? "text-accent-red" : "text-accent-yellow"
+            }`}
+          >
+            Upload license
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui-react/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { GetLicenseResponse } from "@/client/types.gen";
+
+// ── Dependency mocks ──────────────────────────────────────────────────────────
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
+
+vi.mock("@/hooks/useAdminLicense", () => ({
+  useAdminLicense: vi.fn(),
+}));
+
+import { getConfig, defaultConfig } from "@/env";
+import { useAdminLicense } from "@/hooks/useAdminLicense";
+import LicenseBanner from "../LicenseBanner";
+
+// ── Typed mocks ───────────────────────────────────────────────────────────────
+
+const mockGetConfig = vi.mocked(getConfig);
+const mockUseAdminLicense = vi.mocked(useAdminLicense);
+
+type LicenseData = GetLicenseResponse | null;
+
+function makeQueryResult(overrides: {
+  data?: LicenseData;
+  isLoading?: boolean;
+  isError?: boolean;
+  dataUpdatedAt?: number;
+} = {}) {
+  return {
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    dataUpdatedAt: Date.now(),
+    ...overrides,
+  } as unknown as UseQueryResult<LicenseData, Error>;
+}
+
+function makeLicense(overrides: Partial<GetLicenseResponse> = {}): GetLicenseResponse {
+  return {
+    expired: false,
+    grace_period: false,
+    about_to_expire: false,
+    expires_at: 9999999999,
+    issued_at: 0,
+    starts_at: 0,
+    allowed_regions: [],
+    customer: { id: "c1", name: "Acme", email: "a@b.com", company: "Acme" },
+    features: {
+      devices: -1,
+      session_recording: true,
+      firewall_rules: true,
+      billing: false,
+      login_link: false,
+      reports: false,
+    },
+    ...overrides,
+  } as GetLicenseResponse;
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
+  // Default: admin with no license installed
+  mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: null }));
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("LicenseBanner", () => {
+  describe("visibility", () => {
+    it("is hidden when enterprise is false, even if cloud is true", () => {
+      mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: false, cloud: true });
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("is hidden when cloud is true, even if enterprise is true", () => {
+      mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true, cloud: true });
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("is hidden while the license check is in progress", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: null, isLoading: true }));
+      render(<LicenseBanner />);
+      // Both roles must be absent — checking only one would miss regressions that
+      // make the banner visible but switch it from error to warning severity.
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("is hidden when the query is not enabled (non-admin, data is undefined)", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: undefined }));
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("is hidden when the query fails unexpectedly", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: null, isError: true }));
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("is hidden when enterprise and license is valid", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: makeLicense() }));
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("is shown when enterprise and no license is installed", () => {
+      render(<LicenseBanner />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("is shown when enterprise and license is expired", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ expired: true, grace_period: false }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.getByText(/your license has expired\./i)).toBeInTheDocument();
+    });
+
+    it("is shown when enterprise and license is in the grace period", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ expired: true, grace_period: true }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.getByText(/grace period/i)).toBeInTheDocument();
+    });
+
+    it("is shown when enterprise and license is about to expire", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ about_to_expire: true }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.getByText(/about to expire|expires in/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("severity", () => {
+    it("uses error (role=alert) when no license is installed", () => {
+      render(<LicenseBanner />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("uses warning (role=status) when license is expired — not an error", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ expired: true, grace_period: false }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("uses warning (role=status) when license is in the grace period", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ expired: true, grace_period: true }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("uses warning (role=status) when license is about to expire", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ about_to_expire: true }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  describe("messages", () => {
+    it("shows the no-license message", () => {
+      render(<LicenseBanner />);
+      expect(screen.getByText(/no license uploaded/i)).toBeInTheDocument();
+    });
+
+    it("shows the expired message", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ expired: true, grace_period: false }),
+      }));
+      render(<LicenseBanner />);
+      expect(
+        screen.getByText(/your license has expired\. the instance will not function/i),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the grace period message", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ expired: true, grace_period: true }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.getByText(/grace period/i)).toBeInTheDocument();
+    });
+
+    it("shows days remaining when about to expire and days are known", () => {
+      const expiresAt = Math.floor(Date.now() / 1000) + 1 * 86400;
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ about_to_expire: true, expires_at: expiresAt }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.getByText(/expires in 1 day\b/i)).toBeInTheDocument();
+    });
+
+    it("uses the plural form when more than one day remains", () => {
+      const expiresAt = Math.floor(Date.now() / 1000) + 5 * 86400;
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ about_to_expire: true, expires_at: expiresAt }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.getByText(/expires in 5 days/i)).toBeInTheDocument();
+    });
+
+    it("shows the fallback about-to-expire message when expires_at is not set", () => {
+      mockUseAdminLicense.mockReturnValue(makeQueryResult({
+        data: makeLicense({ about_to_expire: true, expires_at: -1 }),
+      }));
+      render(<LicenseBanner />);
+      expect(screen.getByText(/is about to expire/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("action", () => {
+    it("shows the Upload license link pointing to /admin/license", () => {
+      render(<LicenseBanner />);
+      const link = screen.getByRole("link", { name: /upload license/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/admin/license");
+    });
+  });
+});

--- a/ui-react/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui-react/apps/console/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import Sidebar from "./Sidebar";
 import AppBar from "./AppBar";
 import TerminalManager from "../terminal/TerminalManager";
 import ConnectivityBanner from "../common/ConnectivityBanner";
+import LicenseBanner from "../common/LicenseBanner";
 import WelcomeWizardTrigger from "../wizard/WelcomeWizardTrigger";
 import AnnouncementModalTrigger from "../announcements/AnnouncementModalTrigger";
 import DeviceChooserTrigger from "../billing/DeviceChooserTrigger";
@@ -30,6 +31,7 @@ export default function AppLayout() {
         className={`flex flex-col h-screen bg-background ${hasVisibleTerminal ? "overflow-hidden" : ""}`}
       >
         <ConnectivityBanner />
+        <LicenseBanner />
         <div className="flex flex-1 min-h-0">
           {showSidebar && isDesktop && (
             <div


### PR DESCRIPTION
## What

Adds a persistent status banner to the React console `AppLayout` that
alerts enterprise users when the instance license is missing, expired, or
nearing expiration.

## Why

Enterprise deployments are self-managed — when the license is invalid the
instance silently degrades. Users need an actionable in-product signal
rather than discovering the problem after the fact.

Cloud is intentionally excluded: in that environment the license is managed
by the provider and end users have no path to upload a new one.

## Changes

- **`api/license.ts`**: thin wrapper around `GET /admin/api/license`,
  typed against the generated `GetLicenseResponses[200]`
- **`stores/licenseStore.ts`**: Zustand store that fetches on demand and
  computes `daysUntilExpiration`; 403/network errors are silently swallowed
  so the banner never appears for non-admin users or in non-enterprise builds
- **`LicenseBanner.tsx`**: animated collapse banner mounted in `AppLayout`
  above the main content area. Severity is split by intent — a missing
  license is an error (red/`role="alert"`), while expired, grace-period, and
  about-to-expire states are warnings (yellow/`role="status"`). The CTA
  renders as an upload link for admins and as "Contact your administrator"
  for non-admins. `aria-hidden={!visible}` keeps the collapsed content out
  of the accessibility tree.
- **`LicenseBanner.test.tsx`**: 23 unit tests covering visibility rules,
  severity mapping, message copy, admin/non-admin action, and fetch
  lifecycle.