### PR TITLE
chore: bump shellhub version to v0.25.1-rc.1

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # This is in order to avoid conflict with upstream code when updating to a newer version
 
 # ShellHub version. 
-SHELLHUB_VERSION=v0.25.0
+SHELLHUB_VERSION=v0.25.1-rc.1
 
 # The default log level for ShellHub.
 # VALUES: https://pkg.go.dev/github.com/sirupsen/logrus#Level


### PR DESCRIPTION
Bumps `SHELLHUB_VERSION` to `v0.25.1-rc.1` ahead of cutting the release candidate tag.