### PR TITLE
fix(ssh): fall back to base domain for web endpoint host header

### DIFF
--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -57,6 +57,7 @@ services:
   ssh:
     image: registry.infra.ossystems.io/cache/shellhubio/ssh:${SHELLHUB_VERSION}
     environment:
+      - SHELLHUB_DOMAIN=${SHELLHUB_DOMAIN}
       - SHELLHUB_WEB_ENDPOINTS=${SHELLHUB_WEB_ENDPOINTS}
       - SHELLHUB_WEB_ENDPOINTS_DOMAIN=${SHELLHUB_WEB_ENDPOINTS_DOMAIN}
 

--- a/ssh/http/handlers.go
+++ b/ssh/http/handlers.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -135,7 +134,7 @@ func (h *Handlers) HandleHTTPProxy(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, NewMessageFromError(ErrDeviceTunnelParsePath))
 	}
 
-	req.Host = strings.Join([]string{address, h.Config.WebEndpointsDomain}, ".")
+	req.Host = h.Config.webEndpointHost(address)
 
 	// NOTE: endpoint.TLS.Domain doubles as a Host-override hint and (when TLS
 	// is enabled) as the SNI used during the handshake. When non-empty, it

--- a/ssh/http/server.go
+++ b/ssh/http/server.go
@@ -33,7 +33,36 @@ type Config struct {
 	WebEndpoints bool
 	// WebEndpointsDomain is the base domain used when constructing the
 	// host header for tunneled HTTP requests (e.g. <address>.<domain>).
+	// When non-empty it takes precedence over Domain.
 	WebEndpointsDomain string
+	// Domain is the fallback base domain when WebEndpointsDomain is not
+	// set.
+	Domain string
+}
+
+// webEndpointsDomain returns the effective base domain for web endpoint
+// host construction. WebEndpointsDomain takes precedence; if empty,
+// Domain is used. Returns an empty string when neither is set.
+func (c *Config) webEndpointsDomain() string {
+	if c.WebEndpointsDomain != "" {
+		return c.WebEndpointsDomain
+	}
+
+	return c.Domain
+}
+
+// webEndpointHost builds the full host value for a tunneled HTTP
+// request by joining address and the effective domain with a dot.
+// When the effective domain is empty the address is returned as-is
+// (no trailing dot), acting as a regression guard against malformed
+// Host headers.
+func (c *Config) webEndpointHost(address string) string {
+	domain := c.webEndpointsDomain()
+	if domain == "" {
+		return address
+	}
+
+	return address + "." + domain
 }
 
 // Server wires HTTP routes (connection upgrade, reverse dialing,

--- a/ssh/http/server_test.go
+++ b/ssh/http/server_test.go
@@ -1,0 +1,108 @@
+package http
+
+import (
+	"testing"
+)
+
+func TestConfigWebEndpointsDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		description        string
+		webEndpointsDomain string
+		domain             string
+		expected           string
+	}{
+		{
+			description:        "WebEndpointsDomain takes priority over Domain",
+			webEndpointsDomain: "cloud.example",
+			domain:             "example",
+			expected:           "cloud.example",
+		},
+		{
+			description:        "falls back to Domain when WebEndpointsDomain is empty",
+			webEndpointsDomain: "",
+			domain:             "example",
+			expected:           "example",
+		},
+		{
+			description:        "returns empty string when both are empty",
+			webEndpointsDomain: "",
+			domain:             "",
+			expected:           "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				WebEndpointsDomain: tt.webEndpointsDomain,
+				Domain:             tt.domain,
+			}
+
+			got := cfg.webEndpointsDomain()
+			if got != tt.expected {
+				t.Errorf("webEndpointsDomain() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfigWebEndpointHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		description        string
+		webEndpointsDomain string
+		domain             string
+		address            string
+		expected           string
+	}{
+		{
+			description:        "address joined with WebEndpointsDomain when it is set",
+			webEndpointsDomain: "cloud.example",
+			domain:             "",
+			address:            "abc123",
+			expected:           "abc123.cloud.example",
+		},
+		{
+			description:        "address joined with Domain when WebEndpointsDomain is empty",
+			webEndpointsDomain: "",
+			domain:             "example",
+			address:            "abc123",
+			expected:           "abc123.example",
+		},
+		{
+			description:        "regression guard: no trailing dot when both domain fields are empty",
+			webEndpointsDomain: "",
+			domain:             "",
+			address:            "abc123",
+			expected:           "abc123",
+		},
+		{
+			description:        "empty address with both domain fields empty returns empty string",
+			webEndpointsDomain: "",
+			domain:             "",
+			address:            "",
+			expected:           "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{
+				WebEndpointsDomain: tt.webEndpointsDomain,
+				Domain:             tt.domain,
+			}
+
+			got := cfg.webEndpointHost(tt.address)
+			if got != tt.expected {
+				t.Errorf("webEndpointHost(%q) = %q, want %q", tt.address, got, tt.expected)
+			}
+		})
+	}
+}

