### PR TITLE
chore: replace redis with valkey

### DIFF
--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -59,7 +59,7 @@ services:
     image: registry.infra.ossystems.io/cache/shellhubio/cli:${SHELLHUB_VERSION}
 
   redis:
-    image: registry.infra.ossystems.io/cache/redis
+    image: registry.infra.ossystems.io/cache/valkey/valkey:9.1-alpine
 
   ssh:
     image: registry.infra.ossystems.io/cache/shellhubio/ssh:${SHELLHUB_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,9 +172,9 @@ services:
     networks:
       - shellhub
   redis:
-    image: redis
+    image: valkey/valkey:9.1-alpine
     restart: unless-stopped
-    command: ["redis-server", "--appendonly", "no", "--save", "\"\""]
+    command: ["valkey-server", "--appendonly", "no", "--save", "\"\""]
     networks:
       - shellhub
 

--- a/pkg/worker/asynq/client_test.go
+++ b/pkg/worker/asynq/client_test.go
@@ -16,7 +16,7 @@ func TestClient(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	redisContainer, err := redis.Run(ctx, "docker.io/redis:7")
+	redisContainer, err := redis.Run(ctx, "docker.io/valkey/valkey:9.1-alpine")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/worker/asynq/server_test.go
+++ b/pkg/worker/asynq/server_test.go
@@ -15,7 +15,7 @@ func TestServer(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	redisContainer, err := redis.Run(ctx, "docker.io/redis:7")
+	redisContainer, err := redis.Run(ctx, "docker.io/valkey/valkey:9.1-alpine")
 	require.NoError(t, err)
 
 	redisConnStr, err := redisContainer.ConnectionString(ctx)


### PR DESCRIPTION
## What

Swaps the Redis container image for [Valkey](https://valkey.io/) across
the compose files and the asynq test containers.

| Where | Before | After |
|-------|--------|-------|
| `docker-compose.yml` | `redis` | `valkey/valkey:8.1` |
| `docker-compose.enterprise.yml` | `cache/redis` | `cache/valkey/valkey:8.1` |
| `pkg/worker/asynq/{client,server}_test.go` | `docker.io/redis:7` | `docker.io/valkey/valkey:8.1` |

## Why

Redis moved to SSPL/RSALv2 in 2024 and AGPLv3 in 2025. Valkey is the
BSD-3 fork maintained by the Linux Foundation and is a drop-in
replacement: same RESP protocol, same clients.

No Go code changes. The `go-redis`/`asynq` clients, the `redis://` URIs,
and the `redis` service name are kept as-is to minimize churn. The
testcontainers `redis` module boots the Valkey image fine since its wait
strategy matches Valkey's `Ready to accept connections` log line.

## Note

The enterprise registry path `cache/valkey/valkey` assumes the
pull-through cache mirrors the upstream `valkey/valkey` image. Worth
confirming it resolves before merge.