### PR TITLE
feat(ui): auto-lock secure vault after inactivity

### DIFF
--- a/ui/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui/apps/console/src/components/layout/AppLayout.tsx
@@ -12,6 +12,7 @@ import ChatwootProvider from "./ChatwootProvider";
 import { useNamespaces } from "@/hooks/useNamespaces";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useSidebarLayout } from "@/hooks/useSidebarLayout";
+import VaultAutoLockBanner from "@/components/vault/VaultAutoLockBanner";
 
 export default function AppLayout() {
   const { pathname } = useLocation();
@@ -83,6 +84,7 @@ export default function AppLayout() {
         <WelcomeWizardTrigger />
         <AnnouncementModalTrigger />
         <DeviceChooserTrigger />
+        <VaultAutoLockBanner />
       </div>
     </ChatwootProvider>
   );

--- a/ui/apps/console/src/components/vault/VaultAutoLockBanner.tsx
+++ b/ui/apps/console/src/components/vault/VaultAutoLockBanner.tsx
@@ -1,0 +1,70 @@
+/**
+ * VaultAutoLockBanner — ephemeral toast that fires when the vault is locked by
+ * the idle auto-lock timer.
+ *
+ * Distinguished from VaultLockedBanner: that component is a persistent, inline
+ * page banner rendered inside the vault page when the vault is locked (with an
+ * "Unlock" CTA). This component is a floating toast that appears once — briefly —
+ * whenever an auto-lock event happens (nonce bump), regardless of the current page.
+ * It owns its own dismiss and auto-dismiss logic.
+ */
+import { useEffect, useRef, useState } from "react";
+import { useVaultStore } from "@/stores/vaultStore";
+import Alert from "@/components/common/Alert";
+
+const AUTO_DISMISS_MS = 6000;
+
+export default function VaultAutoLockBanner() {
+  const autoLockNonce = useVaultStore((s) => s.autoLockNonce);
+
+  // Initialize seen to the current nonce so the first render never fires the toast
+  const seenNonce = useRef(autoLockNonce);
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (autoLockNonce === seenNonce.current) return;
+
+    // A new auto-lock event occurred — update seen and show the toast
+    seenNonce.current = autoLockNonce;
+    setVisible(true);
+
+    // Clear any pending auto-dismiss from a previous show
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(() => {
+      setVisible(false);
+      timerRef.current = null;
+    }, AUTO_DISMISS_MS);
+  }, [autoLockNonce]);
+
+  // Clear the timer on unmount to prevent state updates after unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[75] w-80">
+      <Alert
+        variant="warning"
+        onDismiss={() => {
+          if (timerRef.current !== null) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
+          }
+          setVisible(false);
+        }}
+      >
+        Vault locked due to inactivity.
+      </Alert>
+    </div>
+  );
+}

--- a/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -1,15 +1,20 @@
-import { useState, useEffect, FormEvent } from "react";
+import { useState, useEffect, useRef, FormEvent } from "react";
 import {
   KeyIcon,
   LockClosedIcon,
   ExclamationTriangleIcon,
   ExclamationCircleIcon,
+  ChevronDownIcon,
 } from "@heroicons/react/24/outline";
 import { useVaultStore } from "@/stores/vaultStore";
+import { ALLOWED_TIMEOUT_MINUTES } from "@/types/vault";
+import type { AllowedTimeoutMinutes } from "@/types/vault";
+import { useClickOutside } from "@/hooks/useClickOutside";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import Drawer from "@/components/common/Drawer";
 import InputField from "@/components/common/fields/InputField";
 import PasswordField from "@/components/common/fields/PasswordField";
