### PR TITLE
refactor(ui-react): extract shared SearchField component

### DIFF
--- a/ui-react/apps/console/src/components/billing/DeviceChooserDialog.tsx
+++ b/ui-react/apps/console/src/components/billing/DeviceChooserDialog.tsx
@@ -7,16 +7,13 @@ import {
   useState,
 } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  ExclamationCircleIcon,
-  MagnifyingGlassIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
+import { ExclamationCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import BaseDialog from "../common/BaseDialog";
 import DataTable, { type Column } from "../common/DataTable";
 import DistroIcon from "../common/DistroIcon";
 import OnlineDot from "../common/OnlineDot";
 import LastSeenCell from "../common/LastSeenCell";
+import SearchField from "@/components/common/fields/SearchField";
 import CheckboxField from "@/components/common/fields/CheckboxField";
 import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
@@ -226,7 +223,13 @@ export default function DeviceChooserDialog({
             aria-labelledby={allTabId}
             className="py-4 space-y-4"
           >
-            <SearchInput value={search} onChange={handleSearchChange} />
+            <SearchField
+              full
+              value={search}
+              onChange={handleSearchChange}
+              placeholder="Search by hostname..."
+              aria-label="Search devices by hostname"
+            />
             <AllTab
               devices={allDevices}
               isLoading={allLoading}
@@ -286,9 +289,7 @@ export default function DeviceChooserDialog({
           aria-disabled={acceptDisabled}
           className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg text-sm font-semibold transition-all bg-primary text-white hover:bg-primary-600 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary disabled:active:scale-100"
         >
-          {choice.isPending && (
-            <Spinner size="sm" tone="onPrimary" />
-          )}
+          {choice.isPending && <Spinner size="sm" tone="onPrimary" />}
           {choice.isPending ? "Saving…" : "Accept"}
         </button>
       </footer>
@@ -416,31 +417,6 @@ const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
     );
   },
 );
-
-function SearchInput({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (next: string) => void;
-}) {
-  return (
-    <label className="relative block">
-      <span className="sr-only">Search by hostname</span>
-      <MagnifyingGlassIcon
-        aria-hidden="true"
-        className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none"
-      />
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="Search by hostname"
-        className="w-full pl-9 pr-3 py-2 bg-surface border border-border rounded-lg text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-primary/60 focus:ring-1 focus:ring-primary/30 transition-colors"
-      />
-    </label>
-  );
-}
 
 function SuggestedTab({
   devices,

--- a/ui-react/apps/console/src/components/billing/__tests__/DeviceChooserDialog.test.tsx
+++ b/ui-react/apps/console/src/components/billing/__tests__/DeviceChooserDialog.test.tsx
@@ -539,7 +539,7 @@ describe("DeviceChooserDialog", () => {
       const user = userEvent.setup();
       renderDialog();
       await user.click(screen.getByRole("tab", { name: "All" }));
-      const searchInput = screen.getByRole("textbox");
+      const searchInput = screen.getByRole("searchbox");
       await user.type(searchInput, "prod");
       await waitFor(() => {
         const lastCall =

--- a/ui-react/apps/console/src/components/common/fields/InputField.tsx
+++ b/ui-react/apps/console/src/components/common/fields/InputField.tsx
@@ -28,6 +28,7 @@ type Props = InputProps & {
   errorRole?: "alert" | "status";
   hint?: string;
   appendIcon?: ReactNode;
+  prependIcon?: ReactNode;
   variant?: "default" | "mono";
 };
 
@@ -43,6 +44,7 @@ export default function InputField({
   hint,
   appendIcon,
   variant = "default",
+  prependIcon,
   type = "text",
   className,
   ...rest
@@ -57,6 +59,7 @@ export default function InputField({
   const inputClassNames = [
     baseByVariant[variant],
     appendIcon && "pr-10",
+    prependIcon && "pl-10",
     rest.readOnly && INPUT_READONLY,
     className,
   ]
@@ -68,7 +71,12 @@ export default function InputField({
       <FieldLabel htmlFor={id} hideLabel={hideLabel} adornment={labelAdornment}>
         {label}
       </FieldLabel>
-      <div className={appendIcon ? "relative" : undefined}>
+      <div className={appendIcon || prependIcon ? "relative" : undefined}>
+        {prependIcon && (
+          <div className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
+            {prependIcon}
+          </div>
+        )}
         <input
           {...rest}
           id={id}

--- a/ui-react/apps/console/src/components/common/fields/SearchField.tsx
+++ b/ui-react/apps/console/src/components/common/fields/SearchField.tsx
@@ -1,0 +1,55 @@
+import { useId } from "react";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import InputField from "@/components/common/fields/InputField";
+
+interface SearchFieldProps {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder: string;
+  /** Required accessible name. Rendered as a visually hidden <label>. */
+  "aria-label": string;
+  /** Layout overrides only (margins, alignment). Don't override colors or sizes. */
+  className?: string;
+  id?: string;
+  /** Remove the max-width cap. Defaults to capping at `max-w-sm`. */
+  full?: boolean;
+}
+
+export default function SearchField({
+  value,
+  onChange,
+  placeholder,
+  "aria-label": ariaLabel,
+  className,
+  id,
+  full = false,
+}: SearchFieldProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+
+  const wrapperClasses = [full ? null : "max-w-sm w-full", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={wrapperClasses || undefined}>
+      <InputField
+        id={inputId}
+        label={ariaLabel}
+        hideLabel
+        variant="mono"
+        type="search"
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        prependIcon={
+          <MagnifyingGlassIcon
+            aria-hidden="true"
+            className="w-4 h-4 text-text-muted"
+            strokeWidth={2}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/ui-react/apps/console/src/components/common/fields/__tests__/SearchField.test.tsx
+++ b/ui-react/apps/console/src/components/common/fields/__tests__/SearchField.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SearchField from "@/components/common/fields/SearchField";
+
+type Overrides = Partial<React.ComponentProps<typeof SearchField>>;
+
+function renderSearchField(overrides: Overrides = {}) {
+  return render(
+    <SearchField
+      value=""
+      onChange={() => {}}
+      placeholder="Search..."
+      aria-label="Search"
+      {...overrides}
+    />,
+  );
+}
+
+describe("SearchField", () => {
+  it("renders the placeholder and current value", () => {
+    renderSearchField({
+      value: "ubuntu",
+      placeholder: "Search devices...",
+      "aria-label": "Search devices",
+    });
+
+    const input = screen.getByRole("searchbox", { name: "Search devices" });
+    expect(input).toHaveAttribute("placeholder", "Search devices...");
+    expect(input).toHaveValue("ubuntu");
+  });
+
+  it("exposes aria-label as the accessible name via a visually hidden <label>", () => {
+    renderSearchField({ "aria-label": "Search users by username" });
+
+    expect(
+      screen.getByRole("searchbox", { name: "Search users by username" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange with the new value as the user types", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    renderSearchField({ onChange });
+
+    await user.type(screen.getByRole("searchbox"), "abc");
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(onChange).toHaveBeenNthCalledWith(1, "a");
+    expect(onChange).toHaveBeenNthCalledWith(2, "b");
+    expect(onChange).toHaveBeenNthCalledWith(3, "c");
+  });
+
+  it("constrains width with max-w-sm by default", () => {
+    const { container } = renderSearchField();
+
+    expect((container.firstChild as HTMLElement).className).toContain(
+      "max-w-sm",
+    );
+  });
+
+  it("omits the contained width when full is set", () => {
+    const { container } = renderSearchField({ full: true });
+
+    expect((container.firstChild as HTMLElement).className).not.toContain(
+      "max-w-sm",
+    );
+  });
+
+  it("appends custom className to the wrapper", () => {
+    const { container } = renderSearchField({ className: "ml-auto mb-5" });
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("ml-auto");
+    expect(wrapper.className).toContain("mb-5");
+  });
+
+  it("renders the magnifying glass icon as decorative (aria-hidden)", () => {
+    const { container } = renderSearchField();
+
+    expect(container.querySelector("svg")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
+  it("generates unique ids when two are rendered together", () => {
+    render(
+      <>
+        <SearchField
+          value=""
+          onChange={() => {}}
+          placeholder="a"
+          aria-label="First"
+        />
+        <SearchField
+          value=""
+          onChange={() => {}}
+          placeholder="b"
+          aria-label="Second"
+        />
+      </>,
+    );
+
+    const [first, second] = screen.getAllByRole("searchbox");
+    expect(first.id).not.toBe(second.id);
+    expect(first.id).toBeTruthy();
+    expect(second.id).toBeTruthy();
+  });
+
+  it("uses the provided id to bind the label and input", () => {
+    renderSearchField({ id: "my-search", "aria-label": "My search" });
+
+    const input = screen.getByRole("searchbox", { name: "My search" });
+    expect(input).toHaveAttribute("id", "my-search");
+  });
+});

--- a/ui-react/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui-react/apps/console/src/pages/WebEndpoints.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef, useEffect, FormEvent } from "react";
+import { useState, useRef, FormEvent } from "react";
 import { isSdkError } from "@/api/errors";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useWebEndpoints } from "@/hooks/useWebEndpoints";
 import {
   useCreateWebEndpoint,
@@ -9,6 +10,7 @@ import {
 import type { Webendpoint } from "@/client";
 import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
 import PageHeader from "@/components/common/PageHeader";
+import SearchField from "@/components/common/fields/SearchField";
 import Drawer from "@/components/common/Drawer";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import NumericInput from "@/components/common/fields/NumericInput";
@@ -30,7 +32,6 @@ import {
   LinkIcon,
   ClockIcon,
   PlusIcon,
-  MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import Spinner from "@/components/common/Spinner";
@@ -816,15 +817,7 @@ const SEARCH_DEBOUNCE_MS = 300;
 function WebEndpointsContent() {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(search.trim());
-      setPage(1);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [search]);
+  const debouncedSearch = useDebouncedValue(search.trim(), SEARCH_DEBOUNCE_MS);
 
   const { webEndpoints, totalCount, isLoading } = useWebEndpoints({
     page,
@@ -1000,31 +993,16 @@ function WebEndpointsContent() {
             </RestrictedAction>
           </PageHeader>
 
-          {/* Search bar */}
-          <form
-            role="search"
-            aria-label="Web endpoints"
+          <SearchField
             className="mb-4 animate-fade-in"
-            onSubmit={(e) => e.preventDefault()}
-          >
-            <div className="relative max-w-sm">
-              <label htmlFor="web-endpoints-search" className="sr-only">
-                Search web endpoints by address
-              </label>
-              <MagnifyingGlassIcon
-                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none"
-                aria-hidden="true"
-              />
-              <input
-                id="web-endpoints-search"
-                type="search"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search by address..."
-                className="w-full pl-9 pr-3.5 py-2 bg-card border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
-              />
-            </div>
-          </form>
+            value={search}
+            onChange={(next) => {
+              setSearch(next);
+              setPage(1);
+            }}
+            placeholder="Search by address..."
+            aria-label="Search web endpoints by address"
+          />
 
           {isNoResults ? (
             <div

--- a/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
@@ -84,7 +84,7 @@ describe("AdminDevices", () => {
     it("renders the search input with correct aria-label", () => {
       renderPage();
       expect(
-        screen.getByRole("textbox", { name: "Search devices by hostname" }),
+        screen.getByRole("searchbox", { name: "Search devices by hostname" }),
       ).toBeInTheDocument();
     });
 
@@ -177,7 +177,7 @@ describe("AdminDevices", () => {
       await user.click(screen.getByRole("tab", { name: "Accepted" }));
       // After clicking a tab the hook is still called; the page should still render
       expect(
-        screen.getByRole("textbox", { name: "Search devices by hostname" }),
+        screen.getByRole("searchbox", { name: "Search devices by hostname" }),
       ).toBeInTheDocument();
     });
   });

--- a/ui-react/apps/console/src/pages/admin/devices/index.tsx
+++ b/ui-react/apps/console/src/pages/admin/devices/index.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import {
   CpuChipIcon,
-  MagnifyingGlassIcon,
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
 import {
@@ -12,7 +11,9 @@ import {
 import type { DeviceStatus } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import DistroIcon from "@/components/common/DistroIcon";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatRelative } from "@/utils/date";
 
@@ -55,18 +56,10 @@ export default function AdminDevices() {
   const navigate = useNavigate();
   const [page, setPage] = useState(1);
   const [searchInput, setSearchInput] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
   const [status, setStatus] = useState<DeviceStatus | "">("");
   const [sortBy, setSortBy] = useState<SortField>("last_seen");
   const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchInput);
-      setPage(1);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   const { devices, totalCount, isLoading, error } = useAdminDevices({
     page,
@@ -210,20 +203,15 @@ export default function AdminDevices() {
           ))}
         </div>
 
-        <div className="relative h-8">
-          <MagnifyingGlassIcon
-            className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted"
-            strokeWidth={2}
-          />
-          <input
-            type="text"
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            placeholder="Search by hostname..."
-            aria-label="Search devices by hostname"
-            className="h-full pl-9 pr-3 bg-card border border-border rounded-md text-xs text-text-primary font-mono placeholder:text-text-secondary focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/15 transition-all duration-200 w-56"
-          />
-        </div>
+        <SearchField
+          value={searchInput}
+          onChange={(next) => {
+            setSearchInput(next);
+            setPage(1);
+          }}
+          placeholder="Search by hostname..."
+          aria-label="Search devices by hostname"
+        />
       </div>
 
       {error && (

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
@@ -31,7 +31,9 @@ const defaultHookState = {
   error: null,
 };
 
-function makeRule(overrides: Partial<FirewallRulesResponse> = {}): FirewallRulesResponse {
+function makeRule(
+  overrides: Partial<FirewallRulesResponse> = {},
+): FirewallRulesResponse {
   return {
     id: "rule-1",
     tenant_id: "tenant-abc",
@@ -72,7 +74,9 @@ describe("AdminFirewallRules", () => {
     it("renders the search input with correct aria-label", () => {
       renderPage();
       expect(
-        screen.getByRole("textbox", { name: "Search firewall rules" }),
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
       ).toBeInTheDocument();
     });
   });
@@ -268,7 +272,9 @@ describe("AdminFirewallRules", () => {
       renderPage();
 
       await user.type(
-        screen.getByRole("textbox", { name: "Search firewall rules" }),
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
         "deny",
       );
 
@@ -283,7 +289,9 @@ describe("AdminFirewallRules", () => {
       renderPage();
 
       await user.type(
-        screen.getByRole("textbox", { name: "Search firewall rules" }),
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
         "172.16.0.1",
       );
 
@@ -298,7 +306,9 @@ describe("AdminFirewallRules", () => {
       renderPage();
 
       await user.type(
-        screen.getByRole("textbox", { name: "Search firewall rules" }),
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
         "zara",
       );
 
@@ -313,7 +323,9 @@ describe("AdminFirewallRules", () => {
       renderPage();
 
       await user.type(
-        screen.getByRole("textbox", { name: "Search firewall rules" }),
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
         "777",
       );
 
@@ -328,7 +340,9 @@ describe("AdminFirewallRules", () => {
       renderPage();
 
       await user.type(
-        screen.getByRole("textbox", { name: "Search firewall rules" }),
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
         "zzz-no-match",
       );
 

--- a/ui-react/apps/console/src/pages/admin/firewall-rules/index.tsx
+++ b/ui-react/apps/console/src/pages/admin/firewall-rules/index.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import {
   ShieldExclamationIcon,
-  MagnifyingGlassIcon,
   ExclamationCircleIcon,
   CheckCircleIcon,
   NoSymbolIcon,
@@ -10,6 +9,7 @@ import {
 import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
 import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import FilterBadge from "@/components/common/FilterBadge";
 import { type FirewallRulesResponse as FirewallRule } from "@/client";
 
@@ -30,10 +30,10 @@ export default function AdminFirewallRules() {
     const q = search.toLowerCase();
     return rules.filter(
       (r) =>
-        r.action.toLowerCase().includes(q)
-        || r.source_ip.toLowerCase().includes(q)
-        || r.username.toLowerCase().includes(q)
-        || String(r.priority).includes(q),
+        r.action.toLowerCase().includes(q) ||
+        r.source_ip.toLowerCase().includes(q) ||
+        r.username.toLowerCase().includes(q) ||
+        String(r.priority).includes(q),
     );
   }, [rules, search]);
 
@@ -57,7 +57,9 @@ export default function AdminFirewallRules() {
           {rule.action === "allow" ? (
             <>
               <CheckCircleIcon className="w-4 h-4 text-accent-green" />
-              <span className="text-xs font-medium text-accent-green">Allow</span>
+              <span className="text-xs font-medium text-accent-green">
+                Allow
+              </span>
             </>
           ) : (
             <>
@@ -75,7 +77,9 @@ export default function AdminFirewallRules() {
         rule.source_ip === ".*" ? (
           <span className="text-xs text-text-secondary">Any IP</span>
         ) : (
-          <span className="text-xs font-mono text-text-primary">{rule.source_ip}</span>
+          <span className="text-xs font-mono text-text-primary">
+            {rule.source_ip}
+          </span>
         ),
     },
     {
@@ -85,7 +89,9 @@ export default function AdminFirewallRules() {
         rule.username === ".*" ? (
           <span className="text-xs text-text-secondary">All users</span>
         ) : (
-          <span className="text-xs font-mono text-text-primary">{rule.username}</span>
+          <span className="text-xs font-mono text-text-primary">
+            {rule.username}
+          </span>
         ),
     },
     {
@@ -132,26 +138,16 @@ export default function AdminFirewallRules() {
         description="View all firewall rules configured across the instance"
       />
 
-      {/* Search bar */}
-      <div className="flex items-center mb-5 animate-fade-in">
-        <div className="relative h-8 w-72 max-w-full sm:w-96">
-          <MagnifyingGlassIcon
-            className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted"
-            strokeWidth={2}
-          />
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-              setPage(1);
-            }}
-            placeholder="Search by action, priority, IP, or username..."
-            aria-label="Search firewall rules"
-            className="h-full w-full pl-9 pr-3 bg-card border border-border rounded-md text-xs text-text-primary font-mono placeholder:text-text-secondary text-ellipsis overflow-hidden focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/15 transition-all duration-200"
-          />
-        </div>
-      </div>
+      <SearchField
+        className="mb-5"
+        value={search}
+        onChange={(next) => {
+          setSearch(next);
+          setPage(1);
+        }}
+        placeholder="Search by action, priority, IP, or username..."
+        aria-label="Search firewall rules by action, priority, IP, or username"
+      />
 
       {error && (
         <div

--- a/ui-react/apps/console/src/pages/admin/namespaces/index.tsx
+++ b/ui-react/apps/console/src/pages/admin/namespaces/index.tsx
@@ -1,16 +1,17 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   ServerStackIcon,
-  MagnifyingGlassIcon,
   PencilSquareIcon,
   TrashIcon,
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminNamespaces } from "@/hooks/useAdminNamespaces";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import type { Namespace } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import EditNamespaceDrawer from "./EditNamespaceDrawer";
 import DeleteNamespaceDialog from "./DeleteNamespaceDialog";
 import { formatDateShort } from "@/utils/date";
@@ -28,17 +29,9 @@ export default function AdminNamespaces() {
   const navigate = useNavigate();
   const [page, setPage] = useState(1);
   const [searchInput, setSearchInput] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
   const [editTarget, setEditTarget] = useState<Namespace | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Namespace | null>(null);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchInput);
-      setPage(1);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   const { namespaces, totalCount, isLoading, error } = useAdminNamespaces({
     page,
@@ -62,9 +55,7 @@ export default function AdminNamespaces() {
       key: "owner",
       header: "Owner",
       render: (ns) => (
-        <span className="text-xs text-text-secondary">
-          {getOwnerEmail(ns)}
-        </span>
+        <span className="text-xs text-text-secondary">{getOwnerEmail(ns)}</span>
       ),
     },
     {
@@ -136,21 +127,16 @@ export default function AdminNamespaces() {
         description="Manage all namespaces in the instance"
       />
 
-      {/* Search */}
-      <div className="relative h-8 ml-auto mb-5 animate-fade-in">
-        <MagnifyingGlassIcon
-          className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted"
-          strokeWidth={2}
-        />
-        <input
-          type="text"
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-          placeholder="Search by name..."
-          aria-label="Search namespaces by name"
-          className="h-full pl-9 pr-3 bg-card border border-border rounded-md text-xs text-text-primary font-mono placeholder:text-text-secondary focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/15 transition-all duration-200 w-56"
-        />
-      </div>
+      <SearchField
+        className="mb-5"
+        value={searchInput}
+        onChange={(next) => {
+          setSearchInput(next);
+          setPage(1);
+        }}
+        placeholder="Search by name..."
+        aria-label="Search namespaces by name"
+      />
 
       {error && (
         <div

--- a/ui-react/apps/console/src/pages/admin/users/index.tsx
+++ b/ui-react/apps/console/src/pages/admin/users/index.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   UsersIcon,
   PlusIcon,
-  MagnifyingGlassIcon,
   PencilSquareIcon,
   TrashIcon,
   ArrowRightStartOnRectangleIcon,
@@ -11,9 +10,11 @@ import {
 } from "@heroicons/react/24/outline";
 import { useAdminUsers } from "@/hooks/useAdminUsers";
 import { useLoginAsUser } from "@/hooks/useLoginAsUser";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import type { UserAdminResponse } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import UserStatusChip from "./UserStatusChip";
 import CreateUserDrawer from "./CreateUserDrawer";
 import EditUserDrawer from "./EditUserDrawer";
@@ -27,7 +28,7 @@ export default function AdminUsers() {
   const navigate = useNavigate();
   const [page, setPage] = useState(1);
   const [searchInput, setSearchInput] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<UserAdminResponse | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<UserAdminResponse | null>(
@@ -38,14 +39,6 @@ export default function AdminUsers() {
     loadingId: loginAsId,
     errorId: loginAsError,
   } = useLoginAsUser();
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchInput);
-      setPage(1);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   const { users, totalCount, isLoading, error } = useAdminUsers({
     page,
@@ -167,21 +160,16 @@ export default function AdminUsers() {
         </button>
       </PageHeader>
 
-      {/* Search */}
-      <div className="relative h-8 ml-auto mb-5 animate-fade-in">
-        <MagnifyingGlassIcon
-          className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted"
-          strokeWidth={2}
-        />
-        <input
-          type="text"
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-          placeholder="Search by username..."
-          aria-label="Search users by username"
-          className="h-full pl-9 pr-3 bg-card border border-border rounded-md text-xs text-text-primary font-mono placeholder:text-text-secondary focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/15 transition-all duration-200 w-56"
-        />
-      </div>
+      <SearchField
+        className="mb-5"
+        value={searchInput}
+        onChange={(next) => {
+          setSearchInput(next);
+          setPage(1);
+        }}
+        placeholder="Search by username..."
+        aria-label="Search users by username"
+      />
 
       {error && (
         <div

--- a/ui-react/apps/console/src/pages/containers/index.tsx
+++ b/ui-react/apps/console/src/pages/containers/index.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useContainers, type NormalizedContainer } from "@/hooks/useContainers";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import type { DeviceStatus } from "@/client";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useAuthStore } from "@/stores/authStore";
@@ -10,6 +11,7 @@ import ConnectDrawer from "@/components/ConnectDrawer";
 import ManageTagsDrawer from "@/components/ManageTagsDrawer";
 import CopyButton from "@/components/common/CopyButton";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import TagFilterDropdown from "@/components/common/TagFilterDropdown";
 import { formatRelative } from "@/utils/date";
 import { buildSshid } from "@/utils/sshid";
@@ -20,7 +22,6 @@ import { getConfig } from "@/env";
 import AddDockerConnectorDrawer from "./AddDockerConnectorDrawer";
 import {
   PlusIcon,
-  MagnifyingGlassIcon,
   TagIcon,
   XMarkIcon,
   ExclamationCircleIcon,
@@ -50,7 +51,10 @@ export default function Containers() {
   );
   const [filterTags, setFilterTags] = useState<string[]>([]);
   const [searchInput, setSearchInput] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(
+    searchInput.trim(),
+    SEARCH_DEBOUNCE_MS,
+  );
   const [actionTarget, setActionTarget] = useState<{
     container: NormalizedContainer;
     action: "accept" | "reject" | "remove";
@@ -63,13 +67,6 @@ export default function Containers() {
   const [manageTagsOpen, setManageTagsOpen] = useState(false);
   const [addConnectorOpen, setAddConnectorOpen] = useState(false);
   const [billingWarningOpen, setBillingWarningOpen] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchInput.trim());
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
 
   const { containers, totalCount, isLoading, error, refetch } = useContainers({
     page,
@@ -350,23 +347,15 @@ export default function Containers() {
             onManageTags={() => setManageTagsOpen(true)}
           />
 
-          <div className="relative h-8">
-            <MagnifyingGlassIcon
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted"
-              strokeWidth={2}
-            />
-            <input
-              type="text"
-              value={searchInput}
-              onChange={(e) => {
-                setSearchInput(e.target.value);
-                setPage(1);
-              }}
-              placeholder="Search containers..."
-              aria-label="Search containers"
-              className="h-full pl-9 pr-3 bg-card border border-border rounded-md text-xs text-text-primary font-mono placeholder:text-text-secondary focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/15 transition-all duration-200 w-56"
-            />
-          </div>
+          <SearchField
+            value={searchInput}
+            onChange={(next) => {
+              setSearchInput(next);
+              setPage(1);
+            }}
+            placeholder="Search by hostname..."
+            aria-label="Search containers by hostname"
+          />
         </div>
       </div>
 

--- a/ui-react/apps/console/src/pages/devices/__tests__/Devices.test.tsx
+++ b/ui-react/apps/console/src/pages/devices/__tests__/Devices.test.tsx
@@ -36,8 +36,17 @@ vi.mock("@/components/common/CopyButton", () => ({
 }));
 
 vi.mock("@/components/common/PageHeader", () => ({
-  default: ({ title, children }: { title: string; children?: React.ReactNode }) => (
-    <div><h1>{title}</h1>{children}</div>
+  default: ({
+    title,
+    children,
+  }: {
+    title: string;
+    children?: React.ReactNode;
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
   ),
 }));
 
@@ -50,7 +59,11 @@ vi.mock("@/components/common/DataTable", () => ({
     onRowClick,
     emptyState,
   }: {
-    columns: { key: string; header: string; render: (row: unknown) => React.ReactNode }[];
+    columns: {
+      key: string;
+      header: string;
+      render: (row: unknown) => React.ReactNode;
+    }[];
     data: unknown[];
     isLoading: boolean;
     loadingMessage: string;
@@ -62,12 +75,18 @@ vi.mock("@/components/common/DataTable", () => ({
     return (
       <table>
         <thead>
-          <tr>{columns.map((c) => <th key={c.key}>{c.header}</th>)}</tr>
+          <tr>
+            {columns.map((c) => (
+              <th key={c.key}>{c.header}</th>
+            ))}
+          </tr>
         </thead>
         <tbody>
           {data.map((row, i) => (
             <tr key={i} onClick={() => onRowClick(row)}>
-              {columns.map((c) => <td key={c.key}>{c.render(row)}</td>)}
+              {columns.map((c) => (
+                <td key={c.key}>{c.render(row)}</td>
+              ))}
             </tr>
           ))}
         </tbody>
@@ -137,7 +156,9 @@ const defaultHookState = {
   refetch: vi.fn(),
 };
 
-function makeDevice(overrides: Partial<NormalizedDevice> = {}): NormalizedDevice {
+function makeDevice(
+  overrides: Partial<NormalizedDevice> = {},
+): NormalizedDevice {
   return {
     uid: "device-uid-1",
     name: "my-device",
@@ -179,19 +200,29 @@ describe("Devices list", () => {
   describe("rendering", () => {
     it("renders the page heading", () => {
       renderPage();
-      expect(screen.getByRole("heading", { name: "Devices" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Devices" }),
+      ).toBeInTheDocument();
     });
 
     it("renders all status filter tabs", () => {
       renderPage();
-      expect(screen.getByRole("button", { name: "Accepted" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Pending" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Rejected" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Accepted" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Pending" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Rejected" }),
+      ).toBeInTheDocument();
     });
 
     it("renders the search input", () => {
       renderPage();
-      expect(screen.getByPlaceholderText("Search devices...")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Search by hostname..."),
+      ).toBeInTheDocument();
     });
 
     it('renders the "Custom Fields" column header', () => {
@@ -201,13 +232,18 @@ describe("Devices list", () => {
         totalCount: 1,
       });
       renderPage();
-      expect(screen.getByRole("columnheader", { name: "Custom Fields" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("columnheader", { name: "Custom Fields" }),
+      ).toBeInTheDocument();
     });
   });
 
   describe("loading state", () => {
     it("renders the loading message", () => {
-      vi.mocked(useDevices).mockReturnValue({ ...defaultHookState, isLoading: true });
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        isLoading: true,
+      });
       renderPage();
       expect(screen.getByText("Loading devices...")).toBeInTheDocument();
     });
@@ -262,7 +298,9 @@ describe("Devices list", () => {
     it("renders key and value badges for each custom field", () => {
       vi.mocked(useDevices).mockReturnValue({
         ...defaultHookState,
-        devices: [makeDevice({ custom_fields: { env: "production", owner: "team-a" } })],
+        devices: [
+          makeDevice({ custom_fields: { env: "production", owner: "team-a" } }),
+        ],
         totalCount: 1,
       });
       renderPage();

--- a/ui-react/apps/console/src/pages/devices/index.tsx
+++ b/ui-react/apps/console/src/pages/devices/index.tsx
@@ -14,6 +14,7 @@ import PlatformBadge from "@/components/common/PlatformBadge";
 import OnlineDot from "@/components/common/OnlineDot";
 import LastSeenCell from "@/components/common/LastSeenCell";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import { buildSshid } from "@/utils/sshid";
 import TagFilterDropdown from "@/components/common/TagFilterDropdown";
 import TagsPopover from "./TagsPopover";
@@ -22,7 +23,6 @@ import BillingWarning from "@/components/billing/BillingWarning";
 import { getConfig } from "@/env";
 import {
   PlusIcon,
-  MagnifyingGlassIcon,
   TagIcon,
   XMarkIcon,
   ExclamationCircleIcon,
@@ -362,22 +362,15 @@ export default function Devices() {
             onManageTags={() => setManageTagsOpen(true)}
           />
 
-          <div className="relative h-8">
-            <MagnifyingGlassIcon
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted"
-              strokeWidth={2}
-            />
-            <input
-              type="text"
-              value={searchInput}
-              onChange={(e) => {
-                setSearchInput(e.target.value);
-                setPage(1);
-              }}
-              placeholder="Search devices..."
-              className="h-full pl-9 pr-3 bg-card border border-border rounded-md text-xs text-text-primary font-mono placeholder:text-text-secondary focus:outline-none focus:border-primary/40 focus:ring-1 focus:ring-primary/15 transition-all duration-200 w-56"
-            />
-          </div>
+          <SearchField
+            value={searchInput}
+            onChange={(next) => {
+              setSearchInput(next);
+              setPage(1);
+            }}
+            placeholder="Search by hostname..."
+            aria-label="Search devices by hostname"
+          />
         </div>
       </div>
 

--- a/ui-react/apps/console/src/pages/firewall-rules/index.tsx
+++ b/ui-react/apps/console/src/pages/firewall-rules/index.tsx
@@ -4,6 +4,7 @@ import { useDeleteFirewallRule } from "@/hooks/useFirewallRuleMutations";
 import PageHeader from "@/components/common/PageHeader";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import FilterBadge from "@/components/common/FilterBadge";
 import RuleDrawer from "./RuleDrawer";
 import RestrictedAction from "@/components/common/RestrictedAction";
@@ -11,7 +12,6 @@ import {
   ExclamationTriangleIcon,
   CheckCircleIcon,
   NoSymbolIcon,
-  MagnifyingGlassIcon,
   PlusIcon,
   UsersIcon,
   Bars3Icon,
@@ -273,7 +273,11 @@ export default function FirewallRules() {
                     onClick={openNew}
                     className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   >
-                    <PlusIcon className="w-4 h-4" strokeWidth={2} aria-hidden="true" />
+                    <PlusIcon
+                      className="w-4 h-4"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    />
                     Add your first rule
                   </button>
                 </RestrictedAction>
@@ -315,30 +319,13 @@ export default function FirewallRules() {
         </RestrictedAction>
       </PageHeader>
 
-      <form
-        role="search"
-        aria-label="Firewall rules"
-        className="mb-4 animate-fade-in"
-        onSubmit={(e) => e.preventDefault()}
-      >
-        <div className="relative max-w-sm">
-          <label htmlFor="firewall-rules-search" className="sr-only">
-            Search firewall rules by action, priority, IP, or username
-          </label>
-          <MagnifyingGlassIcon
-            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none"
-            aria-hidden="true"
-          />
-          <input
-            id="firewall-rules-search"
-            type="search"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search by action, priority, IP, or username..."
-            className="w-full pl-9 pr-3.5 py-2 bg-card border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
-          />
-        </div>
-      </form>
+      <SearchField
+        className="mb-4"
+        value={search}
+        onChange={setSearch}
+        placeholder="Search by action, priority, IP, or username..."
+        aria-label="Search firewall rules by action, priority, IP, or username"
+      />
 
       <DataTable
         columns={columns}

--- a/ui-react/apps/console/src/pages/public-keys/index.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/index.tsx
@@ -5,12 +5,12 @@ import PageHeader from "@/components/common/PageHeader";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import CopyButton from "@/components/common/CopyButton";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import KeyDrawer from "./KeyDrawer";
 import { formatDate } from "@/utils/date";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import {
   KeyIcon,
-  MagnifyingGlassIcon,
   PlusIcon,
   ShieldCheckIcon,
   TagIcon,
@@ -331,18 +331,13 @@ export default function PublicKeys() {
         </RestrictedAction>
       </PageHeader>
 
-      <div className="mb-4 animate-fade-in">
-        <div className="relative max-w-sm">
-          <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search by name or fingerprint..."
-            className="w-full pl-9 pr-3.5 py-2 bg-card border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
-          />
-        </div>
-      </div>
+      <SearchField
+        className="mb-4"
+        value={search}
+        onChange={setSearch}
+        placeholder="Search by name or fingerprint..."
+        aria-label="Search public keys by name or fingerprint"
+      />
 
       <DataTable
         columns={columns}

--- a/ui-react/apps/console/src/pages/secure-vault/index.tsx
+++ b/ui-react/apps/console/src/pages/secure-vault/index.tsx
@@ -4,7 +4,6 @@ import {
   LockClosedIcon,
   KeyIcon,
   PlusIcon,
-  MagnifyingGlassIcon,
   PencilSquareIcon,
   TrashIcon,
   FingerPrintIcon,
@@ -16,6 +15,7 @@ import VaultSetupDialog from "@/components/vault/VaultSetupDialog";
 import VaultUnlockDialog from "@/components/vault/VaultUnlockDialog";
 import VaultSettingsSection from "@/components/vault/VaultSettingsSection";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import SearchField from "@/components/common/fields/SearchField";
 import KeyDrawer from "./KeyDrawer";
 import KeyDeleteDialog from "./KeyDeleteDialog";
 import { formatDate } from "@/utils/date";
@@ -335,18 +335,13 @@ export default function SecureVault() {
             </button>
           </PageHeader>
 
-          <div className="mb-4 animate-fade-in">
-            <div className="relative max-w-sm">
-              <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted pointer-events-none" />
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search by name or fingerprint..."
-                className="w-full pl-9 pr-3.5 py-2 bg-card border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
-              />
-            </div>
-          </div>
+          <SearchField
+            className="mb-4"
+            value={search}
+            onChange={setSearch}
+            placeholder="Search by name or fingerprint..."
+            aria-label="Search vault keys by name or fingerprint"
+          />
 
           <DataTable
             columns={columns}

--- a/ui-react/apps/console/src/utils/styles.ts
+++ b/ui-react/apps/console/src/utils/styles.ts
@@ -1,8 +1,9 @@
-export const LABEL_BASE = "block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
+export const LABEL_BASE =
+  "block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
 export const LABEL = `${LABEL_BASE} mb-1.5`;
 
 export const INPUT_BASE =
-  "w-full px-3.5 py-2.5 bg-card rounded-lg text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed";
+  "w-full px-3.5 py-2.5 bg-card rounded-lg text-text-primary placeholder:text-text-secondary text-ellipsis focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed";
 
 const BORDER_OK = "border border-border";
 const BORDER_ERROR = "border border-accent-red/50";


### PR DESCRIPTION
## What
Consolidates 11 duplicated data-table search inputs into a single `SearchField` built on the existing `InputField` primitive, and adds a `prependIcon` slot so future left-icon inputs don't need a new component.

## Why
The 11 sites had drifted into two visual styles (compact `h-8 w-56 font-mono` on 6 admin/devices pages, comfortable `rounded-lg text-sm` on the other 5) with no semantic reason for the split. Five of them re-implemented the debounce inline with `useEffect + setTimeout` despite `hooks/useDebouncedValue.ts` already existing. Long placeholders were also hard-clipping instead of ellipsising because `INPUT_BASE` was missing `text-overflow: ellipsis`.

## Changes

- **`components/common/fields/SearchField.tsx`** (new): Thin wrapper over `InputField` with `variant="mono"`, `hideLabel`, `type="search"`, and a `MagnifyingGlassIcon` prependIcon. Caps at `max-w-sm` by default; pass `full` to remove the cap (used only by `DeviceChooserDialog`).
- **`components/common/fields/InputField.tsx`**: Added `prependIcon` slot mirroring the existing `appendIcon` (`pl-10` on the input, absolute-positioned with `pointer-events-none`). Existing `appendIcon` consumers unaffected.
- **`utils/styles.ts`**: Added `text-ellipsis` to `INPUT_BASE` so every single-line input truncates gracefully. Inert on the one `<textarea>` consumer (`KeyFileInput`) since it requires `white-space: nowrap`.
- **Five `useEffect + setTimeout` debounce blocks** (admin/devices, admin/users, admin/namespaces, containers, WebEndpoints) replaced with `useDebouncedValue`.
- **`<form role="search">` wrappers** dropped from firewall-rules, WebEndpoints, and DeviceChooserDialog. The input still exposes role `searchbox` with an accessible name.

## Testing

Three behavioral/visual deltas worth eyeballing:

- **Visual unification** on 5 pages: firewall-rules, web-endpoints, public-keys, secure-vault, and the DeviceChooserDialog tab panel switch from the comfortable to the canonical mono compact look. DeviceChooserDialog opts back into full width via `full`.
- **Page-reset timing** on admin/devices, admin/users, admin/namespaces, WebEndpoints: was previously inside the debounce timer; now runs synchronously in the input `onChange` (forced by the `react-hooks/set-state-in-effect` rule from React Hooks 7). A user on page 3+ who starts typing will see one extra "page 1, empty search" query before the debounced one fires. Matches what devices/containers already did.
- **`role=\"search\"` landmark removed** on firewall-rules, WebEndpoints, and DeviceChooserDialog (the 3 sites that had it). The search input is still discoverable as `searchbox`; only the surrounding region landmark is gone.

Not in scope: `pages/public-keys` and `pages/firewall-rules` are server-paginated with client-side filtering on the current page only — searching past `per_page` items still misses matches. Pre-existing bug; needs the hooks to forward `search` to the API.