### PR TITLE
fix(ui-react): cap namespace selector list height to prevent overflow

### DIFF
--- a/ui-react/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui-react/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -143,7 +143,7 @@ export default function NamespaceSelector({
 
           {/* Namespace list */}
           {availableNamespaces.length > 0 && (
-            <div className="p-2">
+            <div className="p-2 overflow-y-auto max-h-72">
               <p className="px-2 py-1.5 text-2xs font-mono font-semibold uppercase tracking-label text-text-muted">
                 {isAdminContext ? "Available Namespaces" : "Switch Namespace"}
               </p>


### PR DESCRIPTION
## What
The namespace selector dropdown now caps its namespace list at a fixed height and scrolls internally instead of growing unbounded.

## Why
With a large number of namespaces, the list grew taller than the viewport, pushing the dropdown past the body height and breaking the page layout.

## Changes
- **NamespaceSelector**: added `max-h-72 overflow-y-auto` to the namespace list container so only the list scrolls while the active-namespace header and the Create/Admin footers stay pinned. This matches the existing scroll pattern used by `InvitationsMenu` (`max-h-[360px] overflow-y-auto`) and `PendingDevices` (`max-h-[280px] overflow-y-auto`).

## Testing
Open the selector in an account with enough namespaces to exceed `~5` rows and confirm the list scrolls within the dropdown, the header and footer stay fixed, and the dropdown no longer overflows the viewport.