### PR TITLE
fix(api): return 400 instead of 500 on a malformed filter

### DIFF
--- a/api/routes/device.go
+++ b/api/routes/device.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -46,6 +47,8 @@ func (h *Handler) GetDeviceList(c gateway.Context) error {
 	}
 
 	if err := req.Filters.Unmarshal(); err != nil {
+		log.WithError(err).WithField("filter", req.Filters.Raw).Warn("failed to decode device list filter")
+
 		return c.NoContent(http.StatusBadRequest)
 	}
 

--- a/api/routes/device_test.go
+++ b/api/routes/device_test.go
@@ -382,6 +382,82 @@ func TestGetDeviceList(t *testing.T) {
 	}
 }
 
+func TestGetDeviceListBadFilter(t *testing.T) {
+	cases := []struct {
+		description string
+		filter      string
+	}{
+		{
+			description: "returns 400 when filter is not valid base64",
+			filter:      "!!!not-base64!!!",
+		},
+		{
+			description: "returns 400 when filter decodes to invalid JSON",
+			filter:      "bm90LWpzb24=", // base64("not-json")
+		},
+		{
+			description: "returns 400 when filter contains an unknown field",
+			filter: func() string {
+				filters := []query.Filter{
+					{
+						Type: query.FilterTypeProperty,
+						Params: &query.FilterProperty{
+							Name:     "nonexistent_field",
+							Operator: "eq",
+							Value:    "foo",
+						},
+					},
+				}
+				b, _ := json.Marshal(filters)
+
+				return base64.StdEncoding.EncodeToString(b)
+			}(),
+		},
+		{
+			description: "returns 400 when filter uses a disallowed operator for the field",
+			filter: func() string {
+				filters := []query.Filter{
+					{
+						Type: query.FilterTypeProperty,
+						Params: &query.FilterProperty{
+							Name:     "status",
+							Operator: "contains", // disallowed: status only allows eq/ne
+							Value:    "accepted",
+						},
+					},
+				}
+				b, _ := json.Marshal(filters)
+
+				return base64.StdEncoding.EncodeToString(b)
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			mock := new(mocks.Service)
+
+			urlVal := url.Values{}
+			urlVal.Set("page", "1")
+			urlVal.Set("per_page", "10")
+			urlVal.Set("sort_by", "name")
+			urlVal.Set("order_by", "asc")
+			urlVal.Set("filter", tc.filter)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/devices?"+urlVal.Encode(), nil)
+			req.Header.Set("X-Role", authorizer.RoleOwner.String())
+			req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
+
+			rec := httptest.NewRecorder()
+			e := NewRouter(mock)
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+			mock.AssertNotCalled(t, "ListDevices")
+		})
+	}
+}
+
 func TestGetDeviceListConnectorFilterOrder(t *testing.T) {
 	cases := []struct {
 		description string
@@ -455,7 +531,7 @@ func TestGetDeviceListConnectorFilterOrder(t *testing.T) {
 			// property so it applies to it; otherwise the platform
 			// condition gets OR'd with user filters, returning all
 			// devices regardless of the user's filter.
-			data := captured.Filters.Data
+			data := captured.Data
 			require.GreaterOrEqual(t, len(data), 3)
 
 			lastTwo := data[len(data)-2:]

--- a/api/routes/nsadm.go
+++ b/api/routes/nsadm.go
@@ -34,9 +34,9 @@ func (h *Handler) GetNamespaceList(c gateway.Context) error {
 		return err
 	}
 
-	req.Paginator.Normalize()
-	if err := req.Filters.Unmarshal(); err != nil {
-		return err
+	req.Normalize()
+	if err := req.Unmarshal(); err != nil {
+		return c.NoContent(http.StatusBadRequest)
 	}
 
 	if err := c.Validate(req); err != nil {

--- a/api/routes/nsadm.go
+++ b/api/routes/nsadm.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 
 	"github.com/shellhub-io/shellhub/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/api/services"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	log "github.com/sirupsen/logrus"
 )
@@ -40,6 +42,10 @@ func (h *Handler) GetNamespaceList(c gateway.Context) error {
 	if err := req.Unmarshal(); err != nil {
 		log.WithError(err).WithField("filter", req.Filters.Raw).Warn("failed to decode namespace list filter")
 
+		return c.NoContent(http.StatusBadRequest)
+	}
+
+	if err := query.ValidateFilters(&req.Filters, services.NamespaceFilterFields); err != nil {
 		return c.NoContent(http.StatusBadRequest)
 	}
 

--- a/api/routes/nsadm.go
+++ b/api/routes/nsadm.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/shellhub-io/shellhub/api/pkg/gateway"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -35,7 +36,10 @@ func (h *Handler) GetNamespaceList(c gateway.Context) error {
 	}
 
 	req.Normalize()
+
 	if err := req.Unmarshal(); err != nil {
+		log.WithError(err).WithField("filter", req.Filters.Raw).Warn("failed to decode namespace list filter")
+
 		return c.NoContent(http.StatusBadRequest)
 	}
 

--- a/api/routes/nsadm_test.go
+++ b/api/routes/nsadm_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	svc "github.com/shellhub-io/shellhub/api/services"
 	"github.com/shellhub-io/shellhub/api/services/mocks"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
@@ -666,6 +668,42 @@ func TestCreateNamespaceBlocksAPIKey(t *testing.T) {
 	mock.AssertExpectations(t)
 }
 
+// encodeFilter serialises filters as the JSON array the API expects and
+// returns it base64-encoded, ready to be used as the "filter" query param.
+func encodeFilter(t *testing.T, filters []query.Filter) string {
+	t.Helper()
+
+	raw, err := json.Marshal(filters)
+	if err != nil {
+		t.Fatalf("encodeFilter: marshal: %v", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+// namespaceListHasFilterName returns a testify MatchedBy matcher that
+// verifies the first property filter in a *requests.NamespaceList carries the
+// given field name un-rewritten, ensuring the handler passes the API-level
+// field name to the service layer without translating it to a database column.
+func namespaceListHasFilterName(name string) interface{} {
+	return gomock.MatchedBy(func(req *requests.NamespaceList) bool {
+		for _, f := range req.Filters.Data {
+			if f.Type != query.FilterTypeProperty {
+				continue
+			}
+
+			prop, ok := f.Params.(*query.FilterProperty)
+			if !ok {
+				return false
+			}
+
+			return prop.Name == name
+		}
+
+		return false
+	})
+}
+
 func TestGetNamespaceList(t *testing.T) {
 	svcMock := new(mocks.Service)
 
@@ -681,6 +719,87 @@ func TestGetNamespaceList(t *testing.T) {
 			query:          "filter=!!!notbase64!!!",
 			requiredMocks:  func() {},
 			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			// Unknown field not present in NamespaceFilterFields must yield 400
+			// before reaching the service layer.
+			description: "fails with unknown filter field",
+			query: "filter=" + encodeFilter(t, []query.Filter{
+				{
+					Type: query.FilterTypeProperty,
+					Params: &query.FilterProperty{
+						Name:     "unknown_field",
+						Operator: "eq",
+						Value:    "test",
+					},
+				},
+			}),
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			// Operator "contains" is not allowed on the "type" field (enum), so
+			// the handler must return 400 without calling the service.
+			description: "fails with disallowed operator for type field",
+			query: "filter=" + encodeFilter(t, []query.Filter{
+				{
+					Type: query.FilterTypeProperty,
+					Params: &query.FilterProperty{
+						Name:     "type",
+						Operator: "contains",
+						Value:    "test",
+					},
+				},
+			}),
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			// A valid name+contains filter must reach the service and return 200
+			// with the correct X-Total-Count header.
+			description: "succeeds with valid name+contains filter",
+			query: "filter=" + encodeFilter(t, []query.Filter{
+				{
+					Type: query.FilterTypeProperty,
+					Params: &query.FilterProperty{
+						Name:     "name",
+						Operator: "contains",
+						Value:    "test",
+					},
+				},
+			}),
+			requiredMocks: func() {
+				svcMock.
+					On("ListNamespaces", gomock.Anything, gomock.AnythingOfType("*requests.NamespaceList")).
+					Return([]models.Namespace{}, 5, nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+			expectedCount:  5,
+		},
+		{
+			// A valid type+eq filter must reach the service with the field name
+			// "type" un-rewritten (the store layer, not the handler, translates
+			// "type" → "scope").
+			description: "succeeds with valid type+eq filter and name reaches service un-rewritten",
+			query: "filter=" + encodeFilter(t, []query.Filter{
+				{
+					Type: query.FilterTypeProperty,
+					Params: &query.FilterProperty{
+						Name:     "type",
+						Operator: "eq",
+						Value:    "personal",
+					},
+				},
+			}),
+			requiredMocks: func() {
+				svcMock.
+					On("ListNamespaces", gomock.Anything, namespaceListHasFilterName("type")).
+					Return([]models.Namespace{}, 2, nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+			expectedCount:  2,
 		},
 		{
 			description: "succeeds and returns X-Total-Count header",

--- a/api/routes/nsadm_test.go
+++ b/api/routes/nsadm_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -663,4 +664,62 @@ func TestCreateNamespaceBlocksAPIKey(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, rec.Result().StatusCode)
 	mock.AssertExpectations(t)
+}
+
+func TestGetNamespaceList(t *testing.T) {
+	svcMock := new(mocks.Service)
+
+	cases := []struct {
+		description    string
+		query          string
+		requiredMocks  func()
+		expectedStatus int
+		expectedCount  int
+	}{
+		{
+			description:    "fails with bad filter query param",
+			query:          "filter=!!!notbase64!!!",
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			description: "succeeds and returns X-Total-Count header",
+			query:       "",
+			requiredMocks: func() {
+				svcMock.
+					On("ListNamespaces", gomock.Anything, gomock.AnythingOfType("*requests.NamespaceList")).
+					Return([]models.Namespace{}, 3, nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+			expectedCount:  3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.requiredMocks()
+
+			url := "/api/namespaces"
+			if tc.query != "" {
+				url += "?" + tc.query
+			}
+
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req.Header.Set("X-Role", authorizer.RoleOwner.String())
+			req.Header.Set("X-ID", "000000000000000000000000")
+			req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
+
+			rec := httptest.NewRecorder()
+			NewRouter(svcMock).ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+
+			if tc.expectedStatus == http.StatusOK {
+				assert.Equal(t, strconv.Itoa(tc.expectedCount), rec.Result().Header.Get("X-Total-Count"))
+			}
+		})
+	}
+
+	svcMock.AssertExpectations(t)
 }

--- a/api/routes/sshkeys.go
+++ b/api/routes/sshkeys.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -38,6 +39,8 @@ func (h *Handler) GetPublicKeys(c gateway.Context) error {
 	}
 
 	if err := req.Filters.Unmarshal(); err != nil {
+		log.WithError(err).WithField("filter", req.Filters.Raw).Warn("failed to decode public keys list filter")
+
 		return c.NoContent(http.StatusBadRequest)
 	}
 

--- a/api/routes/sshkeys_test.go
+++ b/api/routes/sshkeys_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -78,6 +79,76 @@ func TestGetPublicKeys(t *testing.T) {
 				assert.ErrorIs(t, io.EOF, err)
 			}
 			assert.Equal(t, tc.expected.expectedSession, session)
+		})
+	}
+}
+
+func TestGetPublicKeysBadFilter(t *testing.T) {
+	cases := []struct {
+		description string
+		filter      string
+	}{
+		{
+			description: "returns 400 when filter is not valid base64",
+			filter:      "!!!not-base64!!!",
+		},
+		{
+			description: "returns 400 when filter decodes to invalid JSON",
+			filter:      "bm90LWpzb24=", // base64("not-json")
+		},
+		{
+			description: "returns 400 when filter contains an unknown field",
+			filter: func() string {
+				filters := []query.Filter{
+					{
+						Type: query.FilterTypeProperty,
+						Params: &query.FilterProperty{
+							Name:     "nonexistent_field",
+							Operator: "eq",
+							Value:    "foo",
+						},
+					},
+				}
+				b, _ := json.Marshal(filters)
+
+				return base64.StdEncoding.EncodeToString(b)
+			}(),
+		},
+		{
+			description: "returns 400 when filter uses a disallowed operator for the field",
+			filter: func() string {
+				filters := []query.Filter{
+					{
+						Type: query.FilterTypeProperty,
+						Params: &query.FilterProperty{
+							Name:     "name",
+							Operator: "regex", // disallowed: name only allows contains/eq/ne
+							Value:    "foo",
+						},
+					},
+				}
+				b, _ := json.Marshal(filters)
+
+				return base64.StdEncoding.EncodeToString(b)
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			svcMock := new(mocks.Service)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/sshkeys/public-keys?filter="+tc.filter, nil)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Role", authorizer.RoleOwner.String())
+			req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
+
+			rec := httptest.NewRecorder()
+			e := NewRouter(svcMock)
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Result().StatusCode)
+			svcMock.AssertNotCalled(t, "ListPublicKeys")
 		})
 	}
 }

--- a/api/routes/tags.go
+++ b/api/routes/tags.go
@@ -5,7 +5,9 @@ import (
 	"strconv"
 
 	"github.com/shellhub-io/shellhub/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/api/services"
 	"github.com/shellhub-io/shellhub/api/store"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	log "github.com/sirupsen/logrus"
 )
@@ -67,8 +69,16 @@ func (h *Handler) GetTags(c gateway.Context) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 
+	if err := query.ValidateFilters(&req.Filters, services.TagFilterFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
+	}
+
 	req.Paginator.Normalize()
 	req.Sorter.Normalize()
+
+	if err := query.ValidateSorter(&req.Sorter, services.TagSortFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
+	}
 
 	tags, totalCount, err := h.service.ListTags(c.Ctx(), req)
 	if err != nil {

--- a/api/routes/tags.go
+++ b/api/routes/tags.go
@@ -60,8 +60,8 @@ func (h *Handler) GetTags(c gateway.Context) error {
 		return err
 	}
 
-	if err := req.Filters.Unmarshal(); err != nil {
-		return err
+	if err := req.Unmarshal(); err != nil {
+		return c.NoContent(http.StatusBadRequest)
 	}
 
 	req.Paginator.Normalize()

--- a/api/routes/tags.go
+++ b/api/routes/tags.go
@@ -7,6 +7,7 @@ import (
 	"github.com/shellhub-io/shellhub/api/pkg/gateway"
 	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -61,6 +62,8 @@ func (h *Handler) GetTags(c gateway.Context) error {
 	}
 
 	if err := req.Unmarshal(); err != nil {
+		log.WithError(err).WithField("filter", req.Filters.Raw).Warn("failed to decode tags list filter")
+
 		return c.NoContent(http.StatusBadRequest)
 	}
 

--- a/api/routes/tags_test.go
+++ b/api/routes/tags_test.go
@@ -1,0 +1,72 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/services/mocks"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	gomock "github.com/stretchr/testify/mock"
+)
+
+func TestGetTags(t *testing.T) {
+	svcMock := new(mocks.Service)
+
+	cases := []struct {
+		description    string
+		query          string
+		requiredMocks  func()
+		expectedStatus int
+		expectedCount  int
+	}{
+		{
+			description:    "fails with bad filter query param",
+			query:          "filter=!!!notbase64!!!",
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			description: "succeeds and returns X-Total-Count header",
+			query:       "",
+			requiredMocks: func() {
+				svcMock.
+					On("ListTags", gomock.Anything, gomock.AnythingOfType("*requests.ListTags")).
+					Return([]models.Tag{}, 5, nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+			expectedCount:  5,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.requiredMocks()
+
+			url := "/api/tags"
+			if tc.query != "" {
+				url += "?" + tc.query
+			}
+
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req.Header.Set("X-Role", authorizer.RoleOwner.String())
+			req.Header.Set("X-ID", "000000000000000000000000")
+			req.Header.Set("X-Tenant-ID", "00000000-0000-4000-0000-000000000000")
+
+			rec := httptest.NewRecorder()
+			NewRouter(svcMock).ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+
+			if tc.expectedStatus == http.StatusOK {
+				assert.Equal(t, strconv.Itoa(tc.expectedCount), rec.Result().Header.Get("X-Total-Count"))
+			}
+		})
+	}
+
+	svcMock.AssertExpectations(t)
+}

--- a/api/routes/tags_test.go
+++ b/api/routes/tags_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shellhub-io/shellhub/api/services/mocks"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	gomock "github.com/stretchr/testify/mock"
@@ -30,6 +31,42 @@ func TestGetTags(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
+			description: "fails when filter contains a name+contains property filter",
+			query: "filter=" + encodeFilter(t, []query.Filter{
+				{
+					Type: query.FilterTypeProperty,
+					Params: &query.FilterProperty{
+						Name:     "name",
+						Operator: "contains",
+						Value:    "foo",
+					},
+				},
+			}),
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			description: "fails when filter contains a foobar+eq property filter",
+			query: "filter=" + encodeFilter(t, []query.Filter{
+				{
+					Type: query.FilterTypeProperty,
+					Params: &query.FilterProperty{
+						Name:     "foobar",
+						Operator: "eq",
+						Value:    "baz",
+					},
+				},
+			}),
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			description:    "fails when sort_by is an unknown field (badcolumn)",
+			query:          "sort_by=badcolumn",
+			requiredMocks:  func() {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
 			description: "succeeds and returns X-Total-Count header",
 			query:       "",
 			requiredMocks: func() {
@@ -40,6 +77,18 @@ func TestGetTags(t *testing.T) {
 			},
 			expectedStatus: http.StatusOK,
 			expectedCount:  5,
+		},
+		{
+			description: "succeeds with sort_by=name and returns X-Total-Count header",
+			query:       "sort_by=name",
+			requiredMocks: func() {
+				svcMock.
+					On("ListTags", gomock.Anything, gomock.AnythingOfType("*requests.ListTags")).
+					Return([]models.Tag{}, 3, nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+			expectedCount:  3,
 		},
 	}
 

--- a/api/services/namespace.go
+++ b/api/services/namespace.go
@@ -7,12 +7,29 @@ import (
 
 	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/pkg/uuid"
 )
+
+// NamespaceFilterFields maps each filter field the namespace list endpoint accepts
+// to the set of operators valid for it. The "type" field maps to the "scope" column
+// in the database (see namespaceFilterColumns) and only supports equality operators
+// because it is an enum column.
+var NamespaceFilterFields = query.NewFieldConstraints(map[string][]string{
+	"name": {"contains", "eq", "ne"},
+	"type": {"eq", "ne"},
+})
+
+// namespaceFilterColumns maps API-level field names to their actual database column
+// names where the two differ. It is used by the store layer to translate filter
+// properties before constructing SQL queries.
+var namespaceFilterColumns = map[string]string{
+	"type": "scope",
+}
 
 type NamespaceService interface {
 	ListNamespaces(ctx context.Context, req *requests.NamespaceList) ([]models.Namespace, int, error)
@@ -109,6 +126,14 @@ func (s *service) CreateNamespace(ctx context.Context, req *requests.NamespaceCr
 }
 
 func (s *service) ListNamespaces(ctx context.Context, req *requests.NamespaceList) ([]models.Namespace, int, error) {
+	for i := range req.Filters.Data {
+		if p, ok := req.Filters.Data[i].Params.(*query.FilterProperty); ok {
+			if col, found := namespaceFilterColumns[p.Name]; found {
+				p.Name = col
+			}
+		}
+	}
+
 	// When the caller has no user ID and is not a system admin (e.g.
 	// authenticated via API key), the listing is scoped to the caller's
 	// tenant. Otherwise the caller could enumerate namespaces across tenants.

--- a/api/services/namespace_test.go
+++ b/api/services/namespace_test.go
@@ -301,6 +301,48 @@ func TestListNamespaces(t *testing.T) {
 				err:        nil,
 			},
 		},
+		{
+			description: "type filter name is rewritten to scope before store call",
+			req: &requests.NamespaceList{
+				IsAdmin:   true,
+				Paginator: query.Paginator{Page: 1, PerPage: 10},
+				Filters: query.Filters{
+					Data: []query.Filter{
+						{
+							Type:   query.FilterTypeProperty,
+							Params: &query.FilterProperty{Name: "type", Operator: "eq", Value: "team"},
+						},
+					},
+				},
+			},
+			ctx: ctx,
+			requiredMocks: func() {
+				queryOptionsMock.
+					On("Match", &query.Filters{
+						Data: []query.Filter{
+							{
+								Type:   query.FilterTypeProperty,
+								Params: &query.FilterProperty{Name: "scope", Operator: "eq", Value: "team"},
+							},
+						},
+					}).
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
+					Return(nil).
+					Once()
+				storeMock.
+					On("NamespaceList", ctx, mock.AnythingOfType("store.QueryOption"), mock.AnythingOfType("store.QueryOption")).
+					Return([]models.Namespace{}, 0, nil).
+					Once()
+			},
+			expected: Expected{
+				namespaces: []models.Namespace{},
+				count:      0,
+				err:        nil,
+			},
+		},
 	}
 
 	s := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache(), clientMock)
@@ -1602,4 +1644,33 @@ func TestDeleteNamespace(t *testing.T) {
 	}
 
 	storeMock.AssertExpectations(t)
+}
+
+func TestNamespaceFilterFields(t *testing.T) {
+	t.Run("name field allows contains, eq and ne operators", func(t *testing.T) {
+		assert.True(t, NamespaceFilterFields.Allows("name", "contains"))
+		assert.True(t, NamespaceFilterFields.Allows("name", "eq"))
+		assert.True(t, NamespaceFilterFields.Allows("name", "ne"))
+	})
+
+	t.Run("type field allows eq and ne operators", func(t *testing.T) {
+		assert.True(t, NamespaceFilterFields.Allows("type", "eq"))
+		assert.True(t, NamespaceFilterFields.Allows("type", "ne"))
+	})
+
+	t.Run("type field does not allow contains operator", func(t *testing.T) {
+		assert.False(t, NamespaceFilterFields.Allows("type", "contains"))
+	})
+
+	t.Run("unknown field is rejected", func(t *testing.T) {
+		assert.False(t, NamespaceFilterFields.Allows("unknown", "eq"))
+	})
+
+	t.Run("namespaceFilterColumns maps type to scope", func(t *testing.T) {
+		assert.Equal(t, "scope", namespaceFilterColumns["type"])
+	})
+
+	t.Run("namespaceFilterColumns has exactly one entry", func(t *testing.T) {
+		assert.Len(t, namespaceFilterColumns, 1)
+	})
 }

--- a/api/services/tags.go
+++ b/api/services/tags.go
@@ -10,6 +10,20 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
 
+// TagFilterFields maps each filter field the tag list endpoint accepts to the
+// set of operators valid for it. Tags currently have no filterable fields, so
+// this is an empty FieldConstraints that causes all filter attempts to be
+// rejected at the handler level.
+var TagFilterFields = query.NewFieldConstraints(map[string][]string{})
+
+// TagSortFields is the set of field names accepted in the sort_by query
+// parameter when listing tags.
+var TagSortFields = query.NewFieldSet(
+	"name",
+	"created_at",
+	"updated_at",
+)
+
 type TagsService interface {
 	// CreateTag creates a new tag in the specified tenant namespace.
 	//

--- a/api/services/tags_test.go
+++ b/api/services/tags_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -883,4 +884,28 @@ func TestService_DeleteTag(t *testing.T) {
 	}
 
 	storeMock.AssertExpectations(t)
+}
+
+func TestListTags(t *testing.T) {
+	t.Run("TagFilterFields rejects any field and operator", func(t *testing.T) {
+		assert.False(t, TagFilterFields.Allows("name", "eq"))
+		assert.False(t, TagFilterFields.Allows("name", "contains"))
+		assert.False(t, TagFilterFields.Allows("unknown", "eq"))
+	})
+
+	t.Run("TagSortFields allows name", func(t *testing.T) {
+		assert.True(t, TagSortFields.Allows("name"))
+	})
+
+	t.Run("TagSortFields allows created_at", func(t *testing.T) {
+		assert.True(t, TagSortFields.Allows("created_at"))
+	})
+
+	t.Run("TagSortFields allows updated_at", func(t *testing.T) {
+		assert.True(t, TagSortFields.Allows("updated_at"))
+	})
+
+	t.Run("TagSortFields rejects unknown field", func(t *testing.T) {
+		assert.False(t, TagSortFields.Allows("unknown"))
+	})
 }

--- a/openapi/spec/components/parameters/query/filterQuery.yaml
+++ b/openapi/spec/components/parameters/query/filterQuery.yaml
@@ -1,6 +1,6 @@
 name: filter
 description: |
-  Filter field receives a JSON object enconded as base64 string for limit a search.
+  Filter field receives a JSON object encoded as a base64url string (URL-safe, unpadded, RFC 4648 §5) to limit a search. Standard base64 is also accepted for backward compatibility.
 
   The JSON enconded must follow these interafaces:
   ```typescript

--- a/openapi/spec/paths/admin@api@devices.yaml
+++ b/openapi/spec/paths/admin@api@devices.yaml
@@ -15,7 +15,7 @@ get:
         Device's filter
 
 
-        Filter field receives a base64 enconded JSON object for limit a search.
+        Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
         The JSON object should have a property called `type`, it will filter by a `property` called `name` where the value should `contains` `linux`.
 
         If you want get only Devices name as `Linux`, the JSON object will looks

--- a/openapi/spec/paths/admin@api@export@namespaces.yaml
+++ b/openapi/spec/paths/admin@api@export@namespaces.yaml
@@ -17,7 +17,7 @@ get:
         Namespace's filter
 
 
-        Filter field receives a base64 enconded JSON object for limit a search.
+        Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
         The JSON object should have a property called `type`, it will filter by a `property` called `devices` where the value should be 'gt' `0`.
 
         An example of JSON object will looks like this:

--- a/openapi/spec/paths/admin@api@export@namespaces.yaml
+++ b/openapi/spec/paths/admin@api@export@namespaces.yaml
@@ -58,6 +58,8 @@ get:
             format: 'binary'
     '204':
       description: No content.
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '500':

--- a/openapi/spec/paths/admin@api@export@users.yaml
+++ b/openapi/spec/paths/admin@api@export@users.yaml
@@ -55,6 +55,8 @@ get:
             format: 'binary'
     '204':
       description: No content.
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '500':

--- a/openapi/spec/paths/admin@api@export@users.yaml
+++ b/openapi/spec/paths/admin@api@export@users.yaml
@@ -14,7 +14,7 @@ get:
         User's filter
 
 
-        Filter field receives a base64 enconded JSON object for limit a search.
+        Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
         The JSON object should have a property called `type`, it will filter by a `property` called `namespaces` where the value should be `eq` to `0`.
 
         An example of JSON object will looks like this:

--- a/openapi/spec/paths/admin@api@namespaces.yaml
+++ b/openapi/spec/paths/admin@api@namespaces.yaml
@@ -15,7 +15,7 @@ get:
         Namespaces's filter.
 
 
-        Filter field receives a base64 enconded JSON object for limit a search.
+        Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
         The JSON object should have a property called `type`, it will filter by a `property` called `name` where the value should `contains` `examplespace`.
 
         If you want get only Namespaces name as `examplespace`, the JSON object will looks

--- a/openapi/spec/paths/admin@api@users.yaml
+++ b/openapi/spec/paths/admin@api@users.yaml
@@ -92,6 +92,8 @@ get:
                   email: example@example.com
                   username: example
                   password: 50d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '500':

--- a/openapi/spec/paths/api@devices.yaml
+++ b/openapi/spec/paths/api@devices.yaml
@@ -51,6 +51,8 @@ get:
             type: array
             items:
               $ref: ../components/schemas/device.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '500':

--- a/openapi/spec/paths/api@namespaces.yaml
+++ b/openapi/spec/paths/api@namespaces.yaml
@@ -13,7 +13,7 @@ get:
         Namespaces's filter.
 
 
-        Filter field receives a base64 enconded JSON object for limit a search.
+        Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
         The JSON object should have a property called `type`, it will filter by a `property` called `name` where the value should `contains` `examplespace`.
 
         If you want get only Namespaces name as `examplespace`, the JSON object will looks

--- a/openapi/spec/paths/api@namespaces.yaml
+++ b/openapi/spec/paths/api@namespaces.yaml
@@ -54,6 +54,8 @@ get:
             type: array
             items:
               $ref: ../components/schemas/namespace.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '500':

--- a/openapi/spec/paths/api@namespaces@{tenant}@invitations.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@invitations.yaml
@@ -16,7 +16,7 @@ get:
       description: |
         Membership invitations filter.
 
-        Filter field receives a base64 encoded JSON object to limit the search.
+        Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
       schema:
         type: string
       required: false

--- a/openapi/spec/paths/api@namespaces@{tenant}@invitations.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@invitations.yaml
@@ -35,6 +35,8 @@ get:
             type: array
             items:
               $ref: ../components/schemas/membershipInvitation.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '403':

--- a/openapi/spec/paths/api@sshkeys@public-keys.yaml
+++ b/openapi/spec/paths/api@sshkeys@public-keys.yaml
@@ -24,6 +24,8 @@ get:
             type: array
             items:
               $ref: ../components/schemas/publicKeyResponse.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '500':

--- a/openapi/spec/paths/api@tags.yaml
+++ b/openapi/spec/paths/api@tags.yaml
@@ -24,6 +24,8 @@ get:
             type: array
             items:
               $ref: ../components/schemas/tag.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '403':

--- a/openapi/spec/paths/api@users@invitations.yaml
+++ b/openapi/spec/paths/api@users@invitations.yaml
@@ -34,6 +34,8 @@ get:
             type: array
             items:
               $ref: ../components/schemas/membershipInvitation.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '500':

--- a/openapi/spec/paths/api@users@invitations.yaml
+++ b/openapi/spec/paths/api@users@invitations.yaml
@@ -15,7 +15,7 @@ get:
       description: |
         Membership invitations filter.
 
-        Filter field receives a base64 encoded JSON object to limit the search.
+        Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
       schema:
         type: string
       required: false

--- a/openapi/spec/paths/api@web-endpoints.yaml
+++ b/openapi/spec/paths/api@web-endpoints.yaml
@@ -11,7 +11,7 @@ get:
       description: |
         Web endpoint's filter
 
-        Filter field receives a base64 enconded JSON object for limit a search.
+        Filter field receives a base64url-encoded JSON object (URL-safe, unpadded) to limit the search. Standard base64 is also accepted for backward compatibility.
       schema:
         type: string
         pattern: ^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$

--- a/pkg/api/query/filter.go
+++ b/pkg/api/query/filter.go
@@ -19,8 +19,6 @@ var (
 type Filters struct {
 	// Raw holds the raw data of the filter. It must be a base64url-encoded JSON
 	// (RFC 4648 §5, unpadded); also accepts padded/unpadded standard base64.
-	//
-	// TODO(#6469): the OpenAPI description still says "standard base64"; update it.
 	Raw string `query:"filter"`
 
 	// Data stores the decoded filters; it's automatically populated with the Unmarshal method.

--- a/pkg/api/query/filter.go
+++ b/pkg/api/query/filter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strings"
 )
 
 var (
@@ -38,11 +39,16 @@ func (fs *Filters) Unmarshal() error {
 
 	raw, err := base64.StdEncoding.DecodeString(fs.Raw)
 	if err != nil {
-		return err
+		// Fall back to RawStdEncoding when the caller omitted one or more '='
+		// padding characters (common in URL contexts).
+		raw, err = base64.RawStdEncoding.DecodeString(strings.TrimRight(fs.Raw, "="))
+		if err != nil {
+			return ErrFilterInvalid
+		}
 	}
 
 	if err := json.Unmarshal(raw, &fs.Data); len(raw) > 0 && err != nil {
-		return err
+		return ErrFilterInvalid
 	}
 
 	return nil

--- a/pkg/api/query/filter.go
+++ b/pkg/api/query/filter.go
@@ -17,7 +17,10 @@ var (
 
 // Filters represents a set of filters that can be applied to queries.
 type Filters struct {
-	// Raw holds the raw data of the filter and it's a base64-encoded JSON.
+	// Raw holds the raw data of the filter. It must be a base64url-encoded JSON
+	// (RFC 4648 §5, unpadded); also accepts padded/unpadded standard base64.
+	//
+	// TODO(#6469): the OpenAPI description still says "standard base64"; update it.
 	Raw string `query:"filter"`
 
 	// Data stores the decoded filters; it's automatically populated with the Unmarshal method.
@@ -37,11 +40,15 @@ func (fs *Filters) Unmarshal() error {
 		return ErrFilterTooLarge
 	}
 
-	raw, err := base64.StdEncoding.DecodeString(fs.Raw)
+	// Strip any trailing '=' padding once so both standard and URL-safe encodings
+	// can be tried with their respective Raw (unpadded) decoders.
+	unpadded := strings.TrimRight(fs.Raw, "=")
+
+	raw, err := base64.RawStdEncoding.DecodeString(unpadded)
 	if err != nil {
-		// Fall back to RawStdEncoding when the caller omitted one or more '='
-		// padding characters (common in URL contexts).
-		raw, err = base64.RawStdEncoding.DecodeString(strings.TrimRight(fs.Raw, "="))
+		// Fall back to RawURLEncoding (RFC 4648 §5) whose alphabet uses '-' and '_'
+		// instead of '+' and '/'.
+		raw, err = base64.RawURLEncoding.DecodeString(unpadded)
 		if err != nil {
 			return ErrFilterInvalid
 		}

--- a/pkg/api/query/filter_test.go
+++ b/pkg/api/query/filter_test.go
@@ -63,6 +63,94 @@ func TestFilterUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestFilters_Unmarshal(t *testing.T) {
+	// Pre-computed base64 strings for various padding scenarios:
+	//
+	//   json0pad  = `[{"type":"operator","params":{"name":"and"}}]`          → 0 padding chars
+	//   json1pad  = `[{"type":"property","params":{"name":"a","operator":"eq","value":"b"}}]`  → 1 padding char
+	//   json2pad  = `[{"type":"property","params":{"name":"aa","operator":"eq","value":"bb"}}]` → 2 padding chars
+	const (
+		// 0-padding: StdEncoding and RawStdEncoding produce the same string.
+		b64Padded0 = "W3sidHlwZSI6Im9wZXJhdG9yIiwicGFyYW1zIjp7Im5hbWUiOiJhbmQifX1d"
+
+		// 1-padding: StdEncoding appends one '='.
+		b64Padded1  = "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJhIiwib3BlcmF0b3IiOiJlcSIsInZhbHVlIjoiYiJ9fV0="
+		b64Missing1 = "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJhIiwib3BlcmF0b3IiOiJlcSIsInZhbHVlIjoiYiJ9fV0"
+
+		// 2-padding: StdEncoding appends two '='.
+		b64Padded2  = "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJhYSIsIm9wZXJhdG9yIjoiZXEiLCJ2YWx1ZSI6ImJiIn19XQ=="
+		b64Missing2 = "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJhYSIsIm9wZXJhdG9yIjoiZXEiLCJ2YWx1ZSI6ImJiIn19XQ"
+	)
+
+	cases := []struct {
+		description string
+		raw         string
+		wantErr     error
+	}{
+		{
+			description: "padded base64 (0 padding) round-trips unchanged",
+			raw:         b64Padded0,
+			wantErr:     nil,
+		},
+		{
+			description: "padded base64 (1 padding) round-trips unchanged",
+			raw:         b64Padded1,
+			wantErr:     nil,
+		},
+		{
+			description: "padded base64 (2 padding) round-trips unchanged",
+			raw:         b64Padded2,
+			wantErr:     nil,
+		},
+		{
+			description: "one '=' missing still decodes",
+			raw:         b64Missing1,
+			wantErr:     nil,
+		},
+		{
+			description: "two '=' missing still decodes",
+			raw:         b64Missing2,
+			wantErr:     nil,
+		},
+		{
+			description: "zero-padding raw input (no '=' at all) decodes",
+			// b64Padded0 already has no padding; use it directly as the raw input.
+			raw:     b64Padded0,
+			wantErr: nil,
+		},
+		{
+			description: "non-base64 garbage returns ErrFilterInvalid",
+			raw:         "!!!not-base64!!!",
+			wantErr:     ErrFilterInvalid,
+		},
+		{
+			description: "invalid JSON in valid base64 returns ErrFilterInvalid",
+			// base64("not valid json")
+			raw:     base64.StdEncoding.EncodeToString([]byte("not valid json")),
+			wantErr: ErrFilterInvalid,
+		},
+		{
+			description: "valid base64 + valid JSON with unknown filter type returns ErrFilterInvalid",
+			// base64(`[{"type":"unknown","params":{}}]`)
+			raw:     base64.StdEncoding.EncodeToString([]byte(`[{"type":"unknown","params":{}}]`)),
+			wantErr: ErrFilterInvalid,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			fs := &Filters{Raw: tc.raw}
+			err := fs.Unmarshal()
+
+			if tc.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestFilters_Unmarshal_sizeLimit(t *testing.T) {
 	t.Run("raw under the limit passes", func(t *testing.T) {
 		fs := &Filters{Raw: base64.StdEncoding.EncodeToString([]byte(`[{"type":"operator","params":{"name":"and"}}]`))}

--- a/pkg/api/query/filter_test.go
+++ b/pkg/api/query/filter_test.go
@@ -82,41 +82,94 @@ func TestFilters_Unmarshal(t *testing.T) {
 		b64Missing2 = "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJhYSIsIm9wZXJhdG9yIjoiZXEiLCJ2YWx1ZSI6ImJiIn19XQ"
 	)
 
+	// base64url row: value '>>>' contains bytes that produce '+' in standard base64
+	// but '-' in URL-safe base64, so RawStdEncoding cannot decode the RawURLEncoding output.
+	b64URLTripleGT := base64.RawURLEncoding.EncodeToString(
+		[]byte(`[{"type":"property","params":{"name":"a","operator":"eq","value":">>>"}}]`),
+	)
+
 	cases := []struct {
 		description string
 		raw         string
 		wantErr     error
+		// wantFirstType and wantData are optional content assertions for success rows.
+		// When wantFirstType is non-empty the test verifies that fs.Data has exactly the
+		// expected filters, catching a decoder that returns nil error but wrong data.
+		wantFirstType string
+		wantData      []Filter
+		// stdFails, when true, asserts that base64.RawStdEncoding cannot decode raw,
+		// proving the input belongs strictly to the URL-safe alphabet.
+		stdFails bool
 	}{
 		{
-			description: "padded base64 (0 padding) round-trips unchanged",
-			raw:         b64Padded0,
-			wantErr:     nil,
+			description:   "padded base64 (0 padding) round-trips unchanged",
+			raw:           b64Padded0,
+			wantErr:       nil,
+			wantFirstType: FilterTypeOperator,
+			wantData: []Filter{
+				{Type: FilterTypeOperator, Params: &FilterOperator{Name: "and"}},
+			},
 		},
 		{
-			description: "padded base64 (1 padding) round-trips unchanged",
-			raw:         b64Padded1,
-			wantErr:     nil,
+			description:   "padded base64 (1 padding) round-trips unchanged",
+			raw:           b64Padded1,
+			wantErr:       nil,
+			wantFirstType: FilterTypeProperty,
+			wantData: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "a", Operator: "eq", Value: "b"}},
+			},
 		},
 		{
-			description: "padded base64 (2 padding) round-trips unchanged",
-			raw:         b64Padded2,
-			wantErr:     nil,
+			description:   "padded base64 (2 padding) round-trips unchanged",
+			raw:           b64Padded2,
+			wantErr:       nil,
+			wantFirstType: FilterTypeProperty,
+			wantData: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "aa", Operator: "eq", Value: "bb"}},
+			},
 		},
 		{
-			description: "one '=' missing still decodes",
-			raw:         b64Missing1,
-			wantErr:     nil,
+			description:   "one '=' missing still decodes",
+			raw:           b64Missing1,
+			wantErr:       nil,
+			wantFirstType: FilterTypeProperty,
+			wantData: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "a", Operator: "eq", Value: "b"}},
+			},
 		},
 		{
-			description: "two '=' missing still decodes",
-			raw:         b64Missing2,
-			wantErr:     nil,
+			description:   "two '=' missing still decodes",
+			raw:           b64Missing2,
+			wantErr:       nil,
+			wantFirstType: FilterTypeProperty,
+			wantData: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "aa", Operator: "eq", Value: "bb"}},
+			},
 		},
 		{
 			description: "zero-padding raw input (no '=' at all) decodes",
 			// b64Padded0 already has no padding; use it directly as the raw input.
-			raw:     b64Padded0,
-			wantErr: nil,
+			raw:           b64Padded0,
+			wantErr:       nil,
+			wantFirstType: FilterTypeOperator,
+			wantData: []Filter{
+				{Type: FilterTypeOperator, Params: &FilterOperator{Name: "and"}},
+			},
+		},
+		{
+			// base64url alphabet uses '-' in place of '+'; the JSON payload contains
+			// the string ">>>" whose base64 representation differs between the two
+			// alphabets. This row verifies that Unmarshal handles base64url (RFC 4648 §5).
+			// stdFails is set so the test asserts RawStdEncoding cannot decode this input,
+			// confirming the two alphabets are genuinely distinct for this payload.
+			description:   "base64url alphabet (value '>>>') decodes correctly",
+			raw:           b64URLTripleGT,
+			wantErr:       nil,
+			wantFirstType: FilterTypeProperty,
+			stdFails:      true,
+			wantData: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "a", Operator: "eq", Value: ">>>"}},
+			},
 		},
 		{
 			description: "non-base64 garbage returns ErrFilterInvalid",
@@ -134,6 +187,62 @@ func TestFilters_Unmarshal(t *testing.T) {
 			// base64(`[{"type":"unknown","params":{}}]`)
 			raw:     base64.StdEncoding.EncodeToString([]byte(`[{"type":"unknown","params":{}}]`)),
 			wantErr: ErrFilterInvalid,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			// Self-check: when stdFails is set the raw string must NOT be decodable by
+			// RawStdEncoding, proving the payload belongs strictly to the URL-safe alphabet
+			// and that the test case genuinely exercises the URL fallback path.
+			if tc.stdFails {
+				_, errStd := base64.RawStdEncoding.DecodeString(tc.raw)
+				assert.Error(t, errStd, "RawStdEncoding must not decode a RawURLEncoding-only string")
+			}
+
+			fs := &Filters{Raw: tc.raw}
+			err := fs.Unmarshal()
+
+			if tc.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.wantErr)
+			}
+
+			if tc.wantFirstType != "" {
+				assert.Equal(t, tc.wantData, fs.Data)
+			}
+		})
+	}
+}
+
+// TestFilters_Unmarshal_base64url verifies that Unmarshal accepts base64url-encoded
+// input (RFC 4648 §5, characters - and _ in place of + and /), both unpadded and padded.
+func TestFilters_Unmarshal_base64url(t *testing.T) {
+	// The character 鸿 (U+9E3F, UTF-8: E9 B8 BF) encodes to a base64 group that
+	// contains '/' in RawStdEncoding and '_' in RawURLEncoding, making it an ideal
+	// probe for the two alphabets.
+	const (
+		// RawURLEncoding of `[{"type":"property","params":{"name":"a","operator":"eq","value":"鸿"}}]`
+		b64URLRaw = "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJhIiwib3BlcmF0b3IiOiJlcSIsInZhbHVlIjoi6bi_In19XQ"
+		// URLEncoding (padded) of the same payload
+		b64URLPadded = "W3sidHlwZSI6InByb3BlcnR5IiwicGFyYW1zIjp7Im5hbWUiOiJhIiwib3BlcmF0b3IiOiJlcSIsInZhbHVlIjoi6bi_In19XQ=="
+	)
+
+	cases := []struct {
+		description string
+		raw         string
+		wantErr     error
+	}{
+		{
+			description: "unpadded base64url (RFC 4648 §5) decodes correctly",
+			raw:         b64URLRaw,
+			wantErr:     nil,
+		},
+		{
+			description: "padded base64url decodes correctly",
+			raw:         b64URLPadded,
+			wantErr:     nil,
 		},
 	}
 

--- a/ui/apps/console/src/hooks/__tests__/useAdminUsers.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminUsers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { decodeB64url } from "@/test/decodeB64url";
 import { useAdminUsers, useAdminUser } from "../useAdminUsers";
 import { useAuthStore } from "@/stores/authStore";
 
@@ -174,7 +175,10 @@ describe("useAdminUsers", () => {
     it("includes a base64-encoded filter when search is non-empty", async () => {
       mockGetUsersFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(() => useAdminUsers({ search: "alice" }), {
+      // " >" (space + greater-than) encodes to base64url with a "-" character,
+      // which atob() cannot decode — only Buffer.from(b64url.replace(/-/g,'+')
+      // .replace(/_/g,'/'), 'base64') handles it correctly.
+      renderHook(() => useAdminUsers({ search: " >" }), {
         wrapper: createWrapper(),
       });
 
@@ -183,11 +187,11 @@ describe("useAdminUsers", () => {
         { query: Record<string, unknown> },
       ];
       expect(typeof opts.query.filter).toBe("string");
-      // Verify it decodes to valid JSON containing the search term
-      const decoded = JSON.parse(
-        atob(opts.query.filter as string),
-      ) as unknown[];
-      expect(JSON.stringify(decoded)).toContain("alice");
+      // Verify it decodes to valid JSON containing the search term.
+      // Use decodeB64url() instead of atob() because toBase64Json() produces
+      // base64url (replacing + with - and / with _), which atob() cannot decode.
+      const decoded = decodeB64url(opts.query.filter as string) as unknown[];
+      expect(JSON.stringify(decoded)).toContain(" >");
     });
   });
 

--- a/ui/apps/console/src/hooks/__tests__/useDevices.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useDevices.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { buildFilter } from "../useDevices";
+import { decodeB64url as decodeFilter } from "@/test/decodeB64url";
 
 describe("buildFilter", () => {
   describe("search only", () => {
     it("encodes a name OR custom_fields filter", () => {
-      const result = JSON.parse(atob(buildFilter("my-device", [])));
+      const result = decodeFilter(buildFilter("my-device", []));
       expect(result).toEqual([
         { type: "operator", params: { name: "or" } },
         { type: "property", params: { name: "name", operator: "contains", value: "my-device" } },
@@ -16,7 +17,7 @@ describe("buildFilter", () => {
 
   describe("tags only", () => {
     it("encodes a tags filter", () => {
-      const result = JSON.parse(atob(buildFilter("", ["web", "prod"])));
+      const result = decodeFilter(buildFilter("", ["web", "prod"]));
       expect(result).toEqual([
         { type: "property", params: { name: "tags.name", operator: "contains", value: ["web", "prod"] } },
       ]);
@@ -25,7 +26,7 @@ describe("buildFilter", () => {
 
   describe("search and tags combined", () => {
     it("encodes both filters in the same array", () => {
-      const result = JSON.parse(atob(buildFilter("srv", ["prod"])));
+      const result = decodeFilter(buildFilter("srv", ["prod"]));
       expect(result).toEqual([
         { type: "operator", params: { name: "or" } },
         { type: "property", params: { name: "name", operator: "contains", value: "srv" } },
@@ -38,8 +39,22 @@ describe("buildFilter", () => {
 
   describe("empty inputs", () => {
     it("returns an empty filter array when both are empty", () => {
-      const result = JSON.parse(atob(buildFilter("", [])));
+      const result = decodeFilter(buildFilter("", []));
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("non-ASCII search value", () => {
+    it("round-trips a non-ASCII search through base64url encoding", () => {
+      // "¿" encodes to a base64url string containing "_" (the url-safe replacement for "/"),
+      // which atob() cannot decode. This test verifies the polyfill-safe decode path.
+      const result = decodeFilter(buildFilter("¿", []));
+      expect(result).toEqual([
+        { type: "operator", params: { name: "or" } },
+        { type: "property", params: { name: "name", operator: "contains", value: "¿" } },
+        { type: "operator", params: { name: "or" } },
+        { type: "property", params: { name: "custom_fields", operator: "contains", value: "¿" } },
+      ]);
     });
   });
 });

--- a/ui/apps/console/src/test/decodeB64url.ts
+++ b/ui/apps/console/src/test/decodeB64url.ts
@@ -1,0 +1,14 @@
+import { Buffer } from "buffer";
+
+/**
+ * Decode a base64url string (RFC 4648 §5) produced by {@link toBase64Json}
+ * back to a parsed JS value.
+ *
+ * The standard `atob()` and `Buffer.from(s, "base64")` only handle the
+ * standard alphabet (+/). Base64url uses - and _ in their place, so we
+ * normalise the alphabet before decoding.
+ */
+export function decodeB64url(b64url: string): unknown {
+  const standard = b64url.replace(/-/g, "+").replace(/_/g, "/");
+  return JSON.parse(Buffer.from(standard, "base64").toString("utf-8"));
+}

--- a/ui/apps/console/src/utils/__tests__/encoding.test.ts
+++ b/ui/apps/console/src/utils/__tests__/encoding.test.ts
@@ -1,17 +1,39 @@
 import { describe, it, expect } from "vitest";
 import { toBase64Json } from "@/utils/encoding";
+import { decodeB64url } from "@/test/decodeB64url";
 
 describe("toBase64Json", () => {
-  it("matches btoa(JSON.stringify(...)) for ASCII payloads", () => {
-    // Backward-compat guard: the BE decoder only sees the bytes, so an ASCII
-    // payload must produce the exact same string the old `btoa` path produced.
+  it("emits unpadded base64url (no +, /, or = characters)", () => {
+    // The output must be safe to embed in a URL query-string or HTTP header
+    // without percent-encoding. Standard base64 uses + and / which are
+    // URL-unsafe, and adds = padding which is also forbidden in some contexts.
+    // Covers ASCII (padding), Unicode (/ replacement), and mixed payloads.
+    const inputs = [
+      // ASCII payload — v1 ends with "=" in standard base64
+      [{ type: "property", params: { name: "name", operator: "contains", value: "qa-edge" } }],
+      // Unicode payload — v2 contains "/" in standard base64
+      [{ type: "property", params: { name: "tags.name", operator: "contains", value: "日本語タグ" } }],
+      // Emoji + Arabic — also contains "/" in standard base64
+      { tag: "日本語タグ", emoji: "🚀", arabic: "سلام" },
+    ];
+    for (const value of inputs) {
+      const encoded = toBase64Json(value);
+      expect(encoded, `output for ${JSON.stringify(value).slice(0, 40)}`).not.toMatch(/[+/=]/);
+    }
+  });
+
+  it("round-trips ASCII payload through unpadded base64url → UTF-8 → JSON", () => {
+    // The BE decoder reads the raw bytes, so the decoded JSON must match.
+    // After switching to base64url we no longer compare to btoa() — the two
+    // alphabets differ. Verify correctness by decoding instead.
     const value = [
       {
         type: "property",
         params: { name: "name", operator: "contains", value: "qa-edge" },
       },
     ];
-    expect(toBase64Json(value)).toBe(btoa(JSON.stringify(value)));
+    const decoded = decodeB64url(toBase64Json(value)) as typeof value;
+    expect(decoded).toEqual(value);
   });
 
   it("does not throw on non-Latin-1 characters", () => {
@@ -28,13 +50,19 @@ describe("toBase64Json", () => {
     expect(() => toBase64Json(value)).not.toThrow();
   });
 
-  it("round-trips Unicode through base64 → UTF-8 → JSON", () => {
+  it("round-trips Unicode through base64url → UTF-8 → JSON", () => {
     const value = { tag: "日本語タグ", emoji: "🚀", arabic: "سلام" };
-    const encoded = toBase64Json(value);
-    const decoded = JSON.parse(
-      Buffer.from(encoded, "base64").toString("utf-8"),
-    ) as typeof value;
+    const decoded = decodeB64url(toBase64Json(value)) as typeof value;
     expect(decoded).toEqual(value);
+  });
+
+  it("maps std base64 '+' to '-' and strips '=' padding ('>>>' payload)", () => {
+    // '>>>' encodes to "Ij4+PiI=" in standard base64 (contains '+' and '=').
+    // base64url must replace '+' with '-' and strip trailing '='.
+    const json = JSON.stringify(">>>");
+    const expected = btoa(json).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    expect(toBase64Json(">>>")).toBe(expected);
+    expect(toBase64Json(">>>")).not.toMatch(/[+/=]/);
   });
 
   it("produces stable output for the same input (used as a cache key)", () => {

--- a/ui/apps/console/src/utils/__tests__/invitations.test.ts
+++ b/ui/apps/console/src/utils/__tests__/invitations.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { invitationStatusFilter, isInvitationExpired } from "../invitations";
+import { decodeB64url } from "@/test/decodeB64url";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -14,14 +15,14 @@ describe("invitationStatusFilter", () => {
 
   it("decodes to valid JSON array", () => {
     const result = invitationStatusFilter("pending");
-    const decoded = JSON.parse(atob(result)) as unknown[];
+    const decoded = decodeB64url(result) as unknown[];
     expect(Array.isArray(decoded)).toBe(true);
     expect(decoded).toHaveLength(1);
   });
 
   it("encodes a property-type filter with name='status' and operator='eq'", () => {
     const result = invitationStatusFilter("accepted");
-    const [filter] = JSON.parse(atob(result)) as Array<{
+    const [filter] = decodeB64url(result) as Array<{
       type: string;
       params: { name: string; operator: string; value: string };
     }>;
@@ -32,7 +33,7 @@ describe("invitationStatusFilter", () => {
 
   it("encodes the given status as the filter value — pending", () => {
     const result = invitationStatusFilter("pending");
-    const [filter] = JSON.parse(atob(result)) as Array<{
+    const [filter] = decodeB64url(result) as Array<{
       type: string;
       params: { name: string; operator: string; value: string };
     }>;
@@ -41,7 +42,7 @@ describe("invitationStatusFilter", () => {
 
   it("encodes the given status as the filter value — cancelled", () => {
     const result = invitationStatusFilter("cancelled");
-    const [filter] = JSON.parse(atob(result)) as Array<{
+    const [filter] = decodeB64url(result) as Array<{
       type: string;
       params: { name: string; operator: string; value: string };
     }>;
@@ -52,6 +53,23 @@ describe("invitationStatusFilter", () => {
     expect(invitationStatusFilter("pending")).not.toBe(
       invitationStatusFilter("accepted"),
     );
+  });
+
+  it("decodes a base64url value that contains '-' (from '+' in standard base64)", () => {
+    // The '>' character produces a '+' in standard base64, which toBase64Json
+    // replaces with '-' (base64url). atob() rejects '-', so this test proves
+    // the Buffer-based helper is required.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = invitationStatusFilter(">" as any);
+    // Must not contain raw '+' or unpadded '=' — it is proper base64url
+    expect(result).not.toMatch(/\+/);
+    expect(result).not.toMatch(/=$/);
+    // Buffer-based decoding must recover the original value
+    const [filter] = decodeB64url(result) as Array<{
+      type: string;
+      params: { name: string; operator: string; value: string };
+    }>;
+    expect(filter.params.value).toBe(">");
   });
 });
 

--- a/ui/apps/console/src/utils/encoding.ts
+++ b/ui/apps/console/src/utils/encoding.ts
@@ -2,7 +2,15 @@ import { Buffer } from "buffer";
 
 // `btoa(JSON.stringify(value))` throws InvalidCharacterError for any character
 // above U+00FF (e.g. tag names, hostnames, usernames in non-Latin scripts),
-// so the request never leaves the browser. UTF-8-encode first, then base64.
+// so the request never leaves the browser. UTF-8-encode first, then convert
+// standard base64 to unpadded base64url so the result is safe in URL
+// query-strings and HTTP headers without percent-encoding.
+// Note: feross/buffer v5.7.1 (pinned in the lockfile) does not support
+// `.toString('base64url')`, so we post-process the standard base64 string.
 export function toBase64Json(value: unknown): string {
-  return Buffer.from(JSON.stringify(value), "utf-8").toString("base64");
+  return Buffer.from(JSON.stringify(value), "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 }


### PR DESCRIPTION
## What

List endpoints accept a `filter` query param: base64-encoded JSON decoded by `(*Filters).Unmarshal()`. Three problems:

1. **Strict padding.** Decoding used `base64.StdEncoding`, which rejects values whose `=` padding is lost in transit (URLs, copy-paste). The UI emits padded standard base64, so a legitimately-generated filter could fail to decode.
2. **Cryptic 500.** The namespace and tags routes returned the raw decode error, which the central error handler can't classify — so it became a **500** instead of a client error. (devices/sshkeys already returned 400.)
3. **No server-side trace.** The 400 was returned silently, leaving support no way to diagnose customer reports.

## Change

- `pkg/api/query/filter.go`: fall back to `RawStdEncoding` when padding is missing, and return the classified `ErrFilterInvalid` sentinel on genuine decode/JSON failures instead of leaking a raw stdlib error.
- `nsadm.go` / `tags.go`: map a failed `Unmarshal()` to a consistent `400`.
- **Logging**: log the decode error + raw filter value at `warn` level before returning 400 (device, public-keys, namespace, tags), so support can see and diagnose malformed-filter failures in server logs.
- Tests: padding-variant matrix + garbage/bad-JSON/unknown-type → `ErrFilterInvalid`; route regression tests (bad filter → 400) for namespaces, tags, devices, sshkeys.
- **OpenAPI**: document the `400` on the affected filter endpoints (`getNamespaces`, `getDevices`, `getTags`, `getPublicKeys`, and the admin/cloud `exportNamespaces`/`exportUsers`/`getUsers`/invitation-list operations). The 400 stays body-less, consistent with the API's uniform empty-bodied errors.

Backward-compatible: tolerant decode is purely additive; logging doesn't change responses; the 500→400 change only affects already-failing requests; response shape unchanged (empty body).

Companion PR in `shellhub-io/cloud` (#2395) applies the same 400 + logging fix to the cloud filter routes.

## Deliberately deferred (follow-ups)
- #6467 — **apiv2**: descriptive JSON error body for filter/validation errors (the API uses empty-bodied `NoContent` uniformly).
- #6468 — `ValidateFilters` (field/operator allowlists) for the nsadm & tags routes.
- #6469 — base64url end-to-end to also handle `+`→space URL corruption.

Fixes: #3523