### PR TITLE
refactor(api): route MCP tools through API middleware in-process

### DIFF
--- a/api/routes/mcp.go
+++ b/api/routes/mcp.go
@@ -1,32 +1,45 @@
 package routes
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
-	"github.com/shellhub-io/shellhub/api/services"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
-	"github.com/shellhub-io/shellhub/pkg/api/query"
-	"github.com/shellhub-io/shellhub/pkg/api/requests"
-	"github.com/shellhub-io/shellhub/pkg/errors"
-	"github.com/shellhub-io/shellhub/pkg/models"
 )
 
 type mcpContextKey string
 
 const (
 	mcpKeyTenantID mcpContextKey = "mcp_tenant_id"
-	mcpKeyRole     mcpContextKey = "mcp_role"
+	mcpKeyHeaders  mcpContextKey = "mcp_headers"
 )
 
+// mcpAuthHeaders are the headers the API gateway injects to identify an API-key
+// caller. They are captured from the incoming /mcp request and replayed on the
+// in-process API calls the tools make, so the same authentication and
+// authorization the gateway performed for the MCP request flows through to the
+// REST middleware (BlockAPIKey, RequiresPermission, RequiresTenant). MCP auth
+// is API-key-only, so the user-identity headers (X-ID, X-Admin, X-Username)
+// never apply and are intentionally omitted.
+var mcpAuthHeaders = []string{
+	"X-Tenant-ID",
+	"X-Role",
+	"X-Api-Key",
+}
+
 // SetupMCPRoutes mounts the MCP Streamable HTTP server at /mcp.
