### PR TITLE
fix(ui-react): unify namespace name validation across forms

### DIFF
--- a/openapi/spec/components/schemas/namespaceName.yaml
+++ b/openapi/spec/components/schemas/namespaceName.yaml
@@ -1,3 +1,6 @@
 description: Namespace's name
 type: string
+minLength: 1
+maxLength: 30
+pattern: /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 example: examplespace

--- a/ui-react/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui-react/apps/console/src/components/common/CreateNamespace.tsx
@@ -13,17 +13,11 @@ import {
   BookOpenIcon,
 } from "@heroicons/react/24/outline";
 import AmbientBackground from "./AmbientBackground";
-import InputField from "@/components/common/fields/InputField";
-
-const NAME_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
-
-function validate(name: string): string | null {
-  if (name.length < 3) return "Name must be at least 3 characters";
-  if (name.length > 30) return "Name must be at most 30 characters";
-  if (!NAME_REGEX.test(name))
-    return "Only lowercase letters, numbers, and hyphens (cannot start or end with hyphen)";
-  return null;
-}
+import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
+import {
+  NAMESPACE_NAME_MIN_LENGTH,
+  validateNamespaceName,
+} from "@/utils/validation";
 
 /* ─── Cloud/Enterprise form ─── */
 function CloudForm() {
@@ -33,7 +27,7 @@ function CloudForm() {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const err = validate(name);
+    const err = validateNamespaceName(name);
     if (err) {
       setValidationError(err);
       return;
@@ -46,31 +40,29 @@ function CloudForm() {
     }
   };
 
-  const displayError = validationError || (createNs.error?.message ?? null);
+  const displayError = validationError ?? (createNs.error?.message ?? null);
 
   return (
     <form onSubmit={(e) => void handleSubmit(e)} className="w-full">
       <div className="flex items-center gap-2">
         <div className="flex-1">
-          <InputField
+          <NamespaceNameField
             id="create-namespace-name"
-            label="Namespace Name"
             value={name}
             onChange={(v) => {
-              setName(v.toLowerCase());
+              setName(v);
               setValidationError(null);
+              createNs.reset();
             }}
-            placeholder="my-namespace"
-            maxLength={30}
             autoFocus
-            variant="mono"
-            error={displayError || undefined}
-            hint="3–30 characters · lowercase letters, numbers, and hyphens only"
+            error={displayError}
           />
         </div>
         <button
           type="submit"
-          disabled={createNs.isPending || name.length < 3}
+          disabled={
+            createNs.isPending || name.length < NAMESPACE_NAME_MIN_LENGTH
+          }
           className="px-6 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 shrink-0"
         >
           {createNs.isPending ? (

--- a/ui-react/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui-react/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -6,27 +6,16 @@ import {
 } from "@heroicons/react/24/outline";
 import BaseDialog from "./BaseDialog";
 import CopyButton from "./CopyButton";
-import InputField from "./fields/InputField";
+import NamespaceNameField from "./fields/NamespaceNameField";
+import {
+  NAMESPACE_NAME_MIN_LENGTH,
+  NAMESPACE_NAME_RULES,
+  validateNamespaceName,
+} from "@/utils/validation";
 import { getConfig } from "@/env";
 import { useCreateNamespace } from "@/hooks/useNamespaceMutations";
 
 const CLI_COMMAND = "./bin/cli namespace create <namespace> <owner>";
-
-const NAME_REGEX = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
-
-function validate(name: string): string | null {
-  if (name.length < 3) return "Name must be at least 3 characters";
-  if (name.length > 30) return "Name must be at most 30 characters";
-  if (!NAME_REGEX.test(name))
-    return "Only lowercase letters, numbers, and hyphens (cannot start or end with hyphen)";
-  return null;
-}
-
-const rules = [
-  "3–30 characters",
-  "Lowercase letters, numbers, and hyphens only",
-  "Cannot begin or end with a hyphen",
-];
 
 const FORM_ID = "create-namespace-form";
 
@@ -47,18 +36,14 @@ function CloudForm({
 }) {
   return (
     <form id={FORM_ID} onSubmit={onSubmit}>
-      <InputField
+      <NamespaceNameField
         id={inputId}
-        label="Namespace Name"
         value={name}
         onChange={(v) => {
-          setName(v.toLowerCase());
+          setName(v);
           resetError();
         }}
-        placeholder="my-namespace"
-        error={displayError ?? undefined}
-        hint="3–30 characters · lowercase letters, numbers, and hyphens only"
-        maxLength={30}
+        error={displayError}
         autoFocus
       />
     </form>
@@ -100,7 +85,7 @@ function CeInstructions({ descriptionId }: { descriptionId: string }) {
           Naming rules
         </p>
         <ul className="space-y-1.5" aria-label="Namespace naming rules">
-          {rules.map((rule) => (
+          {NAMESPACE_NAME_RULES.map((rule) => (
             <li
               key={rule}
               className="flex items-start gap-2 text-xs text-text-muted"
@@ -148,7 +133,7 @@ export default function CreateNamespaceDialog({
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const err = validate(name);
+    const err = validateNamespaceName(name);
     if (err) {
       setValidationError(err);
       return;
@@ -229,7 +214,9 @@ export default function CreateNamespaceDialog({
             <button
               type="submit"
               form={FORM_ID}
-              disabled={createNs.isPending || name.length < 3}
+              disabled={
+                createNs.isPending || name.length < NAMESPACE_NAME_MIN_LENGTH
+              }
               className="px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-lg text-xs font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
             >
               {createNs.isPending ? (

--- a/ui-react/apps/console/src/components/common/__tests__/CreateNamespaceDialog.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/CreateNamespaceDialog.test.tsx
@@ -93,9 +93,9 @@ describe("CreateNamespaceDialog", () => {
   });
 
   describe("naming rules", () => {
-    it("displays the '3–30 characters' rule", () => {
+    it("displays the '3-30 characters' rule", () => {
       renderDialog(true);
-      expect(screen.getByText("3–30 characters")).toBeInTheDocument();
+      expect(screen.getByText("3-30 characters")).toBeInTheDocument();
     });
 
     it("displays the 'Lowercase letters, numbers, and hyphens only' rule", () => {

--- a/ui-react/apps/console/src/components/common/fields/NamespaceNameField.tsx
+++ b/ui-react/apps/console/src/components/common/fields/NamespaceNameField.tsx
@@ -1,0 +1,35 @@
+import InputField from "@/components/common/fields/InputField";
+import {
+  NAMESPACE_NAME_HINT,
+  NAMESPACE_NAME_MAX_LENGTH,
+} from "@/utils/validation";
+
+interface NamespaceNameFieldProps {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string | null;
+  autoFocus?: boolean;
+}
+
+export default function NamespaceNameField({
+  id,
+  value,
+  onChange,
+  error,
+  autoFocus,
+}: NamespaceNameFieldProps) {
+  return (
+    <InputField
+      id={id}
+      label="Namespace Name"
+      value={value}
+      onChange={(v) => onChange(v.toLowerCase())}
+      placeholder="my-namespace"
+      maxLength={NAMESPACE_NAME_MAX_LENGTH}
+      autoFocus={autoFocus}
+      error={error ?? undefined}
+      hint={NAMESPACE_NAME_HINT}
+    />
+  );
+}

--- a/ui-react/apps/console/src/components/common/fields/__tests__/NamespaceNameField.test.tsx
+++ b/ui-react/apps/console/src/components/common/fields/__tests__/NamespaceNameField.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
+import { NAMESPACE_NAME_HINT } from "@/utils/validation";
+
+afterEach(cleanup);
+
+function renderField(
+  props: Partial<React.ComponentProps<typeof NamespaceNameField>> = {},
+) {
+  const onChange = vi.fn();
+  const utils = render(
+    <NamespaceNameField id="ns-name" value="" onChange={onChange} {...props} />,
+  );
+  return { onChange, ...utils };
+}
+
+describe("NamespaceNameField", () => {
+  it("renders with the canonical label and placeholder", () => {
+    renderField();
+    expect(screen.getByLabelText("Namespace Name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("my-namespace")).toBeInTheDocument();
+  });
+
+  it("renders the canonical hint when no error is present", () => {
+    renderField();
+    expect(screen.getByText(NAMESPACE_NAME_HINT)).toBeInTheDocument();
+  });
+
+  it("lowercases input before calling onChange", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderField();
+    await user.type(screen.getByLabelText("Namespace Name"), "Ab");
+    // userEvent.type fires one onChange per keystroke; both should be lowercased.
+    expect(onChange).toHaveBeenCalledWith("a");
+    expect(onChange).toHaveBeenCalledWith("b");
+  });
+
+  it("enforces the 30-character maxLength on the underlying input", () => {
+    renderField();
+    expect(screen.getByLabelText("Namespace Name")).toHaveAttribute(
+      "maxLength",
+      "30",
+    );
+  });
+
+  it("hides the hint when error is set", () => {
+    renderField({ error: "Name must be at least 3 characters" });
+    expect(screen.queryByText(NAMESPACE_NAME_HINT)).not.toBeInTheDocument();
+  });
+
+  it("marks the input as aria-invalid when error is set", () => {
+    renderField({ error: "bad" });
+    expect(screen.getByLabelText("Namespace Name")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("treats null error the same as no error", () => {
+    renderField({ error: null });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByText(NAMESPACE_NAME_HINT)).toBeInTheDocument();
+  });
+
+  it("autofocuses the input when autoFocus is true", () => {
+    renderField({ autoFocus: true });
+    expect(screen.getByLabelText("Namespace Name")).toHaveFocus();
+  });
+});

--- a/ui-react/apps/console/src/pages/Settings.tsx
+++ b/ui-react/apps/console/src/pages/Settings.tsx
@@ -30,18 +30,9 @@ import Drawer from "../components/common/Drawer";
 import ConfirmDialog from "../components/common/ConfirmDialog";
 import BillingSection from "../components/billing/BillingSection";
 import InputField from "@/components/common/fields/InputField";
+import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
+import { validateNamespaceName } from "@/utils/validation";
 import { getConfig } from "../env";
-
-const NAME_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
-
-function validateName(name: string): string | null {
-  if (name.length < 3) return "Name must be at least 3 characters";
-  if (name.length > 30) return "Name must be at most 30 characters";
-  if (name.includes(".")) return "Name cannot contain dots";
-  if (!NAME_REGEX.test(name))
-    return "Only lowercase letters, numbers, and hyphens allowed";
-  return null;
-}
 
 /* ─── Settings Card ─── */
 
@@ -127,17 +118,14 @@ function EditNameDrawer({
     setError("");
   });
 
-  const validationError = name !== currentName ? validateName(name) : null;
+  const validationError =
+    name !== currentName ? validateNamespaceName(name) : null;
+  const canSubmit = name !== currentName && !validationError && !submitting;
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
-    const err = validateName(name);
-    if (err) {
-      setError(err);
-      return;
-    }
+    if (!canSubmit) return;
     setSubmitting(true);
-    setError("");
     try {
       await editNs.mutateAsync({ path: { tenant: tenantId }, body: { name } });
       onClose();
@@ -165,12 +153,7 @@ function EditNameDrawer({
           </button>
           <button
             onClick={() => void handleSubmit()}
-            disabled={
-              !name.trim() ||
-              name === currentName ||
-              !!validationError ||
-              submitting
-            }
+            disabled={!canSubmit}
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
@@ -184,16 +167,18 @@ function EditNameDrawer({
       }
     >
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
-        <InputField
+        <NamespaceNameField
           id="edit-ns-name"
-          label="Namespace Name"
           value={name}
-          onChange={(v) => setName(v.toLowerCase())}
+          onChange={setName}
           autoFocus={open}
-          hint="3-30 characters, lowercase letters, numbers, and hyphens. No dots."
-          error={validationError ?? undefined}
+          error={validationError}
         />
-        {error && <p className="text-2xs text-accent-red">{error}</p>}
+        {error && (
+          <p role="alert" className="text-2xs text-accent-red">
+            {error}
+          </p>
+        )}
       </form>
     </Drawer>
   );

--- a/ui-react/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
@@ -3,9 +3,10 @@ import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { useAdminEditNamespace } from "@/hooks/useAdminNamespaceMutations";
 import { isSdkError } from "@/api/errors";
 import Drawer from "@/components/common/Drawer";
-import InputField from "@/components/common/fields/InputField";
+import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
 import NumericInput from "@/components/common/fields/NumericInput";
 import CheckboxField from "@/components/common/fields/CheckboxField";
+import { validateNamespaceName } from "@/utils/validation";
 import type { Namespace } from "@/client";
 
 interface EditNamespaceDrawerProps {
@@ -38,7 +39,9 @@ export default function EditNamespaceDrawer({
   });
 
   const isMaxDevicesValid = parseInt(maxDevices, 10) >= -1;
-  const canSubmit = name.trim().length > 0 && isMaxDevicesValid;
+  const nameValidationError =
+    name !== namespace?.name ? validateNamespaceName(name) : null;
+  const canSubmit = !nameValidationError && isMaxDevicesValid;
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
@@ -107,12 +110,12 @@ export default function EditNamespaceDrawer({
       }
     >
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
-        <InputField
+        <NamespaceNameField
           id="edit-ns-name"
-          label="Name"
           value={name}
           onChange={setName}
           autoFocus={open}
+          error={nameValidationError}
         />
 
         <NumericInput

--- a/ui-react/apps/console/src/pages/admin/namespaces/__tests__/EditNamespaceDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/__tests__/EditNamespaceDrawer.test.tsx
@@ -72,7 +72,7 @@ describe("EditNamespaceDrawer", () => {
 
     it("renders the Name input", () => {
       renderDrawer();
-      expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText("Namespace Name")).toBeInTheDocument();
     });
 
     it("renders the Max Devices input", () => {
@@ -103,7 +103,9 @@ describe("EditNamespaceDrawer", () => {
   describe("form pre-filling", () => {
     it("pre-fills the Name field with the namespace name", () => {
       renderDrawer();
-      expect(screen.getByLabelText(/^name$/i)).toHaveValue("my-namespace");
+      expect(screen.getByLabelText("Namespace Name")).toHaveValue(
+        "my-namespace",
+      );
     });
 
     it("pre-fills the Max Devices field with the namespace max_devices", () => {
@@ -144,7 +146,7 @@ describe("EditNamespaceDrawer", () => {
 
     it("disables submit button when name is cleared", async () => {
       renderDrawer();
-      await userEvent.clear(screen.getByLabelText(/^name$/i));
+      await userEvent.clear(screen.getByLabelText("Namespace Name"));
       expect(
         screen.getByRole("button", { name: /save changes/i }),
       ).toBeDisabled();
@@ -152,7 +154,7 @@ describe("EditNamespaceDrawer", () => {
 
     it("re-enables submit button when name is typed back in", async () => {
       renderDrawer();
-      const nameInput = screen.getByLabelText(/^name$/i);
+      const nameInput = screen.getByLabelText("Namespace Name");
       await userEvent.clear(nameInput);
       await userEvent.type(nameInput, "new-name");
       expect(
@@ -166,7 +168,7 @@ describe("EditNamespaceDrawer", () => {
       mockMutateAsync.mockResolvedValue(undefined);
       renderDrawer();
 
-      const nameInput = screen.getByLabelText(/^name$/i);
+      const nameInput = screen.getByLabelText("Namespace Name");
       await userEvent.clear(nameInput);
       await userEvent.type(nameInput, "updated-namespace");
 
@@ -331,7 +333,7 @@ describe("EditNamespaceDrawer", () => {
     it("reloads namespace data when drawer is closed then reopened", async () => {
       const { rerender } = renderDrawer({ namespace: mockNamespace });
 
-      const nameInput = screen.getByLabelText(/^name$/i);
+      const nameInput = screen.getByLabelText("Namespace Name");
       await userEvent.clear(nameInput);
       await userEvent.type(nameInput, "changed-name");
 
@@ -350,7 +352,9 @@ describe("EditNamespaceDrawer", () => {
         />,
       );
 
-      expect(screen.getByLabelText(/^name$/i)).toHaveValue("my-namespace");
+      expect(screen.getByLabelText("Namespace Name")).toHaveValue(
+        "my-namespace",
+      );
     });
 
     it("clears any error when closed then reopened", async () => {
@@ -384,7 +388,7 @@ describe("EditNamespaceDrawer", () => {
   describe("null namespace", () => {
     it("renders the drawer with empty name field when namespace is null", () => {
       renderDrawer({ namespace: null });
-      expect(screen.getByLabelText(/^name$/i)).toHaveValue("");
+      expect(screen.getByLabelText("Namespace Name")).toHaveValue("");
     });
 
     it("renders the drawer with max_devices of -1 when namespace is null", () => {

--- a/ui-react/apps/console/src/utils/__tests__/validation.test.ts
+++ b/ui-react/apps/console/src/utils/__tests__/validation.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { validateNamespaceName } from "../validation";
+
+describe("validateNamespaceName", () => {
+  describe("valid names", () => {
+    it.each([
+      "abc",
+      "a-b",
+      "my-namespace",
+      "a1b2c3",
+      "1abc",
+      "abc1",
+      "a--b",
+      "a".repeat(30),
+    ])("accepts %p", (name) => {
+      expect(validateNamespaceName(name)).toBeNull();
+    });
+  });
+
+  describe("length rules", () => {
+    it.each(["", "a", "ab"])("rejects %p as too short", (name) => {
+      expect(validateNamespaceName(name)).toBe(
+        "Name must be at least 3 characters",
+      );
+    });
+
+    it("rejects names longer than 30 characters", () => {
+      expect(validateNamespaceName("a".repeat(31))).toBe(
+        "Name must be at most 30 characters",
+      );
+    });
+  });
+
+  describe("character rules", () => {
+    it.each([
+      "NameWithCaps",
+      "has space",
+      "has.dot",
+      "has@at",
+      "has#hash",
+      "has$dollar",
+      "has_underscore",
+      "has/slash",
+      "açento",
+    ])("rejects %p", (name) => {
+      expect(validateNamespaceName(name)).toBe(
+        "Only lowercase letters, numbers, and hyphens (cannot start or end with hyphen)",
+      );
+    });
+  });
+
+  describe("structural rules", () => {
+    it.each(["-leading", "trailing-", "-both-"])("rejects %p", (name) => {
+      expect(validateNamespaceName(name)).toBe(
+        "Only lowercase letters, numbers, and hyphens (cannot start or end with hyphen)",
+      );
+    });
+  });
+});

--- a/ui-react/apps/console/src/utils/validation.ts
+++ b/ui-react/apps/console/src/utils/validation.ts
@@ -4,6 +4,31 @@ export function validatePassword(value: string): string | null {
   return null;
 }
 
+export const NAMESPACE_NAME_MIN_LENGTH = 3;
+export const NAMESPACE_NAME_MAX_LENGTH = 30;
+export const NAMESPACE_NAME_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+export const NAMESPACE_NAME_HINT =
+  "3-30 characters, lowercase letters, numbers, and hyphens only.";
+
+export const NAMESPACE_NAME_RULES: readonly string[] = [
+  "3-30 characters",
+  "Lowercase letters, numbers, and hyphens only",
+  "Cannot begin or end with a hyphen",
+];
+
+export function validateNamespaceName(name: string): string | null {
+  if (name.length < NAMESPACE_NAME_MIN_LENGTH) {
+    return `Name must be at least ${NAMESPACE_NAME_MIN_LENGTH} characters`;
+  }
+  if (name.length > NAMESPACE_NAME_MAX_LENGTH) {
+    return `Name must be at most ${NAMESPACE_NAME_MAX_LENGTH} characters`;
+  }
+  if (!NAMESPACE_NAME_REGEX.test(name)) {
+    return "Only lowercase letters, numbers, and hyphens (cannot start or end with hyphen)";
+  }
+  return null;
+}
+
 export function isMaxNamespacesValid(
   limitEnabled: boolean,
   limitDisabled: boolean,


### PR DESCRIPTION
## What

Replaces four divergent namespace-name validation implementations with a single canonical rule shared across every create/edit surface in the React UI, and adds client-side validation to the admin edit drawer (which previously had none).

## Why

Each form encoded its own version of the rule. `CreateNamespace` and `CreateNamespaceDialog` enforced `3-30` chars with `/^[a-z0-9][a-z0-9-]*[a-z0-9]$/`. `Settings` enforced `3-30` chars with a slightly different regex plus an ad-hoc dot check. The admin `EditNamespaceDrawer` accepted any string and relied entirely on backend rejection. Hint text wording also drifted, and the `CreateNamespaceDialog` rules list used an en-dash where the inline hint used an ASCII hyphen. The canonical rule (RFC 1123 hostname subset enforced by the backend at `pkg/api/requests/namespace.go`) is now expressed once and reused everywhere, eliminating the question of whether `@`, `#`, or `$` are allowed (they are not).

## Changes

- **`utils/validation.ts`**: added `NAMESPACE_NAME_MIN_LENGTH`, `NAMESPACE_NAME_MAX_LENGTH`, `NAMESPACE_NAME_REGEX`, `NAMESPACE_NAME_HINT`, `NAMESPACE_NAME_RULES`, and `validateNamespaceName()` as the single source of truth.
- **`components/common/fields/NamespaceNameField.tsx`** (new): thin `InputField` wrapper that owns the label, placeholder, hint, `maxLength`, and lowercase-on-input behavior. Exports only the component; validator and constants live in the util.
- **`CreateNamespace.tsx` / `CreateNamespaceDialog.tsx` / `Settings.tsx`**: now consume `NamespaceNameField` and `validateNamespaceName`. Removed the duplicated local regexes and inline validators. `CreateNamespaceDialog` also reuses `NAMESPACE_NAME_RULES` instead of its own literal array.
- **`admin/namespaces/EditNamespaceDrawer.tsx`**: new client-side validation. `canSubmit` blocks submission when the name fails the canonical rule (gated by `name !== namespace?.name` so the existing value never triggers an error on open). The label changed from `Name` to `Namespace Name` to match the rest of the UI.
- **Tests**: 24 cases for `validateNamespaceName` covering valid names, length boundaries, character rules, and structural rules (leading/trailing hyphen). 8 cases for `NamespaceNameField` covering label, hint, lowercasing, `maxLength`, `aria-invalid`, and `autoFocus`. Existing `CreateNamespaceDialog` and `EditNamespaceDrawer` tests updated for the new label query and hint text.

Out of scope: the OpenAPI schema at `openapi/spec/components/schemas/namespaceName.yaml` is still `type: string` with no constraints. It should document `minLength: 3`, `maxLength: 30`, and the pattern in a follow-up.

## Testing

Try each form (`/setup`, the create dialog from the namespace switcher, `Settings → Rename`, and the admin `Edit` drawer) with: `ab` (too short), `Ab` (auto-lowercased), `a_b` (underscore), `a.b` (dot), `a@b` / `a#b` / `a$b` (special chars), `-ab` / `ab-` (edge hyphens), and a valid `my-namespace`. Each invalid input should surface the same inline error, the Save/Create button should be disabled, and pressing Enter on an invalid value should not submit. Borderline-valid `a--b` (internal double hyphen) should be accepted by both the UI and the backend.