### PR TITLE
fix(ui-react): generate client from combined spec for npm run generate

### DIFF
--- a/ui-react/apps/console/openapi-ts.config.ts
+++ b/ui-react/apps/console/openapi-ts.config.ts
@@ -1,8 +1,16 @@
 import { defineConfig } from "@hey-api/openapi-ts";
 
+const input = process.env.OPENAPI_SPEC_PATH;
+if (!input) {
+  // The openapi container only serves the spec for the active edition, so
+  // generating from its URL produces a client missing the other editions'
+  // schemas. Use `npm run generate -w @shellhub/console`, which bundles the
+  // combined spec before invoking openapi-ts.
+  throw new Error("OPENAPI_SPEC_PATH is not set; run `npm run generate -w @shellhub/console`.");
+}
+
 export default defineConfig({
-  input:
-    process.env.OPENAPI_SPEC_PATH || "http://openapi:8080/openapi/openapi.json",
+  input,
   output: "src/client",
   plugins: [
     "@hey-api/typescript",

--- a/ui-react/apps/console/package.json
+++ b/ui-react/apps/console/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint src",
     "test": "vitest run",
     "test:watch": "vitest",
-    "generate": "openapi-ts"
+    "generate": "../../scripts/generate-client.sh"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.6.0",

--- a/ui-react/scripts/entrypoint-dev.sh
+++ b/ui-react/scripts/entrypoint-dev.sh
@@ -9,10 +9,12 @@ SCRIPTS_DIR="$(dirname "$(readlink -f "$0")")"
 mkdir -p apps/console/public
 "$SCRIPTS_DIR/gen-config.sh" apps/console/public/config.json
 
-# Generate OpenAPI client from the combined spec (all editions)
-echo "Bundling OpenAPI spec..."
-npx @redocly/cli@1.0.0-beta.100 bundle /openapi/spec/openapi.yaml -o /tmp/openapi.json --force
-echo "Generating OpenAPI client..."
-OPENAPI_SPEC_PATH=/tmp/openapi.json npx -w @shellhub/console openapi-ts
+# Generate the OpenAPI client from the combined spec, then keep regenerating
+# it whenever any spec file changes so Vite HMR picks up the new types
+# without needing to recreate the container.
+npm run generate -w @shellhub/console
+# chokidar-cli shells out to $SHELL, which isn't set in this alpine image.
+SHELL=/bin/sh npx -y chokidar-cli@3.0.0 '/openapi/spec/**/*.yaml' --debounce 500 \
+  -c 'npm run generate -w @shellhub/console' &
 
 npm run dev:console

--- a/ui-react/scripts/generate-client.sh
+++ b/ui-react/scripts/generate-client.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# Bundle the combined OpenAPI spec (all editions) and generate the typed
+# client. The Dockerfile builder stage sets OPENAPI_SPEC_PATH to a spec
+# it bundled in an earlier stage; skip the bundle step in that case.
+if [ -z "$OPENAPI_SPEC_PATH" ]; then
+  npx @redocly/cli@1.0.0-beta.100 bundle /openapi/spec/openapi.yaml -o /tmp/openapi.json --force
+  OPENAPI_SPEC_PATH=/tmp/openapi.json
+  export OPENAPI_SPEC_PATH
+fi
+
+cd "$(dirname "$0")/../apps/console"
+exec npx openapi-ts


### PR DESCRIPTION
Fixes #6386.

`npm run generate` for `@shellhub/console` defaulted its input to `http://openapi:8080/openapi/openapi.json`. That URL is served by the `openapi` container, which picks `community-openapi.yaml`, `enterprise-openapi.yaml`, or `cloud-openapi.yaml` based on `SHELLHUB_CLOUD` / `SHELLHUB_ENTERPRISE`. Running the script on a community instance produced a client missing the enterprise and cloud schemas, so any code referencing them broke lint and type-check.

The dev entrypoint avoided this by bundling `openapi/spec/openapi.yaml` (combined, all editions) directly, but a manual `npm run generate` after startup overwrote that client with the edition-filtered one. Easy footgun.

### What changes

- New `ui-react/scripts/generate-client.sh`: bundles `openapi/spec/openapi.yaml` via redocly into `/tmp/openapi.json` and runs `openapi-ts`. If `OPENAPI_SPEC_PATH` is already set (the production Dockerfile builder stage does this), it skips the bundle step and uses that spec.
- `apps/console/package.json`: `generate` now calls the script.
- `openapi-ts.config.ts`: throws if `OPENAPI_SPEC_PATH` is unset, with a message pointing at `npm run generate`. The old HTTP fallback was the bug source.
- `scripts/entrypoint-dev.sh`: replaces the inline bundle + generate with `npm run generate`, then starts a `chokidar-cli` watcher on `openapi/spec/**/*.yaml` in the background that re-runs the same script on changes. Vite HMR picks up the regenerated `types.gen.ts` without recreating the container.

The production Dockerfile is unchanged: its builder stage still bundles into `apps/console/openapi.json` and runs `OPENAPI_SPEC_PATH=./openapi.json npm run generate -w @shellhub/console`, which the new script honors.