### PR TITLE
fix(api): stop persisting unused pty-req modelist

### DIFF
--- a/api/store/pg/migrations/004_drop_pty_req_modelist.tx.down.sql
+++ b/api/store/pg/migrations/004_drop_pty_req_modelist.tx.down.sql
@@ -1,0 +1,3 @@
+-- Irreversible: the dropped "modelist" data cannot be reconstructed. The recorded
+-- SSH terminal modes are unused, so there is nothing to restore.
+SELECT 1;

--- a/api/store/pg/migrations/004_drop_pty_req_modelist.tx.up.sql
+++ b/api/store/pg/migrations/004_drop_pty_req_modelist.tx.up.sql
@@ -1,0 +1,4 @@
+-- Drop the unused "modelist" key from recorded pty-req events.
+UPDATE session_events
+SET data = (data::jsonb - 'modelist')::text
+WHERE type = 'pty-req';

--- a/pkg/models/ssh.go
+++ b/pkg/models/ssh.go
@@ -28,12 +28,13 @@ type SSHWindowChange struct {
 
 // NOTE: [SSHPty] cannot use [SSHWindowChange] inside itself due [ssh.Unmarshal] issues.
 type SSHPty struct {
-	Term     string `json:"term"`
-	Columns  uint32 `json:"columns" `
-	Rows     uint32 `json:"rows"`
-	Width    uint32 `json:"width"`
-	Height   uint32 `json:"height"`
-	Modelist []byte `json:"modelist"`
+	Term    string `json:"term"`
+	Columns uint32 `json:"columns"`
+	Rows    uint32 `json:"rows"`
+	Width   uint32 `json:"width"`
+	Height  uint32 `json:"height"`
+	// Not persisted (json:"-"); kept only so gossh.Unmarshal can consume it.
+	Modelist []byte `json:"-"`
 }
 
 type SSHPtyOutput struct {


### PR DESCRIPTION
The SSH terminal modes recorded in pty-req events are never read back
(playback only needs the dimensions) and older data stored them as a
BSON-binary object that no longer decodes into SSHPty.Modelist ([]byte).
Mark the field json:"-" so it is dropped from new events, and add a
migration to strip it from existing rows.
