### PR TITLE
refactor(agent): extract reusable core into importable agentd package

### DIFF
--- a/agent/connector.go
+++ b/agent/connector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	dockerclient "github.com/docker/docker/client"
+	"github.com/shellhub-io/shellhub/agent/pkg/agentd"
 	"github.com/shellhub-io/shellhub/agent/pkg/connector"
 	"github.com/shellhub-io/shellhub/pkg/api/client"
 	"github.com/shellhub-io/shellhub/pkg/envs"
@@ -264,11 +265,8 @@ func (d *DockerConnector) CheckUpdate() (*semver.Version, error) {
 
 // initContainerAgent initializes the agent for a container.
 func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container connector.Container) {
-	AgentPlatform = "connector"
-	AgentVersion = connector.ConnectorVersion
-
 	// TODO: Let this configuration build next to the Agent [agent.LoadConfigConnectorFromEnv] function.
-	cfg := &Config{
+	cfg := &agentd.Config{
 		ServerAddress:             container.ServerAddress,
 		TenantID:                  container.Tenant,
 		PrivateKey:                container.PrivateKey,
@@ -276,6 +274,8 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 		PreferredHostname:         container.Name,
 		KeepAliveInterval:         30,
 		MaxRetryConnectionTimeout: 60,
+		Version:                   connector.ConnectorVersion,
+		Platform:                  "connector",
 	}
 
 	log.WithFields(log.Fields{
@@ -285,10 +285,10 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 		"tenant_id":      cfg.TenantID,
 		"server_address": cfg.ServerAddress,
 		"timestamp":      time.Now(),
-		"version":        AgentVersion,
+		"version":        cfg.Version,
 	}).Info("Connector container started")
 
-	mode, err := NewConnectorMode(cli, container.ID)
+	mode, err := agentd.NewConnectorMode(cli, container.ID)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"id":             container.ID,
@@ -297,16 +297,16 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 			"tenant_id":      cfg.TenantID,
 			"server_address": cfg.ServerAddress,
 			"timestamp":      time.Now(),
-			"version":        AgentVersion,
+			"version":        cfg.Version,
 		}).Fatal("Failed to create connector mode")
 	}
 
-	ag, err := NewAgentWithConfig(cfg, mode)
+	ag, err := agentd.NewAgentWithConfig(cfg, mode)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"id":            container.ID,
 			"configuration": cfg,
-			"version":       AgentVersion,
+			"version":       cfg.Version,
 		}).Fatal("Failed to create agent")
 	}
 
@@ -314,7 +314,7 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 		log.WithError(err).WithFields(log.Fields{
 			"id":            container.ID,
 			"configuration": cfg,
-			"version":       AgentVersion,
+			"version":       cfg.Version,
 		}).Fatal("Failed to initialize agent")
 	}
 
@@ -325,7 +325,7 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 		"tenant_id":      cfg.TenantID,
 		"server_address": cfg.ServerAddress,
 		"timestamp":      time.Now(),
-		"version":        AgentVersion,
+		"version":        cfg.Version,
 	}).Info("Listening for connections")
 
 	// NOTICE(r): listing for connection and wait for a channel message to close the agent. It will receives
@@ -339,7 +339,7 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 			"tenant_id":      cfg.TenantID,
 			"server_address": cfg.ServerAddress,
 			"timestamp":      time.Now(),
-			"version":        AgentVersion,
+			"version":        cfg.Version,
 		}).Fatal("Failed to listen for connections")
 	}
 
@@ -349,6 +349,6 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 		"hostname":       cfg.PreferredHostname,
 		"tenant_id":      cfg.TenantID,
 		"server_address": cfg.ServerAddress,
-		"version":        AgentVersion,
+		"version":        cfg.Version,
 	}).Info("Connector container done")
 }

--- a/agent/main.go
+++ b/agent/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/shellhub-io/shellhub/agent/pkg/agentd"
 	"github.com/shellhub-io/shellhub/agent/pkg/connector"
 	"github.com/shellhub-io/shellhub/agent/pkg/selfupdater"
 	"github.com/shellhub-io/shellhub/agent/server/modes/host/command"
