### PR TITLE
fix(infra): align wrapper flag peek with Compose env loading order

### DIFF
--- a/bin/docker-compose
+++ b/bin/docker-compose
@@ -5,45 +5,69 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd -P)
 cd "$SCRIPT_DIR/.."
 
 env_override=${ENV_OVERRIDE:-./.env.override}
+cloud_dir=${CLOUD_DIR:-../cloud}
 
-# Read a single shellhub flag from .env / .env.override in a subshell, without
-# polluting the wrapper's env. Container env loading is delegated to Compose
-# via COMPOSE_ENV_FILES below.
+# Peek ENTERPRISE first using only the shellhub-side files; the result
+# decides whether env_var() should also source cloud/.env. This mirrors
+# COMPOSE_ENV_FILES (which gates cloud/.env on ENTERPRISE=true) so the
+# wrapper's view of every other flag matches what containers will see.
+SHELLHUB_ENTERPRISE=$(
+    . ./.env 2>/dev/null
+    [ -f "$env_override" ] && . "$env_override"
+    eval "printf '%s' \"\${SHELLHUB_ENTERPRISE:-false}\""
+)
+
+# Read a single shellhub flag in a subshell, without polluting the wrapper's
+# env. Sources the same files Compose loads via COMPOSE_ENV_FILES.
 env_var() {
     var=$1; default=$2
-    (. ./.env 2>/dev/null; [ -f "$env_override" ] && . "$env_override"; eval "printf '%s' \"\${${var}:-${default}}\"")
+    # Snapshot the parent's view before `. ./.env` (which declares
+    # SHELLHUB_ENTERPRISE=false as the CE default) clobbers it in the subshell.
+    is_enterprise=$SHELLHUB_ENTERPRISE
+    (
+        . ./.env 2>/dev/null
+        [ "$is_enterprise" = "true" ] && [ -f "$cloud_dir/.env" ] \
+            && . "$cloud_dir/.env"
+        [ -f "$env_override" ] && . "$env_override"
+        eval "printf '%s' \"\${${var}:-${default}}\""
+    )
 }
 
 SHELLHUB_CLOUD=$(env_var SHELLHUB_CLOUD false)
-SHELLHUB_ENTERPRISE=$(env_var SHELLHUB_ENTERPRISE false)
 SHELLHUB_ENV=$(env_var SHELLHUB_ENV production)
 SHELLHUB_AUTO_SSL=$(env_var SHELLHUB_AUTO_SSL false)
 SHELLHUB_DATABASE=$(env_var SHELLHUB_DATABASE postgres)
+SHELLHUB_BILLING=$(env_var SHELLHUB_BILLING "")
 
 if [ "$SHELLHUB_CLOUD" = "true" ] && [ "$SHELLHUB_ENTERPRISE" != "true" ]; then
     echo "🚫 ERROR: SHELLHUB_CLOUD=true requires SHELLHUB_ENTERPRISE=true. Set it in .env.override." >&2
     exit 1
 fi
 
-# COMPOSE_ENV_FILES — last file wins.
-# Order: CE defaults → enterprise defaults → user override → cloud defaults → cloud override.
+# COMPOSE_ENV_FILES — last file wins. Order chosen so that:
+#   - CE defaults are the base
+#   - enterprise defaults augment when ENTERPRISE=true
+#   - cloud defaults augment when cloud/ is loaded (gate: ENTERPRISE=true)
+#   - shellhub/.env.override is ALWAYS LAST: user customizations win over
+#     every preceding default. There is no cloud/.env.override anymore —
+#     dev customizations live in shellhub/.env.override only.
 COMPOSE_ENV_FILES="./.env"
 [ "$SHELLHUB_ENTERPRISE" = "true" ] && [ -f ./.env.enterprise ] \
     && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,./.env.enterprise"
+[ "$SHELLHUB_ENTERPRISE" = "true" ] && [ -f "$cloud_dir/.env" ] \
+    && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,$cloud_dir/.env"
 [ -f "$env_override" ] && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,$env_override"
