### PR TITLE
fix(api): widen device pretty_name column to 256 chars

### DIFF
--- a/api/store/pg/migrations/005_device_pretty_name_length.tx.down.sql
+++ b/api/store/pg/migrations/005_device_pretty_name_length.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices ALTER COLUMN pretty_name TYPE character varying(64);

--- a/api/store/pg/migrations/005_device_pretty_name_length.tx.up.sql
+++ b/api/store/pg/migrations/005_device_pretty_name_length.tx.up.sql
@@ -1,0 +1,3 @@
+-- Widen pretty_name to fit longer OS-supplied PRETTY_NAME values
+-- (/etc/os-release); varchar(64) overflowed on some distros.
+ALTER TABLE devices ALTER COLUMN pretty_name TYPE character varying(256);


### PR DESCRIPTION
## What

Migration 005 widens the `devices.pretty_name` column from `varchar(64)` to `varchar(256)`.

## Why

`pretty_name` is populated from the device OS `PRETTY_NAME` (`/etc/os-release`), which is unbounded and routinely exceeds 64 chars on embedded/vendor distros. On the Postgres store the "mark device online" UPDATE failed with `value too long for type character varying(64)` (SQLSTATE 22001), so affected devices could never come online and the agent retried forever. The MongoDB store imposed no such limit, making this a regression on `0.25.x`.

Fixes #6440