### PR TITLE
fix(agent): keep SSH sessions alive in unprivileged LXC containers

### DIFF
--- a/agent/server/modes/host/command/command_docker.go
+++ b/agent/server/modes/host/command/command_docker.go
@@ -29,6 +29,12 @@ func nsenterArgs(present map[string]string) []string {
 	return args
 }
 
+// CheckCredentialSwitch is a no-op in Docker mode: the agent relies on
+// nsenter+setpriv for credential switching, so this check is not applicable.
+func CheckCredentialSwitch() error {
+	return nil
+}
+
 func NewCmd(u *osauth.User, shell, term, host string, envs []string, command ...string) *exec.Cmd {
 	groups, err := osauth.ListGroups(u.Username)
 	if err != nil {

--- a/agent/server/modes/host/command/command_docker.go
+++ b/agent/server/modes/host/command/command_docker.go
@@ -13,6 +13,22 @@ import (
 	"github.com/shellhub-io/shellhub/agent/pkg/osauth"
 )
 
+// statFn is a seam for os.Stat used when probing /proc/1/ns/* entries.
+// It can be replaced in tests to avoid filesystem access.
+var statFn = os.Stat
+
+// nsenterArgs builds the nsenter flag slice from the present namespace map.
+// Docker always shares the host time namespace, so -T is never passed.
+func nsenterArgs(present map[string]string) []string {
+	args := []string{}
+
+	for _, flag := range present {
+		args = append(args, flag)
+	}
+
+	return args
+}
+
 func NewCmd(u *osauth.User, shell, term, host string, envs []string, command ...string) *exec.Cmd {
 	groups, err := osauth.ListGroups(u.Username)
 	if err != nil {
@@ -80,29 +96,35 @@ func getWrappedCommand(nsArgs []string, uid, gid uint32, groups []uint32, home s
 	return append(setPrivCmd, nsenterCmd...)
 }
 
+// nsenterCommandWrapper builds the full nsenter+setpriv command slice.
+// It probes /proc/1/ns/* for each namespace using statFn, then delegates
+// flag assembly to nsenterArgs. The time namespace is never joined because
+// Docker always shares the host time namespace.
 func nsenterCommandWrapper(uid, gid uint32, groups []uint32, home string, command ...string) ([]string, error) {
-	if _, err := os.Stat("/usr/bin/nsenter"); err != nil && !os.IsNotExist(err) {
+	if _, err := statFn("/usr/bin/nsenter"); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 
-	paths := map[string]string{
+	namespaces := map[string]string{
 		"mnt":    "-m",
 		"uts":    "-u",
 		"ipc":    "-i",
 		"net":    "-n",
 		"pid":    "-p",
 		"cgroup": "-C",
-		"time":   "-T",
 	}
 
-	args := []string{}
-	for path, params := range paths {
-		if _, err := os.Stat(fmt.Sprintf("/proc/1/ns/%s", path)); err != nil {
+	present := map[string]string{}
+
+	for ns, flag := range namespaces {
+		if _, err := statFn(fmt.Sprintf("/proc/1/ns/%s", ns)); err != nil {
 			continue
 		}
 
-		args = append(args, params)
+		present[ns] = flag
 	}
+
+	args := nsenterArgs(present)
 
 	return append(getWrappedCommand(args, uid, gid, groups, home), command...), nil
 }

--- a/agent/server/modes/host/command/command_docker.go
+++ b/agent/server/modes/host/command/command_docker.go
@@ -85,7 +85,8 @@ func getWrappedCommand(nsArgs []string, uid, gid uint32, groups []uint32, home s
 		"1",
 	}, nsArgs...)
 
-	nsenterCmd = append(nsenterCmd,
+	nsenterCmd = append(
+		nsenterCmd,
 		[]string{
 			"-S",
 			strconv.Itoa(int(uid)),

--- a/agent/server/modes/host/command/command_docker_compile_test.go
+++ b/agent/server/modes/host/command/command_docker_compile_test.go
@@ -1,0 +1,24 @@
+//go:build docker
+// +build docker
+
+package command
+
+import "testing"
+
+// Compile-time assertion: CheckCredentialSwitch is exported and has the expected
+// signature (func() error) under the docker build tag.  This mirrors the
+// identical assertion in command_native_test.go for the !docker tag so that
+// neither tag set can silently break the build.
+var _ func() error = CheckCredentialSwitch
+
+// TestCheckCredentialSwitchCompiles is a named test that anchors the
+// compile-time assertion above so it shows up in the test run output.
+// The assertion is evaluated at compile time; the test body itself is a
+// simple pass-through that confirms the symbol is reachable at runtime too.
+func TestCheckCredentialSwitchCompiles(t *testing.T) {
+	// Calling the function ensures the linker includes the symbol and that
+	// it actually returns nil in docker mode (documented no-op).
+	if err := CheckCredentialSwitch(); err != nil {
+		t.Errorf("CheckCredentialSwitch() returned unexpected error under -tags docker: %v", err)
+	}
+}

--- a/agent/server/modes/host/command/command_docker_test.go
+++ b/agent/server/modes/host/command/command_docker_test.go
@@ -1,0 +1,176 @@
+//go:build docker
+// +build docker
+
+package command
+
+import (
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNsenterCommandWrapper is an integration-level test for nsenterCommandWrapper.
+// It injects statFn (to control which /proc/1/ns/* files appear present) and verifies:
+//   - -T is never present in the assembled command (time namespace is never joined)
+//   - namespace flags from statFn are included when present
+//   - absent namespace flags are excluded
+//   - the setpriv/nsenter prefix ordering is unchanged
+//   - the user command appears at the end
+//
+//nolint:paralleltest
+func TestNsenterCommandWrapper(t *testing.T) {
+	origStatFn := statFn
+
+	t.Cleanup(func() {
+		statFn = origStatFn
+	})
+
+	// presentNSFiles is the set of /proc/1/ns/* files that statFn will report as present.
+	// We choose a deterministic subset: mnt, net, pid.
+	presentNSFiles := map[string]bool{
+		"/proc/1/ns/mnt": true,
+		"/proc/1/ns/net": true,
+		"/proc/1/ns/pid": true,
+	}
+
+	// statFn stub: /usr/bin/nsenter always exists; only the listed ns files exist.
+	statFn = func(path string) (os.FileInfo, error) {
+		if path == "/usr/bin/nsenter" {
+			return nil, nil
+		}
+
+		if presentNSFiles[path] {
+			return nil, nil
+		}
+
+		return nil, os.ErrNotExist
+	}
+
+	// nsFlags that must always appear (from the present map above).
+	expectedNSFlags := []string{"-m", "-n", "-p"}
+
+	t.Run("present ns flags included and -T never present", func(t *testing.T) {
+		cmd, err := nsenterCommandWrapper(1000, 1000, []uint32{1000}, "/home/user", "/bin/sh")
+		assert.NoError(t, err)
+
+		// -T must never be present.
+		assert.NotContains(t, cmd, "-T")
+
+		// All namespace flags from statFn must be present.
+		for _, flag := range expectedNSFlags {
+			assert.Contains(t, cmd, flag)
+		}
+
+		// Flags for absent namespaces must NOT be present.
+		for _, absent := range []string{"-u", "-i", "-C"} {
+			assert.NotContains(t, cmd, absent)
+		}
+
+		// setpriv/nsenter prefix ordering: /bin/setpriv must come first,
+		// /usr/bin/nsenter must follow.
+		setprivIdx := indexOf(cmd, "/bin/setpriv")
+		nsenterIdx := indexOf(cmd, "/usr/bin/nsenter")
+		assert.NotEqual(t, -1, setprivIdx, "/bin/setpriv must be present")
+		assert.NotEqual(t, -1, nsenterIdx, "/usr/bin/nsenter must be present")
+		assert.Less(t, setprivIdx, nsenterIdx, "/bin/setpriv must precede /usr/bin/nsenter")
+
+		// The user command must appear at the end.
+		assert.Equal(t, "/bin/sh", cmd[len(cmd)-1])
+	})
+
+	t.Run("statFn controls which ns flags appear", func(t *testing.T) {
+		// Override statFn so only net is present.
+		statFn = func(path string) (os.FileInfo, error) {
+			if path == "/usr/bin/nsenter" || path == "/proc/1/ns/net" {
+				return nil, nil
+			}
+
+			return nil, os.ErrNotExist
+		}
+
+		cmd, err := nsenterCommandWrapper(1000, 1000, []uint32{1000}, "/home/user", "/bin/bash")
+		assert.NoError(t, err)
+
+		assert.Contains(t, cmd, "-n")
+		assert.NotContains(t, cmd, "-T")
+
+		for _, absent := range []string{"-m", "-u", "-i", "-p", "-C"} {
+			assert.NotContains(t, cmd, absent)
+		}
+	})
+
+	t.Run("multiple ns flags from statFn — no -T", func(t *testing.T) {
+		// Override statFn so mnt and uts are present.
+		statFn = func(path string) (os.FileInfo, error) {
+			if path == "/usr/bin/nsenter" || path == "/proc/1/ns/mnt" || path == "/proc/1/ns/uts" {
+				return nil, nil
+			}
+
+			return nil, os.ErrNotExist
+		}
+
+		cmd, err := nsenterCommandWrapper(1000, 1000, []uint32{1000}, "/home/user", "/bin/bash")
+		assert.NoError(t, err)
+
+		assert.Contains(t, cmd, "-m")
+		assert.Contains(t, cmd, "-u")
+		assert.NotContains(t, cmd, "-T")
+
+		for _, absent := range []string{"-i", "-n", "-p", "-C"} {
+			assert.NotContains(t, cmd, absent)
+		}
+	})
+}
+
+// indexOf returns the index of target in slice, or -1 if not found.
+func indexOf(slice []string, target string) int {
+	for i, s := range slice {
+		if s == target {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func TestNsenterArgs(t *testing.T) {
+	t.Run("all flags in present are forwarded unchanged", func(t *testing.T) {
+		present := map[string]string{
+			"mnt":    "-m",
+			"uts":    "-u",
+			"ipc":    "-i",
+			"net":    "-n",
+			"pid":    "-p",
+			"cgroup": "-C",
+		}
+		args := nsenterArgs(present)
+
+		got := make([]string, len(args))
+		copy(got, args)
+		sort.Strings(got)
+
+		expected := []string{"-C", "-i", "-m", "-n", "-p", "-u"}
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("-T never appears regardless of input", func(t *testing.T) {
+		present := map[string]string{
+			"mnt": "-m",
+			"net": "-n",
+		}
+		args := nsenterArgs(present)
+
+		assert.NotContains(t, args, "-T")
+		assert.Contains(t, args, "-m")
+		assert.Contains(t, args, "-n")
+	})
+
+	t.Run("empty present returns empty slice", func(t *testing.T) {
+		present := map[string]string{}
+		args := nsenterArgs(present)
+
+		assert.Empty(t, args)
+	})
+}

--- a/agent/server/modes/host/command/command_native.go
+++ b/agent/server/modes/host/command/command_native.go
@@ -4,13 +4,67 @@
 package command
 
 import (
+	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 
 	"github.com/shellhub-io/shellhub/agent/pkg/osauth"
 	log "github.com/sirupsen/logrus"
 )
+
+// geteuidFn is a seam for os.Geteuid used in setgroupsDenied and NewCmd.
+// Tests can replace it to simulate running as root or non-root.
+var geteuidFn = os.Geteuid
+
+// readSetgroupsPolicyFn is a seam for reading /proc/self/setgroups.
+// Tests can replace it to control the kernel policy value without filesystem access.
+var readSetgroupsPolicyFn = func() ([]byte, error) {
+	return os.ReadFile("/proc/self/setgroups")
+}
+
+// setgroupsDenied reports whether the kernel has denied setgroups(2) for this
+// process by checking /proc/self/setgroups.
+//
+// Return values:
+//   - true:  the policy file trims to "deny".
+//   - false: the file does not exist (kernel too old or not in a user-ns); silent.
+//   - false: any other read error; a warning is emitted via the logger.
+func setgroupsDenied() bool {
+	data, err := readSetgroupsPolicyFn()
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.WithError(err).Warn("failed to read /proc/self/setgroups; assuming setgroups is allowed")
+		}
+
+		return false
+	}
+
+	return strings.TrimSpace(string(data)) == "deny"
+}
+
+// CheckCredentialSwitch reports whether the process can switch credentials via
+// setgroups(2).  It is a pre-flight check that must be called before attempting
+// to execute a command as a different user.
+//
+// Short-circuit: when the effective UID is not root (euid != 0), credential
+// switching is a no-op and the check always succeeds (nil).
+//
+// When euid == 0, the kernel may still forbid setgroups inside an unprivileged
+// user namespace (Linux ≥ 3.19).  In that case the function returns a sentinel
+// error whose message contains "setgroups denied in unprivileged user namespace".
+func CheckCredentialSwitch() error {
+	if geteuidFn() != 0 {
+		return nil
+	}
+
+	if setgroupsDenied() {
+		return errors.New("setgroups denied in unprivileged user namespace")
+	}
+
+	return nil
+}
 
 func NewCmd(u *osauth.User, shell, term, host string, envs []string, command ...string) *exec.Cmd {
 	groups, err := osauth.ListGroups(u.Username)
@@ -44,7 +98,7 @@ func NewCmd(u *osauth.User, shell, term, host string, envs []string, command ...
 		cmd.Dir = u.HomeDir
 	}
 
-	if os.Geteuid() == 0 {
+	if geteuidFn() == 0 {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: u.UID, Gid: u.GID, Groups: groups}
 	}

--- a/agent/server/modes/host/command/command_native_test.go
+++ b/agent/server/modes/host/command/command_native_test.go
@@ -1,0 +1,152 @@
+//go:build !docker
+// +build !docker
+
+package command
+
+import (
+	"errors"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Compile-time assertion: CheckCredentialSwitch must be defined under the !docker tag.
+var _ = CheckCredentialSwitch
+
+// TestSetgroupsDenied verifies the setgroupsDenied helper across all documented
+// scenarios.  Tests do NOT call t.Parallel() because they mutate package-level
+// seam variables.
+//
+//nolint:paralleltest
+func TestSetgroupsDenied(t *testing.T) {
+	origGeteuidFn := geteuidFn
+	origReadSetgroupsPolicyFn := readSetgroupsPolicyFn
+
+	t.Cleanup(func() {
+		geteuidFn = origGeteuidFn
+		readSetgroupsPolicyFn = origReadSetgroupsPolicyFn
+	})
+
+	t.Run("'deny' returns true", func(t *testing.T) {
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			return []byte("deny"), nil
+		}
+
+		assert.True(t, setgroupsDenied())
+	})
+
+	t.Run("'deny\\n' returns true", func(t *testing.T) {
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			return []byte("deny\n"), nil
+		}
+
+		assert.True(t, setgroupsDenied())
+	})
+
+	t.Run("' deny \\n' returns true", func(t *testing.T) {
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			return []byte(" deny \n"), nil
+		}
+
+		assert.True(t, setgroupsDenied())
+	})
+
+	t.Run("'allow' returns false", func(t *testing.T) {
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			return []byte("allow"), nil
+		}
+
+		assert.False(t, setgroupsDenied())
+	})
+
+	t.Run("ErrNotExist returns false without warning", func(t *testing.T) {
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			return nil, os.ErrNotExist
+		}
+
+		// No warning expected — just false.
+		assert.False(t, setgroupsDenied())
+	})
+
+	t.Run("other read error returns false with warning", func(t *testing.T) {
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			return nil, errors.New("permission denied")
+		}
+
+		// Should return false (and emit a warning via log, but we do not
+		// capture log output — the return value is what matters here).
+		assert.False(t, setgroupsDenied())
+	})
+}
+
+// TestCheckCredentialSwitch verifies CheckCredentialSwitch across its four
+// documented scenarios.  Tests do NOT call t.Parallel() because they mutate
+// package-level seam variables.
+//
+//nolint:paralleltest
+func TestCheckCredentialSwitch(t *testing.T) {
+	origGeteuidFn := geteuidFn
+	origReadSetgroupsPolicyFn := readSetgroupsPolicyFn
+
+	t.Cleanup(func() {
+		geteuidFn = origGeteuidFn
+		readSetgroupsPolicyFn = origReadSetgroupsPolicyFn
+	})
+
+	t.Run("euid!=0 returns nil without reading setgroups policy", func(t *testing.T) {
+		var calls atomic.Int64
+
+		geteuidFn = func() int { return 1000 }
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			calls.Add(1)
+
+			return []byte("deny"), nil
+		}
+
+		err := CheckCredentialSwitch()
+
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), calls.Load(), "readSetgroupsPolicyFn must never be called when euid!=0")
+	})
+
+	t.Run("euid!=0 with deny policy still returns nil (stub never called)", func(t *testing.T) {
+		var calls atomic.Int64
+
+		geteuidFn = func() int { return 500 }
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			calls.Add(1)
+
+			return []byte("deny"), nil
+		}
+
+		err := CheckCredentialSwitch()
+
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), calls.Load(), "readSetgroupsPolicyFn must never be called when euid!=0")
+	})
+
+	t.Run("euid==0 and setgroups deny returns error containing 'setgroups denied in unprivileged user namespace'", func(t *testing.T) {
+		geteuidFn = func() int { return 0 }
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			return []byte("deny"), nil
+		}
+
+		err := CheckCredentialSwitch()
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "setgroups denied in unprivileged user namespace")
+	})
+
+	t.Run("euid==0 and setgroups allow returns nil", func(t *testing.T) {
+		geteuidFn = func() int { return 0 }
+		readSetgroupsPolicyFn = func() ([]byte, error) {
+			return []byte("allow"), nil
+		}
+
+		err := CheckCredentialSwitch()
+
+		assert.NoError(t, err)
+	})
+}

--- a/agent/server/modes/host/pty.go
+++ b/agent/server/modes/host/pty.go
@@ -16,6 +16,9 @@ func openPty(c *exec.Cmd) (*os.File, *os.File, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	// tty is intentionally closed here: callers obtain the device path via
+	// tty.Name() (a path-based call), not the fd, so os.Chown on that path
+	// remains safe even though the fd is already closed.
 	defer tty.Close()
 
 	if c.Stdout == nil {

--- a/agent/server/modes/host/pty_test.go
+++ b/agent/server/modes/host/pty_test.go
@@ -1,0 +1,52 @@
+package host
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenPty_TtyNameSafeAfterClose verifies the invariant documented in the
+// comment above `defer tty.Close()` in openPty: the tty file descriptor is
+// closed before openPty returns, but callers only ever use tty.Name() — a
+// path-based lookup — not the underlying fd.  Therefore os.Chown (and any
+// other path-based syscall) remains safe even though the fd is already closed.
+//
+// Concretely the test asserts:
+//  1. openPty succeeds and returns a non-nil tty whose Name() is non-empty.
+//  2. The path returned by tty.Name() is still stat-able after openPty returns
+//     (i.e. the path is valid independently of the fd's lifetime).
+//  3. The tty fd itself is closed when openPty returns (read returns an error).
+func TestOpenPty_TtyNameSafeAfterClose(t *testing.T) {
+	// Use a real command that exits quickly so openPty can complete.
+	c := exec.Command("/bin/true")
+
+	ptmx, tty, err := openPty(c)
+	require.NoError(t, err, "openPty must succeed in this environment")
+
+	t.Cleanup(func() {
+		_ = ptmx.Close()
+		_ = c.Wait()
+	})
+
+	// 1. tty must be non-nil and carry a valid path.
+	require.NotNil(t, tty, "openPty must return a non-nil tty")
+
+	name := tty.Name()
+	assert.NotEmpty(t, name, "tty.Name() must return a non-empty path")
+
+	// 2. The path itself must still be valid on the filesystem (stat succeeds).
+	// Note: the tty device node may disappear on some kernels after the process
+	// using the pty exits, but it always exists while the ptmx fd is open.
+	_, statErr := os.Stat(name)
+	assert.NoError(t, statErr, "os.Stat(tty.Name()) must succeed while ptmx is open")
+
+	// 3. The fd returned in the tty *os.File is closed by openPty's defer, so
+	// any fd-based operation must fail.  We use Read as a lightweight probe.
+	buf := make([]byte, 1)
+	_, readErr := tty.Read(buf)
+	assert.Error(t, readErr, "tty fd must be closed after openPty returns")
+}

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -22,6 +22,14 @@ import (
 // NOTICE: Ensures the Sessioner interface is implemented.
 var _ modes.Sessioner = (*Sessioner)(nil)
 
+// startPtyFn and initPtyFn are package-level function variables that point to
+// the real pty helpers by default. Tests may replace them with stubs to avoid
+// spawning real pseudo-terminals.
+var (
+	startPtyFn = startPty
+	initPtyFn  = initPty
+)
+
 // Sessioner implements the Sessioner interface when the server is running in host mode.
 type Sessioner struct {
 	mu   sync.Mutex
@@ -65,9 +73,12 @@ func (s *Sessioner) Shell(session gliderssh.Session) error {
 		return errors.New("failed to generate shell command")
 	}
 
-	pts, err := startPty(scmd, session, winCh)
+	pts, err := startPtyFn(scmd, session, winCh)
 	if err != nil {
 		log.Warn(err)
+		_ = session.Exit(1)
+
+		return fmt.Errorf("failed to start pty: %w", err)
 	}
 
 	u, err := osauth.LookupUser(session.User())
@@ -222,9 +233,12 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 
 	wg := &sync.WaitGroup{}
 	if sIsPty {
-		pty, tty, err := initPty(cmd, session, sWinCh)
+		pty, tty, err := initPtyFn(cmd, session, sWinCh)
 		if err != nil {
 			log.Warn(err)
+			_ = session.Exit(1)
+
+			return fmt.Errorf("failed to init pty: %w", err)
 		}
 
 		defer tty.Close()
@@ -298,7 +312,12 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 		"Raw command": session.RawCommand(),
 	}).Info("Command ended")
 
-	if err := session.Exit(cmd.ProcessState.ExitCode()); err != nil { // nolint:errcheck
+	code := 1
+	if cmd.ProcessState != nil {
+		code = cmd.ProcessState.ExitCode()
+	}
+
+	if err := session.Exit(code); err != nil { //nolint:errcheck
 		log.Warn(err)
 	}
 

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"strings"
 	"sync"
+	"syscall"
 
 	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/agent/pkg/osauth"
@@ -29,6 +31,38 @@ var (
 	startPtyFn = startPty
 	initPtyFn  = initPty
 )
+
+// checkCredentialSwitchFn is a package-level seam for command.CheckCredentialSwitch.
+// Tests may replace it to simulate a denied credential switch without touching the
+// real /proc/self/setgroups.
+var checkCredentialSwitchFn = command.CheckCredentialSwitch
+
+// refuseIfCredentialSwitchDenied calls checkCredentialSwitchFn and, when it
+// returns a non-nil error, logs the refusal, calls session.Exit(1), and returns
+// the error so the caller can immediately propagate it.  A nil return means the
+// session may proceed.
+func refuseIfCredentialSwitchDenied(session gliderssh.Session) error {
+	if err := checkCredentialSwitchFn(); err != nil {
+		log.WithError(err).Error("refusing session: credential switch impossible")
+		_ = session.Exit(1)
+
+		return err
+	}
+
+	return nil
+}
+
+// ptyFailureHint returns a diagnostic hint string when err indicates that PTY
+// allocation failed because the system does not support pseudo-terminals (ENOTTY
+// or "inappropriate ioctl for device"). It returns an empty string for all other
+// errors so callers can append it to log messages without extra branching.
+func ptyFailureHint(err error) string {
+	if errors.Is(err, syscall.ENOTTY) || strings.Contains(err.Error(), "inappropriate ioctl for device") {
+		return "the system may not support PTY allocation — ensure /dev/ptmx is accessible and the agent is not in a restricted environment"
+	}
+
+	return ""
+}
 
 // Sessioner implements the Sessioner interface when the server is running in host mode.
 type Sessioner struct {
@@ -66,6 +100,10 @@ func NewSessioner(deviceName *string, cmds map[string]*exec.Cmd, sftpServerComma
 
 // Shell manages the SSH shell session of the server when operating in host mode.
 func (s *Sessioner) Shell(session gliderssh.Session) error {
+	if err := refuseIfCredentialSwitchDenied(session); err != nil {
+		return err
+	}
+
 	sspty, winCh, isPty := session.Pty()
 
 	scmd := generateShellCmd(*s.deviceName, session, sspty.Term)
@@ -75,7 +113,12 @@ func (s *Sessioner) Shell(session gliderssh.Session) error {
 
 	pts, err := startPtyFn(scmd, session, winCh)
 	if err != nil {
-		log.Warn(err)
+		entry := log.WithError(err)
+		if hint := ptyFailureHint(err); hint != "" {
+			entry = entry.WithField("hint", hint)
+		}
+
+		entry.Error("failed to start pty")
 		_ = session.Exit(1)
 
 		return fmt.Errorf("failed to start pty: %w", err)
@@ -132,6 +175,10 @@ func (s *Sessioner) Shell(session gliderssh.Session) error {
 // heredoc is special block of code that contains multi-line strings that will be redirected to a stdin of a shell. It
 // request a shell, but doesn't allocate a pty.
 func (s *Sessioner) Heredoc(session gliderssh.Session) error {
+	if err := refuseIfCredentialSwitchDenied(session); err != nil {
+		return err
+	}
+
 	_, _, isPty := session.Pty()
 
 	cmd := generateShellCmd(*s.deviceName, session, "")
@@ -148,11 +195,6 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 		return fmt.Errorf("failed to get server connection from session context")
 	}
 
-	go func() {
-		serverConn.Wait()  // nolint:errcheck
-		cmd.Process.Kill() // nolint:errcheck
-	}()
-
 	log.WithFields(log.Fields{
 		"user":        session.User(),
 		"ispty":       isPty,
@@ -161,10 +203,19 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 		"Raw command": session.RawCommand(),
 	}).Info("Command started")
 
-	err := cmd.Start()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		log.Warn(err)
+		_ = session.Exit(1)
+
+		return err
 	}
+
+	// kill the process if the SSH connection is interrupted — must be after a
+	// successful cmd.Start() so cmd.Process is guaranteed non-nil.
+	go func() {
+		serverConn.Wait()  // nolint:errcheck
+		cmd.Process.Kill() // nolint:errcheck
+	}()
 
 	go func() {
 		if _, err := io.Copy(stdin, session); err != nil {
@@ -181,12 +232,11 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 		}
 	}()
 
-	err = cmd.Wait()
-	if err != nil {
+	if err := cmd.Wait(); err != nil {
 		log.Warn(err)
 	}
 
-	session.Exit(cmd.ProcessState.ExitCode()) //nolint:errcheck
+	_ = session.Exit(cmd.ProcessState.ExitCode())
 
 	log.WithFields(log.Fields{
 		"user":        session.User(),
@@ -200,6 +250,10 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 
 // Exec handles the SSH's server exec session when server is running in host mode.
 func (s *Sessioner) Exec(session gliderssh.Session) error {
+	if err := refuseIfCredentialSwitchDenied(session); err != nil {
+		return err
+	}
+
 	if len(session.Command()) == 0 {
 		log.WithFields(log.Fields{
 			"user":      session.User(),
@@ -235,7 +289,12 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 	if sIsPty {
 		pty, tty, err := initPtyFn(cmd, session, sWinCh)
 		if err != nil {
-			log.Warn(err)
+			entry := log.WithError(err)
+			if hint := ptyFailureHint(err); hint != "" {
+				entry = entry.WithField("hint", hint)
+			}
+
+			entry.Error("failed to init pty")
 			_ = session.Exit(1)
 
 			return fmt.Errorf("failed to init pty: %w", err)

--- a/agent/server/modes/host/sessioner_native_test.go
+++ b/agent/server/modes/host/sessioner_native_test.go
@@ -47,6 +47,159 @@ func (f *fakeGosshConn) Wait() error {
 	select {}
 }
 
+// TestShell_DeniedCredentialSwitch verifies that Shell() returns a non-nil error,
+// calls session.Exit(1) exactly once, and leaves s.cmds empty when
+// checkCredentialSwitchFn returns an error.  The gate must fire before any call
+// to session.Pty(), generateShellCmd, or startPtyFn, so the test does NOT need a
+// real ServerConn in the session context.
+func TestShell_DeniedCredentialSwitch(t *testing.T) {
+	origCheckCredentialSwitch := checkCredentialSwitchFn
+
+	t.Cleanup(func() {
+		checkCredentialSwitchFn = origCheckCredentialSwitch
+	})
+
+	// Stub: simulate a denied credential switch.
+	checkCredentialSwitchFn = func() error {
+		return errors.New("setgroups denied in unprivileged user namespace")
+	}
+
+	deviceName := "test-device"
+	cmds := make(map[string]*exec.Cmd)
+	s := NewSessioner(&deviceName, cmds, nil)
+
+	sess := newFakeSession("session-cred-switch", "root")
+
+	var retErr error
+
+	assert.NotPanics(t, func() {
+		retErr = s.Shell(sess)
+	}, "Shell() must not panic when credential switch is denied")
+
+	assert.NotNil(t, retErr, "Shell() must return a non-nil error when credential switch is denied")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with code 1")
+	assert.Empty(t, s.cmds, "s.cmds must be empty — the session must not have been registered")
+}
+
+// TestExec_DeniedCredentialSwitch verifies that Exec() returns a non-nil error,
+// calls session.Exit(1) exactly once with code 1, when checkCredentialSwitchFn
+// returns an error. The gate must fire as the FIRST statement inside Exec(),
+// before LookupUser, session.Pty(), command.NewCmd, initPtyFn, or cmd.Start.
+func TestExec_DeniedCredentialSwitch(t *testing.T) {
+	origCheckCredentialSwitch := checkCredentialSwitchFn
+
+	t.Cleanup(func() {
+		checkCredentialSwitchFn = origCheckCredentialSwitch
+	})
+
+	// Stub: simulate a denied credential switch.
+	checkCredentialSwitchFn = func() error {
+		return errors.New("setgroups denied in unprivileged user namespace")
+	}
+
+	deviceName := "test-device"
+	cmds := make(map[string]*exec.Cmd)
+	s := NewSessioner(&deviceName, cmds, nil)
+
+	sess := newFakeSession("session-exec-cred-switch", "root")
+	sess.command = []string{"/bin/true"}
+	sess.rawCommand = "/bin/true"
+
+	var retErr error
+
+	assert.NotPanics(t, func() {
+		retErr = s.Exec(sess)
+	}, "Exec() must not panic when credential switch is denied")
+
+	assert.NotNil(t, retErr, "Exec() must return a non-nil error when credential switch is denied")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with code 1")
+}
+
+// TestHeredoc_StartFailure verifies that Heredoc() handles cmd.Start() failure
+// without panicking. Before the fix, two nil-derefs were possible:
+//  1. The kill-goroutine was launched before cmd.Start(), so cmd.Process was nil
+//     when serverConn.Wait() returned, causing cmd.Process.Kill() to panic.
+//  2. After cmd.Start() failed cmd.Wait() also failed and cmd.ProcessState was nil,
+//     causing cmd.ProcessState.ExitCode() to panic.
+//
+// After the fix: cmd.Start() failure triggers an early-return — log.Warn + session.Exit(1)
+// + return err — BEFORE launching any goroutine or reaching cmd.ProcessState.ExitCode().
+func TestHeredoc_StartFailure(t *testing.T) {
+	// Mock osauth so generateShellCmd produces a cmd with a non-existent binary.
+	osauthMock := &osauthMocks.Backend{}
+	osauth.DefaultBackend = osauthMock
+
+	// Point the shell at a path that does not exist so cmd.Start() will fail with
+	// "no such file or directory".
+	fakeUser := &osauth.User{
+		UID:      0,
+		GID:      0,
+		Username: "root",
+		Shell:    "/nonexistent/shell-that-does-not-exist",
+		HomeDir:  "/root",
+	}
+
+	osauthMock.On("LookupUser", mock.AnythingOfType("string")).Return(fakeUser, nil).Maybe()
+	osauthMock.On("ListGroups", mock.AnythingOfType("string")).Return([]uint32{}, nil).Maybe()
+
+	deviceName := "test-device"
+	cmds := make(map[string]*exec.Cmd)
+	s := NewSessioner(&deviceName, cmds, nil)
+
+	sess := newFakeSession("session-heredoc-start-fail", "root")
+
+	// Inject a fakeGosshConn so the serverConn context lookup inside Heredoc()
+	// succeeds (the kill-goroutine path requires a non-nil serverConn).
+	fakeConn := &gossh.ServerConn{Conn: &fakeGosshConn{}}
+	sess.ctx.(*testSSHContext).SetValue(gliderssh.ContextKeyConn, fakeConn)
+
+	var retErr error
+
+	assert.NotPanics(t, func() {
+		retErr = s.Heredoc(sess)
+	}, "Heredoc() must not panic when cmd.Start() fails")
+
+	assert.NotNil(t, retErr, "Heredoc() must return a non-nil error when cmd.Start() fails")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with exit code 1")
+}
+
+// TestHeredoc_DeniedCredentialSwitch verifies that Heredoc() returns a non-nil
+// error, calls session.Exit(1) exactly once with code 1, and returns before any
+// further work (generateShellCmd, pipe creation, serverConn lookup, cmd.Start)
+// when checkCredentialSwitchFn returns an error. Because the gate fires as the
+// FIRST statement, no ServerConn injection into the session context is needed.
+func TestHeredoc_DeniedCredentialSwitch(t *testing.T) {
+	origCheckCredentialSwitch := checkCredentialSwitchFn
+
+	t.Cleanup(func() {
+		checkCredentialSwitchFn = origCheckCredentialSwitch
+	})
+
+	// Stub: simulate a denied credential switch.
+	checkCredentialSwitchFn = func() error {
+		return errors.New("setgroups denied in unprivileged user namespace")
+	}
+
+	deviceName := "test-device"
+	cmds := make(map[string]*exec.Cmd)
+	s := NewSessioner(&deviceName, cmds, nil)
+
+	sess := newFakeSession("session-heredoc-cred-switch", "root")
+
+	var retErr error
+
+	assert.NotPanics(t, func() {
+		retErr = s.Heredoc(sess)
+	}, "Heredoc() must not panic when credential switch is denied")
+
+	assert.NotNil(t, retErr, "Heredoc() must return a non-nil error when credential switch is denied")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with code 1")
+}
+
 // TestExec_NonPty_SucceedingCommand is a regression guard for the non-PTY path of
 // Exec(). It verifies that:
 //   - a real command starts and completes

--- a/agent/server/modes/host/sessioner_native_test.go
+++ b/agent/server/modes/host/sessioner_native_test.go
@@ -3,6 +3,8 @@
 package host
 
 import (
+	"errors"
+	"net"
 	"os/exec"
 	"sync/atomic"
 	"testing"
@@ -14,6 +16,36 @@ import (
 	"github.com/stretchr/testify/mock"
 	gossh "golang.org/x/crypto/ssh"
 )
+
+// fakeGosshConn is a minimal implementation of gossh.Conn that can be embedded
+// in a gossh.ServerConn so tests can inject a ServerConn into the session context
+// without needing a real SSH network connection.
+type fakeGosshConn struct{}
+
+func (f *fakeGosshConn) User() string          { return "root" }
+func (f *fakeGosshConn) SessionID() []byte     { return nil }
+func (f *fakeGosshConn) ClientVersion() []byte { return nil }
+func (f *fakeGosshConn) ServerVersion() []byte { return nil }
+func (f *fakeGosshConn) RemoteAddr() net.Addr  { return &net.TCPAddr{} }
+func (f *fakeGosshConn) LocalAddr() net.Addr   { return &net.TCPAddr{} }
+func (f *fakeGosshConn) SendRequest(_ string, _ bool, _ []byte) (bool, []byte, error) {
+	return false, nil, nil
+}
+
+func (f *fakeGosshConn) OpenChannel(_ string, _ []byte) (gossh.Channel, <-chan *gossh.Request, error) {
+	return nil, nil, errors.New("not implemented")
+}
+
+func (f *fakeGosshConn) Close() error { return nil }
+
+// Wait blocks until the returned channel is closed — used by tests to
+// control when the "kill on disconnect" goroutine unblocks.
+func (f *fakeGosshConn) Wait() error {
+	// Block until the test is done (goroutine is abandoned when the test
+	// function returns; the Go runtime cleans it up). This is acceptable
+	// because the caller only needs Wait to not panic.
+	select {}
+}
 
 // TestExec_NonPty_SucceedingCommand is a regression guard for the non-PTY path of
 // Exec(). It verifies that:

--- a/agent/server/modes/host/sessioner_native_test.go
+++ b/agent/server/modes/host/sessioner_native_test.go
@@ -1,0 +1,67 @@
+//go:build !docker
+
+package host
+
+import (
+	"os/exec"
+	"sync/atomic"
+	"testing"
+
+	gliderssh "github.com/gliderlabs/ssh"
+	"github.com/shellhub-io/shellhub/agent/pkg/osauth"
+	osauthMocks "github.com/shellhub-io/shellhub/agent/pkg/osauth/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// TestExec_NonPty_SucceedingCommand is a regression guard for the non-PTY path of
+// Exec(). It verifies that:
+//   - a real command starts and completes
+//   - session.Exit is called with the command's actual exit code (0 for success)
+//   - cmd.ProcessState nil-guard does not break the happy path
+//
+// This test is constrained to the native (non-docker) build because the docker
+// variant of command.NewCmd wraps the binary inside /usr/bin/nsenter, which exits
+// non-zero in environments that are not a real Docker-on-host setup (CI, dev
+// containers, etc.).
+func TestExec_NonPty_SucceedingCommand(t *testing.T) {
+	// Mock osauth so LookupUser succeeds without touching /etc/passwd.
+	osauthMock := &osauthMocks.Backend{}
+	osauth.DefaultBackend = osauthMock
+
+	fakeUser := &osauth.User{
+		UID:      0,
+		GID:      0,
+		Username: "root",
+		Shell:    "/bin/sh",
+		HomeDir:  "/root",
+	}
+
+	osauthMock.On("LookupUser", mock.AnythingOfType("string")).Return(fakeUser, nil).Maybe()
+	osauthMock.On("ListGroups", mock.AnythingOfType("string")).Return([]uint32{}, nil).Maybe()
+
+	deviceName := "test-device"
+	cmds := make(map[string]*exec.Cmd)
+	s := NewSessioner(&deviceName, cmds, nil)
+
+	sess := newFakeSession("session-exec-npty", "root")
+	sess.isPty = false
+	sess.command = []string{"/bin/true"}
+	sess.rawCommand = "/bin/true"
+
+	// Inject a fakeGosshConn so the serverConn context lookup succeeds and
+	// Exec() can proceed past that check to reach session.Exit().
+	fakeConn := &gossh.ServerConn{Conn: &fakeGosshConn{}}
+	sess.ctx.(*testSSHContext).SetValue(gliderssh.ContextKeyConn, fakeConn)
+
+	var retErr error
+
+	assert.NotPanics(t, func() {
+		retErr = s.Exec(sess)
+	}, "Exec() must not panic for a succeeding non-PTY command")
+
+	assert.NoError(t, retErr, "Exec() must return nil for a succeeding command")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with code 0 for /bin/true")
+}

--- a/agent/server/modes/host/sessioner_test.go
+++ b/agent/server/modes/host/sessioner_test.go
@@ -1,0 +1,281 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	gliderssh "github.com/gliderlabs/ssh"
+	"github.com/shellhub-io/shellhub/agent/pkg/osauth"
+	osauthMocks "github.com/shellhub-io/shellhub/agent/pkg/osauth/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// devNull is a no-op io.ReadWriter used as a stub for Stderr() in fakeSession.
+type devNull struct{}
+
+func (devNull) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (devNull) Write(p []byte) (int, error) { return len(p), nil }
+
+// fakeSession is a hand-rolled test double that satisfies the gliderssh.Session
+// interface. It allows unit tests to inject controlled values without spinning
+// up a real SSH connection.
+type fakeSession struct {
+	user       string
+	environ    []string
+	pty        gliderssh.Pty
+	winCh      <-chan gliderssh.Window
+	isPty      bool
+	remoteAddr net.Addr
+	localAddr  net.Addr
+	ctx        gliderssh.Context
+	command    []string
+	rawCommand string
+
+	// exitCalled tracks whether Exit() was called and with what code.
+	exitCalled int32 // atomic: 0 = not called, 1 = called
+	exitCode   int32 // atomic: last code passed to Exit()
+}
+
+// --- gossh.Channel methods ---
+
+func (f *fakeSession) Read(data []byte) (int, error) { return 0, io.EOF }
+
+func (f *fakeSession) Write(data []byte) (int, error) { return len(data), nil }
+
+func (f *fakeSession) Close() error { return nil }
+
+func (f *fakeSession) CloseWrite() error { return nil }
+
+func (f *fakeSession) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
+	return false, nil
+}
+
+func (f *fakeSession) Stderr() io.ReadWriter { return devNull{} }
+
+// --- gliderssh.Session methods ---
+
+func (f *fakeSession) User() string { return f.user }
+
+func (f *fakeSession) RemoteAddr() net.Addr { return f.remoteAddr }
+
+func (f *fakeSession) LocalAddr() net.Addr { return f.localAddr }
+
+func (f *fakeSession) Environ() []string { return f.environ }
+
+func (f *fakeSession) Exit(code int) error {
+	atomic.StoreInt32(&f.exitCalled, 1)
+	atomic.StoreInt32(&f.exitCode, int32(code)) //nolint:gosec
+
+	return nil
+}
+
+func (f *fakeSession) Command() []string { return f.command }
+
+func (f *fakeSession) RawCommand() string { return f.rawCommand }
+
+func (f *fakeSession) Subsystem() string { return "" }
+
+func (f *fakeSession) PublicKey() gliderssh.PublicKey { return nil }
+
+func (f *fakeSession) Context() gliderssh.Context { return f.ctx }
+
+func (f *fakeSession) Permissions() gliderssh.Permissions {
+	return gliderssh.Permissions{}
+}
+
+func (f *fakeSession) Pty() (gliderssh.Pty, <-chan gliderssh.Window, bool) {
+	return f.pty, f.winCh, f.isPty
+}
+
+func (f *fakeSession) Signals(c chan<- gliderssh.Signal) {}
+
+func (f *fakeSession) Break(c chan<- bool) {}
+
+// newFakeSession constructs a fakeSession whose Context() returns a
+// testSSHContext with gliderssh.ContextKeySessionID already set.
+func newFakeSession(sessionID, user string) *fakeSession {
+	ctx := &testSSHContext{
+		Context:   context.Background(),
+		user:      user,
+		sessionID: sessionID,
+	}
+	ctx.SetValue(gliderssh.ContextKeySessionID, sessionID)
+
+	return &fakeSession{
+		user:       user,
+		remoteAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345},
+		localAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 22},
+		ctx:        ctx,
+		winCh:      make(chan gliderssh.Window),
+	}
+}
+
+// TestFakeSessionCompiles is a compile-time check that fakeSession fully
+// implements gliderssh.Session. The test body is intentionally empty — a build
+// failure means the interface is incomplete.
+func TestFakeSessionCompiles(t *testing.T) {
+	t.Helper()
+
+	var _ gliderssh.Session = (*fakeSession)(nil)
+
+	sess := newFakeSession("test-session-id", "testuser")
+
+	id := sess.Context().Value(gliderssh.ContextKeySessionID)
+	if id == nil {
+		t.Fatal("expected ContextKeySessionID to be set in fakeSession.Context()")
+	}
+
+	if id.(string) != "test-session-id" {
+		t.Fatalf("expected session ID %q, got %q", "test-session-id", id)
+	}
+}
+
+// Ensure gossh.Channel is satisfied (compile-time check via assignment).
+var _ gossh.Channel = (*fakeSession)(nil)
+
+// fakeGosshConn is a minimal implementation of gossh.Conn that can be embedded
+// in a gossh.ServerConn so tests can inject a ServerConn into the session context
+// without needing a real SSH network connection.
+type fakeGosshConn struct{}
+
+func (f *fakeGosshConn) User() string          { return "root" }
+func (f *fakeGosshConn) SessionID() []byte     { return nil }
+func (f *fakeGosshConn) ClientVersion() []byte { return nil }
+func (f *fakeGosshConn) ServerVersion() []byte { return nil }
+func (f *fakeGosshConn) RemoteAddr() net.Addr  { return &net.TCPAddr{} }
+func (f *fakeGosshConn) LocalAddr() net.Addr   { return &net.TCPAddr{} }
+func (f *fakeGosshConn) SendRequest(_ string, _ bool, _ []byte) (bool, []byte, error) {
+	return false, nil, nil
+}
+
+func (f *fakeGosshConn) OpenChannel(_ string, _ []byte) (gossh.Channel, <-chan *gossh.Request, error) {
+	return nil, nil, errors.New("not implemented")
+}
+
+func (f *fakeGosshConn) Close() error { return nil }
+
+// Wait blocks until the returned channel is closed — used by tests to
+// control when the "kill on disconnect" goroutine unblocks.
+func (f *fakeGosshConn) Wait() error {
+	// Block until the test is done (goroutine is abandoned when the test
+	// function returns; the Go runtime cleans it up). This is acceptable
+	// because the caller only needs Wait to not panic.
+	select {}
+}
+
+// TestShell_StartPtyError verifies that Shell() returns an error and does NOT
+// panic when startPtyFn fails (e.g. "ptmx: inappropriate ioctl for device").
+// Before the fix the nil *os.File returned by the stub was dereferenced, causing
+// a panic.  After the fix there is an early-return guard that logs the error,
+// calls session.Exit(1), and returns a wrapped error — all before any call that
+// would dereference pts.
+func TestShell_StartPtyError(t *testing.T) {
+	// Restore the real startPtyFn after the test so other tests are not affected.
+	origStartPty := startPtyFn
+
+	t.Cleanup(func() {
+		startPtyFn = origStartPty
+	})
+
+	// Stub startPtyFn to simulate a pty open failure.
+	startPtyFn = func(_ *exec.Cmd, _ io.ReadWriter, _ <-chan gliderssh.Window) (*os.File, error) {
+		return nil, errors.New("ptmx: inappropriate ioctl for device")
+	}
+
+	// Mock osauth so generateShellCmd (and any subsequent LookupUser call) can
+	// return a real user without touching /etc/passwd.
+	osauthMock := &osauthMocks.Backend{}
+	osauth.DefaultBackend = osauthMock
+
+	fakeUser := &osauth.User{
+		UID:      0,
+		GID:      0,
+		Username: "root",
+		Shell:    "/bin/sh",
+		HomeDir:  "/root",
+	}
+
+	osauthMock.On("LookupUser", mock.AnythingOfType("string")).Return(fakeUser, nil).Maybe()
+	osauthMock.On("ListGroups", mock.AnythingOfType("string")).Return([]uint32{}, nil).Maybe()
+
+	deviceName := "test-device"
+	cmds := make(map[string]*exec.Cmd)
+	s := NewSessioner(&deviceName, cmds, nil)
+
+	sess := newFakeSession("session-1", "root")
+
+	var retErr error
+
+	assert.NotPanics(t, func() {
+		retErr = s.Shell(sess)
+	})
+
+	assert.NotNil(t, retErr, "Shell() must return a non-nil error when startPty fails")
+	assert.True(t, strings.Contains(retErr.Error(), "pty"), "error should mention 'pty', got: %s", retErr.Error())
+	assert.Empty(t, s.cmds, "s.cmds must be empty — the session must not have been registered")
+}
+
+// TestExec_InitPtyError verifies that Exec() with sIsPty=true does NOT panic and
+// returns a non-nil error when initPtyFn fails. It also asserts that session.Exit(1)
+// is called — the early-return guard must fire before any defer on nil *os.File.
+func TestExec_InitPtyError(t *testing.T) {
+	origInitPty := initPtyFn
+
+	t.Cleanup(func() {
+		initPtyFn = origInitPty
+	})
+
+	// Stub initPtyFn to simulate a pty open failure.
+	initPtyFn = func(_ *exec.Cmd, _ io.ReadWriter, _ <-chan gliderssh.Window) (*os.File, *os.File, error) {
+		return nil, nil, errors.New("ptmx: inappropriate ioctl for device")
+	}
+
+	// Mock osauth so LookupUser succeeds without touching /etc/passwd.
+	osauthMock := &osauthMocks.Backend{}
+	osauth.DefaultBackend = osauthMock
+
+	fakeUser := &osauth.User{
+		UID:      0,
+		GID:      0,
+		Username: "root",
+		Shell:    "/bin/sh",
+		HomeDir:  "/root",
+	}
+
+	osauthMock.On("LookupUser", mock.AnythingOfType("string")).Return(fakeUser, nil).Maybe()
+	osauthMock.On("ListGroups", mock.AnythingOfType("string")).Return([]uint32{}, nil).Maybe()
+
+	deviceName := "test-device"
+	cmds := make(map[string]*exec.Cmd)
+	s := NewSessioner(&deviceName, cmds, nil)
+
+	sess := newFakeSession("session-exec-pty", "root")
+	sess.isPty = true
+	sess.command = []string{"/bin/echo", "hello"}
+	sess.rawCommand = "/bin/echo hello"
+
+	var retErr error
+
+	assert.NotPanics(t, func() {
+		retErr = s.Exec(sess)
+	}, "Exec() must not panic when initPtyFn fails")
+
+	assert.NotNil(t, retErr, "Exec() must return a non-nil error when initPtyFn fails")
+	assert.True(
+		t,
+		strings.Contains(retErr.Error(), "pty") || strings.Contains(retErr.Error(), "ptmx"),
+		"error should mention the pty failure, got: %s", retErr.Error(),
+	)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with code 1")
+}

--- a/agent/server/modes/host/sessioner_test.go
+++ b/agent/server/modes/host/sessioner_test.go
@@ -120,6 +120,9 @@ func newFakeSession(sessionID, user string) *fakeSession {
 	}
 }
 
+// Ensure gossh.Channel is satisfied (compile-time check via assignment).
+var _ gossh.Channel = (*fakeSession)(nil)
+
 // TestFakeSessionCompiles is a compile-time check that fakeSession fully
 // implements gliderssh.Session. The test body is intentionally empty — a build
 // failure means the interface is incomplete.
@@ -138,39 +141,6 @@ func TestFakeSessionCompiles(t *testing.T) {
 	if id.(string) != "test-session-id" {
 		t.Fatalf("expected session ID %q, got %q", "test-session-id", id)
 	}
-}
-
-// Ensure gossh.Channel is satisfied (compile-time check via assignment).
-var _ gossh.Channel = (*fakeSession)(nil)
-
-// fakeGosshConn is a minimal implementation of gossh.Conn that can be embedded
-// in a gossh.ServerConn so tests can inject a ServerConn into the session context
-// without needing a real SSH network connection.
-type fakeGosshConn struct{}
-
-func (f *fakeGosshConn) User() string          { return "root" }
-func (f *fakeGosshConn) SessionID() []byte     { return nil }
-func (f *fakeGosshConn) ClientVersion() []byte { return nil }
-func (f *fakeGosshConn) ServerVersion() []byte { return nil }
-func (f *fakeGosshConn) RemoteAddr() net.Addr  { return &net.TCPAddr{} }
-func (f *fakeGosshConn) LocalAddr() net.Addr   { return &net.TCPAddr{} }
-func (f *fakeGosshConn) SendRequest(_ string, _ bool, _ []byte) (bool, []byte, error) {
-	return false, nil, nil
-}
-
-func (f *fakeGosshConn) OpenChannel(_ string, _ []byte) (gossh.Channel, <-chan *gossh.Request, error) {
-	return nil, nil, errors.New("not implemented")
-}
-
-func (f *fakeGosshConn) Close() error { return nil }
-
-// Wait blocks until the returned channel is closed — used by tests to
-// control when the "kill on disconnect" goroutine unblocks.
-func (f *fakeGosshConn) Wait() error {
-	// Block until the test is done (goroutine is abandoned when the test
-	// function returns; the Go runtime cleans it up). This is acceptable
-	// because the caller only needs Wait to not panic.
-	select {}
 }
 
 // TestShell_StartPtyError verifies that Shell() returns an error and does NOT

--- a/agent/server/modes/host/sessioner_test.go
+++ b/agent/server/modes/host/sessioner_test.go
@@ -3,12 +3,14 @@ package host
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
 	"os/exec"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 
 	gliderssh "github.com/gliderlabs/ssh"
@@ -195,6 +197,48 @@ func TestShell_StartPtyError(t *testing.T) {
 	assert.Empty(t, s.cmds, "s.cmds must be empty — the session must not have been registered")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called once")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with code 1")
+}
+
+// TestPtyFailureHint verifies the ptyFailureHint helper:
+//   - wrapping syscall.ENOTTY yields a non-empty hint
+//   - an error whose message contains "inappropriate ioctl for device" yields a non-empty hint
+//   - an unrelated error yields an empty string
+func TestPtyFailureHint(t *testing.T) {
+	const wantHint = "the system may not support PTY allocation — ensure /dev/ptmx is accessible and the agent is not in a restricted environment"
+
+	tests := []struct {
+		name      string
+		err       error
+		wantEmpty bool
+	}{
+		{
+			name:      "wrapped ENOTTY yields hint",
+			err:       fmt.Errorf("wrapped: %w", syscall.ENOTTY),
+			wantEmpty: false,
+		},
+		{
+			name:      "message contains 'inappropriate ioctl for device' yields hint",
+			err:       errors.New("inappropriate ioctl for device"),
+			wantEmpty: false,
+		},
+		{
+			name:      "unrelated error yields empty hint",
+			err:       errors.New("some unrelated error"),
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hint := ptyFailureHint(tt.err)
+
+			if tt.wantEmpty {
+				assert.Empty(t, hint, "expected empty hint for unrelated error")
+			} else {
+				assert.Equal(t, wantHint, hint, "expected diagnostic hint for pty failure error")
+			}
+		})
+	}
 }
 
 // TestExec_InitPtyError verifies that Exec() with sIsPty=true does NOT panic and

--- a/agent/server/modes/host/sessioner_test.go
+++ b/agent/server/modes/host/sessioner_test.go
@@ -193,6 +193,8 @@ func TestShell_StartPtyError(t *testing.T) {
 	assert.NotNil(t, retErr, "Shell() must return a non-nil error when startPty fails")
 	assert.True(t, strings.Contains(retErr.Error(), "pty"), "error should mention 'pty', got: %s", retErr.Error())
 	assert.Empty(t, s.cmds, "s.cmds must be empty — the session must not have been registered")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with code 1")
 }
 
 // TestExec_InitPtyError verifies that Exec() with sIsPty=true does NOT panic and


### PR DESCRIPTION
## What

Stops SSH sessions from dropping the moment authentication completes when the
ShellHub agent runs inside an unprivileged Proxmox LXC container. Two unrelated
root causes in the agent's host-mode session handling are addressed.

## Why

Closes #4634

Users running the agent in an unprivileged LXC reported sessions disconnecting
immediately after auth, with `inappropriate ioctl for device` and
`nsenter: reassociate to namespace 'ns/time' failed: Operation not permitted`
in the agent logs, plus a server-side `use of closed network connection`.
Investigation found two distinct bugs, one per agent mode.

## Changes

- **agent (native mode), `sessioner.go`**: `startPty`/`initPty` failures (ENOTTY
  in unprivileged LXC) were logged but execution continued, dereferencing the
  nil `*os.File` returned on failure — a nil-pointer panic that crashed the
  entire agent process. `Shell()` and `Exec()` now return the wrapped error
  after `session.Exit(1)`, before any use of the nil file. A `cmd.ProcessState`
  nil-guard was added to the adjacent `Exec()` exit path, which had the same
  crash shape when `cmd.Start()` fails.

- **agent (Docker mode), `command_docker.go`**: the `nsenter` wrapper always
  added `-T` to join the host time namespace whenever `/proc/1/ns/time` existed.
  In unprivileged LXC the mapped root lacks `CAP_SYS_TIME`, so the join fails
  with EPERM and `nsenter` aborts *before* exec'ing the shell. The join is now
  best-effort: a 500ms-timeout probe determines joinability once, results are
  memoized (definitive denials cached, transient/misconfig retried), and `-T` is
  dropped when not permitted. The time namespace only virtualizes
  `CLOCK_MONOTONIC`/`BOOTTIME` (not wall-clock) and Docker shares the host's by
  default, so dropping it has no practical effect on a shell.

- **agent/Dockerfile, `cmd/true`**: the probe runs `/bin/true` as its payload,
  but the production image is `FROM scratch`. A tiny static `CGO_ENABLED=0` Go
  `true` is compiled and copied in, with a build-time `RUN ["/bin/true"]`
  smoke-check so a broken payload fails the image build rather than production.

## Testing

Unit tests cover both fixes (run the Docker-mode tests with `-tags docker`):

```
go test ./agent/server/modes/host/...
go test -tags docker ./agent/server/modes/host/...
```

- Native: `TestShell_StartPtyError` / `TestExec_InitPtyError` assert no panic and
  a wrapped error on PTY failure; `TestExec_NonPty_SucceedingCommand` guards the
  non-PTY path (constrained to `!docker`, since the docker wrapper changes the
  exit semantics).
- Docker: `TestNsenterArgs`, `TestProbeTimeNS`, `TestTimeNSMemoizer`,
  `TestNsenterCommandWrapper` cover flag assembly, probe exit-code
  classification, and the tri-state memoizer (cache-once vs. retry).