### PR TITLE
fix(install): install shellhub-agent host wrapper for docker and podman installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,18 @@ podman_install() {
     $ARGS \
     docker.io/shellhubio/agent:$AGENT_VERSION \
     $MODE
+
+  if [ -z "$MODE" ]; then
+    _FSUDO=""
+    [ "$(id -u)" -ne 0 ] && _FSUDO="sudo"
+    WRAPPER_PATH="${INSTALL_DIR:-/usr/local/bin}/shellhub-agent"
+    printf '#!/bin/sh\nexec podman exec %s agent "$@"\n' "$CONTAINER_NAME" | $_FSUDO tee "$WRAPPER_PATH" > /dev/null || {
+      echo "❌ Failed to install shellhub-agent wrapper at $WRAPPER_PATH."
+      exit 1
+    }
+    $_FSUDO chmod +x "$WRAPPER_PATH"
+    echo "✅ Installed shellhub-agent wrapper at $WRAPPER_PATH."
+  fi
 }
 
 docker_install() {
@@ -131,6 +143,18 @@ docker_install() {
     $ARGS \
     shellhubio/agent:$AGENT_VERSION \
     $MODE
+
+  if [ -z "$MODE" ]; then
+    _FSUDO=""
+    [ "$(id -u)" -ne 0 ] && _FSUDO="sudo"
+    WRAPPER_PATH="${INSTALL_DIR:-/usr/local/bin}/shellhub-agent"
+    printf '#!/bin/sh\nexec docker exec %s agent "$@"\n' "$CONTAINER_NAME" | $_FSUDO tee "$WRAPPER_PATH" > /dev/null || {
+      echo "❌ Failed to install shellhub-agent wrapper at $WRAPPER_PATH."
+      exit 1
+    }
+    $_FSUDO chmod +x "$WRAPPER_PATH"
+    echo "✅ Installed shellhub-agent wrapper at $WRAPPER_PATH."
+  fi
 }
 
 snap_install() {
@@ -217,6 +241,48 @@ standalone_install() {
   echo "✅ ShellHub agent installed and started."
 
   rm -rf "$TMP_DIR"
+}
+
+docker_uninstall() {
+  _FSUDO=""
+  [ "$(id -u)" -ne 0 ] && _FSUDO="sudo"
+
+  SUDO="${SUDO:-$_FSUDO}"
+
+  CONTAINER_NAME="${CONTAINER_NAME:-shellhub}"
+
+  echo "🗑️ Stopping and removing ShellHub container..."
+  $SUDO docker rm -f "$CONTAINER_NAME" 2>/dev/null || echo "⚠️ Container '$CONTAINER_NAME' not found (may already be removed)."
+
+  WRAPPER_PATH="${INSTALL_DIR:-/usr/local/bin}/shellhub-agent"
+  if [ -f "$WRAPPER_PATH" ]; then
+    echo "🗑️ Removing shellhub-agent wrapper..."
+    $_FSUDO rm -f "$WRAPPER_PATH"
+  fi
+
+  echo "✅ ShellHub agent uninstalled."
+  echo "ℹ️ The private key file was left in place. Remove it manually if no longer needed."
+}
+
+podman_uninstall() {
+  _FSUDO=""
+  [ "$(id -u)" -ne 0 ] && _FSUDO="sudo"
+
+  SUDO="${SUDO:-$_FSUDO}"
+
+  CONTAINER_NAME="${CONTAINER_NAME:-shellhub}"
+
+  echo "🗑️ Stopping and removing ShellHub container..."
+  $SUDO podman rm -f "$CONTAINER_NAME" 2>/dev/null || echo "⚠️ Container '$CONTAINER_NAME' not found (may already be removed)."
+
+  WRAPPER_PATH="${INSTALL_DIR:-/usr/local/bin}/shellhub-agent"
+  if [ -f "$WRAPPER_PATH" ]; then
+    echo "🗑️ Removing shellhub-agent wrapper..."
+    $_FSUDO rm -f "$WRAPPER_PATH"
+  fi
+
+  echo "✅ ShellHub agent uninstalled."
+  echo "ℹ️ The private key file was left in place. Remove it manually if no longer needed."
 }
 
 standalone_uninstall() {
@@ -424,6 +490,14 @@ uninstall)
   standalone|wsl)
     echo "🗑️ Uninstalling ShellHub using standalone method..."
     standalone_uninstall
+    ;;
+  docker)
+    echo "🐳 Uninstalling ShellHub using docker method..."
+    docker_uninstall
+    ;;
+  podman)
+    echo "🐳 Uninstalling ShellHub using podman method..."
+    podman_uninstall
     ;;
   *)
     echo "❌ Uninstall is not yet supported for '$INSTALL_METHOD' install method."


### PR DESCRIPTION
## What

`docker_install()` and `podman_install()` now write a thin shell wrapper
to `$INSTALL_DIR/shellhub-agent` (default `/usr/local/bin`) after starting
the container. The wrapper delegates to the running container:

- Docker: `exec docker exec <name> agent "$@"`
- Podman: `exec podman exec <name> agent "$@"`

`docker_uninstall()` and `podman_uninstall()` are added and wired into the
uninstall dispatcher - they stop/remove the container and delete the wrapper.

Closes: shellhub-io/shellhub#6435

## Why

Standalone and WSL installs already place the binary at
`/usr/local/bin/shellhub-agent`. Docker and podman kept the binary inside the
container, so operators had no `shellhub-agent` command on the host. This
makes all operator-facing install methods consistent.

## Changes

- Container name is resolved at install time and baked into the wrapper, so
  it respects any `CONTAINER_NAME` override (default: `shellhub`).
- Wrapper is only installed in agent mode - connector mode (`shellhub-connector`)
  is intentionally skipped.
- Dev mode (`docker-compose.agent.yml`) is out of scope - that is a contributor
  workflow that never goes through `install.sh`.
- Snap and runc/OCI are out of scope (external repo and no install method in
  `install.sh` respectively).
- If a wrapper already exists pointing to a different container it is silently
  overwritten (last install wins).

## Testing

With a local ShellHub stack running, install the agent using the local script:

```sh
INSTALL_METHOD=docker TENANT_ID=00000000-0000-4000-0000-000000000000 SERVER_ADDRESS=http://localhost ./install.sh
```

Then verify:

```sh
which shellhub-agent          # should resolve to /usr/local/bin/shellhub-agent
shellhub-agent info           # should return output from the running container
```

To test uninstall:

```sh
INSTALL_METHOD=docker ./install.sh uninstall
which shellhub-agent          # should no longer resolve
```
