### PR TITLE
fix(infra): load cloud envs only when `SHELLHUB_CLOUD` is true

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -31,7 +31,7 @@ COMPOSE_ENV_FILES="./.env"
 [ "$SHELLHUB_ENTERPRISE" = "true" ] && [ -f ./.env.enterprise ] \
     && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,./.env.enterprise"
 [ -f "$env_override" ] && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,$env_override"
-if [ "$SHELLHUB_ENTERPRISE" = "true" ]; then
+if [ "$SHELLHUB_CLOUD" = "true" ]; then
     [ -f ../cloud/.env ]          && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,../cloud/.env"
     [ -f ../cloud/.env.override ] && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,../cloud/.env.override"
 fi

--- a/tests/compose/with_cloud.bats
+++ b/tests/compose/with_cloud.bats
@@ -40,8 +40,8 @@ load helpers
     [[ "$out" != *"../cloud/docker-compose.dev.yml"* ]]
 }
 
-@test "enterprise: COMPOSE_ENV_FILES loads cloud/.env when cloud/ is present" {
+@test "enterprise-only: COMPOSE_ENV_FILES does NOT load cloud/.env" {
     require_cloud
     out=$(capture_with SHELLHUB_ENTERPRISE=true)
-    [[ "$out" == *"../cloud/.env"* ]]
+    [[ "$out" != *"../cloud/.env"* ]]
 }


### PR DESCRIPTION
## What 

Fix the Docker Compose bin script to load the environment variables from the `cloud` repo only when `SHELLHUB_CLOUD` is `true`, not `SHELLHUB_ENTERPRISE`

## Why

The Cloud environment variables were being loaded in Enterprise instances, mixing the instances and breaking the API by expecting variables that are not exposed in Enterprise instances (e.g. `SHELLHUB_EMAIL_PROVIDER`).
