### PR TITLE
fix(compose): force build over pull for dev images

### DIFF
--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -1,5 +1,6 @@
 services:
   agent:
+    pull_policy: build
     profiles: [agent]
     image: agent
     restart: unless-stopped

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,6 @@
 services:
   ssh:
+    pull_policy: build
     image: ssh
     build:
       context: .
@@ -17,6 +18,7 @@ services:
       - SHELLHUB_CLOUD=${SHELLHUB_CLOUD}
       - SHELLHUB_ENV=${SHELLHUB_ENV}
   api:
+    pull_policy: build
     image: api
     build:
       context: .
@@ -37,6 +39,7 @@ services:
       - SHELLHUB_CLOUD=${SHELLHUB_CLOUD}
       - SHELLHUB_ENV=${SHELLHUB_ENV}
   ui:
+    pull_policy: build
     image: ui
     build:
       context: .
@@ -49,6 +52,7 @@ services:
       - ./ui:/src
       - ui_node_modules:/src/node_modules
   ui-react:
+    pull_policy: build
     image: ui-react
     build:
       context: .
@@ -61,6 +65,7 @@ services:
       - ./ui-react:/src
       - ./openapi:/openapi:ro
   gateway:
+    pull_policy: build
     image: gateway
     build:
       context: .
@@ -76,6 +81,7 @@ services:
       - SHELLHUB_ENV=${SHELLHUB_ENV}
       - SHELLHUB_GATEWAY_ACCESS_LOGS=${SHELLHUB_GATEWAY_ACCESS_LOGS}
   cli:
+    pull_policy: build
     image: cli
     build:
       context: .
@@ -90,6 +96,7 @@ services:
       - ./api:/go/src/github.com/shellhub-io/shellhub/api
       - ./.golangci.yaml:/.golangci.yaml
   openapi:
+    pull_policy: build
     image: openapi
     build:
       context: .


### PR DESCRIPTION
## What changed?

Add `pull_policy: build` to all services in `docker-compose.dev.yml`
and to `agent` in `docker-compose.agent.yml`.

## Why

After the recent wrapper refactor that replaced `COMPOSE_FILE`
chaining with `include:`, dev mode started pulling the published
release images (e.g. `shellhubio/api:v0.24.2`) instead of building
locally from source. Root cause: `include:` flips merge precedence
versus `COMPOSE_FILE`, the including file wins instead of the
included one. So the dev overlay's `image: api` no longer overrode
the base's published tag, and Compose's default pull-first behavior
kicked in.

`pull_policy: build` makes the build-vs-pull decision explicit and
independent of merge order.

## How to test

1. `./bin/docker-compose down -v`
2. Clear cached release images so Compose has to decide cleanly:
   `docker images --filter 'reference=shellhubio/*' --format '{{.ID}}' | xargs -r docker rmi -f`
3. Confirm `.env.override` has `SHELLHUB_ENV=development`
4. `./bin/docker-compose up -d`
5. Output should show `Built` for each service, not `Pulled`
6. Production parity check: temporarily unset `SHELLHUB_ENV`, repeat
   steps 2 and 4, output should show `Pulled` (registry behavior preserved)