### PR TITLE
refactor(ui-react): extract Spinner and PageLoader primitives

### DIFF
--- a/ui-react/apps/console/src/components/ManageTagsDrawer.tsx
+++ b/ui-react/apps/console/src/components/ManageTagsDrawer.tsx
@@ -14,6 +14,7 @@ import {
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const TAG_PATTERN = /^[a-zA-Z0-9]+$/;
 
@@ -202,9 +203,7 @@ export default function ManageTagsDrawer({
         <div className="flex-1 overflow-y-auto">
           {isLoading && tags.length === 0
             ? (
-              <div className="flex items-center justify-center py-12">
-                <Spinner size="lg" tone="onSurface" />
-              </div>
+              <PageLoader label="Loading tags" padding="sm" />
             )
             : tags.length === 0
               ? (

--- a/ui-react/apps/console/src/components/ManageTagsDrawer.tsx
+++ b/ui-react/apps/console/src/components/ManageTagsDrawer.tsx
@@ -13,6 +13,7 @@ import {
   TrashIcon,
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
+import Spinner from "@/components/common/Spinner";
 
 const TAG_PATTERN = /^[a-zA-Z0-9]+$/;
 
@@ -158,7 +159,7 @@ export default function ManageTagsDrawer({
             >
               {submitting
                 ? (
-                  <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin block" />
+                  <Spinner tone="onPrimary" className="block" />
                 )
                 : (
                   <PlusIcon className="w-4 h-4" strokeWidth={2} />
@@ -202,7 +203,7 @@ export default function ManageTagsDrawer({
           {isLoading && tags.length === 0
             ? (
               <div className="flex items-center justify-center py-12">
-                <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                <Spinner size="lg" tone="onSurface" />
               </div>
             )
             : tags.length === 0

--- a/ui-react/apps/console/src/components/billing/BillingDialog.tsx
+++ b/ui-react/apps/console/src/components/billing/BillingDialog.tsx
@@ -11,6 +11,7 @@ import BillingLetter from "./BillingLetter";
 import BillingPayment from "./BillingPayment";
 import BillingCheckout from "./BillingCheckout";
 import BillingSuccessful from "./BillingSuccessful";
+import Spinner from "@/components/common/Spinner";
 
 const STEPS = ["Overview", "Payment method", "Review", "Success"] as const;
 const TOTAL_STEPS = STEPS.length;
@@ -248,10 +249,7 @@ function PrimaryButton({
         disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary disabled:active:scale-100"
     >
       {loading && (
-        <span
-          aria-hidden="true"
-          className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin"
-        />
+        <Spinner size="sm" tone="onPrimary" />
       )}
       {children}
     </button>

--- a/ui-react/apps/console/src/components/billing/BillingPayment.tsx
+++ b/ui-react/apps/console/src/components/billing/BillingPayment.tsx
@@ -33,6 +33,7 @@ import FieldLabel from "@/components/common/fields/FieldLabel";
 import InputField from "@/components/common/fields/InputField";
 import BillingIcon from "./BillingIcon";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const ELEMENTS_OPTIONS: StripeElementsOptions = {
   appearance: { theme: "night" },
@@ -254,16 +255,7 @@ function BillingPaymentInner({
   }
 
   if (bootstrapping || customerLoading) {
-    return (
-      <div
-        className="flex items-center justify-center py-10"
-        role="status"
-        aria-live="polite"
-      >
-        <Spinner size="lg" tone="onSurface" />
-        <span className="sr-only">Loading payment methods…</span>
-      </div>
-    );
+    return <PageLoader label="Loading payment methods…" padding="sm" />;
   }
 
   return (
@@ -413,9 +405,7 @@ function BillingPaymentInner({
               disabled={!stripe || !cardComplete || submitting}
               className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
-              {submitting && (
-                <Spinner tone="onPrimary" />
-              )}
+              {submitting && <Spinner tone="onPrimary" />}
               Save card
             </button>
           </div>

--- a/ui-react/apps/console/src/components/billing/BillingPayment.tsx
+++ b/ui-react/apps/console/src/components/billing/BillingPayment.tsx
@@ -32,6 +32,7 @@ import { stripeErrorMessage } from "@/utils/stripeErrors";
 import FieldLabel from "@/components/common/fields/FieldLabel";
 import InputField from "@/components/common/fields/InputField";
 import BillingIcon from "./BillingIcon";
+import Spinner from "@/components/common/Spinner";
 
 const ELEMENTS_OPTIONS: StripeElementsOptions = {
   appearance: { theme: "night" },
@@ -259,7 +260,7 @@ function BillingPaymentInner({
         role="status"
         aria-live="polite"
       >
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="lg" tone="onSurface" />
         <span className="sr-only">Loading payment methods…</span>
       </div>
     );
@@ -413,10 +414,7 @@ function BillingPaymentInner({
               className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
               {submitting && (
-                <span
-                  aria-hidden="true"
-                  className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-                />
+                <Spinner tone="onPrimary" />
               )}
               Save card
             </button>

--- a/ui-react/apps/console/src/components/billing/BillingSection.tsx
+++ b/ui-react/apps/console/src/components/billing/BillingSection.tsx
@@ -15,6 +15,7 @@ import { useOpenBillingPortal, useSubscription } from "@/hooks/useBilling";
 import { useInvalidateByIds } from "@/hooks/useInvalidateQueries";
 import { formatExpiry } from "@/utils/date";
 import type { BillingStatus } from "@/client/types.gen";
+import Spinner from "@/components/common/Spinner";
 
 const BillingDialog = lazy(() => import("./BillingDialog"));
 
@@ -352,10 +353,7 @@ export default function BillingSection({ sectionId }: BillingSectionProps) {
                       className="inline-flex items-center gap-1.5 px-4 py-2 bg-card hover:bg-hover-medium border border-border hover:border-border-light text-text-primary rounded-lg text-sm font-medium transition-all disabled:opacity-dim disabled:cursor-not-allowed"
                     >
                       {openPortal.isPending ? (
-                        <span
-                          aria-hidden="true"
-                          className="w-4 h-4 border-2 border-text-muted/30 border-t-text-primary rounded-full animate-spin"
-                        />
+                        <Spinner tone="subtle" />
                       ) : (
                         <ArrowTopRightOnSquareIcon
                           className="w-4 h-4"

--- a/ui-react/apps/console/src/components/billing/DeviceChooserDialog.tsx
+++ b/ui-react/apps/console/src/components/billing/DeviceChooserDialog.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/hooks/useDeviceChooser";
 import { isSdkError } from "@/api/errors";
 import { FREE_TIER_DEVICE_LIMIT } from "./DeviceChooserTrigger";
+import Spinner from "@/components/common/Spinner";
 
 const PER_PAGE = 5;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -286,10 +287,7 @@ export default function DeviceChooserDialog({
           className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg text-sm font-semibold transition-all bg-primary text-white hover:bg-primary-600 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary disabled:active:scale-100"
         >
           {choice.isPending && (
-            <span
-              aria-hidden="true"
-              className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin"
-            />
+            <Spinner size="sm" tone="onPrimary" />
           )}
           {choice.isPending ? "Saving…" : "Accept"}
         </button>

--- a/ui-react/apps/console/src/components/common/AdminRoute.tsx
+++ b/ui-react/apps/console/src/components/common/AdminRoute.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Outlet, Navigate } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
+import Spinner from "@/components/common/Spinner";
 
 export default function AdminRoute() {
   const fetchUser = useAuthStore((s) => s.fetchUser);
@@ -14,7 +15,7 @@ export default function AdminRoute() {
   if (!verified) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
-        <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/components/common/ConfirmDialog.tsx
+++ b/ui-react/apps/console/src/components/common/ConfirmDialog.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useId, useState } from "react";
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import BaseDialog from "./BaseDialog";
+import Spinner from "@/components/common/Spinner";
 
 interface ConfirmDialogProps {
   /** Controls open/close state. */
@@ -149,13 +150,7 @@ export default function ConfirmDialog({
           disabled={confirming || confirmDisabled}
           className={`px-5 py-2.5 ${VARIANT_CLASSES[variant]} rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2`}
         >
-          {confirming && (
-            <span
-              data-testid="confirm-spinner"
-              aria-hidden="true"
-              className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-            />
-          )}
+          {confirming && <Spinner tone="onPrimary" />}
           {confirmLabel}
         </button>
       </div>

--- a/ui-react/apps/console/src/components/common/ConnectivityGuard.tsx
+++ b/ui-react/apps/console/src/components/common/ConnectivityGuard.tsx
@@ -3,6 +3,7 @@ import { Outlet } from "react-router-dom";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { useConnectivityStore } from "@/stores/connectivityStore";
 import AmbientBackground from "./AmbientBackground";
+import Spinner from "@/components/common/Spinner";
 
 function ApiUnavailablePage() {
   return (
@@ -11,11 +12,7 @@ function ApiUnavailablePage() {
 
       {/* Content */}
       <div className="flex flex-col items-center text-center px-6 animate-fade-in">
-        <img
-          src="/logo.svg"
-          alt="ShellHub"
-          className="h-8 mb-10 opacity-50"
-        />
+        <img src="/logo.svg" alt="ShellHub" className="h-8 mb-10 opacity-50" />
 
         <div className="animate-float mb-6">
           <div className="w-20 h-20 rounded-2xl bg-accent-red/10 border border-accent-red/20 flex items-center justify-center shadow-lg shadow-accent-red/5">
@@ -39,7 +36,7 @@ function ApiUnavailablePage() {
         </p>
 
         <div className="flex items-center gap-2.5 bg-card/80 border border-border rounded-lg px-4 py-2.5 backdrop-blur-sm">
-          <span className="w-3 h-3 border-2 border-accent-red/30 border-t-accent-red rounded-full animate-spin" />
+          <Spinner size="xs" tone="subtle" />
           <span className="text-xs font-mono text-text-secondary">
             Checking connection…
           </span>
@@ -50,8 +47,8 @@ function ApiUnavailablePage() {
 }
 
 export default function ConnectivityGuard() {
-  const { initialCheckDone, initialGatePassed, checkInitial }
-    = useConnectivityStore();
+  const { initialCheckDone, initialGatePassed, checkInitial } =
+    useConnectivityStore();
 
   useEffect(() => {
     if (!initialCheckDone) void checkInitial();
@@ -61,7 +58,7 @@ export default function ConnectivityGuard() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="flex items-center gap-3 animate-fade-in">
-          <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+          <Spinner />
           <span className="text-xs font-mono text-text-muted">Connecting…</span>
         </div>
       </div>

--- a/ui-react/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui-react/apps/console/src/components/common/CreateNamespace.tsx
@@ -18,6 +18,7 @@ import {
   NAMESPACE_NAME_MIN_LENGTH,
   validateNamespaceName,
 } from "@/utils/validation";
+import Spinner from "@/components/common/Spinner";
 
 /* ─── Cloud/Enterprise form ─── */
 function CloudForm() {
@@ -40,7 +41,7 @@ function CloudForm() {
     }
   };
 
-  const displayError = validationError ?? (createNs.error?.message ?? null);
+  const displayError = validationError ?? createNs.error?.message ?? null;
 
   return (
     <form onSubmit={(e) => void handleSubmit(e)} className="w-full">
@@ -66,7 +67,7 @@ function CloudForm() {
           className="px-6 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 shrink-0"
         >
           {createNs.isPending ? (
-            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin inline-block" />
+            <Spinner tone="onPrimary" className="block" />
           ) : (
             "Create"
           )}
@@ -181,7 +182,7 @@ function CommunityInstructions() {
           "You're in! Go to dashboard"
         ) : (
           <>
-            <span className="w-4 h-4 border-2 border-white/20 border-t-white/50 rounded-full animate-spin" />
+            <Spinner size="md" tone="onPrimary" />
             Waiting for namespace access...
           </>
         )}

--- a/ui-react/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui-react/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/utils/validation";
 import { getConfig } from "@/env";
 import { useCreateNamespace } from "@/hooks/useNamespaceMutations";
+import Spinner from "@/components/common/Spinner";
 
 const CLI_COMMAND = "./bin/cli namespace create <namespace> <owner>";
 
@@ -220,7 +221,7 @@ export default function CreateNamespaceDialog({
               className="px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-lg text-xs font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
             >
               {createNs.isPending ? (
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin inline-block" />
+                <Spinner size="sm" tone="onPrimary" className="inline-block" />
               ) : (
                 "Create"
               )}

--- a/ui-react/apps/console/src/components/common/DataTable.tsx
+++ b/ui-react/apps/console/src/components/common/DataTable.tsx
@@ -6,7 +6,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { cn } from "@/utils/cn";
 import Pagination from "./Pagination";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const TH_CLASS =
   "px-4 py-3 text-left text-2xs font-mono font-semibold uppercase tracking-compact text-text-muted whitespace-nowrap";
@@ -165,16 +165,7 @@ export default function DataTable<T>({
           {isLoading && data.length === 0 ? (
             <tr>
               <td colSpan={columns.length} className="px-4 py-16 text-center">
-                <div
-                  className="flex items-center justify-center gap-3"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <Spinner />
-                  <span className="text-xs font-mono text-text-muted">
-                    {loadingMessage}
-                  </span>
-                </div>
+                <PageLoader label={loadingMessage} showLabel padding="none" />
               </td>
             </tr>
           ) : data.length === 0 ? (

--- a/ui-react/apps/console/src/components/common/DataTable.tsx
+++ b/ui-react/apps/console/src/components/common/DataTable.tsx
@@ -6,6 +6,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { cn } from "@/utils/cn";
 import Pagination from "./Pagination";
+import Spinner from "@/components/common/Spinner";
 
 const TH_CLASS =
   "px-4 py-3 text-left text-2xs font-mono font-semibold uppercase tracking-compact text-text-muted whitespace-nowrap";
@@ -169,7 +170,7 @@ export default function DataTable<T>({
                   role="status"
                   aria-live="polite"
                 >
-                  <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                  <Spinner />
                   <span className="text-xs font-mono text-text-muted">
                     {loadingMessage}
                   </span>

--- a/ui-react/apps/console/src/components/common/LicenseGuard.tsx
+++ b/ui-react/apps/console/src/components/common/LicenseGuard.tsx
@@ -1,5 +1,6 @@
 import { Outlet, Navigate } from "react-router-dom";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
+import Spinner from "@/components/common/Spinner";
 
 export default function LicenseGuard() {
   const { data: license, isLoading, isError } = useAdminLicense();
@@ -12,7 +13,7 @@ export default function LicenseGuard() {
         aria-label="Loading license information"
       >
         <div className="flex items-center gap-3">
-          <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+          <Spinner />
           <span className="text-xs font-mono text-text-muted">
             Checking license...
           </span>

--- a/ui-react/apps/console/src/components/common/LicenseGuard.tsx
+++ b/ui-react/apps/console/src/components/common/LicenseGuard.tsx
@@ -1,28 +1,16 @@
 import { Outlet, Navigate } from "react-router-dom";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 export default function LicenseGuard() {
   const { data: license, isLoading, isError } = useAdminLicense();
 
   if (isLoading) {
-    return (
-      <div
-        className="flex-1 flex items-center justify-center"
-        role="status"
-        aria-label="Loading license information"
-      >
-        <div className="flex items-center gap-3">
-          <Spinner />
-          <span className="text-xs font-mono text-text-muted">
-            Checking license...
-          </span>
-        </div>
-      </div>
-    );
+    return <PageLoader label="Checking license..." showLabel padding="fill" />;
   }
 
-  const installedLicense = license && "grace_period" in license ? license : null;
+  const installedLicense =
+    license && "grace_period" in license ? license : null;
 
   // Expired, missing, or error -> redirect to license page
   if (isError || !installedLicense || installedLicense.expired) {

--- a/ui-react/apps/console/src/components/common/NamespaceGuard.tsx
+++ b/ui-react/apps/console/src/components/common/NamespaceGuard.tsx
@@ -9,6 +9,7 @@ import { useConnectivityStore } from "@/stores/connectivityStore";
 import AmbientBackground from "./AmbientBackground";
 import CreateNamespace from "./CreateNamespace";
 import UserMenu from "../layout/UserMenu";
+import Spinner from "@/components/common/Spinner";
 
 function MinimalHeader() {
   return (
@@ -100,7 +101,7 @@ export default function NamespaceGuard() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="flex items-center gap-3">
-          <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+          <Spinner />
           <span className="text-xs font-mono text-text-muted">Loading…</span>
         </div>
       </div>

--- a/ui-react/apps/console/src/components/common/PageLoader.tsx
+++ b/ui-react/apps/console/src/components/common/PageLoader.tsx
@@ -1,0 +1,57 @@
+import Spinner, { type SpinnerSize } from "@/components/common/Spinner";
+
+type Padding = "none" | "sm" | "md" | "lg" | "fill";
+
+interface PageLoaderProps {
+  /** Announced to assistive tech. Also rendered as visible text when `showLabel` is true. */
+  label: string;
+  /** Spinner size. Defaults to `"lg"` when the label is hidden, `"md"` when `showLabel` is true. */
+  size?: SpinnerSize;
+  /** Render the label as visible text next to the spinner. Default `false`
+   *  (label is delivered only to screen readers via the Spinner's aria-label). */
+  showLabel?: boolean;
+  /** Vertical breathing room inside the centered wrapper.
+   *  - `"none"` — no padding (use when the parent already controls spacing)
+   *  - `"sm"`   — `py-12` (drawers, popovers)
+   *  - `"md"`   — `py-24` (default, most detail pages)
+   *  - `"lg"`   — `py-32` (long-form settings pages)
+   *  - `"fill"` — `flex-1` (fills the remaining height of a flex parent) */
+  padding?: Padding;
+}
+
+const PADDING: Record<Padding, string> = {
+  none: "",
+  sm: "py-12",
+  md: "py-24",
+  lg: "py-32",
+  fill: "flex-1",
+};
+
+export default function PageLoader({
+  label,
+  size,
+  showLabel = false,
+  padding = "md",
+}: PageLoaderProps) {
+  const resolvedSize = size ?? (showLabel ? "md" : "lg");
+  const wrapper = ["flex items-center justify-center", PADDING[padding]]
+    .filter(Boolean)
+    .join(" ");
+
+  if (showLabel) {
+    // role="status" is `nameFrom: author` — the visible text doesn't become
+    // the accessible name, so set it explicitly via aria-label.
+    return (
+      <div role="status" aria-label={label} className={`${wrapper} gap-3`}>
+        <Spinner size={resolvedSize} />
+        <span className="text-xs font-mono text-text-muted">{label}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={wrapper}>
+      <Spinner size={resolvedSize} aria-label={label} />
+    </div>
+  );
+}

--- a/ui-react/apps/console/src/components/common/SetupGuard.tsx
+++ b/ui-react/apps/console/src/components/common/SetupGuard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Outlet, Navigate, useLocation } from "react-router-dom";
 import { getInfo } from "@/client";
 import { getConfig } from "@/env";
+import Spinner from "@/components/common/Spinner";
 
 export default function SetupGuard() {
   const isCloud = getConfig().cloud;
@@ -22,7 +23,7 @@ export default function SetupGuard() {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="flex items-center gap-3">
-          <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+          <Spinner />
           <span className="text-xs font-mono text-text-muted">Loading...</span>
         </div>
       </div>

--- a/ui-react/apps/console/src/components/common/Spinner.tsx
+++ b/ui-react/apps/console/src/components/common/Spinner.tsx
@@ -1,0 +1,54 @@
+export type SpinnerSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+export type SpinnerTone = "onPrimary" | "onSurface" | "subtle";
+
+interface SpinnerProps {
+  size?: SpinnerSize;
+  tone?: SpinnerTone;
+  /** Layout overrides only (margins, block/inline-block). Don't override color or size. */
+  className?: string;
+  /**
+   * If provided, the spinner is announced to assistive tech as a live status
+   * region. Omit for purely decorative spinners (the default).
+   */
+  "aria-label"?: string;
+}
+
+const SIZE: Record<SpinnerSize, string> = {
+  xs: "w-3 h-3",
+  sm: "w-3.5 h-3.5",
+  md: "w-4 h-4",
+  lg: "w-5 h-5",
+  xl: "w-6 h-6",
+  "2xl": "w-10 h-10",
+};
+
+const TONE: Record<SpinnerTone, string> = {
+  onPrimary: "border-white/30 border-t-white",
+  onSurface: "border-primary/30 border-t-primary",
+  subtle: "border-text-muted/30 border-t-text-muted",
+};
+
+export default function Spinner({
+  size = "md",
+  tone = "onSurface",
+  className,
+  "aria-label": ariaLabel,
+}: SpinnerProps) {
+  const classes = [
+    SIZE[size],
+    TONE[tone],
+    "border-2 rounded-full animate-spin",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span
+      role={ariaLabel ? "status" : undefined}
+      aria-label={ariaLabel}
+      aria-hidden={ariaLabel ? undefined : true}
+      className={classes}
+    />
+  );
+}

--- a/ui-react/apps/console/src/components/common/__tests__/ConfirmDialog.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/ConfirmDialog.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "./helpers/setup-dialog";
 
@@ -124,12 +131,16 @@ describe("ConfirmDialog", () => {
 
     it("renders a custom confirmLabel", () => {
       renderDialog(true, { confirmLabel: "Delete" });
-      expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Delete" }),
+      ).toBeInTheDocument();
     });
 
     it("renders a custom cancelLabel", () => {
       renderDialog(true, { cancelLabel: "Go back" });
-      expect(screen.getByRole("button", { name: "Go back" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Go back" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -166,7 +177,10 @@ describe("ConfirmDialog", () => {
       const user = userEvent.setup();
       let resolve!: () => void;
       const onConfirm = vi.fn(
-        () => new Promise<void>((res) => { resolve = res; }),
+        () =>
+          new Promise<void>((res) => {
+            resolve = res;
+          }),
       );
       renderDialog(true, { onConfirm });
 
@@ -174,9 +188,11 @@ describe("ConfirmDialog", () => {
 
       const confirmBtn = screen.getByRole("button", { name: "Confirm" });
       expect(confirmBtn).toBeDisabled();
-      expect(screen.getByTestId("confirm-spinner")).toBeInTheDocument();
+      expect(confirmBtn.querySelector(".animate-spin")).not.toBeNull();
 
-      act(() => { resolve(); });
+      act(() => {
+        resolve();
+      });
     });
 
     it("re-enables the confirm button after onConfirm resolves", async () => {
@@ -187,7 +203,9 @@ describe("ConfirmDialog", () => {
       await user.click(screen.getByRole("button", { name: "Confirm" }));
 
       await waitFor(() =>
-        expect(screen.getByRole("button", { name: "Confirm" })).not.toBeDisabled(),
+        expect(
+          screen.getByRole("button", { name: "Confirm" }),
+        ).not.toBeDisabled(),
       );
     });
 
@@ -199,7 +217,9 @@ describe("ConfirmDialog", () => {
       await user.click(screen.getByRole("button", { name: "Confirm" }));
 
       await waitFor(() =>
-        expect(screen.getByRole("button", { name: "Confirm" })).not.toBeDisabled(),
+        expect(
+          screen.getByRole("button", { name: "Confirm" }),
+        ).not.toBeDisabled(),
       );
     });
 

--- a/ui-react/apps/console/src/components/common/__tests__/PageLoader.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/PageLoader.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PageLoader from "@/components/common/PageLoader";
+
+describe("PageLoader", () => {
+  it("renders a single status live region announced by the spinner's aria-label", () => {
+    render(<PageLoader label="Loading users" />);
+
+    expect(
+      screen.getByRole("status", { name: "Loading users" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+    expect(screen.queryByText("Loading users")).toBeNull();
+  });
+
+  it("does not put role=status on the wrapper in the default form", () => {
+    const { container } = render(<PageLoader label="Loading users" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.tagName).toBe("DIV");
+    expect(wrapper).not.toHaveAttribute("role");
+  });
+
+  it("when showLabel is true, the wrapper is the live region and the spinner is decorative", () => {
+    render(<PageLoader label="Loading settings..." showLabel />);
+
+    const region = screen.getByRole("status", { name: "Loading settings..." });
+    expect(region.tagName).toBe("DIV");
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+    const spinner = region.querySelector(".animate-spin") as HTMLElement;
+    expect(spinner).toHaveAttribute("aria-hidden", "true");
+    expect(spinner).not.toHaveAttribute("role");
+  });
+
+  it.each([
+    ["none", ""],
+    ["sm", "py-12"],
+    ["md", "py-24"],
+    ["lg", "py-32"],
+    ["fill", "flex-1"],
+  ] as const)("applies padding=%s class", (padding, expected) => {
+    const { container } = render(
+      <PageLoader label="Loading" padding={padding} />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    if (expected) {
+      expect(wrapper.className).toContain(expected);
+    } else {
+      expect(wrapper.className).not.toMatch(/py-\d+|flex-1/);
+    }
+  });
+
+  it("defaults to a large spinner in the page form", () => {
+    const { container } = render(<PageLoader label="Loading" />);
+    const spinner = container.querySelector(".animate-spin") as HTMLElement;
+    expect(spinner.className).toContain("w-5 h-5");
+  });
+
+  it("defaults to a medium spinner when showLabel is true", () => {
+    const { container } = render(<PageLoader label="Loading" showLabel />);
+    const spinner = container.querySelector(".animate-spin") as HTMLElement;
+    expect(spinner.className).toContain("w-4 h-4");
+  });
+
+  it("forwards an explicit size to the spinner", () => {
+    const { container } = render(<PageLoader label="Loading" size="2xl" />);
+    const spinner = container.querySelector(".animate-spin") as HTMLElement;
+    expect(spinner.className).toContain("w-10 h-10");
+  });
+});

--- a/ui-react/apps/console/src/components/common/__tests__/Spinner.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/Spinner.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Spinner, {
+  type SpinnerSize,
+  type SpinnerTone,
+} from "@/components/common/Spinner";
+
+describe("Spinner", () => {
+  it("renders with default md size and onSurface tone", () => {
+    const { container } = render(<Spinner />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain("w-4 h-4");
+    expect(el.className).toContain("border-primary/30 border-t-primary");
+    expect(el.className).toContain("border-2");
+    expect(el.className).toContain("rounded-full");
+    expect(el.className).toContain("animate-spin");
+  });
+
+  it("is decorative by default (aria-hidden=true, no role)", () => {
+    const { container } = render(<Spinner />);
+    const el = container.firstChild as HTMLElement;
+    expect(el).toHaveAttribute("aria-hidden", "true");
+    expect(el).not.toHaveAttribute("role");
+    expect(el).not.toHaveAttribute("aria-label");
+  });
+
+  it("becomes a live status region when aria-label is provided", () => {
+    render(<Spinner aria-label="Loading users" />);
+    const el = screen.getByRole("status");
+    expect(el).toHaveAttribute("aria-label", "Loading users");
+    expect(el).not.toHaveAttribute("aria-hidden");
+  });
+
+  it.each<[SpinnerSize, string]>([
+    ["xs", "w-3 h-3"],
+    ["sm", "w-3.5 h-3.5"],
+    ["md", "w-4 h-4"],
+    ["lg", "w-5 h-5"],
+    ["xl", "w-6 h-6"],
+    ["2xl", "w-10 h-10"],
+  ])("emits the correct classes for size=%s", (size, expected) => {
+    const { container } = render(<Spinner size={size} />);
+    expect((container.firstChild as HTMLElement).className).toContain(expected);
+  });
+
+  it.each<[SpinnerTone, string]>([
+    ["onPrimary", "border-white/30 border-t-white"],
+    ["onSurface", "border-primary/30 border-t-primary"],
+    ["subtle", "border-text-muted/30 border-t-text-muted"],
+  ])("emits the correct classes for tone=%s", (tone, expected) => {
+    const { container } = render(<Spinner tone={tone} />);
+    expect((container.firstChild as HTMLElement).className).toContain(expected);
+  });
+
+  it("appends extra className after built-in classes", () => {
+    const { container } = render(<Spinner className="mb-4" />);
+    const cls = (container.firstChild as HTMLElement).className;
+    expect(cls).toContain("mb-4");
+    expect(cls.indexOf("mb-4")).toBeGreaterThan(cls.indexOf("animate-spin"));
+  });
+});

--- a/ui-react/apps/console/src/components/layout/InvitationsMenu.tsx
+++ b/ui-react/apps/console/src/components/layout/InvitationsMenu.tsx
@@ -22,7 +22,7 @@ import ConfirmDialog from "@/components/common/ConfirmDialog";
 import { formatRelative } from "@/utils/date";
 import { RoleBadge } from "@/pages/team/constants";
 import { isInvitationExpired } from "@/utils/invitations";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 function InvitationCard({
   invitation,
@@ -195,16 +195,7 @@ export default function InvitationsMenu() {
 
             <div className="max-h-[360px] overflow-y-auto">
               {isLoading ? (
-                <div
-                  className="flex items-center justify-center gap-2 py-8"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <Spinner />
-                  <span className="text-2xs font-mono text-text-muted">
-                    Loading...
-                  </span>
-                </div>
+                <PageLoader label="Loading..." showLabel padding="sm" />
               ) : count === 0 ? (
                 <div className="px-3.5 py-10 text-center">
                   <InboxIcon

--- a/ui-react/apps/console/src/components/layout/InvitationsMenu.tsx
+++ b/ui-react/apps/console/src/components/layout/InvitationsMenu.tsx
@@ -22,6 +22,7 @@ import ConfirmDialog from "@/components/common/ConfirmDialog";
 import { formatRelative } from "@/utils/date";
 import { RoleBadge } from "@/pages/team/constants";
 import { isInvitationExpired } from "@/utils/invitations";
+import Spinner from "@/components/common/Spinner";
 
 function InvitationCard({
   invitation,
@@ -199,7 +200,7 @@ export default function InvitationsMenu() {
                   role="status"
                   aria-live="polite"
                 >
-                  <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                  <Spinner />
                   <span className="text-2xs font-mono text-text-muted">
                     Loading...
                   </span>

--- a/ui-react/apps/console/src/components/layout/PendingDevices.tsx
+++ b/ui-react/apps/console/src/components/layout/PendingDevices.tsx
@@ -10,6 +10,7 @@ import {
 import { useDevices } from "@/hooks/useDevices";
 import { useAcceptDevice, useRejectDevice } from "@/hooks/useDeviceMutations";
 import { useClickOutside } from "@/hooks/useClickOutside";
+import Spinner from "@/components/common/Spinner";
 
 export default function PendingDevices() {
   const navigate = useNavigate();
@@ -95,7 +96,7 @@ export default function PendingDevices() {
           <div className="max-h-[280px] overflow-y-auto">
             {loading && devices.length === 0 ? (
               <div className="flex items-center justify-center py-10">
-                <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+                <Spinner />
               </div>
             ) : devices.length === 0 ? (
               <div className="py-10 text-center">
@@ -167,7 +168,7 @@ export default function PendingDevices() {
                               >
                                 {isActing
                                   ? (
-                                    <span className="block w-3.5 h-3.5 border-2 border-text-muted/30 border-t-text-muted rounded-full animate-spin" />
+                                    <Spinner size="sm" tone="subtle" className="block" />
                                   )
                                   : (
                                     <CheckIcon

--- a/ui-react/apps/console/src/components/layout/PendingDevices.tsx
+++ b/ui-react/apps/console/src/components/layout/PendingDevices.tsx
@@ -11,6 +11,7 @@ import { useDevices } from "@/hooks/useDevices";
 import { useAcceptDevice, useRejectDevice } from "@/hooks/useDeviceMutations";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 export default function PendingDevices() {
   const navigate = useNavigate();
@@ -22,7 +23,11 @@ export default function PendingDevices() {
   } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const { devices, totalCount: count, isLoading: loading } = useDevices({
+  const {
+    devices,
+    totalCount: count,
+    isLoading: loading,
+  } = useDevices({
     page: 1,
     perPage: 5,
     status: "pending",
@@ -95,9 +100,7 @@ export default function PendingDevices() {
           {/* Body */}
           <div className="max-h-[280px] overflow-y-auto">
             {loading && devices.length === 0 ? (
-              <div className="flex items-center justify-center py-10">
-                <Spinner />
-              </div>
+              <PageLoader label="Loading..." showLabel padding="sm" />
             ) : devices.length === 0 ? (
               <div className="py-10 text-center">
                 <CheckCircleIcon
@@ -144,52 +147,56 @@ export default function PendingDevices() {
                         </div>
 
                         {/* Actions */}
-                        {isFlashed
-                          ? (
-                            <span
-                              className={`text-2xs font-mono font-semibold ${
-                                flash.action === "accepted"
-                                  ? "text-accent-green"
-                                  : "text-accent-red"
-                              }`}
+                        {isFlashed ? (
+                          <span
+                            className={`text-2xs font-mono font-semibold ${
+                              flash.action === "accepted"
+                                ? "text-accent-green"
+                                : "text-accent-red"
+                            }`}
+                          >
+                            {flash.action === "accepted"
+                              ? "Accepted"
+                              : "Rejected"}
+                          </span>
+                        ) : (
+                          <div className="flex items-center gap-1 shrink-0">
+                            <button
+                              onClick={() =>
+                                void handleAction(d.uid, "accepted")
+                              }
+                              disabled={isActing}
+                              className="p-1.5 rounded-md text-text-muted hover:text-accent-green hover:bg-accent-green/10 transition-colors disabled:opacity-soft"
+                              title="Accept"
                             >
-                              {flash.action === "accepted"
-                                ? "Accepted"
-                                : "Rejected"}
-                            </span>
-                          )
-                          : (
-                            <div className="flex items-center gap-1 shrink-0">
-                              <button
-                                onClick={() => void handleAction(d.uid, "accepted")}
-                                disabled={isActing}
-                                className="p-1.5 rounded-md text-text-muted hover:text-accent-green hover:bg-accent-green/10 transition-colors disabled:opacity-soft"
-                                title="Accept"
-                              >
-                                {isActing
-                                  ? (
-                                    <Spinner size="sm" tone="subtle" className="block" />
-                                  )
-                                  : (
-                                    <CheckIcon
-                                      className="w-3.5 h-3.5"
-                                      strokeWidth={2.5}
-                                    />
-                                  )}
-                              </button>
-                              <button
-                                onClick={() => void handleAction(d.uid, "rejected")}
-                                disabled={isActing}
-                                className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-colors disabled:opacity-soft"
-                                title="Reject"
-                              >
-                                <XMarkIcon
+                              {isActing ? (
+                                <Spinner
+                                  size="sm"
+                                  tone="subtle"
+                                  className="block"
+                                />
+                              ) : (
+                                <CheckIcon
                                   className="w-3.5 h-3.5"
                                   strokeWidth={2.5}
                                 />
-                              </button>
-                            </div>
-                          )}
+                              )}
+                            </button>
+                            <button
+                              onClick={() =>
+                                void handleAction(d.uid, "rejected")
+                              }
+                              disabled={isActing}
+                              className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-colors disabled:opacity-soft"
+                              title="Reject"
+                            >
+                              <XMarkIcon
+                                className="w-3.5 h-3.5"
+                                strokeWidth={2.5}
+                              />
+                            </button>
+                          </div>
+                        )}
                       </div>
                     </div>
                   );

--- a/ui-react/apps/console/src/components/layout/SupportButton.tsx
+++ b/ui-react/apps/console/src/components/layout/SupportButton.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { LifebuoyIcon } from "@heroicons/react/24/outline";
 import { useChatwootContext } from "@/hooks/useChatwoot";
 import SupportPaywallDialog from "./SupportPaywallDialog";
+import Spinner from "@/components/common/Spinner";
 
 const GITHUB_ISSUE_URL = "https://github.com/shellhub-io/shellhub/issues/new";
 
@@ -60,10 +61,7 @@ export default function SupportButton() {
         }`}
       >
         {isLoading ? (
-          <span
-            aria-hidden="true"
-            className="block w-3.5 h-3.5 border-2 border-text-muted/30 border-t-text-secondary rounded-full animate-spin"
-          />
+          <Spinner size="sm" tone="subtle" className="block" />
         ) : (
           <LifebuoyIcon className="w-[18px] h-[18px]" aria-hidden="true" />
         )}

--- a/ui-react/apps/console/src/components/mfa/MfaDisableDialog.tsx
+++ b/ui-react/apps/console/src/components/mfa/MfaDisableDialog.tsx
@@ -3,6 +3,7 @@ import { ExclamationTriangleIcon, CheckCircleIcon } from "@heroicons/react/24/ou
 import { disableMfa } from "@/client";
 import { useOtpInput } from "@/hooks/useOtpInput";
 import { useAuthStore } from "@/stores/authStore";
+import Spinner from "@/components/common/Spinner";
 
 interface MfaDisableDialogProps {
   open: boolean;
@@ -225,7 +226,7 @@ export default function MfaDisableDialog({
                     className="w-full px-4 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all disabled:opacity-dim disabled:cursor-not-allowed flex items-center justify-center gap-2"
                   >
                     {requestingEmail && (
-                      <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                      <Spinner tone="onPrimary" />
                     )}
                     Send Verification Codes
                   </button>
@@ -291,7 +292,7 @@ export default function MfaDisableDialog({
                 className="px-5 py-2.5 bg-accent-red/90 hover:bg-accent-red text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
               >
                 {submitting && (
-                  <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  <Spinner tone="onPrimary" />
                 )}
                 Disable MFA
               </button>

--- a/ui-react/apps/console/src/components/mfa/MfaEnableDrawer.tsx
+++ b/ui-react/apps/console/src/components/mfa/MfaEnableDrawer.tsx
@@ -12,6 +12,7 @@ import { generateMfa, enableMfa, updateUser } from "@/client";
 import { isSdkError } from "@/api/errors";
 import { useOtpInput } from "@/hooks/useOtpInput";
 import { useRecoveryCodeActions } from "@/hooks/useRecoveryCodeActions";
+import Spinner from "@/components/common/Spinner";
 
 interface MfaEnableDrawerProps {
   open: boolean;
@@ -185,7 +186,7 @@ export default function MfaEnableDrawer({
                 className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
               >
                 {loading && (
-                  <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  <Spinner size="sm" tone="onPrimary" />
                 )}
                 Save & Continue
               </button>
@@ -196,7 +197,7 @@ export default function MfaEnableDrawer({
                 className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
               >
                 {loading && (
-                  <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  <Spinner size="sm" tone="onPrimary" />
                 )}
                 Continue
               </button>
@@ -232,7 +233,7 @@ export default function MfaEnableDrawer({
               className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
               {loading && (
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                <Spinner size="sm" tone="onPrimary" />
               )}
               Verify & Enable
             </button>

--- a/ui-react/apps/console/src/components/mfa/MfaRecoveryTimeoutModal.tsx
+++ b/ui-react/apps/console/src/components/mfa/MfaRecoveryTimeoutModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { useCountdown } from "@/hooks/useCountdown";
 import CheckboxField from "@/components/common/fields/CheckboxField";
+import Spinner from "@/components/common/Spinner";
 
 interface MfaRecoveryTimeoutModalProps {
   open: boolean;
@@ -93,7 +94,7 @@ export default function MfaRecoveryTimeoutModal({
             className="px-5 py-2.5 bg-accent-red/90 hover:bg-accent-red text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {disabling && (
-              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <Spinner tone="onPrimary" />
             )}
             Disable MFA
           </button>

--- a/ui-react/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui-react/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -10,6 +10,7 @@ import ConfirmDialog from "@/components/common/ConfirmDialog";
 import Drawer from "@/components/common/Drawer";
 import InputField from "@/components/common/fields/InputField";
 import PasswordField from "@/components/common/fields/PasswordField";
+import Spinner from "@/components/common/Spinner";
 
 function ChangePasswordDrawer({
   open,
@@ -78,7 +79,7 @@ function ChangePasswordDrawer({
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {loading && (
-              <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <Spinner size="sm" tone="onPrimary" />
             )}
             Update Password
           </button>

--- a/ui-react/apps/console/src/components/vault/VaultSetupDialog.tsx
+++ b/ui-react/apps/console/src/components/vault/VaultSetupDialog.tsx
@@ -8,6 +8,7 @@ import { getVaultBackend } from "@/utils/vault-backend-factory";
 import { useAuthStore } from "@/stores/authStore";
 import BaseDialog from "@/components/common/BaseDialog";
 import PasswordField from "@/components/common/fields/PasswordField";
+import Spinner from "@/components/common/Spinner";
 
 interface Props {
   open: boolean;
@@ -136,10 +137,7 @@ function SetupForm({ open, onClose, instanceId }: FormProps) {
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {loading && (
-              <span
-                className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-                aria-hidden="true"
-              />
+              <Spinner tone="onPrimary" />
             )}
             Create Vault
           </button>

--- a/ui-react/apps/console/src/components/vault/VaultUnlockDialog.tsx
+++ b/ui-react/apps/console/src/components/vault/VaultUnlockDialog.tsx
@@ -3,6 +3,7 @@ import { LockClosedIcon } from "@heroicons/react/24/outline";
 import { useVaultStore } from "@/stores/vaultStore";
 import BaseDialog from "@/components/common/BaseDialog";
 import PasswordField from "@/components/common/fields/PasswordField";
+import Spinner from "@/components/common/Spinner";
 
 interface Props {
   open: boolean;
@@ -93,10 +94,7 @@ function UnlockForm({ open, onClose, onReset, instanceId }: FormProps) {
               className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
               {loading && (
-                <span
-                  className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-                  aria-hidden="true"
-                />
+                <Spinner tone="onPrimary" />
               )}
               Unlock
             </button>

--- a/ui-react/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui-react/apps/console/src/pages/AcceptInvite.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/hooks/useInvitationMutations";
 import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
+import Spinner from "@/components/common/Spinner";
 
 type Branch =
   | { kind: "loading" }
@@ -177,7 +178,7 @@ export default function AcceptInvite() {
             role="status"
             aria-live="polite"
           >
-            <span className="w-8 h-8 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+            <Spinner size="2xl" />
             <p className="text-sm text-text-muted">Checking invitation...</p>
           </div>
         )}

--- a/ui-react/apps/console/src/pages/BannerEdit.tsx
+++ b/ui-react/apps/console/src/pages/BannerEdit.tsx
@@ -6,6 +6,7 @@ import type { Namespace } from "../hooks/useNamespaces";
 import { useEditNamespace } from "../hooks/useNamespaceMutations";
 import { useAuthStore } from "../stores/authStore";
 import { useHasPermission } from "../hooks/useHasPermission";
+import Spinner from "@/components/common/Spinner";
 
 const MAX_LENGTH = 4096;
 
@@ -106,7 +107,7 @@ function BannerEditor({ ns, canEdit }: { ns: Namespace; canEdit: boolean }) {
             >
               {saving
                 ? (
-                  <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  <Spinner tone="onPrimary" />
                 )
                 : (
                   <CheckIcon className="w-4 h-4" strokeWidth={2} />
@@ -130,7 +131,7 @@ export default function BannerEdit() {
   if (!ns) {
     return (
       <div className="flex items-center justify-center py-32">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/BannerEdit.tsx
+++ b/ui-react/apps/console/src/pages/BannerEdit.tsx
@@ -7,6 +7,7 @@ import { useEditNamespace } from "../hooks/useNamespaceMutations";
 import { useAuthStore } from "../stores/authStore";
 import { useHasPermission } from "../hooks/useHasPermission";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const MAX_LENGTH = 4096;
 
@@ -130,9 +131,7 @@ export default function BannerEdit() {
 
   if (!ns) {
     return (
-      <div className="flex items-center justify-center py-32">
-        <Spinner size="lg" />
-      </div>
+      <PageLoader label="Loading banner" padding="lg" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/ConfirmAccount.tsx
+++ b/ui-react/apps/console/src/pages/ConfirmAccount.tsx
@@ -7,6 +7,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { useSignUpStore } from "../stores/signUpStore";
 import { useResendEmail } from "../hooks/useResendEmail";
+import Spinner from "@/components/common/Spinner";
 
 export default function ConfirmAccount() {
   const [searchParams] = useSearchParams();
@@ -60,14 +61,14 @@ export default function ConfirmAccount() {
           type="button"
           onClick={() => void handleResend()}
           disabled={resendLoading || resendCooldown > 0}
-          className="w-full bg-primary hover:bg-primary/90 text-white py-2.5 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mb-5"
+          className="w-full bg-primary hover:bg-primary/90 text-white py-2.5 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mb-5 flex items-center justify-center gap-2"
         >
           {resendLoading
             ? (
-              <span className="flex items-center justify-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                <span className="font-mono text-xs">Sending...</span>
-              </span>
+              <>
+                <Spinner size="sm" tone="onPrimary" />
+                Sending...
+              </>
             ) : resendCooldown > 0 ? (
               `Resend Email (${resendCooldown}s)`
             )

--- a/ui-react/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui-react/apps/console/src/pages/ContainerDetails.tsx
@@ -38,7 +38,7 @@ import { formatDateFull, formatRelative } from "../utils/date";
 import { buildSshid } from "../utils/sshid";
 import { useHasPermission } from "../hooks/useHasPermission";
 import RestrictedAction from "../components/common/RestrictedAction";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -341,11 +341,7 @@ export default function ContainerDetails() {
   if (!uid) return <Navigate to="/containers" replace />;
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" />
-      </div>
-    );
+    return <PageLoader label="Loading container details" />;
   }
 
   if (error || !container) {

--- a/ui-react/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui-react/apps/console/src/pages/ContainerDetails.tsx
@@ -38,6 +38,7 @@ import { formatDateFull, formatRelative } from "../utils/date";
 import { buildSshid } from "../utils/sshid";
 import { useHasPermission } from "../hooks/useHasPermission";
 import RestrictedAction from "../components/common/RestrictedAction";
+import Spinner from "@/components/common/Spinner";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -342,7 +343,7 @@ export default function ContainerDetails() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/DeviceDetails.tsx
@@ -41,7 +41,7 @@ import { buildSshid } from "../utils/sshid";
 import { useHasPermission } from "../hooks/useHasPermission";
 import RestrictedAction from "../components/common/RestrictedAction";
 import { getConfig } from "../env";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -451,9 +451,7 @@ export default function DeviceDetails() {
 
   if (isLoading || !device) {
     return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" />
-      </div>
+      <PageLoader label="Loading device details" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/DeviceDetails.tsx
@@ -41,6 +41,7 @@ import { buildSshid } from "../utils/sshid";
 import { useHasPermission } from "../hooks/useHasPermission";
 import RestrictedAction from "../components/common/RestrictedAction";
 import { getConfig } from "../env";
+import Spinner from "@/components/common/Spinner";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -451,7 +452,7 @@ export default function DeviceDetails() {
   if (isLoading || !device) {
     return (
       <div className="flex items-center justify-center py-24">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/ForgotPassword.tsx
+++ b/ui-react/apps/console/src/pages/ForgotPassword.tsx
@@ -7,6 +7,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { recoverPassword } from "../client";
 import InputField from "@/components/common/fields/InputField";
+import Spinner from "@/components/common/Spinner";
 
 export default function ForgotPassword() {
   const [account, setAccount] = useState("");
@@ -101,7 +102,7 @@ export default function ForgotPassword() {
             >
               {loading ? (
                 <>
-                  <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  <Spinner size="sm" tone="onPrimary" />
                   <span className="font-mono text-xs">Sending...</span>
                 </>
               ) : (

--- a/ui-react/apps/console/src/pages/Login.tsx
+++ b/ui-react/apps/console/src/pages/Login.tsx
@@ -19,6 +19,7 @@ import AuthFooterLinks from "../components/common/AuthFooterLinks";
 import { getInfo, getSamlAuthUrl } from "../client";
 import InputField from "@/components/common/fields/InputField";
 import PasswordField from "@/components/common/fields/PasswordField";
+import Spinner from "@/components/common/Spinner";
 
 interface CountdownState {
   display: string;
@@ -196,7 +197,7 @@ export default function Login() {
   if (tokenLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
-        <span className="w-6 h-6 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="xl" />
       </div>
     );
   }
@@ -328,13 +329,13 @@ export default function Login() {
             <button
               type="submit"
               disabled={disableSubmit}
-              className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
+              className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1 flex items-center justify-center gap-2"
             >
               {loading ? (
-                <span className="flex items-center justify-center gap-2">
-                  <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  <span className="font-mono text-xs">Authenticating...</span>
-                </span>
+                <>
+                  <Spinner size="sm" tone="onPrimary" />
+                  Authenticating...
+                </>
               ) : (
                 "Sign In"
               )}
@@ -371,9 +372,7 @@ export default function Login() {
             }`}
           >
             {ssoLoading ? (
-              <span
-                className={`w-3.5 h-3.5 border-2 rounded-full animate-spin ${ssoOnly ? "border-white/30 border-t-white" : "border-primary/30 border-t-primary"}`}
-              />
+              <Spinner size="sm" tone={ssoOnly ? "onPrimary" : "onSurface"} />
             ) : (
               <ArrowRightEndOnRectangleIcon className="w-4 h-4" />
             )}

--- a/ui-react/apps/console/src/pages/MfaLogin.tsx
+++ b/ui-react/apps/console/src/pages/MfaLogin.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from "../stores/authStore";
 import { useOtpInput } from "../hooks/useOtpInput";
 import { getSafeRedirect } from "../utils/navigation";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import Spinner from "@/components/common/Spinner";
 
 export default function MfaLogin() {
   const otp = useOtpInput(6);
@@ -108,13 +109,13 @@ export default function MfaLogin() {
           <button
             type="submit"
             disabled={loading || !otp.isComplete}
-            className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
+            className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1 flex items-center justify-center gap-2"
           >
             {loading ? (
-              <span className="flex items-center justify-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                <span className="font-mono text-xs">Verifying...</span>
-              </span>
+              <>
+                <Spinner size="sm" tone="onPrimary" />
+                Verifying...
+              </>
             ) : (
               "Verify"
             )}

--- a/ui-react/apps/console/src/pages/MfaRecover.tsx
+++ b/ui-react/apps/console/src/pages/MfaRecover.tsx
@@ -1,16 +1,23 @@
 import { useState, FormEvent, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import {
-  ExclamationCircleIcon,
-  KeyIcon,
-} from "@heroicons/react/24/outline";
+import { ExclamationCircleIcon, KeyIcon } from "@heroicons/react/24/outline";
 import { useAuthStore } from "../stores/authStore";
 import { disableMfa } from "../client";
 import MfaRecoveryTimeoutModal from "../components/mfa/MfaRecoveryTimeoutModal";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import Spinner from "@/components/common/Spinner";
 
 export default function MfaRecover() {
-  const { recoverWithCode, loading, error, mfaRecoveryExpiry, updateMfaStatus, user, username, mfaToken } = useAuthStore();
+  const {
+    recoverWithCode,
+    loading,
+    error,
+    mfaRecoveryExpiry,
+    updateMfaStatus,
+    user,
+    username,
+    mfaToken,
+  } = useAuthStore();
   const navigate = useNavigate();
 
   const identifier = user || username;
@@ -49,7 +56,10 @@ export default function MfaRecover() {
 
   const handleDisableMfa = async () => {
     // Use the recovery code that was just entered
-    await disableMfa({ body: { recovery_code: recoveryCode }, throwOnError: true });
+    await disableMfa({
+      body: { recovery_code: recoveryCode },
+      throwOnError: true,
+    });
     updateMfaStatus(false);
     setShowTimeoutModal(false);
     void navigate("/dashboard");
@@ -81,7 +91,8 @@ export default function MfaRecover() {
           Recover Your Account
         </h1>
         <p className="text-sm text-text-muted max-w-md mx-auto leading-relaxed">
-          Enter one of your recovery codes for <span className="font-semibold text-text-primary">{identifier}</span>.
+          Enter one of your recovery codes for{" "}
+          <span className="font-semibold text-text-primary">{identifier}</span>.
         </p>
       </div>
 
@@ -126,13 +137,13 @@ export default function MfaRecover() {
           <button
             type="submit"
             disabled={loading || !recoveryCode.trim()}
-            className="w-full bg-accent-yellow hover:bg-accent-yellow/80 text-background py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
+            className="w-full bg-accent-yellow hover:bg-accent-yellow/80 text-background py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1 flex items-center justify-center gap-2"
           >
             {loading ? (
-              <span className="flex items-center justify-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-background/30 border-t-background rounded-full animate-spin" />
-                <span className="font-mono text-xs">Recovering...</span>
-              </span>
+              <>
+                <Spinner size="sm" tone="onPrimary" />
+                Recovering...
+              </>
             ) : (
               "Recover Account"
             )}

--- a/ui-react/apps/console/src/pages/MfaResetComplete.tsx
+++ b/ui-react/apps/console/src/pages/MfaResetComplete.tsx
@@ -5,6 +5,7 @@ import { resetMfa } from "../client";
 import { useAuthStore } from "../stores/authStore";
 import { useOtpInput } from "../hooks/useOtpInput";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import Spinner from "@/components/common/Spinner";
 
 export default function MfaResetComplete() {
   const [searchParams] = useSearchParams();
@@ -167,13 +168,13 @@ export default function MfaResetComplete() {
           <button
             type="submit"
             disabled={!otpMain.isComplete || !otpRecovery.isComplete || loading}
-            className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
+            className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1 flex items-center justify-center gap-2"
           >
             {loading ? (
-              <span className="flex items-center justify-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                <span className="font-mono text-xs">Verifying...</span>
-              </span>
+              <>
+                <Spinner size="sm" tone="onPrimary" />
+                Verifying...
+              </>
             ) : (
               "Reset MFA and Login"
             )}

--- a/ui-react/apps/console/src/pages/MfaResetRequest.tsx
+++ b/ui-react/apps/console/src/pages/MfaResetRequest.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { EnvelopeIcon, ExclamationCircleIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import { useAuthStore } from "../stores/authStore";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import Spinner from "@/components/common/Spinner";
 
 export default function MfaResetRequest() {
   const { requestMfaReset, loading, error, user, username, mfaToken } = useAuthStore();
@@ -85,13 +86,13 @@ export default function MfaResetRequest() {
             <button
               type="submit"
               disabled={loading}
-              className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
+              className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1 flex items-center justify-center gap-2"
             >
               {loading ? (
-                <span className="flex items-center justify-center gap-2">
-                  <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  <span className="font-mono text-xs">Sending...</span>
-                </span>
+                <>
+                  <Spinner size="sm" tone="onPrimary" />
+                  Sending...
+                </>
               ) : (
                 "Send Verification Codes"
               )}

--- a/ui-react/apps/console/src/pages/MfaResetVerify.tsx
+++ b/ui-react/apps/console/src/pages/MfaResetVerify.tsx
@@ -4,6 +4,7 @@ import { ShieldCheckIcon, ExclamationCircleIcon } from "@heroicons/react/24/outl
 import { useAuthStore } from "../stores/authStore";
 import { useOtpInput } from "../hooks/useOtpInput";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import Spinner from "@/components/common/Spinner";
 
 export default function MfaResetVerify() {
   const { completeMfaReset, mfaResetUserId, mfaResetIdentifier, loading, error } = useAuthStore();
@@ -129,13 +130,13 @@ export default function MfaResetVerify() {
           <button
             type="submit"
             disabled={!otpMain.isComplete || !otpRecovery.isComplete || loading}
-            className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
+            className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1 flex items-center justify-center gap-2"
           >
             {loading ? (
-              <span className="flex items-center justify-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                <span className="font-mono text-xs">Verifying...</span>
-              </span>
+              <>
+                <Spinner size="sm" tone="onPrimary" />
+                Verifying...
+              </>
             ) : (
               "Verify and Reset MFA"
             )}

--- a/ui-react/apps/console/src/pages/MigrationPage.tsx
+++ b/ui-react/apps/console/src/pages/MigrationPage.tsx
@@ -5,6 +5,7 @@ import {
   ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
 import AmbientBackground from "../components/common/AmbientBackground";
+import Spinner from "@/components/common/Spinner";
 
 type MigrationStatus = "running" | "completed" | "failed" | "unknown";
 
@@ -124,7 +125,7 @@ export default function MigrationPage() {
 
         {(status === "running" || status === "unknown") && (
           <div className="flex items-center gap-2.5 bg-card/80 border border-border rounded-lg px-4 py-2.5 backdrop-blur-sm">
-            <span className="w-3 h-3 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+            <Spinner size="xs" />
             <span className="text-xs font-mono text-text-secondary">
               Migrating data…
             </span>

--- a/ui-react/apps/console/src/pages/Profile.tsx
+++ b/ui-react/apps/console/src/pages/Profile.tsx
@@ -29,6 +29,7 @@ import {
 import MfaEnableDrawer from "../components/mfa/MfaEnableDrawer";
 import MfaDisableDialog from "../components/mfa/MfaDisableDialog";
 import { hasMfaSupport } from "../utils/features";
+import Spinner from "@/components/common/Spinner";
 
 const USERNAME_REGEX = /^[a-z0-9_.@-]+$/;
 
@@ -412,7 +413,7 @@ export function EditProfileDrawer({
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
-              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <Spinner tone="onPrimary" />
             ) : (
               <CheckIcon className="w-4 h-4" strokeWidth={2} />
             )}
@@ -550,7 +551,7 @@ function ChangePasswordDrawer({
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
-              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <Spinner tone="onPrimary" />
             ) : (
               <CheckIcon className="w-4 h-4" strokeWidth={2} />
             )}
@@ -619,7 +620,7 @@ export default function Profile() {
   if (!name && !username) {
     return (
       <div className="flex items-center justify-center py-32">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/Profile.tsx
+++ b/ui-react/apps/console/src/pages/Profile.tsx
@@ -30,6 +30,7 @@ import MfaEnableDrawer from "../components/mfa/MfaEnableDrawer";
 import MfaDisableDialog from "../components/mfa/MfaDisableDialog";
 import { hasMfaSupport } from "../utils/features";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const USERNAME_REGEX = /^[a-z0-9_.@-]+$/;
 
@@ -618,11 +619,7 @@ export default function Profile() {
   }, [fetchUser]);
 
   if (!name && !username) {
-    return (
-      <div className="flex items-center justify-center py-32">
-        <Spinner size="lg" />
-      </div>
-    );
+    return <PageLoader label="Loading profile" padding="lg" />;
   }
 
   const openEdit = () => setEditDrawerOpen(true);

--- a/ui-react/apps/console/src/pages/SessionDetails.tsx
+++ b/ui-react/apps/console/src/pages/SessionDetails.tsx
@@ -34,7 +34,7 @@ import DistroIcon from "../components/common/DistroIcon";
 import { formatDateFull, formatRelative, formatDuration } from "../utils/date";
 import type { Session } from "../client";
 import RestrictedAction from "../components/common/RestrictedAction";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 /* ── timeline builder ────────────────────────────── */
 
@@ -340,11 +340,7 @@ export default function SessionDetails() {
   };
 
   if (isLoading || !session) {
-    return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" aria-label="Loading session" />
-      </div>
-    );
+    return <PageLoader label="Loading session" />;
   }
 
   if (error) {

--- a/ui-react/apps/console/src/pages/SessionDetails.tsx
+++ b/ui-react/apps/console/src/pages/SessionDetails.tsx
@@ -22,7 +22,10 @@ import {
 } from "@heroicons/react/24/outline";
 import { PlayIcon } from "@heroicons/react/24/solid";
 import { useSession } from "../hooks/useSession";
-import { useCloseSession, useDeleteSessionRecording } from "../hooks/useSessionMutations";
+import {
+  useCloseSession,
+  useDeleteSessionRecording,
+} from "../hooks/useSessionMutations";
 import { useSessionRecording } from "../hooks/useSessionRecording";
 import SessionPlayerDialog from "./sessions/SessionPlayerDialog";
 import CopyButton from "../components/common/CopyButton";
@@ -31,6 +34,7 @@ import DistroIcon from "../components/common/DistroIcon";
 import { formatDateFull, formatRelative, formatDuration } from "../utils/date";
 import type { Session } from "../client";
 import RestrictedAction from "../components/common/RestrictedAction";
+import Spinner from "@/components/common/Spinner";
 
 /* ── timeline builder ────────────────────────────── */
 
@@ -163,8 +167,8 @@ const NODE_COLORS: Record<EventStatus, string> = {
   muted: "text-text-muted border-border bg-surface",
 };
 
-const LABEL
-  = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
+const LABEL =
+  "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
 const VALUE = "text-sm text-text-primary font-medium mt-0.5";
 
 /* ── Info Row ── */
@@ -295,7 +299,13 @@ export default function SessionDetails() {
   const { session, isLoading, error } = useSession(uid!);
   const closeSession = useCloseSession();
   const deleteRecording = useDeleteSessionRecording();
-  const { logs: sessionLogs, isLoading: logsLoading, error: logsError, fetchLogs, clearLogs } = useSessionRecording();
+  const {
+    logs: sessionLogs,
+    isLoading: logsLoading,
+    error: logsError,
+    fetchLogs,
+    clearLogs,
+  } = useSessionRecording();
   const [showClose, setShowClose] = useState(false);
   const [showPlayer, setShowPlayer] = useState(false);
   const [showDeleteLogs, setShowDeleteLogs] = useState(false);
@@ -332,7 +342,7 @@ export default function SessionDetails() {
   if (isLoading || !session) {
     return (
       <div className="flex items-center justify-center py-24">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="lg" aria-label="Loading session" />
       </div>
     );
   }
@@ -541,7 +551,8 @@ export default function SessionDetails() {
                 <DeviceChip
                   uid={session.device.uid}
                   name={
-                    session.device.name ?? (session.device_uid ?? "").substring(0, 8)
+                    session.device.name ??
+                    (session.device_uid ?? "").substring(0, 8)
                   }
                   online={session.device.online}
                   osId={session.device.info?.id}
@@ -588,7 +599,10 @@ export default function SessionDetails() {
           <div className="relative bg-surface border border-border rounded-2xl w-full max-w-sm mx-4 p-6 shadow-2xl animate-slide-up">
             <div className="flex items-center gap-3 mb-4">
               <div className="w-10 h-10 rounded-full bg-accent-red/10 border border-accent-red/20 flex items-center justify-center shrink-0">
-                <TrashIcon className="w-5 h-5 text-accent-red" strokeWidth={2} />
+                <TrashIcon
+                  className="w-5 h-5 text-accent-red"
+                  strokeWidth={2}
+                />
               </div>
               <div>
                 <h2 className="text-base font-semibold text-text-primary">
@@ -658,7 +672,8 @@ export default function SessionDetails() {
               </span>{" "}
               on{" "}
               <span className="font-medium text-text-primary">
-                {session.device?.name ?? (session.device_uid ?? "").substring(0, 8)}
+                {session.device?.name ??
+                  (session.device_uid ?? "").substring(0, 8)}
               </span>
               ?
             </p>
@@ -697,7 +712,10 @@ export default function SessionDetails() {
       {showPlayer && sessionLogs && (
         <SessionPlayerDialog
           open={showPlayer}
-          onClose={() => { setShowPlayer(false); clearLogs(); }}
+          onClose={() => {
+            setShowPlayer(false);
+            clearLogs();
+          }}
           logs={sessionLogs}
         />
       )}

--- a/ui-react/apps/console/src/pages/Settings.tsx
+++ b/ui-react/apps/console/src/pages/Settings.tsx
@@ -33,6 +33,7 @@ import InputField from "@/components/common/fields/InputField";
 import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
 import { validateNamespaceName } from "@/utils/validation";
 import { getConfig } from "../env";
+import Spinner from "@/components/common/Spinner";
 
 /* ─── Settings Card ─── */
 
@@ -157,7 +158,7 @@ function EditNameDrawer({
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
-              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <Spinner tone="onPrimary" />
             ) : (
               <CheckIcon className="w-4 h-4" strokeWidth={2} />
             )}
@@ -445,7 +446,7 @@ export default function Settings() {
   if (!ns) {
     return (
       <div className="flex items-center justify-center py-32">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/Settings.tsx
+++ b/ui-react/apps/console/src/pages/Settings.tsx
@@ -34,6 +34,7 @@ import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
 import { validateNamespaceName } from "@/utils/validation";
 import { getConfig } from "../env";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 /* ─── Settings Card ─── */
 
@@ -444,11 +445,7 @@ export default function Settings() {
   };
 
   if (!ns) {
-    return (
-      <div className="flex items-center justify-center py-32">
-        <Spinner size="lg" />
-      </div>
-    );
+    return <PageLoader label="Loading settings" padding="lg" />;
   }
 
   return (

--- a/ui-react/apps/console/src/pages/Setup.tsx
+++ b/ui-react/apps/console/src/pages/Setup.tsx
@@ -7,6 +7,7 @@ import { getConfig } from "../env";
 import { validate, type FormErrors } from "./setup/validate";
 import InputField from "@/components/common/fields/InputField";
 import PasswordField from "@/components/common/fields/PasswordField";
+import Spinner from "@/components/common/Spinner";
 
 const STEP_ONBOARDING = 1;
 const STEP_ACCOUNT = 2;
@@ -289,13 +290,13 @@ export default function Setup() {
                 <button
                   type="submit"
                   disabled={disableCreateAccountButton}
-                  className={`${showOnboarding ? "flex-[2]" : "w-full"} bg-primary hover:bg-primary-600 text-white py-2.5 px-4 rounded-md text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200`}
+                  className={`${showOnboarding ? "flex-[2]" : "w-full"} bg-primary hover:bg-primary-600 text-white py-2.5 px-4 rounded-md text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 flex items-center justify-center gap-2`}
                 >
                   {loading ? (
-                    <span className="flex items-center justify-center gap-2">
-                      <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                      <span className="font-mono text-xs">Creating...</span>
-                    </span>
+                    <>
+                      <Spinner size="sm" tone="onPrimary" />
+                      Creating...
+                    </>
                   ) : (
                     "Create Account"
                   )}

--- a/ui-react/apps/console/src/pages/SignUp.tsx
+++ b/ui-react/apps/console/src/pages/SignUp.tsx
@@ -11,6 +11,7 @@ import AccountCreated from "../components/auth/AccountCreated";
 import InputField from "@/components/common/fields/InputField";
 import PasswordField from "@/components/common/fields/PasswordField";
 import CheckboxField from "@/components/common/fields/CheckboxField";
+import Spinner from "@/components/common/Spinner";
 
 const SERVER_FIELD_MAP: Record<string, keyof FormErrors> = {
   username: "username",
@@ -311,13 +312,13 @@ export default function SignUp() {
             <button
               type="submit"
               disabled={signUpLoading || !isFormValid}
-              className="w-full bg-primary hover:bg-primary/90 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-2"
+              className="w-full bg-primary hover:bg-primary/90 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-2 flex items-center justify-center gap-2"
             >
               {signUpLoading ? (
-                <span className="flex items-center justify-center gap-2">
-                  <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                  <span className="font-mono text-xs">Creating account...</span>
-                </span>
+                <>
+                  <Spinner size="sm" tone="onPrimary" />
+                  Creating account...
+                </>
               ) : (
                 "Create Account"
               )}

--- a/ui-react/apps/console/src/pages/UpdatePassword.tsx
+++ b/ui-react/apps/console/src/pages/UpdatePassword.tsx
@@ -7,6 +7,7 @@ import {
 import { updateRecoverPassword } from "../client";
 import { validatePassword } from "../utils/validation";
 import PasswordField from "@/components/common/fields/PasswordField";
+import Spinner from "@/components/common/Spinner";
 
 export default function UpdatePassword() {
   const [searchParams] = useSearchParams();
@@ -146,13 +147,13 @@ export default function UpdatePassword() {
           <button
             type="submit"
             disabled={loading || !isValid}
-            className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1"
+            className="w-full bg-primary hover:bg-primary-600 text-white py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1 flex items-center justify-center gap-2"
           >
             {loading ? (
-              <span className="flex items-center justify-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                <span className="font-mono text-xs">Updating...</span>
-              </span>
+              <>
+                <Spinner size="sm" tone="onPrimary" />
+                Updating...
+              </>
             ) : (
               "Update Password"
             )}

--- a/ui-react/apps/console/src/pages/ValidationAccount.tsx
+++ b/ui-react/apps/console/src/pages/ValidationAccount.tsx
@@ -1,10 +1,8 @@
 import { useEffect } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import {
-  CheckCircleIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/outline";
+import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/outline";
 import { useSignUpStore } from "../stores/signUpStore";
+import Spinner from "@/components/common/Spinner";
 
 export default function ValidationAccount() {
   const navigate = useNavigate();
@@ -44,9 +42,7 @@ export default function ValidationAccount() {
 
   return (
     <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
-      <div
-        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm text-center animate-slide-up"
-      >
+      <div className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm text-center animate-slide-up">
         <h1 className="text-lg font-semibold text-text-primary mb-5">
           Account Verification
         </h1>
@@ -58,7 +54,7 @@ export default function ValidationAccount() {
         >
           {validationStatus === "processing" || validationStatus === "idle" ? (
             <>
-              <span className="w-10 h-10 border-2 border-primary/20 border-t-primary rounded-full animate-spin mb-4" />
+              <Spinner size="2xl" className="mb-4" />
               <p className="text-sm text-text-secondary">
                 Processing your account activation...
               </p>
@@ -66,7 +62,10 @@ export default function ValidationAccount() {
           ) : validationStatus === "success" ? (
             <>
               <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-green/10 border border-accent-green/20 mb-4">
-                <CheckCircleIcon className="w-7 h-7 text-accent-green" strokeWidth={1.5} />
+                <CheckCircleIcon
+                  className="w-7 h-7 text-accent-green"
+                  strokeWidth={1.5}
+                />
               </div>
               <p className="text-sm text-text-secondary leading-relaxed">
                 Congratulations! Your account has been activated successfully.
@@ -76,7 +75,10 @@ export default function ValidationAccount() {
           ) : validationStatus === "failed-token" ? (
             <>
               <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-red/10 border border-accent-red/20 mb-4">
-                <XCircleIcon className="w-7 h-7 text-accent-red" strokeWidth={1.5} />
+                <XCircleIcon
+                  className="w-7 h-7 text-accent-red"
+                  strokeWidth={1.5}
+                />
               </div>
               <p className="text-sm text-text-secondary leading-relaxed">
                 Your account activation token has expired. Go to the login page
@@ -86,7 +88,10 @@ export default function ValidationAccount() {
           ) : (
             <>
               <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-red/10 border border-accent-red/20 mb-4">
-                <XCircleIcon className="w-7 h-7 text-accent-red" strokeWidth={1.5} />
+                <XCircleIcon
+                  className="w-7 h-7 text-accent-red"
+                  strokeWidth={1.5}
+                />
               </div>
               <p className="text-sm text-text-secondary leading-relaxed">
                 There was a problem activating your account. Go to the login

--- a/ui-react/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui-react/apps/console/src/pages/WebEndpoints.tsx
@@ -33,6 +33,7 @@ import {
   MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
 import RestrictedAction from "@/components/common/RestrictedAction";
+import Spinner from "@/components/common/Spinner";
 
 /* ─── Constants ─── */
 
@@ -430,13 +431,13 @@ function EndpointDrawer({
             type="submit"
             onClick={() => void handleSubmit()}
             disabled={submitting || confirmDisabled}
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
-              <span className="flex items-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <>
+                <Spinner size="sm" tone="onPrimary" />
                 Creating...
-              </span>
+              </>
             ) : (
               "Create Endpoint"
             )}
@@ -880,7 +881,7 @@ function WebEndpointsContent() {
           aria-live="polite"
           aria-label="Loading web endpoints"
         >
-          <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+          <Spinner size="lg" />
         </div>
       ) : isTrulyEmpty ? (
         /* Empty state */

--- a/ui-react/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui-react/apps/console/src/pages/WebEndpoints.tsx
@@ -34,6 +34,7 @@ import {
 } from "@heroicons/react/24/outline";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 /* ─── Constants ─── */
 
@@ -875,14 +876,7 @@ function WebEndpointsContent() {
     <div>
       {/* Content */}
       {isLoading && webEndpoints.length === 0 && !isSearching ? (
-        <div
-          className="flex items-center justify-center py-16"
-          role="status"
-          aria-live="polite"
-          aria-label="Loading web endpoints"
-        >
-          <Spinner size="lg" />
-        </div>
+        <PageLoader label="Loading web endpoints" />
       ) : isTrulyEmpty ? (
         /* Empty state */
         <div className="relative -mx-8 -mt-8 min-h-[calc(100vh-3.5rem)] flex flex-col">

--- a/ui-react/apps/console/src/pages/admin/Dashboard.tsx
+++ b/ui-react/apps/console/src/pages/admin/Dashboard.tsx
@@ -20,6 +20,7 @@ import { useAdminSessions } from "@/hooks/useAdminSessions";
 import { formatDate } from "@/utils/date";
 import { sessionType } from "@/utils/session";
 import type { Session } from "@/client";
+import Spinner from "@/components/common/Spinner";
 
 export default function AdminDashboard() {
   const {
@@ -41,10 +42,7 @@ export default function AdminDashboard() {
         role="status"
         aria-label="Loading dashboard statistics"
       >
-        <span
-          className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin"
-          aria-hidden="true"
-        />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/admin/Dashboard.tsx
+++ b/ui-react/apps/console/src/pages/admin/Dashboard.tsx
@@ -20,7 +20,7 @@ import { useAdminSessions } from "@/hooks/useAdminSessions";
 import { formatDate } from "@/utils/date";
 import { sessionType } from "@/utils/session";
 import type { Session } from "@/client";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 export default function AdminDashboard() {
   const {
@@ -36,15 +36,7 @@ export default function AdminDashboard() {
   const navigate = useNavigate();
 
   if (statsLoading) {
-    return (
-      <div
-        className="flex-1 flex items-center justify-center"
-        role="status"
-        aria-label="Loading dashboard statistics"
-      >
-        <Spinner size="lg" />
-      </div>
-    );
+    return <PageLoader label="Loading dashboard statistics" padding="fill" />;
   }
 
   if (statsError) {

--- a/ui-react/apps/console/src/pages/admin/License.tsx
+++ b/ui-react/apps/console/src/pages/admin/License.tsx
@@ -25,6 +25,7 @@ import {
   getLicenseAlertConfig,
 } from "@/utils/license";
 import type { GetLicenseResponse } from "@/client/types.gen";
+import Spinner from "@/components/common/Spinner";
 
 type HeroIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
@@ -342,7 +343,7 @@ function LicenseUpload() {
             className="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
           >
             {upload.isPending
-              ? <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" aria-hidden="true" />
+              ? <Spinner size="md" tone="onPrimary" />
               : <ArrowUpTrayIcon className="w-4 h-4" aria-hidden="true" />}
             {upload.isPending ? "Uploading..." : "Upload"}
           </button>
@@ -374,7 +375,7 @@ export default function AdminLicense() {
         role="status"
         aria-label="Loading license information"
       >
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/admin/License.tsx
+++ b/ui-react/apps/console/src/pages/admin/License.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/utils/license";
 import type { GetLicenseResponse } from "@/client/types.gen";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 type HeroIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
@@ -370,13 +371,7 @@ export default function AdminLicense() {
 
   if (isLoading) {
     return (
-      <div
-        className="flex-1 flex items-center justify-center"
-        role="status"
-        aria-label="Loading license information"
-      >
-        <Spinner size="lg" />
-      </div>
+      <PageLoader label="Loading license information" padding="fill" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
@@ -9,6 +9,7 @@ import { useAdminSessionDetail } from "@/hooks/useAdminSessionDetail";
 import PageHeader from "@/components/common/PageHeader";
 import { formatDateFull } from "@/utils/date";
 import { sessionType } from "@/utils/session";
+import Spinner from "@/components/common/Spinner";
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -38,8 +39,8 @@ export default function AdminSessionDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex-1 flex items-center justify-center" role="status" aria-label="Loading session">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" aria-hidden="true" />
+      <div className="flex-1 flex items-center justify-center">
+        <Spinner size="lg" aria-label="Loading session" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
@@ -9,7 +9,7 @@ import { useAdminSessionDetail } from "@/hooks/useAdminSessionDetail";
 import PageHeader from "@/components/common/PageHeader";
 import { formatDateFull } from "@/utils/date";
 import { sessionType } from "@/utils/session";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -39,9 +39,7 @@ export default function AdminSessionDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-        <Spinner size="lg" aria-label="Loading session" />
-      </div>
+      <PageLoader label="Loading session" padding="fill" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
@@ -12,6 +12,7 @@ import CopyButton from "@/components/common/CopyButton";
 import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import AnnouncementContent from "./AnnouncementContent";
 import { formatDateFull } from "@/utils/date";
+import Spinner from "@/components/common/Spinner";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -28,9 +29,8 @@ export default function AnnouncementDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24" role="status">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-        <span className="sr-only">Loading announcement details</span>
+      <div className="flex items-center justify-center py-24">
+        <Spinner size="lg" aria-label="Loading announcement details" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
@@ -12,7 +12,7 @@ import CopyButton from "@/components/common/CopyButton";
 import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import AnnouncementContent from "./AnnouncementContent";
 import { formatDateFull } from "@/utils/date";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -29,9 +29,7 @@ export default function AnnouncementDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" aria-label="Loading announcement details" />
-      </div>
+      <PageLoader label="Loading announcement details" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
@@ -10,6 +10,7 @@ import { useAdminUpdateAnnouncement } from "@/hooks/useAdminAnnouncementMutation
 import AnnouncementEditor from "./AnnouncementEditor";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
+import Spinner from "@/components/common/Spinner";
 
 const TITLE_MAX = 90;
 
@@ -54,9 +55,8 @@ export default function EditAnnouncement() {
 
   if (isFetching) {
     return (
-      <div className="flex items-center justify-center py-24" role="status">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-        <span className="sr-only">Loading announcement</span>
+      <div className="flex items-center justify-center py-24">
+        <Spinner size="lg" aria-label="Loading announcement" />
       </div>
     );
   }
@@ -165,7 +165,7 @@ export default function EditAnnouncement() {
             className="flex items-center gap-2 px-4 py-2.5 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {updateAnnouncement.isPending && (
-              <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <Spinner size="sm" tone="onPrimary" />
             )}
             Save
           </button>

--- a/ui-react/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
@@ -11,6 +11,7 @@ import AnnouncementEditor from "./AnnouncementEditor";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const TITLE_MAX = 90;
 
@@ -55,9 +56,7 @@ export default function EditAnnouncement() {
 
   if (isFetching) {
     return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" aria-label="Loading announcement" />
-      </div>
+      <PageLoader label="Loading announcement" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
@@ -8,6 +8,7 @@ import { useAdminCreateAnnouncement } from "@/hooks/useAdminAnnouncementMutation
 import AnnouncementEditor from "./AnnouncementEditor";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
+import Spinner from "@/components/common/Spinner";
 
 const TITLE_MAX = 90;
 
@@ -113,7 +114,7 @@ export default function NewAnnouncement() {
             className="flex items-center gap-2 px-4 py-2.5 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {createAnnouncement.isPending && (
-              <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <Spinner size="sm" tone="onPrimary" />
             )}
             Create
           </button>

--- a/ui-react/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -14,7 +14,7 @@ import DistroIcon from "@/components/common/DistroIcon";
 import PlatformBadge from "@/components/common/PlatformBadge";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatDateFull, formatRelative } from "@/utils/date";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -26,9 +26,7 @@ export default function AdminDeviceDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" aria-label="Loading device details" />
-      </div>
+      <PageLoader label="Loading device details" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -14,6 +14,7 @@ import DistroIcon from "@/components/common/DistroIcon";
 import PlatformBadge from "@/components/common/PlatformBadge";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatDateFull, formatRelative } from "@/utils/date";
+import Spinner from "@/components/common/Spinner";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -25,9 +26,8 @@ export default function AdminDeviceDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24" role="status">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-        <span className="sr-only">Loading device details</span>
+      <div className="flex items-center justify-center py-24">
+        <Spinner size="lg" aria-label="Loading device details" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDeviceDetails.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDeviceDetails.test.tsx
@@ -76,7 +76,7 @@ describe("AdminDeviceDetails", () => {
   });
 
   describe("loading state", () => {
-    it('renders an sr-only "Loading device details" message while loading', () => {
+    it('announces "Loading device details" while loading', () => {
       vi.mocked(useAdminDevice).mockReturnValue({
         data: undefined,
         isLoading: true,
@@ -85,8 +85,9 @@ describe("AdminDeviceDetails", () => {
 
       renderPage();
 
-      expect(screen.getByRole("status")).toBeInTheDocument();
-      expect(screen.getByText("Loading device details")).toBeInTheDocument();
+      expect(
+        screen.getByRole("status", { name: "Loading device details" }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
@@ -10,7 +10,7 @@ import {
 import { useAdminFirewallRule } from "@/hooks/useAdminFirewallRules";
 import CopyButton from "@/components/common/CopyButton";
 import FilterBadge from "@/components/common/FilterBadge";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -22,9 +22,7 @@ export default function AdminFirewallRuleDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" aria-label="Loading firewall rule details" />
-      </div>
+      <PageLoader label="Loading firewall rule details" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
@@ -10,6 +10,7 @@ import {
 import { useAdminFirewallRule } from "@/hooks/useAdminFirewallRules";
 import CopyButton from "@/components/common/CopyButton";
 import FilterBadge from "@/components/common/FilterBadge";
+import Spinner from "@/components/common/Spinner";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -21,9 +22,8 @@ export default function AdminFirewallRuleDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24" role="status">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-        <span className="sr-only">Loading firewall rule details</span>
+      <div className="flex items-center justify-center py-24">
+        <Spinner size="lg" aria-label="Loading firewall rule details" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRuleDetails.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRuleDetails.test.tsx
@@ -38,7 +38,9 @@ function makeTag(name: string) {
   };
 }
 
-function makeRule(overrides: Partial<FirewallRulesResponse> = {}): FirewallRulesResponse {
+function makeRule(
+  overrides: Partial<FirewallRulesResponse> = {},
+): FirewallRulesResponse {
   return {
     id: "rule-1",
     tenant_id: "tenant-abc",
@@ -72,7 +74,7 @@ describe("AdminFirewallRuleDetails", () => {
   });
 
   describe("loading state", () => {
-    it('renders a loading spinner with sr-only "Loading firewall rule details" while loading', () => {
+    it('announces "Loading firewall rule details" while loading', () => {
       vi.mocked(useAdminFirewallRule).mockReturnValue({
         data: undefined,
         isLoading: true,
@@ -81,9 +83,8 @@ describe("AdminFirewallRuleDetails", () => {
 
       renderPage();
 
-      expect(screen.getByRole("status")).toBeInTheDocument();
       expect(
-        screen.getByText("Loading firewall rule details"),
+        screen.getByRole("status", { name: "Loading firewall rule details" }),
       ).toBeInTheDocument();
     });
   });
@@ -253,7 +254,9 @@ describe("AdminFirewallRuleDetails", () => {
 
     it("renders tag FilterBadge when filter has tags", () => {
       vi.mocked(useAdminFirewallRule).mockReturnValue({
-        data: makeRule({ filter: { tags: [makeTag("production"), makeTag("web")] } }),
+        data: makeRule({
+          filter: { tags: [makeTag("production"), makeTag("web")] },
+        }),
         isLoading: false,
         error: null,
       } as ReturnType<typeof useAdminFirewallRule>);

--- a/ui-react/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
@@ -8,6 +8,7 @@ import NumericInput from "@/components/common/fields/NumericInput";
 import CheckboxField from "@/components/common/fields/CheckboxField";
 import { validateNamespaceName } from "@/utils/validation";
 import type { Namespace } from "@/client";
+import Spinner from "@/components/common/Spinner";
 
 interface EditNamespaceDrawerProps {
   open: boolean;
@@ -99,10 +100,7 @@ export default function EditNamespaceDrawer({
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {editNamespace.isPending && (
-              <span
-                aria-hidden="true"
-                className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-              />
+              <Spinner tone="onPrimary" />
             )}
             Save Changes
           </button>

--- a/ui-react/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -15,7 +15,7 @@ import EditNamespaceDrawer from "./EditNamespaceDrawer";
 import DeleteNamespaceDialog from "./DeleteNamespaceDialog";
 import { formatDateFull } from "@/utils/date";
 import { formatMaxDevices } from "./utils";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -34,9 +34,7 @@ export default function NamespaceDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" aria-label="Loading namespace details" />
-      </div>
+      <PageLoader label="Loading namespace details" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -15,6 +15,7 @@ import EditNamespaceDrawer from "./EditNamespaceDrawer";
 import DeleteNamespaceDialog from "./DeleteNamespaceDialog";
 import { formatDateFull } from "@/utils/date";
 import { formatMaxDevices } from "./utils";
+import Spinner from "@/components/common/Spinner";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -33,9 +34,8 @@ export default function NamespaceDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24" role="status">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-        <span className="sr-only">Loading namespace details</span>
+      <div className="flex items-center justify-center py-24">
+        <Spinner size="lg" aria-label="Loading namespace details" />
       </div>
     );
   }

--- a/ui-react/apps/console/src/pages/admin/settings/Authentication.tsx
+++ b/ui-react/apps/console/src/pages/admin/settings/Authentication.tsx
@@ -14,7 +14,7 @@ import { isSdkError } from "../../../api/errors";
 import PageHeader from "../../../components/common/PageHeader";
 import CopyButton from "../../../components/common/CopyButton";
 import SamlConfigDrawer from "./SamlConfigDrawer";
-import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 type AuthSettings = GetAuthenticationSettingsResponse;
 
@@ -141,9 +141,8 @@ export default function AdminAuthentication() {
           title="Authentication"
           description="Control how users authenticate to ShellHub, including local credentials and SAML SSO."
         />
-        <div className="flex items-center gap-3 mt-8" role="status">
-          <Spinner />
-          <span className="text-xs font-mono text-text-muted">Loading settings...</span>
+        <div className="mt-8">
+          <PageLoader label="Loading settings..." showLabel padding="none" />
         </div>
       </div>
     );

--- a/ui-react/apps/console/src/pages/admin/settings/Authentication.tsx
+++ b/ui-react/apps/console/src/pages/admin/settings/Authentication.tsx
@@ -14,6 +14,7 @@ import { isSdkError } from "../../../api/errors";
 import PageHeader from "../../../components/common/PageHeader";
 import CopyButton from "../../../components/common/CopyButton";
 import SamlConfigDrawer from "./SamlConfigDrawer";
+import Spinner from "@/components/common/Spinner";
 
 type AuthSettings = GetAuthenticationSettingsResponse;
 
@@ -141,7 +142,7 @@ export default function AdminAuthentication() {
           description="Control how users authenticate to ShellHub, including local credentials and SAML SSO."
         />
         <div className="flex items-center gap-3 mt-8" role="status">
-          <span className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+          <Spinner />
           <span className="text-xs font-mono text-text-muted">Loading settings...</span>
         </div>
       </div>

--- a/ui-react/apps/console/src/pages/admin/settings/SamlConfigDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/settings/SamlConfigDrawer.tsx
@@ -11,6 +11,7 @@ import InputField from "@/components/common/fields/InputField";
 import CheckboxField from "@/components/common/fields/CheckboxField";
 import { INPUT } from "@/utils/styles";
 import FieldLabel from "@/components/common/fields/FieldLabel";
+import Spinner from "@/components/common/Spinner";
 
 type SamlSettings = NonNullable<GetAuthenticationSettingsResponse>["saml"];
 
@@ -218,7 +219,7 @@ export default function SamlConfigDrawer({
         className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
       >
         {saving && (
-          <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+          <Spinner size="sm" tone="onPrimary" />
         )}
         Save Configuration
       </button>

--- a/ui-react/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
@@ -4,6 +4,7 @@ import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { useCreateUser } from "@/hooks/useAdminUserMutations";
 import { isSdkError } from "@/api/errors";
 import Drawer from "@/components/common/Drawer";
+import Spinner from "@/components/common/Spinner";
 import UserFormFields from "./UserFormFields";
 import { useUserForm } from "./useUserForm";
 
@@ -61,10 +62,7 @@ export default function CreateUserDrawer({
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {createUser.isPending ? (
-              <span
-                aria-hidden="true"
-                className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-              />
+              <Spinner tone="onPrimary" />
             ) : (
               <PlusIcon className="w-4 h-4" strokeWidth={2} />
             )}

--- a/ui-react/apps/console/src/pages/admin/users/EditUserDrawer.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/EditUserDrawer.tsx
@@ -7,6 +7,7 @@ import Drawer from "@/components/common/Drawer";
 import UserFormFields from "./UserFormFields";
 import { useUserForm } from "./useUserForm";
 import type { UserAdminResponse } from "@/client";
+import Spinner from "@/components/common/Spinner";
 
 interface EditUserDrawerProps {
   open: boolean;
@@ -75,10 +76,7 @@ export default function EditUserDrawer({
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {updateUser.isPending && (
-              <span
-                aria-hidden="true"
-                className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-              />
+              <Spinner tone="onPrimary" />
             )}
             Save Changes
           </button>

--- a/ui-react/apps/console/src/pages/admin/users/ResetPasswordDialog.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/ResetPasswordDialog.tsx
@@ -6,6 +6,7 @@ import { isSdkError } from "@/api/errors";
 import CopyButton from "@/components/common/CopyButton";
 import BaseDialog from "@/components/common/BaseDialog";
 import InputField from "@/components/common/fields/InputField";
+import Spinner from "@/components/common/Spinner";
 
 interface ResetPasswordDialogProps {
   open: boolean;
@@ -97,10 +98,7 @@ export default function ResetPasswordDialog({
               className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
               {resetPassword.isPending && (
-                <span
-                  aria-hidden="true"
-                  className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-                />
+                <Spinner tone="onPrimary" />
               )}
               Enable
             </button>

--- a/ui-react/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -19,6 +19,7 @@ import ResetPasswordDialog from "./ResetPasswordDialog";
 import DeleteUserDialog from "./DeleteUserDialog";
 import { formatDateFull } from "@/utils/date";
 import Spinner from "@/components/common/Spinner";
+import PageLoader from "@/components/common/PageLoader";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -74,9 +75,7 @@ export default function UserDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24">
-        <Spinner size="lg" aria-label="Loading user details" />
-      </div>
+      <PageLoader label="Loading user details" />
     );
   }
 

--- a/ui-react/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -18,6 +18,7 @@ import EditUserDrawer from "./EditUserDrawer";
 import ResetPasswordDialog from "./ResetPasswordDialog";
 import DeleteUserDialog from "./DeleteUserDialog";
 import { formatDateFull } from "@/utils/date";
+import Spinner from "@/components/common/Spinner";
 
 const LABEL
   = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -73,9 +74,8 @@ export default function UserDetails() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24" role="status">
-        <span className="w-5 h-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-        <span className="sr-only">Loading user details</span>
+      <div className="flex items-center justify-center py-24">
+        <Spinner size="lg" aria-label="Loading user details" />
       </div>
     );
   }
@@ -173,10 +173,7 @@ export default function UserDetails() {
             }`}
           >
             {loginAsId === id ? (
-              <span
-                aria-hidden="true"
-                className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"
-              />
+              <Spinner tone="onPrimary" />
             ) : (
               <ArrowRightStartOnRectangleIcon className="w-4 h-4" />
             )}

--- a/ui-react/apps/console/src/pages/admin/users/index.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/index.tsx
@@ -18,6 +18,7 @@ import UserStatusChip from "./UserStatusChip";
 import CreateUserDrawer from "./CreateUserDrawer";
 import EditUserDrawer from "./EditUserDrawer";
 import DeleteUserDialog from "./DeleteUserDialog";
+import Spinner from "@/components/common/Spinner";
 
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -128,10 +129,7 @@ export default function AdminUsers() {
             aria-label={`Login as ${user.name}`}
           >
             {loginAsId === user.id ? (
-              <span
-                aria-hidden="true"
-                className="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin block"
-              />
+              <Spinner className="block" />
             ) : (
               <ArrowRightStartOnRectangleIcon className="w-4 h-4" />
             )}

--- a/ui-react/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
@@ -24,6 +24,7 @@ import {
 import { DevicesIcon as DevicesIconComponent } from "@/components/icons";
 import NumericInput from "@/components/common/fields/NumericInput";
 import { LABEL } from "@/utils/styles";
+import Spinner from "@/components/common/Spinner";
 
 /* ─── Icons ─── */
 const UsersIcon = <UserGroupIcon className="w-4 h-4" />;
@@ -190,13 +191,13 @@ export default function RuleDrawer({
             type="submit"
             onClick={() => void handleSubmit()}
             disabled={submitting || confirmDisabled}
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
-              <span className="flex items-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <>
+                <Spinner size="sm" tone="onPrimary" />
                 Saving...
-              </span>
+              </>
             ) : isEdit ? (
               "Save Changes"
             ) : (

--- a/ui-react/apps/console/src/pages/public-keys/KeyDrawer.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/KeyDrawer.tsx
@@ -18,6 +18,7 @@ import TagsSelector from "@/components/common/fields/TagsSelector";
 import Drawer from "@/components/common/Drawer";
 import InputField from "@/components/common/fields/InputField";
 import KeyDataInput from "./KeyDataInput";
+import Spinner from "@/components/common/Spinner";
 
 /* --- Drawer --- */
 function KeyDrawer({
@@ -180,13 +181,13 @@ function KeyDrawer({
             type="submit"
             onClick={() => void handleSubmit()}
             disabled={submitting || confirmDisabled}
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
-              <span className="flex items-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <>
+                <Spinner size="sm" tone="onPrimary" />
                 Saving...
-              </span>
+              </>
             ) : isEdit ? (
               "Save Changes"
             ) : (

--- a/ui-react/apps/console/src/pages/secure-vault/KeyDrawer.tsx
+++ b/ui-react/apps/console/src/pages/secure-vault/KeyDrawer.tsx
@@ -12,6 +12,7 @@ import KeyFileInput from "@/components/common/fields/KeyFileInput";
 import InputField from "@/components/common/fields/InputField";
 import PasswordField from "@/components/common/fields/PasswordField";
 import type { VaultKeyEntry } from "@/types/vault";
+import Spinner from "@/components/common/Spinner";
 
 interface Props {
   open: boolean;
@@ -174,13 +175,13 @@ export default function KeyDrawer({ open, editKey, onClose }: Props) {
             type="submit"
             onClick={() => void handleSubmit()}
             disabled={!canSubmit}
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
-              <span className="flex items-center gap-2">
-                <span className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <>
+                <Spinner size="sm" tone="onPrimary" />
                 Saving...
-              </span>
+              </>
             ) : isEdit ? (
               "Save Changes"
             ) : (

--- a/ui-react/apps/console/src/pages/sessions/index.tsx
+++ b/ui-react/apps/console/src/pages/sessions/index.tsx
@@ -18,6 +18,7 @@ import SessionPlayerDialog from "./SessionPlayerDialog";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import { formatDate, formatDuration } from "@/utils/date";
 import { sessionType } from "@/utils/session";
+import Spinner from "@/components/common/Spinner";
 
 const PER_PAGE = 10;
 
@@ -185,7 +186,7 @@ export default function Sessions() {
                 className="inline-flex items-center gap-1 px-2.5 py-1 bg-primary/10 text-primary text-2xs font-semibold rounded-md hover:bg-primary/20 border border-primary/20 transition-all disabled:opacity-dim"
               >
                 {logsLoading && playTarget === s.uid ? (
-                  <span className="w-3 h-3 border border-primary/40 border-t-primary rounded-full animate-spin" />
+                  <Spinner size="xs" tone="onSurface" />
                 ) : (
                   <PlayIcon className="w-3 h-3" />
                 )}

--- a/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/AddMemberDrawer.tsx
@@ -7,6 +7,7 @@ import InputField from "@/components/common/fields/InputField";
 import { EMAIL_REGEX } from "@/utils/validation";
 import { RoleSelector } from "./constants";
 import { type AssignableRole } from "./helpers";
+import Spinner from "@/components/common/Spinner";
 
 /* --- Add Member Drawer --- */
 
@@ -78,7 +79,7 @@ function AddMemberDrawer({
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
             {submitting ? (
-              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <Spinner tone="onPrimary" />
             ) : (
               <PlusIcon className="w-4 h-4" strokeWidth={2} />
             )}

--- a/ui-react/apps/console/src/pages/team/GenerateKeyDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/GenerateKeyDrawer.tsx
@@ -12,6 +12,7 @@ import RadioPill from "@/components/common/fields/RadioPill";
 import { RoleSelector } from "./constants";
 import { EXPIRY_OPTIONS, type AssignableRole } from "./helpers";
 import { LABEL } from "@/utils/styles";
+import Spinner from "@/components/common/Spinner";
 
 function validateName(value: string): string {
   if (value.length < 3) return "Name must be at least 3 characters.";
@@ -110,7 +111,7 @@ function GenerateKeyDrawer({
               className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
               {submitting ? (
-                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                <Spinner size="md" tone="onPrimary" />
               ) : (
                 <KeyIcon className="w-4 h-4" strokeWidth={2} />
               )}

--- a/ui-react/apps/console/src/pages/team/InvitationDrawer.tsx
+++ b/ui-react/apps/console/src/pages/team/InvitationDrawer.tsx
@@ -15,6 +15,7 @@ import Drawer from "@/components/common/Drawer";
 import CopyButton from "@/components/common/CopyButton";
 import InputField from "@/components/common/fields/InputField";
 import CheckboxField from "@/components/common/fields/CheckboxField";
+import Spinner from "@/components/common/Spinner";
 import { RoleSelector } from "./constants";
 import { type AssignableRole } from "./helpers";
 import { LABEL } from "@/utils/styles";
@@ -154,7 +155,7 @@ function InvitationDrawer({
               className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
               {submitting ? (
-                <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                <Spinner tone="onPrimary" />
               ) : wantLink ? (
                 <LinkIcon className="w-4 h-4" strokeWidth={2} />
               ) : (


### PR DESCRIPTION
## What

Two new shared primitives in `apps/console/src/components/common/` collapse copy-pasted loading UI across the console:

- `Spinner` replaces 85 inline `animate-spin` border-CSS spans across 67 files.
- `PageLoader` replaces the surrounding centered-div + Spinner pattern at 20 callsites, owning the layout and live-region semantics.

After this change the codebase has one way to render an inline spinner and one way to render a page-level loader.

## Why

Before:

- 11 distinct colour/size combinations for spinners, ~84% of which were two tones. Style drift was already underway.
- Only 2 of 85 spinner spans set `aria-hidden`, so screen readers heard the decorative spinner element everywhere.
- Two coexisting "page is loading" patterns: a manual `role="status"` wrapper around a decorative spinner vs. a bare spinner carrying its own `aria-label`. Several callsites had neither and were silent to assistive tech (`Profile`, `Settings`, `BannerEdit`, `DeviceDetails`, `ContainerDetails`, `ManageTagsDrawer`).

## Changes

- **Spinner primitive** (`components/common/Spinner.tsx`): 6 sizes (`xs`–`2xl`), 3 tones (`onPrimary`, `onSurface`, `subtle`). Decorative by default (`aria-hidden="true"`); passing `aria-label` opts into `role="status"`. Convention matches the sibling `BaseDialog` (dashed `aria-label` prop, not `ariaLabel`).
- **PageLoader primitive** (`components/common/PageLoader.tsx`): centered layout with required `label`. Two modes via `showLabel`: hidden label (default — Spinner carries `aria-label`) or visible label (wrapper is the live region, Spinner is decorative). Padding tiers cover every existing caller (`none` / `sm` / `md` / `lg` / `fill`).
- **Outliers adapted to the canonical set**, not preserved. Examples: the red `ConnectivityGuard` ring becomes `onSurface`; the inverted-transparent `AdminRoute` ring becomes the standard partial ring; the `accent-yellow` background variant in `MfaRecover` becomes `onPrimary`. Six previously silent loaders gain an accessible name. `InvitationsMenu`'s popover loader bumps from `py-8 gap-2 text-2xs` to `py-12 gap-3 text-xs` (canonical family).
- **Genuinely different shapes kept inline**: `AcceptInvite` (column loading-card with description and sans-serif body font) and `AdminRoute` (`min-h-screen` guard before the layout chain).

## Testing

The bulk of the work is mechanical; the points worth probing manually are the a11y semantics and the visual shifts on the outliers.

- Toggle a screen reader and visit one of the previously silent pages (`/profile`, `/settings`, `/banner`). Confirm the loading state is now announced once (not twice — no nested live regions).
- Open the invitations and pending-devices menus from the top bar while their lists load. Both should announce a single "Loading" status; both should look visually consistent.
- Hit a slow admin detail page (e.g. `/admin/users/<id>`) and confirm the centered loader matches what shipped before the refactor.
- Visually diff the adapted outliers against `master`: `/login` cold + offline → `ConnectivityGuard` is primary-blue, not red. `/accept-invite` → spinner is `2xl` (40px), slightly larger than before. `/mfa/recover` → spinner inside the yellow button is white, not dark.