--- a/ssh/main.go
+++ b/ssh/main.go
@@ -30,9 +30,16 @@ type Envs struct {
 	// Allows SSH to connect with an agent via a public key when the agent version is less than 0.6.0.
 	// Agents 0.5.x or earlier do not validate the public key request and may panic.
 	// Please refer to: https://github.com/shellhub-io/shellhub/issues/3453
-	AllowPublickeyAccessBelow060 bool   `env:"ALLOW_PUBLIC_KEY_ACCESS_BELLOW_0_6_0,default=false"`
-	WebEndpoints                 bool   `env:"SHELLHUB_WEB_ENDPOINTS,default=false"`
-	WebEndpointsDomain           string `env:"SHELLHUB_WEB_ENDPOINTS_DOMAIN"`
+	AllowPublickeyAccessBelow060 bool `env:"ALLOW_PUBLIC_KEY_ACCESS_BELLOW_0_6_0,default=false"`
+	WebEndpoints                 bool `env:"SHELLHUB_WEB_ENDPOINTS,default=false"`
+	// WebEndpointsDomain is the dedicated subdomain for web endpoints. When
+	// empty, Domain is used as the fallback. The env key must stay
+	// SHELLHUB_WEB_ENDPOINTS_DOMAIN (not SSH_SHELLHUB_WEB_ENDPOINTS_DOMAIN)
+	// because the prefix "SSH_" is stripped by envs.ParseWithPrefix.
+	WebEndpointsDomain string `env:"SHELLHUB_WEB_ENDPOINTS_DOMAIN,default=$SHELLHUB_DOMAIN"`
+	// Domain is the base domain for this ShellHub instance. The env key must
+	// stay SHELLHUB_DOMAIN (not SSH_SHELLHUB_DOMAIN) for the same reason.
+	Domain string `env:"SHELLHUB_DOMAIN"`
 }
 
 func main() {
@@ -59,6 +66,7 @@ func main() {
 	h := http.NewServer(d, cli, &http.Config{
 		WebEndpoints:       env.WebEndpoints,
 		WebEndpointsDomain: env.WebEndpointsDomain,
+		Domain:             env.Domain,
 	})
 
 	router := h.Router


### PR DESCRIPTION
## What

The web endpoint HTTP proxy in the `ssh` service now builds a correctly-formed upstream `Host` header when `SHELLHUB_WEB_ENDPOINTS_DOMAIN` is empty, falling back to the base `SHELLHUB_DOMAIN` instead of emitting a malformed `Host: <hash>.`.

## Why

Closes #6442. This is the ssh-side half of the cloud `full_address` fix (shellhub-io/cloud#2390).

The proxy built the Host header directly from `h.Config.WebEndpointsDomain` with no fallback and no empty-guard (`ssh/http/handlers.go:138`). When that variable is empty — the documented enterprise default (`.env.enterprise`: "if empty, `SHELLHUB_DOMAIN` will be used"), and how the dev/enterprise compose injects it (present-but-empty) — the proxy wrote `Host: <hash>.` (trailing dot, empty domain) to the device backend. The gateway (nginx template + startup mutation) and the cloud API (`webEndpointsDomain()` helper) both honor the empty→`SHELLHUB_DOMAIN` fallback; the ssh proxy was the one component that did not, and it did not even carry the base domain.

Impact is bounded but real: Host-agnostic backends ignore the header, but Host-sensitive backends (name-based vhost selection, allowed-host checks, canonical-hostname redirects) break on non-TLS endpoints. TLS-to-backend endpoints were already spared by the `endpoint.TLS.Domain` override.

## Changes

- **ssh/http/server.go**: added a `Domain` fallback field to `Config` plus two pure helpers — `webEndpointsDomain()` (prefers `WebEndpointsDomain`, falls back to `Domain`) and `webEndpointHost(address)` (joins address and the effective domain, returning the bare address with no trailing dot when neither is configured). This is the load-bearing fix.
- **ssh/http/handlers.go**: replaced the inline `strings.Join` host construction with `h.Config.webEndpointHost(address)`; dropped the now-unused `strings` import. The `endpoint.TLS.Domain` override is unchanged.
- **ssh/main.go**: added a `Domain` env field (`SHELLHUB_DOMAIN`), wired it into `http.Config`, and added `default=$SHELLHUB_DOMAIN` to the `WebEndpointsDomain` tag for parity with `cloud/pkg/envs`. The env key stays unprefixed (`SHELLHUB_DOMAIN`, not `SSH_SHELLHUB_DOMAIN`) because it resolves through the unprefixed lookuper of `envs.ParseWithPrefix`. The env default is inert under the present-but-empty compose injection, so the runtime helper remains the load-bearing path.
- **docker-compose.enterprise.yml**: pass `SHELLHUB_DOMAIN` to the ssh service so the fallback has a value (`SHELLHUB_DOMAIN` is always present as the base `COMPOSE_ENV_FILES` layer).

## Testing

New `ssh/http/server_test.go` (internal `package http`, table-driven) covers `webEndpointsDomain()` (precedence, fallback, both-empty) and `webEndpointHost()` (join with either domain field, the no-trailing-dot regression guard, and the degenerate empty-address case). Handler-level behavior is intentionally not unit-tested — `HandleHTTPProxy` hijacks the connection and would need the dialer, client, and a live socket mocked; the helper carries the logic and the call-site swap is covered by compile.

Manual check (optional): boot ssh with `SHELLHUB_WEB_ENDPOINTS=true`, `SHELLHUB_WEB_ENDPOINTS_DOMAIN=` (empty), `SHELLHUB_DOMAIN=localhost`, hit a web endpoint, and confirm the device backend receives `Host: <hash>.localhost`, not `<hash>.`.

## Notes

The empty→`Domain` fallback is now reimplemented in three places (gateway, cloud API, ssh) with three slightly different mechanisms. Consolidating them into one shared helper to prevent drift is tracked separately in #6446.
