### PR TITLE
refactor: consolidate web endpoints domain fallback into shared pkg

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/loglevel"
+	"github.com/shellhub-io/shellhub/pkg/webendpoints"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -85,9 +86,7 @@ func NewGateway(config *GatewayConfig, controller *NginxController, features []s
 	// SSL's enabled.
 	if slices.Contains(features, WebEndpointsFeature) {
 		if g.Certbot != nil {
-			if g.Config.WebEndpointsDomain == "" {
-				g.Config.WebEndpointsDomain = g.Config.Domain
-			}
+			g.Config.WebEndpointsDomain = webendpoints.Domain(g.Config.WebEndpointsDomain, g.Config.Domain)
 
 			g.Certbot.Certificates = append(
 				g.Certbot.Certificates,

--- a/pkg/webendpoints/webendpoints.go
+++ b/pkg/webendpoints/webendpoints.go
@@ -1,0 +1,44 @@
+// Package webendpoints provides helpers for composing web-endpoint hostnames.
+//
+// A web endpoint is a named HTTP tunnel that ShellHub exposes on behalf of a
+// device.  Each endpoint is reachable at an address that is formed by joining
+// an address token (typically a short random slug) and a domain:
+//
+//	<address>.<domain>   e.g. abc123.tunnel.example.com
+//
+// The domain itself can be configured at two levels: a per-namespace
+// "preferred" override and a system-wide fallback.  The helpers in this
+// package centralise that logic so that every caller (nginx template
+// generation, API responses, agent-side URL construction) derives the hostname
+// the same way.
+//
+// Note: the nginx-template duplication is by design — keeping the template and
+// the Go logic in sync is easier than introducing an indirection layer.
+package webendpoints
+
+// Domain returns the effective domain for a web endpoint.
+//
+// When preferred is non-empty it is returned as-is, giving namespace
+// administrators the ability to customise the domain without changing the
+// system-wide default.  Otherwise fallback (the system-level default) is
+// returned.  Both values may be empty strings; callers must handle that case.
+func Domain(preferred, fallback string) string {
+	if preferred != "" {
+		return preferred
+	}
+
+	return fallback
+}
+
+// Host builds the full hostname for a web endpoint.
+//
+// The result is "<address>.<domain>" when domain is non-empty, or just
+// "<address>" when domain is empty.  The trailing-dot regression guard
+// ensures that an empty domain never produces a string ending in ".".
+func Host(address, domain string) string {
+	if domain == "" {
+		return address
+	}
+
+	return address + "." + domain
+}

--- a/pkg/webendpoints/webendpoints_test.go
+++ b/pkg/webendpoints/webendpoints_test.go
@@ -1,0 +1,81 @@
+package webendpoints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDomain(t *testing.T) {
+	cases := []struct {
+		description string
+		preferred   string
+		fallback    string
+		expected    string
+	}{
+		{
+			description: "returns preferred when preferred is set",
+			preferred:   "cloud.example",
+			fallback:    "example",
+			expected:    "cloud.example",
+		},
+		{
+			description: "returns fallback when preferred is empty",
+			preferred:   "",
+			fallback:    "example",
+			expected:    "example",
+		},
+		{
+			description: "returns empty string when both are empty",
+			preferred:   "",
+			fallback:    "",
+			expected:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.expected, Domain(tc.preferred, tc.fallback))
+		})
+	}
+}
+
+func TestHost(t *testing.T) {
+	cases := []struct {
+		description string
+		address     string
+		domain      string
+		expected    string
+	}{
+		{
+			description: "returns address.domain when domain is set",
+			address:     "abc123",
+			domain:      "cloud.example",
+			expected:    "abc123.cloud.example",
+		},
+		{
+			description: "returns address.domain with simple domain",
+			address:     "abc123",
+			domain:      "example",
+			expected:    "abc123.example",
+		},
+		{
+			description: "returns address only when domain is empty (no trailing dot)",
+			address:     "abc123",
+			domain:      "",
+			expected:    "abc123",
+		},
+		{
+			description: "returns empty string when both address and domain are empty",
+			address:     "",
+			domain:      "",
+			expected:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.expected, Host(tc.address, tc.domain))
+		})
+	}
+}

--- a/ssh/http/server.go
+++ b/ssh/http/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/api/internalclient"
 	"github.com/shellhub-io/shellhub/pkg/revdial"
 	"github.com/shellhub-io/shellhub/pkg/validator"