+import CheckboxField from "@/components/common/fields/CheckboxField";
 import Spinner from "@/components/common/Spinner";
 
 function ChangePasswordDrawer({
@@ -78,9 +83,7 @@ function ChangePasswordDrawer({
             disabled={!canSubmit}
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
-            {loading && (
-              <Spinner size="sm" tone="onPrimary" />
-            )}
+            {loading && <Spinner size="sm" tone="onPrimary" />}
             Update Password
           </button>
         </>
@@ -132,10 +135,82 @@ function ChangePasswordDrawer({
   );
 }
 
+const TIMEOUT_LABELS: Record<AllowedTimeoutMinutes, string> = {
+  0: "Never",
+  5: "5 minutes",
+  15: "15 minutes",
+  30: "30 minutes",
+  60: "60 minutes",
+};
+
+function AutoLockTimeoutSelect({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (minutes: AllowedTimeoutMinutes) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  useClickOutside(containerRef, () => setOpen(false));
+
+  const currentLabel =
+    TIMEOUT_LABELS[value as AllowedTimeoutMinutes] ?? `${value} minutes`;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-label="Auto-lock timeout"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm text-text-primary bg-card border border-border rounded-md hover:border-border-light transition-colors"
+      >
+        {currentLabel}
+        <ChevronDownIcon
+          className={`w-3.5 h-3.5 text-text-muted transition-transform duration-150 ${open ? "rotate-180" : ""}`}
+          strokeWidth={2.5}
+        />
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label="Auto-lock timeout options"
+          className="absolute right-0 top-full mt-1 w-36 bg-surface border border-border rounded-lg shadow-2xl shadow-black/40 z-50 overflow-hidden animate-slide-down"
+        >
+          {ALLOWED_TIMEOUT_MINUTES.map((minutes) => (
+            <li
+              key={minutes}
+              role="option"
+              aria-selected={value === minutes}
+              onClick={() => {
+                onChange(minutes);
+                setOpen(false);
+              }}
+              className={`px-3 py-2 text-sm cursor-pointer transition-colors ${
+                value === minutes
+                  ? "text-primary bg-primary/10"
+                  : "text-text-secondary hover:text-text-primary hover:bg-hover-medium"
+              }`}
+            >
+              {TIMEOUT_LABELS[minutes]}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 export default function VaultSettingsSection() {
   const status = useVaultStore((s) => s.status);
   const lock = useVaultStore((s) => s.lock);
   const resetVault = useVaultStore((s) => s.resetVault);
+  const autoLockTimeoutMinutes = useVaultStore((s) => s.autoLockTimeoutMinutes);
+  const lockOnHidden = useVaultStore((s) => s.lockOnHidden);
+  const updateAutoLockSettings = useVaultStore((s) => s.updateAutoLockSettings);
   const [changeOpen, setChangeOpen] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
   const [resetConfirmText, setResetConfirmText] = useState("");
@@ -164,6 +239,38 @@ export default function VaultSettingsSection() {
               </p>
             </div>
           </button>
+
+          <div className="flex items-center gap-3 w-full px-4 py-3.5">
+            <LockClosedIcon className="w-4 h-4 text-text-muted shrink-0" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">
+                Auto-lock Timeout
+              </p>
+              <p className="text-2xs text-text-muted">
+                Automatically lock the vault after this period of inactivity.
+              </p>
+            </div>
+            <AutoLockTimeoutSelect
+              value={autoLockTimeoutMinutes}
+              onChange={(minutes) =>
+                updateAutoLockSettings({ autoLockTimeoutMinutes: minutes })
+              }
+            />
+          </div>
+
+          <div className="flex items-center gap-3 w-full px-4 py-3.5">
+            <div className="min-w-0 flex-1">
+              <CheckboxField
+                id="vault-lock-on-hidden"
+                label="Lock when hidden"
+                description="Locks the vault about a minute after you switch away or minimize."
+                checked={lockOnHidden}
+                onChange={(checked) =>
+                  updateAutoLockSettings({ lockOnHidden: checked })
+                }
+              />
+            </div>
+          </div>
 
           <button
             type="button"

--- a/ui/apps/console/src/components/vault/__tests__/VaultAutoLockBanner.test.tsx
+++ b/ui/apps/console/src/components/vault/__tests__/VaultAutoLockBanner.test.tsx
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { useVaultStore } from "@/stores/vaultStore";
+import VaultAutoLockBanner from "../VaultAutoLockBanner";
+
+// Prevent real vault-crypto / backend calls from running in tests
+vi.mock("@/utils/vault-crypto", () => ({
+  createVaultMeta: vi.fn(),
+  verifyPassword: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  setSessionKey: vi.fn(),
+  getSessionKey: vi.fn(),
+  clearSessionKey: vi.fn(),
+}));
+
+vi.mock("@/utils/vault-backend-factory", () => ({
+  getVaultBackend: vi.fn(() => ({
+    loadMeta: vi.fn(() => null),
+    loadData: vi.fn(() => null),
+    loadSettings: vi.fn(() => ({
+      autoLockTimeoutMinutes: 15,
+      lockOnHidden: false,
+    })),
+    saveMeta: vi.fn(),
+    saveData: vi.fn(),
+    saveSettings: vi.fn(),
+    loadLegacyKeys: vi.fn(() => []),
+    clearLegacyKeys: vi.fn(),
+    clear: vi.fn(),
+  })),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: {
+    getState: vi.fn(() => ({ user: "testuser", tenant: "test-tenant" })),
+  },
+}));
+
+vi.mock("@/utils/vault-activity-tracker", () => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
+beforeEach(() => {
+  // Reset vault store to a known base state before each test (nonce = 0)
+  useVaultStore.setState({
+    status: "locked",
+    keys: [],
+    loading: false,
+    error: null,
+    autoLockTimeoutMinutes: 15,
+    lockOnHidden: false,
+    autoLockNonce: 0,
+  });
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("VaultAutoLockBanner", () => {
+  describe("initial render (pre-existing nonce)", () => {
+    it("does NOT show the toast on mount when autoLockNonce is 0", () => {
+      useVaultStore.setState({ autoLockNonce: 0 });
+      render(<VaultAutoLockBanner />);
+      expect(
+        screen.queryByText(/vault locked due to inactivity/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does NOT show the toast on mount even when autoLockNonce is already > 0 (pre-existing)", () => {
+      // Simulate a nonce that was set before the component mounted
+      useVaultStore.setState({ autoLockNonce: 3 });
+      render(<VaultAutoLockBanner />);
+      // The banner was not mounted when those nonce bumps happened — it should not fire
+      expect(
+        screen.queryByText(/vault locked due to inactivity/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("nonce bump after mount", () => {
+    it("shows the toast when autoLockNonce is bumped after mount", () => {
+      useVaultStore.setState({ autoLockNonce: 0 });
+      render(<VaultAutoLockBanner />);
+
+      // Simulate vault auto-locking: bump the nonce
+      act(() => {
+        useVaultStore.setState({ autoLockNonce: 1 });
+      });
+
+      expect(
+        screen.getByText(/vault locked due to inactivity/i),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the toast on a second nonce bump (multiple lock events)", () => {
+      // Fake timers must be in place BEFORE render so the auto-dismiss setTimeout
+      // is captured as a fake timer and can be controlled by advanceTimersByTime.
+      vi.useFakeTimers();
+
+      useVaultStore.setState({ autoLockNonce: 0 });
+      render(<VaultAutoLockBanner />);
+
+      // First lock event — toast should appear
+      act(() => {
+        useVaultStore.setState({ autoLockNonce: 1 });
+      });
+
+      expect(
+        screen.getByText(/vault locked due to inactivity/i),
+      ).toBeInTheDocument();
+
+      // Advance past AUTO_DISMISS_MS so the first toast actually disappears
+      act(() => {
+        vi.advanceTimersByTime(6500);
+      });
+
+      // Confirm the first toast is gone before bumping again
+      expect(
+        screen.queryByText(/vault locked due to inactivity/i),
+      ).not.toBeInTheDocument();
+
+      // Second lock event — toast must reappear
+      act(() => {
+        useVaultStore.setState({ autoLockNonce: 2 });
+      });
+
+      expect(
+        screen.getByText(/vault locked due to inactivity/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("dismiss behavior", () => {
+    it("hides the toast when the dismiss button is clicked", () => {
+      // Use real timers here — we're only testing the dismiss click,
+      // not the auto-dismiss setTimeout
+      useVaultStore.setState({ autoLockNonce: 0 });
+      render(<VaultAutoLockBanner />);
+
+      act(() => {
+        useVaultStore.setState({ autoLockNonce: 1 });
+      });
+
+      expect(
+        screen.getByText(/vault locked due to inactivity/i),
+      ).toBeInTheDocument();
+
+      act(() => {
+        screen.getByRole("button", { name: /dismiss/i }).click();
+      });
+
+      expect(
+        screen.queryByText(/vault locked due to inactivity/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("auto-dismiss", () => {
+    it("hides the toast automatically after ~6 seconds", () => {
+      vi.useFakeTimers();
+
+      useVaultStore.setState({ autoLockNonce: 0 });
+      render(<VaultAutoLockBanner />);
+
+      act(() => {
+        useVaultStore.setState({ autoLockNonce: 1 });
+      });
+
+      expect(
+        screen.getByText(/vault locked due to inactivity/i),
+      ).toBeInTheDocument();
+
+      // Advance past the auto-dismiss threshold
+      act(() => {
+        vi.advanceTimersByTime(6100);
+      });
+
+      expect(
+        screen.queryByText(/vault locked due to inactivity/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does NOT hide the toast before ~6 seconds elapse", () => {
+      vi.useFakeTimers();
+
+      useVaultStore.setState({ autoLockNonce: 0 });
+      render(<VaultAutoLockBanner />);
+
+      act(() => {
+        useVaultStore.setState({ autoLockNonce: 1 });
+      });
+
+      // Advance just under the threshold
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(
+        screen.getByText(/vault locked due to inactivity/i),
+      ).toBeInTheDocument();
+    });
+
+    it("clears the auto-dismiss timer on unmount (no state-update after unmount)", () => {
+      vi.useFakeTimers();
+
+      useVaultStore.setState({ autoLockNonce: 0 });
+      const { unmount } = render(<VaultAutoLockBanner />);
+
+      act(() => {
+        useVaultStore.setState({ autoLockNonce: 1 });
+      });
+
+      // Unmount before timer fires
+      unmount();
+
+      // Advancing timers should not throw (timer must have been cleared)
+      expect(() => {
+        act(() => {
+          vi.advanceTimersByTime(7000);
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("positioning and z-index", () => {
+    it("renders inside a fixed container with correct positioning classes when visible", () => {
+      useVaultStore.setState({ autoLockNonce: 0 });
+      const { container } = render(<VaultAutoLockBanner />);
+
+      act(() => {
+        useVaultStore.setState({ autoLockNonce: 1 });
+      });
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.className).toContain("fixed");
+      expect(wrapper.className).toContain("bottom-4");
+      expect(wrapper.className).toContain("right-4");
+      expect(wrapper.className).toContain("z-[75]");
+    });
+  });
+});

--- a/ui/apps/console/src/components/vault/__tests__/VaultSettingsSection.test.tsx
+++ b/ui/apps/console/src/components/vault/__tests__/VaultSettingsSection.test.tsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useVaultStore } from "@/stores/vaultStore";
+import VaultSettingsSection from "../VaultSettingsSection";
+
+// Prevent real vault-crypto / backend calls from running in tests
+vi.mock("@/utils/vault-crypto", () => ({
+  createVaultMeta: vi.fn(),
+  verifyPassword: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  setSessionKey: vi.fn(),
+  getSessionKey: vi.fn(),
+  clearSessionKey: vi.fn(),
+}));
+
+vi.mock("@/utils/vault-backend-factory", () => ({
+  getVaultBackend: vi.fn(() => ({
+    loadMeta: vi.fn(() => null),
+    loadData: vi.fn(() => null),
+    loadSettings: vi.fn(() => ({
+      autoLockTimeoutMinutes: 15,
+      lockOnHidden: false,
+    })),
+    saveMeta: vi.fn(),
+    saveData: vi.fn(),
+    saveSettings: vi.fn(),
+    loadLegacyKeys: vi.fn(() => []),
+    clearLegacyKeys: vi.fn(),
+    clear: vi.fn(),
+  })),
+}));
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: {
+    getState: vi.fn(() => ({ user: "testuser", tenant: "test-tenant" })),
+  },
+}));
+
+vi.mock("@/utils/vault-activity-tracker", () => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
+function renderSection() {
+  return render(<VaultSettingsSection />);
+}
+
+function setUnlocked(
+  overrides: { autoLockTimeoutMinutes?: number; lockOnHidden?: boolean } = {},
+) {
+  useVaultStore.setState({
+    status: "unlocked",
+    autoLockTimeoutMinutes: overrides.autoLockTimeoutMinutes ?? 15,
+    lockOnHidden: overrides.lockOnHidden ?? false,
+  });
+}
+
+beforeEach(() => {
+  // Reset to a known base state before each test
+  useVaultStore.setState({
+    status: "locked",
+    keys: [],
+    loading: false,
+    error: null,
+    autoLockTimeoutMinutes: 15,
+    lockOnHidden: false,
+    autoLockNonce: 0,
+  });
+  vi.clearAllMocks();
+});
+
+describe("VaultSettingsSection", () => {
+  describe("when vault is not unlocked", () => {
+    it("renders nothing when locked", () => {
+      useVaultStore.setState({ status: "locked" });
+      const { container } = renderSection();
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when uninitialized", () => {
+      useVaultStore.setState({ status: "uninitialized" });
+      const { container } = renderSection();
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("Auto-lock timeout dropdown", () => {
+    it("renders all 5 timeout options when dropdown is opened", async () => {
+      setUnlocked();
+      renderSection();
+
+      // Open the dropdown
+      const trigger = screen.getByRole("button", {
+        name: /auto-lock timeout/i,
+      });
+      await userEvent.click(trigger);
+
+      // All 5 options should be visible — use exact strings to avoid
+      // substring collisions (e.g. "5 minutes" inside "15 minutes")
+      expect(
+        screen.getByRole("option", { name: "5 minutes" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "15 minutes" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "30 minutes" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: "60 minutes" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /never/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls updateAutoLockSettings with correct timeout when an option is selected", async () => {
+      setUnlocked({ autoLockTimeoutMinutes: 15 });
+      const updateAutoLockSettings = vi.fn();
+      useVaultStore.setState({ updateAutoLockSettings });
+
+      renderSection();
+
+      const trigger = screen.getByRole("button", {
+        name: /auto-lock timeout/i,
+      });
+      await userEvent.click(trigger);
+
+      const option30 = screen.getByRole("option", { name: /30 minutes/i });
+      await userEvent.click(option30);
+
+      expect(updateAutoLockSettings).toHaveBeenCalledWith({
+        autoLockTimeoutMinutes: 30,
+      });
+    });
+
+    it("calls updateAutoLockSettings with 0 when Never is selected", async () => {
+      setUnlocked({ autoLockTimeoutMinutes: 15 });
+      const updateAutoLockSettings = vi.fn();
+      useVaultStore.setState({ updateAutoLockSettings });
+
+      renderSection();
+
+      const trigger = screen.getByRole("button", {
+        name: /auto-lock timeout/i,
+      });
+      await userEvent.click(trigger);
+
+      const neverOption = screen.getByRole("option", { name: /never/i });
+      await userEvent.click(neverOption);
+
+      expect(updateAutoLockSettings).toHaveBeenCalledWith({
+        autoLockTimeoutMinutes: 0,
+      });
+    });
+
+    it("reflects the persisted timeout value on first paint (15 min)", () => {
+      setUnlocked({ autoLockTimeoutMinutes: 15 });
+      renderSection();
+
+      // The trigger button should display the current setting
+      expect(
+        screen.getByRole("button", { name: /auto-lock timeout/i }),
+      ).toHaveTextContent("15 minutes");
+    });
+
+    it("reflects the persisted timeout value on first paint (Never)", () => {
+      setUnlocked({ autoLockTimeoutMinutes: 0 });
+      renderSection();
+
+      expect(
+        screen.getByRole("button", { name: /auto-lock timeout/i }),
+      ).toHaveTextContent("Never");
+    });
+
+    it("closes the dropdown after selecting an option", async () => {
+      setUnlocked();
+      const updateAutoLockSettings = vi.fn();
+      useVaultStore.setState({ updateAutoLockSettings });
+
+      renderSection();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /auto-lock timeout/i }),
+      );
+      // Use exact string to avoid substring collision with "15 minutes"
+      await userEvent.click(screen.getByRole("option", { name: "5 minutes" }));
+
+      // Options should no longer be visible
+      expect(
+        screen.queryByRole("option", { name: "5 minutes" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Lock-when-tab-hidden checkbox", () => {
+    it("renders the lock-when-hidden checkbox with a description", () => {
+      setUnlocked();
+      renderSection();
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: /lock when hidden/i,
+      });
+      expect(checkbox).toBeInTheDocument();
+    });
+
+    it("renders the description text about switching away", () => {
+      setUnlocked();
+      renderSection();
+
+      expect(
+        screen.getByText(
+          /locks the vault about a minute after you switch away or minimize/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("calls updateAutoLockSettings with lockOnHidden:true when checked", async () => {
+      setUnlocked({ lockOnHidden: false });
+      const updateAutoLockSettings = vi.fn();
+      useVaultStore.setState({ updateAutoLockSettings });
+
+      renderSection();
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: /lock when hidden/i,
+      });
+      await userEvent.click(checkbox);
+
+      expect(updateAutoLockSettings).toHaveBeenCalledWith({
+        lockOnHidden: true,
+      });
+    });
+
+    it("calls updateAutoLockSettings with lockOnHidden:false when unchecked", async () => {
+      setUnlocked({ lockOnHidden: true });
+      const updateAutoLockSettings = vi.fn();
+      useVaultStore.setState({ updateAutoLockSettings });
+
+      renderSection();
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: /lock when hidden/i,
+      });
+      await userEvent.click(checkbox);
+
+      expect(updateAutoLockSettings).toHaveBeenCalledWith({
+        lockOnHidden: false,
+      });
+    });
+
+    it("reflects persisted lockOnHidden=true on first paint (checked)", () => {
+      setUnlocked({ lockOnHidden: true });
+      renderSection();
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: /lock when hidden/i,
+      });
+      expect(checkbox).toBeChecked();
+    });
+
+    it("reflects persisted lockOnHidden=false on first paint (unchecked)", () => {
+      setUnlocked({ lockOnHidden: false });
+      renderSection();
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: /lock when hidden/i,
+      });
+      expect(checkbox).not.toBeChecked();
+    });
+  });
+});

--- a/ui/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
+++ b/ui/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useVaultStore } from "@/stores/vaultStore";
 import SecureVault from "../index";
+import ConnectDrawer from "@/components/ConnectDrawer";
 import type { VaultKeyEntry } from "@/types/vault";
 
 vi.mock("@/utils/date", () => ({
@@ -27,44 +28,200 @@ vi.mock("@/components/common/PageHeader", () => ({
 
 vi.mock("@/stores/vaultStore", () => ({
   useVaultStore: vi.fn((selector?: (s: Record<string, unknown>) => unknown) => {
-    const state = (useVaultStore as unknown as { _state: Record<string, unknown> })._state;
+    const state = (
+      useVaultStore as unknown as { _state: Record<string, unknown> }
+    )._state;
     return selector ? selector(state) : state;
   }),
 }));
 
-// Mock heavy vault dialog/banner components to isolate page logic
-vi.mock("@/components/vault/VaultSetupDialog", () => ({
+vi.mock("@/stores/terminalStore", () => ({
+  useTerminalStore: vi.fn(
+    (selector?: (s: Record<string, unknown>) => unknown) => {
+      const state = { open: vi.fn() };
+      return selector ? selector(state) : state;
+    },
+  ),
+}));
+
+vi.mock("@/utils/ssh-keys", () => ({
+  validatePrivateKey: vi.fn(() => ({ valid: false, encrypted: false })),
+  getFingerprint: vi.fn(() => "fp"),
+}));
+
+vi.mock("@/components/common/Drawer", () => ({
   default: ({
     open,
-    onClose,
+    children,
+    footer,
+    title,
   }: {
     open: boolean;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+    title: string;
     onClose: () => void;
   }) =>
-    open
-      ? (
-        <div role="dialog" aria-label="Setup Vault">
-          <button onClick={onClose}>Close Setup</button>
-        </div>
-      )
-      : null,
+    open ? (
+      <div role="dialog" aria-label={title}>
+        {children}
+        {footer}
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/vault/VaultLockedBanner", () => ({
+  default: ({ onUnlock }: { onUnlock: () => void }) => (
+    <div data-testid="vault-locked-banner">
+      <button onClick={onUnlock}>Unlock Vault</button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/common/CopyButton", () => ({
+  default: ({ text }: { text: string }) => (
+    <button aria-label={`Copy ${text}`}>Copy</button>
+  ),
+}));
+
+vi.mock("@/components/common/fields/InputField", () => ({
+  default: ({
+    id,
+    label,
+    value,
+    onChange,
+    placeholder,
+  }: {
+    id: string;
+    label: string;
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+    autoFocus?: boolean;
+  }) => (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  ),
+}));
+
+vi.mock("@/components/common/fields/PasswordField", () => ({
+  default: ({
+    id,
+    label,
+    value,
+    onChange,
+    placeholder,
+  }: {
+    id: string;
+    label: string;
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+    autoComplete?: string;
+    suppressPasswordManager?: boolean;
+    hint?: string;
+  }) => (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        type="password"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  ),
+}));
+
+vi.mock("@/components/common/fields/FieldLabel", () => ({
+  default: ({
+    children,
+    htmlFor,
+  }: {
+    children: React.ReactNode;
+    htmlFor?: string;
+  }) => <label htmlFor={htmlFor}>{children}</label>,
+}));
+
+vi.mock("@/components/common/fields/RadioCard", () => ({
+  default: ({
+    value,
+    label,
+  }: {
+    value: string;
+    label: string;
+    icon?: React.ReactNode;
+    description?: string;
+  }) => <div data-testid={`radio-card-${value}`}>{label}</div>,
+}));
+
+vi.mock("@/components/common/fields/RadioGroupField", () => ({
+  default: ({
+    label,
+    value,
+    onChange,
+    children,
+    containerClassName,
+  }: {
+    label: string;
+    value: string;
+    onChange: (v: string) => void;
+    children: React.ReactNode;
+    containerClassName?: string;
+  }) => (
+    <div>
+      <span>{label}</span>
+      <div className={containerClassName}>{children}</div>
+      <select
+        aria-label={label}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value="password">Password</option>
+        <option value="key">Private Key</option>
+        <option value="vault">Vault</option>
+        <option value="manual">Manual</option>
+      </select>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/common/fields/RadioSegment", () => ({
+  default: ({
+    value,
+    label,
+  }: {
+    value: string;
+    label: string;
+    icon?: React.ReactNode;
+  }) => <div data-testid={`radio-segment-${value}`}>{label}</div>,
+}));
+
+// Mock heavy vault dialog/banner components to isolate page logic
+vi.mock("@/components/vault/VaultSetupDialog", () => ({
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div role="dialog" aria-label="Setup Vault">
+        <button onClick={onClose}>Close Setup</button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/components/vault/VaultUnlockDialog", () => ({
-  default: ({
-    open,
-    onClose,
-  }: {
-    open: boolean;
-    onClose: () => void;
-  }) =>
-    open
-      ? (
-        <div role="dialog" aria-label="Unlock Vault">
-          <button onClick={onClose}>Close Unlock</button>
-        </div>
-      )
-      : null,
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div role="dialog" aria-label="Unlock Vault">
+        <button onClick={onClose}>Close Unlock</button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/components/vault/VaultSettingsSection", () => ({
@@ -83,16 +240,14 @@ vi.mock("../KeyDrawer", () => ({
     editKey: VaultKeyEntry | null;
     onClose: () => void;
   }) =>
-    open
-      ? (
-        <div
-          role="dialog"
-          aria-label={editKey ? "Edit Private Key" : "Add Private Key"}
-        >
-          <button onClick={onClose}>Close Drawer</button>
-        </div>
-      )
-      : null,
+    open ? (
+      <div
+        role="dialog"
+        aria-label={editKey ? "Edit Private Key" : "Add Private Key"}
+      >
+        <button onClick={onClose}>Close Drawer</button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("../KeyDeleteDialog", () => ({
@@ -105,21 +260,12 @@ vi.mock("../KeyDeleteDialog", () => ({
     entry: VaultKeyEntry | null;
     onClose: () => void;
   }) =>
-    open
-      ? (
-        <div role="dialog" aria-label="Delete Key Dialog">
-          {entry && <span>{entry.name}</span>}
-          <button onClick={onClose}>Close Delete</button>
-        </div>
-      )
-      : null,
-}));
-
-// CopyButton is used inside the key table — stub it out
-vi.mock("@/components/common/CopyButton", () => ({
-  default: ({ text }: { text: string }) => (
-    <button aria-label={`Copy ${text}`}>Copy</button>
-  ),
+    open ? (
+      <div role="dialog" aria-label="Delete Key Dialog">
+        {entry && <span>{entry.name}</span>}
+        <button onClick={onClose}>Close Delete</button>
+      </div>
+    ) : null,
 }));
 
 const makeKey = (overrides: Partial<VaultKeyEntry> = {}): VaultKeyEntry => ({
@@ -138,12 +284,19 @@ const mockRefreshStatus = vi.fn();
 function setupStore(
   status: "uninitialized" | "locked" | "unlocked",
   keys: VaultKeyEntry[] = [],
+  autoLockNonce: number = 0,
 ) {
   (useVaultStore as unknown as { _state: Record<string, unknown> })._state = {
     status,
     keys,
     refreshStatus: mockRefreshStatus,
+    autoLockNonce,
   };
+}
+
+function getState() {
+  return (useVaultStore as unknown as { _state: Record<string, unknown> })
+    ._state;
 }
 
 afterEach(cleanup);
@@ -196,7 +349,9 @@ describe("SecureVault", () => {
       await userEvent.click(
         screen.getByRole("button", { name: /set up secure vault/i }),
       );
-      await userEvent.click(screen.getByRole("button", { name: /close setup/i }));
+      await userEvent.click(
+        screen.getByRole("button", { name: /close setup/i }),
+      );
 
       expect(
         screen.queryByRole("dialog", { name: /setup vault/i }),
@@ -214,7 +369,9 @@ describe("SecureVault", () => {
     it("renders the full-screen locked page with heading and highlights", () => {
       setupStore("locked");
       render(<SecureVault />);
-      expect(screen.getByRole("heading", { name: /your vault is locked/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: /your vault is locked/i }),
+      ).toBeInTheDocument();
       expect(screen.getByText("AES-256 Encryption")).toBeInTheDocument();
       expect(screen.getByText("Zero Knowledge")).toBeInTheDocument();
       expect(screen.getByText("Quick Connect")).toBeInTheDocument();
@@ -224,7 +381,9 @@ describe("SecureVault", () => {
       setupStore("locked");
       render(<SecureVault />);
 
-      await userEvent.click(screen.getByRole("button", { name: /unlock vault/i }));
+      await userEvent.click(
+        screen.getByRole("button", { name: /unlock vault/i }),
+      );
 
       expect(
         screen.getByRole("dialog", { name: /unlock vault/i }),
@@ -235,7 +394,9 @@ describe("SecureVault", () => {
       setupStore("locked");
       render(<SecureVault />);
 
-      await userEvent.click(screen.getByRole("button", { name: /unlock vault/i }));
+      await userEvent.click(
+        screen.getByRole("button", { name: /unlock vault/i }),
+      );
       await userEvent.click(
         screen.getByRole("button", { name: /close unlock/i }),
       );
@@ -256,9 +417,7 @@ describe("SecureVault", () => {
     it("renders the empty state message", () => {
       setupStore("unlocked", []);
       render(<SecureVault />);
-      expect(
-        screen.getByText(/no keys yet/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/no keys yet/i)).toBeInTheDocument();
     });
 
     it("renders 'Add Private Key' button in empty state", () => {
@@ -301,7 +460,11 @@ describe("SecureVault", () => {
 
   describe("unlocked state — with keys", () => {
     const keys = [
-      makeKey({ id: "key-1", name: "Production Server", fingerprint: "aa:bb:cc:dd" }),
+      makeKey({
+        id: "key-1",
+        name: "Production Server",
+        fingerprint: "aa:bb:cc:dd",
+      }),
       makeKey({
         id: "key-2",
         name: "Staging Server",
@@ -325,7 +488,14 @@ describe("SecureVault", () => {
     });
 
     it("does not show lock icon for keys without passphrase", () => {
-      setupStore("unlocked", [makeKey({ id: "key-1", name: "Production Server", fingerprint: "aa:bb:cc:dd", hasPassphrase: false })]);
+      setupStore("unlocked", [
+        makeKey({
+          id: "key-1",
+          name: "Production Server",
+          fingerprint: "aa:bb:cc:dd",
+          hasPassphrase: false,
+        }),
+      ]);
       render(<SecureVault />);
       expect(screen.queryByTitle("Encrypted")).not.toBeInTheDocument();
     });
@@ -409,8 +579,16 @@ describe("SecureVault", () => {
 
   describe("search filtering", () => {
     const keys = [
-      makeKey({ id: "key-1", name: "Production Server", fingerprint: "aa:bb:cc:dd" }),
-      makeKey({ id: "key-2", name: "Staging Server", fingerprint: "11:22:33:44" }),
+      makeKey({
+        id: "key-1",
+        name: "Production Server",
+        fingerprint: "aa:bb:cc:dd",
+      }),
+      makeKey({
+        id: "key-2",
+        name: "Staging Server",
+        fingerprint: "11:22:33:44",
+      }),
     ];
 
     it("shows all rows when search is empty", () => {
@@ -455,9 +633,7 @@ describe("SecureVault", () => {
         "nonexistent",
       );
 
-      expect(
-        screen.getByText(/no keys matching/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/no keys matching/i)).toBeInTheDocument();
     });
 
     it("search is case-insensitive", async () => {
@@ -494,6 +670,184 @@ describe("SecureVault", () => {
       expect(
         screen.queryByTestId("vault-settings-section"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("auto-lock nonce — auto-open unlock dialog", () => {
+    it("opens VaultUnlockDialog when autoLockNonce bumps while mounted (unlocked → locked)", () => {
+      // Start unlocked with nonce=0
+      setupStore("unlocked", [], 0);
+      const { rerender } = render(<SecureVault />);
+
+      // Simulate auto-lock: status becomes locked AND nonce bumps to 1
+      act(() => {
+        getState().status = "locked";
+        getState().autoLockNonce = 1;
+      });
+      rerender(<SecureVault />);
+
+      // The unlock dialog must auto-open
+      expect(
+        screen.getByRole("dialog", { name: /unlock vault/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("does NOT auto-open unlock dialog on manual lock (nonce unchanged)", () => {
+      // Start unlocked with nonce=0
+      setupStore("unlocked", [], 0);
+      const { rerender } = render(<SecureVault />);
+
+      // Simulate manual lock: status becomes locked but nonce stays at 0
+      act(() => {
+        getState().status = "locked";
+        // autoLockNonce remains 0 — no bump
+      });
+      rerender(<SecureVault />);
+
+      // Locked screen is shown but unlock dialog must NOT auto-open
+      expect(
+        screen.getByRole("heading", { name: /your vault is locked/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", { name: /unlock vault/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does NOT auto-open unlock dialog for a stale nonce after remount", () => {
+      // First mount: nonce was already 1 (a past auto-lock event)
+      // Navigating away and back — fresh mount should NOT pop the dialog
+      setupStore("locked", [], 1);
+      render(<SecureVault />);
+
+      // Locked screen is shown but unlock dialog must NOT auto-open
+      expect(
+        screen.getByRole("heading", { name: /your vault is locked/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", { name: /unlock vault/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("hook count is stable across unlocked→locked transition (no hook-order crash)", () => {
+      // Start unlocked
+      setupStore("unlocked", [], 0);
+      const { rerender } = render(<SecureVault />);
+
+      // Mutate BOTH status and nonce simultaneously before rerender
+      act(() => {
+        getState().status = "locked";
+        getState().autoLockNonce = 1;
+      });
+
+      // Must not throw (hook count must be identical in both renders)
+      expect(() => rerender(<SecureVault />)).not.toThrow();
+    });
+  });
+
+  describe("ConnectDrawer — auto-lock degrade", () => {
+    const vaultKey = makeKey({
+      id: "vault-key-1",
+      name: "My Key",
+      fingerprint: "ff:ee:dd:cc",
+    });
+
+    function setupConnectStore(
+      status: "uninitialized" | "locked" | "unlocked",
+      keys: VaultKeyEntry[] = [],
+    ) {
+      (useVaultStore as unknown as { _state: Record<string, unknown> })._state =
+        {
+          status,
+          keys,
+          refreshStatus: mockRefreshStatus,
+          autoLockNonce: 0,
+        };
+    }
+
+    function renderConnectDrawer() {
+      return render(
+        <ConnectDrawer
+          open
+          onClose={vi.fn()}
+          deviceUid="dev-1"
+          deviceName="my-device"
+          sshid="my-device.ns@localhost"
+        />,
+      );
+    }
+
+    it("shows locked UI and disables Connect when vault auto-locks while drawer is open", () => {
+      // Start with vault unlocked and a vault key available
+      setupConnectStore("unlocked", [vaultKey]);
+      const { rerender } = renderConnectDrawer();
+
+      // Vault auto-locks
+      act(() => {
+        setupConnectStore("locked", []);
+      });
+      rerender(
+        <ConnectDrawer
+          open
+          onClose={vi.fn()}
+          deviceUid="dev-1"
+          deviceName="my-device"
+          sshid="my-device.ns@localhost"
+        />,
+      );
+
+      // Locked banner should be visible when auth method is "key"
+      // Connect button must be disabled (canConnect is false: no username)
+      const connectBtn = screen.getByRole("button", { name: /connect/i });
+      expect(connectBtn).toBeDisabled();
+    });
+
+    it("hides key-selection UI when vault is locked", () => {
+      // Start unlocked with vault key
+      setupConnectStore("unlocked", [vaultKey]);
+      const { rerender } = renderConnectDrawer();
+
+      // Auto-lock
+      act(() => {
+        setupConnectStore("locked", []);
+      });
+      rerender(
+        <ConnectDrawer
+          open
+          onClose={vi.fn()}
+          deviceUid="dev-1"
+          deviceName="my-device"
+          sshid="my-device.ns@localhost"
+        />,
+      );
+
+      // Key source toggle (Vault/Manual) must NOT be present since vault has no keys
+      expect(
+        screen.queryByTestId("radio-segment-vault"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("radio-segment-manual"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not crash when vault auto-locks while key auth mode is active", () => {
+      setupConnectStore("unlocked", [vaultKey]);
+      const { rerender } = renderConnectDrawer();
+
+      act(() => {
+        setupConnectStore("locked", []);
+      });
+
+      expect(() =>
+        rerender(
+          <ConnectDrawer
+            open
+            onClose={vi.fn()}
+            deviceUid="dev-1"
+            deviceName="my-device"
+            sshid="my-device.ns@localhost"
+          />,
+        ),
+      ).not.toThrow();
     });
   });
 });

--- a/ui/apps/console/src/pages/secure-vault/index.tsx
+++ b/ui/apps/console/src/pages/secure-vault/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ShieldCheckIcon,
   LockClosedIcon,
@@ -49,6 +49,7 @@ export default function SecureVault() {
   const status = useVaultStore((s) => s.status);
   const keys = useVaultStore((s) => s.keys);
   const refreshStatus = useVaultStore((s) => s.refreshStatus);
+  const autoLockNonce = useVaultStore((s) => s.autoLockNonce);
   const [setupOpen, setSetupOpen] = useState(false);
   const [unlockOpen, setUnlockOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -59,6 +60,14 @@ export default function SecureVault() {
   useEffect(() => {
     refreshStatus();
   }, [refreshStatus]);
+
+  const seenNonce = useRef(autoLockNonce);
+  useEffect(() => {
+    if (autoLockNonce !== seenNonce.current) {
+      seenNonce.current = autoLockNonce;
+      setUnlockOpen(true);
+    }
+  }, [autoLockNonce]);
 
   const openNew = () => {
     setEditTarget(null);

--- a/ui/apps/console/src/stores/__tests__/vaultStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/vaultStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { VaultMeta, VaultData, VaultKeyEntry } from "@/types/vault";
+import { DEFAULT_VAULT_SETTINGS } from "@/types/vault";
 
 vi.mock("@/utils/vault-crypto", () => ({
   createVaultMeta: vi.fn(),
@@ -21,6 +22,11 @@ vi.mock("../authStore", () => ({
   },
 }));
 
+vi.mock("@/utils/vault-activity-tracker", () => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
 import {
   createVaultMeta,
   verifyPassword,
@@ -32,6 +38,7 @@ import {
 } from "@/utils/vault-crypto";
 
 import { getVaultBackend } from "@/utils/vault-backend-factory";
+import * as activityTracker from "@/utils/vault-activity-tracker";
 
 import { useVaultStore, DuplicateKeyError } from "../vaultStore";
 
@@ -43,6 +50,8 @@ const mockSetSession = vi.mocked(setSessionKey);
 const mockGetSession = vi.mocked(getSessionKey);
 const mockClearSession = vi.mocked(clearSessionKey);
 const mockGetBackend = vi.mocked(getVaultBackend);
+const mockTrackerStart = vi.mocked(activityTracker.start);
+const mockTrackerStop = vi.mocked(activityTracker.stop);
 
 function makeFakeKey(overrides: Partial<VaultKeyEntry> = {}): VaultKeyEntry {
   return {
@@ -58,7 +67,13 @@ function makeFakeKey(overrides: Partial<VaultKeyEntry> = {}): VaultKeyEntry {
 }
 
 function makeMeta(): VaultMeta {
-  return { version: 1, salt: "c2FsdA==", iterations: 600000, verifier: "dmVyaWZpZXI=", verifierIv: "aXY=" };
+  return {
+    version: 1,
+    salt: "c2FsdA==",
+    iterations: 600000,
+    verifier: "dmVyaWZpZXI=",
+    verifierIv: "aXY=",
+  };
 }
 
 function makeVaultData(): VaultData {
@@ -74,11 +89,18 @@ function makeFakeBackend() {
     clear: vi.fn(),
     loadLegacyKeys: vi.fn().mockReturnValue([]),
     clearLegacyKeys: vi.fn(),
+    loadSettings: vi.fn().mockReturnValue(DEFAULT_VAULT_SETTINGS),
+    saveSettings: vi.fn(),
   };
 }
 
 function makeFakeCryptoKey(label = "AES-GCM"): CryptoKey {
-  return { type: "secret", extractable: false, algorithm: { name: label }, usages: ["encrypt", "decrypt"] };
+  return {
+    type: "secret",
+    extractable: false,
+    algorithm: { name: label },
+    usages: ["encrypt", "decrypt"],
+  };
 }
 
 beforeEach(() => {
@@ -87,6 +109,9 @@ beforeEach(() => {
     keys: [],
     loading: false,
     error: null,
+    autoLockNonce: 0,
+    autoLockTimeoutMinutes: 15,
+    lockOnHidden: false,
   });
   vi.clearAllMocks();
 });
@@ -124,6 +149,91 @@ describe("vaultStore", () => {
 
       expect(useVaultStore.getState().status).toBe("unlocked");
     });
+
+    it("loads settings from backend ONLY when meta exists", () => {
+      const backend = makeFakeBackend();
+      const customSettings = { autoLockTimeoutMinutes: 30, lockOnHidden: true };
+      backend.loadMeta.mockReturnValue(makeMeta());
+      backend.loadSettings.mockReturnValue(customSettings);
+      mockGetBackend.mockReturnValue(backend);
+      mockGetSession.mockReturnValue(null);
+
+      useVaultStore.getState().refreshStatus();
+
+      expect(backend.loadSettings).toHaveBeenCalled();
+      expect(useVaultStore.getState().autoLockTimeoutMinutes).toBe(30);
+      expect(useVaultStore.getState().lockOnHidden).toBe(true);
+    });
+
+    it("does NOT call loadSettings when meta is absent (uninitialized)", () => {
+      const backend = makeFakeBackend();
+      backend.loadMeta.mockReturnValue(null);
+      mockGetBackend.mockReturnValue(backend);
+      mockGetSession.mockReturnValue(null);
+
+      useVaultStore.getState().refreshStatus();
+
+      expect(backend.loadSettings).not.toHaveBeenCalled();
+    });
+
+    it("does not change autoLockNonce on any refreshStatus call", () => {
+      const backend = makeFakeBackend();
+      backend.loadMeta.mockReturnValue(makeMeta());
+      mockGetBackend.mockReturnValue(backend);
+      mockGetSession.mockReturnValue(null);
+
+      useVaultStore.setState({ autoLockNonce: 5 });
+      useVaultStore.getState().refreshStatus();
+
+      expect(useVaultStore.getState().autoLockNonce).toBe(5);
+    });
+
+    it("calls activityTracker.stop() when no meta (uninitialized return)", () => {
+      const backend = makeFakeBackend();
+      backend.loadMeta.mockReturnValue(null);
+      mockGetBackend.mockReturnValue(backend);
+      mockGetSession.mockReturnValue(null);
+
+      useVaultStore.getState().refreshStatus();
+
+      expect(mockTrackerStop).toHaveBeenCalled();
+    });
+
+    it("calls activityTracker.stop() when meta exists but no session key (locked)", () => {
+      const backend = makeFakeBackend();
+      backend.loadMeta.mockReturnValue(makeMeta());
+      mockGetBackend.mockReturnValue(backend);
+      mockGetSession.mockReturnValue(null);
+
+      useVaultStore.getState().refreshStatus();
+
+      expect(mockTrackerStop).toHaveBeenCalled();
+    });
+
+    it("does NOT call activityTracker.start() on the unlocked branch", () => {
+      const backend = makeFakeBackend();
+      backend.loadMeta.mockReturnValue(makeMeta());
+      mockGetBackend.mockReturnValue(backend);
+      mockGetSession.mockReturnValue(makeFakeCryptoKey());
+
+      useVaultStore.getState().refreshStatus();
+
+      expect(mockTrackerStart).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when backend.loadSettings throws (exception-safe)", () => {
+      const backend = makeFakeBackend();
+      backend.loadMeta.mockReturnValue(makeMeta());
+      backend.loadSettings.mockImplementation(() => {
+        throw new Error("storage error");
+      });
+      mockGetBackend.mockReturnValue(backend);
+      mockGetSession.mockReturnValue(null);
+
+      expect(() => useVaultStore.getState().refreshStatus()).not.toThrow();
+      // Status should still be set despite settings load failure
+      expect(useVaultStore.getState().status).toBe("locked");
+    });
   });
 
   describe("initialize", () => {
@@ -150,11 +260,37 @@ describe("vaultStore", () => {
       expect(backend.saveData).toHaveBeenCalledWith(encryptedData);
     });
 
+    it("calls loadSettings then startTracker (activityTracker.start) after success", async () => {
+      const backend = makeFakeBackend();
+      const derivedKey = makeFakeCryptoKey();
+      const customSettings = { autoLockTimeoutMinutes: 30, lockOnHidden: true };
+      backend.loadSettings.mockReturnValue(customSettings);
+
+      mockGetBackend.mockReturnValue(backend);
+      mockCrypto.mockResolvedValue({ meta: makeMeta(), derivedKey });
+      mockGetSession.mockReturnValue(derivedKey);
+      mockEncrypt.mockResolvedValue(makeVaultData());
+
+      await useVaultStore.getState().initialize("master-pass");
+
+      expect(backend.loadSettings).toHaveBeenCalled();
+      expect(mockTrackerStart).toHaveBeenCalled();
+      const startArg = mockTrackerStart.mock.calls[0][0];
+      expect(startArg.idleTimeoutMs).toBe(30 * 60000);
+      expect(startArg.lockOnHidden).toBe(true);
+    });
+
     it("migrates legacy keys when they exist", async () => {
       const backend = makeFakeBackend();
       const derivedKey = makeFakeCryptoKey();
       const legacyKeys = [
-        { id: 1, name: "Old Key", data: "-----BEGIN", hasPassphrase: false, fingerprint: "ff:ee:dd" },
+        {
+          id: 1,
+          name: "Old Key",
+          data: "-----BEGIN",
+          hasPassphrase: false,
+          fingerprint: "ff:ee:dd",
+        },
       ];
       backend.loadLegacyKeys.mockReturnValue(legacyKeys);
 
@@ -207,7 +343,11 @@ describe("vaultStore", () => {
 
       let resolve: (v: { meta: VaultMeta; derivedKey: CryptoKey }) => void;
       mockGetBackend.mockReturnValue(backend);
-      mockCrypto.mockReturnValue(new Promise((r) => { resolve = r; }));
+      mockCrypto.mockReturnValue(
+        new Promise((r) => {
+          resolve = r;
+        }),
+      );
 
       const promise = useVaultStore.getState().initialize("master-pass");
       expect(useVaultStore.getState().loading).toBe(true);
@@ -241,6 +381,27 @@ describe("vaultStore", () => {
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();
       expect(mockSetSession).toHaveBeenCalledWith(derivedKey);
+    });
+
+    it("calls loadSettings then startTracker (activityTracker.start) after success", async () => {
+      const backend = makeFakeBackend();
+      const derivedKey = makeFakeCryptoKey();
+      const customSettings = { autoLockTimeoutMinutes: 5, lockOnHidden: false };
+      backend.loadMeta.mockReturnValue(makeMeta());
+      backend.loadData.mockReturnValue(makeVaultData());
+      backend.loadSettings.mockReturnValue(customSettings);
+
+      mockGetBackend.mockReturnValue(backend);
+      mockVerify.mockResolvedValue(derivedKey);
+      mockDecrypt.mockResolvedValue(JSON.stringify([makeFakeKey()]));
+
+      await useVaultStore.getState().unlock("master-pass");
+
+      expect(backend.loadSettings).toHaveBeenCalled();
+      expect(mockTrackerStart).toHaveBeenCalled();
+      const startArg = mockTrackerStart.mock.calls[0][0];
+      expect(startArg.idleTimeoutMs).toBe(5 * 60000);
+      expect(startArg.lockOnHidden).toBe(false);
     });
 
     it("loads empty keys when vault has no data yet", async () => {
@@ -311,7 +472,11 @@ describe("vaultStore", () => {
 
   describe("lock", () => {
     it("clears session key, empties keys, and transitions to locked", () => {
-      useVaultStore.setState({ status: "unlocked", keys: [makeFakeKey()], error: "old error" });
+      useVaultStore.setState({
+        status: "unlocked",
+        keys: [makeFakeKey()],
+        error: "old error",
+      });
 
       useVaultStore.getState().lock();
 
@@ -320,6 +485,149 @@ describe("vaultStore", () => {
       expect(state.keys).toEqual([]);
       expect(state.error).toBeNull();
       expect(mockClearSession).toHaveBeenCalled();
+    });
+
+    it("calls activityTracker.stop() when locking manually", () => {
+      useVaultStore.setState({ status: "unlocked", keys: [] });
+
+      useVaultStore.getState().lock();
+
+      expect(mockTrackerStop).toHaveBeenCalled();
+    });
+
+    it("does NOT bump autoLockNonce on manual lock", () => {
+      useVaultStore.setState({
+        status: "unlocked",
+        keys: [],
+        autoLockNonce: 3,
+      });
+
+      useVaultStore.getState().lock();
+
+      expect(useVaultStore.getState().autoLockNonce).toBe(3);
+    });
+  });
+
+  describe("onIdle callback behavior", () => {
+    it("onIdle sets status to locked, clears keys, and bumps autoLockNonce", async () => {
+      const backend = makeFakeBackend();
+      const derivedKey = makeFakeCryptoKey();
+      backend.loadMeta.mockReturnValue(makeMeta());
+      backend.loadData.mockReturnValue(makeVaultData());
+      mockGetBackend.mockReturnValue(backend);
+      mockVerify.mockResolvedValue(derivedKey);
+      mockDecrypt.mockResolvedValue(JSON.stringify([makeFakeKey()]));
+
+      await useVaultStore.getState().unlock("master-pass");
+
+      expect(mockTrackerStart).toHaveBeenCalled();
+      const { onIdle } = mockTrackerStart.mock.calls[0][0];
+
+      // Simulate vault becoming locked before onIdle fires (ensure session key cleared)
+      mockGetSession.mockReturnValue(derivedKey);
+      useVaultStore.setState({ autoLockNonce: 0 });
+
+      onIdle();
+
+      const state = useVaultStore.getState();
+      expect(state.status).toBe("locked");
+      expect(state.keys).toEqual([]);
+      expect(state.error).toBeNull();
+      expect(state.autoLockNonce).toBe(1);
+      expect(mockClearSession).toHaveBeenCalled();
+      expect(mockTrackerStop).toHaveBeenCalled();
+    });
+
+    it("onIdle is a no-op (no nonce bump) when vault is already locked", async () => {
+      const backend = makeFakeBackend();
+      const derivedKey = makeFakeCryptoKey();
+      backend.loadMeta.mockReturnValue(makeMeta());
+      backend.loadData.mockReturnValue(makeVaultData());
+      mockGetBackend.mockReturnValue(backend);
+      mockVerify.mockResolvedValue(derivedKey);
+      mockDecrypt.mockResolvedValue(JSON.stringify([]));
+
+      await useVaultStore.getState().unlock("master-pass");
+
+      const { onIdle } = mockTrackerStart.mock.calls[0][0];
+
+      // Manually lock the vault first
+      useVaultStore.setState({ status: "locked", autoLockNonce: 2 });
+      vi.clearAllMocks();
+
+      onIdle();
+
+      expect(useVaultStore.getState().autoLockNonce).toBe(2);
+      expect(mockClearSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateAutoLockSettings", () => {
+    it("saves settings to backend, updates state, and restarts tracker when unlocked", () => {
+      const backend = makeFakeBackend();
+      mockGetBackend.mockReturnValue(backend);
+      useVaultStore.setState({
+        status: "unlocked",
+        autoLockTimeoutMinutes: 15,
+        lockOnHidden: false,
+      });
+
+      useVaultStore.getState().updateAutoLockSettings({
+        autoLockTimeoutMinutes: 30,
+        lockOnHidden: true,
+      });
+
+      expect(backend.saveSettings).toHaveBeenCalledWith({
+        autoLockTimeoutMinutes: 30,
+        lockOnHidden: true,
+      });
+      const state = useVaultStore.getState();
+      expect(state.autoLockTimeoutMinutes).toBe(30);
+      expect(state.lockOnHidden).toBe(true);
+      expect(mockTrackerStart).toHaveBeenCalled();
+      const startArg = mockTrackerStart.mock.calls[0][0];
+      expect(startArg.idleTimeoutMs).toBe(30 * 60000);
+      expect(startArg.lockOnHidden).toBe(true);
+    });
+
+    it("saves settings and updates state but does NOT restart tracker when locked", () => {
+      const backend = makeFakeBackend();
+      mockGetBackend.mockReturnValue(backend);
+      useVaultStore.setState({
+        status: "locked",
+        autoLockTimeoutMinutes: 15,
+        lockOnHidden: false,
+      });
+
+      useVaultStore
+        .getState()
+        .updateAutoLockSettings({ autoLockTimeoutMinutes: 60 });
+
+      expect(backend.saveSettings).toHaveBeenCalledWith({
+        autoLockTimeoutMinutes: 60,
+        lockOnHidden: false,
+      });
+      expect(useVaultStore.getState().autoLockTimeoutMinutes).toBe(60);
+      expect(mockTrackerStart).not.toHaveBeenCalled();
+    });
+
+    it("can update only lockOnHidden (partial update)", () => {
+      const backend = makeFakeBackend();
+      mockGetBackend.mockReturnValue(backend);
+      useVaultStore.setState({
+        status: "unlocked",
+        autoLockTimeoutMinutes: 15,
+        lockOnHidden: false,
+      });
+
+      useVaultStore.getState().updateAutoLockSettings({ lockOnHidden: true });
+
+      expect(backend.saveSettings).toHaveBeenCalledWith({
+        autoLockTimeoutMinutes: 15,
+        lockOnHidden: true,
+      });
+      expect(useVaultStore.getState().lockOnHidden).toBe(true);
+      expect(useVaultStore.getState().autoLockTimeoutMinutes).toBe(15);
     });
   });
 
@@ -351,30 +659,59 @@ describe("vaultStore", () => {
     });
 
     it("throws DuplicateKeyError with field 'name' when name already exists", async () => {
-      useVaultStore.setState({ status: "unlocked", keys: [makeFakeKey({ name: "My Key", fingerprint: "aa:bb:cc" })] });
+      useVaultStore.setState({
+        status: "unlocked",
+        keys: [makeFakeKey({ name: "My Key", fingerprint: "aa:bb:cc" })],
+      });
 
       await expect(
-        useVaultStore.getState().addKey({ name: "My Key", data: "x", hasPassphrase: false, fingerprint: "dd:ee:ff" }),
+        useVaultStore.getState().addKey({
+          name: "My Key",
+          data: "x",
+          hasPassphrase: false,
+          fingerprint: "dd:ee:ff",
+        }),
       ).rejects.toBeInstanceOf(DuplicateKeyError);
 
       await expect(
-        useVaultStore.getState().addKey({ name: "My Key", data: "x", hasPassphrase: false, fingerprint: "dd:ee:ff" }),
+        useVaultStore.getState().addKey({
+          name: "My Key",
+          data: "x",
+          hasPassphrase: false,
+          fingerprint: "dd:ee:ff",
+        }),
       ).rejects.toMatchObject({ field: "name" });
     });
 
     it("throws DuplicateKeyError with field 'private_key' when fingerprint already exists", async () => {
-      useVaultStore.setState({ status: "unlocked", keys: [makeFakeKey({ name: "My Key", fingerprint: "aa:bb:cc" })] });
+      useVaultStore.setState({
+        status: "unlocked",
+        keys: [makeFakeKey({ name: "My Key", fingerprint: "aa:bb:cc" })],
+      });
 
       await expect(
-        useVaultStore.getState().addKey({ name: "Other Key", data: "x", hasPassphrase: false, fingerprint: "aa:bb:cc" }),
+        useVaultStore.getState().addKey({
+          name: "Other Key",
+          data: "x",
+          hasPassphrase: false,
+          fingerprint: "aa:bb:cc",
+        }),
       ).rejects.toMatchObject({ field: "private_key" });
     });
 
     it("throws DuplicateKeyError with field 'both' when both name and fingerprint are duplicates", async () => {
-      useVaultStore.setState({ status: "unlocked", keys: [makeFakeKey({ name: "My Key", fingerprint: "aa:bb:cc" })] });
+      useVaultStore.setState({
+        status: "unlocked",
+        keys: [makeFakeKey({ name: "My Key", fingerprint: "aa:bb:cc" })],
+      });
 
       await expect(
-        useVaultStore.getState().addKey({ name: "My Key", data: "x", hasPassphrase: false, fingerprint: "aa:bb:cc" }),
+        useVaultStore.getState().addKey({
+          name: "My Key",
+          data: "x",
+          hasPassphrase: false,
+          fingerprint: "aa:bb:cc",
+        }),
       ).rejects.toMatchObject({ field: "both" });
     });
 
@@ -385,8 +722,49 @@ describe("vaultStore", () => {
       mockGetBackend.mockReturnValue(backend);
 
       await expect(
-        useVaultStore.getState().addKey({ name: "Key", data: "x", hasPassphrase: false, fingerprint: "11:22:33" }),
+        useVaultStore.getState().addKey({
+          name: "Key",
+          data: "x",
+          hasPassphrase: false,
+          fingerprint: "11:22:33",
+        }),
       ).rejects.toThrow("Vault is locked");
+    });
+
+    it("aborts set({keys}) if vault locks mid-flight during persistKeys", async () => {
+      const derivedKey = makeFakeCryptoKey();
+      const backend = makeFakeBackend();
+
+      useVaultStore.setState({ status: "unlocked", keys: [] });
+      mockGetSession.mockReturnValue(derivedKey);
+      mockGetBackend.mockReturnValue(backend);
+
+      let resolveEncrypt!: (v: VaultData) => void;
+      mockEncrypt.mockReturnValue(
+        new Promise<VaultData>((r) => {
+          resolveEncrypt = r;
+        }),
+      );
+
+      const promise = useVaultStore.getState().addKey({
+        name: "New Key",
+        data: "-----BEGIN",
+        hasPassphrase: false,
+        fingerprint: "11:22:33",
+      });
+
+      // Lock the vault mid-flight (simulating onIdle firing during await)
+      useVaultStore.setState({ status: "locked", keys: [] });
+
+      // Resolve encrypt so persistKeys finishes
+      resolveEncrypt(makeVaultData());
+      await promise.catch(() => {
+        /* may throw */
+      });
+
+      // keys should remain [] (the locked state, not overwritten by addKey)
+      expect(useVaultStore.getState().keys).toEqual([]);
+      expect(useVaultStore.getState().status).toBe("locked");
     });
   });
 
@@ -394,7 +772,11 @@ describe("vaultStore", () => {
     it("updates key fields and persists", async () => {
       const derivedKey = makeFakeCryptoKey();
       const backend = makeFakeBackend();
-      const existing = makeFakeKey({ id: "key-1", name: "Old Name", fingerprint: "aa:bb:cc" });
+      const existing = makeFakeKey({
+        id: "key-1",
+        name: "Old Name",
+        fingerprint: "aa:bb:cc",
+      });
 
       useVaultStore.setState({ status: "unlocked", keys: [existing] });
       mockGetSession.mockReturnValue(derivedKey);
@@ -409,7 +791,10 @@ describe("vaultStore", () => {
     });
 
     it("throws when key id does not exist", async () => {
-      useVaultStore.setState({ status: "unlocked", keys: [makeFakeKey({ id: "key-1" })] });
+      useVaultStore.setState({
+        status: "unlocked",
+        keys: [makeFakeKey({ id: "key-1" })],
+      });
 
       await expect(
         useVaultStore.getState().updateKey("non-existent", { name: "X" }),
@@ -431,7 +816,11 @@ describe("vaultStore", () => {
     it("allows updating a key's own name without throwing duplicate error", async () => {
       const derivedKey = makeFakeCryptoKey();
       const backend = makeFakeBackend();
-      const key = makeFakeKey({ id: "key-1", name: "My Key", fingerprint: "aa:bb:cc" });
+      const key = makeFakeKey({
+        id: "key-1",
+        name: "My Key",
+        fingerprint: "aa:bb:cc",
+      });
 
       useVaultStore.setState({ status: "unlocked", keys: [key] });
       mockGetSession.mockReturnValue(derivedKey);
@@ -441,6 +830,39 @@ describe("vaultStore", () => {
       await expect(
         useVaultStore.getState().updateKey("key-1", { name: "My Key" }),
       ).resolves.toBeUndefined();
+    });
+
+    it("aborts set({keys}) if vault locks mid-flight during persistKeys", async () => {
+      const derivedKey = makeFakeCryptoKey();
+      const backend = makeFakeBackend();
+      const existing = makeFakeKey({ id: "key-1", name: "Old Name" });
+
+      useVaultStore.setState({ status: "unlocked", keys: [existing] });
+      mockGetSession.mockReturnValue(derivedKey);
+      mockGetBackend.mockReturnValue(backend);
+
+      let resolveEncrypt!: (v: VaultData) => void;
+      mockEncrypt.mockReturnValue(
+        new Promise<VaultData>((r) => {
+          resolveEncrypt = r;
+        }),
+      );
+
+      const promise = useVaultStore
+        .getState()
+        .updateKey("key-1", { name: "New Name" });
+
+      // Lock mid-flight
+      useVaultStore.setState({ status: "locked", keys: [] });
+
+      resolveEncrypt(makeVaultData());
+      await promise.catch(() => {
+        /* may throw or not */
+      });
+
+      // Name should NOT have been updated; keys still [] from the locked state
+      expect(useVaultStore.getState().keys).toEqual([]);
+      expect(useVaultStore.getState().status).toBe("locked");
     });
   });
 
@@ -472,7 +894,40 @@ describe("vaultStore", () => {
       useVaultStore.setState({ status: "unlocked", keys });
       mockGetBackend.mockReturnValue(backend);
 
-      await expect(useVaultStore.getState().removeKey("ghost-id")).rejects.toThrow("Key not found");
+      await expect(
+        useVaultStore.getState().removeKey("ghost-id"),
+      ).rejects.toThrow("Key not found");
+    });
+
+    it("aborts set({keys}) if vault locks mid-flight during persistKeys", async () => {
+      const derivedKey = makeFakeCryptoKey();
+      const backend = makeFakeBackend();
+      const existing = makeFakeKey({ id: "key-1", name: "Key" });
+
+      useVaultStore.setState({ status: "unlocked", keys: [existing] });
+      mockGetSession.mockReturnValue(derivedKey);
+      mockGetBackend.mockReturnValue(backend);
+
+      let resolveEncrypt!: (v: VaultData) => void;
+      mockEncrypt.mockReturnValue(
+        new Promise<VaultData>((r) => {
+          resolveEncrypt = r;
+        }),
+      );
+
+      const promise = useVaultStore.getState().removeKey("key-1");
+
+      // Lock mid-flight
+      useVaultStore.setState({ status: "locked", keys: [] });
+
+      resolveEncrypt(makeVaultData());
+      await promise.catch(() => {
+        /* may throw or not */
+      });
+
+      // keys should remain [] (locked state not overwritten with post-remove keys)
+      expect(useVaultStore.getState().keys).toEqual([]);
+      expect(useVaultStore.getState().status).toBe("locked");
     });
   });
 
@@ -493,7 +948,9 @@ describe("vaultStore", () => {
 
       useVaultStore.setState({ status: "unlocked", keys: [makeFakeKey()] });
 
-      await useVaultStore.getState().changeMasterPassword("current-pass", "new-pass");
+      await useVaultStore
+        .getState()
+        .changeMasterPassword("current-pass", "new-pass");
 
       const state = useVaultStore.getState();
       expect(state.loading).toBe(false);
@@ -507,7 +964,9 @@ describe("vaultStore", () => {
       backend.loadMeta.mockReturnValue(null);
       mockGetBackend.mockReturnValue(backend);
 
-      await useVaultStore.getState().changeMasterPassword("current-pass", "new-pass");
+      await useVaultStore
+        .getState()
+        .changeMasterPassword("current-pass", "new-pass");
 
       const state = useVaultStore.getState();
       expect(state.error).toBe("No vault found");
@@ -523,7 +982,9 @@ describe("vaultStore", () => {
 
       useVaultStore.setState({ status: "unlocked", keys: [] });
 
-      await useVaultStore.getState().changeMasterPassword("wrong-pass", "new-pass");
+      await useVaultStore
+        .getState()
+        .changeMasterPassword("wrong-pass", "new-pass");
 
       const state = useVaultStore.getState();
       expect(state.error).toBe("Current password is incorrect");
@@ -538,7 +999,9 @@ describe("vaultStore", () => {
 
       useVaultStore.setState({ status: "locked", keys: [] });
 
-      await useVaultStore.getState().changeMasterPassword("current-pass", "new-pass");
+      await useVaultStore
+        .getState()
+        .changeMasterPassword("current-pass", "new-pass");
 
       const state = useVaultStore.getState();
       expect(state.error).toBe("Vault is locked");
@@ -561,14 +1024,67 @@ describe("vaultStore", () => {
 
       useVaultStore.setState({ status: "unlocked", keys: [] });
 
-      await useVaultStore.getState().changeMasterPassword("current-pass", "new-pass");
+      await useVaultStore
+        .getState()
+        .changeMasterPassword("current-pass", "new-pass");
 
       const state = useVaultStore.getState();
       expect(state.error).toBe("Encrypt failed");
       // Session should have been restored to old key as the last setSessionKey call
-      expect(mockSetSession.mock.calls[mockSetSession.mock.calls.length - 1]?.[0]).toBe(oldKey);
+      expect(
+        mockSetSession.mock.calls[mockSetSession.mock.calls.length - 1]?.[0],
+      ).toBe(oldKey);
       // Old data should have been restored
       expect(backend.saveData).toHaveBeenCalledWith(oldData);
+    });
+
+    it("CRITICAL: early return when vault locks during createVaultMeta (after verifyPassword)", async () => {
+      const backend = makeFakeBackend();
+      const oldKey = makeFakeCryptoKey("old");
+      const newKey = makeFakeCryptoKey("new");
+      const newMeta = makeMeta();
+
+      backend.loadMeta.mockReturnValue(makeMeta());
+      backend.loadData.mockReturnValue(makeVaultData());
+      mockGetBackend.mockReturnValue(backend);
+      mockGetSession.mockReturnValue(oldKey);
+      mockVerify.mockResolvedValue(oldKey);
+
+      let resolveCrypto!: (v: {
+        meta: VaultMeta;
+        derivedKey: CryptoKey;
+      }) => void;
+      mockCrypto.mockReturnValue(
+        new Promise<{ meta: VaultMeta; derivedKey: CryptoKey }>((r) => {
+          resolveCrypto = r;
+        }),
+      );
+
+      useVaultStore.setState({ status: "unlocked", keys: [makeFakeKey()] });
+
+      const promise = useVaultStore
+        .getState()
+        .changeMasterPassword("current-pass", "new-pass");
+
+      // Vault locks while createVaultMeta is in flight
+      useVaultStore.setState({ status: "locked", keys: [] });
+      mockGetSession.mockReturnValue(null);
+
+      // Now resolve createVaultMeta
+      resolveCrypto({ meta: newMeta, derivedKey: newKey });
+      await promise;
+
+      // CRITICAL: neither setSessionKey(newKey) nor setSessionKey(oldKey) should be called
+      // after the early return path. getSessionKey() should remain null.
+      expect(mockGetSession()).toBeNull();
+      // saveMeta should NOT be called with newMeta
+      expect(backend.saveMeta).not.toHaveBeenCalledWith(newMeta);
+      // saveData should NOT have been re-called (the new encrypt path never ran)
+      expect(mockEncrypt).not.toHaveBeenCalled();
+      // Error should be set
+      expect(useVaultStore.getState().error).toBe(
+        "Vault locked during password change",
+      );
     });
   });
 
@@ -591,6 +1107,46 @@ describe("vaultStore", () => {
       expect(state.error).toBeNull();
       expect(backend.clear).toHaveBeenCalled();
       expect(mockClearSession).toHaveBeenCalled();
+    });
+
+    it("calls activityTracker.stop() on resetVault", () => {
+      const backend = makeFakeBackend();
+      mockGetBackend.mockReturnValue(backend);
+      useVaultStore.setState({ status: "unlocked", keys: [] });
+
+      useVaultStore.getState().resetVault();
+
+      expect(mockTrackerStop).toHaveBeenCalled();
+    });
+
+    it("resets autoLockTimeoutMinutes and lockOnHidden to defaults", () => {
+      const backend = makeFakeBackend();
+      mockGetBackend.mockReturnValue(backend);
+
+      useVaultStore.setState({
+        status: "unlocked",
+        autoLockTimeoutMinutes: 60,
+        lockOnHidden: true,
+      });
+
+      useVaultStore.getState().resetVault();
+
+      const state = useVaultStore.getState();
+      expect(state.autoLockTimeoutMinutes).toBe(
+        DEFAULT_VAULT_SETTINGS.autoLockTimeoutMinutes,
+      );
+      expect(state.lockOnHidden).toBe(DEFAULT_VAULT_SETTINGS.lockOnHidden);
+    });
+  });
+
+  describe("authStore.logout() path -> lock() -> activityTracker.stop()", () => {
+    it("lock() called from logout stops the activity tracker", () => {
+      useVaultStore.setState({ status: "unlocked", keys: [] });
+
+      // Simulate what authStore.logout() does: calls useVaultStore.getState().lock()
+      useVaultStore.getState().lock();
+
+      expect(mockTrackerStop).toHaveBeenCalled();
     });
   });
 

--- a/ui/apps/console/src/stores/vaultStore.ts
+++ b/ui/apps/console/src/stores/vaultStore.ts
@@ -1,5 +1,11 @@
 import { create } from "zustand";
-import type { VaultStatus, VaultKeyEntry, LegacyPrivateKey } from "@/types/vault";
+import type {
+  VaultStatus,
+  VaultKeyEntry,
+  LegacyPrivateKey,
+  VaultSettings,
+} from "@/types/vault";
+import { DEFAULT_VAULT_SETTINGS, HIDDEN_GRACE_MS } from "@/types/vault";
 import {
   createVaultMeta,
   verifyPassword,
@@ -11,6 +17,7 @@ import {
 } from "@/utils/vault-crypto";
 import { getVaultBackend } from "@/utils/vault-backend-factory";
 import type { IVaultBackend } from "@/utils/vault-backend";
+import * as activityTracker from "@/utils/vault-activity-tracker";
 import { useAuthStore } from "@/stores/authStore";
 import { generateRandomUUID } from "@/utils/random-uuid";
 
@@ -34,20 +41,43 @@ interface VaultState {
   keys: VaultKeyEntry[];
   loading: boolean;
   error: string | null;
+  autoLockTimeoutMinutes: number;
+  lockOnHidden: boolean;
+  autoLockNonce: number;
 
   refreshStatus: () => void;
   initialize: (masterPassword: string) => Promise<void>;
   unlock: (masterPassword: string) => Promise<void>;
   lock: () => void;
-  addKey: (entry: Pick<VaultKeyEntry, "name" | "data" | "hasPassphrase" | "fingerprint" | "algorithm">) => Promise<void>;
-  updateKey: (id: string, updates: Partial<Pick<VaultKeyEntry, "name" | "data" | "hasPassphrase" | "fingerprint" | "algorithm">>) => Promise<void>;
+  addKey: (
+    entry: Pick<
+      VaultKeyEntry,
+      "name" | "data" | "hasPassphrase" | "fingerprint" | "algorithm"
+    >,
+  ) => Promise<void>;
+  updateKey: (
+    id: string,
+    updates: Partial<
+      Pick<
+        VaultKeyEntry,
+        "name" | "data" | "hasPassphrase" | "fingerprint" | "algorithm"
+      >
+    >,
+  ) => Promise<void>;
   removeKey: (id: string) => Promise<void>;
-  changeMasterPassword: (currentPassword: string, newPassword: string) => Promise<void>;
+  changeMasterPassword: (
+    currentPassword: string,
+    newPassword: string,
+  ) => Promise<void>;
   resetVault: () => void;
   clearError: () => void;
+  updateAutoLockSettings: (updates: Partial<VaultSettings>) => void;
 }
 
-async function persistKeys(keys: VaultKeyEntry[], be?: IVaultBackend): Promise<void> {
+async function persistKeys(
+  keys: VaultKeyEntry[],
+  be?: IVaultBackend,
+): Promise<void> {
   const key = getSessionKey();
   if (!key) throw new Error("Vault is locked");
 
@@ -62,8 +92,14 @@ function checkDuplicates(
   excludeId?: string,
 ): void {
   const { name, fingerprint } = entry;
-  const hasDuplicateName = name != null && existing.some((key) => key.id !== excludeId && key.name === name);
-  const hasDuplicateKey = fingerprint != null && existing.some((key) => key.id !== excludeId && key.fingerprint === fingerprint);
+  const hasDuplicateName =
+    name != null &&
+    existing.some((key) => key.id !== excludeId && key.name === name);
+  const hasDuplicateKey =
+    fingerprint != null &&
+    existing.some(
+      (key) => key.id !== excludeId && key.fingerprint === fingerprint,
+    );
   if (hasDuplicateName && hasDuplicateKey) throw new DuplicateKeyError("both");
   if (hasDuplicateName) throw new DuplicateKeyError("name");
   if (hasDuplicateKey) throw new DuplicateKeyError("private_key");
@@ -82,208 +118,302 @@ function migrateLegacyKeys(legacy: LegacyPrivateKey[]): VaultKeyEntry[] {
   }));
 }
 
-export const useVaultStore = create<VaultState>((set, get) => ({
-  status: "uninitialized",
-  keys: [],
-  loading: false,
-  error: null,
-
-  refreshStatus: () => {
-    const backend = getBackend();
-    const meta = backend.loadMeta();
-
-    if (!meta) {
-      set({ status: "uninitialized" });
-      return;
-    }
-
-    set({ status: getSessionKey() ? "unlocked" : "locked" });
-  },
-
-  initialize: async (masterPassword) => {
-    set({ loading: true, error: null });
-    const backend = getBackend();
-    try {
-      const { meta, derivedKey } = await createVaultMeta(masterPassword);
-      backend.saveMeta(meta);
-
-      setSessionKey(derivedKey);
-
-      const legacyKeys = backend.loadLegacyKeys();
-      const keys = legacyKeys.length > 0
-        ? migrateLegacyKeys(legacyKeys)
-        : [];
-
-      await persistKeys(keys);
-
-      if (legacyKeys.length > 0) {
-        backend.clearLegacyKeys();
-      }
-
-      set({ status: "unlocked", keys, loading: false });
-    } catch (err) {
-      // Rollback saved meta so the vault returns to "uninitialized"
-      backend.clear();
-      clearSessionKey();
-      const msg = err instanceof Error ? err.message : "Failed to create vault";
-      set({ loading: false, error: msg });
-    }
-  },
-
-  unlock: async (masterPassword) => {
-    set({ loading: true, error: null });
+export const useVaultStore = create<VaultState>((set, get) => {
+  function loadSettingsIntoState(): void {
     try {
       const backend = getBackend();
+      const settings = backend.loadSettings();
+      set({
+        autoLockTimeoutMinutes: settings.autoLockTimeoutMinutes,
+        lockOnHidden: settings.lockOnHidden,
+      });
+    } catch {
+      // Exception-safe: ignore storage errors
+    }
+  }
+
+  function startTracker(): void {
+    const { autoLockTimeoutMinutes, lockOnHidden } = get();
+
+    activityTracker.start({
+      idleTimeoutMs: autoLockTimeoutMinutes * 60000,
+      lockOnHidden,
+      hiddenGraceMs: HIDDEN_GRACE_MS,
+      onIdle: () => {
+        if (get().status !== "unlocked") return;
+        clearSessionKey();
+        activityTracker.stop();
+        set({
+          status: "locked",
+          keys: [],
+          error: null,
+          autoLockNonce: get().autoLockNonce + 1,
+        });
+      },
+    });
+  }
+
+  return {
+    status: "uninitialized",
+    keys: [],
+    loading: false,
+    error: null,
+    autoLockTimeoutMinutes: DEFAULT_VAULT_SETTINGS.autoLockTimeoutMinutes,
+    lockOnHidden: DEFAULT_VAULT_SETTINGS.lockOnHidden,
+    autoLockNonce: 0,
+
+    refreshStatus: () => {
+      const backend = getBackend();
       const meta = backend.loadMeta();
+
       if (!meta) {
-        set({ loading: false, error: "No vault found" });
+        activityTracker.stop();
+        set({ status: "uninitialized" });
         return;
       }
 
-      let derivedKey: CryptoKey;
-      try {
-        derivedKey = await verifyPassword(masterPassword, meta);
-      } catch {
-        set({ loading: false, error: "Incorrect master password" });
+      loadSettingsIntoState();
+
+      if (!getSessionKey()) {
+        activityTracker.stop();
+        set({ status: "locked" });
         return;
       }
 
-      setSessionKey(derivedKey);
+      set({ status: "unlocked" });
+    },
 
+    initialize: async (masterPassword) => {
+      set({ loading: true, error: null });
+      const backend = getBackend();
       try {
-        const vaultData = backend.loadData();
-        const parsed: unknown = vaultData
-          ? JSON.parse(await decrypt(derivedKey, vaultData))
-          : [];
-        if (!Array.isArray(parsed)) throw new Error("Vault data is corrupted");
-        const isValid = parsed.every(
-          (item: unknown) =>
-            typeof item === "object"
-            && item !== null
-            && typeof (item as Record<string, unknown>).id === "string"
-            && typeof (item as Record<string, unknown>).name === "string"
-            && typeof (item as Record<string, unknown>).data === "string"
-            && typeof (item as Record<string, unknown>).fingerprint === "string"
-            && typeof (item as Record<string, unknown>).hasPassphrase === "boolean"
-            && typeof (item as Record<string, unknown>).createdAt === "string"
-            && typeof (item as Record<string, unknown>).updatedAt === "string",
-        );
-        if (!isValid) throw new Error("Vault data is corrupted");
-        const keys = parsed as VaultKeyEntry[];
+        const { meta, derivedKey } = await createVaultMeta(masterPassword);
+        backend.saveMeta(meta);
+
+        setSessionKey(derivedKey);
+
+        const legacyKeys = backend.loadLegacyKeys();
+        const keys = legacyKeys.length > 0 ? migrateLegacyKeys(legacyKeys) : [];
+
+        await persistKeys(keys);
+
+        if (legacyKeys.length > 0) {
+          backend.clearLegacyKeys();
+        }
 
         set({ status: "unlocked", keys, loading: false });
-      } catch {
-        clearSessionKey();
-        set({ loading: false, error: "Vault data is corrupted" });
-      }
-    } catch (err) {
-      clearSessionKey();
-      const msg = err instanceof Error ? err.message : "Failed to unlock vault";
-      set({ loading: false, error: msg });
-    }
-  },
-
-  lock: () => {
-    clearSessionKey();
-    set({ status: "locked", keys: [], error: null });
-  },
-
-  // addKey, updateKey, and removeKey intentionally throw raw errors to the caller
-  // rather than writing to the store's loading/error fields. Their callers (KeyDrawer,
-  // KeyDeleteDialog) manage their own local error UI. This keeps vault-wide loading/error
-  // state reserved for operations that affect the whole vault (initialize, unlock, changeMasterPassword).
-  addKey: async (entry) => {
-    const existing = get().keys;
-    checkDuplicates(existing, entry);
-
-    const now = new Date().toISOString();
-    const newKey: VaultKeyEntry = {
-      ...entry,
-      id: generateRandomUUID(),
-      createdAt: now,
-      updatedAt: now,
-    };
-    const keys = [...existing, newKey];
-    await persistKeys(keys);
-    set({ keys });
-  },
-
-  updateKey: async (id, updates) => {
-    const existing = get().keys;
-    if (!existing.some((k) => k.id === id)) throw new Error("Key not found");
-    checkDuplicates(existing, updates, id);
-
-    const keys = existing.map((key) =>
-      key.id === id
-        ? { ...key, ...updates, updatedAt: new Date().toISOString() }
-        : key,
-    );
-    await persistKeys(keys);
-    set({ keys });
-  },
-
-  removeKey: async (id) => {
-    const existing = get().keys;
-    if (!existing.some((k) => k.id === id)) throw new Error("Key not found");
-    const keys = existing.filter((key) => key.id !== id);
-    await persistKeys(keys);
-    set({ keys });
-  },
-
-  changeMasterPassword: async (currentPassword, newPassword) => {
-    set({ loading: true, error: null });
-    try {
-      const backend = getBackend();
-      const meta = backend.loadMeta();
-      if (!meta) {
-        set({ loading: false, error: "No vault found" });
-        return;
-      }
-
-      if (get().status !== "unlocked") throw new Error("Vault is locked");
-      const oldKey = getSessionKey();
-      if (!oldKey) throw new Error("Session key missing while vault is unlocked");
-
-      try {
-        await verifyPassword(currentPassword, meta);
-      } catch {
-        set({ loading: false, error: "Current password is incorrect" });
-        return;
-      }
-
-      const { meta: newMeta, derivedKey: newKey } = await createVaultMeta(newPassword);
-
-      // Save current encrypted data and meta for rollback before re-encrypting.
-      const oldData = backend.loadData();
-      const oldMeta = meta;
-
-      setSessionKey(newKey);
-      try {
-        await persistKeys(get().keys, backend);
-        backend.saveMeta(newMeta);
+        loadSettingsIntoState();
+        startTracker();
       } catch (err) {
-        // Restore old session key, encrypted data, and meta
-        setSessionKey(oldKey);
-        if (oldData) backend.saveData(oldData);
-        backend.saveMeta(oldMeta);
-        throw err;
+        // Rollback saved meta so the vault returns to "uninitialized"
+        backend.clear();
+        clearSessionKey();
+        const msg =
+          err instanceof Error ? err.message : "Failed to create vault";
+        set({ loading: false, error: msg });
       }
+    },
 
-      set({ loading: false });
-    } catch (err) {
+    unlock: async (masterPassword) => {
+      set({ loading: true, error: null });
+      try {
+        const backend = getBackend();
+        const meta = backend.loadMeta();
+        if (!meta) {
+          set({ loading: false, error: "No vault found" });
+          return;
+        }
+
+        let derivedKey: CryptoKey;
+        try {
+          derivedKey = await verifyPassword(masterPassword, meta);
+        } catch {
+          set({ loading: false, error: "Incorrect master password" });
+          return;
+        }
+
+        setSessionKey(derivedKey);
+
+        try {
+          const vaultData = backend.loadData();
+          const parsed: unknown = vaultData
+            ? JSON.parse(await decrypt(derivedKey, vaultData))
+            : [];
+          if (!Array.isArray(parsed))
+            throw new Error("Vault data is corrupted");
+          const isValid = parsed.every(
+            (item: unknown) =>
+              typeof item === "object" &&
+              item !== null &&
+              typeof (item as Record<string, unknown>).id === "string" &&
+              typeof (item as Record<string, unknown>).name === "string" &&
+              typeof (item as Record<string, unknown>).data === "string" &&
+              typeof (item as Record<string, unknown>).fingerprint ===
+                "string" &&
+              typeof (item as Record<string, unknown>).hasPassphrase ===
+                "boolean" &&
+              typeof (item as Record<string, unknown>).createdAt === "string" &&
+              typeof (item as Record<string, unknown>).updatedAt === "string",
+          );
+          if (!isValid) throw new Error("Vault data is corrupted");
+          const keys = parsed as VaultKeyEntry[];
+
+          set({ status: "unlocked", keys, loading: false });
+          loadSettingsIntoState();
+          startTracker();
+        } catch {
+          clearSessionKey();
+          set({ loading: false, error: "Vault data is corrupted" });
+        }
+      } catch (err) {
+        clearSessionKey();
+        const msg =
+          err instanceof Error ? err.message : "Failed to unlock vault";
+        set({ loading: false, error: msg });
+      }
+    },
+
+    lock: () => {
+      clearSessionKey();
+      activityTracker.stop();
+      set({ status: "locked", keys: [], error: null });
+    },
+
+    // addKey, updateKey, and removeKey intentionally throw raw errors to the caller
+    // rather than writing to the store's loading/error fields. Their callers (KeyDrawer,
+    // KeyDeleteDialog) manage their own local error UI. This keeps vault-wide loading/error
+    // state reserved for operations that affect the whole vault (initialize, unlock, changeMasterPassword).
+    addKey: async (entry) => {
+      const existing = get().keys;
+      checkDuplicates(existing, entry);
+
+      const now = new Date().toISOString();
+      const newKey: VaultKeyEntry = {
+        ...entry,
+        id: generateRandomUUID(),
+        createdAt: now,
+        updatedAt: now,
+      };
+      const keys = [...existing, newKey];
+      await persistKeys(keys);
+      if (get().status !== "unlocked") return;
+      set({ keys });
+    },
+
+    updateKey: async (id, updates) => {
+      const existing = get().keys;
+      if (!existing.some((k) => k.id === id)) throw new Error("Key not found");
+      checkDuplicates(existing, updates, id);
+
+      const keys = existing.map((key) =>
+        key.id === id
+          ? { ...key, ...updates, updatedAt: new Date().toISOString() }
+          : key,
+      );
+      await persistKeys(keys);
+      if (get().status !== "unlocked") return;
+      set({ keys });
+    },
+
+    removeKey: async (id) => {
+      const existing = get().keys;
+      if (!existing.some((k) => k.id === id)) throw new Error("Key not found");
+      const keys = existing.filter((key) => key.id !== id);
+      await persistKeys(keys);
+      if (get().status !== "unlocked") return;
+      set({ keys });
+    },
+
+    changeMasterPassword: async (currentPassword, newPassword) => {
+      set({ loading: true, error: null });
+      try {
+        const backend = getBackend();
+        const meta = backend.loadMeta();
+        if (!meta) {
+          set({ loading: false, error: "No vault found" });
+          return;
+        }
+
+        if (get().status !== "unlocked") throw new Error("Vault is locked");
+        const oldKey = getSessionKey();
+        if (!oldKey)
+          throw new Error("Session key missing while vault is unlocked");
+
+        try {
+          await verifyPassword(currentPassword, meta);
+        } catch {
+          set({ loading: false, error: "Current password is incorrect" });
+          return;
+        }
+
+        const { meta: newMeta, derivedKey: newKey } =
+          await createVaultMeta(newPassword);
+
+        // CRITICAL: early return if vault locked while createVaultMeta was in flight
+        if (get().status !== "unlocked") {
+          set({ loading: false, error: "Vault locked during password change" });
+          return;
+        }
+
+        // Save current encrypted data and meta for rollback before re-encrypting.
+        const oldData = backend.loadData();
+        const oldMeta = meta;
+
+        setSessionKey(newKey);
+        try {
+          await persistKeys(get().keys, backend);
+          backend.saveMeta(newMeta);
+        } catch (err) {
+          // Restore old session key, encrypted data, and meta
+          setSessionKey(oldKey);
+          if (oldData) backend.saveData(oldData);
+          backend.saveMeta(oldMeta);
+          throw err;
+        }
+
+        set({ loading: false });
+      } catch (err) {
+        set({
+          loading: false,
+          error:
+            err instanceof Error
+              ? err.message
+              : "Failed to change master password",
+        });
+      }
+    },
+
+    resetVault: () => {
+      const backend = getBackend();
+      backend.clear();
+      clearSessionKey();
+      activityTracker.stop();
       set({
-        loading: false,
-        error: err instanceof Error ? err.message : "Failed to change master password",
+        status: "uninitialized",
+        keys: [],
+        error: null,
+        autoLockTimeoutMinutes: DEFAULT_VAULT_SETTINGS.autoLockTimeoutMinutes,
+        lockOnHidden: DEFAULT_VAULT_SETTINGS.lockOnHidden,
       });
-    }
-  },
+    },
 
-  resetVault: () => {
-    const backend = getBackend();
-    backend.clear();
-    clearSessionKey();
-    set({ status: "uninitialized", keys: [], error: null });
-  },
+    clearError: () => set({ error: null }),
 
-  clearError: () => set({ error: null }),
-}));
+    updateAutoLockSettings: (updates) => {
+      const current = get();
+      const newSettings: VaultSettings = {
+        autoLockTimeoutMinutes:
+          updates.autoLockTimeoutMinutes ?? current.autoLockTimeoutMinutes,
+        lockOnHidden: updates.lockOnHidden ?? current.lockOnHidden,
+      };
+
+      const backend = getBackend();
+      backend.saveSettings(newSettings);
+      set(newSettings);
+
+      if (get().status === "unlocked") {
+        startTracker();
+      }
+    },
+  };
+});

--- a/ui/apps/console/src/types/vault.ts
+++ b/ui/apps/console/src/types/vault.ts
@@ -1,5 +1,20 @@
 export type VaultStatus = "uninitialized" | "locked" | "unlocked";
 
+export const ALLOWED_TIMEOUT_MINUTES = [0, 5, 15, 30, 60] as const;
+export type AllowedTimeoutMinutes = (typeof ALLOWED_TIMEOUT_MINUTES)[number];
+
+export interface VaultSettings {
+  autoLockTimeoutMinutes: number;
+  lockOnHidden: boolean;
+}
+
+export const DEFAULT_VAULT_SETTINGS: VaultSettings = {
+  autoLockTimeoutMinutes: 15,
+  lockOnHidden: false,
+};
+
+export const HIDDEN_GRACE_MS = 60000;
+
 export interface VaultMeta {
   version: 1;
   salt: string;

--- a/ui/apps/console/src/utils/__tests__/vault-activity-tracker.test.ts
+++ b/ui/apps/console/src/utils/__tests__/vault-activity-tracker.test.ts
@@ -1,0 +1,429 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { start, stop, reset } from "../vault-activity-tracker";
+
+// ---------------------------------------------------------------------------
+// Fake-timer helpers
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+});
+
+afterEach(() => {
+  stop();
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for visibilityState override
+// ---------------------------------------------------------------------------
+
+let originalVisibilityDescriptor: PropertyDescriptor | undefined;
+
+function setVisibility(state: "visible" | "hidden") {
+  if (!originalVisibilityDescriptor) {
+    originalVisibilityDescriptor =
+      Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState") ??
+      Object.getOwnPropertyDescriptor(document, "visibilityState");
+  }
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+function restoreVisibility() {
+  if (originalVisibilityDescriptor) {
+    Object.defineProperty(
+      document,
+      "visibilityState",
+      originalVisibilityDescriptor,
+    );
+    originalVisibilityDescriptor = undefined;
+  } else {
+    // Delete the override so the prototype chain is visible again
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (document as any).visibilityState;
+    } catch {
+      // ignore
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const IDLE_MS = 5_000;
+const GRACE_MS = 2_000;
+
+// ---------------------------------------------------------------------------
+// 1. onIdle fires after idleTimeoutMs with no activity
+// ---------------------------------------------------------------------------
+
+describe("idle timer", () => {
+  it("fires onIdle after idleTimeoutMs elapses with no activity", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: IDLE_MS,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle,
+    });
+
+    vi.advanceTimersByTime(IDLE_MS - 1);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. activity event re-arms idle timer (no premature fire)
+  // ---------------------------------------------------------------------------
+
+  it("re-arms idle timer on activity so it does not fire early", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: IDLE_MS,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle,
+    });
+
+    // Advance close to the deadline, then fire activity to re-arm
+    vi.advanceTimersByTime(IDLE_MS - 100);
+    window.dispatchEvent(new Event("mousemove"));
+
+    // Advance by another IDLE_MS - 1 (total way past original deadline)
+    vi.advanceTimersByTime(IDLE_MS - 1);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    // Now finish the re-armed timer
+    vi.advanceTimersByTime(1);
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. idleTimeoutMs:0 never fires
+  // ---------------------------------------------------------------------------
+
+  it("never fires when idleTimeoutMs is 0", () => {
+    const onIdle = vi.fn();
+    start({ idleTimeoutMs: 0, lockOnHidden: false, hiddenGraceMs: 0, onIdle });
+
+    vi.advanceTimersByTime(1_000_000);
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. First activity immediately after start() re-arms exactly once
+// ---------------------------------------------------------------------------
+
+describe("first-activity throttle", () => {
+  it("first activity immediately after start() triggers exactly one re-arm", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: IDLE_MS,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle,
+    });
+
+    // Fire activity at t=0 (well within throttle window relative to stamp=0)
+    window.dispatchEvent(new Event("mousemove"));
+
+    // Advance past idle — it was re-armed by the above event
+    vi.advanceTimersByTime(IDLE_MS - 1);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Throttle: at most one reset per 1000ms
+// ---------------------------------------------------------------------------
+
+describe("throttle", () => {
+  it("second event within throttle window does NOT re-arm; idle fires at t=0-based deadline", () => {
+    const onIdle = vi.fn();
+    // idleTimeoutMs=60_000 so the deadline is clearly separated from the throttle window
+    start({
+      idleTimeoutMs: 60_000,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle,
+    });
+
+    // t=0: first event — passes throttle (stamp was 0), re-arms idle timer to fire at t=60_000
+    vi.setSystemTime(0);
+    window.dispatchEvent(new Event("mousemove"));
+
+    // t=500ms: second event — within 1000ms throttle window, should NOT re-arm the timer.
+    // If it DID re-arm, the new deadline would be t=500+60_000=60_500ms, meaning onIdle
+    // would NOT fire at exactly t=60_000ms below — which is what would happen if the
+    // throttle guard were removed.
+    vi.advanceTimersByTime(500);
+    window.dispatchEvent(new Event("mousedown"));
+
+    // Advance to 1ms before the t=0-based deadline: timer must not have fired yet.
+    vi.advanceTimersByTime(60_000 - 500 - 1); // total elapsed: 59_999ms
+    expect(onIdle).not.toHaveBeenCalled();
+
+    // Advance the final 1ms to exactly t=60_000ms.
+    // The idle MUST fire here because the timer was last armed at t=0 (the second event
+    // at t=500 was throttled and did not re-arm it).
+    // If the throttle guard is broken the timer would have been re-armed at t=500ms and
+    // would still have 500ms remaining — so onIdle would NOT fire, making this assertion fail.
+    vi.advanceTimersByTime(1); // total elapsed: 60_000ms
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+
+  it("event outside throttle window DOES re-arm; idle fires from that event's deadline", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: 60_000,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle,
+    });
+
+    // t=0: first event — re-arms idle timer to fire at t=60_000
+    vi.setSystemTime(0);
+    window.dispatchEvent(new Event("mousemove"));
+
+    // t=1_500ms: third event — >1s after last re-arm at t=0, passes throttle, re-arms to t=61_500
+    vi.advanceTimersByTime(1_500);
+    window.dispatchEvent(new Event("keydown"));
+
+    // At t=60_000ms the original deadline passes; onIdle must NOT fire because the timer
+    // was re-armed at t=1_500ms.
+    vi.advanceTimersByTime(60_000 - 1_500 - 1); // total elapsed: 59_999ms
+    expect(onIdle).not.toHaveBeenCalled();
+
+    // Still not fired at just before t=61_500ms
+    vi.advanceTimersByTime(1_500 - 1); // total elapsed: 61_498ms (= 60_000 + 1_498)
+    expect(onIdle).not.toHaveBeenCalled();
+
+    // Now fires at exactly t=61_500ms
+    vi.advanceTimersByTime(2); // total elapsed: 61_500ms
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. stop() cancels timers, removes listeners, and is idempotent
+// ---------------------------------------------------------------------------
+
+describe("stop()", () => {
+  it("cancels the idle timer so onIdle never fires after stop()", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: IDLE_MS,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle,
+    });
+
+    vi.advanceTimersByTime(IDLE_MS / 2);
+    stop();
+    vi.advanceTimersByTime(IDLE_MS);
+
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it("removes activity listeners so events no longer re-arm after stop()", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: IDLE_MS,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle,
+    });
+    stop();
+
+    // Events dispatched after stop must not cause any effect
+    window.dispatchEvent(new Event("mousemove"));
+    window.dispatchEvent(new Event("keydown"));
+    vi.advanceTimersByTime(IDLE_MS * 2);
+
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — calling stop() multiple times does not throw", () => {
+    expect(() => {
+      stop();
+      stop();
+      stop();
+    }).not.toThrow();
+  });
+
+  it("is safe to call stop() before start()", () => {
+    expect(() => stop()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. lockOnHidden: hidden fires after grace period; visible cancels it
+// ---------------------------------------------------------------------------
+
+describe("lockOnHidden", () => {
+  afterEach(() => {
+    restoreVisibility();
+  });
+
+  it("fires onIdle after hiddenGraceMs when document becomes hidden", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: 0,
+      lockOnHidden: true,
+      hiddenGraceMs: GRACE_MS,
+      onIdle,
+    });
+
+    setVisibility("hidden");
+
+    vi.advanceTimersByTime(GRACE_MS - 1);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+
+  it("cancels the grace timer when document becomes visible before grace elapses", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: 0,
+      lockOnHidden: true,
+      hiddenGraceMs: GRACE_MS,
+      onIdle,
+    });
+
+    setVisibility("hidden");
+    vi.advanceTimersByTime(GRACE_MS / 2);
+
+    setVisibility("visible");
+    vi.advanceTimersByTime(GRACE_MS); // advance well past original grace deadline
+
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it("does not attach visibilitychange listener when lockOnHidden is false", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: 0,
+      lockOnHidden: false,
+      hiddenGraceMs: GRACE_MS,
+      onIdle,
+    });
+
+    setVisibility("hidden");
+    vi.advanceTimersByTime(GRACE_MS * 2);
+
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. start() restarts cleanly (calls stop() first)
+// ---------------------------------------------------------------------------
+
+describe("start() restart", () => {
+  it("calling start() a second time cancels the first session and starts fresh", () => {
+    const onIdle1 = vi.fn();
+    const onIdle2 = vi.fn();
+
+    start({
+      idleTimeoutMs: IDLE_MS,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle: onIdle1,
+    });
+
+    // Advance partway through first session
+    vi.advanceTimersByTime(IDLE_MS / 2);
+
+    // Restart with a different callback
+    start({
+      idleTimeoutMs: IDLE_MS,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle: onIdle2,
+    });
+
+    // Advance past where the first timer would have fired
+    vi.advanceTimersByTime(IDLE_MS / 2 + 1);
+
+    // First timer must have been cancelled
+    expect(onIdle1).not.toHaveBeenCalled();
+
+    // Advance to complete the second timer
+    vi.advanceTimersByTime(IDLE_MS / 2);
+    expect(onIdle2).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. reset() re-arms idle timer (exported for tests)
+// ---------------------------------------------------------------------------
+
+describe("reset()", () => {
+  it("re-arms the idle timer when called directly", () => {
+    const onIdle = vi.fn();
+    start({
+      idleTimeoutMs: IDLE_MS,
+      lockOnHidden: false,
+      hiddenGraceMs: 0,
+      onIdle,
+    });
+
+    vi.advanceTimersByTime(IDLE_MS - 100);
+    reset();
+
+    vi.advanceTimersByTime(IDLE_MS - 1);
+    expect(onIdle).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onIdle).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. All ACTIVITY_EVENTS trigger re-arm
+// ---------------------------------------------------------------------------
+
+describe("ACTIVITY_EVENTS", () => {
+  const EVENTS = [
+    "mousemove",
+    "mousedown",
+    "keydown",
+    "scroll",
+    "touchstart",
+  ] as const;
+
+  for (const eventName of EVENTS) {
+    it(`'${eventName}' event re-arms the idle timer`, () => {
+      const onIdle = vi.fn();
+      start({
+        idleTimeoutMs: IDLE_MS,
+        lockOnHidden: false,
+        hiddenGraceMs: 0,
+        onIdle,
+      });
+
+      vi.advanceTimersByTime(IDLE_MS - 100);
+      window.dispatchEvent(new Event(eventName));
+
+      vi.advanceTimersByTime(IDLE_MS - 1);
+      expect(onIdle).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(onIdle).toHaveBeenCalledOnce();
+    });
+  }
+});

--- a/ui/apps/console/src/utils/__tests__/vault-backend-factory.test.ts
+++ b/ui/apps/console/src/utils/__tests__/vault-backend-factory.test.ts
@@ -26,10 +26,15 @@ describe("getVaultBackend", () => {
     expect(typeof backend.clear).toBe("function");
     expect(typeof backend.loadLegacyKeys).toBe("function");
     expect(typeof backend.clearLegacyKeys).toBe("function");
+    expect(typeof backend.loadSettings).toBe("function");
+    expect(typeof backend.saveSettings).toBe("function");
   });
 
   it("scopes storage keys when scope is provided", () => {
-    const backend = getVaultBackend({ user: "testuser", tenant: "test-tenant" });
+    const backend = getVaultBackend({
+      user: "testuser",
+      tenant: "test-tenant",
+    });
     const meta = {
       version: 1 as const,
       salt: "c2FsdA==",
@@ -38,7 +43,9 @@ describe("getVaultBackend", () => {
       verifierIv: "aXY=",
     };
     backend.saveMeta(meta);
-    expect(localStorage.getItem("shellhub-vault-meta:testuser:test-tenant")).toBe(JSON.stringify(meta));
+    expect(
+      localStorage.getItem("shellhub-vault-meta:testuser:test-tenant"),
+    ).toBe(JSON.stringify(meta));
     expect(localStorage.getItem("shellhub-vault-meta")).toBeNull();
   });
 
@@ -52,6 +59,8 @@ describe("getVaultBackend", () => {
       verifierIv: "aXY=",
     };
     backend.saveMeta(meta);
-    expect(localStorage.getItem("shellhub-vault-meta")).toBe(JSON.stringify(meta));
+    expect(localStorage.getItem("shellhub-vault-meta")).toBe(
+      JSON.stringify(meta),
+    );
   });
 });

--- a/ui/apps/console/src/utils/__tests__/vault-backend-local.test.ts
+++ b/ui/apps/console/src/utils/__tests__/vault-backend-local.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { LocalVaultBackend } from "../vault-backend-local";
 import type { VaultMeta, VaultData, LegacyPrivateKey } from "@/types/vault";
+import { DEFAULT_VAULT_SETTINGS } from "@/types/vault";
 
 const VAULT_META_KEY = "shellhub-vault-meta";
 const VAULT_DATA_KEY = "shellhub-vault-data";
+const VAULT_SETTINGS_KEY = "shellhub-vault-settings";
 const LEGACY_KEYS_KEY = "privateKeys";
 
 const META: VaultMeta = {
@@ -71,32 +73,50 @@ describe("LocalVaultBackend", () => {
     });
 
     it("returns null when version is not 1", () => {
-      localStorage.setItem(VAULT_META_KEY, JSON.stringify({ ...META, version: 2 }));
+      localStorage.setItem(
+        VAULT_META_KEY,
+        JSON.stringify({ ...META, version: 2 }),
+      );
       expect(backend.loadMeta()).toBeNull();
     });
 
     it("returns null when iterations is below minimum", () => {
-      localStorage.setItem(VAULT_META_KEY, JSON.stringify({ ...META, iterations: 99_999 }));
+      localStorage.setItem(
+        VAULT_META_KEY,
+        JSON.stringify({ ...META, iterations: 99_999 }),
+      );
       expect(backend.loadMeta()).toBeNull();
     });
 
     it("returns null when iterations exceeds maximum", () => {
-      localStorage.setItem(VAULT_META_KEY, JSON.stringify({ ...META, iterations: 10_000_001 }));
+      localStorage.setItem(
+        VAULT_META_KEY,
+        JSON.stringify({ ...META, iterations: 10_000_001 }),
+      );
       expect(backend.loadMeta()).toBeNull();
     });
 
     it("returns null when iterations is not an integer", () => {
-      localStorage.setItem(VAULT_META_KEY, JSON.stringify({ ...META, iterations: 600000.5 }));
+      localStorage.setItem(
+        VAULT_META_KEY,
+        JSON.stringify({ ...META, iterations: 600000.5 }),
+      );
       expect(backend.loadMeta()).toBeNull();
     });
 
     it("returns null when salt is not a string", () => {
-      localStorage.setItem(VAULT_META_KEY, JSON.stringify({ ...META, salt: 42 }));
+      localStorage.setItem(
+        VAULT_META_KEY,
+        JSON.stringify({ ...META, salt: 42 }),
+      );
       expect(backend.loadMeta()).toBeNull();
     });
 
     it("returns null when verifier is not a string", () => {
-      localStorage.setItem(VAULT_META_KEY, JSON.stringify({ ...META, verifier: null }));
+      localStorage.setItem(
+        VAULT_META_KEY,
+        JSON.stringify({ ...META, verifier: null }),
+      );
       expect(backend.loadMeta()).toBeNull();
     });
   });
@@ -183,7 +203,10 @@ describe("LocalVaultBackend", () => {
 
   describe("storage quota exceeded error", () => {
     it("throws a descriptive error when saving meta exceeds quota", () => {
-      const quotaError = new DOMException("QuotaExceededError", "QuotaExceededError");
+      const quotaError = new DOMException(
+        "QuotaExceededError",
+        "QuotaExceededError",
+      );
       vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
         throw quotaError;
       });
@@ -193,7 +216,10 @@ describe("LocalVaultBackend", () => {
     });
 
     it("throws a descriptive error when saving data exceeds quota", () => {
-      const quotaError = new DOMException("QuotaExceededError", "QuotaExceededError");
+      const quotaError = new DOMException(
+        "QuotaExceededError",
+        "QuotaExceededError",
+      );
       vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
         throw quotaError;
       });
@@ -208,6 +234,99 @@ describe("LocalVaultBackend", () => {
         throw unknownError;
       });
       expect(() => backend.saveMeta(META)).toThrow("disk failure");
+    });
+  });
+
+  describe("settings", () => {
+    it("returns DEFAULT_VAULT_SETTINGS when nothing is stored", () => {
+      expect(backend.loadSettings()).toEqual(DEFAULT_VAULT_SETTINGS);
+    });
+
+    it("save->load round-trip returns the same settings", () => {
+      const settings = { autoLockTimeoutMinutes: 30, lockOnHidden: true };
+      backend.saveSettings(settings);
+      expect(backend.loadSettings()).toEqual(settings);
+    });
+
+    it("returns DEFAULT_VAULT_SETTINGS when stored JSON is invalid", () => {
+      localStorage.setItem(VAULT_SETTINGS_KEY, "not-json{{{");
+      expect(backend.loadSettings()).toEqual(DEFAULT_VAULT_SETTINGS);
+    });
+
+    it("autoLockTimeoutMinutes:0 round-trips as 0 (valid member, not coerced)", () => {
+      backend.saveSettings({ autoLockTimeoutMinutes: 0, lockOnHidden: false });
+      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(0);
+    });
+
+    it("autoLockTimeoutMinutes:7 (not in allowed list) falls back to 15", () => {
+      localStorage.setItem(
+        VAULT_SETTINGS_KEY,
+        JSON.stringify({ autoLockTimeoutMinutes: 7, lockOnHidden: false }),
+      );
+      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+    });
+
+    it("autoLockTimeoutMinutes:999999 falls back to 15", () => {
+      localStorage.setItem(
+        VAULT_SETTINGS_KEY,
+        JSON.stringify({ autoLockTimeoutMinutes: 999999, lockOnHidden: false }),
+      );
+      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+    });
+
+    it("autoLockTimeoutMinutes:15.5 (float, not a member) falls back to 15", () => {
+      localStorage.setItem(
+        VAULT_SETTINGS_KEY,
+        JSON.stringify({ autoLockTimeoutMinutes: 15.5, lockOnHidden: false }),
+      );
+      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+    });
+
+    it("autoLockTimeoutMinutes as string '15' falls back to 15 (no coercion)", () => {
+      localStorage.setItem(
+        VAULT_SETTINGS_KEY,
+        JSON.stringify({ autoLockTimeoutMinutes: "15", lockOnHidden: false }),
+      );
+      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+    });
+
+    it("autoLockTimeoutMinutes:null falls back to 15", () => {
+      localStorage.setItem(
+        VAULT_SETTINGS_KEY,
+        JSON.stringify({ autoLockTimeoutMinutes: null, lockOnHidden: false }),
+      );
+      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+    });
+
+    it("missing autoLockTimeoutMinutes falls back to 15", () => {
+      localStorage.setItem(
+        VAULT_SETTINGS_KEY,
+        JSON.stringify({ lockOnHidden: false }),
+      );
+      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+    });
+
+    it("non-boolean lockOnHidden falls back to false", () => {
+      localStorage.setItem(
+        VAULT_SETTINGS_KEY,
+        JSON.stringify({ autoLockTimeoutMinutes: 15, lockOnHidden: "yes" }),
+      );
+      expect(backend.loadSettings().lockOnHidden).toBe(false);
+    });
+
+    it("clear() removes the settings key", () => {
+      backend.saveSettings({ autoLockTimeoutMinutes: 30, lockOnHidden: true });
+      backend.clear();
+      expect(localStorage.getItem(VAULT_SETTINGS_KEY)).toBeNull();
+    });
+
+    it("scoped backend uses prefixed settings key", () => {
+      const scoped = new LocalVaultBackend({ user: "alice", tenant: "t1" });
+      scoped.saveSettings({ autoLockTimeoutMinutes: 60, lockOnHidden: true });
+      expect(localStorage.getItem(`${VAULT_SETTINGS_KEY}:alice:t1`)).toBe(
+        JSON.stringify({ autoLockTimeoutMinutes: 60, lockOnHidden: true }),
+      );
+      expect(localStorage.getItem(VAULT_SETTINGS_KEY)).toBeNull();
     });
   });
 });

--- a/ui/apps/console/src/utils/vault-activity-tracker.ts
+++ b/ui/apps/console/src/utils/vault-activity-tracker.ts
@@ -1,0 +1,150 @@
+/**
+ * Framework-agnostic activity tracker module.
+ *
+ * Tracks user activity events to drive idle-lock and hidden-lock behaviour
+ * for the vault. No React imports — safe to use outside the component tree.
+ */
+
+export const ACTIVITY_EVENTS = [
+  "mousemove",
+  "mousedown",
+  "keydown",
+  "scroll",
+  "touchstart",
+] as const;
+
+export const THROTTLE_MS = 1_000;
+
+export interface TrackerOptions {
+  /** Milliseconds of inactivity before onIdle fires. 0 = disabled. */
+  idleTimeoutMs: number;
+  /** When true, start a hidden-grace timer whenever the document becomes hidden. */
+  lockOnHidden: boolean;
+  /** Milliseconds to wait after the document becomes hidden before calling onIdle. */
+  hiddenGraceMs: number;
+  /** Called when the idle or hidden-grace timer expires. */
+  onIdle: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton state
+// ---------------------------------------------------------------------------
+
+/** Timestamp (Date.now()) of the last throttled activity reset. 0 = never. */
+let lastResetStamp = 0;
+
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+let hiddenTimer: ReturnType<typeof setTimeout> | null = null;
+
+let currentOptions: TrackerOptions | null = null;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function fireIdle(): void {
+  currentOptions?.onIdle();
+}
+
+function clearIdleTimer(): void {
+  if (idleTimer !== null) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+}
+
+function clearHiddenTimer(): void {
+  if (hiddenTimer !== null) {
+    clearTimeout(hiddenTimer);
+    hiddenTimer = null;
+  }
+}
+
+function armIdleTimer(): void {
+  if (!currentOptions || currentOptions.idleTimeoutMs === 0) return;
+  clearIdleTimer();
+  idleTimer = setTimeout(fireIdle, currentOptions.idleTimeoutMs);
+}
+
+/**
+ * Throttled activity handler.
+ *
+ * The initial stamp is 0, which means `Date.now() - 0 >= THROTTLE_MS` is true
+ * immediately after start(), so the very first event always passes through and
+ * re-arms the idle timer exactly once.
+ */
+function onActivity(): void {
+  const now = Date.now();
+  if (now - lastResetStamp < THROTTLE_MS) return;
+  lastResetStamp = now;
+  reset();
+}
+
+function onDocumentHidden(): void {
+  if (!currentOptions) return;
+  hiddenTimer = setTimeout(fireIdle, currentOptions.hiddenGraceMs);
+}
+
+function onDocumentVisible(): void {
+  clearHiddenTimer();
+}
+
+function onVisibilityChange(): void {
+  if (document.visibilityState === "hidden") {
+    onDocumentHidden();
+  } else {
+    onDocumentVisible();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-arm the idle timer. Exported so tests can drive it directly.
+ * No-op when idleTimeoutMs is 0 or the tracker has not been started.
+ */
+export function reset(): void {
+  armIdleTimer();
+}
+
+/**
+ * Stop the tracker: clear all timers, remove all listeners, and reset state.
+ * Idempotent — safe to call when never started or already stopped.
+ */
+export function stop(): void {
+  clearIdleTimer();
+  clearHiddenTimer();
+
+  for (const event of ACTIVITY_EVENTS) {
+    window.removeEventListener(event, onActivity);
+  }
+
+  document.removeEventListener("visibilitychange", onVisibilityChange);
+
+  currentOptions = null;
+  lastResetStamp = 0;
+}
+
+/**
+ * Start the activity tracker with the given options.
+ * Calls stop() first so repeated calls restart cleanly.
+ */
+export function start(opts: TrackerOptions): void {
+  stop();
+
+  currentOptions = opts;
+  // stop() already reset lastResetStamp to 0, guaranteeing the first activity
+  // event after start() always passes the throttle check.
+
+  for (const event of ACTIVITY_EVENTS) {
+    window.addEventListener(event, onActivity);
+  }
+
+  if (opts.lockOnHidden) {
+    document.addEventListener("visibilitychange", onVisibilityChange);
+  }
+
+  armIdleTimer();
+}

--- a/ui/apps/console/src/utils/vault-backend-local.ts
+++ b/ui/apps/console/src/utils/vault-backend-local.ts
@@ -2,11 +2,14 @@ import type {
   VaultMeta,
   VaultData,
   LegacyPrivateKey,
+  VaultSettings,
 } from "@/types/vault";
+import { ALLOWED_TIMEOUT_MINUTES, DEFAULT_VAULT_SETTINGS } from "@/types/vault";
 import type { IVaultBackend } from "@/utils/vault-backend";
 
 const VAULT_META_KEY = "shellhub-vault-meta";
 const VAULT_DATA_KEY = "shellhub-vault-data";
+const VAULT_SETTINGS_KEY = "shellhub-vault-settings";
 const LEGACY_KEYS_KEY = "privateKeys";
 
 function prefixKey(base: string, prefix?: string): string {
@@ -18,7 +21,10 @@ function safeSetItem(key: string, value: string): void {
     localStorage.setItem(key, value);
   } catch (err) {
     if (err instanceof DOMException && err.name === "QuotaExceededError") {
-      throw new Error("Storage quota exceeded. Free up space or reset the vault.", { cause: err });
+      throw new Error(
+        "Storage quota exceeded. Free up space or reset the vault.",
+        { cause: err },
+      );
     }
     throw err;
   }
@@ -46,15 +52,15 @@ export class LocalVaultBackend implements IVaultBackend {
       null,
     );
     if (
-      !raw
-      || raw.version !== 1
-      || typeof raw.salt !== "string"
-      || typeof raw.iterations !== "number"
-      || !Number.isInteger(raw.iterations)
-      || raw.iterations < 100_000
-      || raw.iterations > 10_000_000
-      || typeof raw.verifier !== "string"
-      || typeof raw.verifierIv !== "string"
+      !raw ||
+      raw.version !== 1 ||
+      typeof raw.salt !== "string" ||
+      typeof raw.iterations !== "number" ||
+      !Number.isInteger(raw.iterations) ||
+      raw.iterations < 100_000 ||
+      raw.iterations > 10_000_000 ||
+      typeof raw.verifier !== "string" ||
+      typeof raw.verifierIv !== "string"
     )
       return null;
     return raw as unknown as VaultMeta;
@@ -69,7 +75,12 @@ export class LocalVaultBackend implements IVaultBackend {
       localStorage.getItem(prefixKey(VAULT_DATA_KEY, this.prefix)),
       null,
     );
-    if (!raw || typeof raw.iv !== "string" || typeof raw.ciphertext !== "string") return null;
+    if (
+      !raw ||
+      typeof raw.iv !== "string" ||
+      typeof raw.ciphertext !== "string"
+    )
+      return null;
     return raw as unknown as VaultData;
   }
 
@@ -80,6 +91,36 @@ export class LocalVaultBackend implements IVaultBackend {
   clear(): void {
     localStorage.removeItem(prefixKey(VAULT_META_KEY, this.prefix));
     localStorage.removeItem(prefixKey(VAULT_DATA_KEY, this.prefix));
+    localStorage.removeItem(prefixKey(VAULT_SETTINGS_KEY, this.prefix));
+  }
+
+  loadSettings(): VaultSettings {
+    const raw = safeParse<Record<string, unknown> | null>(
+      localStorage.getItem(prefixKey(VAULT_SETTINGS_KEY, this.prefix)),
+      null,
+    );
+    if (!raw) return { ...DEFAULT_VAULT_SETTINGS };
+
+    const rawTimeout = raw.autoLockTimeoutMinutes;
+    const autoLockTimeoutMinutes =
+      typeof rawTimeout === "number" &&
+      (ALLOWED_TIMEOUT_MINUTES as readonly number[]).includes(rawTimeout)
+        ? rawTimeout
+        : DEFAULT_VAULT_SETTINGS.autoLockTimeoutMinutes;
+
+    const lockOnHidden =
+      typeof raw.lockOnHidden === "boolean"
+        ? raw.lockOnHidden
+        : DEFAULT_VAULT_SETTINGS.lockOnHidden;
+
+    return { autoLockTimeoutMinutes, lockOnHidden };
+  }
+
+  saveSettings(settings: VaultSettings): void {
+    safeSetItem(
+      prefixKey(VAULT_SETTINGS_KEY, this.prefix),
+      JSON.stringify(settings),
+    );
   }
 
   loadLegacyKeys(): LegacyPrivateKey[] {
@@ -87,12 +128,12 @@ export class LocalVaultBackend implements IVaultBackend {
     if (!Array.isArray(raw)) return [];
     return raw.filter(
       (item): item is LegacyPrivateKey =>
-        typeof item === "object"
-        && item !== null
-        && typeof (item as Record<string, unknown>).name === "string"
-        && typeof (item as Record<string, unknown>).data === "string"
-        && typeof (item as Record<string, unknown>).hasPassphrase === "boolean"
-        && typeof (item as Record<string, unknown>).fingerprint === "string",
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as Record<string, unknown>).name === "string" &&
+        typeof (item as Record<string, unknown>).data === "string" &&
+        typeof (item as Record<string, unknown>).hasPassphrase === "boolean" &&
+        typeof (item as Record<string, unknown>).fingerprint === "string",
     );
   }
 

--- a/ui/apps/console/src/utils/vault-backend.ts
+++ b/ui/apps/console/src/utils/vault-backend.ts
@@ -2,6 +2,7 @@ import type {
   VaultMeta,
   VaultData,
   LegacyPrivateKey,
+  VaultSettings,
 } from "@/types/vault";
 
 export interface IVaultBackend {
@@ -12,4 +13,6 @@ export interface IVaultBackend {
   clear(): void;
   loadLegacyKeys(): LegacyPrivateKey[];
   clearLegacyKeys(): void;
+  loadSettings(): VaultSettings;
+  saveSettings(settings: VaultSettings): void;
 }


### PR DESCRIPTION
## What
Adds idle-timeout auto-lock to the Secure Vault: the vault locks itself after a configurable period of user inactivity, and optionally when the tab is hidden, clearing decrypted private keys and the derived session key from memory.

## Why
The Secure Vault (`shellhub-io/team#84`) only locked on manual action, logout, and 401 expiry, so an unattended browser kept decrypted keys in memory indefinitely — the attack surface every password manager closes with an idle lock. This was explicitly deferred from the vault MVP. Closes shellhub-io/team#85.

## Changes
- **Activity tracker (`utils/vault-activity-tracker.ts`)**: new framework-agnostic module watching `mousemove`/`mousedown`/`keydown`/`scroll`/`touchstart` (throttled to one reset per second) plus a `visibilitychange` grace timer, firing an `onIdle` callback. No React imports, so it is unit-testable in isolation.
- **Settings persistence (`types/vault.ts`, `vault-backend.ts`, `vault-backend-local.ts`)**: a separate `shellhub-vault-settings` localStorage key (scoped per user/tenant) holds `autoLockTimeoutMinutes` and `lockOnHidden`, deliberately kept out of the cryptographic `VaultMeta`. `loadSettings` never throws and normalizes against a strict allowlist (`[0, 5, 15, 30, 60]`); out-of-set or hand-edited values fall back to the 15-minute default, and `0` means Never.
- **Store integration (`stores/vaultStore.ts`)**: `unlock`/`initialize` arm the tracker, `lock`/`resetVault`/`refreshStatus` stop it, and an idempotent `onIdle` locks via a monotonic `autoLockNonce`. Concurrency guards in `addKey`/`updateKey`/`removeKey`, and a pre-`setSessionKey` early return in `changeMasterPassword`, stop an in-flight key operation from re-arming a session key onto an already auto-locked vault.
- **Settings UI (`components/vault/VaultSettingsSection.tsx`)**: an auto-lock timeout dropdown and a lock-when-hidden toggle, gated on the unlocked state.
- **Feedback (`components/vault/VaultAutoLockBanner.tsx`, `components/layout/AppLayout.tsx`, `pages/secure-vault/index.tsx`)**: a global toast announces the inactivity lock from any page, and the Secure Vault page auto-opens the unlock dialog. Both react to `autoLockNonce` changes via a mount-initialized ref, so a past lock never replays across navigation.

## Testing
`cd apps/console && npm run test` — 2128 passing, lint clean. Worth probing specifically: the `changeMasterPassword` race (fire `onIdle` during each of the two PBKDF2 awaits, confirm `getSessionKey()` stays `null` and `saveMeta` is not called), and hook-order stability of the auto-open dialog across the unlocked→locked transition on the Secure Vault page.
