### PR TITLE
fix(ssh): close dead device connections to stop log spam and CPU spin

### DIFF
--- a/pkg/wsconnadapter/wsconnadapter.go
+++ b/pkg/wsconnadapter/wsconnadapter.go
@@ -19,8 +19,8 @@ import (
 var ErrUnexpectedMessageType = errors.New("unexpected websocket message type")
 
 const (
-	pongTimeout  = time.Second * 35
-	pingInterval = time.Second * 30
+	defaultPongTimeout  = time.Second * 35
+	defaultPingInterval = time.Second * 30
 )
 
 type Adapter struct {
@@ -36,6 +36,11 @@ type Adapter struct {
 	closeErr   error
 	Logger     *log.Entry
 	CreatedAt  time.Time
+
+	// pingInterval and pongTimeout control the keep-alive loop. They default to
+	// the package defaults and are only overridden in tests.
+	pingInterval time.Duration
+	pongTimeout  time.Duration
 }
 
 type Option func(*Adapter)
@@ -64,7 +69,9 @@ func New(conn *websocket.Conn, options ...Option) *Adapter {
 			Hooks:     log.StandardLogger().Hooks,
 			Level:     log.StandardLogger().Level,
 		}),
-		CreatedAt: clock.Now(),
+		CreatedAt:    clock.Now(),
+		pingInterval: defaultPingInterval,
+		pongTimeout:  defaultPongTimeout,
 	}
 
 	for _, option := range options {
@@ -79,14 +86,14 @@ func (a *Adapter) Ping() chan bool {
 		a.stopPingCh = make(chan struct{})
 		a.pongCh = make(chan bool)
 
-		timeout := time.AfterFunc(pongTimeout, func() {
+		timeout := time.AfterFunc(a.pongTimeout, func() {
 			a.Logger.Debug("close connection due pong timeout")
 
 			_ = a.Close()
 		})
 
 		a.conn.SetPongHandler(func(_ string) error {
-			timeout.Reset(pongTimeout)
+			timeout.Reset(a.pongTimeout)
 			a.Logger.Trace("pong timeout")
 
 			// non-blocking channel write
@@ -101,14 +108,23 @@ func (a *Adapter) Ping() chan bool {
 
 		// ping loop
 		go func() {
-			ticker := time.NewTicker(pingInterval)
+			ticker := time.NewTicker(a.pingInterval)
 			defer ticker.Stop()
 
 			for {
 				select {
 				case <-ticker.C:
 					if err := a.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(5*time.Second)); err != nil {
-						a.Logger.WithError(err).Error("failed to write ping message")
+						// A failed ping write is terminal (broken pipe / closed socket):
+						// close the adapter so teardown propagates to the consumer, and stop.
+						a.Logger.
+							WithError(err).
+							WithField("lifetime", clock.Now().Sub(a.CreatedAt).String()).
+							Warn("reverse connection ping failed, tearing down connection")
+
+						_ = a.Close()
+
+						return
 					}
 				case <-a.stopPingCh:
 					a.Logger.Debug("stop ping message received")

--- a/pkg/wsconnadapter/wsconnadapter_test.go
+++ b/pkg/wsconnadapter/wsconnadapter_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -106,4 +107,35 @@ func TestCloseWithoutPing(t *testing.T) {
 	// Close without ever calling Ping — stopPingCh is nil.
 	err := client.Close()
 	assert.NoError(t, err)
+}
+
+// TestPingFailureClosesConnection verifies the keep-alive contract: when a ping
+// write fails the loop closes the adapter and stops, so a dead connection does
+// not stay registered.
+func TestPingFailureClosesConnection(t *testing.T) {
+	client, server := newTestPair(t)
+
+	// Drive the ping loop fast so the test doesn't wait the default 30s.
+	client.pingInterval = 5 * time.Millisecond
+	client.pongTimeout = time.Hour // keep the pong timeout out of the picture
+
+	client.Ping()
+
+	// Kill the peer so the next ping write fails with a closed/broken connection.
+	server.Close()
+
+	// The ping loop must Close() the adapter on the write failure, which closes
+	// stopPingCh. A closed channel reads immediately, so this returns quickly;
+	// if teardown never happens the test times out.
+	require.Eventually(t, func() bool {
+		select {
+		case <-client.stopPingCh:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 5*time.Millisecond, "ping failure did not tear down the connection")
+
+	// Close() must remain safe to call again after the auto-teardown.
+	assert.NotPanics(t, func() { _ = client.Close() })
 }

--- a/ssh/server/channels/session.go
+++ b/ssh/server/channels/session.go
@@ -141,7 +141,9 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 
 		var wg sync.WaitGroup
 
-		done := make(chan bool)
+		// Buffered so pipe's completion signal never blocks the sender, even if
+		// this goroutine is still looping on agent.Requests.
+		done := make(chan bool, 1)
 
 		oncePipe := sync.OnceFunc(func() {
 			go pipe(sess, client.Channel, agent.Channel, seat, done)

--- a/ssh/server/channels/tcpip.go
+++ b/ssh/server/channels/tcpip.go
@@ -134,8 +134,12 @@ func DefaultDirectTCPIPHandler(server *gliderssh.Server, conn *gossh.ServerConn,
 			"dest_addr":   data.DestAddr,
 		}).Trace("copying data from client to agent")
 
-		if _, err := io.Copy(client, agent); err != nil && err != io.EOF {
+		if _, err := io.Copy(client, &deadReadGuard{r: agent}); err != nil && err != io.EOF {
 			log.WithError(err).Error("failed to copy data from agent to client")
+
+			// Close both ends so the peer goroutine unblocks and wg.Wait can return.
+			_ = agent.Close()
+			_ = client.Close()
 
 			return
 		}
@@ -154,8 +158,11 @@ func DefaultDirectTCPIPHandler(server *gliderssh.Server, conn *gossh.ServerConn,
 			"dest_addr":   data.DestAddr,
 		}).Trace("copying data from agent to client")
 
-		if _, err := io.Copy(agent, client); err != nil && err != io.EOF {
+		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && err != io.EOF {
 			log.WithError(err).Error("failed to copy data from client to agent")
+
+			_ = agent.Close()
+			_ = client.Close()
 
 			return
 		}

--- a/ssh/server/channels/utils.go
+++ b/ssh/server/channels/utils.go
@@ -29,6 +29,35 @@ func NewRecorder(session *session.Session, seat int) (io.Writer, error) {
 // PtyOutputEventType is the event's type for an output.
 const PtyOutputEventType = "pty-output"
 
+// maxConsecutiveEmptyReads bounds how many times a reader may return (0, nil)
+// before we treat it as dead. It mirrors the guard the standard library's bufio
+// package uses against a broken reader.
+const maxConsecutiveEmptyReads = 100
+
+// deadReadGuard wraps a reader so a connection stuck returning (0, nil) is turned
+// into io.ErrNoProgress after maxConsecutiveEmptyReads. io.Copy treats (0, nil) as
+// "nothing happened, try again", so without this a dead or half-closed channel
+// busy-loops a CPU core instead of terminating the copy.
+type deadReadGuard struct {
+	r     io.Reader
+	zeros int
+}
+
+func (g *deadReadGuard) Read(p []byte) (int, error) {
+	n, err := g.r.Read(p)
+	if n == 0 && err == nil {
+		if g.zeros++; g.zeros >= maxConsecutiveEmptyReads {
+			return 0, io.ErrNoProgress
+		}
+
+		return 0, nil
+	}
+
+	g.zeros = 0
+
+	return n, err
+}
+
 func (c *Recorder) Write(output []byte) (int, error) {
 	// NOTE: Writes the event into the event stream to be processed and send to target endpoint.
 	c.session.Event(PtyOutputEventType, &models.SSHPtyOutput{
@@ -82,8 +111,12 @@ func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, seat
 		}
 
 		multi := io.MultiWriter(writers...)
-		if _, err := io.Copy(multi, a); err != nil && err != io.EOF {
-			log.WithError(err).Error("failed on coping data from client to agent")
+		if _, err := io.Copy(multi, &deadReadGuard{r: a}); err != nil && err != io.EOF {
+			log.WithError(err).Error("failed on coping data from agent to client")
+
+			// Close both ends so the other copy goroutine unblocks and pipe can return.
+			_ = agent.Close()
+			_ = client.Close()
 		}
 
 		log.Trace("agent channel data copy done")
@@ -106,8 +139,12 @@ func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, seat
 			}
 		}()
 
-		if _, err := io.Copy(agent, c); err != nil && err != io.EOF {
+		if _, err := io.Copy(agent, &deadReadGuard{r: c}); err != nil && err != io.EOF {
 			log.WithError(err).Error("failed on coping data from client to agent")
+
+			// Close both ends so the other copy goroutine unblocks and pipe can return.
+			_ = agent.Close()
+			_ = client.Close()
 		}
 
 		log.Trace("client channel data copy done")
@@ -132,8 +169,11 @@ func hose(sess *session.Session, agent gossh.Channel, client gossh.Channel) {
 		defer wg.Done()
 		defer agent.CloseWrite() //nolint:errcheck
 
-		if _, err := io.Copy(agent, c); err != nil && err != io.EOF {
+		if _, err := io.Copy(agent, &deadReadGuard{r: c}); err != nil && err != io.EOF {
 			log.WithError(err).Error("failed on coping data from client to agent")
+
+			// Close the agent so the other copy goroutine unblocks.
+			_ = agent.Close()
 		}
 
 		log.Trace("agent channel data copy done")
@@ -143,8 +183,11 @@ func hose(sess *session.Session, agent gossh.Channel, client gossh.Channel) {
 		defer wg.Done()
 		defer client.CloseWrite() //nolint:errcheck
 
-		if _, err := io.Copy(client, a); err != nil && err != io.EOF {
+		if _, err := io.Copy(client, &deadReadGuard{r: a}); err != nil && err != io.EOF {
 			log.WithError(err).Error("failed on coping data from agent to client")
+
+			// Close the client so the other copy goroutine unblocks.
+			_ = client.Close()
 		}
 
 		log.Trace("client channel data copy done")

--- a/ssh/server/channels/utils_test.go
+++ b/ssh/server/channels/utils_test.go
@@ -1,0 +1,104 @@
+package channels
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emptyReader always returns (0, nil), the broken-reader case that makes io.Copy
+// busy-loop without the guard.
+type emptyReader struct{}
+
+func (emptyReader) Read(_ []byte) (int, error) { return 0, nil }
+
+// scriptedReader returns each step in order, then (0, io.EOF).
+type scriptedReader struct {
+	steps []readStep
+	i     int
+}
+
+type readStep struct {
+	data []byte
+	err  error
+}
+
+func (r *scriptedReader) Read(p []byte) (int, error) {
+	if r.i >= len(r.steps) {
+		return 0, io.EOF
+	}
+
+	step := r.steps[r.i]
+	r.i++
+
+	n := copy(p, step.data)
+
+	return n, step.err
+}
+
+func TestDeadReadGuard(t *testing.T) {
+	t.Run("io.Copy terminates on a reader stuck at (0, nil)", func(t *testing.T) {
+		_, err := io.Copy(io.Discard, &deadReadGuard{r: emptyReader{}})
+		assert.ErrorIs(t, err, io.ErrNoProgress)
+	})
+
+	t.Run("returns ErrNoProgress after maxConsecutiveEmptyReads", func(t *testing.T) {
+		g := &deadReadGuard{r: emptyReader{}}
+		buf := make([]byte, 8)
+
+		// The first maxConsecutiveEmptyReads-1 calls report (0, nil)...
+		for range maxConsecutiveEmptyReads - 1 {
+			n, err := g.Read(buf)
+			require.Equal(t, 0, n)
+			require.NoError(t, err)
+		}
+
+		// ...and the next one trips the guard.
+		n, err := g.Read(buf)
+		assert.Equal(t, 0, n)
+		assert.ErrorIs(t, err, io.ErrNoProgress)
+	})
+
+	t.Run("real data resets the empty-read counter", func(t *testing.T) {
+		// 99 empty reads, then a real read, then empties again: the data read in
+		// the middle must reset the counter so the guard does not trip early.
+		steps := make([]readStep, 0, maxConsecutiveEmptyReads*2)
+		for range maxConsecutiveEmptyReads - 1 {
+			steps = append(steps, readStep{})
+		}
+		steps = append(steps, readStep{data: []byte("hi")})
+		for range maxConsecutiveEmptyReads - 1 {
+			steps = append(steps, readStep{})
+		}
+
+		g := &deadReadGuard{r: &scriptedReader{steps: steps}}
+		buf := make([]byte, 8)
+
+		total := 0
+		for i := range steps {
+			n, err := g.Read(buf)
+			require.NoErrorf(t, err, "unexpected error at step %d", i)
+			total += n
+		}
+
+		// The single non-empty step ("hi") must have flowed through, and resetting
+		// the counter on it kept the guard from tripping across the surrounding empties.
+		assert.Equal(t, len("hi"), total)
+	})
+
+	t.Run("EOF passes straight through", func(t *testing.T) {
+		g := &deadReadGuard{r: &scriptedReader{steps: []readStep{{err: io.EOF}}}}
+		n, err := g.Read(make([]byte, 8))
+		assert.Equal(t, 0, n)
+		assert.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("real errors pass straight through", func(t *testing.T) {
+		g := &deadReadGuard{r: &scriptedReader{steps: []readStep{{err: io.ErrClosedPipe}}}}
+		n, err := g.Read(make([]byte, 8))
+		assert.Equal(t, 0, n)
+		assert.ErrorIs(t, err, io.ErrClosedPipe)
+	})
+}


### PR DESCRIPTION
Dead or flapping device connections could drive high CPU usage and flood the logs in the `ssh` service. The root cause is that a dead connection was never torn down, which surfaced in two ways.

**Ping spam and a leaked connection.** `wsconnadapter` logged every failed keep-alive ping at `error` and kept looping, so one dead connection re-logged on every interval and stayed registered. It now closes the adapter and returns on the first failure, which is the same close the pong timeout already did, just immediate. It logs once at `warning` with the connection lifetime, and the close propagates through revdial/manager so the device is marked offline.

**A CPU spin in the copy loops.** The `io.Copy` loops in `pipe`, `hose` and `direct-tcpip` had no guard against a reader returning `(0, nil)` repeatedly. `io.Copy` retries on that, so a half-dead gossh channel pegs a core. A `deadReadGuard` now returns `io.ErrNoProgress` after 100 such reads, matching the standard library `bufio` guard. The web terminal path already handled this (`ssh/web/session.go`); the channel paths did not. A copy that ends on a read error now also closes the channel so the other goroutine unblocks instead of leaking.

The two changes are independent: the teardown clears the ping spam and the leaked connection, and the copy guard clears the spin. Behavior only changes on the error path (`err != nil && err != io.EOF`), so healthy sessions that close on EOF are untouched. Unit tests cover both paths: the adapter auto-closing on a failed ping, and `deadReadGuard` terminating an `io.Copy` over a `(0, nil)` reader.

Refs: shellhub-io/team#113