+	"github.com/shellhub-io/shellhub/pkg/webendpoints"
 	"github.com/shellhub-io/shellhub/ssh/pkg/dialer"
 )
 
@@ -40,29 +41,13 @@ type Config struct {
 	Domain string
 }
 
-// webEndpointsDomain returns the effective base domain for web endpoint
-// host construction. WebEndpointsDomain takes precedence; if empty,
-// Domain is used. Returns an empty string when neither is set.
-func (c *Config) webEndpointsDomain() string {
-	if c.WebEndpointsDomain != "" {
-		return c.WebEndpointsDomain
-	}
-
-	return c.Domain
-}
-
 // webEndpointHost builds the full host value for a tunneled HTTP
 // request by joining address and the effective domain with a dot.
 // When the effective domain is empty the address is returned as-is
 // (no trailing dot), acting as a regression guard against malformed
 // Host headers.
 func (c *Config) webEndpointHost(address string) string {
-	domain := c.webEndpointsDomain()
-	if domain == "" {
-		return address
-	}
-
-	return address + "." + domain
+	return webendpoints.Host(address, webendpoints.Domain(c.WebEndpointsDomain, c.Domain))
 }
 
 // Server wires HTTP routes (connection upgrade, reverse dialing,

--- a/ssh/http/server_test.go
+++ b/ssh/http/server_test.go
@@ -4,52 +4,6 @@ import (
 	"testing"
 )
 
-func TestConfigWebEndpointsDomain(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		description        string
-		webEndpointsDomain string
-		domain             string
-		expected           string
-	}{
-		{
-			description:        "WebEndpointsDomain takes priority over Domain",
-			webEndpointsDomain: "cloud.example",
-			domain:             "example",
-			expected:           "cloud.example",
-		},
-		{
-			description:        "falls back to Domain when WebEndpointsDomain is empty",
-			webEndpointsDomain: "",
-			domain:             "example",
-			expected:           "example",
-		},
-		{
-			description:        "returns empty string when both are empty",
-			webEndpointsDomain: "",
-			domain:             "",
-			expected:           "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := &Config{
-				WebEndpointsDomain: tt.webEndpointsDomain,
-				Domain:             tt.domain,
-			}
-
-			got := cfg.webEndpointsDomain()
-			if got != tt.expected {
-				t.Errorf("webEndpointsDomain() = %q, want %q", got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestConfigWebEndpointHost(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Extract the two web-endpoints domain rules — fallback resolution (prefer `SHELLHUB_WEB_ENDPOINTS_DOMAIN`, else `SHELLHUB_DOMAIN`) and `<address>.<domain>` host formatting (bare address when no domain, never a trailing dot) — into a new shared `pkg/webendpoints`, and adopt it in the ssh proxy and the gateway.

## Why

These rules were reimplemented independently in the ssh proxy and the gateway, with nothing keeping them in sync; a future change to one (normalization, lowercasing, trailing-dot handling) would silently skip the others. The helper lives in the root module so ssh and gateway import it directly, and the cloud API can adopt it via its module replace (done in a separate change). The package is the single source of truth for both rules.

## Changes

- **pkg/webendpoints (new)**: two pure functions, `Domain(preferred, fallback)` and `Host(address, domain)`, with table-driven tests. `Host` returns the bare address when the domain is empty, so the result never degrades to a malformed `<address>.`.
- **ssh/http/server.go**: `Config.webEndpointHost` now delegates to the shared helpers; the redundant `webEndpointsDomain` method is removed. The `Config` fields and the `handlers.go` call site (including the `endpoint.TLS.Domain` override) are unchanged.
- **gateway/main.go**: the inline empty→`Domain` mutation now calls `webendpoints.Domain` (behavior-identical). The nginx-template `or $cfg.WebEndpointsDomain $cfg.Domain` fallback stays — a Go template cannot call Go, so that duplication is by design.

## Testing

Behavior-preserving — the helper reproduces the prior logic exactly. The fallback is live at runtime, not dead code: the shipped compose injects `SHELLHUB_WEB_ENDPOINTS_DOMAIN` present-but-empty, which bypasses the env-tag default and forces the resolver to fall back to `SHELLHUB_DOMAIN`. `go test ./pkg/webendpoints/...` covers the rules; `go test ./ssh/http/...` keeps the ssh field-binding guard (`TestConfigWebEndpointHost`).
