### PR TITLE
fix(api): block API keys on account-level routes

### DIFF
--- a/api/routes/api-key_test.go
+++ b/api/routes/api-key_test.go
@@ -289,6 +289,21 @@ func TestListAPIKey(t *testing.T) {
 		expected      Expected
 	}{
 		{
+			description: "fails with api key",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-API-KEY":    "b2f7cc0e-d933-4aad-9ab2-b557f2f2554f",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       "owner",
+			},
+			query: func() string {
+				return ""
+			},
+			requiredMocks: func() {
+			},
+			expected: Expected{body: nil, status: http.StatusForbidden},
+		},
+		{
 			description: "success",
 			headers: map[string]string{
 				"Content-Type": "application/json",

--- a/api/routes/nsadm_test.go
+++ b/api/routes/nsadm_test.go
@@ -514,6 +514,16 @@ func TestHandler_LeaveNamespace(t *testing.T) {
 		expected      int
 	}{
 		{
+			description: "fails with api key",
+			tenantID:    "00000000-0000-4000-0000-000000000000",
+			headers: map[string]string{
+				"X-API-KEY":   "b2f7cc0e-d933-4aad-9ab2-b557f2f2554f",
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+			},
+			requiredMocks: func() {},
+			expected:      http.StatusForbidden,
+		},
+		{
 			description: "fails to leave the namespace",
 			tenantID:    "00000000-0000-4000-0000-000000000000",
 			headers: map[string]string{
@@ -673,29 +683,31 @@ func TestNamespaceCrossTenantAccess(t *testing.T) {
 	}
 }
 
-// TestListNamespacesAPIKeyScope ensures a caller without a user ID (API key
-// path) cannot enumerate namespaces across tenants: the list is scoped to the
-// caller's own tenant. Covers the regression described in GHSA-vwx9-7qcf-gg7f.
-func TestListNamespacesAPIKeyScope(t *testing.T) {
-	const callerTenant = "00000000-0000-4000-0000-000000000000"
-
+func TestGetNamespaceListBlocksAPIKey(t *testing.T) {
 	mock := new(mocks.Service)
-	scopedNS := &models.Namespace{TenantID: callerTenant, Name: "dev"}
-	mock.
-		On("ListNamespaces", gomock.Anything, gomock.MatchedBy(func(req *requests.NamespaceList) bool {
-			return req.UserID == "" && req.TenantID == callerTenant && !req.IsAdmin
-		})).
-		Return([]models.Namespace{*scopedNS}, 1, nil).
-		Once()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/namespaces", nil)
-	req.Header.Set("X-Role", authorizer.RoleOwner.String())
-	req.Header.Set("X-Tenant-ID", callerTenant)
-	// No X-ID set: this simulates an API key caller.
+	req.Header.Set("X-API-KEY", "b2f7cc0e-d933-4aad-9ab2-b557f2f2554f")
+	req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
 
 	rec := httptest.NewRecorder()
 	NewRouter(mock).ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	assert.Equal(t, http.StatusForbidden, rec.Result().StatusCode)
+	mock.AssertExpectations(t)
+}
+
+func TestCreateNamespaceBlocksAPIKey(t *testing.T) {
+	mock := new(mocks.Service)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/namespaces", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-KEY", "b2f7cc0e-d933-4aad-9ab2-b557f2f2554f")
+	req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
+
+	rec := httptest.NewRecorder()
+	NewRouter(mock).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Result().StatusCode)
 	mock.AssertExpectations(t)
 }

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -133,7 +133,7 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	publicAPI.POST(AuthPublicKeyURL, gateway.Handler(handler.AuthPublicKey))
 
 	publicAPI.POST(CreateAPIKeyURL, gateway.Handler(handler.CreateAPIKey), routesmiddleware.BlockAPIKey, routesmiddleware.RequiresPermission(authorizer.APIKeyCreate))
-	publicAPI.GET(ListAPIKeysURL, gateway.Handler(handler.ListAPIKeys))
+	publicAPI.GET(ListAPIKeysURL, gateway.Handler(handler.ListAPIKeys), routesmiddleware.BlockAPIKey)
 	publicAPI.PATCH(UpdateAPIKeyURL, gateway.Handler(handler.UpdateAPIKey), routesmiddleware.BlockAPIKey, routesmiddleware.RequiresPermission(authorizer.APIKeyUpdate))
 	publicAPI.DELETE(DeleteAPIKeyURL, gateway.Handler(handler.DeleteAPIKey), routesmiddleware.BlockAPIKey, routesmiddleware.RequiresPermission(authorizer.APIKeyDelete))
 
@@ -178,16 +178,16 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	publicAPI.PUT(UpdatePublicKeyURL, gateway.Handler(handler.UpdatePublicKey), routesmiddleware.DecodeParam(ParamPublicKeyFingerprint), routesmiddleware.RequiresPermission(authorizer.PublicKeyEdit))
 	publicAPI.DELETE(DeletePublicKeyURL, gateway.Handler(handler.DeletePublicKey), routesmiddleware.DecodeParam(ParamPublicKeyFingerprint), routesmiddleware.RequiresPermission(authorizer.PublicKeyRemove))
 
-	publicAPI.POST(CreateNamespaceURL, gateway.Handler(handler.CreateNamespace))
+	publicAPI.POST(CreateNamespaceURL, gateway.Handler(handler.CreateNamespace), routesmiddleware.BlockAPIKey)
 	publicAPI.GET(GetNamespaceURL, gateway.Handler(handler.GetNamespace), routesmiddleware.RequiresTenant(ParamNamespaceTenant))
-	publicAPI.GET(ListNamespaceURL, gateway.Handler(handler.GetNamespaceList))
+	publicAPI.GET(ListNamespaceURL, gateway.Handler(handler.GetNamespaceList), routesmiddleware.BlockAPIKey)
 	publicAPI.PUT(EditNamespaceURL, gateway.Handler(handler.EditNamespace), routesmiddleware.RequiresTenant(ParamNamespaceTenant), routesmiddleware.RequiresPermission(authorizer.NamespaceUpdate))
 	publicAPI.DELETE(DeleteNamespaceURL, gateway.Handler(handler.DeleteNamespace), routesmiddleware.RequiresTenant(ParamNamespaceTenant), routesmiddleware.RequiresPermission(authorizer.NamespaceDelete))
 
 	publicAPI.POST(AddNamespaceMemberURL, gateway.Handler(handler.AddNamespaceMember), routesmiddleware.RequiresPermission(authorizer.NamespaceAddMember))
 	publicAPI.PATCH(EditNamespaceMemberURL, gateway.Handler(handler.EditNamespaceMember), routesmiddleware.RequiresPermission(authorizer.NamespaceEditMember))
 	publicAPI.DELETE(RemoveNamespaceMemberURL, gateway.Handler(handler.RemoveNamespaceMember), routesmiddleware.RequiresPermission(authorizer.NamespaceRemoveMember))
-	publicAPI.DELETE(LeaveNamespaceURL, gateway.Handler(handler.LeaveNamespace))
+	publicAPI.DELETE(LeaveNamespaceURL, gateway.Handler(handler.LeaveNamespace), routesmiddleware.BlockAPIKey)
 
 	publicAPI.GET(GetSessionRecordURL, gateway.Handler(handler.GetSessionRecord))
 	publicAPI.PUT(EditSessionRecordStatusURL, gateway.Handler(handler.EditSessionRecordStatus), routesmiddleware.RequiresTenant(ParamNamespaceTenant), routesmiddleware.RequiresPermission(authorizer.NamespaceEnableSessionRecord))

--- a/openapi/spec/paths/api@namespaces.yaml
+++ b/openapi/spec/paths/api@namespaces.yaml
@@ -1,6 +1,5 @@
 get:
   operationId: getNamespaces
-  x-internal: true
   summary: Get namespaces list
   description: Returns a list of namespaces.
   tags:
@@ -8,7 +7,6 @@ get:
     - namespaces
   security:
     - jwt: []
-    - api-key: []
   parameters:
     - name: filter
       description: |
@@ -62,7 +60,6 @@ get:
       $ref: ../components/responses/500.yaml
 post:
   operationId: createNamespace
-  x-internal: true
   summary: Create namespace
   description: Create a namespace.
   tags:
@@ -70,7 +67,6 @@ post:
     - namespaces
   security:
     - jwt: []
-    - api-key: []
   requestBody:
     content:
       application/json:

--- a/openapi/spec/paths/api@namespaces@api-key.yaml
+++ b/openapi/spec/paths/api@namespaces@api-key.yaml
@@ -34,7 +34,6 @@ post:
       $ref: ../components/responses/500.yaml
 get:
   operationId: apiKeyList
-  x-internal: true
   summary: List API Keys
   tags:
     - api-keys
@@ -42,7 +41,6 @@ get:
     - namespaces
   security:
     - jwt: []
-    - api-key: []
   parameters:
     - $ref: ../components/parameters/query/pageQuery.yaml
     - $ref: ../components/parameters/query/perPageQuery.yaml

--- a/openapi/spec/paths/api@namespaces@{tenant}@members.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@members.yaml
@@ -1,6 +1,5 @@
 delete:
   operationId: leaveNamespace
-  x-internal: true
   summary: Leave Namespace
   description: |
     Allows the authenticated user to leave the specified namespace. Owners
@@ -13,7 +12,6 @@ delete:
     - namespaces
   security:
     - jwt: []
-    - api-key: []
   parameters:
     - $ref: ../components/parameters/path/namespaceTenantIDPath.yaml
   responses:


### PR DESCRIPTION
## What

Added `BlockAPIKey` middleware to four routes that were missing it:
`ListAPIKeys`, `GetNamespaceList`, `CreateNamespace`, and
`LeaveNamespace`. Removed the `x-internal` overrides and `api-key`
security entries from the OpenAPI spec for the same operations.

## Why

API keys are namespace-scoped and not tied to a user. These routes
are account-level actions that should never accept an API key.
`ListAPIKeys` was the real gap -- it actually succeeded, allowing an
API key to enumerate all other keys in the namespace. The other three
were safe by accident (the service layer rejected them) but returned
confusing 404s instead of a clean 403.

Closes #6390. Follow-up to #6392 .

## Testing

1. Start the environment with `./bin/docker-compose up`
2. Create a user and namespace via the CLI or UI
3. Generate an API key via curl:

```
curl -X POST http://localhost/api/namespaces/api-key \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-Tenant-ID: <tenant-id>" \
  -d '{"name": "testkey", "expires_at": 30}'
```

4. Use the returned key -- all four requests below should return 403:

`curl -v -H "X-API-Key: <key>" http://localhost/api/namespaces/api-key`
`curl -v -H "X-API-Key: <key>" http://localhost/api/namespaces`
`curl -v -H "X-API-Key: <key>" -X POST http://localhost/api/namespaces`
`curl -v -H "X-API-Key: <key>" -X DELETE http://localhost/api/namespaces/<tenant>/members`