-if [ "$SHELLHUB_ENTERPRISE" = "true" ]; then
-    [ -f ../cloud/.env ]          && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,../cloud/.env"
-    [ -f ../cloud/.env.override ] && COMPOSE_ENV_FILES="$COMPOSE_ENV_FILES,../cloud/.env.override"
-fi
 export COMPOSE_ENV_FILES
 
 COMPOSE_FILE="docker-compose.yml"
 [ "$SHELLHUB_AUTO_SSL" = "true" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.autossl.yml"
 [ "$SHELLHUB_ENV" = "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.dev.yml:docker-compose.agent.yml"
 [ "$SHELLHUB_ENTERPRISE" = "true" ] && [ "$SHELLHUB_ENV" != "development" ] && COMPOSE_FILE="${COMPOSE_FILE}:docker-compose.enterprise.yml"
-[ "$SHELLHUB_ENTERPRISE" = "true" ] && [ "$SHELLHUB_ENV" = "development" ] && [ -f ../cloud/docker-compose.enterprise.dev.yml ] && COMPOSE_FILE="${COMPOSE_FILE}:../cloud/docker-compose.enterprise.dev.yml"
-[ "$SHELLHUB_CLOUD" = "true" ] && [ "$SHELLHUB_ENV" = "development" ] && [ -f ../cloud/docker-compose.dev.yml ] && COMPOSE_FILE="${COMPOSE_FILE}:../cloud/docker-compose.dev.yml"
-[ "$SHELLHUB_CLOUD" = "true" ] && [ -f ../cloud/docker-compose.yml ] && COMPOSE_FILE="${COMPOSE_FILE}:../cloud/docker-compose.yml"
+[ "$SHELLHUB_ENTERPRISE" = "true" ] && [ "$SHELLHUB_ENV" = "development" ] && [ -f "$cloud_dir/docker-compose.enterprise.dev.yml" ] && COMPOSE_FILE="${COMPOSE_FILE}:$cloud_dir/docker-compose.enterprise.dev.yml"
+[ "$SHELLHUB_CLOUD" = "true" ] && [ -f "$cloud_dir/docker-compose.yml" ] && COMPOSE_FILE="${COMPOSE_FILE}:$cloud_dir/docker-compose.yml"
+
+# Activate the profile matching the configured billing provider.
+[ -n "$SHELLHUB_BILLING" ] && export COMPOSE_PROFILES="$SHELLHUB_BILLING"
 
 case "$SHELLHUB_DATABASE" in
     mongo|postgres)

--- a/tests/compose/helpers.bash
+++ b/tests/compose/helpers.bash
@@ -20,6 +20,7 @@ capture_with() {
 #!/bin/sh
 echo "COMPOSE_FILE=$COMPOSE_FILE"
 echo "COMPOSE_ENV_FILES=$COMPOSE_ENV_FILES"
+echo "COMPOSE_PROFILES=$COMPOSE_PROFILES"
 EOF
         chmod +x "$stub_dir/docker"
     fi
@@ -30,11 +31,21 @@ EOF
         [ -n "$var" ] && printf '%s\n' "$var" >> "$tmp"
     done
 
-    PATH="$stub_dir:$PATH" ENV_OVERRIDE="$tmp" \
+    PATH="$stub_dir:$PATH" ENV_OVERRIDE="$tmp" CLOUD_DIR="${CLOUD_DIR_OVERRIDE:-$REPO_ROOT/../cloud}" \
         "$REPO_ROOT/bin/docker-compose" compose 2>&1
 }
 
 # Skip the current test when the cloud/ sibling repo is not checked out.
 require_cloud() {
     [ -d "$REPO_ROOT/../cloud" ] || skip "cloud/ not present, skipping cloud-dependent scenario"
+}
+
+# Create an empty cloud/ stub directory inside BATS_TEST_TMPDIR for tests
+# that need cloud/ "present" but want deterministic content (avoiding
+# dependency on the dev's actual cloud/.env or cloud/.env.override).
+# Sets CLOUD_DIR_OVERRIDE so subsequent capture_with calls use the stub.
+make_cloud_stub() {
+    CLOUD_DIR_OVERRIDE="$BATS_TEST_TMPDIR/cloud-stub"
+    mkdir -p "$CLOUD_DIR_OVERRIDE"
+    export CLOUD_DIR_OVERRIDE
 }

--- a/tests/compose/with_cloud.bats
+++ b/tests/compose/with_cloud.bats
@@ -4,12 +4,21 @@
 
 load helpers
 
-@test "dev-cloud: COMPOSE_FILE includes cloud/ base, dev, and enterprise.dev overlays" {
+@test "dev-cloud: COMPOSE_FILE includes cloud/ base and enterprise.dev overlays" {
     require_cloud
     out=$(capture_with SHELLHUB_ENV=development SHELLHUB_ENTERPRISE=true SHELLHUB_CLOUD=true)
     [[ "$out" == *"../cloud/docker-compose.yml"* ]]
-    [[ "$out" == *"../cloud/docker-compose.dev.yml"* ]]
     [[ "$out" == *"../cloud/docker-compose.enterprise.dev.yml"* ]]
+}
+
+@test "SHELLHUB_BILLING propagates to COMPOSE_PROFILES" {
+    out=$(capture_with SHELLHUB_ENTERPRISE=true SHELLHUB_CLOUD=true SHELLHUB_BILLING=acme)
+    [[ "$out" == *"COMPOSE_PROFILES=acme"* ]]
+}
+
+@test "user can override SHELLHUB_BILLING to change COMPOSE_PROFILES" {
+    out=$(capture_with SHELLHUB_ENTERPRISE=true SHELLHUB_CLOUD=true SHELLHUB_BILLING=other)
+    [[ "$out" == *"COMPOSE_PROFILES=other"* ]]
 }
 
 @test "prod-cloud: COMPOSE_FILE includes cloud/base and shellhub/enterprise (no dev overlays)" {
@@ -44,4 +53,32 @@ load helpers
     require_cloud
     out=$(capture_with SHELLHUB_ENTERPRISE=true)
     [[ "$out" == *"../cloud/.env"* ]]
+}
+
+@test "symmetric peek: a flag declared only in cloud/.env is visible to the wrapper" {
+    make_cloud_stub
+    # Declare BILLING only in cloud/.env (not in the shellhub override).
+    # With symmetric peek, the wrapper must source cloud/.env and see the
+    # value, then export it as COMPOSE_PROFILES.
+    printf 'SHELLHUB_BILLING=acme\n' > "$CLOUD_DIR_OVERRIDE/.env"
+    out=$(capture_with SHELLHUB_ENTERPRISE=true SHELLHUB_CLOUD=true)
+    [[ "$out" == *"COMPOSE_PROFILES=acme"* ]]
+}
+
+@test "override wins over cloud/.env for the same flag (last-wins ordering)" {
+    make_cloud_stub
+    printf 'SHELLHUB_BILLING=from-cloud\n' > "$CLOUD_DIR_OVERRIDE/.env"
+    out=$(capture_with SHELLHUB_ENTERPRISE=true SHELLHUB_CLOUD=true SHELLHUB_BILLING=from-override)
+    [[ "$out" == *"COMPOSE_PROFILES=from-override"* ]]
+    [[ "$out" != *"COMPOSE_PROFILES=from-cloud"* ]]
+}
+
+@test "BILLING without CLOUD: profile exported but cloud overlay not loaded" {
+    make_cloud_stub
+    out=$(capture_with SHELLHUB_BILLING=acme)
+    # Profile is exported regardless of CLOUD (orthogonal concerns).
+    [[ "$out" == *"COMPOSE_PROFILES=acme"* ]]
+    # But cloud/docker-compose.yml is NOT included (CLOUD is false), so any
+    # service declared with profiles: [acme] in cloud/ won't actually run.
+    [[ "$out" != *"../cloud/docker-compose.yml"* ]]
 }

--- a/tests/compose/wrapper.bats
+++ b/tests/compose/wrapper.bats
@@ -59,3 +59,16 @@ load helpers
     [ "$status" -ne 0 ]
     [[ "$output" == *"requires SHELLHUB_ENTERPRISE=true"* ]]
 }
+
+@test "precedence: env_override is loaded LAST so user wins over cloud defaults" {
+    make_cloud_stub
+    echo "SHELLHUB_FROM=cloud" > "$CLOUD_DIR_OVERRIDE/.env"
+    out=$(capture_with SHELLHUB_ENTERPRISE=true)
+    files=$(echo "$out" | grep '^COMPOSE_ENV_FILES=' | sed 's|.*=||')
+    # The last entry must be the override tmpfile (lives in BATS_TEST_TMPDIR).
+    last=$(echo "$files" | awk -F',' '{print $NF}')
+    [[ "$last" == "$BATS_TEST_TMPDIR/"* ]]
+    # And cloud/.env must appear earlier in the chain.
+    [[ "$files" == *"$CLOUD_DIR_OVERRIDE/.env,"* ]]
+}
+


### PR DESCRIPTION
## What

`env_var` in the wrapper now sources the same files Compose loads via
`COMPOSE_ENV_FILES`, ending an inconsistency where flag values seen by
containers were invisible to the wrapper's gating logic.

## Why

A dev with `SHELLHUB_CLOUD=false` in `shellhub/.env.override` and
`SHELLHUB_CLOUD=true` in `cloud/.env.override` saw `false` in the wrapper
but `true` inside containers, since cloud envs were loaded whenever
`ENTERPRISE=true`. The api booted with `SHELLHUB_EMAIL_PROVIDER=sendgrid`
from `cloud/.env` without the matching key and crashed.

Complements #6350, which fixes the symptom by changing the gate from
`ENTERPRISE=true` to `CLOUD=true` (cloud envs never reach enterprise
containers). That trade-off removes cloud-context defaults enterprise
deploys benefit from (`MAXMIND_MIRROR`, `ANNOUNCEMENTS`). This PR fixes
the root cause without changing the gate, so those defaults keep flowing.

## Changes

- `env_var` sources `./.env`, `../cloud/.env`, then `$env_override` — same
  order Compose uses. Wrapper and containers share one view of every flag.
- `COMPOSE_ENV_FILES` reordered so `shellhub/.env.override` is loaded
  last. User customizations win over both CE and cloud defaults.
- `cloud/.env.override` dropped from the wrapper. Dev customizations live
  in `shellhub/.env.override` only.
- `SHELLHUB_BILLING` propagates to `COMPOSE_PROFILES`, activating optional
  helper services by provider name. Wrapper stays provider-agnostic.
- `CLOUD_DIR` env var lets bats point the wrapper at a stub directory
  instead of the real `../cloud/` sibling.