-func SetupMCPRoutes(router *echo.Echo, service services.Service) {
-	s := buildMCPServer(service)
+func SetupMCPRoutes(router *echo.Echo) {
+	s := buildMCPServer(router)
 
 	httpCtxFn := func(ctx context.Context, r *http.Request) context.Context {
 		tenantID := r.Header.Get("X-Tenant-ID")
@@ -37,12 +50,16 @@ func SetupMCPRoutes(router *echo.Echo, service services.Service) {
 		}
 
 		ctx = context.WithValue(ctx, mcpKeyTenantID, tenantID)
-		ctx = context.WithValue(ctx, mcpKeyRole, role)
 
-		// Mirror tenant into the key gateway.TenantFromContext looks up so
-		// service methods (GetDevice, GetSession, …) automatically scope
-		// queries to this namespace.
-		ctx = context.WithValue(ctx, "tenant", tenantID) //nolint:staticcheck // SA1029: matches gateway.TenantFromContext key
+		// Capture the gateway-injected auth headers so tools can replay them
+		// on in-process API calls and inherit the REST middleware.
+		headers := http.Header{}
+		for _, key := range mcpAuthHeaders {
+			if value := r.Header.Get(key); value != "" {
+				headers.Set(key, value)
+			}
+		}
+		ctx = context.WithValue(ctx, mcpKeyHeaders, headers)
 
 		return ctx
 	}
@@ -55,47 +72,99 @@ func SetupMCPRoutes(router *echo.Echo, service services.Service) {
 	router.Any("/mcp/*", echo.WrapHandler(streamable))
 }
 
-func buildMCPServer(svc services.Service) *mcpserver.MCPServer {
+func buildMCPServer(router http.Handler) *mcpserver.MCPServer {
 	s := mcpserver.NewMCPServer("shellhub", "1.0.0",
 		mcpserver.WithToolCapabilities(true),
 	)
 
-	addDeviceTools(s, svc)
-	addSessionTools(s, svc)
-	addNamespaceTools(s, svc)
+	addDeviceTools(s, router)
+	addSessionTools(s, router)
+	addNamespaceTools(s, router)
 
 	return s
 }
 
 // --- helpers ---
 
-func mcpForbidden() *mcp.CallToolResult {
-	return mcp.NewToolResultError("forbidden: insufficient permissions")
+// mcpAPICall replays the caller's request against the API's own Echo router
+// in-process, so the full middleware chain (BlockAPIKey, RequiresPermission,
+// RequiresTenant) runs exactly as it would for a REST caller. The MCP server
+// is an in-binary client of the API, not a shortcut past it -- no network hop,
+// but the same authorization path. body may be nil.
+func mcpAPICall(ctx context.Context, router http.Handler, method, target string, body io.Reader) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, target, body)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	if headers, ok := ctx.Value(mcpKeyHeaders).(http.Header); ok {
+		for key, values := range headers {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	return rec
 }
 
-// mcpServiceError maps known service errors to fixed user-facing messages,
-// hiding internal store details from MCP clients.
-func mcpServiceError(err error) *mcp.CallToolResult {
-	switch {
-	case errors.Is(err, services.ErrDeviceNotFound):
-		return mcp.NewToolResultError("device not found")
-	case errors.Is(err, services.ErrSessionNotFound):
-		return mcp.NewToolResultError("session not found")
-	case errors.Is(err, services.ErrNamespaceNotFound):
-		return mcp.NewToolResultError("namespace not found")
+// mcpAPIResult turns an in-process API response into a tool result: a 2xx
+// forwards the JSON body verbatim, anything else maps the status code to a
+// fixed message so internal store details never leak to MCP clients.
+func mcpAPIResult(rec *httptest.ResponseRecorder) *mcp.CallToolResult {
+	if rec.Code >= http.StatusOK && rec.Code < http.StatusMultipleChoices {
+		return mcp.NewToolResultText(rec.Body.String())
+	}
+
+	switch rec.Code {
+	case http.StatusUnauthorized:
+		return mcpUnauth()
+	case http.StatusForbidden:
+		return mcpForbidden()
+	case http.StatusNotFound:
+		return mcp.NewToolResultError("not found")
 	default:
 		return mcp.NewToolResultError("internal error")
 	}
 }
 
-func mcpUnauth() *mcp.CallToolResult {
-	return mcp.NewToolResultError("unauthorized: missing or invalid token")
+// mcpAPIListResult wraps a paginated list response as {total, <key>: [...]},
+// reading the count from the X-Total-Count header the list handlers set and
+// forwarding the body array verbatim. Non-2xx responses fall back to the
+// shared error mapping.
+func mcpAPIListResult(rec *httptest.ResponseRecorder, key string) *mcp.CallToolResult {
+	if rec.Code < http.StatusOK || rec.Code >= http.StatusMultipleChoices {
+		return mcpAPIResult(rec)
+	}
+
+	total, _ := strconv.Atoi(rec.Header().Get("X-Total-Count"))
+
+	return mcp.NewToolResultText(toJSON(map[string]any{
+		"total": total,
+		key:     json.RawMessage(rec.Body.Bytes()),
+	}))
 }
 
-func roleFromCtx(ctx context.Context) (authorizer.Role, bool) {
-	r, ok := ctx.Value(mcpKeyRole).(authorizer.Role)
+// mcpAPIOK returns a fixed success message for write operations whose REST
+// response body isn't useful to forward. Non-2xx responses fall back to the
+// shared error mapping.
+func mcpAPIOK(rec *httptest.ResponseRecorder, msg string) *mcp.CallToolResult {
+	if rec.Code >= http.StatusOK && rec.Code < http.StatusMultipleChoices {
+		return mcp.NewToolResultText(msg)
+	}
 
-	return r, ok
+	return mcpAPIResult(rec)
+}
+
+func mcpForbidden() *mcp.CallToolResult {
+	return mcp.NewToolResultError("forbidden: insufficient permissions")
+}
+
+func mcpUnauth() *mcp.CallToolResult {
+	return mcp.NewToolResultError("unauthorized: missing or invalid token")
 }
 
 func tenantFromCtx(ctx context.Context) string {
@@ -121,7 +190,7 @@ func toJSON(v any) string {
 
 // --- Device tools ---
 
-func addDeviceTools(s *mcpserver.MCPServer, svc services.Service) {
+func addDeviceTools(s *mcpserver.MCPServer, router http.Handler) {
 	s.AddTool(
 		mcp.NewTool("shellhub_list_devices",
 			mcp.WithDescription("List devices in the ShellHub namespace. Filter by status and paginate results."),
@@ -130,35 +199,18 @@ func addDeviceTools(s *mcpserver.MCPServer, svc services.Service) {
 			mcp.WithInteger("per_page", mcp.Description("Results per page (max 100). Default: 20.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			role, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-			if !role.HasPermission(authorizer.DeviceDetails) {
-				return mcpForbidden(), nil
-			}
-
 			args := req.GetArguments()
-			status, _ := args["status"].(string)
-			page := intArg(args, "page", 1)
-			perPage := intArg(args, "per_page", 20)
 
-			r := &requests.DeviceList{
-				TenantID:     tenantFromCtx(ctx),
-				DeviceStatus: models.DeviceStatus(status),
-				Paginator:    query.Paginator{Page: page, PerPage: perPage},
+			q := url.Values{}
+			if status, _ := args["status"].(string); status != "" {
+				q.Set("status", status)
 			}
-			r.Paginator.Normalize()
+			q.Set("page", strconv.Itoa(intArg(args, "page", 1)))
+			q.Set("per_page", strconv.Itoa(intArg(args, "per_page", 20)))
 
-			devices, count, err := svc.ListDevices(ctx, r)
-			if err != nil {
-				return mcpServiceError(err), nil
-			}
+			rec := mcpAPICall(ctx, router, http.MethodGet, "/api/devices?"+q.Encode(), nil)
 
-			return mcp.NewToolResultText(toJSON(map[string]any{
-				"total":   count,
-				"devices": devices,
-			})), nil
+			return mcpAPIListResult(rec, "devices"), nil
 		},
 	)
 
@@ -168,22 +220,11 @@ func addDeviceTools(s *mcpserver.MCPServer, svc services.Service) {
 			mcp.WithString("uid", mcp.Required(), mcp.Description("Device UID.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			role, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-			if !role.HasPermission(authorizer.DeviceDetails) {
-				return mcpForbidden(), nil
-			}
+			uid, _ := req.GetArguments()["uid"].(string)
 
-			args := req.GetArguments()
-			uid, _ := args["uid"].(string)
-			device, err := svc.GetDevice(ctx, models.UID(uid))
-			if err != nil {
-				return mcpServiceError(err), nil
-			}
+			rec := mcpAPICall(ctx, router, http.MethodGet, "/api/devices/"+url.PathEscape(uid), nil)
 
-			return mcp.NewToolResultText(toJSON(device)), nil
+			return mcpAPIResult(rec), nil
 		},
 	)
 
@@ -194,39 +235,20 @@ func addDeviceTools(s *mcpserver.MCPServer, svc services.Service) {
 			mcp.WithString("status", mcp.Required(), mcp.Description("New status: accepted or rejected.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			role, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-
 			args := req.GetArguments()
 			uid, _ := args["uid"].(string)
 			status, _ := args["status"].(string)
 
-			switch status {
-			case "accepted":
-				if !role.HasPermission(authorizer.DeviceAccept) {
-					return mcpForbidden(), nil
-				}
-			case "rejected":
-				if !role.HasPermission(authorizer.DeviceReject) {
-					return mcpForbidden(), nil
-				}
-			default:
+			// The REST route expects the legacy short form in the path param.
+			pathStatus := map[string]string{"accepted": "accept", "rejected": "reject"}[status]
+			if pathStatus == "" {
 				return mcp.NewToolResultError("status must be 'accepted' or 'rejected'"), nil
 			}
 
-			r := &requests.DeviceUpdateStatus{
-				TenantID: tenantFromCtx(ctx),
-				UID:      uid,
-				Status:   status,
-			}
+			rec := mcpAPICall(ctx, router, http.MethodPatch,
+				"/api/devices/"+url.PathEscape(uid)+"/"+pathStatus, nil)
 
-			if err := svc.UpdateDeviceStatus(ctx, r); err != nil {
-				return mcpServiceError(err), nil
-			}
-
-			return mcp.NewToolResultText(fmt.Sprintf("device %s status updated to %s", uid, status)), nil
+			return mcpAPIOK(rec, fmt.Sprintf("device %s status updated to %s", uid, status)), nil
 		},
 	)
 
@@ -236,23 +258,11 @@ func addDeviceTools(s *mcpserver.MCPServer, svc services.Service) {
 			mcp.WithString("uid", mcp.Required(), mcp.Description("Device UID.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			role, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-			if !role.HasPermission(authorizer.DeviceRemove) {
-				return mcpForbidden(), nil
-			}
+			uid, _ := req.GetArguments()["uid"].(string)
 
-			args := req.GetArguments()
-			uid, _ := args["uid"].(string)
-			tenant := tenantFromCtx(ctx)
+			rec := mcpAPICall(ctx, router, http.MethodDelete, "/api/devices/"+url.PathEscape(uid), nil)
 
-			if err := svc.DeleteDevice(ctx, models.UID(uid), tenant); err != nil {
-				return mcpServiceError(err), nil
-			}
-
-			return mcp.NewToolResultText(fmt.Sprintf("device %s deleted", uid)), nil
+			return mcpAPIOK(rec, fmt.Sprintf("device %s deleted", uid)), nil
 		},
 	)
 
@@ -263,24 +273,15 @@ func addDeviceTools(s *mcpserver.MCPServer, svc services.Service) {
 			mcp.WithString("name", mcp.Required(), mcp.Description("New device name (hostname format).")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			role, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-			if !role.HasPermission(authorizer.DeviceRename) {
-				return mcpForbidden(), nil
-			}
-
 			args := req.GetArguments()
 			uid, _ := args["uid"].(string)
 			name, _ := args["name"].(string)
-			tenant := tenantFromCtx(ctx)
 
-			if err := svc.RenameDevice(ctx, models.UID(uid), name, tenant); err != nil {
-				return mcpServiceError(err), nil
-			}
+			body, _ := json.Marshal(map[string]string{"name": name})
+			rec := mcpAPICall(ctx, router, http.MethodPatch,
+				"/api/devices/"+url.PathEscape(uid), bytes.NewReader(body))
 
-			return mcp.NewToolResultText(fmt.Sprintf("device %s renamed to %s", uid, name)), nil
+			return mcpAPIOK(rec, fmt.Sprintf("device %s renamed to %s", uid, name)), nil
 		},
 	)
 
@@ -289,30 +290,16 @@ func addDeviceTools(s *mcpserver.MCPServer, svc services.Service) {
 			mcp.WithDescription("Get ShellHub instance statistics: registered/online/pending/rejected devices and active sessions."),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			_, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
+			rec := mcpAPICall(ctx, router, http.MethodGet, "/api/stats", nil)
 
-			tenant := tenantFromCtx(ctx)
-			if tenant == "" {
-				return mcpForbidden(), nil
-			}
-
-			r := &requests.GetStats{TenantID: tenant}
-			stats, err := svc.GetStats(ctx, r)
-			if err != nil {
-				return mcpServiceError(err), nil
-			}
-
-			return mcp.NewToolResultText(toJSON(stats)), nil
+			return mcpAPIResult(rec), nil
 		},
 	)
 }
 
 // --- Session tools ---
 
-func addSessionTools(s *mcpserver.MCPServer, svc services.Service) {
+func addSessionTools(s *mcpserver.MCPServer, router http.Handler) {
 	s.AddTool(
 		mcp.NewTool("shellhub_list_sessions",
 			mcp.WithDescription("List SSH sessions in the namespace. Returns active and historical sessions."),
@@ -320,33 +307,15 @@ func addSessionTools(s *mcpserver.MCPServer, svc services.Service) {
 			mcp.WithInteger("per_page", mcp.Description("Results per page (max 100). Default: 20.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			role, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-			if !role.HasPermission(authorizer.SessionDetails) {
-				return mcpForbidden(), nil
-			}
-
 			args := req.GetArguments()
-			page := intArg(args, "page", 1)
-			perPage := intArg(args, "per_page", 20)
 
-			r := &requests.ListSessions{
-				TenantID:  tenantFromCtx(ctx),
-				Paginator: query.Paginator{Page: page, PerPage: perPage},
-			}
-			r.Paginator.Normalize()
+			q := url.Values{}
+			q.Set("page", strconv.Itoa(intArg(args, "page", 1)))
+			q.Set("per_page", strconv.Itoa(intArg(args, "per_page", 20)))
 
-			sessions, count, err := svc.ListSessions(ctx, r)
-			if err != nil {
-				return mcpServiceError(err), nil
-			}
+			rec := mcpAPICall(ctx, router, http.MethodGet, "/api/sessions?"+q.Encode(), nil)
 
-			return mcp.NewToolResultText(toJSON(map[string]any{
-				"total":    count,
-				"sessions": sessions,
-			})), nil
+			return mcpAPIListResult(rec, "sessions"), nil
 		},
 	)
 
@@ -356,89 +325,39 @@ func addSessionTools(s *mcpserver.MCPServer, svc services.Service) {
 			mcp.WithString("uid", mcp.Required(), mcp.Description("Session UID.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			role, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-			if !role.HasPermission(authorizer.SessionDetails) {
-				return mcpForbidden(), nil
-			}
+			uid, _ := req.GetArguments()["uid"].(string)
 
-			args := req.GetArguments()
-			uid, _ := args["uid"].(string)
-			session, err := svc.GetSession(ctx, models.UID(uid))
-			if err != nil {
-				return mcpServiceError(err), nil
-			}
+			rec := mcpAPICall(ctx, router, http.MethodGet, "/api/sessions/"+url.PathEscape(uid), nil)
 
-			return mcp.NewToolResultText(toJSON(session)), nil
+			return mcpAPIResult(rec), nil
 		},
 	)
 }
 
 // --- Namespace tools ---
 
-func addNamespaceTools(s *mcpserver.MCPServer, svc services.Service) {
-	s.AddTool(
-		mcp.NewTool("shellhub_list_namespaces",
-			mcp.WithDescription("List ShellHub namespaces accessible to the authenticated user."),
-			mcp.WithInteger("page", mcp.Description("Page number (1-based). Default: 1.")),
-			mcp.WithInteger("per_page", mcp.Description("Results per page. Default: 20.")),
-		),
-		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			_, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-
-			args := req.GetArguments()
-			page := intArg(args, "page", 1)
-			perPage := intArg(args, "per_page", 20)
-
-			r := &requests.NamespaceList{
-				TenantID:  tenantFromCtx(ctx),
-				Paginator: query.Paginator{Page: page, PerPage: perPage},
-			}
-			r.Paginator.Normalize()
-
-			namespaces, count, err := svc.ListNamespaces(ctx, r)
-			if err != nil {
-				return mcpServiceError(err), nil
-			}
-
-			return mcp.NewToolResultText(toJSON(map[string]any{
-				"total":      count,
-				"namespaces": namespaces,
-			})), nil
-		},
-	)
-
+func addNamespaceTools(s *mcpserver.MCPServer, router http.Handler) {
+	// No "list namespaces" tool: an API key is scoped to one namespace, and
+	// listing namespaces is an account-level action the REST API blocks for
+	// API keys (BlockAPIKey on GetNamespaceList). get_namespace reads the
+	// caller's own namespace.
 	s.AddTool(
 		mcp.NewTool("shellhub_get_namespace",
-			mcp.WithDescription("Get details and settings of a ShellHub namespace by its tenant ID."),
-			mcp.WithString("tenant_id", mcp.Required(), mcp.Description("Namespace tenant ID (UUID).")),
+			mcp.WithDescription("Get details and settings of the caller's ShellHub namespace."),
+			mcp.WithString("tenant_id", mcp.Description("Namespace tenant ID (UUID). Defaults to the caller's own namespace; any other value is rejected.")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			_, ok := roleFromCtx(ctx)
-			if !ok {
-				return mcpUnauth(), nil
-			}
-
 			args := req.GetArguments()
 			tenantID, _ := args["tenant_id"].(string)
-
-			// GetNamespace performs no membership check — only fetch the
-			// namespace the caller already belongs to.
-			if tenantID != tenantFromCtx(ctx) {
-				return mcpForbidden(), nil
+			if tenantID == "" {
+				tenantID = tenantFromCtx(ctx)
 			}
 
-			namespace, err := svc.GetNamespace(ctx, tenantID)
-			if err != nil {
-				return mcpServiceError(err), nil
-			}
+			// Cross-tenant access is rejected by RequiresTenant on the route;
+			// no manual guard needed here.
+			rec := mcpAPICall(ctx, router, http.MethodGet, "/api/namespaces/"+url.PathEscape(tenantID), nil)
 
-			return mcp.NewToolResultText(toJSON(namespace)), nil
+			return mcpAPIResult(rec), nil
 		},
 	)
 }

--- a/api/routes/mcp_test.go
+++ b/api/routes/mcp_test.go
@@ -1,0 +1,301 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/services/mocks"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	gomock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mcpToolCall builds a tools/call JSON-RPC body for the given tool and args.
+func mcpToolCall(name, args string) string {
+	return `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + name + `","arguments":` + args + `}}`
+}
+
+const mcpCallerTenant = "00000000-0000-4000-0000-000000000000"
+
+// mcpCall posts a JSON-RPC message to the MCP endpoint, simulating the headers
+// nginx injects for an API-key caller (X-Tenant-ID and X-Role, no X-ID).
+func mcpCall(t *testing.T, router http.Handler, tenant, role, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	// The stateless session manager only validates the format of the session
+	// ID, not its existence -- a well-formed value stands in for a client that
+	// has already completed the initialize handshake.
+	req.Header.Set("Mcp-Session-Id", "mcp-session-00000000-0000-4000-8000-000000000000")
+	if tenant != "" {
+		req.Header.Set("X-Tenant-ID", tenant)
+	}
+	if role != "" {
+		req.Header.Set("X-Role", role)
+	}
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	return rec
+}
+
+// mcpToolResult decodes a tools/call response into the tool's first text
+// content and its isError flag.
+func mcpToolResult(t *testing.T, rec *httptest.ResponseRecorder) (string, bool) {
+	t.Helper()
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var env struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env), rec.Body.String())
+	require.NotEmpty(t, env.Result.Content)
+
+	return env.Result.Content[0].Text, env.Result.IsError
+}
+
+// TestMCPGetNamespaceDefaultsToCaller ensures shellhub_get_namespace reads the
+// caller's own namespace when no tenant_id argument is supplied -- the MCP
+// credential is scoped to a single namespace.
+func TestMCPGetNamespaceDefaultsToCaller(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("GetNamespace", gomock.Anything, mcpCallerTenant).
+		Return(&models.Namespace{TenantID: mcpCallerTenant, Name: "dev"}, nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"shellhub_get_namespace","arguments":{}}}`)
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, mcpCallerTenant)
+	mock.AssertExpectations(t)
+}
+
+// TestMCPGetNamespaceRejectsOtherTenant ensures the caller cannot read another
+// tenant's namespace by passing an explicit tenant_id. The service must never
+// be reached.
+func TestMCPGetNamespaceRejectsOtherTenant(t *testing.T) {
+	mock := new(mocks.Service)
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"shellhub_get_namespace","arguments":{"tenant_id":"11111111-1111-4000-0000-000000000000"}}}`)
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.True(t, isErr)
+	assert.Contains(t, text, "forbidden")
+	mock.AssertNotCalled(t, "GetNamespace", gomock.Anything, gomock.Anything)
+}
+
+// TestMCPDoesNotExposeListNamespaces locks in parity with the REST API: listing
+// namespaces is an account-level action blocked for API keys (BlockAPIKey on
+// GetNamespaceList), so the MCP server must not expose it as a tool.
+func TestMCPDoesNotExposeListNamespaces(t *testing.T) {
+	mock := new(mocks.Service)
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var env struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env), rec.Body.String())
+	require.NotEmpty(t, env.Result.Tools)
+
+	for _, tool := range env.Result.Tools {
+		assert.NotEqual(t, "shellhub_list_namespaces", tool.Name)
+	}
+}
+
+// --- device tools ---
+
+// TestMCPListDevices ensures status and pagination args reach the REST list
+// handler and the response is wrapped as {total, devices}.
+func TestMCPListDevices(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("ListDevices", gomock.Anything, gomock.MatchedBy(func(r *requests.DeviceList) bool {
+			return r.TenantID == mcpCallerTenant &&
+				r.DeviceStatus == models.DeviceStatus("accepted") &&
+				r.Paginator.Page == 2 && r.Paginator.PerPage == 50
+		})).
+		Return([]models.Device{{UID: "uid1"}}, 1, nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		mcpToolCall("shellhub_list_devices", `{"status":"accepted","page":2,"per_page":50}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, `"total": 1`)
+	assert.Contains(t, text, "uid1")
+	mock.AssertExpectations(t)
+}
+
+// TestMCPGetDevice ensures the uid arg becomes the path parameter.
+func TestMCPGetDevice(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("GetDevice", gomock.Anything, models.UID("uid1")).
+		Return(&models.Device{UID: "uid1", Name: "dev1"}, nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		mcpToolCall("shellhub_get_device", `{"uid":"uid1"}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, "dev1")
+	mock.AssertExpectations(t)
+}
+
+// TestMCPUpdateDeviceStatus ensures uid and status become path parameters and
+// an owner (who has DeviceAccept) succeeds.
+func TestMCPUpdateDeviceStatus(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("UpdateDeviceStatus", gomock.Anything, gomock.MatchedBy(func(r *requests.DeviceUpdateStatus) bool {
+			return r.UID == "uid1" && r.Status == "accepted"
+		})).
+		Return(nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		mcpToolCall("shellhub_update_device_status", `{"uid":"uid1","status":"accepted"}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, "status updated")
+	mock.AssertExpectations(t)
+}
+
+// TestMCPUpdateDeviceStatusForbidden is the crux of the parity work: an
+// observer lacks DeviceAccept, so RequiresPermission on the route returns 403
+// before the handler runs. The tool no longer checks permissions itself -- the
+// middleware does. The service must never be reached.
+func TestMCPUpdateDeviceStatusForbidden(t *testing.T) {
+	mock := new(mocks.Service)
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleObserver.String(),
+		mcpToolCall("shellhub_update_device_status", `{"uid":"uid1","status":"accepted"}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.True(t, isErr)
+	assert.Contains(t, text, "forbidden")
+	mock.AssertNotCalled(t, "UpdateDeviceStatus", gomock.Anything, gomock.Anything)
+}
+
+// TestMCPDeleteDevice ensures the uid arg becomes the path parameter.
+func TestMCPDeleteDevice(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("DeleteDevice", gomock.Anything, models.UID("uid1"), mcpCallerTenant).
+		Return(nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		mcpToolCall("shellhub_delete_device", `{"uid":"uid1"}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, "deleted")
+	mock.AssertExpectations(t)
+}
+
+// TestMCPRenameDevice ensures the name arg is sent as the JSON body.
+func TestMCPRenameDevice(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("RenameDevice", gomock.Anything, models.UID("uid1"), "newname", mcpCallerTenant).
+		Return(nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		mcpToolCall("shellhub_rename_device", `{"uid":"uid1","name":"newname"}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, "renamed")
+	mock.AssertExpectations(t)
+}
+
+// TestMCPGetStats ensures the tool reaches the stats handler scoped to the
+// caller's tenant.
+func TestMCPGetStats(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("GetStats", gomock.Anything, gomock.MatchedBy(func(r *requests.GetStats) bool {
+			return r.TenantID == mcpCallerTenant
+		})).
+		Return(&models.Stats{RegisteredDevices: 7}, nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		mcpToolCall("shellhub_get_stats", `{}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, "registered_devices")
+	mock.AssertExpectations(t)
+}
+
+// --- session tools ---
+
+// TestMCPListSessions ensures pagination reaches the list handler and the
+// response is wrapped as {total, sessions}.
+func TestMCPListSessions(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("ListSessions", gomock.Anything, gomock.MatchedBy(func(r *requests.ListSessions) bool {
+			return r.TenantID == mcpCallerTenant && r.Paginator.Page == 1 && r.Paginator.PerPage == 20
+		})).
+		Return([]models.Session{{UID: "sess1"}}, 1, nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		mcpToolCall("shellhub_list_sessions", `{}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, `"total": 1`)
+	assert.Contains(t, text, "sess1")
+	mock.AssertExpectations(t)
+}
+
+// TestMCPGetSession ensures the uid arg becomes the path parameter.
+func TestMCPGetSession(t *testing.T) {
+	mock := new(mocks.Service)
+	mock.
+		On("GetSession", gomock.Anything, models.UID("sess1")).
+		Return(&models.Session{UID: "sess1"}, nil).
+		Once()
+
+	rec := mcpCall(t, NewRouter(mock), mcpCallerTenant, authorizer.RoleOwner.String(),
+		mcpToolCall("shellhub_get_session", `{"uid":"sess1"}`))
+
+	text, isErr := mcpToolResult(t, rec)
+	assert.False(t, isErr)
+	assert.Contains(t, text, "sess1")
+	mock.AssertExpectations(t)
+}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -198,7 +198,7 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	}
 
 	// MCP server (Model Context Protocol) for AI assistants.
-	SetupMCPRoutes(router, service)
+	SetupMCPRoutes(router)
 
 	// Apply route extensions (enterprise/cloud features)
 	if err := applyExtensions(router, service); err != nil {


### PR DESCRIPTION
## What

The MCP tools now reach the API through its own Echo router in-process
(`router.ServeHTTP`) instead of calling the service layer directly. Each tool
replays the caller's gateway-injected auth headers (`X-Tenant-ID`, `X-Role`,
`X-Api-Key`) onto the in-process request, so the full REST middleware chain
(`BlockAPIKey`, `RequiresPermission`, `RequiresTenant`) runs for every call.

Authorization is deleted from the tools: the per-tool `roleFromCtx` /
`HasPermission` checks and the `mcpServiceError` mapping are gone, replaced by
shared helpers (`mcpAPICall`, `mcpAPIResult`, `mcpAPIListResult`, `mcpAPIOK`).

The `list_namespaces` tool is dropped (account-level action blocked for API
keys), and `get_namespace` defaults to the caller's own tenant.

Adds `api/routes/mcp_test.go` (none existed), covering all tools, including an
observer being rejected by `RequiresPermission` rather than by the tool.

## Why

The MCP server reused the service layer but left authorization in the HTTP
middleware, so direct service calls skipped it. Each tool re-implemented the
permission checks by hand, which could drift from the REST API. Routing through
the middleware makes capability parity automatic: the MCP can do exactly what
its API key can do over REST, no more.