### PR TITLE
refactor(ui-react): consolidate admin user drawers with shared form hook

### DIFF
--- a/ui-react/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
@@ -4,11 +4,8 @@ import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { useCreateUser } from "@/hooks/useAdminUserMutations";
 import { isSdkError } from "@/api/errors";
 import Drawer from "@/components/common/Drawer";
-import InputField from "@/components/common/fields/InputField";
-import PasswordField from "@/components/common/fields/PasswordField";
-import CheckboxField from "@/components/common/fields/CheckboxField";
-import NamespaceLimitFields from "./NamespaceLimitFields";
-import { isMaxNamespacesValid } from "@/utils/validation";
+import UserFormFields from "./UserFormFields";
+import { useUserForm } from "./useUserForm";
 
 interface CreateUserDrawerProps {
   open: boolean;
@@ -20,63 +17,26 @@ export default function CreateUserDrawer({
   onClose,
 }: CreateUserDrawerProps) {
   const createUser = useCreateUser();
-
-  const [name, setName] = useState("");
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [admin, setAdmin] = useState(false);
-  const [limitEnabled, setLimitEnabled] = useState(false);
-  const [limitDisabled, setLimitDisabled] = useState(false);
-  const [maxNamespaces, setMaxNamespaces] = useState("1");
-  const [error, setError] = useState("");
+  const form = useUserForm({ mode: "create" });
+  const [submitError, setSubmitError] = useState("");
 
   useResetOnOpen(open, () => {
-    setName("");
-    setUsername("");
-    setEmail("");
-    setPassword("");
-    setAdmin(false);
-    setLimitEnabled(false);
-    setLimitDisabled(false);
-    setMaxNamespaces("1");
-    setError("");
+    form.reset();
+    setSubmitError("");
   });
-
-  const computeMaxNamespaces = (): number | undefined => {
-    if (!limitEnabled) return undefined;
-    if (limitDisabled) return 0;
-    return parseInt(maxNamespaces, 10);
-  };
-
-  const canSubmit =
-    name.trim() &&
-    username.trim() &&
-    email.trim() &&
-    password.trim() &&
-    isMaxNamespacesValid(limitEnabled, limitDisabled, maxNamespaces);
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
-    if (!canSubmit) return;
-    setError("");
+    if (!form.validateAll()) return;
+    setSubmitError("");
     try {
-      await createUser.mutateAsync({
-        body: {
-          name: name.trim(),
-          username: username.trim(),
-          email: email.trim(),
-          password,
-          admin,
-          max_namespaces: computeMaxNamespaces(),
-        },
-      });
+      await createUser.mutateAsync({ body: form.buildPayload() });
       onClose();
     } catch (err) {
       if (isSdkError(err) && err.status === 409) {
-        setError("A user with this email or username already exists.");
+        setSubmitError("A user with this email or username already exists.");
       } else {
-        setError("Failed to create user. Please try again.");
+        setSubmitError("Failed to create user. Please try again.");
       }
     }
   };
@@ -97,7 +57,7 @@ export default function CreateUserDrawer({
           </button>
           <button
             onClick={() => void handleSubmit()}
-            disabled={!canSubmit || createUser.isPending}
+            disabled={!form.isSubmittable || createUser.isPending}
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {createUser.isPending ? (
@@ -113,67 +73,19 @@ export default function CreateUserDrawer({
         </>
       }
     >
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
-        <InputField
-          id="create-user-name"
-          label="Name"
-          value={name}
-          onChange={setName}
-          placeholder="John Doe"
+      <form
+        onSubmit={(e) => void handleSubmit(e)}
+        className="space-y-5"
+        noValidate
+      >
+        <UserFormFields
+          form={form}
+          idPrefix="create-user"
           autoFocus={open}
         />
-
-        <InputField
-          id="create-user-username"
-          label="Username"
-          value={username}
-          onChange={setUsername}
-          placeholder="johndoe"
-          hint="3-30 characters, letters, numbers, hyphens, dots, underscores, @"
-        />
-
-        <InputField
-          id="create-user-email"
-          label="Email"
-          type="email"
-          value={email}
-          onChange={setEmail}
-          placeholder="john@example.com"
-        />
-
-        <PasswordField
-          id="create-user-password"
-          label="Password"
-          value={password}
-          onChange={setPassword}
-          placeholder="Enter password"
-          hint="5-30 characters"
-          suppressPasswordManager
-        />
-
-        {/* Namespace Limit */}
-        <NamespaceLimitFields
-          idPrefix="create-user"
-          limitEnabled={limitEnabled}
-          onLimitEnabledChange={setLimitEnabled}
-          limitDisabled={limitDisabled}
-          onLimitDisabledChange={setLimitDisabled}
-          maxNamespaces={maxNamespaces}
-          onMaxNamespacesChange={setMaxNamespaces}
-        />
-
-        {/* Admin */}
-        <CheckboxField
-          id="create-user-admin"
-          label="Admin user"
-          checked={admin}
-          onChange={setAdmin}
-        />
-
-        {/* Error */}
-        {error && (
+        {submitError && (
           <p role="alert" className="text-2xs text-accent-red">
-            {error}
+            {submitError}
           </p>
         )}
       </form>

--- a/ui-react/apps/console/src/pages/admin/users/EditUserDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/EditUserDrawer.tsx
@@ -4,27 +4,14 @@ import { useUpdateUser } from "@/hooks/useAdminUserMutations";
 import { useAuthStore } from "@/stores/authStore";
 import { isSdkError } from "@/api/errors";
 import Drawer from "@/components/common/Drawer";
-import InputField from "@/components/common/fields/InputField";
-import PasswordField from "@/components/common/fields/PasswordField";
-import CheckboxField from "@/components/common/fields/CheckboxField";
-import NamespaceLimitFields from "./NamespaceLimitFields";
-import { isMaxNamespacesValid } from "@/utils/validation";
-import type { UserStatus } from "./UserStatusChip";
-
-export interface EditableUser {
-  id: string;
-  name: string;
-  username: string;
-  email: string;
-  admin?: boolean;
-  max_namespaces?: number;
-  status?: UserStatus;
-}
+import UserFormFields from "./UserFormFields";
+import { useUserForm } from "./useUserForm";
+import type { UserAdminResponse } from "@/client";
 
 interface EditUserDrawerProps {
   open: boolean;
   onClose: () => void;
-  user: EditableUser | null;
+  user: UserAdminResponse | null;
 }
 
 export default function EditUserDrawer({
@@ -34,82 +21,33 @@ export default function EditUserDrawer({
 }: EditUserDrawerProps) {
   const updateUser = useUpdateUser();
   const currentUsername = useAuthStore((s) => s.username);
-
-  const [name, setName] = useState("");
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmed, setConfirmed] = useState(false);
-  const [admin, setAdmin] = useState(false);
-  const [limitEnabled, setLimitEnabled] = useState(false);
-  const [limitDisabled, setLimitDisabled] = useState(false);
-  const [maxNamespaces, setMaxNamespaces] = useState("1");
-  const [error, setError] = useState("");
+  const form = useUserForm({ mode: "edit" });
+  const [submitError, setSubmitError] = useState("");
 
   useResetOnOpen(open, () => {
-    setName(user?.name ?? "");
-    setUsername(user?.username ?? "");
-    setEmail(user?.email ?? "");
-    setPassword("");
-    setConfirmed(user?.status === "confirmed");
-    setAdmin(user?.admin ?? false);
-
-    const maxNs = user?.max_namespaces;
-    if (maxNs !== undefined && maxNs >= 0) {
-      setLimitEnabled(true);
-      setLimitDisabled(maxNs === 0);
-      setMaxNamespaces(String(maxNs || 1));
-    } else {
-      setLimitEnabled(false);
-      setLimitDisabled(false);
-      setMaxNamespaces("1");
-    }
-
-    setError("");
+    form.reset(user);
+    setSubmitError("");
   });
 
-  const isConfirmed = user?.status === "confirmed";
-  const canChangeStatus = !isConfirmed;
   const isSelf = user?.username === currentUsername;
-
-  const computeMaxNamespaces = (): number | undefined => {
-    if (!limitEnabled) {
-      const orig = user?.max_namespaces;
-      return orig !== undefined && orig < 0 ? orig : undefined;
-    }
-    if (limitDisabled) return 0;
-    return parseInt(maxNamespaces, 10);
-  };
-
-  const canSubmit =
-    name.trim() &&
-    username.trim() &&
-    email.trim() &&
-    isMaxNamespacesValid(limitEnabled, limitDisabled, maxNamespaces);
+  const canChangeConfirmed = user?.status !== "confirmed";
+  const disableAdmin = !!user?.admin && isSelf;
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
-    if (!canSubmit || !user) return;
-    setError("");
+    if (!user || !form.validateAll()) return;
+    setSubmitError("");
     try {
       await updateUser.mutateAsync({
         path: { id: user.id },
-        body: {
-          name: name.trim(),
-          username: username.trim(),
-          email: email.trim(),
-          password,
-          confirmed,
-          admin,
-          max_namespaces: computeMaxNamespaces(),
-        },
+        body: form.buildPayload(user),
       });
       onClose();
     } catch (err) {
       if (isSdkError(err) && err.status === 409) {
-        setError("A user with this email or username already exists.");
+        setSubmitError("A user with this email or username already exists.");
       } else {
-        setError("Failed to update user. Please try again.");
+        setSubmitError("Failed to update user. Please try again.");
       }
     }
   };
@@ -133,7 +71,7 @@ export default function EditUserDrawer({
           </button>
           <button
             onClick={() => void handleSubmit()}
-            disabled={!canSubmit || updateUser.isPending}
+            disabled={!form.isSubmittable || updateUser.isPending}
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {updateUser.isPending && (
@@ -147,84 +85,21 @@ export default function EditUserDrawer({
         </>
       }
     >
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
-        <InputField
-          id="edit-user-name"
-          label="Name"
-          value={name}
-          onChange={setName}
-          autoFocus={open}
-        />
-
-        <InputField
-          id="edit-user-username"
-          label="Username"
-          value={username}
-          onChange={setUsername}
-          hint="3-30 characters, letters, numbers, hyphens, dots, underscores, @"
-        />
-
-        <InputField
-          id="edit-user-email"
-          label="Email"
-          type="email"
-          value={email}
-          onChange={setEmail}
-        />
-
-        <PasswordField
-          id="edit-user-password"
-          label="Password"
-          value={password}
-          onChange={setPassword}
-          placeholder="Leave blank to keep current"
-          hint="Leave blank to keep the current password"
-          suppressPasswordManager
-        />
-
-        {/* Namespace Limit */}
-        <NamespaceLimitFields
+      <form
+        onSubmit={(e) => void handleSubmit(e)}
+        className="space-y-5"
+        noValidate
+      >
+        <UserFormFields
+          form={form}
           idPrefix="edit-user"
-          limitEnabled={limitEnabled}
-          onLimitEnabledChange={setLimitEnabled}
-          limitDisabled={limitDisabled}
-          onLimitDisabledChange={setLimitDisabled}
-          maxNamespaces={maxNamespaces}
-          onMaxNamespacesChange={setMaxNamespaces}
+          autoFocus={open}
+          canChangeConfirmed={canChangeConfirmed}
+          disableAdmin={disableAdmin}
         />
-
-        {/* Confirmed */}
-        <CheckboxField
-          id="edit-user-confirmed"
-          label="Confirmed"
-          checked={confirmed}
-          onChange={setConfirmed}
-          disabled={!canChangeStatus}
-          title={
-            isConfirmed
-              ? "Cannot remove confirmation from a confirmed user"
-              : undefined
-          }
-        />
-
-        {/* Admin */}
-        <CheckboxField
-          id="edit-user-admin"
-          label="Admin user"
-          checked={admin}
-          onChange={setAdmin}
-          disabled={isSelf && admin}
-          title={
-            isSelf && admin
-              ? "Cannot remove your own admin privilege"
-              : undefined
-          }
-        />
-
-        {/* Error */}
-        {error && (
+        {submitError && (
           <p role="alert" className="text-2xs text-accent-red">
-            {error}
+            {submitError}
           </p>
         )}
       </form>

--- a/ui-react/apps/console/src/pages/admin/users/NamespaceLimitFields.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/NamespaceLimitFields.tsx
@@ -1,6 +1,6 @@
 import NumericInput from "@/components/common/fields/NumericInput";
 import CheckboxField from "@/components/common/fields/CheckboxField";
-import { isMaxNamespacesValid } from "@/utils/validation";
+import { MAX_NAMESPACES_ERROR, isMaxNamespacesValid } from "@/utils/validation";
 
 interface NamespaceLimitFieldsProps {
   idPrefix: string;
@@ -49,11 +49,7 @@ export default function NamespaceLimitFields({
               label="Max namespaces"
               value={maxNamespaces}
               onChange={onMaxNamespacesChange}
-              error={
-                valid
-                  ? undefined
-                  : "Max namespaces must be a number greater than or equal to 1"
-              }
+              error={valid ? undefined : MAX_NAMESPACES_ERROR}
             />
           )}
         </div>

--- a/ui-react/apps/console/src/pages/admin/users/UserFormFields.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/UserFormFields.tsx
@@ -1,0 +1,133 @@
+import InputField from "@/components/common/fields/InputField";
+import PasswordField from "@/components/common/fields/PasswordField";
+import CheckboxField from "@/components/common/fields/CheckboxField";
+import NamespaceLimitFields from "./NamespaceLimitFields";
+import {
+  NAME_MAX_LENGTH,
+  PASSWORD_HINT,
+  PASSWORD_MAX_LENGTH,
+  USERNAME_HINT,
+  USERNAME_MAX_LENGTH,
+} from "@/utils/validation";
+import type { UserFormApi } from "./useUserForm";
+
+interface UserFormFieldsProps {
+  form: UserFormApi;
+  idPrefix: string;
+  autoFocus?: boolean;
+  /** Edit only: false when the user is already confirmed (cannot un-confirm). */
+  canChangeConfirmed?: boolean;
+  /** Edit only: true when editing your own admin user (cannot self-demote). */
+  disableAdmin?: boolean;
+}
+
+export default function UserFormFields({
+  form,
+  idPrefix,
+  autoFocus,
+  canChangeConfirmed = true,
+  disableAdmin = false,
+}: UserFormFieldsProps) {
+  const { mode, values, errors, setField, validateField } = form;
+  const isCreate = mode === "create";
+
+  return (
+    <>
+      <InputField
+        id={`${idPrefix}-name`}
+        label="Name"
+        value={values.name}
+        onChange={(v) => setField("name", v)}
+        onBlur={() => validateField("name")}
+        error={errors.name}
+        errorRole="status"
+        placeholder={isCreate ? "John Doe" : undefined}
+        autoFocus={autoFocus}
+        maxLength={NAME_MAX_LENGTH}
+        required
+      />
+
+      <InputField
+        id={`${idPrefix}-username`}
+        label="Username"
+        value={values.username}
+        onChange={(v) => setField("username", v)}
+        onBlur={() => validateField("username")}
+        error={errors.username}
+        errorRole="status"
+        placeholder={isCreate ? "johndoe" : undefined}
+        hint={USERNAME_HINT}
+        autoComplete="username"
+        maxLength={USERNAME_MAX_LENGTH}
+        required
+      />
+
+      <InputField
+        id={`${idPrefix}-email`}
+        label="Email"
+        type="email"
+        value={values.email}
+        onChange={(v) => setField("email", v)}
+        onBlur={() => validateField("email")}
+        error={errors.email}
+        errorRole="status"
+        placeholder={isCreate ? "john@example.com" : undefined}
+        autoComplete="email"
+        required
+      />
+
+      <PasswordField
+        id={`${idPrefix}-password`}
+        label="Password"
+        value={values.password}
+        onChange={(v) => setField("password", v)}
+        onBlur={() => validateField("password")}
+        error={errors.password}
+        errorRole="status"
+        placeholder={
+          isCreate ? "Enter password" : "Leave blank to keep current"
+        }
+        hint={isCreate ? PASSWORD_HINT : undefined}
+        maxLength={PASSWORD_MAX_LENGTH}
+        suppressPasswordManager
+        required={isCreate}
+      />
+
+      <NamespaceLimitFields
+        idPrefix={idPrefix}
+        limitEnabled={values.limitEnabled}
+        onLimitEnabledChange={(v) => setField("limitEnabled", v)}
+        limitDisabled={values.limitDisabled}
+        onLimitDisabledChange={(v) => setField("limitDisabled", v)}
+        maxNamespaces={values.maxNamespaces}
+        onMaxNamespacesChange={(v) => setField("maxNamespaces", v)}
+      />
+
+      {mode === "edit" && (
+        <CheckboxField
+          id={`${idPrefix}-confirmed`}
+          label="Confirmed"
+          checked={values.confirmed}
+          onChange={(v) => setField("confirmed", v)}
+          disabled={!canChangeConfirmed}
+          title={
+            !canChangeConfirmed
+              ? "Cannot remove confirmation from a confirmed user"
+              : undefined
+          }
+        />
+      )}
+
+      <CheckboxField
+        id={`${idPrefix}-admin`}
+        label="Admin user"
+        checked={values.admin}
+        onChange={(v) => setField("admin", v)}
+        disabled={disableAdmin}
+        title={
+          disableAdmin ? "Cannot remove your own admin privilege" : undefined
+        }
+      />
+    </>
+  );
+}

--- a/ui-react/apps/console/src/pages/admin/users/__tests__/CreateUserDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/__tests__/CreateUserDrawer.test.tsx
@@ -374,6 +374,73 @@ describe("CreateUserDrawer", () => {
     });
   });
 
+  describe("client-side validation", () => {
+    it("marks username invalid on blur for an uppercase value", async () => {
+      renderDrawer();
+      const usernameInput = screen.getByLabelText(/^username$/i);
+      await userEvent.type(usernameInput, "Alice");
+      await userEvent.tab();
+      expect(usernameInput).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("marks email invalid on blur for a malformed value", async () => {
+      renderDrawer();
+      const emailInput = screen.getByLabelText(/^email$/i);
+      await userEvent.type(emailInput, "not-an-email");
+      await userEvent.tab();
+      expect(emailInput).toHaveAttribute("aria-invalid", "true");
+      expect(
+        await screen.findByText(/enter a valid email address/i),
+      ).toBeInTheDocument();
+    });
+
+    it("marks password invalid on blur for a too-short value", async () => {
+      renderDrawer();
+      const passwordInput = screen.getByLabelText(/^password$/i);
+      await userEvent.type(passwordInput, "abc");
+      await userEvent.tab();
+      expect(passwordInput).toHaveAttribute("aria-invalid", "true");
+      expect(await screen.findByText(/5–32 characters/i)).toBeInTheDocument();
+    });
+
+    it("blocks submit when fields are non-empty but format is invalid", async () => {
+      mockMutateAsync.mockResolvedValue(undefined);
+      renderDrawer();
+      // All fields non-empty (so isSubmittable=true, button enabled) but
+      // format-invalid. validateAll must block the mutation.
+      await fillForm({ username: "Alice", email: "bad", password: "abc" });
+
+      const submit = screen.getByRole("button", { name: /create user/i });
+      expect(submit).not.toBeDisabled();
+      await userEvent.click(submit);
+
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(screen.getByLabelText(/^username$/i)).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+      expect(screen.getByLabelText(/^email$/i)).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+      expect(screen.getByLabelText(/^password$/i)).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+    });
+
+    it("clears the invalid state when the user edits the field again", async () => {
+      renderDrawer();
+      const usernameInput = screen.getByLabelText(/^username$/i);
+      await userEvent.type(usernameInput, "Alice");
+      await userEvent.tab();
+      expect(usernameInput).toHaveAttribute("aria-invalid", "true");
+
+      await userEvent.type(usernameInput, "x");
+      expect(usernameInput).not.toHaveAttribute("aria-invalid");
+    });
+  });
+
   describe("cancel", () => {
     it("calls onClose when Cancel is clicked", async () => {
       const { onClose } = renderDrawer();

--- a/ui-react/apps/console/src/pages/admin/users/__tests__/EditUserDrawer.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/__tests__/EditUserDrawer.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import EditUserDrawer, { type EditableUser } from "../EditUserDrawer";
+import EditUserDrawer from "../EditUserDrawer";
 import { useUpdateUser } from "@/hooks/useAdminUserMutations";
 import { useAuthStore } from "@/stores/authStore";
+import type { UserAdminResponse } from "@/client";
 vi.mock("@/hooks/useAdminUserMutations", () => ({
   useUpdateUser: vi.fn(),
 }));
@@ -14,16 +15,18 @@ vi.mock("@/components/common/Drawer", async () => ({
 
 const mockMutateAsync = vi.fn();
 
-const mockUser: EditableUser = {
+const mockUser: UserAdminResponse = {
   id: "u1",
   name: "Alice Smith",
   username: "alice",
   email: "alice@example.com",
   admin: false,
   status: "not-confirmed",
+  created_at: "2024-01-01T00:00:00Z",
+  last_login: "2024-01-01T00:00:00Z",
 };
 
-const confirmedUser: EditableUser = {
+const confirmedUser: UserAdminResponse = {
   ...mockUser,
   status: "confirmed",
 };
@@ -40,7 +43,7 @@ function renderDrawer(
   overrides: Partial<{
     open: boolean;
     onClose: () => void;
-    user: EditableUser | null;
+    user: UserAdminResponse | null;
   }> = {},
 ) {
   const defaults = { open: true, onClose: vi.fn(), user: mockUser };
@@ -177,7 +180,7 @@ describe("EditUserDrawer", () => {
     });
 
     it("recognises status='confirmed' as a confirmed user", () => {
-      const userWithStatus: EditableUser = {
+      const userWithStatus: UserAdminResponse = {
         ...mockUser,
         status: "confirmed",
       };
@@ -189,14 +192,14 @@ describe("EditUserDrawer", () => {
   describe("admin checkbox — self-demotion constraint", () => {
     it("admin checkbox is disabled when editing your own admin account", () => {
       useAuthStore.setState({ username: "alice" } as never);
-      const selfAdmin: EditableUser = { ...mockUser, admin: true };
+      const selfAdmin: UserAdminResponse = { ...mockUser, admin: true };
       renderDrawer({ user: selfAdmin });
       expect(screen.getByLabelText(/^admin user$/i)).toBeDisabled();
     });
 
     it("admin checkbox is enabled when editing another admin", () => {
       useAuthStore.setState({ username: "admin" } as never);
-      const otherAdmin: EditableUser = {
+      const otherAdmin: UserAdminResponse = {
         ...mockUser,
         username: "bob",
         admin: true,
@@ -207,7 +210,7 @@ describe("EditUserDrawer", () => {
 
     it("admin checkbox is enabled for a non-admin self user", () => {
       useAuthStore.setState({ username: "alice" } as never);
-      const selfNonAdmin: EditableUser = { ...mockUser, admin: false };
+      const selfNonAdmin: UserAdminResponse = { ...mockUser, admin: false };
       renderDrawer({ user: selfNonAdmin });
       expect(screen.getByLabelText(/^admin user$/i)).not.toBeDisabled();
     });
@@ -387,6 +390,45 @@ describe("EditUserDrawer", () => {
 
       await waitFor(() => screen.getByRole("alert"));
       expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("client-side validation", () => {
+    it("allows submit with a blank password (password kept as-is)", async () => {
+      mockMutateAsync.mockResolvedValue(undefined);
+      renderDrawer();
+      // Default state: pre-filled valid mockUser with empty password.
+      await userEvent.click(
+        screen.getByRole("button", { name: /save changes/i }),
+      );
+      await waitFor(() => expect(mockMutateAsync).toHaveBeenCalled());
+    });
+
+    it("rejects a too-short password on edit when the user is changing it", async () => {
+      mockMutateAsync.mockResolvedValue(undefined);
+      renderDrawer();
+      const passwordInput = screen.getByLabelText(/^password$/i);
+      await userEvent.type(passwordInput, "abc");
+      await userEvent.click(
+        screen.getByRole("button", { name: /save changes/i }),
+      );
+
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(passwordInput).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("blocks submit when an existing field is edited to an invalid value", async () => {
+      mockMutateAsync.mockResolvedValue(undefined);
+      renderDrawer();
+      const usernameInput = screen.getByLabelText(/^username$/i);
+      await userEvent.clear(usernameInput);
+      await userEvent.type(usernameInput, "Invalid Username!");
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /save changes/i }),
+      );
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+      expect(usernameInput).toHaveAttribute("aria-invalid", "true");
     });
   });
 

--- a/ui-react/apps/console/src/pages/admin/users/useUserForm.ts
+++ b/ui-react/apps/console/src/pages/admin/users/useUserForm.ts
@@ -1,0 +1,212 @@
+import { useState } from "react";
+import type { UserAdminRequest, UserAdminResponse } from "@/client";
+import {
+  MAX_NAMESPACES_ERROR,
+  isMaxNamespacesValid,
+  validateEmail,
+  validateName,
+  validatePassword,
+  validateUsername,
+} from "@/utils/validation";
+
+export type UserFormMode = "create" | "edit";
+
+export interface UserFormValues {
+  name: string;
+  username: string;
+  email: string;
+  password: string;
+  confirmed: boolean;
+  admin: boolean;
+  limitEnabled: boolean;
+  limitDisabled: boolean;
+  maxNamespaces: string;
+}
+
+export type UserFormErrorKey =
+  | "name"
+  | "username"
+  | "email"
+  | "password"
+  | "maxNamespaces";
+
+export type UserFormErrors = Partial<Record<UserFormErrorKey, string>>;
+
+export interface UseUserFormOptions {
+  mode: UserFormMode;
+}
+
+export interface UserFormApi {
+  mode: UserFormMode;
+  values: UserFormValues;
+  errors: UserFormErrors;
+  setField: <K extends keyof UserFormValues>(
+    key: K,
+    value: UserFormValues[K],
+  ) => void;
+  validateField: (key: UserFormErrorKey) => void;
+  validateAll: () => boolean;
+  isSubmittable: boolean;
+  buildPayload: (initial?: UserAdminResponse | null) => UserAdminRequest;
+  reset: (next?: UserAdminResponse | null) => void;
+}
+
+function blankValues(): UserFormValues {
+  return {
+    name: "",
+    username: "",
+    email: "",
+    password: "",
+    confirmed: false,
+    admin: false,
+    limitEnabled: false,
+    limitDisabled: false,
+    maxNamespaces: "1",
+  };
+}
+
+function valuesFromUser(user: UserAdminResponse): UserFormValues {
+  const max = user.max_namespaces;
+  const limitEnabled = max !== undefined && max >= 0;
+  const limitDisabled = limitEnabled && max === 0;
+  return {
+    name: user.name ?? "",
+    username: user.username ?? "",
+    email: user.email ?? "",
+    password: "",
+    confirmed: user.status === "confirmed",
+    admin: user.admin ?? false,
+    limitEnabled,
+    limitDisabled,
+    maxNamespaces: limitEnabled && max ? String(max) : "1",
+  };
+}
+
+export function useUserForm({ mode }: UseUserFormOptions): UserFormApi {
+  const [values, setValues] = useState<UserFormValues>(blankValues);
+  const [errors, setErrors] = useState<UserFormErrors>({});
+
+  const setField: UserFormApi["setField"] = (key, value) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+    setErrors((prev) => {
+      if (!(key in prev) && !isNamespaceLimitKey(key)) return prev;
+      const next: UserFormErrors = { ...prev };
+      if (isNamespaceLimitKey(key)) delete next.maxNamespaces;
+      else delete next[key as UserFormErrorKey];
+      return next;
+    });
+  };
+
+  const computeFieldError = (
+    key: UserFormErrorKey,
+    v: UserFormValues,
+  ): string | null => {
+    if (key === "name") return validateName(v.name);
+    if (key === "username") return validateUsername(v.username);
+    if (key === "email") return validateEmail(v.email);
+    if (key === "password") {
+      if (mode === "edit" && v.password === "") return null;
+      return validatePassword(v.password);
+    }
+    if (key === "maxNamespaces") {
+      return isMaxNamespacesValid(
+        v.limitEnabled,
+        v.limitDisabled,
+        v.maxNamespaces,
+      )
+        ? null
+        : MAX_NAMESPACES_ERROR;
+    }
+    return null;
+  };
+
+  const validateField = (key: UserFormErrorKey) => {
+    const err = computeFieldError(key, values);
+    setErrors((prev) => {
+      const next = { ...prev };
+      if (err) next[key] = err;
+      else delete next[key];
+      return next;
+    });
+  };
+
+  const validateAll = (): boolean => {
+    const next: UserFormErrors = {};
+    const keys: UserFormErrorKey[] = [
+      "name",
+      "username",
+      "email",
+      "password",
+      "maxNamespaces",
+    ];
+    for (const key of keys) {
+      const err = computeFieldError(key, values);
+      if (err) next[key] = err;
+    }
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  };
+
+  const isSubmittable =
+    values.name.trim() !== "" &&
+    values.username.trim() !== "" &&
+    values.email.trim() !== "" &&
+    (mode === "edit" || values.password.trim() !== "") &&
+    isMaxNamespacesValid(
+      values.limitEnabled,
+      values.limitDisabled,
+      values.maxNamespaces,
+    );
+
+  const computeMaxNamespaces = (
+    initial?: UserAdminResponse | null,
+  ): number | undefined => {
+    if (!values.limitEnabled) {
+      if (mode === "edit") {
+        const orig = initial?.max_namespaces;
+        return orig !== undefined && orig < 0 ? orig : undefined;
+      }
+      return undefined;
+    }
+    if (values.limitDisabled) return 0;
+    return parseInt(values.maxNamespaces, 10);
+  };
+
+  const buildPayload: UserFormApi["buildPayload"] = (initial) => {
+    // Always send `password`. On edit, an empty string signals "no change" to
+    // the backend (preserves the pre-refactor wire behavior and keeps the
+    // generated `UserAdminRequest.password: string` contract honest).
+    return {
+      name: values.name.trim(),
+      username: values.username.trim(),
+      email: values.email.trim(),
+      password: values.password,
+      admin: values.admin,
+      max_namespaces: computeMaxNamespaces(initial),
+      ...(mode === "edit" && { confirmed: values.confirmed }),
+    };
+  };
+
+  const reset: UserFormApi["reset"] = (next) => {
+    setValues(next ? valuesFromUser(next) : blankValues());
+    setErrors({});
+  };
+
+  return {
+    mode,
+    values,
+    errors,
+    setField,
+    validateField,
+    validateAll,
+    isSubmittable,
+    buildPayload,
+    reset,
+  };
+}
+
+function isNamespaceLimitKey(key: keyof UserFormValues): boolean {
+  return (
+    key === "limitEnabled" || key === "limitDisabled" || key === "maxNamespaces"
+  );
+}

--- a/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
@@ -4,10 +4,9 @@ import { PlusIcon } from "@heroicons/react/24/outline";
 import { useAddMember } from "@/hooks/useMemberMutations";
 import Drawer from "@/components/common/Drawer";
 import InputField from "@/components/common/fields/InputField";
+import { EMAIL_REGEX } from "@/utils/validation";
 import { RoleSelector } from "./constants";
 import { type AssignableRole } from "./helpers";
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /* --- Add Member Drawer --- */
 

--- a/ui-react/apps/console/src/pages/team/InvitationDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/InvitationDrawer.tsx
@@ -18,8 +18,7 @@ import CheckboxField from "@/components/common/fields/CheckboxField";
 import { RoleSelector } from "./constants";
 import { type AssignableRole } from "./helpers";
 import { LABEL } from "@/utils/styles";
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+import { EMAIL_REGEX } from "@/utils/validation";
 
 interface InvitationDrawerProps {
   open: boolean;

--- a/ui-react/apps/console/src/utils/__tests__/validation.test.ts
+++ b/ui-react/apps/console/src/utils/__tests__/validation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { validateNamespaceName } from "../validation";
+import {
+  validateEmail,
+  validateName,
+  validateNamespaceName,
+  validatePassword,
+  validateUsername,
+} from "../validation";
 
 describe("validateNamespaceName", () => {
   describe("valid names", () => {
@@ -55,5 +61,89 @@ describe("validateNamespaceName", () => {
         "Only lowercase letters, numbers, and hyphens (cannot start or end with hyphen)",
       );
     });
+  });
+});
+
+describe("validateName", () => {
+  it.each(["a", "Alice Smith", "X", "a".repeat(64), "  Alice  "])(
+    "accepts %p",
+    (value) => {
+      expect(validateName(value)).toBeNull();
+    },
+  );
+
+  it.each(["", "   "])("rejects empty/whitespace %p as required", (value) => {
+    expect(validateName(value)).toBe("Name is required");
+  });
+
+  it("rejects names longer than 64 characters", () => {
+    expect(validateName("a".repeat(65))).toBe(
+      "Name must be at most 64 characters",
+    );
+  });
+});
+
+describe("validateUsername", () => {
+  it.each([
+    "alice",
+    "alice123",
+    "alice.smith",
+    "alice_smith",
+    "alice-smith",
+    "user@example",
+    "abc",
+    "a".repeat(32),
+  ])("accepts %p", (value) => {
+    expect(validateUsername(value)).toBeNull();
+  });
+
+  it.each(["", "   "])("rejects empty/whitespace %p as required", (value) => {
+    expect(validateUsername(value)).toBe("Username is required");
+  });
+
+  it.each([
+    "ab", // too short
+    "a".repeat(33), // too long
+    "Alice", // uppercase
+    "ALICE",
+    "has space",
+    "has#hash",
+    "has/slash",
+    "has!bang",
+  ])("rejects %p with the hint message", (value) => {
+    expect(validateUsername(value)).toMatch(/^3-32 characters/);
+  });
+});
+
+describe("validateEmail", () => {
+  it.each([
+    "alice@example.com",
+    "user.name@example.co.uk",
+    "user+tag@example.org",
+  ])("accepts %p", (value) => {
+    expect(validateEmail(value)).toBeNull();
+  });
+
+  it.each(["", "   "])("rejects empty/whitespace %p as required", (value) => {
+    expect(validateEmail(value)).toBe("Email is required");
+  });
+
+  it.each(["plainstring", "no@domain", "missing.at.sign", "two@@signs.com"])(
+    "rejects %p",
+    (value) => {
+      expect(validateEmail(value)).toBe("Enter a valid email address");
+    },
+  );
+});
+
+describe("validatePassword", () => {
+  it.each(["12345", "a".repeat(32), "P@ssw0rd!"])("accepts %p", (value) => {
+    expect(validatePassword(value)).toBeNull();
+  });
+
+  it.each(["", "1234", "a".repeat(33)])("rejects %p", (value) => {
+    expect(validatePassword(value)).toBe(
+      "Password must be 5–32 characters long",
+    );
   });
 });

--- a/ui-react/apps/console/src/utils/validation.ts
+++ b/ui-react/apps/console/src/utils/validation.ts
@@ -1,6 +1,43 @@
+export const NAME_MIN_LENGTH = 1;
+export const NAME_MAX_LENGTH = 64;
+
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 32;
+export const USERNAME_REGEX = /^[a-z0-9._@-]{3,32}$/;
+export const USERNAME_HINT =
+  "3-32 characters: lowercase letters, numbers, hyphens, dots, underscores, @";
+
+export const PASSWORD_MIN_LENGTH = 5;
+export const PASSWORD_MAX_LENGTH = 32;
+export const PASSWORD_HINT = "5-32 characters";
+
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function validateName(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return "Name is required";
+  if (trimmed.length > NAME_MAX_LENGTH)
+    return `Name must be at most ${NAME_MAX_LENGTH} characters`;
+  return null;
+}
+
+export function validateUsername(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return "Username is required";
+  if (!USERNAME_REGEX.test(trimmed)) return USERNAME_HINT;
+  return null;
+}
+
+export function validateEmail(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return "Email is required";
+  if (!EMAIL_REGEX.test(trimmed)) return "Enter a valid email address";
+  return null;
+}
+
 export function validatePassword(value: string): string | null {
-  if (value.length < 5 || value.length > 32)
-    return "Password must be 5–32 characters long";
+  if (value.length < PASSWORD_MIN_LENGTH || value.length > PASSWORD_MAX_LENGTH)
+    return `Password must be ${PASSWORD_MIN_LENGTH}–${PASSWORD_MAX_LENGTH} characters long`;
   return null;
 }
 
@@ -28,6 +65,9 @@ export function validateNamespaceName(name: string): string | null {
   }
   return null;
 }
+
+export const MAX_NAMESPACES_ERROR =
+  "Max namespaces must be a number greater than or equal to 1";
 
 export function isMaxNamespacesValid(
   limitEnabled: boolean,


### PR DESCRIPTION
## What

Replaced the admin Create/Edit user drawers' zero-validation submit gate with a client-side mirror of the backend validators, and collapsed the two near-identical drawers onto a shared `useUserForm` hook plus a `UserFormFields` presentational component.

## Why

Three converging problems on `/admin/users`: (1) invalid usernames, malformed emails, and too-short passwords passed a `.trim()`-only submit gate and failed at the server with a generic toast; (2) the username and password hints came from the OpenAPI spec, which disagrees with the backend Go validator on case, max length, and character set; (3) Create and Edit drawers duplicated state shape, reset logic, `computeMaxNamespaces`, the 409 branch, footer markup, and a local `EditableUser` interface that re-declared a subset of the generated `UserAdminResponse`.

## Changes

- **`utils/validation.ts`**: added `validateName` (1-64), `validateUsername` (`^[a-z0-9._@-]{3,32}$`, lowercase only), `validateEmail`, plus `USERNAME_HINT`, `PASSWORD_HINT`, `MAX_NAMESPACES_ERROR`, and length constants. Regexes mirror `pkg/validator/validator.go` (backend), not the spec.
- **`useUserForm` hook**: single source of truth for state, errors, blur-time validation, `isSubmittable`, `buildPayload`, and `reset`. Edit mode preserves the original negative `max_namespaces` (`-1`) when the limit checkbox is unchecked. Blank password on edit is sent through as-is to match the pre-refactor wire behaviour.
- **`UserFormFields` component**: mode-aware presentational layer (placeholders, hints, edit-only Confirmed checkbox, admin self-demotion gate). Each drawer body now collapses to a single `<UserFormFields>` plus the submit-error paragraph.
- **`CreateUserDrawer` / `EditUserDrawer`**: adopt the hook and component. `EditableUser` deleted; drawers accept `UserAdminResponse | null`. The admin self-demotion gate now reads `user.admin && isSelf` (original value) rather than the local editable state.
- **A11y**: field errors use `role="status"` (polite) for blur-time announcements. Hard caps via `maxLength` on name (64), username (32), and password (32) mirror `Setup.tsx`.
- **DRY**: `NamespaceLimitFields` consumes the shared `MAX_NAMESPACES_ERROR`. `AddMemberDrawer` and `InvitationDrawer` use the shared `EMAIL_REGEX`.

## Testing

49 new tests: unit-level validators in `validation.test.ts` plus drawer-level `client-side validation` suites covering blur-time `aria-invalid`, the `isSubmittable` vs `validateAll` divergence (button enabled, submit blocked, mutation not called), and blank-password-keeps-current on edit. Full suite at 118 files / 1957 tests.

Worth probing manually: edit your own admin account and confirm the Admin checkbox stays disabled and unflippable; edit an already-confirmed user and confirm Confirmed stays disabled; edit a user with `max_namespaces: 0` and uncheck "Disable namespace creation" — the input falls back to `1`, which is the pre-existing behaviour and is called out here so it does not look like a regression.