### PR TITLE
fix(api): enforce unique namespace names in postgres

### DIFF
--- a/api/services/namespace.go
+++ b/api/services/namespace.go
@@ -94,7 +94,14 @@ func (s *service) CreateNamespace(ctx context.Context, req *requests.NamespaceCr
 		ns.MaxDevices = -1
 	}
 
+	// The NamespaceConflicts pre-check above is the fast path; store.ErrDuplicate
+	// here means a concurrent insert raced past it. Map it to ErrNamespaceDuplicated
+	// so callers get a consistent duplicate signal regardless of timing.
 	if _, err := s.store.NamespaceCreate(ctx, ns); err != nil {
+		if errors.Is(err, store.ErrDuplicate) {
+			return nil, NewErrNamespaceDuplicated(err)
+		}
+
 		return nil, NewErrNamespaceCreateStore(err)
 	}
 
@@ -196,7 +203,14 @@ func (s *service) EditNamespace(ctx context.Context, req *requests.NamespaceEdit
 		namespace.Settings.ConnectionAnnouncement = *req.Settings.ConnectionAnnouncement
 	}
 
+	// NamespaceUpdate returns store.ErrDuplicate when the new name collides with an
+	// existing namespace. Map it to ErrNamespaceDuplicated so callers get a
+	// consistent duplicate signal regardless of timing.
 	if err := s.store.NamespaceUpdate(ctx, namespace); err != nil {
+		if errors.Is(err, store.ErrDuplicate) {
+			return nil, NewErrNamespaceDuplicated(err)
+		}
+
 		return nil, err
 	}
 

