### PR TITLE
refactor(ui-react): extract MFA reset flow into dedicated store

### DIFF
--- a/ui/apps/console/src/components/common/__tests__/AdminRoute.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/AdminRoute.test.tsx
@@ -34,8 +34,6 @@ const baseState = {
   mfaEnabled: false,
   mfaToken: null,
   mfaRecoveryExpiry: null,
-  mfaResetUserId: null,
-  mfaResetIdentifier: null,
 };
 
 beforeEach(() => {

--- a/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
+++ b/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
@@ -4,6 +4,7 @@ import { disableMfa } from "@/client";
 import Alert from "@/components/common/Alert";
 import { useOtpInput } from "@/hooks/useOtpInput";
 import { useAuthStore } from "@/stores/authStore";
+import { useMfaResetStore } from "@/stores/mfaResetStore";
 import Spinner from "@/components/common/Spinner";
 import BaseDialog from "@/components/common/BaseDialog";
 
@@ -29,7 +30,8 @@ export default function MfaDisableDialog({
   const [requestingEmail, setRequestingEmail] = useState(false);
   const otpMainEmail = useOtpInput(5, true);
   const otpRecoveryEmail = useOtpInput(5, true);
-  const { user, username, requestMfaReset } = useAuthStore();
+  const { user, username } = useAuthStore();
+  const { requestMfaReset } = useMfaResetStore();
 
   const handleRequestEmailReset = async (): Promise<void> => {
     const identifier = user || username;

--- a/ui/apps/console/src/pages/MfaResetRequest.tsx
+++ b/ui/apps/console/src/pages/MfaResetRequest.tsx
@@ -3,11 +3,13 @@ import { useNavigate, Link } from "react-router-dom";
 import { EnvelopeIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import Alert from "@/components/common/Alert";
 import { useAuthStore } from "../stores/authStore";
+import { useMfaResetStore } from "../stores/mfaResetStore";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
 import Spinner from "@/components/common/Spinner";
 
 export default function MfaResetRequest() {
-  const { requestMfaReset, loading, error, user, username, mfaToken } = useAuthStore();
+  const { user, username, mfaToken } = useAuthStore();
+  const { requestMfaReset, loading, error } = useMfaResetStore();
   const navigate = useNavigate();
   const [emailsSent, setEmailsSent] = useState(false);
 
@@ -15,7 +17,7 @@ export default function MfaResetRequest() {
 
   // Clear stale error from previous session
   useEffect(() => {
-    useAuthStore.setState({ error: null });
+    useMfaResetStore.setState({ error: null });
   }, []);
 
   // Redirect to login if no identifier available (but only if not in active MFA session)

--- a/ui/apps/console/src/pages/MfaResetVerify.tsx
+++ b/ui/apps/console/src/pages/MfaResetVerify.tsx
@@ -2,13 +2,13 @@ import { FormEvent, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { ShieldCheckIcon } from "@heroicons/react/24/outline";
 import Alert from "@/components/common/Alert";
-import { useAuthStore } from "../stores/authStore";
+import { useMfaResetStore } from "../stores/mfaResetStore";
 import { useOtpInput } from "../hooks/useOtpInput";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
 import Spinner from "@/components/common/Spinner";
 
 export default function MfaResetVerify() {
-  const { completeMfaReset, mfaResetUserId, mfaResetIdentifier, loading, error } = useAuthStore();
+  const { completeMfaReset, mfaResetUserId, mfaResetIdentifier, loading, error } = useMfaResetStore();
   const navigate = useNavigate();
 
   const otpMain = useOtpInput(5, true);
@@ -16,7 +16,7 @@ export default function MfaResetVerify() {
 
   // Clear stale error from previous session
   useEffect(() => {
-    useAuthStore.setState({ error: null });
+    useMfaResetStore.setState({ error: null });
   }, []);
 
   // State guard: redirect if no reset session

--- a/ui/apps/console/src/stores/__tests__/authStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/authStore.test.ts
@@ -9,8 +9,6 @@ vi.mock("@/client", () => ({
   deleteUser: vi.fn(),
   authMfa: vi.fn(),
   mfaRecover: vi.fn(),
-  requestResetMfa: vi.fn(),
-  resetMfa: vi.fn(),
 }));
 
 import { login as loginSdk, getUserInfo, authMfa, mfaRecover } from "@/client";
@@ -71,6 +69,7 @@ beforeEach(() => {
     mfaEnabled: false,
     mfaToken: null,
     mfaRecoveryExpiry: null,
+    isAdmin: false,
   });
   vi.clearAllMocks();
 });
@@ -324,7 +323,6 @@ describe("authStore", () => {
         mfaEnabled: true,
         mfaToken: "mfa-temp-token",
         mfaRecoveryExpiry: "1234567890",
-        mfaResetUserId: "some-user-id",
       };
 
       const persisted = partialize(full) as Record<string, unknown>;
@@ -345,10 +343,9 @@ describe("authStore", () => {
       expect(persisted).not.toHaveProperty("username");
       expect(persisted).not.toHaveProperty("recoveryEmail");
 
-      // Should NOT persist sensitive MFA session/flow state
+      // Should NOT persist transient MFA session state
       expect(persisted).not.toHaveProperty("mfaToken");
       expect(persisted).not.toHaveProperty("mfaRecoveryExpiry");
-      expect(persisted).not.toHaveProperty("mfaResetUserId");
     });
   });
 

--- a/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useMfaResetStore } from "../mfaResetStore";
+import { useAuthStore } from "../authStore";
+import type { UserAuth } from "@/client";
+
+vi.mock("@/client", () => ({
+  requestResetMfa: vi.fn(),
+  resetMfa: vi.fn(),
+  // Dependencies pulled in transitively by authStore
+  login: vi.fn(),
+  getUserInfo: vi.fn(),
+  updateUser: vi.fn(),
+  deleteUser: vi.fn(),
+  authMfa: vi.fn(),
+  mfaRecover: vi.fn(),
+}));
+
+import { requestResetMfa, resetMfa } from "@/client";
+
+const mockedRequestResetMfa = vi.mocked(requestResetMfa);
+const mockedResetMfa = vi.mocked(resetMfa);
+
+type SdkResponse<T = unknown> = {
+  data: T;
+  request: Request;
+  response: Response;
+};
+
+function mockSdkResponse<T>(data: T): SdkResponse<T> {
+  return {
+    data,
+    request: new Request("http://localhost"),
+    response: new Response(),
+  };
+}
+
+function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
+  return {
+    token: "jwt-token",
+    id: "user-123",
+    origin: "local",
+    user: "admin",
+    name: "Admin User",
+    email: "admin@test.com",
+    recovery_email: "recovery@test.com",
+    tenant: "tenant-456",
+    role: "owner",
+    mfa: false,
+    admin: false,
+    max_namespaces: -1,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useMfaResetStore.setState({
+    mfaResetUserId: null,
+    mfaResetIdentifier: null,
+    loading: false,
+    error: null,
+  });
+  useAuthStore.setState({
+    token: null,
+    user: null,
+    userId: null,
+    email: null,
+    tenant: null,
+    name: null,
+    isAdmin: false,
+    mfaEnabled: false,
+    loading: false,
+    error: null,
+    mfaToken: null,
+    mfaRecoveryExpiry: null,
+    username: null,
+    recoveryEmail: null,
+    role: null,
+  });
+  vi.clearAllMocks();
+});
+
+describe("mfaResetStore", () => {
+  describe("initial state", () => {
+    it("initializes with clean state", () => {
+      const state = useMfaResetStore.getState();
+      expect(state.mfaResetUserId).toBeNull();
+      expect(state.mfaResetIdentifier).toBeNull();
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it("does not use Zustand persist", () => {
+      expect(
+        (useMfaResetStore as unknown as Record<string, unknown>).persist,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("requestMfaReset", () => {
+    it("sets mfaResetUserId and mfaResetIdentifier on success", async () => {
+      mockedRequestResetMfa.mockResolvedValueOnce(mockSdkResponse(null));
+
+      await useMfaResetStore.getState().requestMfaReset("admin");
+
+      const state = useMfaResetStore.getState();
+      expect(state.mfaResetUserId).toBe("admin");
+      expect(state.mfaResetIdentifier).toBe("admin");
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it("sets loading during request", async () => {
+      let resolve!: (v: SdkResponse<null>) => void;
+      mockedRequestResetMfa.mockReturnValueOnce(
+        new Promise<SdkResponse<null>>((r) => {
+          resolve = r;
+        }),
+      );
+
+      const promise = useMfaResetStore.getState().requestMfaReset("admin");
+      expect(useMfaResetStore.getState().loading).toBe(true);
+
+      resolve(mockSdkResponse(null));
+      await promise;
+
+      expect(useMfaResetStore.getState().loading).toBe(false);
+    });
+
+    it("sets error and throws on failure", async () => {
+      mockedRequestResetMfa.mockRejectedValueOnce(new Error("network error"));
+
+      await expect(
+        useMfaResetStore.getState().requestMfaReset("admin"),
+      ).rejects.toThrow("Reset request failed");
+
+      const state = useMfaResetStore.getState();
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe(
+        "Unable to send reset emails. Please check your identifier.",
+      );
+      expect(state.mfaResetUserId).toBeNull();
+    });
+  });
+
+  describe("completeMfaReset", () => {
+    beforeEach(() => {
+      useMfaResetStore.setState({ mfaResetUserId: "user-123" });
+    });
+
+    it("throws when no mfaResetUserId", async () => {
+      useMfaResetStore.setState({ mfaResetUserId: null });
+
+      await expect(
+        useMfaResetStore.getState().completeMfaReset("code1", "code2"),
+      ).rejects.toThrow("No user ID available");
+
+      expect(useMfaResetStore.getState().error).toBe(
+        "Invalid reset session. Please start over.",
+      );
+    });
+
+    it("sets auth state in authStore on success", async () => {
+      mockedResetMfa.mockResolvedValueOnce(
+        mockSdkResponse(mockUserAuth({ token: "reset-token", mfa: false })),
+      );
+
+      await useMfaResetStore.getState().completeMfaReset("AAA11", "BBB22");
+
+      const auth = useAuthStore.getState();
+      expect(auth.token).toBe("reset-token");
+      expect(auth.user).toBe("admin");
+      expect(auth.userId).toBe("user-123");
+      expect(auth.email).toBe("admin@test.com");
+      expect(auth.tenant).toBe("tenant-456");
+      expect(auth.isAdmin).toBe(false);
+      expect(auth.mfaEnabled).toBe(false);
+    });
+
+    it("clears mfaResetUserId and mfaResetIdentifier on success", async () => {
+      useMfaResetStore.setState({
+        mfaResetUserId: "user-123",
+        mfaResetIdentifier: "admin",
+      });
+      mockedResetMfa.mockResolvedValueOnce(mockSdkResponse(mockUserAuth()));
+
+      await useMfaResetStore.getState().completeMfaReset("AAA11", "BBB22");
+
+      const state = useMfaResetStore.getState();
+      expect(state.mfaResetUserId).toBeNull();
+      expect(state.mfaResetIdentifier).toBeNull();
+      expect(state.loading).toBe(false);
+    });
+
+    it("calls resetMfa with correct arguments", async () => {
+      mockedResetMfa.mockResolvedValueOnce(mockSdkResponse(mockUserAuth()));
+
+      await useMfaResetStore.getState().completeMfaReset("AAA11", "BBB22");
+
+      expect(mockedResetMfa).toHaveBeenCalledWith({
+        path: { "user-id": "user-123" },
+        body: { main_email_code: "AAA11", recovery_email_code: "BBB22" },
+        throwOnError: true,
+      });
+    });
+
+    it("sets error and throws on failure", async () => {
+      mockedResetMfa.mockRejectedValueOnce(new Error("invalid codes"));
+
+      await expect(
+        useMfaResetStore.getState().completeMfaReset("WRONG", "CODES"),
+      ).rejects.toThrow("Invalid codes");
+
+      const state = useMfaResetStore.getState();
+      expect(state.loading).toBe(false);
+      expect(state.error).toBe(
+        "Invalid verification codes. Please check and try again.",
+      );
+      // Reset fields not cleared on failure
+      expect(state.mfaResetUserId).toBe("user-123");
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all state to initial values", () => {
+      useMfaResetStore.setState({
+        mfaResetUserId: "user-abc",
+        mfaResetIdentifier: "admin",
+        loading: true,
+        error: "some error",
+      });
+
+      useMfaResetStore.getState().reset();
+
+      const state = useMfaResetStore.getState();
+      expect(state.mfaResetUserId).toBeNull();
+      expect(state.mfaResetIdentifier).toBeNull();
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+    });
+  });
+});

--- a/ui/apps/console/src/stores/authStore.ts
+++ b/ui/apps/console/src/stores/authStore.ts
@@ -8,8 +8,6 @@ import {
   deleteUser as deleteUserSdk,
   authMfa,
   mfaRecover,
-  requestResetMfa,
-  resetMfa,
 } from "../client";
 import { queryClient } from "../api/queryClient";
 import { tearDownChatwoot } from "../hooks/chatwootRuntime";
@@ -31,8 +29,6 @@ interface AuthState {
   mfaEnabled: boolean;
   mfaToken: string | null;
   mfaRecoveryExpiry: number | null;
-  mfaResetUserId: string | null;
-  mfaResetIdentifier: string | null;
   login: (username: string, password: string) => Promise<void>;
   loginWithToken: (token: string) => Promise<void>;
   logout: () => void;
@@ -51,11 +47,6 @@ interface AuthState {
   deleteUser: () => Promise<void>;
   loginWithMfa: (code: string) => Promise<void>;
   recoverWithCode: (code: string, identifier?: string) => Promise<void>;
-  requestMfaReset: (identifier: string) => Promise<void>;
-  completeMfaReset: (
-    mainEmailCode: string,
-    recoveryEmailCode: string,
-  ) => Promise<void>;
   updateMfaStatus: (enabled: boolean) => void;
   setMfaToken: (token: string) => void;
 }
@@ -76,8 +67,6 @@ const initialState = {
   mfaEnabled: false,
   mfaToken: null,
   mfaRecoveryExpiry: null,
-  mfaResetUserId: null,
-  mfaResetIdentifier: null,
 };
 
 export const useAuthStore = create<AuthState>()(
@@ -289,72 +278,6 @@ export const useAuthStore = create<AuthState>()(
         }
       },
 
-      requestMfaReset: async (identifier: string) => {
-        set({ loading: true, error: null });
-        try {
-          await requestResetMfa({
-            body: { identifier },
-            throwOnError: true,
-          });
-          set({
-            mfaResetUserId: identifier,
-            mfaResetIdentifier: identifier,
-            loading: false,
-          });
-        } catch {
-          set({
-            loading: false,
-            error: "Unable to send reset emails. Please check your identifier.",
-          });
-          throw new Error("Reset request failed");
-        }
-      },
-
-      completeMfaReset: async (
-        mainEmailCode: string,
-        recoveryEmailCode: string,
-      ) => {
-        const { mfaResetUserId } = get();
-        if (!mfaResetUserId) {
-          set({ error: "Invalid reset session. Please start over." });
-          throw new Error("No user ID available");
-        }
-
-        set({ loading: true, error: null });
-        try {
-          const { data } = await resetMfa({
-            path: { "user-id": mfaResetUserId },
-            body: {
-              main_email_code: mainEmailCode,
-              recovery_email_code: recoveryEmailCode,
-            },
-            throwOnError: true,
-          });
-
-          const userData = data;
-          // Successful reset = authenticated, same as login
-          set({
-            token: userData.token,
-            user: userData.user,
-            userId: userData.id,
-            email: userData.email,
-            tenant: userData.tenant,
-            name: userData.name,
-            isAdmin: userData.admin ?? false,
-            mfaEnabled: userData.mfa || false,
-            mfaResetUserId: null,
-            mfaResetIdentifier: null,
-            loading: false,
-          });
-        } catch {
-          set({
-            loading: false,
-            error: "Invalid verification codes. Please check and try again.",
-          });
-          throw new Error("Invalid codes");
-        }
-      },
-
       updateMfaStatus: (enabled: boolean) => {
         set({ mfaEnabled: enabled });
       },
@@ -378,7 +301,7 @@ export const useAuthStore = create<AuthState>()(
         name: state.name,
         mfaEnabled: state.mfaEnabled,
         // Do NOT persist: username, recoveryEmail (fetched fresh via fetchUser)
-        // Do NOT persist: mfaToken, mfaRecoveryExpiry, mfaResetUserId, mfaResetIdentifier
+        // Do NOT persist: mfaToken, mfaRecoveryExpiry (transient MFA session state)
       }),
     },
   ),

--- a/ui/apps/console/src/stores/mfaResetStore.ts
+++ b/ui/apps/console/src/stores/mfaResetStore.ts
@@ -1,0 +1,92 @@
+import { create } from "zustand";
+import { requestResetMfa, resetMfa } from "../client";
+import { useAuthStore } from "./authStore";
+
+interface MfaResetState {
+  mfaResetUserId: string | null;
+  mfaResetIdentifier: string | null;
+  loading: boolean;
+  error: string | null;
+  requestMfaReset: (identifier: string) => Promise<void>;
+  completeMfaReset: (
+    mainEmailCode: string,
+    recoveryEmailCode: string,
+  ) => Promise<void>;
+  reset: () => void;
+}
+
+const initialState = {
+  mfaResetUserId: null,
+  mfaResetIdentifier: null,
+  loading: false,
+  error: null,
+};
+
+export const useMfaResetStore = create<MfaResetState>()((set, get) => ({
+  ...initialState,
+
+  requestMfaReset: async (identifier: string) => {
+    set({ loading: true, error: null });
+    try {
+      await requestResetMfa({
+        body: { identifier },
+        throwOnError: true,
+      });
+      set({
+        mfaResetUserId: identifier,
+        mfaResetIdentifier: identifier,
+        loading: false,
+      });
+    } catch {
+      set({
+        loading: false,
+        error: "Unable to send reset emails. Please check your identifier.",
+      });
+      throw new Error("Reset request failed");
+    }
+  },
+
+  completeMfaReset: async (
+    mainEmailCode: string,
+    recoveryEmailCode: string,
+  ) => {
+    const { mfaResetUserId } = get();
+    if (!mfaResetUserId) {
+      set({ error: "Invalid reset session. Please start over." });
+      throw new Error("No user ID available");
+    }
+
+    set({ loading: true, error: null });
+    try {
+      const { data } = await resetMfa({
+        path: { "user-id": mfaResetUserId },
+        body: {
+          main_email_code: mainEmailCode,
+          recovery_email_code: recoveryEmailCode,
+        },
+        throwOnError: true,
+      });
+
+      const userData = data;
+      useAuthStore.setState({
+        token: userData.token,
+        user: userData.user,
+        userId: userData.id,
+        email: userData.email,
+        tenant: userData.tenant,
+        name: userData.name,
+        isAdmin: userData.admin ?? false,
+        mfaEnabled: userData.mfa || false,
+      });
+      set({ mfaResetUserId: null, mfaResetIdentifier: null, loading: false });
+    } catch {
+      set({
+        loading: false,
+        error: "Invalid verification codes. Please check and try again.",
+      });
+      throw new Error("Invalid codes");
+    }
+  },
+
+  reset: () => set(initialState),
+}));


### PR DESCRIPTION
## What

Moves the MFA reset wizard state and actions out of the persisted
`authStore` into a new non-persistent `useMfaResetStore`. Reset flow
state (`mfaResetUserId`, `mfaResetIdentifier`, `requestMfaReset`,
`completeMfaReset`) now lives entirely in memory and clears on page
refresh.

## Why

`authStore` uses Zustand persist and writes to `localStorage`. The MFA
reset fields were already excluded from the serialized payload via
`partialize`, but they still lived as mutable state inside the persisted
store, coupling an ephemeral multi-step wizard to the auth boundary.
Abandoning the reset flow mid-way left stale `mfaResetUserId` /
`mfaResetIdentifier` in-memory state that survived until the next full
page reload, and the shared `loading`/`error` fields were clobbered by
reset operations while also being used by unrelated auth actions.

## Changes

- **`mfaResetStore.ts`** (new): plain `create<MfaResetState>()` store,
  no persist middleware. Owns `mfaResetUserId`, `mfaResetIdentifier`,
  `loading`, `error`, `requestMfaReset`, `completeMfaReset`, and
  `reset`. On a successful `completeMfaReset` it writes the resulting
  session into `useAuthStore` directly, keeping the auth boundary clean
  while avoiding a circular dependency.
- **`authStore.ts`**: removed `mfaResetUserId`, `mfaResetIdentifier`,
  `requestMfaReset`, `completeMfaReset`, and the now-unused
  `requestResetMfa`/`resetMfa` client imports.
- **`MfaResetRequest`, `MfaResetVerify`**: consume `useMfaResetStore`
  for all reset-specific state/actions; `MfaResetRequest` retains
  `useAuthStore` only for `user`/`username`/`mfaToken`.
- **`MfaDisableDialog`**: pulls `requestMfaReset` from
  `useMfaResetStore`; `user`/`username` remain in `useAuthStore`.
- **`mfaResetStore.test.ts`** (new): 11 tests covering initial state,
  `requestMfaReset`, `completeMfaReset` (including cross-store auth
  population), `reset`, and the absence of the persist API.
- Updated `authStore.test.ts` and `AdminRoute.test.tsx` to remove
  references to the extracted fields.