### PR TITLE
fix(ui-react): parse `keepaliveInternal` before inserting in command

### DIFF
--- a/ui-react/apps/console/src/pages/AddDevice.tsx
+++ b/ui-react/apps/console/src/pages/AddDevice.tsx
@@ -159,7 +159,7 @@ export default function AddDevice() {
     if (hostname.trim()) parts.push(`PREFERRED_HOSTNAME=${hostname.trim()}`);
     if (identity.trim()) parts.push(`PREFERRED_IDENTITY=${identity.trim()}`);
     if (keepaliveInterval.trim() && !keepaliveIntervalError)
-      parts.push(`KEEPALIVE_INTERVAL=${keepaliveInterval.trim()}`);
+      parts.push(`KEEPALIVE_INTERVAL=${parseInt(keepaliveInterval, 10)}`);
     parts.push("sh");
     return parts.join(" ");
   };


### PR DESCRIPTION
## What

Parse `keepaliveInternal` before pushing to the generated command

## Why 

The KeepAlive Internal field accepts inputs like "000060", and the previous implementation didn't remove those leading zeros. By parsing it before adding to the command, it gets the leading zeros removed AND trims whitespaces, improving the previous behavior.
