### PR TITLE
chore(ui): remove custom fields column from device list

### DIFF
--- a/ui-react/apps/console/src/pages/devices/__tests__/Devices.test.tsx
+++ b/ui-react/apps/console/src/pages/devices/__tests__/Devices.test.tsx
@@ -224,18 +224,6 @@ describe("Devices list", () => {
         screen.getByPlaceholderText("Search by hostname..."),
       ).toBeInTheDocument();
     });
-
-    it('renders the "Custom Fields" column header', () => {
-      vi.mocked(useDevices).mockReturnValue({
-        ...defaultHookState,
-        devices: [makeDevice()],
-        totalCount: 1,
-      });
-      renderPage();
-      expect(
-        screen.getByRole("columnheader", { name: "Custom Fields" }),
-      ).toBeInTheDocument();
-    });
   });
 
   describe("loading state", () => {
@@ -281,48 +269,6 @@ describe("Devices list", () => {
       renderPage();
       await user.click(screen.getByText("clickable"));
       expect(mockNavigate).toHaveBeenCalledWith("/devices/uid-abc");
-    });
-  });
-
-  describe("custom fields column", () => {
-    it("renders '—' when device has no custom fields", () => {
-      vi.mocked(useDevices).mockReturnValue({
-        ...defaultHookState,
-        devices: [makeDevice({ custom_fields: {} })],
-        totalCount: 1,
-      });
-      renderPage();
-      expect(screen.getByText("—")).toBeInTheDocument();
-    });
-
-    it("renders key and value badges for each custom field", () => {
-      vi.mocked(useDevices).mockReturnValue({
-        ...defaultHookState,
-        devices: [
-          makeDevice({ custom_fields: { env: "production", owner: "team-a" } }),
-        ],
-        totalCount: 1,
-      });
-      renderPage();
-      expect(screen.getByText("env")).toBeInTheDocument();
-      expect(screen.getByText("production")).toBeInTheDocument();
-      expect(screen.getByText("owner")).toBeInTheDocument();
-      expect(screen.getByText("team-a")).toBeInTheDocument();
-    });
-
-    it("renders multiple custom field badges for multiple fields", () => {
-      vi.mocked(useDevices).mockReturnValue({
-        ...defaultHookState,
-        devices: [makeDevice({ custom_fields: { a: "1", b: "2", c: "3" } })],
-        totalCount: 1,
-      });
-      renderPage();
-      expect(screen.getByText("a")).toBeInTheDocument();
-      expect(screen.getByText("1")).toBeInTheDocument();
-      expect(screen.getByText("b")).toBeInTheDocument();
-      expect(screen.getByText("2")).toBeInTheDocument();
-      expect(screen.getByText("c")).toBeInTheDocument();
-      expect(screen.getByText("3")).toBeInTheDocument();
     });
   });
 

--- a/ui-react/apps/console/src/pages/devices/index.tsx
+++ b/ui-react/apps/console/src/pages/devices/index.tsx
@@ -137,34 +137,6 @@ export default function Devices() {
         ),
       },
       {
-        key: "custom_fields",
-        header: "Custom Fields",
-        render: (device) => {
-          const entries = Object.entries(device.custom_fields ?? {});
-          if (entries.length === 0)
-            return (
-              <span className="text-2xs text-text-muted/30 font-mono">—</span>
-            );
-          return (
-            <div className="flex flex-wrap gap-1">
-              {entries.map(([k, v]) => (
-                <span
-                  key={k}
-                  className="inline-flex items-center text-2xs rounded overflow-hidden border border-border font-mono"
-                >
-                  <span className="px-1.5 py-0.5 bg-surface text-text-muted">
-                    {k}
-                  </span>
-                  <span className="px-1.5 py-0.5 bg-card text-text-primary font-medium">
-                    {v}
-                  </span>
-                </span>
-              ))}
-            </div>
-          );
-        },
-      },
-      {
         key: "last_seen",
         header: "Last Seen",
         render: (device) => <LastSeenCell value={device.last_seen} />,


### PR DESCRIPTION
## Summary
- Removes the "Custom Fields" column from the device listing on the React console.
- Affects all status tabs (accepted, pending, rejected) since they share `baseColumns`.