### PR TITLE
fix(api): return clean 404 for malformed namespace ID in InNamespace filter

### DIFF
--- a/api/store/pg/query-options.go
+++ b/api/store/pg/query-options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shellhub-io/shellhub/api/store/pg/internal"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/pkg/uuid"
 	"github.com/uptrace/bun"
 )
 
@@ -156,6 +157,14 @@ func (*queryOptions) InNamespace(namespaceID string) store.QueryOption {
 		wrapper, ok := ctx.Value("query").(*queryWrapper)
 		if !ok {
 			return ErrQueryNotFound
+		}
+
+		// namespace_id is a uuid-typed column in Postgres. Passing a non-UUID
+		// string would produce SQLSTATE 22P02 ("invalid input syntax for type
+		// uuid") and a misleading SQL error in the logs. Return ErrNoDocuments
+		// early so the caller gets a clean not-found result. See #6406.
+		if _, err := uuid.Parse(namespaceID); err != nil {
+			return store.ErrNoDocuments
 		}
 
 		col := "namespace_id"

--- a/api/store/storetest/apikey_tests.go
+++ b/api/store/storetest/apikey_tests.go
@@ -100,6 +100,19 @@ func (s *Suite) TestAPIKeyResolve(t *testing.T) {
 		assert.Nil(t, apiKey)
 	})
 
+	// namespace_id is uuid-typed; a malformed tenant ID must return ErrNoDocuments
+	// without reaching the database (avoids SQLSTATE 22P02 on Postgres). See #6406.
+	t.Run("fails with malformed (non-UUID) namespace ID", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		// 'l' in position 13 makes this an invalid UUID (not a hex digit).
+		malformedTenantID := "83176492-e6cl-43d7-922e-ee01c3693e26"
+
+		apiKey, err := st.APIKeyResolve(ctx, store.APIKeyIDResolver, "any-key-id", st.Options().InNamespace(malformedTenantID))
+		assert.ErrorIs(t, err, store.ErrNoDocuments)
+		assert.Nil(t, apiKey)
+	})
+
 	t.Run("succeeds resolving API key by ID", func(t *testing.T) {
 		require.NoError(t, s.provider.CleanDatabase(t))
 


### PR DESCRIPTION
## Summary

Follow-up to #6404 / #6405. The `InNamespace` query option filters on the `uuid`-typed `namespace_id` column with a raw, externally-supplied string. A malformed (non-UUID) value reached Postgres and failed with `invalid input syntax for type uuid (SQLSTATE 22P02)`, logging a misleading SQL error — even though the result is effectively not-found. Same root cause as #6404, different code path.

## Change

`InNamespace` now validates the value as a UUID (via the existing `pkg/uuid.Parse`) and returns `store.ErrNoDocuments` **before** appending the filter, so no doomed query is issued. This covers every resolver that scopes by namespace through this option:

- `DeviceResolve` (on the device-auth path)
- `APIKeyResolve`
- `PublicKeyResolve`
- `SessionResolve`

`applyOptions` already routes option errors through `fromSQLError`, which passes `store.ErrNoDocuments` through unchanged, so the not-found surfaces cleanly without a logged SQL error — no changes needed in `utils.go`.

## Tests

Added a `fails with malformed (non-UUID) namespace ID` subtest to the shared `TestAPIKeyResolve` suite, which runs against **both** Mongo and Postgres backends to verify parity (on Mongo a non-matching string already yields `ErrNoDocuments`). The full Postgres store suite passes locally.

Fixes: shellhub-io/shellhub#6406
