### PR TITLE
chore: bump shellhub version to v0.25.0-rc.2

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # This is in order to avoid conflict with upstream code when updating to a newer version
 
 # ShellHub version. 
-SHELLHUB_VERSION=v0.25.0-rc.1
+SHELLHUB_VERSION=v0.25.0-rc.2
 
 # The default log level for ShellHub.
 # VALUES: https://pkg.go.dev/github.com/sirupsen/logrus#Level


### PR DESCRIPTION
Bumps `SHELLHUB_VERSION` from `v0.25.0-rc.1` to `v0.25.0-rc.2` in `.env`.

Cuts the second release candidate for the v0.25.0 cycle. Since rc.1 the master branch accumulated 67 commits, including dropping the MongoDB store in favor of Postgres only, renaming `ui-react/` to `ui/` and removing the legacy Vue frontend, swapping redis for valkey, and routing MCP tools through the API middleware. This RC lets that set be validated before the final v0.25.0.

Once merged, the `v0.25.0-rc.2` tag is pushed on shellhub (triggering docker-publish) and mirrored on cloud.