### PR TITLE
fix(api): return clean 404 for malformed tenant_id in namespace resolve

### DIFF
--- a/api/store/pg/namespace.go
+++ b/api/store/pg/namespace.go
@@ -104,6 +104,15 @@ func (pg *Pg) NamespaceResolve(ctx context.Context, resolver store.NamespaceReso
 		return nil, err
 	}
 
+	// namespaces.id is a uuid-typed column; a malformed value would otherwise reach
+	// Postgres and fail with SQLSTATE 22P02. Treat it as not-found to match the prior
+	// Mongo behavior and avoid logging a misleading SQL error (see #6404).
+	if resolver == store.NamespaceTenantIDResolver {
+		if _, err := uuid.Parse(val); err != nil {
+			return nil, store.ErrNoDocuments
+		}
+	}
+
 	ns := new(entity.Namespace)
 	query := db.NewSelect().Model(ns).Relation("Memberships.User").Where("? = ?", bun.Ident(column), val)
 	if err := query.Scan(ctx); err != nil {

--- a/api/store/storetest/namespace_tests.go
+++ b/api/store/storetest/namespace_tests.go
@@ -167,6 +167,18 @@ func (s *Suite) TestNamespaceResolve(t *testing.T) {
 		assert.Nil(t, ns)
 	})
 
+	t.Run("returns ErrNoDocuments for malformed tenant ID", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		// A tenant_id that is not a valid UUID (letter 'l' instead of digit '1').
+		// Must resolve to not-found on both stores rather than erroring (see #6404).
+		malformedID := "83176492-e6cl-43d7-922e-ee01c3693e26"
+
+		ns, err := st.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, malformedID)
+		assert.ErrorIs(t, err, store.ErrNoDocuments)
+		assert.Nil(t, ns)
+	})
+
 	t.Run("returns error for non-existent name", func(t *testing.T) {
 		require.NoError(t, s.provider.CleanDatabase(t))
 


### PR DESCRIPTION
## Summary

When a device authenticates with a `tenant_id` that is not a valid UUID, the Postgres store passed the raw string straight into the `uuid`-typed `namespaces.id` column. The query failed with `invalid input syntax for type uuid (SQLSTATE 22P02)` and logged a misleading SQL error — even though the request still returned 404.

With the previous Mongo store, `tenant_id` was a plain string field, so a malformed value (e.g. a misconfigured agent sending `83176492-e6cl-...`, a letter `l` instead of digit `1`) simply matched nothing and returned a silent 404. This restores that behavior.

## Change

`NamespaceResolve` now validates the value as a UUID (via the existing `pkg/uuid.Parse`) before issuing the query when resolving by tenant ID, returning `store.ErrNoDocuments` when invalid. This:

- Restores Mongo parity — a malformed tenant_id is a clean not-found, no error logged.
- Avoids a doomed database round-trip for malformed input.
- Flows up exactly as a normal not-found: the service wraps it via `NewErrNamespaceNotFound`, which maps to HTTP 404. No service/handler changes needed.

The targeted per-resolver validation was chosen over a blanket SQLSTATE 22P02 → not-found mapping in `fromSQLError`, to avoid masking genuine type-mismatch bugs elsewhere.

## Tests

Added a `returns ErrNoDocuments for malformed tenant ID` subtest to the shared `TestNamespaceResolve` suite, which runs against **both** Mongo and Postgres backends to verify parity. The Postgres suite passes locally (the Mongo run requires testcontainers networking unavailable in my local dev setup, but the Mongo path needs no code change — a non-matching string already returns `ErrNoDocuments`).

## Notes

A related latent issue exists at sibling call sites that filter on the same uuid-typed `namespace_id` via the shared `InNamespace` query option (`DeviceResolve`, `APIKeyResolve`, `PublicKeyResolve`, `SessionResolve`). That's out of scope for this issue and could be a follow-up.

Fixes: shellhub-io/shellhub#6404
