### PR TITLE
fix(api,ui-react): public keys search across all pages

### DIFF
--- a/api/routes/sshkeys.go
+++ b/api/routes/sshkeys.go
@@ -5,7 +5,9 @@ import (
 	"strconv"
 
 	"github.com/shellhub-io/shellhub/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/api/services"
 	"github.com/shellhub-io/shellhub/api/store"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
@@ -33,6 +35,14 @@ func (h *Handler) GetPublicKeys(c gateway.Context) error {
 
 	if err := c.Validate(req); err != nil {
 		return err
+	}
+
+	if err := req.Filters.Unmarshal(); err != nil {
+		return c.NoContent(http.StatusBadRequest)
+	}
+
+	if err := query.ValidateFilters(&req.Filters, services.PublicKeyFilterFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
 	}
 
 	// TODO: normalize is not required when request is privileged

--- a/api/services/sshkeys.go
+++ b/api/services/sshkeys.go
@@ -10,12 +10,20 @@ import (
 	"slices"
 
 	"github.com/shellhub-io/shellhub/api/store"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/api/responses"
 	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"golang.org/x/crypto/ssh"
 )
+
+// PublicKeyFilterFields maps each filter field the public key list endpoint
+// accepts to the set of operators valid for it.
+var PublicKeyFilterFields = query.NewFieldConstraints(map[string][]string{
+	"name":        {"contains", "eq", "ne"},
+	"fingerprint": {"contains", "eq", "ne"},
+})
 
 type SSHKeysService interface {
 	EvaluateKeyFilter(ctx context.Context, key *models.PublicKey, dev models.Device) (bool, error)
@@ -159,6 +167,7 @@ func (s *service) ListPublicKeys(ctx context.Context, req *requests.ListPublicKe
 	return s.store.PublicKeyList(
 		ctx,
 		s.store.Options().InNamespace(req.TenantID),
+		s.store.Options().Match(&req.Filters),
 		s.store.Options().Paginate(&req.Paginator),
 	)
 }

--- a/api/services/sshkeys_test.go
+++ b/api/services/sshkeys_test.go
@@ -197,11 +197,15 @@ func TestListPublicKeys(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
+					On("Match", &query.Filters{}).
+					Return(nil).
+					Once()
+				queryOptionsMock.
 					On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
 					Return(nil).
 					Once()
 				storeMock.
-					On("PublicKeyList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
+					On("PublicKeyList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
 					Return(nil, 0, errors.New("error", "", 0)).
 					Once()
 			},
@@ -220,11 +224,15 @@ func TestListPublicKeys(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
+					On("Match", &query.Filters{}).
+					Return(nil).
+					Once()
+				queryOptionsMock.
 					On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
 					Return(nil).
 					Once()
 				storeMock.
-					On("PublicKeyList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
+					On("PublicKeyList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
 					Return(keys, len(keys), nil).
 					Once()
 			},

--- a/pkg/api/requests/publickey.go
+++ b/pkg/api/requests/publickey.go
@@ -10,6 +10,7 @@ type FingerprintParam struct {
 type ListPublicKeys struct {
 	TenantID string `header:"X-Tenant-ID"`
 	query.Paginator
+	query.Filters
 }
 
 // PublicKeyGet is the structure to represent the request data for get public key endpoint.

--- a/ui-react/apps/console/src/hooks/usePublicKeys.ts
+++ b/ui-react/apps/console/src/hooks/usePublicKeys.ts
@@ -8,26 +8,44 @@ import {
 import { getPublicKeysQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 
+export function buildPublicKeyFilter(search: string): string {
+  const filters = [
+    { type: "operator", params: { name: "or" } },
+    {
+      type: "property",
+      params: { name: "name", operator: "contains", value: search },
+    },
+    { type: "operator", params: { name: "or" } },
+    {
+      type: "property",
+      params: { name: "fingerprint", operator: "contains", value: search },
+    },
+  ];
+  return btoa(JSON.stringify(filters));
+}
+
 interface UsePublicKeysParams {
   page?: number;
   perPage?: number;
+  search?: string;
 }
 
 export function usePublicKeys({
   page = 1,
   perPage = 10,
+  search = "",
 }: UsePublicKeysParams = {}) {
-  const options = { query: { page, per_page: perPage } satisfies GetPublicKeysData["query"] };
+  const query: GetPublicKeysData["query"] = { page, per_page: perPage };
+  if (search) query.filter = buildPublicKeyFilter(search);
+
+  const options = { query };
 
   const result = useQuery<PaginatedResult<PublicKeyResponse>>({
     queryKey: getPublicKeysQueryKey(options),
     queryFn: paginatedQueryFn(getPublicKeysSdk, options),
   });
 
-  const publicKeys = useMemo(
-    () => result.data?.data ?? [],
-    [result.data],
-  );
+  const publicKeys = useMemo(() => result.data?.data ?? [], [result.data]);
 
   return {
     publicKeys,

--- a/ui-react/apps/console/src/pages/public-keys/index.tsx
+++ b/ui-react/apps/console/src/pages/public-keys/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { usePublicKeys } from "@/hooks/usePublicKeys";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useDeletePublicKey } from "@/hooks/usePublicKeyMutations";
 import PageHeader from "@/components/common/PageHeader";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
@@ -86,9 +87,16 @@ function ScopeCell({ pk }: { pk: PublicKey }) {
 
 /* ── page ────────────────────────────────────────── */
 
+const SEARCH_DEBOUNCE_MS = 300;
+
 export default function PublicKeys() {
   const [page, setPage] = useState(1);
-  const { publicKeys, totalCount, isLoading } = usePublicKeys({ page });
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
+  const { publicKeys, totalCount, isLoading } = usePublicKeys({
+    page,
+    search: debouncedSearch,
+  });
   const deleteKey = useDeletePublicKey();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<PublicKey | null>(null);
@@ -97,7 +105,6 @@ export default function PublicKeys() {
     name: string;
   } | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
 
   const closeDelete = () => {
     setDeleteError(null);
@@ -134,13 +141,6 @@ export default function PublicKeys() {
   };
 
   const totalPages = Math.ceil(totalCount / PER_PAGE);
-  const filtered = search
-    ? publicKeys.filter(
-        (k) =>
-          k.name.toLowerCase().includes(search.toLowerCase()) ||
-          k.fingerprint.toLowerCase().includes(search.toLowerCase()),
-      )
-    : publicKeys;
 
   const columns: Column<PublicKey>[] = [
     {
@@ -214,7 +214,7 @@ export default function PublicKeys() {
   ];
 
   /* Full-page onboarding empty state (no keys at all) */
-  if (!isLoading && publicKeys.length === 0) {
+  if (!isLoading && publicKeys.length === 0 && !debouncedSearch) {
     return (
       <div>
         <div className="relative -mx-8 -mt-8 min-h-[calc(100vh-3.5rem)] flex flex-col">
@@ -334,14 +334,17 @@ export default function PublicKeys() {
       <SearchField
         className="mb-4"
         value={search}
-        onChange={setSearch}
+        onChange={(next) => {
+          setSearch(next);
+          setPage(1);
+        }}
         placeholder="Search by name or fingerprint..."
         aria-label="Search public keys by name or fingerprint"
       />
 
       <DataTable
         columns={columns}
-        data={filtered}
+        data={publicKeys}
         rowKey={(pk) => pk.fingerprint}
         isLoading={isLoading}
         loadingMessage="Loading public keys..."
@@ -351,8 +354,8 @@ export default function PublicKeys() {
         itemLabel="key"
         onPageChange={setPage}
         emptyMessage={
-          search
-            ? `No keys matching \u201C${search}\u201D`
+          debouncedSearch
+            ? `No keys matching \u201C${debouncedSearch}\u201D`
             : "No public keys found"
         }
       />


### PR DESCRIPTION
## What

The public keys search box now finds matches across all server pages instead of only the page currently in view.

## Why

The React UI was already sending a `filter` query parameter on `GET /api/sshkeys/public-keys` (the same shape `/devices` uses), but the API handler bound only `Paginator` and silently dropped the filter. The page then ran a client-side `.filter()` over the 10 rows the server returned, so searches for a name or fingerprint living on page 2+ returned nothing.

## Changes

- **api**: `ListPublicKeys` request now embeds `query.Filters`; the handler runs `Unmarshal` + `ValidateFilters` against a new `PublicKeyFilterFields` registry that restricts the filter to `contains`/`eq`/`ne` on `name` and `fingerprint`; the service appends `Options().Match` to the store call. The generic store `Match` already supports this without per-entity wiring, and the existing service test was updated to expect the third `QueryOption`.
- **ui-react**: `usePublicKeys` accepts a `search` param and forwards `buildPublicKeyFilter(search)` to the `filter` query param. The page debounces the input (300ms), drops the old client-side `.filter()` block, and resets to page 1 in the SearchField `onChange` handler so a new search always starts from the first page of results.

## Testing

- Seed >10 keys in a namespace and search for a fragment that matches keys on page 2+. Pre-fix: zero hits while viewing page 1. Post-fix: all matches surface and the pager footer reflects the filtered total.
- Search by a fingerprint fragment — same behavior, since the registry covers both fields.
- Clear the search — the full paginated list is restored.
- Delete the last key on page > 1 while filtered — the existing empty-page back-step still works.