### PR TITLE
fix(ui-react): encode list filters as UTF-8 base64

### DIFF
--- a/ui-react/apps/console/src/hooks/useAdminDevices.ts
+++ b/ui-react/apps/console/src/hooks/useAdminDevices.ts
@@ -13,6 +13,7 @@ import {
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
+import { toBase64Json } from "@/utils/encoding";
 
 export type NormalizedDevice = Omit<Device, "tags"> & { tags: string[] };
 
@@ -21,9 +22,9 @@ function normalizeDevice(device: Device): NormalizedDevice {
     ...device,
     tags: Array.isArray(device.tags)
       ? device.tags.map((t) => {
-        if (typeof t === "object" && t !== null && "name" in t) return t.name;
-        return String(t);
-      })
+          if (typeof t === "object" && t !== null && "name" in t) return t.name;
+          return String(t);
+        })
       : [],
   };
 }
@@ -35,7 +36,7 @@ function buildNameFilter(search: string): string {
       params: { name: "name", operator: "contains", value: search },
     },
   ];
-  return btoa(JSON.stringify(filter));
+  return toBase64Json(filter);
 }
 
 interface UseAdminDevicesParams {

--- a/ui-react/apps/console/src/hooks/useAdminNamespaces.ts
+++ b/ui-react/apps/console/src/hooks/useAdminNamespaces.ts
@@ -11,6 +11,7 @@ import {
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
+import { toBase64Json } from "@/utils/encoding";
 
 function buildNameFilter(search: string): string {
   const filter = [
@@ -19,7 +20,7 @@ function buildNameFilter(search: string): string {
       params: { name: "name", operator: "contains", value: search },
     },
   ];
-  return btoa(JSON.stringify(filter));
+  return toBase64Json(filter);
 }
 
 interface UseAdminNamespacesParams {

--- a/ui-react/apps/console/src/hooks/useAdminUsers.ts
+++ b/ui-react/apps/console/src/hooks/useAdminUsers.ts
@@ -11,6 +11,7 @@ import {
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
+import { toBase64Json } from "@/utils/encoding";
 
 function buildUsernameFilter(search: string): string {
   const filter = [
@@ -19,7 +20,7 @@ function buildUsernameFilter(search: string): string {
       params: { name: "username", operator: "contains", value: search },
     },
   ];
-  return btoa(JSON.stringify(filter));
+  return toBase64Json(filter);
 }
 
 interface UseAdminUsersParams {

--- a/ui-react/apps/console/src/hooks/useContainers.ts
+++ b/ui-react/apps/console/src/hooks/useContainers.ts
@@ -7,6 +7,7 @@ import {
 import type { Device, DeviceStatus } from "../client";
 import { getContainersQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
+import { toBase64Json } from "@/utils/encoding";
 
 export type NormalizedContainer = Omit<Device, "tags"> & { tags: string[] };
 
@@ -24,7 +25,7 @@ function buildFilter(search: string, tags: string[]): string {
       params: { name: "tags.name", operator: "contains", value: tags },
     });
   }
-  return btoa(JSON.stringify(filters));
+  return toBase64Json(filters);
 }
 
 export function normalizeContainer(container: Device): NormalizedContainer {

--- a/ui-react/apps/console/src/hooks/useDevices.ts
+++ b/ui-react/apps/console/src/hooks/useDevices.ts
@@ -8,6 +8,7 @@ import {
 import { getDevicesQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import type { Device as GeneratedDevice } from "../client";
+import { toBase64Json } from "@/utils/encoding";
 
 export type NormalizedDevice = Omit<GeneratedDevice, "tags"> & {
   tags: string[];
@@ -35,7 +36,7 @@ export function buildFilter(search: string, tags: string[]): string {
       params: { name: "tags.name", operator: "contains", value: tags },
     });
   }
-  return btoa(JSON.stringify(filters));
+  return toBase64Json(filters);
 }
 
 export function normalizeDevice(device: GeneratedDevice): NormalizedDevice {

--- a/ui-react/apps/console/src/hooks/usePublicKeys.ts
+++ b/ui-react/apps/console/src/hooks/usePublicKeys.ts
@@ -7,6 +7,7 @@ import {
 } from "../client";
 import { getPublicKeysQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
+import { toBase64Json } from "@/utils/encoding";
 
 export function buildPublicKeyFilter(search: string): string {
   const filters = [
@@ -21,7 +22,7 @@ export function buildPublicKeyFilter(search: string): string {
       params: { name: "fingerprint", operator: "contains", value: search },
     },
   ];
-  return btoa(JSON.stringify(filters));
+  return toBase64Json(filters);
 }
 
 interface UsePublicKeysParams {

--- a/ui-react/apps/console/src/hooks/useWebEndpoints.ts
+++ b/ui-react/apps/console/src/hooks/useWebEndpoints.ts
@@ -6,6 +6,7 @@ import {
 } from "../client";
 import { listWebEndpointsQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
+import { toBase64Json } from "@/utils/encoding";
 
 interface UseWebEndpointsParams {
   page?: number;
@@ -24,7 +25,7 @@ function encodeAddressFilter(value: string): string {
       params: { name: "address", operator: "contains", value },
     },
   ];
-  return btoa(JSON.stringify(clauses));
+  return toBase64Json(clauses);
 }
 
 export function useWebEndpoints({

--- a/ui-react/apps/console/src/utils/__tests__/encoding.test.ts
+++ b/ui-react/apps/console/src/utils/__tests__/encoding.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { toBase64Json } from "@/utils/encoding";
+
+describe("toBase64Json", () => {
+  it("matches btoa(JSON.stringify(...)) for ASCII payloads", () => {
+    // Backward-compat guard: the BE decoder only sees the bytes, so an ASCII
+    // payload must produce the exact same string the old `btoa` path produced.
+    const value = [
+      {
+        type: "property",
+        params: { name: "name", operator: "contains", value: "qa-edge" },
+      },
+    ];
+    expect(toBase64Json(value)).toBe(btoa(JSON.stringify(value)));
+  });
+
+  it("does not throw on non-Latin-1 characters", () => {
+    const value = [
+      {
+        type: "property",
+        params: {
+          name: "tags.name",
+          operator: "contains",
+          value: "日本語タグ",
+        },
+      },
+    ];
+    expect(() => toBase64Json(value)).not.toThrow();
+  });
+
+  it("round-trips Unicode through base64 → UTF-8 → JSON", () => {
+    const value = { tag: "日本語タグ", emoji: "🚀", arabic: "سلام" };
+    const encoded = toBase64Json(value);
+    const decoded = JSON.parse(
+      Buffer.from(encoded, "base64").toString("utf-8"),
+    ) as typeof value;
+    expect(decoded).toEqual(value);
+  });
+
+  it("produces stable output for the same input (used as a cache key)", () => {
+    const value = [
+      { type: "property", params: { name: "x", operator: "eq", value: 1 } },
+    ];
+    expect(toBase64Json(value)).toBe(toBase64Json(value));
+  });
+});

--- a/ui-react/apps/console/src/utils/encoding.ts
+++ b/ui-react/apps/console/src/utils/encoding.ts
@@ -1,0 +1,8 @@
+import { Buffer } from "buffer";
+
+// `btoa(JSON.stringify(value))` throws InvalidCharacterError for any character
+// above U+00FF (e.g. tag names, hostnames, usernames in non-Latin scripts),
+// so the request never leaves the browser. UTF-8-encode first, then base64.
+export function toBase64Json(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf-8").toString("base64");
+}

--- a/ui-react/apps/console/src/utils/invitations.ts
+++ b/ui-react/apps/console/src/utils/invitations.ts
@@ -1,4 +1,5 @@
 import type { MembershipInvitation } from "@/client";
+import { toBase64Json } from "@/utils/encoding";
 
 export type InvitationStatus = MembershipInvitation["status"];
 
@@ -13,7 +14,7 @@ export function invitationStatusFilter(status: InvitationStatus): string {
       params: { name: "status", operator: "eq", value: status },
     },
   ];
-  return btoa(JSON.stringify(filter));
+  return toBase64Json(filter);
 }
 
 export function isInvitationExpired(expiresAt: string | null): boolean {


### PR DESCRIPTION
## What

The filter encoder used on every list page (`btoa(JSON.stringify(...))`) throws `InvalidCharacterError` for any value containing characters above U+00FF, blocking searches and tag filters that include non-Latin-1 text. Replaced the inline encoder with a shared helper that goes through UTF-8 bytes first.

## Why

Reproduced while stress-testing the Enterprise RC: filtering devices by a tag named `日本語タグ`, or searching for a hostname containing Japanese characters, never sends the request — the browser throws at encode time and the UI looks broken even though the backend is fine. Affects every list page that builds a filter URL: namespace devices, admin devices, admin users, admin namespaces, public keys, containers, web endpoints, invitations.

## Changes

- **`utils/encoding.ts`**: new `toBase64Json(value: unknown): string` helper using `Buffer.from(JSON.stringify(value), "utf-8").toString("base64")`. `Buffer` is already polyfilled in the bundle via `vite-plugin-node-polyfills` and used elsewhere for byte-level work (`ssh-keys.ts`, `TerminalInstance.tsx`), so no new dependency surface.
- **8 filter call sites**: swapped `btoa(JSON.stringify(x))` for `toBase64Json(x)`. ASCII payloads serialize to the exact same bytes the old code produced, so the backend decoder (`base64.StdEncoding.DecodeString` then `json.Unmarshal` at `pkg/api/query/filter.go:39`) is unchanged.
- **Test coverage**: ASCII round-trip pinned byte-for-byte against the legacy `btoa` output to lock in backward compatibility; Unicode round-trip guards the bug from regressing.

## Testing

Reproducer needs non-Latin-1 data in the DB — any tag/device/namespace/user with characters above U+00FF.

- Without the fix: dev tools shows `InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range`, and the request never leaves the browser.
- With the fix: the list loads; the `filter` query param decodes (via `atob` then `JSON.parse`) to the expected clauses.
- Regression check: existing ASCII filters produce the same network payload as before — `toBase64Json(x) === btoa(JSON.stringify(x))` for ASCII input, locked by the unit test.

Pages to exercise: namespace devices, admin devices, admin users, admin namespaces, public keys, containers, web endpoints, invitations.