### PR TITLE
refactor(ui-react): drop firewall rule response normalization

### DIFF
--- a/openapi/spec/components/schemas/firewallRulesResponse.yaml
+++ b/openapi/spec/components/schemas/firewallRulesResponse.yaml
@@ -48,6 +48,7 @@ properties:
     type: string
     example: .*
 required:
+  - id
   - tenant_id
   - action
   - active

--- a/ui-react/apps/console/src/components/common/FilterBadge.tsx
+++ b/ui-react/apps/console/src/components/common/FilterBadge.tsx
@@ -1,3 +1,4 @@
+import { Tag } from "@/client";
 import {
   TagIcon,
   CpuChipIcon,
@@ -7,18 +8,18 @@ import {
 export default function FilterBadge({
   filter,
 }: {
-  filter: { tags?: string[]; hostname?: string };
+  filter: { tags?: Tag[]; hostname?: string };
 }) {
   if (filter.tags && filter.tags.length > 0) {
     return (
       <div className="flex flex-wrap gap-1">
         {filter.tags.map((tag) => (
           <span
-            key={tag}
+            key={tag.name}
             className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-primary/10 text-primary text-2xs rounded font-medium"
           >
             <TagIcon className="w-2.5 h-2.5" strokeWidth={2} />
-            {tag}
+            {tag.name}
           </span>
         ))}
       </div>

--- a/ui-react/apps/console/src/hooks/__tests__/useAdminFirewallRules.test.ts
+++ b/ui-react/apps/console/src/hooks/__tests__/useAdminFirewallRules.test.ts
@@ -64,7 +64,7 @@ describe("useAdminFirewallRules", () => {
           active: true,
           source_ip: ".*",
           username: ".*",
-          filter: { hostname: ".*" },
+          filter: { hostname: ".*", tags: [] },
         },
         {
           id: "rule-2",
@@ -74,7 +74,7 @@ describe("useAdminFirewallRules", () => {
           active: false,
           source_ip: "192.168.1.0/24",
           username: "admin",
-          filter: { hostname: "my-host" },
+          filter: { hostname: "my-host", tags: [] },
         },
       ];
       mockGetFirewallRulesAdminFn.mockResolvedValue({
@@ -90,86 +90,6 @@ describe("useAdminFirewallRules", () => {
       expect(result.current.rules).toHaveLength(2);
       expect(result.current.rules[0].id).toBe("rule-1");
       expect(result.current.rules[1].id).toBe("rule-2");
-    });
-
-    it("normalizes hostname filter from raw rule", async () => {
-      const rules = [
-        {
-          id: "rule-1",
-          tenant_id: "tenant-abc",
-          priority: 1,
-          action: "allow",
-          active: true,
-          source_ip: ".*",
-          username: ".*",
-          filter: { hostname: "my-host" },
-        },
-      ];
-      mockGetFirewallRulesAdminFn.mockResolvedValue({
-        data: rules,
-        totalCount: 1,
-      });
-
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
-
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-      expect(result.current.rules[0].filter).toEqual({ hostname: "my-host" });
-    });
-
-    it("normalizes tags filter from raw rule", async () => {
-      const rules = [
-        {
-          id: "rule-1",
-          tenant_id: "tenant-abc",
-          priority: 1,
-          action: "allow",
-          active: true,
-          source_ip: ".*",
-          username: ".*",
-          filter: { tags: [{ name: "production" }, "staging"] },
-        },
-      ];
-      mockGetFirewallRulesAdminFn.mockResolvedValue({
-        data: rules,
-        totalCount: 1,
-      });
-
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
-
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-      expect(result.current.rules[0].filter).toEqual({
-        tags: ["production", "staging"],
-      });
-    });
-
-    it("treats empty tags array as wildcard hostname filter", async () => {
-      const rules = [
-        {
-          id: "rule-1",
-          tenant_id: "t",
-          priority: 1,
-          action: "allow",
-          active: true,
-          source_ip: ".*",
-          username: ".*",
-          filter: { tags: [] },
-        },
-      ];
-      mockGetFirewallRulesAdminFn.mockResolvedValue({
-        data: rules,
-        totalCount: 1,
-      });
-
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
-
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-      expect(result.current.rules[0].filter).toEqual({ hostname: ".*" });
     });
 
     it("returns totalCount from the paginated query result", async () => {
@@ -188,7 +108,7 @@ describe("useAdminFirewallRules", () => {
 
     it("defaults rules to empty array while loading", () => {
       // Never resolves — stays in loading state
-      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => { }));
+      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
 
       const { result } = renderHook(() => useAdminFirewallRules(), {
         wrapper: createWrapper(),
@@ -198,7 +118,7 @@ describe("useAdminFirewallRules", () => {
     });
 
     it("defaults totalCount to 0 while loading", () => {
-      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => { }));
+      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
 
       const { result } = renderHook(() => useAdminFirewallRules(), {
         wrapper: createWrapper(),
@@ -208,7 +128,7 @@ describe("useAdminFirewallRules", () => {
     });
 
     it("returns isLoading true initially", () => {
-      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => { }));
+      mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
 
       const { result } = renderHook(() => useAdminFirewallRules(), {
         wrapper: createWrapper(),
@@ -227,43 +147,6 @@ describe("useAdminFirewallRules", () => {
 
       await waitFor(() => expect(result.current.error).toBeTruthy());
       expect(result.current.error).toBe(networkError);
-    });
-
-    it("filters out rules without an id", async () => {
-      const rules = [
-        {
-          id: "rule-1",
-          tenant_id: "tenant-abc",
-          priority: 1,
-          action: "allow",
-          active: true,
-          source_ip: ".*",
-          username: ".*",
-          filter: { hostname: ".*" },
-        },
-        // Rule without an id — should be filtered out
-        {
-          tenant_id: "tenant-abc",
-          priority: 2,
-          action: "deny",
-          active: false,
-          source_ip: ".*",
-          username: ".*",
-          filter: { hostname: ".*" },
-        },
-      ];
-      mockGetFirewallRulesAdminFn.mockResolvedValue({
-        data: rules,
-        totalCount: 2,
-      });
-
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
-
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-      expect(result.current.rules).toHaveLength(1);
-      expect(result.current.rules[0].id).toBe("rule-1");
     });
   });
 
@@ -334,7 +217,7 @@ describe("useAdminFirewallRule", () => {
         active: true,
         source_ip: ".*",
         username: ".*",
-        filter: { hostname: ".*" },
+        filter: { hostname: ".*", tags: [] },
       };
       mockGetFirewallRuleAdminFn.mockResolvedValue(rawRule);
 
@@ -346,7 +229,7 @@ describe("useAdminFirewallRule", () => {
       expect(result.current.data?.id).toBe("rule-1");
     });
 
-    it("applies normalization via select — returns FirewallRule shape", async () => {
+    it("passes through the filter unchanged", async () => {
       const rawRule = {
         id: "rule-1",
         tenant_id: "tenant-abc",
@@ -355,7 +238,7 @@ describe("useAdminFirewallRule", () => {
         active: true,
         source_ip: ".*",
         username: ".*",
-        filter: { hostname: "my-host" },
+        filter: { hostname: "my-host", tags: [] },
       };
       mockGetFirewallRuleAdminFn.mockResolvedValue(rawRule);
 
@@ -364,11 +247,14 @@ describe("useAdminFirewallRule", () => {
       });
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
-      expect(result.current.data?.filter).toEqual({ hostname: "my-host" });
+      expect(result.current.data?.filter).toEqual({
+        hostname: "my-host",
+        tags: [],
+      });
     });
 
     it("is loading initially when id is provided", () => {
-      mockGetFirewallRuleAdminFn.mockReturnValue(new Promise(() => { }));
+      mockGetFirewallRuleAdminFn.mockReturnValue(new Promise(() => {}));
 
       const { result } = renderHook(() => useAdminFirewallRule("rule-1"), {
         wrapper: createWrapper(),

--- a/ui-react/apps/console/src/hooks/useAdminFirewallRules.ts
+++ b/ui-react/apps/console/src/hooks/useAdminFirewallRules.ts
@@ -13,9 +13,6 @@ import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
 
-import { normalizeFirewallRule } from "./useFirewallRules";
-export type { FirewallRule, FirewallFilter } from "./useFirewallRules";
-
 interface UseAdminFirewallRulesParams {
   page?: number;
   perPage?: number;
@@ -44,16 +41,7 @@ export function useAdminFirewallRules({
     refetchOnWindowFocus: false,
   });
 
-  const rules = useMemo(
-    () =>
-      result.data?.data
-        .filter(
-          (r): r is FirewallRulesResponse & { id: string } =>
-            r.id !== undefined,
-        )
-        .map(normalizeFirewallRule) ?? [],
-    [result.data],
-  );
+  const rules = useMemo(() => result.data?.data ?? [], [result.data]);
 
   return {
     rules,
@@ -73,12 +61,5 @@ export function useAdminFirewallRule(id: string) {
     retry: (count, err) =>
       isSdkError(err) && err.status === 401 ? false : count < 1,
     refetchOnWindowFocus: false,
-    select: (data) => {
-      const rule = data;
-      if (!rule.id) return undefined;
-      return normalizeFirewallRule(
-        rule as FirewallRulesResponse & { id: string },
-      );
-    },
   });
 }

--- a/ui-react/apps/console/src/hooks/useFirewallRules.ts
+++ b/ui-react/apps/console/src/hooks/useFirewallRules.ts
@@ -8,48 +8,6 @@ import {
 import { getFirewallRulesQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 
-export interface FirewallFilter {
-  hostname?: string;
-  tags?: string[];
-}
-
-export interface FirewallRule {
-  id: string;
-  tenant_id: string;
-  priority: number;
-  action: "allow" | "deny";
-  active: boolean;
-  source_ip: string;
-  username: string;
-  filter: FirewallFilter;
-}
-
-export function normalizeFirewallRule(
-  rule: FirewallRulesResponse & { id: string },
-): FirewallRule {
-  let filter: FirewallFilter;
-  if (
-    "tags" in rule.filter
-    && Array.isArray(rule.filter.tags)
-    && rule.filter.tags.length > 0
-  ) {
-    filter = {
-      tags: rule.filter.tags.map((t) =>
-        typeof t === "object" && t !== null && "name" in t ? t.name : String(t),
-      ),
-    };
-  } else if ("hostname" in rule.filter) {
-    filter = { hostname: rule.filter.hostname };
-  } else {
-    filter = { hostname: ".*" };
-  }
-
-  return {
-    ...rule,
-    filter,
-  };
-}
-
 interface UseFirewallRulesParams {
   page?: number;
   perPage?: number;
@@ -68,16 +26,7 @@ export function useFirewallRules({
     queryFn: paginatedQueryFn(getFirewallRulesSdk, options),
   });
 
-  const rules = useMemo(
-    () =>
-      result.data?.data
-        .filter(
-          (r): r is FirewallRulesResponse & { id: string } =>
-            r.id !== undefined,
-        )
-        .map(normalizeFirewallRule) ?? [],
-    [result.data],
-  );
+  const rules = useMemo(() => result.data?.data ?? [], [result.data]);
 
   return {
     rules,

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRuleDetails.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRuleDetails.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import type { FirewallRule } from "@/hooks/useAdminFirewallRules";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -26,10 +25,20 @@ vi.mock("@/components/common/CopyButton", () => ({
 
 import { useAdminFirewallRule } from "@/hooks/useAdminFirewallRules";
 import AdminFirewallRuleDetails from "../AdminFirewallRuleDetails";
+import { FirewallRulesResponse } from "@/client";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function makeRule(overrides: Partial<FirewallRule> = {}): FirewallRule {
+function makeTag(name: string) {
+  return {
+    name,
+    tenant_id: "tenant-abc",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeRule(overrides: Partial<FirewallRulesResponse> = {}): FirewallRulesResponse {
   return {
     id: "rule-1",
     tenant_id: "tenant-abc",
@@ -38,7 +47,7 @@ function makeRule(overrides: Partial<FirewallRule> = {}): FirewallRule {
     active: true,
     source_ip: ".*",
     username: ".*",
-    filter: { hostname: ".*" },
+    filter: { hostname: ".*", tags: [] },
     ...overrides,
   };
 }
@@ -233,7 +242,7 @@ describe("AdminFirewallRuleDetails", () => {
   describe("rule data — device filter", () => {
     it("renders hostname FilterBadge when filter has a specific hostname", () => {
       vi.mocked(useAdminFirewallRule).mockReturnValue({
-        data: makeRule({ filter: { hostname: "my-server" } }),
+        data: makeRule({ filter: { hostname: "my-server", tags: [] } }),
         isLoading: false,
         error: null,
       } as ReturnType<typeof useAdminFirewallRule>);
@@ -244,7 +253,7 @@ describe("AdminFirewallRuleDetails", () => {
 
     it("renders tag FilterBadge when filter has tags", () => {
       vi.mocked(useAdminFirewallRule).mockReturnValue({
-        data: makeRule({ filter: { tags: ["production", "web"] } }),
+        data: makeRule({ filter: { tags: [makeTag("production"), makeTag("web")] } }),
         isLoading: false,
         error: null,
       } as ReturnType<typeof useAdminFirewallRule>);

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import type { FirewallRule } from "@/hooks/useAdminFirewallRules";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -21,17 +20,18 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
 import AdminFirewallRules from "../index";
+import { FirewallRulesResponse } from "@/client";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const defaultHookState = {
-  rules: [] as FirewallRule[],
+  rules: [],
   totalCount: 0,
   isLoading: false,
   error: null,
 };
 
-function makeRule(overrides: Partial<FirewallRule> = {}): FirewallRule {
+function makeRule(overrides: Partial<FirewallRulesResponse> = {}): FirewallRulesResponse {
   return {
     id: "rule-1",
     tenant_id: "tenant-abc",
@@ -40,7 +40,7 @@ function makeRule(overrides: Partial<FirewallRule> = {}): FirewallRule {
     active: true,
     source_ip: ".*",
     username: ".*",
-    filter: { hostname: ".*" },
+    filter: { hostname: ".*", tags: [] },
     ...overrides,
   };
 }

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/index.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/index.tsx
@@ -7,13 +7,11 @@ import {
   CheckCircleIcon,
   NoSymbolIcon,
 } from "@heroicons/react/24/outline";
-import {
-  useAdminFirewallRules,
-  type FirewallRule,
-} from "@/hooks/useAdminFirewallRules";
+import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
 import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
 import FilterBadge from "@/components/common/FilterBadge";
+import { type FirewallRulesResponse as FirewallRule } from "@/client";
 
 const PER_PAGE = 10;
 

--- a/ui-react/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
@@ -4,8 +4,7 @@ import {
   useCreateFirewallRule,
   useUpdateFirewallRule,
 } from "@/hooks/useFirewallRuleMutations";
-import type { FirewallRule } from "@/hooks/useFirewallRules";
-import type { FirewallRulesRequest } from "@/client";
+import type { FirewallRulesRequest, FirewallRulesResponse } from "@/client";
 import Drawer from "@/components/common/Drawer";
 import RadioCard from "@/components/common/fields/RadioCard";
 import RadioGroupField from "@/components/common/fields/RadioGroupField";
@@ -48,7 +47,7 @@ export default function RuleDrawer({
   onClose,
 }: {
   open: boolean;
-  editRule: FirewallRule | null;
+  editRule: FirewallRulesResponse | null;
   onClose: () => void;
 }) {
   const createRule = useCreateFirewallRule();
@@ -76,7 +75,7 @@ export default function RuleDrawer({
 
   useResetOnOpen(open, () => {
     const filterInit = editRule
-      ? editRule.filter.tags && editRule.filter.tags.length > 0
+      ? editRule.filter.tags.length > 0
         ? "tags"
         : editRule.filter.hostname && editRule.filter.hostname !== ".*"
           ? "hostname"
@@ -105,7 +104,9 @@ export default function RuleDrawer({
         : "",
     );
     setSelectedTags(
-      editRule && filterInit === "tags" ? (editRule.filter.tags ?? []) : [],
+      editRule && filterInit === "tags"
+        ? editRule.filter.tags.map((t) => t.name)
+        : [],
     );
     setSubmitting(false);
     setError(null);
@@ -113,7 +114,8 @@ export default function RuleDrawer({
 
   const buildFilter = (): FirewallRulesRequest["filter"] => {
     if (filterOption === "hostname" && hostname) return { hostname };
-    if (filterOption === "tags" && selectedTags.length > 0) return { tags: selectedTags };
+    if (filterOption === "tags" && selectedTags.length > 0)
+      return { tags: selectedTags };
     return { hostname: ".*" };
   };
 
@@ -207,7 +209,9 @@ export default function RuleDrawer({
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
         {/* Status toggle */}
         <div>
-          <span id="rule-status-label" className={LABEL}>Status</span>
+          <span id="rule-status-label" className={LABEL}>
+            Status
+          </span>
           <button
             type="button"
             role="switch"

--- a/ui-react/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { FirewallRule } from "@/hooks/useFirewallRules";
+import { FirewallRulesResponse } from "@/client";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -66,7 +66,7 @@ import FirewallRules from "../index";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function makeRule(overrides: Partial<FirewallRule> = {}): FirewallRule {
+function makeRule(overrides: Partial<FirewallRulesResponse> = {}): FirewallRulesResponse {
   return {
     id: "rule-1",
     tenant_id: "tenant-abc",
@@ -75,7 +75,7 @@ function makeRule(overrides: Partial<FirewallRule> = {}): FirewallRule {
     active: true,
     source_ip: ".*",
     username: ".*",
-    filter: { hostname: ".*" },
+    filter: { hostname: ".*", tags: [] },
     ...overrides,
   };
 }

--- a/ui-react/apps/console/src/pages/firewall-rules/index.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useFirewallRules, type FirewallRule } from "@/hooks/useFirewallRules";
+import { useFirewallRules } from "@/hooks/useFirewallRules";
 import { useDeleteFirewallRule } from "@/hooks/useFirewallRuleMutations";
 import PageHeader from "@/components/common/PageHeader";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
@@ -18,6 +18,7 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline";
+import { type FirewallRulesResponse as FirewallRule } from "@/client";
 
 const PER_PAGE = 10;
 


### PR DESCRIPTION
## What

Removes the client-side workaround that filtered out `id`-less firewall rules and coerced mixed-shape `filter.tags` into `string[]`. The console now consumes the SDK-generated `FirewallRulesResponse` type directly.

## Why

Depends on shellhub-io/cloud#2373, which makes the cloud API always return a fully-populated firewall rule (with `id` and `filter.tags` as `Tag[]`). With that contract honored on the server side, `normalizeFirewallRule` and the `r.id !== undefined` type-guard filter are dead weight.

## Changes

- **openapi**: marked `id` as required on `firewallRulesResponse` to reflect the server contract.
- **hooks**: deleted `normalizeFirewallRule`, the local `FirewallRule`/`FirewallFilter` types, the id-less rule filter, and the `select` callback in `useAdminFirewallRule`. Both hooks now return `FirewallRulesResponse[]` straight from the paginated query.
- **components**: `FilterBadge` accepts `Tag[]` instead of `string[]` and renders `tag.name`. `RuleDrawer` consumes `FirewallRulesResponse` and maps tag objects to names inline.
- **pages**: `firewall-rules` and `admin/firewall-rules` alias `FirewallRulesResponse as FirewallRule` at the call site (matches the existing `PublicKeyResponse as PublicKey` convention).
- **tests**: dropped the normalization-specific test cases; the remaining mocks were updated to include `tags: []` to match the new required-field schema.

## Testing

Hit the firewall rules and admin firewall rules pages with a mix of hostname-filtered, tag-filtered, and unfiltered rules, then edit one of each to confirm the drawer initializes the correct filter mode and tag set. Make sure this is merged only after shellhub-io/cloud#2373 — otherwise the cloud response may still arrive without `id` and rules will render with broken edit/delete actions.