### PR TITLE
refactor(ui-react): extract shared Breadcrumb component

### DIFF
--- a/ui-react/apps/console/src/components/common/Breadcrumb.tsx
+++ b/ui-react/apps/console/src/components/common/Breadcrumb.tsx
@@ -1,0 +1,62 @@
+import { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { ChevronRightIcon } from "@heroicons/react/24/outline";
+
+export interface BreadcrumbItem {
+  label: ReactNode;
+  /** Linked when present, unless the item is the last in the list. */
+  to?: string;
+  title?: string;
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+export default function Breadcrumb({ items, className = "" }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className={`mb-5 ${className}`}>
+      <ol className="flex items-center gap-1.5 min-w-0">
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1;
+          const titleAttr =
+            item.title ??
+            (typeof item.label === "string" ? item.label : undefined);
+
+          return (
+            <li
+              key={item.to ?? `leaf-${i}`}
+              className="flex items-center gap-1.5 min-w-0"
+            >
+              {i > 0 && (
+                <ChevronRightIcon
+                  className="w-3 h-3 text-text-muted/40 shrink-0"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+              )}
+              {item.to && !isLast ? (
+                <Link
+                  to={item.to}
+                  title={titleAttr}
+                  className="text-2xs font-mono text-text-muted hover:text-primary transition-colors truncate rounded-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span
+                  aria-current={isLast ? "page" : undefined}
+                  title={titleAttr}
+                  className="text-2xs font-mono text-text-secondary truncate"
+                >
+                  {item.label}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/ui-react/apps/console/src/components/common/__tests__/Breadcrumb.test.tsx
+++ b/ui-react/apps/console/src/components/common/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Breadcrumb from "../Breadcrumb";
+
+function renderBreadcrumb(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe("Breadcrumb", () => {
+  it("renders a navigation landmark named 'Breadcrumb'", () => {
+    renderBreadcrumb(
+      <Breadcrumb
+        items={[{ label: "Devices", to: "/devices" }, { label: "host-a" }]}
+      />,
+    );
+    expect(
+      screen.getByRole("navigation", { name: "Breadcrumb" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one list item per breadcrumb entry inside an ordered list", () => {
+    renderBreadcrumb(
+      <Breadcrumb
+        items={[
+          { label: "Announcements", to: "/admin/announcements" },
+          { label: "Title", to: "/admin/announcements/1" },
+          { label: "Edit" },
+        ]}
+      />,
+    );
+    const nav = screen.getByRole("navigation", { name: "Breadcrumb" });
+    const list = within(nav).getByRole("list");
+    expect(list.tagName).toBe("OL");
+    expect(within(list).getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("renders items with `to` as links and the final item as a non-link span", () => {
+    renderBreadcrumb(
+      <Breadcrumb
+        items={[{ label: "Devices", to: "/devices" }, { label: "host-a" }]}
+      />,
+    );
+    const parent = screen.getByRole("link", { name: "Devices" });
+    expect(parent).toHaveAttribute("href", "/devices");
+    expect(
+      screen.queryByRole("link", { name: "host-a" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("host-a").tagName).toBe("SPAN");
+  });
+
+  it("marks only the final crumb with aria-current='page'", () => {
+    renderBreadcrumb(
+      <Breadcrumb
+        items={[
+          { label: "A", to: "/a" },
+          { label: "B", to: "/a/b" },
+          { label: "C" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("C")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByText("A")).not.toHaveAttribute("aria-current");
+    expect(screen.getByText("B")).not.toHaveAttribute("aria-current");
+  });
+
+  it("renders a final item as a span even when `to` is provided", () => {
+    renderBreadcrumb(
+      <Breadcrumb
+        items={[
+          { label: "Devices", to: "/devices" },
+          { label: "host-a", to: "/devices/host-a" },
+        ]}
+      />,
+    );
+    expect(
+      screen.queryByRole("link", { name: "host-a" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("host-a")).toHaveAttribute("aria-current", "page");
+  });
+
+  it("renders a chevron between each item but not before the first", () => {
+    const { container } = renderBreadcrumb(
+      <Breadcrumb
+        items={[
+          { label: "A", to: "/a" },
+          { label: "B", to: "/a/b" },
+          { label: "C" },
+        ]}
+      />,
+    );
+    const chevrons = container.querySelectorAll("svg[aria-hidden='true']");
+    expect(chevrons).toHaveLength(2);
+  });
+
+  it("forwards `title` to the rendered link or span for tooltip support", () => {
+    renderBreadcrumb(
+      <Breadcrumb
+        items={[
+          { label: "Devices", to: "/devices", title: "All devices" },
+          { label: "host-a", title: "host-a.example.com" },
+        ]}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Devices" })).toHaveAttribute(
+      "title",
+      "All devices",
+    );
+    expect(screen.getByText("host-a")).toHaveAttribute(
+      "title",
+      "host-a.example.com",
+    );
+  });
+
+  it("falls back to the string label as the title when none is provided", () => {
+    renderBreadcrumb(
+      <Breadcrumb
+        items={[{ label: "Devices", to: "/devices" }, { label: "host-a" }]}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Devices" })).toHaveAttribute(
+      "title",
+      "Devices",
+    );
+    expect(screen.getByText("host-a")).toHaveAttribute("title", "host-a");
+  });
+});

--- a/ui-react/apps/console/src/pages/AddDevice.tsx
+++ b/ui-react/apps/console/src/pages/AddDevice.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import { useAuthStore } from "../stores/authStore";
 import {
   ArchiveBoxIcon,
@@ -168,22 +169,9 @@ export default function AddDevice() {
 
   return (
     <div className="max-w-2xl animate-fade-in">
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/devices"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Devices
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary">
-          Add Device
-        </span>
-      </div>
+      <Breadcrumb
+        items={[{ label: "Devices", to: "/devices" }, { label: "Add Device" }]}
+      />
 
       {/* Header */}
       <div className="flex items-start gap-4 mb-8">

--- a/ui-react/apps/console/src/pages/BannerEdit.tsx
+++ b/ui-react/apps/console/src/pages/BannerEdit.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { CheckIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { CheckIcon } from "@heroicons/react/24/outline";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import { useNamespace } from "../hooks/useNamespaces";
 import type { Namespace } from "../hooks/useNamespaces";
 import { useEditNamespace } from "../hooks/useNamespaceMutations";
@@ -32,7 +33,13 @@ function BannerEditor({ ns, canEdit }: { ns: Namespace; canEdit: boolean }) {
     try {
       await editNs.mutateAsync({
         path: { tenant: ns.tenant_id },
-        body: { settings: { connection_announcement: text, session_record: ns.settings?.session_record ?? false, device_auto_accept: ns.settings?.device_auto_accept ?? false } },
+        body: {
+          settings: {
+            connection_announcement: text,
+            session_record: ns.settings?.session_record ?? false,
+            device_auto_accept: ns.settings?.device_auto_accept ?? false,
+          },
+        },
       });
       void navigate("/settings");
     } catch {
@@ -68,9 +75,7 @@ function BannerEditor({ ns, canEdit }: { ns: Namespace; canEdit: boolean }) {
           <span
             className={`text-2xs font-mono ${overLimit ? "text-accent-red font-semibold" : "text-text-muted/50"}`}
           >
-            {text.length.toLocaleString()}
-            /
-            {MAX_LENGTH.toLocaleString()}
+            {text.length.toLocaleString()}/{MAX_LENGTH.toLocaleString()}
           </span>
           {overLimit && (
             <span className="text-2xs text-accent-red">
@@ -139,26 +144,19 @@ export default function BannerEdit() {
     <div className="flex flex-col flex-1 min-h-0">
       {/* Header */}
       <div className="relative -mx-8 -mt-8 px-8 py-6 mb-8 border-b border-border bg-surface shrink-0">
-        <div className="flex items-start gap-4">
-          <Link
-            to="/settings"
-            className="w-12 h-12 rounded-lg bg-hover-medium border border-border flex items-center justify-center text-text-muted hover:text-text-primary hover:border-border-light transition-all shrink-0"
-          >
-            <ArrowLeftIcon className="w-5 h-5" />
-          </Link>
-          <div>
-            <p className="text-2xs font-mono font-semibold uppercase tracking-label text-primary mb-1">
-              Settings
-            </p>
-            <h1 className="text-xl font-semibold text-text-primary leading-tight">
-              SSH Banner
-            </h1>
-            <p className="text-sm text-text-muted mt-1 max-w-xl">
-              This message is displayed when users connect to any device in this
-              namespace via SSH.
-            </p>
-          </div>
-        </div>
+        <Breadcrumb
+          items={[
+            { label: "Settings", to: "/settings" },
+            { label: "SSH Banner" },
+          ]}
+        />
+        <h1 className="text-xl font-semibold text-text-primary leading-tight">
+          SSH Banner
+        </h1>
+        <p className="text-sm text-text-muted mt-1 max-w-xl">
+          This message is displayed when users connect to any device in this
+          namespace via SSH.
+        </p>
       </div>
 
       <BannerEditor ns={ns} canEdit={canEdit} />

--- a/ui-react/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui-react/apps/console/src/pages/ContainerDetails.tsx
@@ -4,15 +4,14 @@ import {
   useNavigate,
   useSearchParams,
   Navigate,
-  Link,
 } from "react-router-dom";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import {
   TagIcon,
   XMarkIcon,
   PlusIcon,
   PencilSquareIcon,
   CheckIcon,
-  ChevronRightIcon,
   TrashIcon,
   InformationCircleIcon,
   ServerIcon,
@@ -359,22 +358,12 @@ export default function ContainerDetails() {
 
   return (
     <div className="animate-fade-in">
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/containers"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Containers
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary">
-          {container.name}
-        </span>
-      </div>
+      <Breadcrumb
+        items={[
+          { label: "Containers", to: "/containers" },
+          { label: container.name },
+        ]}
+      />
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4 mb-8">

--- a/ui-react/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/DeviceDetails.tsx
@@ -1,17 +1,12 @@
 import { useEffect, useState } from "react";
-import {
-  useParams,
-  useNavigate,
-  useSearchParams,
-  Link,
-} from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import {
   TagIcon,
   XMarkIcon,
   PlusIcon,
   PencilSquareIcon,
   CheckIcon,
-  ChevronRightIcon,
   TrashIcon,
   InformationCircleIcon,
   ComputerDesktopIcon,
@@ -334,37 +329,41 @@ function CustomFieldsSection({
         {Object.entries(customFields).map(([key, value]) => (
           <div key={key} className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-2 min-w-0">
-              <span className="text-xs font-mono text-text-muted shrink-0">{key}:</span>
-              <span className="text-sm text-text-primary font-medium truncate">{value}</span>
+              <span className="text-xs font-mono text-text-muted shrink-0">
+                {key}:
+              </span>
+              <span className="text-sm text-text-primary font-medium truncate">
+                {value}
+              </span>
             </div>
-            {canEdit && (
-              confirmKey === key
-                ? (
-                  <div className="flex items-center gap-1 shrink-0">
-                    <span className="text-2xs text-text-muted">Remove?</span>
-                    <button
-                      onClick={() => { void handleRemove(key); setConfirmKey(null); }}
-                      className="px-1.5 py-0.5 rounded text-2xs font-semibold bg-accent-red/90 hover:bg-accent-red text-white transition-all"
-                    >
-                      Yes
-                    </button>
-                    <button
-                      onClick={() => setConfirmKey(null)}
-                      className="px-1.5 py-0.5 rounded text-2xs font-semibold text-text-muted hover:text-text-primary hover:bg-hover-subtle transition-all"
-                    >
-                      No
-                    </button>
-                  </div>
-                )
-                : (
+            {canEdit &&
+              (confirmKey === key ? (
+                <div className="flex items-center gap-1 shrink-0">
+                  <span className="text-2xs text-text-muted">Remove?</span>
                   <button
-                    onClick={() => setConfirmKey(key)}
-                    className="shrink-0 p-1 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all"
+                    onClick={() => {
+                      void handleRemove(key);
+                      setConfirmKey(null);
+                    }}
+                    className="px-1.5 py-0.5 rounded text-2xs font-semibold bg-accent-red/90 hover:bg-accent-red text-white transition-all"
                   >
-                    <XMarkIcon className="w-3 h-3" strokeWidth={2} />
+                    Yes
                   </button>
-                )
-            )}
+                  <button
+                    onClick={() => setConfirmKey(null)}
+                    className="px-1.5 py-0.5 rounded text-2xs font-semibold text-text-muted hover:text-text-primary hover:bg-hover-subtle transition-all"
+                  >
+                    No
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setConfirmKey(key)}
+                  className="shrink-0 p-1 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all"
+                >
+                  <XMarkIcon className="w-3 h-3" strokeWidth={2} />
+                </button>
+              ))}
           </div>
         ))}
       </dl>
@@ -373,8 +372,16 @@ function CustomFieldsSection({
           <input
             type="text"
             value={keyInput}
-            onChange={(e) => { setKeyInput(e.target.value); setError(null); }}
-            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAdd(); } }}
+            onChange={(e) => {
+              setKeyInput(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void handleAdd();
+              }
+            }}
             placeholder="key"
             className="w-24 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
           />
@@ -382,8 +389,16 @@ function CustomFieldsSection({
           <input
             type="text"
             value={valueInput}
-            onChange={(e) => { setValueInput(e.target.value); setError(null); }}
-            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); void handleAdd(); } }}
+            onChange={(e) => {
+              setValueInput(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void handleAdd();
+              }
+            }}
             placeholder="value"
             className="w-32 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
           />
@@ -483,22 +498,9 @@ export default function DeviceDetails() {
 
   return (
     <div className="animate-fade-in">
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/devices"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Devices
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary">
-          {device.name}
-        </span>
-      </div>
+      <Breadcrumb
+        items={[{ label: "Devices", to: "/devices" }, { label: device.name }]}
+      />
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4 mb-8">

--- a/ui-react/apps/console/src/pages/SessionDetails.tsx
+++ b/ui-react/apps/console/src/pages/SessionDetails.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import {
-  ChevronRightIcon,
   ClockIcon,
   ShieldExclamationIcon,
   ShieldCheckIcon,
@@ -362,22 +362,12 @@ export default function SessionDetails() {
 
   return (
     <div className="animate-fade-in">
-      {/* Breadcrumb */}
-      <div className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/sessions"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Sessions
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary">
-          {session.uid.slice(0, 8)}
-        </span>
-      </div>
+      <Breadcrumb
+        items={[
+          { label: "Sessions", to: "/sessions" },
+          { label: session.uid.slice(0, 8), title: session.uid },
+        ]}
+      />
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4 mb-8">

--- a/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/SessionDetails.tsx
@@ -6,12 +6,18 @@ import {
   MinusCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminSessionDetail } from "@/hooks/useAdminSessionDetail";
-import PageHeader from "@/components/common/PageHeader";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import { formatDateFull } from "@/utils/date";
 import { sessionType } from "@/utils/session";
 import PageLoader from "@/components/common/PageLoader";
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="py-3 border-b border-border/50 last:border-0">
       <p className="text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-1">
@@ -22,12 +28,22 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-function BoolField({ value, falseColor = "text-accent-red" }: { value: boolean; falseColor?: string }) {
+function BoolField({
+  value,
+  falseColor = "text-accent-red",
+}: {
+  value: boolean;
+  falseColor?: string;
+}) {
   return (
-    <span className={`flex items-center gap-1.5 text-sm ${value ? "text-accent-green" : falseColor}`}>
-      {value
-        ? <CheckCircleIcon className="w-4 h-4" strokeWidth={2} />
-        : <MinusCircleIcon className="w-4 h-4" strokeWidth={2} />}
+    <span
+      className={`flex items-center gap-1.5 text-sm ${value ? "text-accent-green" : falseColor}`}
+    >
+      {value ? (
+        <CheckCircleIcon className="w-4 h-4" strokeWidth={2} />
+      ) : (
+        <MinusCircleIcon className="w-4 h-4" strokeWidth={2} />
+      )}
       {value ? "Yes" : "No"}
     </span>
   );
@@ -48,9 +64,12 @@ export default function AdminSessionDetails() {
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center" role="alert">
           <ExclamationCircleIcon className="w-10 h-10 text-accent-red mx-auto mb-3" />
-          <p className="text-sm font-medium text-text-primary">Session not found</p>
+          <p className="text-sm font-medium text-text-primary">
+            Session not found
+          </p>
           <p className="text-2xs text-text-muted mt-1">
-            {error?.message ?? "The session may have been removed or the ID is invalid."}
+            {error?.message ??
+              "The session may have been removed or the ID is invalid."}
           </p>
         </div>
       </div>
@@ -61,29 +80,49 @@ export default function AdminSessionDetails() {
 
   return (
     <div>
-      <PageHeader
-        icon={<CommandLineIcon className="w-6 h-6" />}
-        overline="Admin · Sessions"
-        title="Session Details"
-        description="Detailed information about the selected session."
-      >
-        <div className="flex items-center gap-2">
+      <Breadcrumb
+        items={[
+          { label: "Sessions", to: "/admin/sessions" },
+          { label: session.uid.slice(0, 8), title: session.uid },
+        ]}
+      />
+
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
+        <div className="flex items-start gap-4">
+          <div className="w-14 h-14 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center text-primary shrink-0">
+            <CommandLineIcon className="w-7 h-7" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-text-primary leading-tight">
+              Session Details
+            </h1>
+            <p className="text-sm text-text-muted mt-1 max-w-xl">
+              Detailed information about the selected session.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
           <span
             className={`w-2 h-2 rounded-full inline-block shrink-0 ${
               session.active
                 ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
                 : "bg-text-muted/40"
             }`}
+            aria-label={session.active ? "Active" : "Inactive"}
           />
-          <code className="text-xs font-mono text-text-muted">{session.uid}</code>
+          <code className="text-xs font-mono text-text-muted break-all">
+            {session.uid}
+          </code>
         </div>
-      </PageHeader>
+      </div>
 
       <div className="bg-card border border-border rounded-lg overflow-hidden animate-fade-in">
         <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
           <div className="px-6 py-2">
             <Field label="UID">
-              <code className="text-xs font-mono text-text-secondary break-all">{session.uid}</code>
+              <code className="text-xs font-mono text-text-secondary break-all">
+                {session.uid}
+              </code>
             </Field>
 
             {session.device && (
@@ -108,13 +147,17 @@ export default function AdminSessionDetails() {
             </Field>
 
             <Field label="Type">
-              {type
-                ? (
-                  <span className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}>
-                    {type.label}
-                  </span>
-                )
-                : <span className="text-text-secondary capitalize">{session.type}</span>}
+              {type ? (
+                <span
+                  className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}
+                >
+                  {type.label}
+                </span>
+              ) : (
+                <span className="text-text-secondary capitalize">
+                  {session.type}
+                </span>
+              )}
             </Field>
 
             <Field label="Terminal">
@@ -127,24 +170,36 @@ export default function AdminSessionDetails() {
           <div className="px-6 py-2">
             {session.device?.namespace && (
               <Field label="Namespace">
-                <span className="text-text-secondary">{session.device.namespace}</span>
+                <span className="text-text-secondary">
+                  {session.device.namespace}
+                </span>
               </Field>
             )}
 
             <Field label="Authenticated">
-              <BoolField value={session.authenticated} falseColor="text-accent-red" />
+              <BoolField
+                value={session.authenticated}
+                falseColor="text-accent-red"
+              />
             </Field>
 
             <Field label="Recorded">
-              <BoolField value={session.recorded} falseColor="text-text-secondary" />
+              <BoolField
+                value={session.recorded}
+                falseColor="text-text-secondary"
+              />
             </Field>
 
             <Field label="Started At">
-              <span className="text-text-secondary">{formatDateFull(session.started_at)}</span>
+              <span className="text-text-secondary">
+                {formatDateFull(session.started_at)}
+              </span>
             </Field>
 
             <Field label="Last Seen">
-              <span className="text-text-secondary">{formatDateFull(session.last_seen)}</span>
+              <span className="text-text-secondary">
+                {formatDateFull(session.last_seen)}
+              </span>
             </Field>
           </div>
         </div>

--- a/ui-react/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import {
-  ChevronRightIcon,
   MegaphoneIcon,
   InformationCircleIcon,
   PencilSquareIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminAnnouncement } from "@/hooks/useAdminAnnouncements";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
 import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import AnnouncementContent from "./AnnouncementContent";
@@ -53,22 +53,12 @@ export default function AnnouncementDetails() {
 
   return (
     <div className="animate-fade-in">
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/admin/announcements"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Announcements
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary truncate min-w-0">
-          {announcement.title}
-        </span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Announcements", to: "/admin/announcements" },
+          { label: announcement.title },
+        ]}
+      />
 
       {/* Header */}
       <div className="flex items-start justify-between gap-4 mb-8">

--- a/ui-react/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
-  ChevronRightIcon,
   ExclamationCircleIcon,
   MegaphoneIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminAnnouncement } from "@/hooks/useAdminAnnouncements";
 import { useAdminUpdateAnnouncement } from "@/hooks/useAdminAnnouncementMutations";
 import AnnouncementEditor from "./AnnouncementEditor";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
 import Spinner from "@/components/common/Spinner";
@@ -80,24 +80,13 @@ export default function EditAnnouncement() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/admin/announcements"
-          className="text-2xs font-mono text-text-muted hover:text-primary"
-        >
-          Announcements
-        </Link>
-        <ChevronRightIcon className="w-3 h-3 text-text-muted/40" />
-        <Link
-          to={`/admin/announcements/${uuid}`}
-          className="text-2xs font-mono text-text-muted hover:text-primary truncate max-w-[200px]"
-        >
-          {announcement.title}
-        </Link>
-        <ChevronRightIcon className="w-3 h-3 text-text-muted/40" />
-        <span className="text-2xs font-mono text-text-secondary">Edit</span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Announcements", to: "/admin/announcements" },
+          { label: announcement.title, to: `/admin/announcements/${uuid}` },
+          { label: "Edit" },
+        ]}
+      />
 
       {/* Header */}
       <h1 className="text-xl font-semibold text-text-primary mb-6">

--- a/ui-react/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
+++ b/ui-react/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import {
-  ChevronRightIcon,
-  ExclamationCircleIcon,
-} from "@heroicons/react/24/outline";
+import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 import { useAdminCreateAnnouncement } from "@/hooks/useAdminAnnouncementMutations";
 import AnnouncementEditor from "./AnnouncementEditor";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
 import Spinner from "@/components/common/Spinner";
@@ -41,17 +39,12 @@ export default function NewAnnouncement() {
 
   return (
     <div>
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/admin/announcements"
-          className="text-2xs font-mono text-text-muted hover:text-primary"
-        >
-          Announcements
-        </Link>
-        <ChevronRightIcon className="w-3 h-3 text-text-muted/40" />
-        <span className="text-2xs font-mono text-text-secondary">New</span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Announcements", to: "/admin/announcements" },
+          { label: "New" },
+        ]}
+      />
 
       {/* Header */}
       <h1 className="text-xl font-semibold text-text-primary mb-6">

--- a/ui-react/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -1,6 +1,5 @@
 import { useParams, Link } from "react-router-dom";
 import {
-  ChevronRightIcon,
   CpuChipIcon,
   InformationCircleIcon,
   ComputerDesktopIcon,
@@ -9,6 +8,7 @@ import {
   KeyIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminDevice } from "@/hooks/useAdminDevices";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
 import DistroIcon from "@/components/common/DistroIcon";
 import PlatformBadge from "@/components/common/PlatformBadge";
@@ -16,8 +16,8 @@ import DeviceStatusChip from "./DeviceStatusChip";
 import { formatDateFull, formatRelative } from "@/utils/date";
 import PageLoader from "@/components/common/PageLoader";
 
-const LABEL
-  = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
+const LABEL =
+  "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
 const VALUE = "text-sm text-text-primary font-medium mt-0.5";
 
 export default function AdminDeviceDetails() {
@@ -52,22 +52,12 @@ export default function AdminDeviceDetails() {
 
   return (
     <div className="animate-fade-in">
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/admin/devices"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Devices
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary">
-          {device.name}
-        </span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Devices", to: "/admin/devices" },
+          { label: device.name },
+        ]}
+      />
 
       {/* Header */}
       <div className="flex items-start gap-4 mb-8">

--- a/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDeviceDetails.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDeviceDetails.test.tsx
@@ -199,12 +199,5 @@ describe("AdminDeviceDetails", () => {
         screen.getByRole("link", { name: "my-namespace" }),
       ).toBeInTheDocument();
     });
-
-    it("renders a breadcrumb back-link to devices", () => {
-      renderPage();
-      expect(
-        screen.getByRole("navigation", { name: "Breadcrumb" }),
-      ).toBeInTheDocument();
-    });
   });
 });

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
@@ -1,6 +1,5 @@
 import { useParams, Link } from "react-router-dom";
 import {
-  ChevronRightIcon,
   ShieldExclamationIcon,
   InformationCircleIcon,
   FunnelIcon,
@@ -8,12 +7,13 @@ import {
   NoSymbolIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminFirewallRule } from "@/hooks/useAdminFirewallRules";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
 import FilterBadge from "@/components/common/FilterBadge";
 import PageLoader from "@/components/common/PageLoader";
 
-const LABEL
-  = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
+const LABEL =
+  "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
 const VALUE = "text-sm text-text-primary font-medium mt-0.5";
 
 export default function AdminFirewallRuleDetails() {
@@ -48,22 +48,12 @@ export default function AdminFirewallRuleDetails() {
 
   return (
     <div className="animate-fade-in">
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/admin/firewall-rules"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Firewall Rules
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary truncate min-w-0">
-          {rule.id}
-        </span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Firewall Rules", to: "/admin/firewall-rules" },
+          { label: rule.id },
+        ]}
+      />
 
       {/* Header */}
       <div className="flex items-start gap-4 mb-8">

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRuleDetails.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRuleDetails.test.tsx
@@ -130,16 +130,6 @@ describe("AdminFirewallRuleDetails", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders the breadcrumb navigation with Firewall Rules link", () => {
-      renderPage();
-      expect(
-        screen.getByRole("navigation", { name: "Breadcrumb" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("link", { name: "Firewall Rules" }),
-      ).toBeInTheDocument();
-    });
-
     it("renders the rule ID", () => {
       renderPage();
       expect(screen.getAllByText("rule-1").length).toBeGreaterThanOrEqual(1);

--- a/ui-react/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import {
-  ChevronRightIcon,
   ServerStackIcon,
   PencilSquareIcon,
   TrashIcon,
@@ -9,6 +8,7 @@ import {
   Cog6ToothIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminNamespace } from "@/hooks/useAdminNamespaces";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
 import DataTable, { type Column } from "@/components/common/DataTable";
 import EditNamespaceDrawer from "./EditNamespaceDrawer";
@@ -17,12 +17,14 @@ import { formatDateFull } from "@/utils/date";
 import { formatMaxDevices } from "./utils";
 import PageLoader from "@/components/common/PageLoader";
 
-const LABEL
-  = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
+const LABEL =
+  "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
 const VALUE = "text-sm text-text-primary font-medium mt-0.5";
 const ZERO_DATE = "0001-01-01T00:00:00Z";
 
-type Member = NonNullable<NonNullable<ReturnType<typeof useAdminNamespace>["data"]>["members"]>[number];
+type Member = NonNullable<
+  NonNullable<ReturnType<typeof useAdminNamespace>["data"]>["members"]
+>[number];
 
 export default function NamespaceDetails() {
   const { id } = useParams<{ id: string }>();
@@ -58,10 +60,10 @@ export default function NamespaceDetails() {
 
   const ownerMember = namespace.members?.find((m) => m.id === namespace.owner);
   const ownerLabel = ownerMember?.email || namespace.owner;
-  const totalDevices
-    = (namespace.devices_accepted_count || 0)
-      + (namespace.devices_pending_count || 0)
-      + (namespace.devices_rejected_count || 0);
+  const totalDevices =
+    (namespace.devices_accepted_count || 0) +
+    (namespace.devices_pending_count || 0) +
+    (namespace.devices_rejected_count || 0);
 
   const memberColumns: Column<Member>[] = [
     {
@@ -105,22 +107,12 @@ export default function NamespaceDetails() {
 
   return (
     <div className="animate-fade-in">
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/admin/namespaces"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Namespaces
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary">
-          {namespace.name}
-        </span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Namespaces", to: "/admin/namespaces" },
+          { label: namespace.name },
+        ]}
+      />
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4 mb-8">
@@ -231,7 +223,9 @@ export default function NamespaceDetails() {
                       : "bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20"
                   }`}
                 >
-                  {namespace.settings?.device_auto_accept ? "Enabled" : "Disabled"}
+                  {namespace.settings?.device_auto_accept
+                    ? "Enabled"
+                    : "Disabled"}
                 </span>
               </dd>
             </div>

--- a/ui-react/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import {
-  ChevronRightIcon,
   UsersIcon,
   PencilSquareIcon,
   TrashIcon,
@@ -11,6 +10,7 @@ import {
   KeyIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminUser } from "@/hooks/useAdminUsers";
+import Breadcrumb from "@/components/common/Breadcrumb";
 import { useLoginAsUser } from "@/hooks/useLoginAsUser";
 import CopyButton from "@/components/common/CopyButton";
 import UserStatusChip from "./UserStatusChip";
@@ -21,8 +21,8 @@ import { formatDateFull } from "@/utils/date";
 import Spinner from "@/components/common/Spinner";
 import PageLoader from "@/components/common/PageLoader";
 
-const LABEL
-  = "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
+const LABEL =
+  "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
 const VALUE = "text-sm text-text-primary font-medium mt-0.5";
 const ZERO_DATE = "0001-01-01T00:00:00Z";
 
@@ -97,30 +97,20 @@ export default function UserDetails() {
     );
   }
 
-  const isSamlOnly
-    = user.preferences.auth_methods.length === 1
-      && user.preferences.auth_methods[0] === "saml";
+  const isSamlOnly =
+    user.preferences.auth_methods.length === 1 &&
+    user.preferences.auth_methods[0] === "saml";
   const userStatus = user.status;
   const lastLogin = user.last_login === ZERO_DATE ? null : user.last_login;
 
   return (
     <div className="animate-fade-in">
-      {/* Breadcrumb */}
-      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 mb-5">
-        <Link
-          to="/admin/users"
-          className="text-2xs font-mono text-text-muted hover:text-primary transition-colors"
-        >
-          Users
-        </Link>
-        <ChevronRightIcon
-          className="w-3 h-3 text-text-muted/40"
-          strokeWidth={2}
-        />
-        <span className="text-2xs font-mono text-text-secondary">
-          {user.username}
-        </span>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Users", to: "/admin/users" },
+          { label: user.username },
+        ]}
+      />
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4 mb-8">


### PR DESCRIPTION
## What

Replace 11 ad-hoc breadcrumb implementations across console detail and form pages with a single shared component, and add a breadcrumb to two pages that should have had the pattern but didn't.

## Why

Every detail page open-coded its own `<Link>` + `ChevronRightIcon` + `<span>` markup. Copies drifted: user-facing pages wrapped the row in a plain `<div>` (no `nav` landmark), no call site set `aria-current="page"` on the leaf, and truncation, chevron stroke width, focus-ring styling, and `transition-colors` varied across copies. New pages were copy-pasting one of the existing variants, locking the drift in.

## Changes

- **`components/common/Breadcrumb.tsx`**: array-of-items API (`{ label, to?, title? }`) with `<nav aria-label="Breadcrumb">` + `<ol>/<li>` semantics, `aria-current="page"` on the leaf, `aria-hidden` chevrons, `focus-visible` ring (the default browser outline is invisible on the dark theme), and a `title` fallback so truncated long names remain exposed to mouse and screen readers. Responsive via `min-w-0` + `truncate` so the leaf shrinks inside the flex row rather than overflowing.
- **11 migrations**: `AddDevice`, `DeviceDetails`, `SessionDetails`, `ContainerDetails`, and the admin variants for devices, namespaces, users, firewall rules, and announcements (list/new/details/edit). The four user-facing pages gain the `nav` landmark and `aria-current` they were missing.
- **`BannerEdit`**: the back-arrow tile and "Settings" overline are replaced with `Settings > SSH Banner`. The Cancel button still routes back to `/settings`, so the back path is preserved.
- **`admin/SessionDetails`**: replaces `PageHeader` with an inline header in the same shape as the other admin detail pages. `PageHeader` uses `-mt-8` to draw a full-bleed surface bar; pairing it with a preceding `<Breadcrumb>` (default `mb-5`) would visually clip the breadcrumb. The inline pattern avoids this and matches what every other admin detail page already does.
- **Tests**: new component covers landmark, list structure, link vs. leaf rendering, `aria-current` placement, chevron count, and `title` forwarding/fallback. The breadcrumb assertions in `AdminDeviceDetails` and `AdminFirewallRuleDetails` page tests are removed; the component now owns its own coverage.

## Testing

- `tsc --noEmit`, `eslint`, and `vitest` all clean (1959 tests).
- Tab onto a breadcrumb link on any detail page — the focus ring should be visible (it wasn't before, on dark theme).
- Open `/admin/sessions/<uid>` and confirm the breadcrumb is not clipped by the header below it (this was the bug that motivated dropping `PageHeader` on that page).
- Open a device with a very long name on a narrow viewport — the leaf should ellipsis with a `title` tooltip exposing the full name.