--- a/api/services/namespace_test.go
+++ b/api/services/namespace_test.go
@@ -654,6 +654,83 @@ func TestCreateNamespace(t *testing.T) {
 			},
 		},
 		{
+			// store.ErrDuplicate from NamespaceCreate means a concurrent insert raced past the
+			// NamespaceConflicts pre-check (case-sensitive name=? queries rely on lowercased
+			// writes). The service must map it to ErrNamespaceDuplicated, not ErrNamespaceCreateStore.
+			description: "fails when NamespaceCreate returns store.ErrDuplicate",
+			req: &requests.NamespaceCreate{
+				UserID:   "000000000000000000000000",
+				Name:     "namespace",
+				TenantID: "00000000-0000-4000-0000-000000000000",
+			},
+			requiredMocks: func() {
+				storeMock.
+					On("UserGetInfo", ctx, "000000000000000000000000").
+					Return(
+						&models.UserInfo{
+							OwnedNamespaces:      []models.Namespace{{}},
+							AssociatedNamespaces: []models.Namespace{},
+						},
+						nil,
+					).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(&models.User{
+						ID:            "000000000000000000000000",
+						MaxNamespaces: 3,
+					}, nil).
+					Once()
+				storeMock.
+					On("NamespaceConflicts", ctx, &models.NamespaceConflicts{Name: "namespace"}).
+					Return(nil, false, nil).
+					Once()
+				// envs.IsCommunity() calls SHELLHUB_CLOUD then SHELLHUB_ENTERPRISE.
+				envMock.
+					On("Get", "SHELLHUB_CLOUD").
+					Return("false").
+					Once()
+				envMock.
+					On("Get", "SHELLHUB_ENTERPRISE").
+					Return("false").
+					Once()
+				// envs.IsCloud() calls SHELLHUB_CLOUD once more.
+				envMock.
+					On("Get", "SHELLHUB_CLOUD").
+					Return("false").
+					Once()
+				storeMock.
+					On(
+						"NamespaceCreate",
+						ctx,
+						&models.Namespace{
+							TenantID: "00000000-0000-4000-0000-000000000000",
+							Name:     "namespace",
+							Owner:    "000000000000000000000000",
+							Type:     models.TypeTeam,
+							Members: []models.Member{
+								{
+									ID:      "000000000000000000000000",
+									Role:    authorizer.RoleOwner,
+									AddedAt: now,
+								},
+							},
+							Settings: &models.NamespaceSettings{
+								SessionRecord:          true,
+								ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+							},
+							MaxDevices: -1,
+						},
+					).
+					Return("", store.ErrDuplicate).
+					Once()
+			},
+			expected: Expected{
+				ns:  nil,
+				err: NewErrNamespaceDuplicated(store.ErrDuplicate),
+			},
+		},
+		{
 			description: "succeeds to create a namespace",
 			req: &requests.NamespaceCreate{
 				UserID:   "000000000000000000000000",
@@ -1104,6 +1181,33 @@ func TestEditNamespace(t *testing.T) {
 			expected: Expected{
 				nil,
 				errors.New("error"),
+			},
+		},
+		{
+			description:   "fails with ErrNamespaceDuplicated when store returns ErrDuplicate",
+			tenantID:      "xxxxx",
+			namespaceName: "newname",
+			requiredMocks: func() {
+				namespace := &models.Namespace{
+					TenantID: "xxxxx",
+					Name:     "oldname",
+					Settings: &models.NamespaceSettings{SessionRecord: false},
+				}
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "xxxxx").
+					Return(namespace, nil).
+					Once()
+
+				expectedNamespace := *namespace
+				expectedNamespace.Name = "newname"
+				storeMock.
+					On("NamespaceUpdate", ctx, &expectedNamespace).
+					Return(store.ErrDuplicate).
+					Once()
+			},
+			expected: Expected{
+				nil,
+				NewErrNamespaceDuplicated(store.ErrDuplicate),
 			},
 		},
 		{

--- a/api/store/pg/migrations/004_namespaces_name_unique.tx.down.sql
+++ b/api/store/pg/migrations/004_namespaces_name_unique.tx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS namespaces_name_unique;

--- a/api/store/pg/migrations/004_namespaces_name_unique.tx.up.sql
+++ b/api/store/pg/migrations/004_namespaces_name_unique.tx.up.sql
@@ -1,0 +1,39 @@
+-- Step a: deduplicate existing rows non-destructively by renaming duplicates.
+-- For each case-insensitive name group the oldest row (by created_at, ties broken
+-- by id ASC) keeps its original name; every other row in that group is renamed to
+-- "<base>-<first-8-chars-of-id>" where <base> is the lower-cased original name
+-- truncated so the full result never exceeds 63 characters.
+-- Trailing hyphens are stripped from the base before the suffix is appended, so
+-- the resulting name always starts and ends with an alphanumeric character.
+-- Re-running this statement is safe (idempotent): rows that were already renamed
+-- by a previous run will not match the duplicate-detection predicate again.
+WITH winners AS (
+    -- One winner per lower(name) group: oldest created_at, smallest id on ties.
+    SELECT DISTINCT ON (lower(name)) id
+    FROM namespaces
+    ORDER BY lower(name), created_at ASC, id ASC
+),
+duplicates AS (
+    -- Every row that is NOT the winner of its group.
+    SELECT n.id,
+           lower(n.name) AS lower_name
+    FROM   namespaces n
+    WHERE  n.id NOT IN (SELECT id FROM winners)
+)
+UPDATE namespaces n
+SET name = (
+    -- Build "<base>-<suffix>" where suffix = first 8 hex chars of the UUID.
+    -- Base = lower(name) truncated to at most 54 chars, then right-stripped of
+    -- hyphens so the final name never starts/ends with '-'.
+    rtrim(
+        left(lower(n.name), 54),
+        '-'
+    ) || '-' || left(replace(n.id::text, '-', ''), 8)
+)
+FROM duplicates d
+WHERE n.id = d.id;
+
+--bun:split
+
+-- Step b: create a case-insensitive unique index on lower(name).
+CREATE UNIQUE INDEX namespaces_name_unique ON namespaces USING btree (lower(name));

--- a/api/store/pg/migrations_test.go
+++ b/api/store/pg/migrations_test.go
@@ -1,0 +1,445 @@
+package pg_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/api/store/pg"
+	"github.com/shellhub-io/shellhub/api/store/pg/dbtest"
+	"github.com/shellhub-io/shellhub/api/store/pg/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// migration004Statements reads 004_namespaces_name_unique.tx.up.sql from disk
+// (relative to this file) and splits on "--bun:split", returning each non-empty
+// statement in order.
+func migration004Statements(t *testing.T) []string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must succeed")
+
+	// This file lives at api/store/pg/migrations_test.go
+	path := filepath.Join(filepath.Dir(file), "migrations", "004_namespaces_name_unique.tx.up.sql")
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err, "004 migration file must exist on disk")
+
+	var stmts []string
+	for _, part := range strings.Split(string(raw), "--bun:split") {
+		if s := strings.TrimSpace(part); s != "" {
+			stmts = append(stmts, s)
+		}
+	}
+
+	require.NotEmpty(t, stmts, "004 migration must have at least one statement")
+
+	return stmts
+}
+
+// execSQL runs a literal SQL string with no parameters.
+func execSQL(t *testing.T, ctx context.Context, db *bun.DB, query string) {
+	t.Helper()
+
+	_, err := db.ExecContext(ctx, query)
+	require.NoError(t, err, "execSQL failed:\n%s", query)
+}
+
+// TestMigration004Dedup verifies that the dedup step (a) of migration 004 renames
+// duplicate namespace rows non-destructively, keeping the oldest (by created_at,
+// ties broken by id ASC) unchanged and renaming every other duplicate so that all
+// values of lower(name) are unique, each name fits in 63 chars, and no renamed name
+// starts or ends with a hyphen.  It also asserts that the resulting unique index
+// blocks a subsequent duplicate INSERT (SQLSTATE 23505) and that re-running the
+// dedup UPDATE is idempotent.
+func TestMigration004Dedup(t *testing.T) {
+	ctx := context.Background()
+
+	// ── Spin up a real Postgres container ───────────────────────────────────────
+	srv := &dbtest.Server{}
+	require.NoError(t, srv.Up(ctx))
+
+	t.Cleanup(func() {
+		if err := srv.Down(ctx); err != nil {
+			t.Logf("warn: container teardown: %v", err)
+		}
+	})
+
+	connStr, err := srv.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	// ── Apply all migrations (001-004) via pg.New so schema + index exist ───────
+	st, err := pg.New(ctx, connStr, options.Migrate())
+	require.NoError(t, err, "pg.New with Migrate must succeed")
+
+	db := st.(*pg.Pg).Driver()
+
+	// ── Drop the unique index so we can insert conflicting names ─────────────────
+	execSQL(t, ctx, db, `DROP INDEX IF EXISTS namespaces_name_unique`)
+
+	// ── Insert FK-parent user (literal SQL, no bind params) ──────────────────────
+	const ownerID = "11111111-1111-4111-8111-111111111111"
+
+	execSQL(t, ctx, db, `
+		INSERT INTO users
+		    (id, created_at, updated_at, origin, status, name, username, email,
+		     password_digest, auth_methods, namespace_ownership_limit)
+		VALUES ('`+ownerID+`', now(), now(), 'local', 'confirmed', 'Owner', 'nsowner',
+		        'nsowner@example.com', 'x', ARRAY['local']::user_auth_method[], 10)
+	`)
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	insertNS := func(id, name string, createdAt time.Time) {
+		t.Helper()
+
+		ts := createdAt.UTC().Format("2006-01-02 15:04:05Z")
+		execSQL(t, ctx, db, fmt.Sprintf(`
+			INSERT INTO namespaces
+			    (id, created_at, updated_at, scope, name, owner_id, max_devices, record_sessions)
+			VALUES ('%s', '%s', '%s', 'personal', '%s', '%s', -1, false)
+		`, id, ts, ts, name, ownerID))
+	}
+
+	// Group 1: three rows sharing "myapp" (case-insensitively).
+	const (
+		nsOldest  = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" // oldest → keeps "myapp"
+		nsMiddle  = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" // newer  → renamed
+		nsMixed   = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" // "MyApp" → renamed
+		nsControl = "dddddddd-dddd-4ddd-8ddd-dddddddddddd" // unrelated control
+	)
+
+	insertNS(nsOldest, "myapp", base)
+	insertNS(nsMiddle, "myapp", base.Add(time.Hour))
+	insertNS(nsMixed, "MyApp", base.Add(2*time.Hour))
+	insertNS(nsControl, "otherapp", base.Add(3*time.Hour))
+
+	// ── Run the full 004 migration from disk ─────────────────────────────────────
+	stmts := migration004Statements(t)
+	for i, stmt := range stmts {
+		_, execErr := db.ExecContext(ctx, stmt)
+		require.NoError(t, execErr, "004 migration statement %d failed:\n%s", i, stmt)
+	}
+
+	// ── Read back all four rows ──────────────────────────────────────────────────
+	type nsRow struct {
+		ID   string `bun:"id"`
+		Name string `bun:"name"`
+	}
+
+	var rows []nsRow
+	err = db.NewSelect().
+		TableExpr("namespaces").
+		ColumnExpr("id, name").
+		OrderExpr("created_at ASC").
+		Scan(ctx, &rows)
+	require.NoError(t, err)
+
+	require.Len(t, rows, 4, "all four rows must survive — dedup must be non-destructive")
+
+	byID := make(map[string]string, 4)
+	for _, r := range rows {
+		byID[r.ID] = r.Name
+	}
+
+	// 1. Oldest row keeps its exact original name.
+	assert.Equal(t, "myapp", byID[nsOldest], "oldest row must keep original name")
+
+	// 2. Newer duplicates are renamed.
+	assert.NotEqual(t, "myapp", byID[nsMiddle], "middle duplicate must be renamed")
+	assert.NotEqual(t, "MyApp", byID[nsMixed], "mixed-case duplicate must be renamed")
+
+	// 3. Renamed rows must not collide with the winner even case-insensitively.
+	assert.NotEqual(t, "myapp", strings.ToLower(byID[nsMiddle]),
+		"renamed middle must not collide with oldest under lower()")
+	assert.NotEqual(t, "myapp", strings.ToLower(byID[nsMixed]),
+		"renamed mixed-case must not collide with oldest under lower()")
+
+	// 4. Control namespace is untouched.
+	assert.Equal(t, "otherapp", byID[nsControl], "unrelated namespace must not be changed")
+
+	// 5. All four lower(name) values are unique.
+	lowerSeen := make(map[string]string) // lower → id
+	for id, name := range byID {
+		lower := strings.ToLower(name)
+		if prev, dup := lowerSeen[lower]; dup {
+			t.Errorf("lower(name) collision: ids %s and %s both have lower=%q", prev, id, lower)
+		}
+
+		lowerSeen[lower] = id
+	}
+
+	// 6. No name exceeds 63 characters (RFC1123 label limit).
+	for id, name := range byID {
+		assert.LessOrEqual(t, len(name), 63,
+			"name too long after dedup: id=%s name=%q", id, name)
+	}
+
+	// 7. No name starts or ends with a hyphen.
+	for id, name := range byID {
+		assert.NotEqual(t, byte('-'), name[0],
+			"leading hyphen: id=%s name=%q", id, name)
+		assert.NotEqual(t, byte('-'), name[len(name)-1],
+			"trailing hyphen: id=%s name=%q", id, name)
+	}
+
+	// 8. The unique index now blocks a duplicate INSERT (SQLSTATE 23505).
+	t.Run("unique_index_enforced", func(t *testing.T) {
+		_, insertErr := db.ExecContext(ctx, `
+			INSERT INTO namespaces
+			    (id, created_at, updated_at, scope, name, owner_id, max_devices, record_sessions)
+			VALUES ('eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee', now(), now(),
+			        'personal', 'myapp', '`+ownerID+`', -1, false)
+		`)
+		require.Error(t, insertErr, "inserting a name that duplicates an existing one must fail")
+		assert.Contains(t, insertErr.Error(), "23505",
+			"error must be unique_violation (SQLSTATE 23505)")
+	})
+
+	// 9. Re-running the dedup UPDATE is idempotent — no name changes a second time.
+	t.Run("idempotency", func(t *testing.T) {
+		snapBefore := make(map[string]string)
+		for id, name := range byID {
+			snapBefore[id] = name
+		}
+
+		// Re-execute only statement 0 (the dedup step).
+		_, execErr := db.ExecContext(ctx, stmts[0])
+		require.NoError(t, execErr, "re-running dedup step must not error")
+
+		var rows2 []nsRow
+		err = db.NewSelect().
+			TableExpr("namespaces").
+			ColumnExpr("id, name").
+			Scan(ctx, &rows2)
+		require.NoError(t, err)
+
+		for _, r := range rows2 {
+			before, known := snapBefore[r.ID]
+			if !known {
+				continue // extra row inserted by sub-test 8
+			}
+
+			assert.Equal(t, before, r.Name,
+				"re-running dedup must not change name of id=%s", r.ID)
+		}
+	})
+}
+
+// TestMigration004DedupTieBreak verifies that when two rows share the same
+// created_at, the one with the lexicographically smallest id wins (keeps its name)
+// and the other is renamed.
+func TestMigration004DedupTieBreak(t *testing.T) {
+	ctx := context.Background()
+
+	srv := &dbtest.Server{}
+	require.NoError(t, srv.Up(ctx))
+
+	t.Cleanup(func() { srv.Down(ctx) }) //nolint:errcheck
+
+	connStr, err := srv.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	st, err := pg.New(ctx, connStr, options.Migrate())
+	require.NoError(t, err)
+
+	db := st.(*pg.Pg).Driver()
+
+	execSQL(t, ctx, db, `DROP INDEX IF EXISTS namespaces_name_unique`)
+
+	const ownerID = "22222222-2222-4222-8222-222222222222"
+
+	execSQL(t, ctx, db, `
+		INSERT INTO users
+		    (id, created_at, updated_at, origin, status, name, username, email,
+		     password_digest, auth_methods, namespace_ownership_limit)
+		VALUES ('`+ownerID+`', now(), now(), 'local', 'confirmed', 'Tie Owner', 'tieowner',
+		        'tieowner@example.com', 'x', ARRAY['local']::user_auth_method[], 10)
+	`)
+
+	sameTime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	ts := sameTime.UTC().Format("2006-01-02 15:04:05Z")
+
+	// lex-smallest id wins the group and keeps its name.
+	const (
+		idSmall = "aaaaaaaa-0000-4000-8000-000000000000"
+		idLarge = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+	)
+
+	for _, ns := range []struct{ id, name string }{
+		{idSmall, "tieapp"},
+		{idLarge, "tieapp"},
+	} {
+		execSQL(t, ctx, db, fmt.Sprintf(`
+			INSERT INTO namespaces
+			    (id, created_at, updated_at, scope, name, owner_id, max_devices, record_sessions)
+			VALUES ('%s', '%s', '%s', 'personal', '%s', '%s', -1, false)
+		`, ns.id, ts, ts, ns.name, ownerID))
+	}
+
+	stmts := migration004Statements(t)
+	for i, stmt := range stmts {
+		_, execErr := db.ExecContext(ctx, stmt)
+		require.NoError(t, execErr, "statement %d failed", i)
+	}
+
+	nameSmall := nsName(t, ctx, db, idSmall)
+	nameLarge := nsName(t, ctx, db, idLarge)
+
+	assert.Equal(t, "tieapp", nameSmall, "lex-smallest id must keep its name")
+	assert.NotEqual(t, "tieapp", nameLarge, "lex-largest id must be renamed")
+	assert.NotEqual(t, strings.ToLower("tieapp"), strings.ToLower(nameLarge),
+		"renamed name must not collide case-insensitively")
+}
+
+// nsName fetches the name column for a single namespace row by id.
+func nsName(t *testing.T, ctx context.Context, db *bun.DB, id string) string {
+	t.Helper()
+
+	var name string
+
+	err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT name FROM namespaces WHERE id = '%s'`, id)).Scan(&name)
+	if err == sql.ErrNoRows {
+		return ""
+	}
+
+	require.NoError(t, err)
+
+	return name
+}
+
+// TestMigration004AtomicRollback proves that the two 004 statements run atomically:
+// when CREATE UNIQUE INDEX (step b) fails due to a pre-existing row whose name
+// collides with a would-be renamed duplicate, the whole transaction rolls back and
+// no rows are renamed (step a is undone).
+//
+// Setup:
+//   - "rollapp"         – oldest, winner of the "rollapp" lower(name) group
+//   - "Rollapp"         – loser (same lower(name) group, newer), would be renamed to
+//     "rollapp-cccccccc" by step a (first 8 hex chars of its UUID)
+//   - "rollapp-cccccccc"– control row that already occupies the rename target,
+//     causing CREATE UNIQUE INDEX to violate the uniqueness constraint
+//
+// Expected outcome: transaction rolls back → all three rows keep their original names.
+func TestMigration004AtomicRollback(t *testing.T) {
+	ctx := context.Background()
+
+	srv := &dbtest.Server{}
+	require.NoError(t, srv.Up(ctx))
+
+	t.Cleanup(func() {
+		if err := srv.Down(ctx); err != nil {
+			t.Logf("warn: container teardown: %v", err)
+		}
+	})
+
+	connStr, err := srv.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	// Apply migrations 001-003 (schema) via pg.New with Migrate, then drop the
+	// unique index added by 004 so we can insert conflicting names for the test.
+	st, err := pg.New(ctx, connStr, options.Migrate())
+	require.NoError(t, err, "pg.New with Migrate must succeed")
+
+	db := st.(*pg.Pg).Driver()
+
+	// Drop the unique index created by migration 004 so we can insert duplicates.
+	execSQL(t, ctx, db, `DROP INDEX IF EXISTS namespaces_name_unique`)
+
+	const ownerID = "33333333-3333-4333-8333-333333333333"
+
+	execSQL(t, ctx, db, `
+		INSERT INTO users
+		    (id, created_at, updated_at, origin, status, name, username, email,
+		     password_digest, auth_methods, namespace_ownership_limit)
+		VALUES ('`+ownerID+`', now(), now(), 'local', 'confirmed', 'Rollback Owner', 'rollbackowner',
+		        'rollbackowner@example.com', 'x', ARRAY['local']::user_auth_method[], 10)
+	`)
+
+	base := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// loserID determines the rename target produced by step a:
+	//   lower("Rollapp") → "rollapp"
+	//   left("rollapp", 54) → "rollapp"
+	//   rtrim("rollapp", '-') → "rollapp"
+	//   left(replace("cccccccc-cccc-4ccc-8ccc-cccccccccccc", '-', ''), 8) → "cccccccc"
+	//   rename target → "rollapp-cccccccc"
+	const (
+		winnerID  = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+		loserID   = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+		controlID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+
+		winnerName  = "rollapp"          // oldest in lower("rollapp") group → kept
+		loserName   = "Rollapp"          // same lower(name) group, newer → renamed by step a
+		controlName = "rollapp-cccccccc" // pre-seeded to collide with step a's rename target
+	)
+
+	insertRollbackNS := func(id, name string, createdAt time.Time) {
+		t.Helper()
+
+		ts := createdAt.UTC().Format("2006-01-02 15:04:05Z")
+		execSQL(t, ctx, db, fmt.Sprintf(`
+			INSERT INTO namespaces
+			    (id, created_at, updated_at, scope, name, owner_id, max_devices, record_sessions)
+			VALUES ('%s', '%s', '%s', 'personal', '%s', '%s', -1, false)
+		`, id, ts, ts, name, ownerID))
+	}
+
+	// winner and loser share lower(name)="rollapp" → step a renames loser to
+	// "rollapp-cccccccc". control row already has that name, so CREATE UNIQUE INDEX
+	// (step b) will see a collision and fail.
+	insertRollbackNS(winnerID, winnerName, base)
+	insertRollbackNS(loserID, loserName, base.Add(time.Hour))
+	insertRollbackNS(controlID, controlName, base.Add(2*time.Hour))
+
+	stmts := migration004Statements(t)
+	require.Len(t, stmts, 2, "004 migration must have exactly 2 statements (dedup + index)")
+
+	// ── Run both 004 statements inside a single explicit transaction ─────────────
+	// This mirrors bun's .tx. wrapping that the migration runner uses for .tx. files.
+	// If CREATE UNIQUE INDEX (step b) fails, the whole transaction is rolled back,
+	// undoing the UPDATE (step a) so no rows are renamed.
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err, "BEGIN must succeed")
+
+	var stmtErr error
+
+	for i, stmt := range stmts {
+		if _, execErr := tx.ExecContext(ctx, stmt); execErr != nil {
+			stmtErr = execErr
+			t.Logf("statement %d failed (expected): %v", i, execErr)
+
+			break
+		}
+	}
+
+	if stmtErr != nil {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			t.Logf("warn: ROLLBACK failed: %v", rollbackErr)
+		}
+	} else {
+		// If somehow no error occurred, commit so the test can inspect the state;
+		// the assertions below will then fail (proving the test is misconfigured).
+		_ = tx.Commit()
+	}
+
+	// ── Assert: migration must fail (index creation conflicts with control row) ───
+	require.Error(t, stmtErr, "the 004 migration must fail when a rename target already exists")
+
+	// ── Assert: no rows were renamed (rollback preserved original names) ─────────
+	assert.Equal(t, winnerName, nsName(t, ctx, db, winnerID),
+		"winner row must be untouched after rollback")
+	assert.Equal(t, loserName, nsName(t, ctx, db, loserID),
+		"loser row must NOT be renamed — transaction atomicity must roll back step a")
+	assert.Equal(t, controlName, nsName(t, ctx, db, controlID),
+		"control row must be untouched after rollback")
+}

--- a/api/store/pg/store_test.go
+++ b/api/store/pg/store_test.go
@@ -30,6 +30,7 @@ func TestPgStore(t *testing.T) {
 		suite.TestNamespaceResolve(t)
 		suite.TestNamespaceGetPreferred(t)
 		suite.TestNamespaceCreate(t)
+		suite.TestNamespaceCreateDuplicate(t)
 		suite.TestNamespaceConflicts(t)
 		suite.TestNamespaceUpdate(t)
 		suite.TestNamespaceIncrementDeviceCount(t)

--- a/api/store/storetest/namespace_tests.go
+++ b/api/store/storetest/namespace_tests.go
@@ -310,6 +310,66 @@ func (s *Suite) TestNamespaceCreate(t *testing.T) {
 	})
 }
 
+// TestNamespaceCreateDuplicate verifies that NamespaceCreate enforces a
+// case-insensitive unique constraint on the namespace name (lower(name)).
+func (s *Suite) TestNamespaceCreateDuplicate(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	tests := []struct {
+		description string
+		first       string // name of the namespace created first (always succeeds)
+		second      string // name of the namespace created second
+		wantErr     bool   // whether the second creation must be rejected
+	}{
+		{
+			description: "exact duplicate name is rejected",
+			first:       "my-namespace",
+			second:      "my-namespace",
+			wantErr:     true,
+		},
+		{
+			description: "mixed-case duplicate name is rejected",
+			first:       "case-test",
+			second:      "Case-Test",
+			wantErr:     true,
+		},
+		{
+			description: "fully upper-case variant is rejected",
+			first:       "unique-ns",
+			second:      "UNIQUE-NS",
+			wantErr:     true,
+		},
+		{
+			description: "distinct name succeeds after first creation",
+			first:       "alpha-ns",
+			second:      "beta-ns",
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			require.NoError(t, s.provider.CleanDatabase(t))
+
+			userID := s.CreateUser(t)
+			s.CreateNamespace(t, WithOwner(userID), WithNamespaceName(tc.first))
+
+			_, err := st.NamespaceCreate(ctx, &models.Namespace{
+				Name:       tc.second,
+				Owner:      userID,
+				MaxDevices: -1,
+				Settings:   &models.NamespaceSettings{SessionRecord: true},
+			})
+			if tc.wantErr {
+				assert.ErrorIs(t, err, store.ErrDuplicate)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestNamespaceConflicts tests checking for namespace conflicts
 func (s *Suite) TestNamespaceConflicts(t *testing.T) {
 	ctx := context.Background()

--- a/api/store/storetest/suite.go
+++ b/api/store/storetest/suite.go
@@ -21,6 +21,7 @@ func (s *Suite) Run(t *testing.T) {
 		s.TestNamespaceResolve(t)
 		s.TestNamespaceGetPreferred(t)
 		s.TestNamespaceCreate(t)
+		s.TestNamespaceCreateDuplicate(t)
 		s.TestNamespaceConflicts(t)
 		s.TestNamespaceUpdate(t)
 		s.TestNamespaceIncrementDeviceCount(t)


### PR DESCRIPTION
## What
Restores the global uniqueness of `namespaces.name` that MongoDB enforced
but was lost in the Mongo→Postgres migration, enforcing it at the database
level with a case-insensitive unique index.

## Why
The Postgres `namespaces` table carried only a primary key on `id` and a
foreign key on `owner_id` — Mongo's unique index on `name` was never
recreated. Two namespaces could therefore share a name. Device lookup
resolves a namespace by name (`service.LookupDevice` →
`NamespaceResolve(NamespaceNameResolver, ...)`) and scans a single row, so
duplicate names made the SSH flow resolve to the wrong tenant and return
`device not found` (404) for an existing device. Uniqueness was previously
guarded only in the application layer (`NamespaceConflicts`), which has a
check-then-insert race and does nothing for data created out-of-band.

Closes #6438

## Changes
- **migration 004**: a single transactional `.tx.` migration that (a)
  deduplicates pre-existing rows **non-destructively** — the oldest row per
  `lower(name)` group keeps its name, the rest are renamed to
  `<base>-<8 hex of id>` (≤63 chars, RFC1123-safe, no leading/trailing
  hyphen) — then (b) creates `UNIQUE INDEX namespaces_name_unique ON
  namespaces (lower(name))`. Both steps share one transaction, so a residual
  collision on index creation rolls the renames back atomically rather than
  leaving a half-migrated table.
- **case-insensitive constraint**: indexes `lower(name)` to match the
  app-level invariant that names are always stored lowercased, and to be
  defensive against any stray mixed-case row.
- **service error mapping**: `CreateNamespace` and `EditNamespace` now map
  `store.ErrDuplicate` (pg 23505) to `NewErrNamespaceDuplicated`, so both the
  create race and the rename path return a 409 instead of a generic 500.
  `EditNamespace` previously returned the store error raw.

## Testing
`./bin/docker-compose exec api go test ./store/pg/ ./store/storetest/... ./services/`

Migration tests run against a real Postgres (`dbtest.Server` + testcontainers)
and cover: non-destructive dedup, oldest-wins tie-break, idempotency of the
rename, and atomic rollback when index creation fails on a seeded collision.

Note: the dedup suffix uses 8 hex chars of the row UUID. A renamed value
colliding with an *unrelated* pre-existing namespace would abort the
auto-upgrade migration (and block API startup) until an operator resolves it
— extremely unlikely, and a safe no-data-loss failure mode by design.