@@ -25,10 +26,13 @@ func main() {
 		Run: func(cmd *cobra.Command, _ []string) {
 			loglevel.SetLogLevel()
 
-			cfg, fields, err := LoadConfigFromEnv()
+			cfg, fields, err := agentd.LoadConfigFromEnv()
 			if err != nil {
 				log.WithError(err).WithFields(fields).Fatal("Failed to load de configuration from the environmental variables")
 			}
+
+			cfg.Version = AgentVersion
+			cfg.Platform = AgentPlatform
 
 			if os.Geteuid() == 0 && cfg.SingleUserPassword != "" {
 				log.Error("ShellHub agent cannot run as root when single-user mode is enabled.")
@@ -76,7 +80,7 @@ func main() {
 				"mode":    mode,
 			}).Info("Starting ShellHub")
 
-			ag, err := NewAgentWithConfig(cfg, new(HostMode))
+			ag, err := agentd.NewAgentWithConfig(cfg, new(agentd.HostMode))
 			if err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"version":       AgentVersion,
@@ -272,12 +276,15 @@ func main() {
 		Run: func(cmd *cobra.Command, _ []string) {
 			loglevel.SetLogLevel()
 
-			cfg, err := envs.ParseWithPrefix[Config]("SHELLHUB_")
+			cfg, err := envs.ParseWithPrefix[agentd.Config]("SHELLHUB_")
 			if err != nil {
 				log.Fatal(err)
 			}
 
-			info, err := GetInfo(cfg)
+			cfg.Version = AgentVersion
+			cfg.Platform = AgentPlatform
+
+			info, err := agentd.GetInfo(cfg)
 			if err != nil {
 				log.WithError(err).WithFields(log.Fields{
 					"version":       AgentVersion,

--- a/agent/pkg/agentd/agent.go
+++ b/agent/pkg/agentd/agent.go
@@ -1,4 +1,4 @@
-// Package agent provides packages and functions to create a new ShellHub Agent instance.
+// Package agentd provides packages and functions to create a new ShellHub Agent instance.
 //
 // The ShellHub Agent is a lightweight software component that runs the device and provide communication between the
 // device and ShellHub's server. Its main role is to provide a reserve SSH server always connected to the ShellHub
@@ -23,7 +23,7 @@
 //	    }
 //
 //	    ctx := context.Background()
-//	    ag, err := NewAgentWithConfig(&cfg)
+//	    ag, err := NewAgentWithConfig(&cfg, new(HostMode))
 //	    if err != nil {
 //	        panic(err)
 //	    }
@@ -35,8 +35,16 @@
 //	    ag.Listen(ctx)
 //	}
 //
+// # Embedding the agent
+//
+// This package is meant to be importable so the agent can run in-process inside another Go
+// program (for example, ShellHub Desktop). Note that the agent's go.mod replaces
+// github.com/gliderlabs/ssh with github.com/shellhub-io/ssh (a fork). Go ignores replace
+// directives from non-main modules, so any program embedding this package must replicate that
+// same replace directive in its own go.mod.
+//
 // [ShellHub Agent]: https://github.com/shellhub-io/shellhub/tree/master/agent
-package main
+package agentd
 
 import (
 	"context"
@@ -46,6 +54,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -111,6 +120,22 @@ type Config struct {
 	// Version 1 uses HTTP-based revdial, version 2 uses yamux multiplexing with multistream.
 	// Supported values are 1 and 2. Default is 2.
 	TransportVersion int `env:"TRANSPORT_VERSION,default=2"`
+
+	// Version is the agent version reported to the server and embedded in the device info.
+	// The CLI injects the value set at build time via `-ldflags -X main.AgentVersion=...`.
+	// Embedders must set it explicitly.
+	Version string
+
+	// Platform identifies the platform the agent is running on (e.g. "native", "docker",
+	// "connector"). The CLI injects the value detected at build time; embedders set it
+	// explicitly.
+	Platform string
+
+	// SFTPServerCommand builds the command used to start the SFTP server subprocess. When nil,
+	// the agent re-executes its own binary (/proc/self/exe) with the "sftp" subcommand. An
+	// embedding program (where /proc/self/exe is not the agent binary) must set this to point
+	// at a binary/subcommand that runs the SFTP server.
+	SFTPServerCommand func() *exec.Cmd
 }
 
 func LoadConfigFromEnv() (*Config, map[string]interface{}, error) {
@@ -173,7 +198,9 @@ type Agent struct {
 // NewAgent creates a new agent instance, requiring the ShellHub server's address to connect to, the namespace's tenant
 // where device own and the path to the private key on the file system.
 //
-// To create a new [Agent] instance with all configurations, you can use [NewAgentWithConfig].
+// It builds a minimal [Config], leaving optional fields (including Version and Platform) unset. As a result the device
+// is registered with an empty version. Embedders that need to report a version or override other defaults should use
+// [NewAgentWithConfig] with a fully populated [Config].
 func NewAgent(address string, tenantID string, privateKey string, mode Mode) (*Agent, error) {
 	return NewAgentWithConfig(&Config{
 		ServerAddress: address,
@@ -227,7 +254,7 @@ func NewAgentWithConfig(config *Config, mode Mode) (*Agent, error) {
 func (a *Agent) Initialize() error {
 	var err error
 
-	a.cli, err = client.NewClient(a.config.ServerAddress, client.WithVersion(AgentVersion))
+	a.cli, err = client.NewClient(a.config.ServerAddress, client.WithVersion(a.config.Version))
 	if err != nil {
 		return errors.Wrap(err, "failed to create the HTTP client")
 	}
@@ -259,7 +286,7 @@ func (a *Agent) Initialize() error {
 	a.closed.Store(false)
 
 	a.logger = log.WithFields(log.Fields{
-		"version":           AgentVersion,
+		"version":           a.config.Version,
 		"tenant_id":         a.authData.Namespace,
 		"server_address":    a.config.ServerAddress,
 		"ssh_endpoint":      a.serverInfo.Endpoints.SSH,
@@ -325,8 +352,8 @@ func (a *Agent) loadDeviceInfo() error {
 	a.Info = &models.DeviceInfo{
 		ID:         info.ID,
 		PrettyName: info.Name,
-		Version:    AgentVersion,
-		Platform:   AgentPlatform,
+		Version:    a.config.Version,
+		Platform:   a.config.Platform,
 		Arch:       runtime.GOARCH,
 	}
 
@@ -335,7 +362,7 @@ func (a *Agent) loadDeviceInfo() error {
 
 // probeServerInfo gets information about the ShellHub server.
 func (a *Agent) probeServerInfo() error {
-	info, err := a.cli.GetInfo(AgentVersion)
+	info, err := a.cli.GetInfo(a.config.Version)
 	a.serverInfo = info
 
 	return err
@@ -553,7 +580,7 @@ func (a *Agent) ping(ctx context.Context, interval time.Duration) error {
 		select {
 		case <-ctx.Done():
 			log.WithFields(log.Fields{
-				"version":        AgentVersion,
+				"version":        a.config.Version,
 				"tenant_id":      a.authData.Namespace,
 				"server_address": a.config.ServerAddress,
 			}).Debug("stopped pinging server due to context cancellation")
@@ -562,7 +589,7 @@ func (a *Agent) ping(ctx context.Context, interval time.Duration) error {
 		case ok := <-a.listening:
 			if ok {
 				log.WithFields(log.Fields{
-					"version":        AgentVersion,
+					"version":        a.config.Version,
 					"tenant_id":      a.authData.Namespace,
 					"server_address": a.config.ServerAddress,
 					"timestamp":      time.Now(),
@@ -571,7 +598,7 @@ func (a *Agent) ping(ctx context.Context, interval time.Duration) error {
 				ticker.Reset(interval)
 			} else {
 				log.WithFields(log.Fields{
-					"version":        AgentVersion,
+					"version":        a.config.Version,
 					"tenant_id":      a.authData.Namespace,
 					"server_address": a.config.ServerAddress,
 					"timestamp":      time.Now(),
@@ -585,7 +612,7 @@ func (a *Agent) ping(ctx context.Context, interval time.Duration) error {
 			}
 
 			log.WithFields(log.Fields{
-				"version":        AgentVersion,
+				"version":        a.config.Version,
 				"tenant_id":      a.authData.Namespace,
 				"server_address": a.config.ServerAddress,
 				"name":           a.authData.Name,
@@ -602,7 +629,7 @@ func (a *Agent) ping(ctx context.Context, interval time.Duration) error {
 
 // CheckUpdate gets the ShellHub's server version.
 func (a *Agent) CheckUpdate() (*semver.Version, error) {
-	info, err := a.cli.GetInfo(AgentVersion)
+	info, err := a.cli.GetInfo(a.config.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +643,7 @@ func (a *Agent) GetInfo() (*models.Info, error) {
 		return a.serverInfo, nil
 	}
 
-	info, err := a.cli.GetInfo(AgentVersion)
+	info, err := a.cli.GetInfo(a.config.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -633,7 +660,7 @@ func GetInfo(cfg *Config) (*models.Info, error) {
 		return nil, errors.Wrap(err, "failed to create the HTTP client")
 	}
 
-	info, err := cli.GetInfo(AgentVersion)
+	info, err := cli.GetInfo(cfg.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/pkg/agentd/agent_test.go
+++ b/agent/pkg/agentd/agent_test.go
@@ -1,4 +1,4 @@
-package main
+package agentd
 
 import (
 	"testing"
@@ -251,15 +251,14 @@ func TestNewAgentWithConfig(t *testing.T) {
 func TestAgent_GetInfo(t *testing.T) {
 	clientMocks := new(client_mocks.Client)
 
-	AgentVersion = "latest"
-
 	type expected struct {
 		info *models.Info
 		err  error
 	}
 
 	agent := &Agent{
-		cli: clientMocks,
+		cli:    clientMocks,
+		config: &Config{Version: "latest"},
 	}
 
 	err := errors.New("")

--- a/agent/pkg/agentd/handlers.go
+++ b/agent/pkg/agentd/handlers.go
@@ -1,4 +1,4 @@
-package main
+package agentd
 
 import (
 	"context"
@@ -215,7 +215,7 @@ func sshCloseHandlerV2(agent *Agent) tunnel.HandlerFunc {
 		log.WithFields(
 			log.Fields{
 				"id":             id,
-				"version":        AgentVersion,
+				"version":        agent.config.Version,
 				"tenant_id":      agent.authData.Namespace,
 				"server_address": agent.config.ServerAddress,
 			},
@@ -239,7 +239,7 @@ func httpProxyHandlerV1(agent *Agent) func(c echo.Context) error {
 			"remote":    c.Request().RemoteAddr,
 			"namespace": c.Request().Header.Get("X-Namespace"),
 			"path":      c.Request().Header.Get("X-Path"),
-			"version":   AgentVersion,
+			"version":   agent.config.Version,
 		})
 
 		errorResponse := func(err error, msg string, code int) error {
@@ -397,7 +397,7 @@ func sshCloseHandlerV1(a *Agent) func(c echo.Context) error {
 		log.WithFields(
 			log.Fields{
 				"id":             id,
-				"version":        AgentVersion,
+				"version":        a.config.Version,
 				"tenant_id":      a.authData.Namespace,
 				"server_address": a.config.ServerAddress,
 			},

--- a/agent/pkg/agentd/modes.go
+++ b/agent/pkg/agentd/modes.go
@@ -1,4 +1,4 @@
-package main
+package agentd
 
 import (
 	"context"
@@ -42,7 +42,7 @@ func (m *HostMode) Serve(agent *Agent) {
 		agent.cli,
 		&host.Mode{
 			Authenticator: *host.NewAuthenticator(agent.cli, agent.authData, agent.config.SingleUserPassword, &agent.authData.Name),
-			Sessioner:     *host.NewSessioner(&agent.authData.Name, make(map[string]*exec.Cmd)),
+			Sessioner:     *host.NewSessioner(&agent.authData.Name, make(map[string]*exec.Cmd), agent.config.SFTPServerCommand),
 		},
 		&server.Config{
 			PrivateKey:        agent.config.PrivateKey,

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -30,6 +30,11 @@ type Sessioner struct {
 	//
 	// NOTICE: It's a pointer because when the server is created, we don't know the device name yet, that is set later.
 	deviceName *string
+	// sftpServerCommand builds the command used to start the SFTP server subprocess. When nil,
+	// [command.SFTPServerCommand] is used, which re-executes the current binary
+	// (/proc/self/exe) with the "sftp" subcommand. It can be overridden so the agent can run
+	// embedded in another binary, where /proc/self/exe is not the agent.
+	sftpServerCommand func() *exec.Cmd
 }
 
 func (s *Sessioner) SetCmds(cmds map[string]*exec.Cmd) {
@@ -39,10 +44,15 @@ func (s *Sessioner) SetCmds(cmds map[string]*exec.Cmd) {
 // NewSessioner creates a new instance of Sessioner for the host mode.
 // The device name is a pointer to a string because when the server is created, we don't know the device name yet, that
 // is set later.
-func NewSessioner(deviceName *string, cmds map[string]*exec.Cmd) *Sessioner {
+//
+// sftpServerCommand builds the command used to start the SFTP server subprocess. When nil,
+// [command.SFTPServerCommand] is used (re-executing /proc/self/exe). It can be overridden so
+// the agent can run embedded in another binary, where /proc/self/exe is not the agent.
+func NewSessioner(deviceName *string, cmds map[string]*exec.Cmd, sftpServerCommand func() *exec.Cmd) *Sessioner {
 	return &Sessioner{
-		deviceName: deviceName,
-		cmds:       cmds,
+		deviceName:        deviceName,
+		cmds:              cmds,
+		sftpServerCommand: sftpServerCommand,
 	}
 }
 
@@ -304,7 +314,12 @@ func (s *Sessioner) SFTP(session gliderssh.Session) error {
 	}).Info("SFTP session started")
 	defer session.Close()
 
-	cmd := command.SFTPServerCommand()
+	newSFTPServerCommand := command.SFTPServerCommand
+	if s.sftpServerCommand != nil {
+		newSFTPServerCommand = s.sftpServerCommand
+	}
+
+	cmd := newSFTPServerCommand()
 
 	looked, err := user.Lookup(session.User())
 	if err != nil {


### PR DESCRIPTION
## What
Extracts the agent's core (lifecycle, modes, handlers) out of `package main` into a new importable library, `agent/pkg/agentd`, so the agent can run in-process inside another Go program. The `agent/` binary stays a thin `package main` CLI that imports the new package.

## Why
The Agent type and its lifecycle lived in `package main`, which Go cannot import. ShellHub Desktop (Wails v3) needs to embed the agent in-process to register the host as a device, rather than shelling out to a subprocess.

Closes #6430

## Changes
- **agent/pkg/agentd (new)**: moved `agent.go`, `modes.go`, `handlers.go`, and their test out of `package main` (via `git mv`, history preserved) and re-declared them as `package agentd`. Public API is unchanged: `NewAgentWithConfig`, `Initialize`, `Listen`, `Close`, `Config`, `Mode`, `HostMode`, `ConnectorMode`, `GetInfo`, `LoadConfigFromEnv`.
- **Version/Platform via Config**: a library can't read another package's `main` globals, so the core no longer references `AgentVersion`/`AgentPlatform`. Added `Config.Version` and `Config.Platform`; the CLI injects them from its ldflags globals. The build invocation is unchanged — the ldflags target is still `main.AgentVersion`. Self-update stays entirely in the CLI loop, so an embedded agent never self-updates.
- **Injectable SFTP command**: the host SFTP server starts by re-executing `/proc/self/exe sftp` — which breaks when embedded, since that path is the host program, not the agent. Added `Config.SFTPServerCommand func() *exec.Cmd`, threaded through `host.NewSessioner`; when nil (the CLI path) behavior is identical to before. Embedders point it at a binary that runs the SFTP server.
- **os.Exit confinement**: all `os.Exit` calls remain in `package main` (`main.go`, `sftp.go`); the library has none, so embedding it cannot abort the host process.

## Testing
A consumer embedding this package must replicate the agent module's `replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh` directive in its own go.mod — Go ignores replace directives from non-main modules. This is documented in the agentd package comment.

Verify the CLI path is unchanged: build with `-ldflags "-X main.AgentVersion=<v>"` and confirm `agent --version` reports it and a host-mode device still serves SSH and SFTP. Both the native and `docker` build tags compile; `go vet` and the agentd tests pass.