### PR TITLE
fix(api): upsert active_sessions to prevent duplicate key error on session update

### DIFF
--- a/api/store/pg/session.go
+++ b/api/store/pg/session.go
@@ -154,7 +154,10 @@ func (pg *Pg) ActiveSessionCreate(ctx context.Context, session *models.Session) 
 
 	activeSession := &models.ActiveSession{UID: models.UID(session.UID), LastSeen: session.StartedAt, TenantID: session.TenantID}
 	e := entity.ActiveSessionFromModel(activeSession)
-	if _, err := db.NewInsert().Model(e).Exec(ctx); err != nil {
+	if _, err := db.NewInsert().Model(e).
+		On("CONFLICT (session_id) DO UPDATE").
+		Set("seen_at = NOW()").
+		Exec(ctx); err != nil {
 		return fromSQLError(err)
 	}
 


### PR DESCRIPTION
## What

`ActiveSessionCreate` now uses `ON CONFLICT (session_id) DO UPDATE SET seen_at = NOW()` instead of a plain `INSERT`.

## Why

The service calls `ActiveSessionCreate` on every `UpdateSession` where `Authenticated=true`, not only on the initial authenticated transition. A single pty session triggers it at least twice - once on auth and again on the recorded update - causing a duplicate key violation on `active_sessions_pkey`. The error was swallowed as a warning so sessions were not broken, but it spammed logs and left `seen_at` stale on subsequent calls.

## Changes

- One-line change in `api/store/pg/session.go`: plain insert replaced with an upsert.
- No migration needed - no schema change.
- No service-layer changes - the fix is at the store boundary where the constraint is enforced.

## Testing

Open a recorded shell session through ShellHub and confirm no `failed to activate the session` warnings appear in the api service logs.

Closes: #6459
