### PR TITLE
chore: relax go directive to 1.25 across modules

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/agent
 
-go 1.25.8
+go 1.25
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/api
 
-go 1.25.8
+go 1.25
 
 require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/cli
 
-go 1.25.8
+go 1.25
 
 require (
 	github.com/shellhub-io/shellhub v0.0.0

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/gateway
 
-go 1.25.8
+go 1.25
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub
 
-go 1.25.8
+go 1.25
 
 require (
 	github.com/adhocore/gronx v1.8.1

--- a/openapi/go.mod
+++ b/openapi/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/openapi
 
-go 1.25.8
+go 1.25
 
 require github.com/shellhub-io/shellhub v0.0.0
 

--- a/ssh/go.mod
+++ b/ssh/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/ssh
 
-go 1.25.8
+go 1.25
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/tests
 
-go 1.25.8
+go 1.25
 
 require (
 	github.com/bramvdbogaerde/go-scp v1.5.0


### PR DESCRIPTION
## What

Relax the `go` directive from `go 1.25.8` to `go 1.25` across all eight
modules (`agent`, `api`, `cli`, `gateway`, `openapi`, `ssh`, `tests`, root).

## Why

`go 1.25.8` requires a toolchain of at least 1.25.8. Buildroot `2026.02`
ships Go `1.25.7`, and its golang package infra builds offline
(`GOPROXY=direct`, no toolchain download). The agent build fails trying
to resolve the unavailable 1.25.8 toolchain.

The `.8` patch was a leak from a contributor's local toolchain, not a real
constraint. The highest `go` directive across the entire agent dependency
graph (all 106 modules) is `1.25.0`, so `go 1.25` is the lowest valid
floor and keeps the same language version. The toolchain actually used is
whatever Buildroot pins, which decouples the build from Go patch bumps that
land in point releases.
