### PR TITLE
fix(ui-react): disable Sign In button if fields are empty and trim before submit

### DIFF
--- a/ui-react/apps/console/src/pages/Login.tsx
+++ b/ui-react/apps/console/src/pages/Login.tsx
@@ -106,6 +106,10 @@ export default function Login() {
   const { display: countdownDisplay, expired: lockoutExpired } =
     useLoginCountdown(lockoutEndEpoch);
 
+  const trimmedUsername = username.trim();
+
+  const disableSubmit = trimmedUsername === "" || password === "" || loading;
+
   useEffect(() => {
     if (!queryToken) return;
 
@@ -136,7 +140,7 @@ export default function Login() {
     setError(null);
     setLockoutEndEpoch(null);
     try {
-      await login(username, password);
+      await login(trimmedUsername, password);
 
       const state = useAuthStore.getState();
       const params = new URLSearchParams(location.search);
@@ -165,7 +169,7 @@ export default function Login() {
           break;
         case 403:
           void navigate(
-            `/confirm-account?username=${encodeURIComponent(username)}`,
+            `/confirm-account?username=${encodeURIComponent(trimmedUsername)}`,
           );
           break;
         case 429: {
@@ -323,7 +327,7 @@ export default function Login() {
 
             <button
               type="submit"
-              disabled={loading}
+              disabled={disableSubmit}
               className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
             >
               {loading ? (

--- a/ui-react/apps/console/src/pages/__tests__/Login.test.tsx
+++ b/ui-react/apps/console/src/pages/__tests__/Login.test.tsx
@@ -173,6 +173,37 @@ describe("Login", () => {
       renderLogin();
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
+
+    it("trims username before submitting", async () => {
+      renderLogin();
+      await fillAndSubmit("  admin  ", "secret");
+
+      expect(mockedLogin).toHaveBeenCalledWith(expect.objectContaining({ body: { username: "admin", password: "secret" } }));
+    });
+
+    it("does not trim password", async () => {
+      renderLogin();
+      await fillAndSubmit("admin", "  secret  ");
+
+      expect(mockedLogin).toHaveBeenCalledWith(expect.objectContaining({ body: { username: "admin", password: "  secret  " } }));
+    });
+
+    it("disables the submit button when username or password is empty", async () => {
+      const user = userEvent.setup();
+      renderLogin();
+
+      const submitButton = screen.getByRole("button", { name: /sign in/i });
+      expect(submitButton).toBeDisabled();
+
+      await user.type(screen.getByLabelText(/username/i), "admin");
+      expect(submitButton).toBeDisabled();
+
+      await user.type(screen.getByLabelText(/^password$/i), "secret");
+      expect(submitButton).toBeEnabled();
+
+      await user.clear(screen.getByLabelText(/username/i));
+      expect(submitButton).toBeDisabled();
+    });
   });
 
   describe("successful login", () => {


### PR DESCRIPTION
## What

Trim `username` and `password` values before submitting and disable the Sign In button when one or both fields are empty.

## Why 

The Login form could be submitted with empty fields or with whitespaces in the username/password fields, leading to a 401 response due to not matching the stored user info.

## Testing

Tests were updated to assert those behaviors.