### PR TITLE
refactor(ui): add design-system primitives and adopt across apps

### DIFF
--- a/ui/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui/apps/console/src/components/ConnectDrawer.tsx
@@ -20,6 +20,7 @@ import RadioCard from "@/components/common/fields/RadioCard";
 import RadioGroupField from "@/components/common/fields/RadioGroupField";
 import RadioSegment from "@/components/common/fields/RadioSegment";
 import { INPUT, LABEL } from "../utils/styles";
+import { Card } from "@shellhub/design-system/primitives";
 import type { VaultKeyEntry } from "../types/vault";
 
 interface Props {
@@ -254,7 +255,7 @@ export default function ConnectDrawer({
           className="space-y-5"
         >
           {/* SSHID helper */}
-          <div className="bg-card border border-border rounded-lg p-3.5">
+          <Card className="rounded-lg p-3.5">
             <span className={LABEL}>Connect via terminal</span>
             <div className="flex items-center gap-2">
               <code className="text-xs font-mono flex-1 truncate">
@@ -289,7 +290,7 @@ export default function ConnectDrawer({
                 Enter your device OS username below to complete this command.
               </p>
             )}
-          </div>
+          </Card>
 
           <div className="flex items-center gap-3">
             <div className="flex-1 h-px bg-border" />

--- a/ui/apps/console/src/components/announcements/AnnouncementModal.tsx
+++ b/ui/apps/console/src/components/announcements/AnnouncementModal.tsx
@@ -5,6 +5,7 @@ import Link from "@tiptap/extension-link";
 import Image from "@tiptap/extension-image";
 import { Markdown } from "@tiptap/markdown";
 import { MegaphoneIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { IconBadge } from "@shellhub/design-system/primitives";
 import BaseDialog from "@/components/common/BaseDialog";
 import { formatDateShort } from "@/utils/date";
 import { isAllowedUrl } from "@/utils/url";
@@ -58,12 +59,17 @@ export default function AnnouncementModal({
   const titleId = useId();
 
   return (
-    <BaseDialog open={open} onClose={onClose} size="md" aria-labelledby={titleId}>
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      size="md"
+      aria-labelledby={titleId}
+    >
       <div className="flex items-start justify-between gap-4 p-6 border-b border-border">
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center shrink-0">
+          <IconBadge size="md">
             <MegaphoneIcon className="w-5 h-5 text-primary" strokeWidth={1.5} />
-          </div>
+          </IconBadge>
           <div>
             <h2
               id={titleId}
@@ -87,7 +93,10 @@ export default function AnnouncementModal({
       </div>
 
       <div className="p-6 overflow-y-auto max-h-[60vh]">
-        <AnnouncementContent key={announcement.uuid} content={announcement.content} />
+        <AnnouncementContent
+          key={announcement.uuid}
+          content={announcement.content}
+        />
       </div>
 
       <div className="flex justify-end gap-2 p-5 border-t border-border">

--- a/ui/apps/console/src/components/billing/BillingCheckout.tsx
+++ b/ui/apps/console/src/components/billing/BillingCheckout.tsx
@@ -1,3 +1,4 @@
+import { Card } from "@shellhub/design-system/primitives";
 import { useCustomer } from "@/hooks/useBilling";
 import BillingIcon from "./BillingIcon";
 
@@ -18,7 +19,7 @@ export default function BillingCheckout() {
       </div>
 
       {defaultPm ? (
-        <div className="bg-card border border-border rounded-xl p-4 flex items-center gap-4">
+        <Card className="p-4 flex items-center gap-4">
           <span className="shrink-0 text-text-primary">
             <BillingIcon brand={defaultPm.brand} className="w-8 h-8" />
           </span>
@@ -39,11 +40,11 @@ export default function BillingCheckout() {
               {defaultPm.exp_year}
             </p>
           </div>
-        </div>
+        </Card>
       ) : (
-        <div className="bg-card border border-border rounded-xl p-4 text-sm text-text-muted">
+        <Card className="p-4 text-sm text-text-muted">
           No default payment method. Go back and choose one before confirming.
-        </div>
+        </Card>
       )}
 
       <ul className="text-xs text-text-muted space-y-1.5 leading-relaxed list-disc list-inside">

--- a/ui/apps/console/src/components/billing/BillingLetter.tsx
+++ b/ui/apps/console/src/components/billing/BillingLetter.tsx
@@ -1,12 +1,13 @@
 import { SparklesIcon } from "@heroicons/react/24/outline";
+import { IconBadge } from "@shellhub/design-system/primitives";
 
 export default function BillingLetter() {
   return (
     <div className="space-y-5">
       <div className="flex items-center gap-3">
-        <span className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center text-primary shrink-0">
+        <IconBadge size="md">
           <SparklesIcon className="w-5 h-5" />
-        </span>
+        </IconBadge>
         <div>
           <p className="text-2xs font-mono font-semibold uppercase tracking-label text-primary">
             ShellHub Cloud

--- a/ui/apps/console/src/components/billing/BillingPayment.tsx
+++ b/ui/apps/console/src/components/billing/BillingPayment.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Card } from "@shellhub/design-system/primitives";
 import { isSdkError } from "@/api/errors";
 import {
   Elements,
@@ -291,9 +292,10 @@ function BillingPaymentInner({
       {paymentMethods.length > 0 && (
         <ul className="space-y-2" aria-label="Saved payment methods">
           {paymentMethods.map((pm) => (
-            <li
+            <Card
+              as="li"
               key={pm.id}
-              className="bg-card border border-border rounded-lg px-4 py-3 flex items-center gap-3"
+              className="rounded-lg px-4 py-3 flex items-center gap-3"
             >
               <span className="shrink-0 text-text-primary">
                 <BillingIcon brand={pm.brand} className="w-7 h-7" />
@@ -349,7 +351,7 @@ function BillingPaymentInner({
                   <TrashIcon className="w-4 h-4" />
                 </button>
               </div>
-            </li>
+            </Card>
           ))}
         </ul>
       )}
@@ -366,7 +368,7 @@ function BillingPaymentInner({
       )}
 
       {isAddingCard && (
-        <div className="bg-card border border-border rounded-lg p-4 space-y-3">
+        <Card className="rounded-lg p-4 space-y-3">
           <div>
             <FieldLabel htmlFor="stripe-card-element">Card details</FieldLabel>
             <div
@@ -409,7 +411,7 @@ function BillingPaymentInner({
               Save card
             </button>
           </div>
-        </div>
+        </Card>
       )}
 
       {error && (

--- a/ui/apps/console/src/components/common/ActiveBadge.tsx
+++ b/ui/apps/console/src/components/common/ActiveBadge.tsx
@@ -1,0 +1,9 @@
+import { Badge } from "@shellhub/design-system/primitives";
+
+export default function ActiveBadge({ active }: { active: boolean }) {
+  return (
+    <Badge color={active ? "green" : "yellow"}>
+      {active ? "Active" : "Inactive"}
+    </Badge>
+  );
+}

--- a/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -4,6 +4,7 @@ import {
   BookOpenIcon,
   FolderPlusIcon,
 } from "@heroicons/react/24/outline";
+import { Card, IconBadge } from "@shellhub/design-system/primitives";
 import BaseDialog from "./BaseDialog";
 import CopyButton from "./CopyButton";
 import NamespaceNameField from "./fields/NamespaceNameField";
@@ -60,7 +61,7 @@ function CeInstructions({ descriptionId }: { descriptionId: string }) {
       </p>
 
       {/* Command block */}
-      <div className="bg-card border border-border rounded-xl overflow-hidden">
+      <Card className="overflow-hidden">
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-surface/50">
           <div className="flex items-center gap-1.5">
             <span className="w-2.5 h-2.5 rounded-full bg-accent-red/60" />
@@ -78,7 +79,7 @@ function CeInstructions({ descriptionId }: { descriptionId: string }) {
             {CLI_COMMAND}
           </pre>
         </div>
-      </div>
+      </Card>
 
       {/* Name rules */}
       <div>
@@ -159,9 +160,9 @@ export default function CreateNamespaceDialog({
       {/* Header */}
       <header className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
         <div className="flex items-center gap-3">
-          <span className="w-8 h-8 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center text-primary shrink-0">
+          <IconBadge size="sm">
             <FolderPlusIcon className="w-4 h-4" />
-          </span>
+          </IconBadge>
           <h2 id={titleId} className="text-sm font-semibold text-text-primary">
             Create a Namespace
           </h2>

--- a/ui/apps/console/src/components/common/DataTable.tsx
+++ b/ui/apps/console/src/components/common/DataTable.tsx
@@ -4,15 +4,13 @@ import {
   ChevronDownIcon,
   ChevronUpDownIcon,
 } from "@heroicons/react/24/outline";
+import { Card } from "@shellhub/design-system/primitives";
 import { cn } from "@/utils/cn";
 import Pagination from "./Pagination";
 import PageLoader from "@/components/common/PageLoader";
 
 const TH_CLASS =
   "px-4 py-3 text-left text-2xs font-mono font-semibold uppercase tracking-compact text-text-muted whitespace-nowrap";
-
-const DEFAULT_WRAPPER =
-  "bg-card border border-border rounded-xl overflow-hidden";
 
 export interface Column<T> {
   key: string;
@@ -224,7 +222,7 @@ export default function DataTable<T>({
       {noWrapper ? (
         tableContent
       ) : (
-        <div className={DEFAULT_WRAPPER}>{tableContent}</div>
+        <Card className="overflow-hidden">{tableContent}</Card>
       )}
 
       {hasPagination && (

--- a/ui/apps/console/src/components/common/EmptyState.tsx
+++ b/ui/apps/console/src/components/common/EmptyState.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useId } from "react";
+import { IconBadge } from "@shellhub/design-system/primitives";
 
 export type EmptyStateAccent = "primary" | "yellow";
 
@@ -132,12 +133,14 @@ export default function EmptyState({
                 className="bg-card/60 border border-border rounded-xl p-5 text-center animate-slide-up"
                 style={{ animationDelay: `${150 + idx * 100}ms` }}
               >
-                <div
+                <IconBadge
                   aria-hidden="true"
-                  className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center mx-auto mb-3 text-primary"
+                  size="md"
+                  color="primary"
+                  className="mx-auto mb-3"
                 >
                   {feature.icon}
-                </div>
+                </IconBadge>
                 <h2 className="text-sm font-semibold text-text-primary mb-1">
                   {feature.title}
                 </h2>

--- a/ui/apps/console/src/components/common/FilterBadge.tsx
+++ b/ui/apps/console/src/components/common/FilterBadge.tsx
@@ -1,4 +1,5 @@
 import { Tag } from "@/client";
+import { Badge } from "@shellhub/design-system/primitives";
 import {
   TagIcon,
   CpuChipIcon,
@@ -14,13 +15,10 @@ export default function FilterBadge({
     return (
       <div className="flex flex-wrap gap-1">
         {filter.tags.map((tag) => (
-          <span
-            key={tag.name}
-            className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-primary/10 text-primary text-2xs rounded font-medium"
-          >
+          <Badge key={tag.name} color="primary">
             <TagIcon className="w-2.5 h-2.5" strokeWidth={2} />
             {tag.name}
-          </span>
+          </Badge>
         ))}
       </div>
     );

--- a/ui/apps/console/src/components/common/OnlineDot.tsx
+++ b/ui/apps/console/src/components/common/OnlineDot.tsx
@@ -1,25 +1,5 @@
-interface OnlineDotProps {
-  online?: boolean;
-}
+import { StatusDot } from "@shellhub/design-system/primitives";
 
-export default function OnlineDot({ online }: OnlineDotProps) {
-  if (online) {
-    return (
-      <span
-        className="relative flex h-2.5 w-2.5 mx-auto"
-        aria-label="Online"
-        role="img"
-      >
-        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-green opacity-40" />
-        <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]" />
-      </span>
-    );
-  }
-  return (
-    <span
-      className="block w-2.5 h-2.5 rounded-full mx-auto bg-text-muted/30"
-      aria-label="Offline"
-      role="img"
-    />
-  );
+export default function OnlineDot({ online }: { online?: boolean }) {
+  return <StatusDot online={online} className="mx-auto" />;
 }

--- a/ui/apps/console/src/components/common/PageHeader.tsx
+++ b/ui/apps/console/src/components/common/PageHeader.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { IconBadge, type Palette } from "@shellhub/design-system/primitives";
 
 interface PageHeaderProps {
   icon: ReactNode;
@@ -7,6 +8,7 @@ interface PageHeaderProps {
   description?: string;
   children?: ReactNode;
   variant?: "default" | "decorated";
+  iconColor?: Palette;
 }
 
 export default function PageHeader({
@@ -16,6 +18,7 @@ export default function PageHeader({
   description,
   children,
   variant = "default",
+  iconColor = "primary",
 }: PageHeaderProps) {
   return (
     <div
@@ -36,9 +39,9 @@ export default function PageHeader({
         className={`${variant === "decorated" ? "relative " : ""}flex flex-col sm:flex-row sm:items-center justify-between gap-4`}
       >
         <div className="flex items-start gap-4">
-          <div className="w-12 h-12 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center text-primary shrink-0">
+          <IconBadge size="lg" color={iconColor}>
             {icon}
-          </div>
+          </IconBadge>
           <div>
             <p className="text-2xs font-mono font-semibold uppercase tracking-label text-primary mb-1">
               {overline}

--- a/ui/apps/console/src/components/common/PlatformBadge.tsx
+++ b/ui/apps/console/src/components/common/PlatformBadge.tsx
@@ -1,19 +1,20 @@
+import { Badge } from "@shellhub/design-system/primitives";
 import { ServerStackIcon } from "@heroicons/react/24/outline";
 import { DockerIcon } from "../icons";
 
 export default function PlatformBadge({ platform }: { platform: string }) {
   if (platform === "docker") {
     return (
-      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-accent-blue/10 text-accent-blue text-2xs rounded font-medium">
+      <Badge color="blue">
         <DockerIcon className="w-2.5 h-2.5" />
         Docker
-      </span>
+      </Badge>
     );
   }
   return (
-    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-accent-green/10 text-accent-green text-2xs rounded font-medium">
+    <Badge color="green">
       <ServerStackIcon className="w-2.5 h-2.5" strokeWidth={2} />
       Native
-    </span>
+    </Badge>
   );
 }

--- a/ui/apps/console/src/components/common/StatCard.tsx
+++ b/ui/apps/console/src/components/common/StatCard.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
+import { Card } from "@shellhub/design-system/primitives";
 
 interface StatCardBaseProps {
   icon: ReactNode;
@@ -25,7 +26,7 @@ export default function StatCard(props: StatCardProps) {
   const { icon, title, value, linkLabel, accent } = props;
 
   return (
-    <div className="bg-card border border-border rounded-lg p-6 flex flex-col items-center text-center group hover:border-primary/30 transition-all duration-300">
+    <Card className="rounded-lg p-6 flex flex-col items-center text-center group hover:border-primary/30 transition-all duration-300">
       <div className="w-14 h-14 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center text-primary mb-5">
         {icon}
       </div>
@@ -40,27 +41,21 @@ export default function StatCard(props: StatCardProps) {
         {value}
       </p>
 
-      {props.onClick
-        ? (
-          <button
-            onClick={props.onClick}
-            className="text-xs font-medium text-primary hover:text-primary-400 transition-colors"
-          >
-            {linkLabel}
-            {" "}
-            &rarr;
-          </button>
-        )
-        : (
-          <Link
-            to={props.linkTo}
-            className="text-xs font-medium text-primary hover:text-primary-400 transition-colors"
-          >
-            {linkLabel}
-            {" "}
-            &rarr;
-          </Link>
-        )}
-    </div>
+      {props.onClick ? (
+        <button
+          onClick={props.onClick}
+          className="text-xs font-medium text-primary hover:text-primary-400 transition-colors"
+        >
+          {linkLabel} &rarr;
+        </button>
+      ) : (
+        <Link
+          to={props.linkTo}
+          className="text-xs font-medium text-primary hover:text-primary-400 transition-colors"
+        >
+          {linkLabel} &rarr;
+        </Link>
+      )}
+    </Card>
   );
 }

--- a/ui/apps/console/src/components/common/WelcomeScreen.tsx
+++ b/ui/apps/console/src/components/common/WelcomeScreen.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRightIcon,
   BookOpenIcon,
 } from "@heroicons/react/24/outline";
+import { IconBadge } from "@shellhub/design-system/primitives";
 
 interface WelcomeScreenProps {
   namespaceName: string;
@@ -186,9 +187,13 @@ export default function WelcomeScreen({ namespaceName }: WelcomeScreenProps) {
 
               <div className="relative">
                 <div className="flex items-center justify-between mb-4">
-                  <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center text-primary group-hover:bg-primary/15 group-hover:border-primary/30 transition-all duration-300">
+                  <IconBadge
+                    size="md"
+                    color="primary"
+                    className="group-hover:bg-primary/15 group-hover:border-primary/30 transition-all duration-300"
+                  >
                     {step.icon}
-                  </div>
+                  </IconBadge>
                   <span className="text-2xs font-mono font-bold text-text-muted/40">
                     {step.num}
                   </span>

--- a/ui/apps/console/src/components/common/__tests__/ActiveBadge.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/ActiveBadge.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import ActiveBadge from "../ActiveBadge";
+
+describe("ActiveBadge", () => {
+  describe("active=true", () => {
+    it("renders the text 'Active'", () => {
+      render(<ActiveBadge active />);
+      expect(screen.getByText("Active")).toBeInTheDocument();
+    });
+
+    it("chip carries green colour class (text-accent-green)", () => {
+      render(<ActiveBadge active />);
+      const chip = screen.getByText("Active").closest("span");
+      expect(chip).not.toBeNull();
+      expect(chip!.className).toContain("text-accent-green");
+    });
+  });
+
+  describe("active=false", () => {
+    it("renders the text 'Inactive'", () => {
+      render(<ActiveBadge active={false} />);
+      expect(screen.getByText("Inactive")).toBeInTheDocument();
+    });
+
+    it("chip carries yellow colour class (text-accent-yellow)", () => {
+      render(<ActiveBadge active={false} />);
+      const chip = screen.getByText("Inactive").closest("span");
+      expect(chip).not.toBeNull();
+      expect(chip!.className).toContain("text-accent-yellow");
+    });
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/DataTable.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/DataTable.test.tsx
@@ -548,6 +548,12 @@ describe("DataTable", () => {
       expect(wrapper.className).toContain("rounded-xl");
     });
 
+    it("wrapper has overflow-hidden so content does not bleed outside rounded corners", () => {
+      const { container } = renderTable();
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.className).toContain("overflow-hidden");
+    });
+
     it("skips the default card wrapper when noWrapper is true", () => {
       const { container } = renderTable({ noWrapper: true });
       const firstChild = container.firstChild as HTMLElement;
@@ -565,9 +571,7 @@ describe("DataTable", () => {
   describe("label prop", () => {
     it("sets an aria-label on the table when label is provided", () => {
       renderTable({ label: "Users" });
-      expect(
-        screen.getByRole("table", { name: "Users" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("table", { name: "Users" })).toBeInTheDocument();
     });
 
     it("does not set an aria-label when label is omitted", () => {

--- a/ui/apps/console/src/components/common/__tests__/FilterBadge.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/FilterBadge.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import FilterBadge from "../FilterBadge";
+
+describe("FilterBadge", () => {
+  describe("tags variant — uses Badge component with color=primary", () => {
+    it("renders a chip for each tag", () => {
+      render(
+        <FilterBadge
+          filter={{
+            tags: [
+              { name: "web", tenant_id: "", created_at: "", updated_at: "" },
+              { name: "iot", tenant_id: "", created_at: "", updated_at: "" },
+            ],
+          }}
+        />,
+      );
+      expect(screen.getByText("web")).toBeInTheDocument();
+      expect(screen.getByText("iot")).toBeInTheDocument();
+    });
+  });
+
+  describe("hostname variant — stays inline (font-mono, no font-weight — NOT a Badge)", () => {
+    it("renders the hostname text", () => {
+      render(<FilterBadge filter={{ hostname: "web-server-01" }} />);
+      expect(screen.getByText("web-server-01")).toBeInTheDocument();
+    });
+
+    it("chip keeps font-mono (not font-medium) — non-lossless, must stay inline", () => {
+      render(<FilterBadge filter={{ hostname: "web-server-01" }} />);
+      const chip = screen.getByText("web-server-01").closest("span");
+      expect(chip!.className).toContain("font-mono");
+      // Badge default shape adds font-medium which would be wrong here
+      expect(chip!.className).not.toContain("font-medium");
+    });
+  });
+
+  describe("all-devices variant — stays inline (bg-hover-medium, no palette — NOT a Badge)", () => {
+    it("renders 'All devices' when filter is empty", () => {
+      render(<FilterBadge filter={{}} />);
+      expect(screen.getByText("All devices")).toBeInTheDocument();
+    });
+
+    it("renders 'All devices' when hostname is '.*'", () => {
+      render(<FilterBadge filter={{ hostname: ".*" }} />);
+      expect(screen.getByText("All devices")).toBeInTheDocument();
+    });
+
+    it("chip uses bg-hover-medium (not a palette colour — must stay inline)", () => {
+      render(<FilterBadge filter={{}} />);
+      const chip = screen.getByText("All devices").closest("span");
+      expect(chip!.className).toContain("bg-hover-medium");
+    });
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/OnlineDot.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/OnlineDot.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import OnlineDot from "../OnlineDot";
+
+vi.mock("@shellhub/design-system/primitives", () => ({
+  StatusDot: ({
+    online,
+    className,
+  }: {
+    online?: boolean;
+    className?: string;
+  }) => (
+    <span
+      role="img"
+      aria-label={online === false ? "Offline" : "Online"}
+      className={`status-dot-mock ${className ?? ""}`}
+      data-testid="status-dot"
+    />
+  ),
+}));
+
+describe("OnlineDot", () => {
+  describe("online", () => {
+    it("renders aria-label Online", () => {
+      render(<OnlineDot online />);
+      expect(screen.getByRole("img", { name: "Online" })).toBeInTheDocument();
+    });
+
+    it("has mx-auto class on outer span", () => {
+      render(<OnlineDot online />);
+      const el = screen.getByRole("img", { name: "Online" });
+      expect(el.className).toContain("mx-auto");
+    });
+
+    it("delegates to StatusDot", () => {
+      render(<OnlineDot online />);
+      expect(screen.getByTestId("status-dot")).toBeInTheDocument();
+    });
+  });
+
+  describe("offline", () => {
+    it("renders aria-label Offline", () => {
+      render(<OnlineDot online={false} />);
+      expect(screen.getByRole("img", { name: "Offline" })).toBeInTheDocument();
+    });
+
+    it("has mx-auto class on the single span", () => {
+      render(<OnlineDot online={false} />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      expect(el.className).toContain("mx-auto");
+    });
+
+    it("delegates to StatusDot", () => {
+      render(<OnlineDot online={false} />);
+      expect(screen.getByTestId("status-dot")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/PageHeader.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/PageHeader.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import PageHeader from "@/components/common/PageHeader";
+
+describe("PageHeader", () => {
+  it("renders the overline, title and icon", () => {
+    render(
+      <PageHeader
+        icon={<svg data-testid="icon" />}
+        overline="Devices"
+        title="All Devices"
+      />,
+    );
+    expect(screen.getByText("Devices")).toBeInTheDocument();
+    expect(screen.getByText("All Devices")).toBeInTheDocument();
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("renders description when provided", () => {
+    render(
+      <PageHeader
+        icon={<svg />}
+        overline="Devices"
+        title="All Devices"
+        description="Manage your devices."
+      />,
+    );
+    expect(screen.getByText("Manage your devices.")).toBeInTheDocument();
+  });
+
+  it("renders children (action area) when provided", () => {
+    render(
+      <PageHeader icon={<svg />} overline="Devices" title="All Devices">
+        <button type="button">Add Device</button>
+      </PageHeader>,
+    );
+    expect(
+      screen.getByRole("button", { name: "Add Device" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders correct color classes when iconColor is set", () => {
+    const { container } = render(
+      <PageHeader
+        icon={<svg />}
+        overline="Sessions"
+        title="All Sessions"
+        iconColor="cyan"
+      />,
+    );
+    const badge = container.querySelector(".w-12.h-12");
+    expect(badge).not.toBeNull();
+    expect(badge!.className).toContain("bg-accent-cyan/10");
+    expect(badge!.className).toContain("border-accent-cyan/20");
+    expect(badge!.className).toContain("text-accent-cyan");
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/PlatformBadge.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/PlatformBadge.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import PlatformBadge from "../PlatformBadge";
+
+describe("PlatformBadge", () => {
+  describe("docker variant — Badge color=blue", () => {
+    it("renders the text 'Docker'", () => {
+      render(<PlatformBadge platform="docker" />);
+      expect(screen.getByText("Docker")).toBeInTheDocument();
+    });
+
+    it("chip carries blue colour classes (bg-accent-blue/10 text-accent-blue)", () => {
+      render(<PlatformBadge platform="docker" />);
+      const chip = screen.getByText("Docker").closest("span");
+      expect(chip).not.toBeNull();
+      expect(chip!.className).toContain("bg-accent-blue/10");
+      expect(chip!.className).toContain("text-accent-blue");
+    });
+  });
+
+  describe("native variant — Badge color=green", () => {
+    it("renders the text 'Native'", () => {
+      render(<PlatformBadge platform="native" />);
+      expect(screen.getByText("Native")).toBeInTheDocument();
+    });
+
+    it("chip carries green colour classes (bg-accent-green/10 text-accent-green)", () => {
+      render(<PlatformBadge platform="native" />);
+      const chip = screen.getByText("Native").closest("span");
+      expect(chip).not.toBeNull();
+      expect(chip!.className).toContain("bg-accent-green/10");
+      expect(chip!.className).toContain("text-accent-green");
+    });
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/StatCard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/StatCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import StatCard from "../StatCard";
+
+function renderLink() {
+  return render(
+    <MemoryRouter>
+      <StatCard
+        icon={<span>icon</span>}
+        title="Online Devices"
+        value={42}
+        linkLabel="View all"
+        linkTo="/devices"
+      />
+    </MemoryRouter>,
+  );
+}
+
+function renderButton() {
+  return render(
+    <MemoryRouter>
+      <StatCard
+        icon={<span>icon</span>}
+        title="Pending Devices"
+        value={5}
+        linkLabel="View pending"
+        onClick={() => undefined}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("StatCard", () => {
+  it("title is visible", () => {
+    renderLink();
+    expect(screen.getByText("Online Devices")).toBeInTheDocument();
+  });
+
+  it("value is visible", () => {
+    renderLink();
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("link-variant renders a link to the correct destination", () => {
+    renderLink();
+    const link = screen.getByRole("link", { name: /view all/i });
+    expect(link).toHaveAttribute("href", "/devices");
+  });
+
+  it("button-variant renders a button", () => {
+    renderButton();
+    expect(
+      screen.getByRole("button", { name: /view pending/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/components/mfa/MfaEnableDrawer.tsx
+++ b/ui/apps/console/src/components/mfa/MfaEnableDrawer.tsx
@@ -4,6 +4,7 @@ import {
   CheckCircleIcon,
   EnvelopeIcon,
 } from "@heroicons/react/24/outline";
+import { IconBadge } from "@shellhub/design-system/primitives";
 import Alert from "@/components/common/Alert";
 import Drawer from "../common/Drawer";
 import CheckboxField from "@/components/common/fields/CheckboxField";
@@ -68,11 +69,18 @@ export default function MfaEnableDrawer({
     setLoading(true);
 
     try {
-      await updateUser({ body: { recovery_email: recoveryEmail }, throwOnError: true });
+      await updateUser({
+        body: { recovery_email: recoveryEmail },
+        throwOnError: true,
+      });
       await handleGenerateMfa();
       setStep(2);
     } catch (err) {
-      setError(isSdkError(err) && err.status === 409 ? "Email already in use" : "Failed to save recovery email");
+      setError(
+        isSdkError(err) && err.status === 409
+          ? "Email already in use"
+          : "Failed to save recovery email",
+      );
     } finally {
       setLoading(false);
     }
@@ -118,7 +126,10 @@ export default function MfaEnableDrawer({
     setLoading(true);
 
     try {
-      await enableMfa({ body: { code: otp.getValue(), secret, recovery_codes: recoveryCodes }, throwOnError: true });
+      await enableMfa({
+        body: { code: otp.getValue(), secret, recovery_codes: recoveryCodes },
+        throwOnError: true,
+      });
       setStep(4);
     } catch {
       setError("Invalid verification code");
@@ -185,9 +196,7 @@ export default function MfaEnableDrawer({
                 disabled={loading || !recoveryEmail.trim()}
                 className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
               >
-                {loading && (
-                  <Spinner size="sm" tone="onPrimary" />
-                )}
+                {loading && <Spinner size="sm" tone="onPrimary" />}
                 Save & Continue
               </button>
             ) : (
@@ -196,9 +205,7 @@ export default function MfaEnableDrawer({
                 disabled={loading}
                 className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
               >
-                {loading && (
-                  <Spinner size="sm" tone="onPrimary" />
-                )}
+                {loading && <Spinner size="sm" tone="onPrimary" />}
                 Continue
               </button>
             )}
@@ -232,9 +239,7 @@ export default function MfaEnableDrawer({
               disabled={loading || !isCodeComplete || !qrLink || !secret}
               className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
-              {loading && (
-                <Spinner size="sm" tone="onPrimary" />
-              )}
+              {loading && <Spinner size="sm" tone="onPrimary" />}
               Verify & Enable
             </button>
           </>
@@ -256,7 +261,10 @@ export default function MfaEnableDrawer({
           <div className="space-y-4">
             <div>
               <h3 className="text-sm font-semibold text-text-primary mb-2">
-                Step 1: {showRecoveryEmailInput ? "Set Recovery Email" : "Confirm Recovery Email"}
+                Step 1:{" "}
+                {showRecoveryEmailInput
+                  ? "Set Recovery Email"
+                  : "Confirm Recovery Email"}
               </h3>
               <p className="text-xs text-text-muted leading-relaxed mb-4">
                 {showRecoveryEmailInput
@@ -287,9 +295,9 @@ export default function MfaEnableDrawer({
               <div className="space-y-3">
                 <div className="bg-surface border border-border rounded-lg p-4">
                   <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center shrink-0">
+                    <IconBadge size="md">
                       <EnvelopeIcon className="w-5 h-5 text-primary" />
-                    </div>
+                    </IconBadge>
                     <div className="min-w-0 flex-1">
                       <p className="text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-1">
                         Current Recovery Email
@@ -356,7 +364,8 @@ export default function MfaEnableDrawer({
               ) : (
                 <div className="py-8 text-center">
                   <p className="text-sm text-text-muted">
-                    Recovery codes failed to generate. Please close and try again.
+                    Recovery codes failed to generate. Please close and try
+                    again.
                   </p>
                 </div>
               )}

--- a/ui/apps/console/src/components/sessions/SessionPlayer.tsx
+++ b/ui/apps/console/src/components/sessions/SessionPlayer.tsx
@@ -2,18 +2,31 @@ import { useEffect, useRef, useState } from "react";
 import { create, type AsciinemaPlayer } from "asciinema-player";
 import "asciinema-player/dist/bundle/asciinema-player.css";
 import { PlayIcon, PauseIcon } from "@heroicons/react/24/solid";
+import { Card } from "@shellhub/design-system/primitives";
 
 type Speed = 0.5 | 1 | 1.5 | 2;
 
 function formatTime(secs: number): string {
-  const m = Math.floor(secs / 60).toString().padStart(2, "0");
-  const s = Math.floor(secs % 60).toString().padStart(2, "0");
+  const m = Math.floor(secs / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = Math.floor(secs % 60)
+    .toString()
+    .padStart(2, "0");
   return `${m}:${s}`;
 }
 
 function KeyboardIcon({ className }: { className?: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" className={className}>
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
       <rect x="2" y="7" width="20" height="11" rx="2" />
       <path d="M6 11h.01M10 11h.01M14 11h.01M18 11h.01M8 15h8" />
     </svg>
@@ -93,16 +106,12 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
 
   const setupPlayer = (startAt = 0) => {
     if (!containerRef.current) return;
-    const p = create(
-      { data: logs },
-      containerRef.current,
-      {
-        fit: "width",
-        controls: false,
-        speed: speedRef.current,
-        startAt,
-      },
-    );
+    const p = create({ data: logs }, containerRef.current, {
+      fit: "width",
+      controls: false,
+      speed: speedRef.current,
+      startAt,
+    });
     playerRef.current = p;
     attachListeners(p);
     p.play();
@@ -116,7 +125,7 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
       playerRef.current?.dispose();
       playerRef.current = null;
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const seekTo = (t: number) => {
@@ -133,7 +142,11 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLSelectElement) return;
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLSelectElement
+      )
+        return;
 
       switch (e.key) {
         case " ":
@@ -151,11 +164,17 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
           break;
         case "ArrowLeft":
           e.preventDefault();
-          seekTo(currentTimeRef.current - (e.shiftKey ? durationRef.current * 0.1 : 5));
+          seekTo(
+            currentTimeRef.current -
+              (e.shiftKey ? durationRef.current * 0.1 : 5),
+          );
           break;
         case "ArrowRight":
           e.preventDefault();
-          seekTo(currentTimeRef.current + (e.shiftKey ? durationRef.current * 0.1 : 5));
+          seekTo(
+            currentTimeRef.current +
+              (e.shiftKey ? durationRef.current * 0.1 : 5),
+          );
           break;
         case ",":
           if (!isPlayingRef.current) seekTo(currentTimeRef.current - 0.1);
@@ -179,8 +198,14 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
           }
           break;
         default:
-          if (e.key >= "0" && e.key <= "9" && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
-            seekTo(durationRef.current * parseInt(e.key) / 10);
+          if (
+            e.key >= "0" &&
+            e.key <= "9" &&
+            !e.shiftKey &&
+            !e.ctrlKey &&
+            !e.metaKey
+          ) {
+            seekTo((durationRef.current * parseInt(e.key)) / 10);
           }
       }
     };
@@ -258,7 +283,9 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
 
         <select
           value={speed}
-          onChange={(e) => handleSpeedChange(parseFloat(e.target.value) as Speed)}
+          onChange={(e) =>
+            handleSpeedChange(parseFloat(e.target.value) as Speed)
+          }
           className="bg-surface border border-border rounded text-xs font-mono text-text-secondary px-2 py-1 shrink-0"
           aria-label="Playback speed"
         >
@@ -283,14 +310,19 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
 
         {/* Shortcuts popover */}
         {showShortcuts && (
-          <div className="absolute bottom-full right-4 mb-2 bg-card border border-border rounded-lg shadow-lg p-3 w-80">
+          <Card className="absolute bottom-full right-4 mb-2 rounded-lg shadow-lg p-3 w-80">
             <p className="text-2xs font-mono font-semibold uppercase tracking-widest text-text-muted/60 mb-2.5">
               Keyboard Shortcuts
             </p>
             <div className="space-y-1.5">
               {SHORTCUTS.map(({ keys, description }) => (
-                <div key={description} className="flex items-center justify-between gap-4">
-                  <span className="text-xs text-text-secondary">{description}</span>
+                <div
+                  key={description}
+                  className="flex items-center justify-between gap-4"
+                >
+                  <span className="text-xs text-text-secondary">
+                    {description}
+                  </span>
                   <div className="flex items-center gap-1 shrink-0">
                     {keys.map((k) => (
                       <kbd
@@ -304,7 +336,7 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
                 </div>
               ))}
             </div>
-          </div>
+          </Card>
         )}
       </div>
     </div>

--- a/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, FormEvent } from "react";
+import { Card } from "@shellhub/design-system/primitives";
 import {
   KeyIcon,
   LockClosedIcon,
@@ -223,7 +224,7 @@ export default function VaultSettingsSection() {
         <h3 className="text-xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3">
           Vault Settings
         </h3>
-        <div className="bg-card border border-border rounded-lg divide-y divide-border">
+        <Card className="divide-y divide-border">
           <button
             type="button"
             onClick={() => setChangeOpen(true)}
@@ -304,7 +305,7 @@ export default function VaultSettingsSection() {
               </p>
             </div>
           </button>
-        </div>
+        </Card>
       </div>
 
       <ChangePasswordDrawer

--- a/ui/apps/console/src/components/wizard/WizardStep3Device.tsx
+++ b/ui/apps/console/src/components/wizard/WizardStep3Device.tsx
@@ -5,6 +5,7 @@ import {
   ChevronUpIcon,
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
+import { IconBadge } from "@shellhub/design-system/primitives";
 import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
 import DistroIcon from "@/components/common/DistroIcon";
 import CopyButton from "@/components/common/CopyButton";
@@ -67,7 +68,10 @@ export default function WizardStep3Device({
       )}
 
       {fetchError && (
-        <div role="alert" className="flex items-center gap-3 bg-accent-red/10 border border-accent-red/25 rounded-xl px-4 py-3">
+        <div
+          role="alert"
+          className="flex items-center gap-3 bg-accent-red/10 border border-accent-red/25 rounded-xl px-4 py-3"
+        >
           <ExclamationCircleIcon className="w-5 h-5 text-accent-red shrink-0" />
           <span className="text-sm text-accent-red">
             No pending device found. It may have already been processed.
@@ -83,19 +87,20 @@ export default function WizardStep3Device({
             onClick={() => setExpanded((v) => !v)}
             className="w-full flex items-center gap-3 px-4 py-3.5 hover:bg-hover-subtle transition-colors"
           >
-            <div className="w-8 h-8 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center text-primary text-lg">
-              <DistroIcon id={device.info?.id ?? ""} className="text-base leading-none" />
-            </div>
+            <IconBadge size="sm" className="text-lg">
+              <DistroIcon
+                id={device.info?.id ?? ""}
+                className="text-base leading-none"
+              />
+            </IconBadge>
             <span className="flex-1 text-sm font-mono font-semibold text-text-primary text-left">
               {device.name}
             </span>
-            {expanded
-              ? (
-                <ChevronUpIcon className="w-4 h-4 text-text-muted shrink-0" />
-              )
-              : (
-                <ChevronDownIcon className="w-4 h-4 text-text-muted shrink-0" />
-              )}
+            {expanded ? (
+              <ChevronUpIcon className="w-4 h-4 text-text-muted shrink-0" />
+            ) : (
+              <ChevronDownIcon className="w-4 h-4 text-text-muted shrink-0" />
+            )}
           </button>
 
           {/* Detail rows */}
@@ -104,14 +109,18 @@ export default function WizardStep3Device({
               <DetailRow label="OS" value={device.info?.pretty_name ?? "—"} />
               <DetailRow
                 label="UID"
-                value={(
+                value={
                   <span className="flex items-center gap-2 min-w-0">
                     <span className="font-mono text-2xs truncate">
                       {device.uid}
                     </span>
-                    <CopyButton text={device.uid} size="sm" className="shrink-0" />
+                    <CopyButton
+                      text={device.uid}
+                      size="sm"
+                      className="shrink-0"
+                    />
                   </span>
-                )}
+                }
               />
               <DetailRow label="MAC" value={device.identity?.mac ?? "—"} />
               <DetailRow label="Agent" value={device.info?.version ?? "—"} />

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -26,6 +26,7 @@ import NumericInput from "@/components/common/fields/NumericInput";
 import RadioCard from "@/components/common/fields/RadioCard";
 import RadioGroupField from "@/components/common/fields/RadioGroupField";
 import { LABEL_BASE } from "@/utils/styles";
+import { Card } from "@shellhub/design-system/primitives";
 
 /* ─── Types ─── */
 type Method =
@@ -264,7 +265,7 @@ export default function AddDevice() {
         </div>
 
         {selectedMethod.manual ? (
-          <div className="bg-card border border-border rounded-xl p-5">
+          <Card className="p-5">
             <div className="flex items-start gap-3">
               <div className="w-9 h-9 rounded-lg bg-accent-yellow/10 border border-accent-yellow/20 flex items-center justify-center shrink-0">
                 <BookOpenIcon className="w-4.5 h-4.5 text-accent-yellow" />
@@ -291,9 +292,9 @@ export default function AddDevice() {
                 </a>
               </div>
             </div>
-          </div>
+          </Card>
         ) : (
-          <div className="bg-card border border-border rounded-xl overflow-hidden">
+          <Card className="overflow-hidden">
             {/* Terminal chrome */}
             <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-surface/50">
               <div className="flex items-center gap-1.5">
@@ -313,7 +314,7 @@ export default function AddDevice() {
                 {command}
               </pre>
             </div>
-          </div>
+          </Card>
         )}
       </div>
 
@@ -332,7 +333,7 @@ export default function AddDevice() {
           </button>
 
           {showAdvanced && (
-            <div className="mt-3 bg-card border border-border rounded-xl p-4 space-y-4 animate-fade-in">
+            <Card className="mt-3 p-4 space-y-4 animate-fade-in">
               <InputField
                 id="add-device-hostname"
                 label="Preferred Hostname"
@@ -373,7 +374,7 @@ export default function AddDevice() {
                 hint="Interval in seconds between keep-alive messages sent by the agent. Defaults to 30."
                 error={keepaliveIntervalError || undefined}
               />
-            </div>
+            </Card>
           )}
         </div>
       )}

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -38,6 +38,7 @@ import { buildSshid } from "../utils/sshid";
 import { useHasPermission } from "../hooks/useHasPermission";
 import RestrictedAction from "../components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
+import { Card } from "@shellhub/design-system/primitives";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -495,7 +496,7 @@ export default function ContainerDetails() {
 
       {/* SSHID Banner */}
       {container.status === "accepted" && (
-        <div className="bg-card border border-border rounded-xl p-4 mb-6 flex items-center justify-between gap-4">
+        <Card className="p-4 mb-6 flex items-center justify-between gap-4">
           <div>
             <p className={LABEL}>SSHID</p>
             <code className="text-sm font-mono text-accent-cyan mt-0.5 block">
@@ -503,12 +504,12 @@ export default function ContainerDetails() {
             </code>
           </div>
           <CopyButton text={sshid} />
-        </div>
+        </Card>
       )}
 
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <InformationCircleIcon className="w-4 h-4 text-primary" />
             Identity
@@ -533,9 +534,9 @@ export default function ContainerDetails() {
               mono
             />
           </dl>
-        </div>
+        </Card>
 
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <ServerIcon className="w-4 h-4 text-primary" />
             Container
@@ -557,9 +558,9 @@ export default function ContainerDetails() {
               mono
             />
           </dl>
-        </div>
+        </Card>
 
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <ClockIcon className="w-4 h-4 text-primary" />
             Timeline
@@ -587,13 +588,13 @@ export default function ContainerDetails() {
               </dd>
             </div>
           </dl>
-        </div>
+        </Card>
       </div>
 
       {/* Tags */}
-      <div className="bg-card border border-border rounded-xl p-5 mb-6">
+      <Card className="p-5 mb-6">
         <TagsSection uid={container.uid} tags={tags} />
-      </div>
+      </Card>
 
       {/* Connect Drawer */}
       <ConnectDrawer

--- a/ui/apps/console/src/pages/Dashboard.tsx
+++ b/ui/apps/console/src/pages/Dashboard.tsx
@@ -21,6 +21,7 @@ import DeviceChip from "@/components/common/DeviceChip";
 import DataTable, { type Column } from "@/components/common/DataTable";
 import { sessionType } from "@/utils/session";
 import type { Session } from "@/client";
+import { Card } from "@shellhub/design-system/primitives";
 
 export default function Dashboard() {
   const tenantId = useAuthStore((s) => s.tenant) ?? "";
@@ -131,7 +132,7 @@ export default function Dashboard() {
         description="Manage your ShellHub namespace"
       >
         {currentNamespace && (
-          <div className="flex items-center gap-2 bg-card border border-border rounded-lg px-3 py-2">
+          <Card className="flex items-center gap-2 px-3 py-2">
             <span className="text-2xs font-mono font-semibold uppercase tracking-compact text-text-muted">
               Tenant ID
             </span>
@@ -139,7 +140,7 @@ export default function Dashboard() {
               {currentNamespace.tenant_id}
             </span>
             <CopyButton text={currentNamespace.tenant_id} size="sm" />
-          </div>
+          </Card>
         )}
       </PageHeader>
 
@@ -193,8 +194,8 @@ export default function Dashboard() {
         </Link>
       </div>
 
-      <div
-        className="bg-card border border-border rounded-lg overflow-hidden animate-slide-up"
+      <Card
+        className="overflow-hidden animate-slide-up"
         style={{ animationDelay: "300ms" }}
       >
         <DataTable
@@ -217,7 +218,7 @@ export default function Dashboard() {
             </div>
           }
         />
-      </div>
+      </Card>
     </div>
   );
 }

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -29,6 +29,7 @@ import InfoItem from "./devices/InfoItem";
 import TagsSection from "./devices/TagsSection";
 import RenameSection from "./devices/RenameSection";
 import CustomFieldsSection from "./devices/CustomFieldsSection";
+import { Card } from "@shellhub/design-system/primitives";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -84,9 +85,7 @@ export default function DeviceDetails() {
   }, [searchParams, device, existingSession, restoreTerminal]);
 
   if (isLoading || !device) {
-    return (
-      <PageLoader label="Loading device details" />
-    );
+    return <PageLoader label="Loading device details" />;
   }
 
   const nsName = currentNamespace?.name ?? "";
@@ -250,7 +249,7 @@ export default function DeviceDetails() {
 
       {/* SSHID Banner */}
       {device.status === "accepted" && (
-        <div className="bg-card border border-border rounded-xl p-4 mb-6 flex items-center justify-between gap-4">
+        <Card className="p-4 mb-6 flex items-center justify-between gap-4">
           <div>
             <p className={LABEL}>SSHID</p>
             <code className="text-sm font-mono text-accent-cyan mt-0.5 block">
@@ -258,12 +257,12 @@ export default function DeviceDetails() {
             </code>
           </div>
           <CopyButton text={sshid} />
-        </div>
+        </Card>
       )}
 
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <InformationCircleIcon className="w-4 h-4 text-primary" />
             Identity
@@ -288,9 +287,9 @@ export default function DeviceDetails() {
               mono
             />
           </dl>
-        </div>
+        </Card>
 
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <ComputerDesktopIcon className="w-4 h-4 text-primary" />
             System
@@ -321,9 +320,9 @@ export default function DeviceDetails() {
               mono
             />
           </dl>
-        </div>
+        </Card>
 
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <ClockIcon className="w-4 h-4 text-primary" />
             Timeline
@@ -351,20 +350,20 @@ export default function DeviceDetails() {
               </dd>
             </div>
           </dl>
-        </div>
+        </Card>
       </div>
 
       {/* Tags + Custom Fields */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-        <div className="bg-card border border-border rounded-xl p-5">
+        <Card className="p-5">
           <TagsSection uid={device.uid} tags={tags} />
-        </div>
-        <div className="bg-card border border-border rounded-xl p-5">
+        </Card>
+        <Card className="p-5">
           <CustomFieldsSection
             uid={device.uid}
             customFields={device.custom_fields ?? {}}
           />
-        </div>
+        </Card>
       </div>
 
       {/* Delete Dialog */}

--- a/ui/apps/console/src/pages/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/SessionDetails.tsx
@@ -36,6 +36,8 @@ import type { Session } from "../client";
 import RestrictedAction from "../components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
 import ConfirmDialog from "../components/common/ConfirmDialog";
+import { Badge, Card } from "@shellhub/design-system/primitives";
+import SessionTypeBadge from "./sessions/SessionTypeBadge";
 
 /* ── timeline builder ────────────────────────────── */
 
@@ -252,28 +254,6 @@ function TimelineNode({ event, isLast }: { event: TLEvent; isLast: boolean }) {
   );
 }
 
-function SessionTypeBadge({ types }: { types: string[] }) {
-  if (types.includes("subsystem"))
-    return (
-      <span className="inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded-md border bg-accent-cyan/10 text-accent-cyan border-accent-cyan/20">
-        sftp
-      </span>
-    );
-  if (types.includes("exec"))
-    return (
-      <span className="inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded-md border bg-accent-yellow/10 text-accent-yellow border-accent-yellow/20">
-        exec
-      </span>
-    );
-  if (types.includes("shell") || types.includes("pty-req"))
-    return (
-      <span className="inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded-md border bg-primary/10 text-primary border-primary/20">
-        shell
-      </span>
-    );
-  return null;
-}
-
 function DurationStat({
   startedAt,
   lastSeen,
@@ -413,10 +393,10 @@ export default function SessionDetails() {
                 {session.active ? "Active" : "Closed"}
               </span>
               {!session.authenticated && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-mono font-semibold rounded-md bg-accent-red/10 text-accent-red border border-accent-red/20">
+                <Badge color="red" shape="pill">
                   <ShieldExclamationIcon className="w-3 h-3" strokeWidth={2} />
                   not authenticated
-                </span>
+                </Badge>
               )}
               <SessionTypeBadge types={session.events?.types ?? []} />
               <DurationStat
@@ -485,7 +465,7 @@ export default function SessionDetails() {
       {/* Body */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         {/* Timeline */}
-        <div className="lg:col-span-2 bg-card border border-border rounded-xl p-5">
+        <Card className="lg:col-span-2 p-5">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2 mb-5">
             <ClockIcon className="w-4 h-4 text-primary" />
             Session flow
@@ -497,12 +477,12 @@ export default function SessionDetails() {
               isLast={i === timeline.length - 1}
             />
           ))}
-        </div>
+        </Card>
 
         {/* Right column */}
         <div className="space-y-5">
           {/* Session meta */}
-          <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+          <Card className="p-5 space-y-4">
             <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
               <InformationCircleIcon className="w-4 h-4 text-primary" />
               Details
@@ -534,11 +514,11 @@ export default function SessionDetails() {
                 </div>
               )}
             </dl>
-          </div>
+          </Card>
 
           {/* Device */}
           {session.device?.uid && (
-            <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+            <Card className="p-5 space-y-4">
               <div className="flex items-center justify-between">
                 <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
                   <CpuChipIcon className="w-4 h-4 text-primary" />
@@ -580,7 +560,7 @@ export default function SessionDetails() {
                   />
                 </dl>
               )}
-            </div>
+            </Card>
           )}
         </div>
       </div>
@@ -617,7 +597,8 @@ export default function SessionDetails() {
             </span>{" "}
             on{" "}
             <span className="font-medium text-text-primary">
-              {session.device?.name ?? (session.device_uid ?? "").substring(0, 8)}
+              {session.device?.name ??
+                (session.device_uid ?? "").substring(0, 8)}
             </span>
             ?
           </>

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -37,6 +37,7 @@ import {
 import RestrictedAction from "@/components/common/RestrictedAction";
 import Spinner from "@/components/common/Spinner";
 import PageLoader from "@/components/common/PageLoader";
+import { Badge } from "@shellhub/design-system/primitives";
 
 /* ─── Constants ─── */
 
@@ -761,24 +762,24 @@ function EndpointCard({
 
               {/* TLS-to-device indicator */}
               {endpoint.tls?.enabled && (
-                <span
-                  className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-accent-green/10 text-accent-green text-2xs rounded font-medium"
+                <Badge
+                  color="green"
                   title="The service on the device uses HTTPS"
                 >
                   <LockClosedIcon className="w-2.5 h-2.5" strokeWidth={2} />
                   TLS
-                </span>
+                </Badge>
               )}
 
               {/* Expired badge */}
               {expired && (
-                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-accent-yellow/10 text-accent-yellow text-2xs rounded font-medium">
+                <Badge color="yellow">
                   <ExclamationCircleIcon
                     className="w-2.5 h-2.5"
                     strokeWidth={2}
                   />
                   Expired
-                </span>
+                </Badge>
               )}
 
               {/* Expiration / Created */}

--- a/ui/apps/console/src/pages/admin/Dashboard.tsx
+++ b/ui/apps/console/src/pages/admin/Dashboard.tsx
@@ -18,6 +18,7 @@ import DataTable, { type Column } from "@/components/common/DataTable";
 import { useAdminStats } from "@/hooks/useAdminStats";
 import { useAdminSessions } from "@/hooks/useAdminSessions";
 import { formatDate } from "@/utils/date";
+import { Card } from "@shellhub/design-system/primitives";
 import { sessionType } from "@/utils/session";
 import type { Session } from "@/client";
 import PageLoader from "@/components/common/PageLoader";
@@ -244,8 +245,8 @@ export default function AdminDashboard() {
             </Link>
           </div>
 
-          <div
-            className="bg-card border border-border rounded-lg overflow-hidden animate-slide-up"
+          <Card
+            className="overflow-hidden animate-slide-up"
             style={{ animationDelay: "560ms" }}
           >
             <DataTable
@@ -268,7 +269,7 @@ export default function AdminDashboard() {
                 </div>
               }
             />
-          </div>
+          </Card>
         </>
       )}
     </div>

--- a/ui/apps/console/src/pages/admin/License.tsx
+++ b/ui/apps/console/src/pages/admin/License.tsx
@@ -27,25 +27,49 @@ import {
 import type { GetLicenseResponse } from "@/client/types.gen";
 import Spinner from "@/components/common/Spinner";
 import PageLoader from "@/components/common/PageLoader";
+import { Card } from "@shellhub/design-system/primitives";
 
 type HeroIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
 /* ─── Status Alert ─── */
 
-const alertStyles: Record<"info" | "warning" | "error", {
-  container: string;
-  Icon: HeroIcon;
-  text: string;
-}> = {
-  info: { container: "bg-accent-blue/[0.06] border-accent-blue/10", Icon: InformationCircleIcon, text: "text-accent-blue" },
-  warning: { container: "bg-accent-yellow/[0.06] border-accent-yellow/10", Icon: ExclamationTriangleIcon, text: "text-accent-yellow" },
-  error: { container: "bg-accent-red/[0.06] border-accent-red/10", Icon: ExclamationCircleIcon, text: "text-accent-red" },
+const alertStyles: Record<
+  "info" | "warning" | "error",
+  {
+    container: string;
+    Icon: HeroIcon;
+    text: string;
+  }
+> = {
+  info: {
+    container: "bg-accent-blue/[0.06] border-accent-blue/10",
+    Icon: InformationCircleIcon,
+    text: "text-accent-blue",
+  },
+  warning: {
+    container: "bg-accent-yellow/[0.06] border-accent-yellow/10",
+    Icon: ExclamationTriangleIcon,
+    text: "text-accent-yellow",
+  },
+  error: {
+    container: "bg-accent-red/[0.06] border-accent-red/10",
+    Icon: ExclamationCircleIcon,
+    text: "text-accent-red",
+  },
 };
 
-function LicenseStatusAlert({ license }: { license: GetLicenseResponse | null }) {
+function LicenseStatusAlert({
+  license,
+}: {
+  license: GetLicenseResponse | null;
+}) {
   const config = getLicenseAlertConfig(
     license
-      ? { expired: license.expired, about_to_expire: license.about_to_expire, grace_period: license.grace_period }
+      ? {
+          expired: license.expired,
+          about_to_expire: license.about_to_expire,
+          grace_period: license.grace_period,
+        }
       : null,
   );
 
@@ -68,7 +92,13 @@ function LicenseStatusAlert({ license }: { license: GetLicenseResponse | null })
 
 /* ─── Detail Row ─── */
 
-function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="flex items-center justify-between py-2.5">
       <span className="text-sm text-text-muted">{label}</span>
@@ -100,9 +130,11 @@ function LicenseDetails({ license }: { license: GetLicenseResponse }) {
         </DetailRow>
         <DetailRow label="Allowed regions">
           <span className="inline-flex items-center gap-1.5">
-            {isGlobal
-              ? <GlobeAltIcon className="w-4 h-4 text-text-muted" />
-              : <FlagIcon className="w-4 h-4 text-text-muted" />}
+            {isGlobal ? (
+              <GlobeAltIcon className="w-4 h-4 text-text-muted" />
+            ) : (
+              <FlagIcon className="w-4 h-4 text-text-muted" />
+            )}
             {regionText}
           </span>
         </DetailRow>
@@ -113,7 +145,11 @@ function LicenseDetails({ license }: { license: GetLicenseResponse }) {
 
 /* ─── License Owner ─── */
 
-function LicenseOwner({ customer }: { customer: GetLicenseResponse["customer"] }) {
+function LicenseOwner({
+  customer,
+}: {
+  customer: GetLicenseResponse["customer"];
+}) {
   return (
     <section>
       <h2 className="text-xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3">
@@ -128,15 +164,9 @@ function LicenseOwner({ customer }: { customer: GetLicenseResponse["customer"] }
             {customer.id && <CopyButton text={customer.id} />}
           </span>
         </DetailRow>
-        <DetailRow label="Name">
-          {customer.name ?? "\u2014"}
-        </DetailRow>
-        <DetailRow label="Email">
-          {customer.email ?? "\u2014"}
-        </DetailRow>
-        <DetailRow label="Company">
-          {customer.company ?? "\u2014"}
-        </DetailRow>
+        <DetailRow label="Name">{customer.name ?? "\u2014"}</DetailRow>
+        <DetailRow label="Email">{customer.email ?? "\u2014"}</DetailRow>
+        <DetailRow label="Company">{customer.company ?? "\u2014"}</DetailRow>
       </div>
     </section>
   );
@@ -144,7 +174,11 @@ function LicenseOwner({ customer }: { customer: GetLicenseResponse["customer"] }
 
 /* ─── License Features ─── */
 
-function LicenseFeatures({ features }: { features: GetLicenseResponse["features"] }) {
+function LicenseFeatures({
+  features,
+}: {
+  features: GetLicenseResponse["features"];
+}) {
   const display = getDisplayFeatures(features);
 
   return (
@@ -155,25 +189,21 @@ function LicenseFeatures({ features }: { features: GetLicenseResponse["features"
       <div className="divide-y divide-border">
         {display.map((feature) => (
           <DetailRow key={feature.name} label={feature.label}>
-            {feature.type === "number"
-              ? (
-                <span className="inline-flex items-center px-2 py-0.5 text-xs font-mono font-semibold bg-primary/10 text-primary border border-primary/20 rounded">
-                  {formatDeviceCount(feature.value)}
-                </span>
-              )
-              : feature.value
-                ? (
-                  <CheckCircleIcon
-                    className="w-5 h-5 text-accent-green"
-                    aria-label="Included"
-                  />
-                )
-                : (
-                  <XCircleIcon
-                    className="w-5 h-5 text-accent-red"
-                    aria-label="Not included"
-                  />
-                )}
+            {feature.type === "number" ? (
+              <span className="inline-flex items-center px-2 py-0.5 text-xs font-mono font-semibold bg-primary/10 text-primary border border-primary/20 rounded">
+                {formatDeviceCount(feature.value)}
+              </span>
+            ) : feature.value ? (
+              <CheckCircleIcon
+                className="w-5 h-5 text-accent-green"
+                aria-label="Included"
+              />
+            ) : (
+              <XCircleIcon
+                className="w-5 h-5 text-accent-red"
+                aria-label="Not included"
+              />
+            )}
           </DetailRow>
         ))}
       </div>
@@ -187,7 +217,10 @@ function LicenseUpload() {
   const upload = useUploadLicense();
   const [file, setFile] = useState<File | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const [feedback, setFeedback] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragCounter = useRef(0);
@@ -224,7 +257,10 @@ function LicenseUpload() {
     setFeedback(null);
     try {
       await upload.mutateAsync({ body: { file } });
-      setFeedback({ type: "success", message: "License uploaded successfully." });
+      setFeedback({
+        type: "success",
+        message: "License uploaded successfully.",
+      });
       clearFile();
     } catch {
       setFeedback({ type: "error", message: "Failed to upload the license." });
@@ -235,7 +271,10 @@ function LicenseUpload() {
 
   return (
     <section aria-labelledby="upload-license-heading">
-      <h2 id="upload-license-heading" className="text-xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3">
+      <h2
+        id="upload-license-heading"
+        className="text-xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3"
+      >
         Upload License
       </h2>
       <div className="space-y-3">
@@ -256,7 +295,9 @@ function LicenseUpload() {
               accept=".dat"
               tabIndex={-1}
               onChange={handleFileChange}
-              aria-describedby={validationError ? "license-file-error" : undefined}
+              aria-describedby={
+                validationError ? "license-file-error" : undefined
+              }
               aria-invalid={!!validationError || undefined}
               className="sr-only"
             />
@@ -273,9 +314,15 @@ function LicenseUpload() {
                 }
               }}
               onDrop={handleDrop}
-              onDragEnter={(e) => { e.preventDefault(); dragCounter.current++; setIsDragging(true); }}
+              onDragEnter={(e) => {
+                e.preventDefault();
+                dragCounter.current++;
+                setIsDragging(true);
+              }}
               onDragOver={(e) => e.preventDefault()}
-              onDragLeave={() => { if (--dragCounter.current === 0) setIsDragging(false); }}
+              onDragLeave={() => {
+                if (--dragCounter.current === 0) setIsDragging(false);
+              }}
               className={[
                 "flex items-center gap-3 w-full px-3.5 py-2.5 rounded-lg border border-dashed cursor-pointer select-none transition-all duration-150",
                 "focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-1 focus-visible:ring-offset-card focus-visible:outline-none",
@@ -289,7 +336,10 @@ function LicenseUpload() {
             >
               {file ? (
                 <>
-                  <DocumentIcon className="w-4 h-4 text-primary shrink-0" aria-hidden="true" />
+                  <DocumentIcon
+                    className="w-4 h-4 text-primary shrink-0"
+                    aria-hidden="true"
+                  />
                   <span className="text-sm text-text-primary font-medium truncate flex-1 min-w-0">
                     {file.name}
                   </span>
@@ -299,10 +349,18 @@ function LicenseUpload() {
                 </>
               ) : (
                 <>
-                  <ArrowUpTrayIcon className="w-4 h-4 text-text-muted shrink-0" aria-hidden="true" />
+                  <ArrowUpTrayIcon
+                    className="w-4 h-4 text-text-muted shrink-0"
+                    aria-hidden="true"
+                  />
                   <span className="text-sm">
-                    <span className="text-text-secondary">Choose a .dat file</span>
-                    <span className="text-text-muted hidden sm:inline"> or drag and drop</span>
+                    <span className="text-text-secondary">
+                      Choose a .dat file
+                    </span>
+                    <span className="text-text-muted hidden sm:inline">
+                      {" "}
+                      or drag and drop
+                    </span>
                   </span>
                   <span className="ml-auto text-2xs font-mono text-text-muted/60 shrink-0">
                     under 32 KB
@@ -325,7 +383,11 @@ function LicenseUpload() {
           </div>
 
           {/* Persistent live region — always in DOM so SR catches text changes */}
-          <div aria-live="polite" aria-atomic="true" className="min-h-[1rem] mt-1.5">
+          <div
+            aria-live="polite"
+            aria-atomic="true"
+            className="min-h-[1rem] mt-1.5"
+          >
             {validationError && (
               <p id="license-file-error" className="text-2xs text-accent-red">
                 {validationError}
@@ -340,19 +402,27 @@ function LicenseUpload() {
             onClick={() => void handleUpload()}
             disabled={!canUpload}
             aria-busy={upload.isPending}
-            aria-label={upload.isPending ? "Uploading license file" : "Upload license file"}
+            aria-label={
+              upload.isPending
+                ? "Uploading license file"
+                : "Upload license file"
+            }
             className="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
           >
-            {upload.isPending
-              ? <Spinner size="md" tone="onPrimary" />
-              : <ArrowUpTrayIcon className="w-4 h-4" aria-hidden="true" />}
+            {upload.isPending ? (
+              <Spinner size="md" tone="onPrimary" />
+            ) : (
+              <ArrowUpTrayIcon className="w-4 h-4" aria-hidden="true" />
+            )}
             {upload.isPending ? "Uploading..." : "Upload"}
           </button>
           {feedback && (
             <p
               role={feedback.type === "error" ? "alert" : "status"}
               className={`text-sm font-medium ${
-                feedback.type === "success" ? "text-accent-green" : "text-accent-red"
+                feedback.type === "success"
+                  ? "text-accent-green"
+                  : "text-accent-red"
               }`}
             >
               {feedback.message}
@@ -370,9 +440,7 @@ export default function AdminLicense() {
   const { data, isLoading, isError } = useAdminLicense();
 
   if (isLoading) {
-    return (
-      <PageLoader label="Loading license information" padding="fill" />
-    );
+    return <PageLoader label="Loading license information" padding="fill" />;
   }
 
   if (isError) {
@@ -380,8 +448,12 @@ export default function AdminLicense() {
       <div className="h-full flex items-center justify-center">
         <div className="text-center" role="alert">
           <ExclamationCircleIcon className="w-10 h-10 text-accent-red mx-auto mb-3" />
-          <p className="text-sm font-medium text-text-primary">Failed to load license information</p>
-          <p className="text-2xs text-text-muted mt-1">Please try again later.</p>
+          <p className="text-sm font-medium text-text-primary">
+            Failed to load license information
+          </p>
+          <p className="text-2xs text-text-muted mt-1">
+            Please try again later.
+          </p>
         </div>
       </div>
     );
@@ -402,18 +474,18 @@ export default function AdminLicense() {
         <LicenseStatusAlert license={installedLicense} />
 
         {installedLicense && (
-          <div className="bg-card border border-border rounded-xl p-6 space-y-6">
+          <Card className="p-6 space-y-6">
             <LicenseDetails license={installedLicense} />
             <hr className="border-border" />
             <LicenseOwner customer={installedLicense.customer} />
             <hr className="border-border" />
             <LicenseFeatures features={installedLicense.features} />
-          </div>
+          </Card>
         )}
 
-        <div className="bg-card border border-border rounded-xl p-6">
+        <Card className="p-6">
           <LicenseUpload />
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/ui/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/admin/SessionDetails.tsx
@@ -10,6 +10,7 @@ import Breadcrumb from "@/components/common/Breadcrumb";
 import { formatDateFull } from "@/utils/date";
 import { sessionType } from "@/utils/session";
 import PageLoader from "@/components/common/PageLoader";
+import { Card } from "@shellhub/design-system/primitives";
 
 function Field({
   label,
@@ -54,9 +55,7 @@ export default function AdminSessionDetails() {
   const { session, isLoading, error } = useAdminSessionDetail(uid);
 
   if (isLoading) {
-    return (
-      <PageLoader label="Loading session" padding="fill" />
-    );
+    return <PageLoader label="Loading session" padding="fill" />;
   }
 
   if (error || !session) {
@@ -116,7 +115,7 @@ export default function AdminSessionDetails() {
         </div>
       </div>
 
-      <div className="bg-card border border-border rounded-lg overflow-hidden animate-fade-in">
+      <Card className="rounded-lg overflow-hidden animate-fade-in">
         <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
           <div className="px-6 py-2">
             <Field label="UID">
@@ -203,7 +202,7 @@ export default function AdminSessionDetails() {
             </Field>
           </div>
         </div>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
@@ -13,6 +13,7 @@ import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import AnnouncementContent from "./AnnouncementContent";
 import { formatDateFull } from "@/utils/date";
 import PageLoader from "@/components/common/PageLoader";
+import { Card } from "@shellhub/design-system/primitives";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -28,9 +29,7 @@ export default function AnnouncementDetails() {
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   if (isLoading) {
-    return (
-      <PageLoader label="Loading announcement details" />
-    );
+    return <PageLoader label="Loading announcement details" />;
   }
 
   if (error || !announcement) {
@@ -94,7 +93,7 @@ export default function AnnouncementDetails() {
       </div>
 
       {/* Properties Card */}
-      <div className="bg-card border border-border rounded-xl p-5 space-y-4 mb-6">
+      <Card className="p-5 space-y-4 mb-6">
         <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
           <InformationCircleIcon className="w-4 h-4 text-primary" />
           Properties
@@ -119,10 +118,10 @@ export default function AnnouncementDetails() {
             </dd>
           </div>
         </dl>
-      </div>
+      </Card>
 
       {/* Content Card */}
-      <div className="bg-card border border-border rounded-xl p-5">
+      <Card className="p-5">
         <h3 className="text-xs font-semibold text-text-primary mb-4">
           Content
         </h3>
@@ -130,7 +129,7 @@ export default function AnnouncementDetails() {
           key={announcement.uuid}
           content={announcement.content}
         />
-      </div>
+      </Card>
 
       <DeleteAnnouncementDialog
         open={deleteOpen}

--- a/ui/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import {
-  MegaphoneIcon,
-} from "@heroicons/react/24/outline";
+import { MegaphoneIcon } from "@heroicons/react/24/outline";
 import Alert from "@/components/common/Alert";
 import { useAdminAnnouncement } from "@/hooks/useAdminAnnouncements";
 import { useAdminUpdateAnnouncement } from "@/hooks/useAdminAnnouncementMutations";
@@ -12,6 +10,7 @@ import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
 import Spinner from "@/components/common/Spinner";
 import PageLoader from "@/components/common/PageLoader";
+import { Card } from "@shellhub/design-system/primitives";
 
 const TITLE_MAX = 90;
 
@@ -55,9 +54,7 @@ export default function EditAnnouncement() {
   };
 
   if (isFetching) {
-    return (
-      <PageLoader label="Loading announcement" />
-    );
+    return <PageLoader label="Loading announcement" />;
   }
 
   if (fetchError || !announcement) {
@@ -100,12 +97,13 @@ export default function EditAnnouncement() {
       )}
 
       {/* Form */}
-      <form
-        onSubmit={(e) => {
+      <Card
+        as="form"
+        onSubmit={(e: React.FormEvent) => {
           e.preventDefault();
           void handleSubmit();
         }}
-        className="bg-card border border-border rounded-xl p-6 space-y-5"
+        className="p-6 space-y-5"
       >
         <InputField
           id="announcement-title"
@@ -151,7 +149,7 @@ export default function EditAnnouncement() {
             Save
           </button>
         </div>
-      </form>
+      </Card>
     </div>
   );
 }

--- a/ui/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
@@ -7,6 +7,7 @@ import Breadcrumb from "@/components/common/Breadcrumb";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
 import Spinner from "@/components/common/Spinner";
+import { Card } from "@shellhub/design-system/primitives";
 
 const TITLE_MAX = 90;
 
@@ -58,12 +59,13 @@ export default function NewAnnouncement() {
       )}
 
       {/* Form */}
-      <form
-        onSubmit={(e) => {
+      <Card
+        as="form"
+        onSubmit={(e: React.FormEvent) => {
           e.preventDefault();
           void handleSubmit();
         }}
-        className="bg-card border border-border rounded-xl p-6 space-y-5"
+        className="p-6 space-y-5"
       >
         <InputField
           id="announcement-title"
@@ -105,7 +107,7 @@ export default function NewAnnouncement() {
             Create
           </button>
         </div>
-      </form>
+      </Card>
     </div>
   );
 }

--- a/ui/apps/console/src/pages/admin/announcements/index.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/index.tsx
@@ -13,6 +13,7 @@ import DataTable, { type Column } from "@/components/common/DataTable";
 import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import { formatDateShort } from "@/utils/date";
 import type { AnnouncementShort } from "@/client";
+import { Badge } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 
@@ -37,9 +38,9 @@ export default function AdminAnnouncements() {
       key: "uuid",
       header: "UUID",
       render: (a) => (
-        <span className="inline-flex items-center px-1.5 py-0.5 bg-primary/10 text-primary text-2xs rounded font-mono font-medium max-w-[120px] truncate">
+        <Badge color="primary" className="max-w-32 truncate">
           {a.uuid.slice(0, 8)}
-        </span>
+        </Badge>
       ),
     },
     {

--- a/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -15,6 +15,7 @@ import PlatformBadge from "@/components/common/PlatformBadge";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatDateFull, formatRelative } from "@/utils/date";
 import PageLoader from "@/components/common/PageLoader";
+import { Card } from "@shellhub/design-system/primitives";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -25,9 +26,7 @@ export default function AdminDeviceDetails() {
   const { data: device, isLoading, error } = useAdminDevice(uid ?? "");
 
   if (isLoading) {
-    return (
-      <PageLoader label="Loading device details" />
-    );
+    return <PageLoader label="Loading device details" />;
   }
 
   if (error || !device) {
@@ -94,7 +93,7 @@ export default function AdminDeviceDetails() {
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
         {/* Identity Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <InformationCircleIcon className="w-4 h-4 text-primary" />
             Identity
@@ -132,10 +131,10 @@ export default function AdminDeviceDetails() {
               </dd>
             </div>
           </dl>
-        </div>
+        </Card>
 
         {/* System Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <ComputerDesktopIcon className="w-4 h-4 text-primary" />
             System
@@ -180,10 +179,10 @@ export default function AdminDeviceDetails() {
               </dd>
             </div>
           </dl>
-        </div>
+        </Card>
 
         {/* Namespace & Timeline Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <ClockIcon className="w-4 h-4 text-primary" />
             Namespace & Timeline
@@ -222,11 +221,11 @@ export default function AdminDeviceDetails() {
               <dd className={VALUE}>{formatRelative(device.last_seen)}</dd>
             </div>
           </dl>
-        </div>
+        </Card>
       </div>
 
       {/* Tags Section */}
-      <div className="bg-card border border-border rounded-xl p-5 mb-6">
+      <Card className="p-5 mb-6">
         <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2 mb-3">
           <TagIcon className="w-4 h-4 text-primary" />
           Tags
@@ -245,11 +244,11 @@ export default function AdminDeviceDetails() {
         ) : (
           <p className="text-xs font-mono text-text-muted/50">No tags</p>
         )}
-      </div>
+      </Card>
 
       {/* Public Key Section */}
       {device.public_key && (
-        <div className="bg-card border border-border rounded-xl p-5">
+        <Card className="p-5">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2 mb-3">
             <KeyIcon className="w-4 h-4 text-primary" />
             Public Key
@@ -257,7 +256,7 @@ export default function AdminDeviceDetails() {
           <pre className="text-2xs font-mono text-text-secondary bg-surface border border-border rounded-lg p-4 overflow-x-auto whitespace-pre-wrap break-all">
             {device.public_key}
           </pre>
-        </div>
+        </Card>
       )}
     </div>
   );

--- a/ui/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
@@ -7,10 +7,12 @@ import {
   NoSymbolIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminFirewallRule } from "@/hooks/useAdminFirewallRules";
+import ActiveBadge from "@/components/common/ActiveBadge";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
 import FilterBadge from "@/components/common/FilterBadge";
 import PageLoader from "@/components/common/PageLoader";
+import { Card } from "@shellhub/design-system/primitives";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -21,9 +23,7 @@ export default function AdminFirewallRuleDetails() {
   const { data: rule, isLoading, error } = useAdminFirewallRule(id ?? "");
 
   if (isLoading) {
-    return (
-      <PageLoader label="Loading firewall rule details" />
-    );
+    return <PageLoader label="Loading firewall rule details" />;
   }
 
   if (error || !rule) {
@@ -78,15 +78,7 @@ export default function AdminFirewallRuleDetails() {
             <span className="inline-flex items-center px-1.5 py-0.5 bg-hover-strong text-text-muted text-2xs rounded font-mono">
               Priority {rule.priority}
             </span>
-            {rule.active ? (
-              <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-green/10 text-accent-green border border-accent-green/20">
-                Active
-              </span>
-            ) : (
-              <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20">
-                Inactive
-              </span>
-            )}
+            <ActiveBadge active={rule.active} />
           </div>
         </div>
       </div>
@@ -94,7 +86,7 @@ export default function AdminFirewallRuleDetails() {
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {/* Rule Properties Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <InformationCircleIcon className="w-4 h-4 text-primary" />
             Rule Properties
@@ -151,22 +143,14 @@ export default function AdminFirewallRuleDetails() {
             <div>
               <dt className={LABEL}>Status</dt>
               <dd className="mt-0.5">
-                {rule.active ? (
-                  <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-green/10 text-accent-green border border-accent-green/20">
-                    Active
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20">
-                    Inactive
-                  </span>
-                )}
+                <ActiveBadge active={rule.active} />
               </dd>
             </div>
           </dl>
-        </div>
+        </Card>
 
         {/* Connection Criteria Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <FunnelIcon className="w-4 h-4 text-primary" />
             Connection Criteria
@@ -199,7 +183,7 @@ export default function AdminFirewallRuleDetails() {
               </dd>
             </div>
           </dl>
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/ui/apps/console/src/pages/admin/firewall-rules/index.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/index.tsx
@@ -5,13 +5,15 @@ import {
   CheckCircleIcon,
   NoSymbolIcon,
 } from "@heroicons/react/24/outline";
+import ActiveBadge from "@/components/common/ActiveBadge";
 import Alert from "@/components/common/Alert";
-import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
-import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
-import SearchField from "@/components/common/fields/SearchField";
 import FilterBadge from "@/components/common/FilterBadge";
+import PageHeader from "@/components/common/PageHeader";
+import SearchField from "@/components/common/fields/SearchField";
+import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
 import { type FirewallRulesResponse as FirewallRule } from "@/client";
+import { Badge } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 
@@ -43,11 +45,7 @@ export default function AdminFirewallRules() {
     {
       key: "priority",
       header: "Priority",
-      render: (rule) => (
-        <span className="inline-flex items-center px-1.5 py-0.5 bg-primary/10 text-primary text-2xs rounded font-mono font-medium">
-          {rule.priority}
-        </span>
-      ),
+      render: (rule) => <Badge color="primary">{rule.priority}</Badge>,
     },
     {
       key: "action",
@@ -102,16 +100,7 @@ export default function AdminFirewallRules() {
     {
       key: "status",
       header: "Status",
-      render: (rule) =>
-        rule.active ? (
-          <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-green/10 text-accent-green border border-accent-green/20">
-            Active
-          </span>
-        ) : (
-          <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20">
-            Inactive
-          </span>
-        ),
+      render: (rule) => <ActiveBadge active={rule.active} />,
     },
     {
       key: "namespace",

--- a/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -16,6 +16,7 @@ import DeleteNamespaceDialog from "./DeleteNamespaceDialog";
 import { formatDateFull } from "@/utils/date";
 import { formatMaxDevices } from "./utils";
 import PageLoader from "@/components/common/PageLoader";
+import { Badge, Card } from "@shellhub/design-system/primitives";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -35,9 +36,7 @@ export default function NamespaceDetails() {
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   if (isLoading) {
-    return (
-      <PageLoader label="Loading namespace details" />
-    );
+    return <PageLoader label="Loading namespace details" />;
   }
 
   if (error || !namespace) {
@@ -87,9 +86,9 @@ export default function NamespaceDetails() {
       key: "role",
       header: "Role",
       render: (member) => (
-        <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-primary/10 text-primary border border-primary/20 capitalize">
+        <Badge color="primary" className="capitalize">
           {member.role || "member"}
-        </span>
+        </Badge>
       ),
     },
     {
@@ -149,7 +148,7 @@ export default function NamespaceDetails() {
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
         {/* Properties Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <InformationCircleIcon className="w-4 h-4 text-primary" />
             Properties
@@ -184,10 +183,10 @@ export default function NamespaceDetails() {
               <dd className={VALUE}>{formatDateFull(namespace.created_at)}</dd>
             </div>
           </dl>
-        </div>
+        </Card>
 
         {/* Settings Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <Cog6ToothIcon className="w-4 h-4 text-primary" />
             Settings
@@ -264,11 +263,11 @@ export default function NamespaceDetails() {
               </div>
             </div>
           </dl>
-        </div>
+        </Card>
       </div>
 
       {/* Members Section */}
-      <div className="bg-card border border-border rounded-xl overflow-hidden">
+      <Card className="overflow-hidden">
         <div className="px-5 py-4 border-b border-border">
           <h3 className="text-xs font-semibold text-text-primary">
             Members ({namespace.members?.length || 0})
@@ -282,7 +281,7 @@ export default function NamespaceDetails() {
           noWrapper
           emptyMessage="No members"
         />
-      </div>
+      </Card>
 
       <EditNamespaceDrawer
         open={editOpen}

--- a/ui/apps/console/src/pages/admin/settings/Authentication.tsx
+++ b/ui/apps/console/src/pages/admin/settings/Authentication.tsx
@@ -15,6 +15,7 @@ import PageHeader from "../../../components/common/PageHeader";
 import CopyButton from "../../../components/common/CopyButton";
 import SamlConfigDrawer from "./SamlConfigDrawer";
 import PageLoader from "@/components/common/PageLoader";
+import { Card } from "@shellhub/design-system/primitives";
 
 type AuthSettings = GetAuthenticationSettingsResponse;
 
@@ -67,7 +68,9 @@ export default function AdminAuthentication() {
     let cancelled = false;
     void (async () => {
       try {
-        const { data } = await getAuthenticationSettings({ throwOnError: true });
+        const { data } = await getAuthenticationSettings({
+          throwOnError: true,
+        });
         if (!cancelled) setSettings(data);
       } catch {
         if (!cancelled) setError("Failed to load authentication settings.");
@@ -75,7 +78,9 @@ export default function AdminAuthentication() {
         if (!cancelled) setLoading(false);
       }
     })();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [refreshKey]);
 
   const handleLocalToggle = async () => {
@@ -169,14 +174,15 @@ export default function AdminAuthentication() {
 
       <div className="space-y-4">
         {/* Local Authentication */}
-        <div className="bg-card border border-border rounded-xl p-5">
+        <Card className="p-5">
           <div className="flex items-center justify-between gap-4">
             <div className="flex-1">
               <h3 className="text-sm font-semibold text-text-primary mb-0.5">
                 Local Authentication
               </h3>
               <p className="text-xs text-text-muted leading-relaxed">
-                Allow users to sign in with a username and password stored locally.
+                Allow users to sign in with a username and password stored
+                locally.
               </p>
             </div>
             <Toggle
@@ -186,10 +192,10 @@ export default function AdminAuthentication() {
               ariaLabel="Toggle local authentication"
             />
           </div>
-        </div>
+        </Card>
 
         {/* SAML Authentication */}
-        <div className="bg-card border border-border rounded-xl overflow-hidden">
+        <Card className="overflow-hidden">
           <div className="flex items-center justify-between gap-4 p-5">
             <div className="flex-1">
               <h3 className="text-sm font-semibold text-text-primary mb-0.5">
@@ -199,7 +205,8 @@ export default function AdminAuthentication() {
                 Allow users to sign in via a SAML Identity Provider (SSO).
                 {!samlEnabled && (
                   <span className="text-text-secondary">
-                    {" "}Enable to configure your IdP settings.
+                    {" "}
+                    Enable to configure your IdP settings.
                   </span>
                 )}
               </p>
@@ -232,8 +239,9 @@ export default function AdminAuthentication() {
                     <CopyButton text={saml.assertion_url} size="md" />
                   </div>
                   <p className="mt-1 text-2xs text-text-muted leading-relaxed">
-                    The URL where your IdP should redirect users after successful authentication.
-                    Configure this as the Assertion Consumer Service (ACS) URL in your IdP.
+                    The URL where your IdP should redirect users after
+                    successful authentication. Configure this as the Assertion
+                    Consumer Service (ACS) URL in your IdP.
                   </p>
                 </div>
               )}
@@ -283,7 +291,10 @@ export default function AdminAuthentication() {
                     className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-border hover:border-border-light hover:text-text-primary rounded-lg transition-all"
                     title="Opens a new window directly calling the authentication URL"
                   >
-                    <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5" strokeWidth={2} />
+                    <ArrowTopRightOnSquareIcon
+                      className="w-3.5 h-3.5"
+                      strokeWidth={2}
+                    />
                     Test Auth Integration
                   </a>
                 )}
@@ -298,7 +309,7 @@ export default function AdminAuthentication() {
               </div>
             </div>
           )}
-        </div>
+        </Card>
       </div>
 
       <SamlConfigDrawer

--- a/ui/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -20,6 +20,7 @@ import DeleteUserDialog from "./DeleteUserDialog";
 import { formatDateFull } from "@/utils/date";
 import Spinner from "@/components/common/Spinner";
 import PageLoader from "@/components/common/PageLoader";
+import { Badge, Card } from "@shellhub/design-system/primitives";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -74,9 +75,7 @@ export default function UserDetails() {
   } = useLoginAsUser();
 
   if (isLoading) {
-    return (
-      <PageLoader label="Loading user details" />
-    );
+    return <PageLoader label="Loading user details" />;
   }
 
   if (error || !user) {
@@ -124,11 +123,7 @@ export default function UserDetails() {
             </h1>
             <div className="flex items-center gap-2 mt-1.5">
               <UserStatusChip status={userStatus} />
-              {user.admin && (
-                <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20">
-                  Admin
-                </span>
-              )}
+              {user.admin && <Badge color="yellow">Admin</Badge>}
             </div>
           </div>
         </div>
@@ -182,7 +177,7 @@ export default function UserDetails() {
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
         {/* Identity Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <InformationCircleIcon className="w-4 h-4 text-primary" />
             Identity
@@ -203,10 +198,10 @@ export default function UserDetails() {
               </dd>
             </div>
           </dl>
-        </div>
+        </Card>
 
         {/* Account Card */}
-        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+        <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
             <ClockIcon className="w-4 h-4 text-primary" />
             Account
@@ -250,17 +245,14 @@ export default function UserDetails() {
               <dt className={LABEL}>Auth Methods</dt>
               <dd className="flex items-center gap-1.5 mt-1">
                 {user.preferences.auth_methods.map((method) => (
-                  <span
-                    key={method}
-                    className="inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md bg-primary/10 text-primary border border-primary/20"
-                  >
+                  <Badge key={method} color="primary">
                     {method.toUpperCase()}
-                  </span>
+                  </Badge>
                 ))}
               </dd>
             </div>
           </dl>
-        </div>
+        </Card>
       </div>
 
       {/* Edit Drawer */}

--- a/ui/apps/console/src/pages/admin/users/index.tsx
+++ b/ui/apps/console/src/pages/admin/users/index.tsx
@@ -20,6 +20,7 @@ import CreateUserDrawer from "./CreateUserDrawer";
 import EditUserDrawer from "./EditUserDrawer";
 import DeleteUserDialog from "./DeleteUserDialog";
 import Spinner from "@/components/common/Spinner";
+import { Badge } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -57,11 +58,7 @@ export default function AdminUsers() {
           <span className="text-sm font-medium text-text-primary group-hover:text-primary transition-colors">
             {user.name}
           </span>
-          {user.admin && (
-            <span className="inline-flex items-center px-1.5 py-0.5 text-2xs font-semibold rounded bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20">
-              Admin
-            </span>
-          )}
+          {user.admin && <Badge color="yellow">Admin</Badge>}
         </div>
       ),
     },

--- a/ui/apps/console/src/pages/containers/AddDockerConnectorDrawer.tsx
+++ b/ui/apps/console/src/pages/containers/AddDockerConnectorDrawer.tsx
@@ -1,4 +1,5 @@
 import { CubeIcon } from "@heroicons/react/24/outline";
+import { Card } from "@shellhub/design-system/primitives";
 import Drawer from "@/components/common/Drawer";
 import CopyButton from "@/components/common/CopyButton";
 import { useAuthStore } from "@/stores/authStore";
@@ -30,31 +31,31 @@ function AddDockerConnectorDrawer({
         </p>
 
         <p className="text-sm text-text-secondary leading-relaxed">
-          The easiest way to install the ShellHub Connector is with our automatic
-          one-line installation script, which connects to the Docker API and
-          exposes the running containers within ShellHub.
+          The easiest way to install the ShellHub Connector is with our
+          automatic one-line installation script, which connects to the Docker
+          API and exposes the running containers within ShellHub.
         </p>
 
         <div>
           <p className="text-xs font-semibold text-text-primary mb-2">
             Run the following command on your Docker host:
           </p>
-          <div className="bg-card border border-border rounded-xl p-4 relative group">
+          <Card className="p-4 relative group">
             <pre className="text-xs font-mono text-accent-cyan break-all whitespace-pre-wrap pr-8">
               {command}
             </pre>
             <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
               <CopyButton text={command} />
             </div>
-          </div>
+          </Card>
         </div>
 
         <div className="bg-primary/5 border border-primary/15 rounded-xl p-4">
           <p className="text-xs text-text-secondary leading-relaxed">
             <span className="font-semibold text-primary">Note:</span> Once the
             connector is running, any Docker containers on the host will
-            automatically appear under the Pending tab. Accept them to allow
-            SSH access.
+            automatically appear under the Pending tab. Accept them to allow SSH
+            access.
           </p>
         </div>
       </div>

--- a/ui/apps/console/src/pages/firewall-rules/index.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/index.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 import { useFirewallRules } from "@/hooks/useFirewallRules";
 import { useDeleteFirewallRule } from "@/hooks/useFirewallRuleMutations";
-import PageHeader from "@/components/common/PageHeader";
-import EmptyState from "@/components/common/EmptyState";
+import ActiveBadge from "@/components/common/ActiveBadge";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import DataTable, { type Column } from "@/components/common/DataTable";
-import SearchField from "@/components/common/fields/SearchField";
+import EmptyState from "@/components/common/EmptyState";
 import FilterBadge from "@/components/common/FilterBadge";
+import PageHeader from "@/components/common/PageHeader";
+import SearchField from "@/components/common/fields/SearchField";
 import RuleDrawer from "./RuleDrawer";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import {
@@ -20,6 +21,7 @@ import {
   TrashIcon,
 } from "@heroicons/react/24/outline";
 import { type FirewallRulesResponse as FirewallRule } from "@/client";
+import { Badge } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 
@@ -86,11 +88,7 @@ export default function FirewallRules() {
     {
       key: "priority",
       header: "Priority",
-      render: (rule) => (
-        <span className="inline-flex items-center px-1.5 py-0.5 bg-primary/10 text-primary text-2xs rounded font-mono font-medium">
-          {rule.priority}
-        </span>
-      ),
+      render: (rule) => <Badge color="primary">{rule.priority}</Badge>,
     },
     {
       key: "action",
@@ -145,16 +143,7 @@ export default function FirewallRules() {
     {
       key: "status",
       header: "Status",
-      render: (rule) =>
-        rule.active ? (
-          <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-green/10 text-accent-green border border-accent-green/20">
-            Active
-          </span>
-        ) : (
-          <span className="inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20">
-            Inactive
-          </span>
-        ),
+      render: (rule) => <ActiveBadge active={rule.active} />,
     },
     {
       key: "actions",

--- a/ui/apps/console/src/pages/sessions/SessionTypeBadge.tsx
+++ b/ui/apps/console/src/pages/sessions/SessionTypeBadge.tsx
@@ -1,0 +1,18 @@
+import { Badge } from "@shellhub/design-system/primitives";
+
+interface SessionTypeBadgeProps {
+  types: string[];
+}
+
+export default function SessionTypeBadge({ types }: SessionTypeBadgeProps) {
+  if (types.includes("subsystem"))
+    return <Badge color="cyan" shape="pill">sftp</Badge>;
+
+  if (types.includes("exec"))
+    return <Badge color="yellow" shape="pill">exec</Badge>;
+
+  if (types.includes("shell") || types.includes("pty-req"))
+    return <Badge color="primary" shape="pill">shell</Badge>;
+
+  return null;
+}

--- a/ui/apps/console/src/pages/sessions/__tests__/SessionTypeBadge.test.tsx
+++ b/ui/apps/console/src/pages/sessions/__tests__/SessionTypeBadge.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SessionTypeBadge from "../SessionTypeBadge";
+
+describe("SessionTypeBadge", () => {
+  it("renders 'sftp' for subsystem type", () => {
+    render(<SessionTypeBadge types={["subsystem"]} />);
+    expect(screen.getByText("sftp")).toBeInTheDocument();
+  });
+
+  it("renders 'exec' for exec type", () => {
+    render(<SessionTypeBadge types={["exec"]} />);
+    expect(screen.getByText("exec")).toBeInTheDocument();
+  });
+
+  it("renders 'shell' for shell type", () => {
+    render(<SessionTypeBadge types={["shell"]} />);
+    expect(screen.getByText("shell")).toBeInTheDocument();
+  });
+
+  it("renders 'shell' for pty-req type", () => {
+    render(<SessionTypeBadge types={["pty-req"]} />);
+    expect(screen.getByText("shell")).toBeInTheDocument();
+  });
+
+  it("renders nothing for unknown types", () => {
+    const { container } = render(<SessionTypeBadge types={["unknown"]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for empty types array", () => {
+    const { container } = render(<SessionTypeBadge types={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("prefers 'sftp' when subsystem type is present alongside others", () => {
+    render(<SessionTypeBadge types={["subsystem", "shell"]} />);
+    expect(screen.getByText("sftp")).toBeInTheDocument();
+    expect(screen.queryByText("shell")).not.toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/pages/team/GenerateKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/team/GenerateKeyDrawer.tsx
@@ -2,6 +2,7 @@ import { useState, FormEvent } from "react";
 import { isSdkError } from "@/api/errors";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { KeyIcon, CheckIcon } from "@heroicons/react/24/outline";
+import { Card } from "@shellhub/design-system/primitives";
 import { useCreateApiKey } from "@/hooks/useApiKeyMutations";
 import { type ApiKeyCreate } from "@/client";
 import CopyButton from "@/components/common/CopyButton";
@@ -140,15 +141,15 @@ function GenerateKeyDrawer({
             <span id="generated-api-key-label" className={LABEL}>
               Your API Key
             </span>
-            <div
+            <Card
               aria-labelledby="generated-api-key-label"
-              className="flex items-center gap-2 bg-card border border-border rounded-lg px-3.5 py-2.5"
+              className="rounded-lg px-3.5 py-2.5 flex items-center gap-2"
             >
               <code className="flex-1 text-xs font-mono text-accent-cyan break-all select-all">
                 {generatedKey}
               </code>
               <CopyButton text={generatedKey} size="md" />
-            </div>
+            </Card>
           </div>
         </div>
       ) : (

--- a/ui/apps/console/src/pages/team/InvitationDrawer.tsx
+++ b/ui/apps/console/src/pages/team/InvitationDrawer.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, FormEvent } from "react";
 import { isSdkError } from "@/api/errors";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { Card } from "@shellhub/design-system/primitives";
 import {
   EnvelopeIcon,
   LinkIcon,
@@ -187,16 +188,18 @@ function InvitationDrawer({
             </div>
           </div>
           <div>
-            <span id="invitation-link-label" className={LABEL}>Invitation link</span>
-            <div
+            <span id="invitation-link-label" className={LABEL}>
+              Invitation link
+            </span>
+            <Card
               aria-labelledby="invitation-link-label"
-              className="flex items-center gap-2 bg-card border border-border rounded-lg px-3.5 py-2.5"
+              className="rounded-lg px-3.5 py-2.5 flex items-center gap-2"
             >
               <code className="flex-1 text-xs font-mono text-accent-cyan break-all select-all">
                 {generatedLink}
               </code>
               <CopyButton text={generatedLink} size="md" />
-            </div>
+            </Card>
           </div>
         </div>
       ) : (

--- a/ui/apps/console/src/pages/team/constants.tsx
+++ b/ui/apps/console/src/pages/team/constants.tsx
@@ -1,35 +1,21 @@
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 import RadioCard from "@/components/common/fields/RadioCard";
 import RadioGroupField from "@/components/common/fields/RadioGroupField";
+import { Badge, type BadgeColor } from "@shellhub/design-system/primitives";
 import { ROLES, type AssignableRole } from "./helpers";
 
 /* ─── Constants ─── */
 
-const ROLE_STYLES: Record<
-  string,
-  { bg: string; text: string; border: string }
-> = {
-  owner: {
-    bg: "bg-accent-yellow/10",
-    text: "text-accent-yellow",
-    border: "border-accent-yellow/20",
-  },
-  administrator: {
-    bg: "bg-primary/10",
-    text: "text-primary",
-    border: "border-primary/20",
-  },
-  operator: {
-    bg: "bg-accent-green/10",
-    text: "text-accent-green",
-    border: "border-accent-green/20",
-  },
-  observer: {
-    bg: "bg-hover-medium",
-    text: "text-text-muted",
-    border: "border-border",
-  },
+/** Roles that map directly to a Badge palette color. */
+const ROLE_COLOR: Record<string, BadgeColor> = {
+  owner: "yellow",
+  administrator: "primary",
+  operator: "green",
 };
+
+/** Fallback inline styles for roles that have no palette equivalent (observer). */
+const ROLE_NEUTRAL_STYLE =
+  "inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border bg-hover-medium text-text-muted border-border";
 
 const ROLE_META: Record<string, { icon: string; summary: string }> = {
   administrator: {
@@ -51,24 +37,26 @@ const ROLE_META: Record<string, { icon: string; summary: string }> = {
 /** Small destructive badge shown next to expired API keys or invitations. */
 export function ExpiredBadge() {
   return (
-    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-2xs font-mono font-semibold text-accent-red bg-accent-red/10 border border-accent-red/20 rounded">
+    <Badge color="red" shape="pill">
       <ExclamationCircleIcon className="w-2.5 h-2.5" strokeWidth={2} />
       Expired
-    </span>
+    </Badge>
   );
 }
 
 /* ─── Role Badge ─── */
 
 export function RoleBadge({ role }: { role: string }) {
-  const style = ROLE_STYLES[role] ?? ROLE_STYLES.observer;
-  return (
-    <span
-      className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${style.bg} ${style.text} ${style.border}`}
-    >
-      {role}
-    </span>
-  );
+  const color = ROLE_COLOR[role];
+  if (color) {
+    return (
+      <Badge color={color} shape="pill">
+        {role}
+      </Badge>
+    );
+  }
+  // observer and unknown roles use a neutral style not in the Badge palette
+  return <span className={ROLE_NEUTRAL_STYLE}>{role}</span>;
 }
 
 /* ─── Role Selector ─── */

--- a/ui/apps/website/src/pages/enterprise/AdminPanel.tsx
+++ b/ui/apps/website/src/pages/enterprise/AdminPanel.tsx
@@ -1,12 +1,31 @@
+import { Card } from "@shellhub/design-system/primitives";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 const capabilities = [
-  { label: "User management", desc: "Create, invite, and manage users across your organization" },
-  { label: "Namespace administration", desc: "Organize devices into namespaces with fine-grained access" },
-  { label: "Role-based access control", desc: "Assign roles and permissions at namespace and device level" },
-  { label: "Billing & license management", desc: "View usage, manage subscriptions, and track licenses" },
-  { label: "Global settings", desc: "Configure security policies, session limits, and defaults" },
-  { label: "API key management", desc: "Create and revoke API keys for automation and integrations" },
+  {
+    label: "User management",
+    desc: "Create, invite, and manage users across your organization",
+  },
+  {
+    label: "Namespace administration",
+    desc: "Organize devices into namespaces with fine-grained access",
+  },
+  {
+    label: "Role-based access control",
+    desc: "Assign roles and permissions at namespace and device level",
+  },
+  {
+    label: "Billing & license management",
+    desc: "View usage, manage subscriptions, and track licenses",
+  },
+  {
+    label: "Global settings",
+    desc: "Configure security policies, session limits, and defaults",
+  },
+  {
+    label: "API key management",
+    desc: "Create and revoke API keys for automation and integrations",
+  },
 ];
 
 export function AdminPanel() {
@@ -23,7 +42,9 @@ export function AdminPanel() {
                 Manage everything from the browser
               </h2>
               <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                No more CLI commands for admin tasks. The Enterprise admin panel gives your team a complete web interface for user management, namespace administration, and security policies.
+                No more CLI commands for admin tasks. The Enterprise admin panel
+                gives your team a complete web interface for user management,
+                namespace administration, and security policies.
               </p>
             </Reveal>
 
@@ -31,12 +52,26 @@ export function AdminPanel() {
               {capabilities.map((cap, i) => (
                 <Reveal key={i} delay={i * 0.04}>
                   <div className="flex items-start gap-3">
-                    <svg className="w-4 h-4 text-accent-green shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                    <svg
+                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m4.5 12.75 6 6 9-13.5"
+                      />
                     </svg>
                     <div>
-                      <p className="text-sm font-medium text-text-primary">{cap.label}</p>
-                      <p className="text-xs text-text-secondary leading-relaxed">{cap.desc}</p>
+                      <p className="text-sm font-medium text-text-primary">
+                        {cap.label}
+                      </p>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {cap.desc}
+                      </p>
                     </div>
                   </div>
                 </Reveal>
@@ -45,55 +80,81 @@ export function AdminPanel() {
           </div>
 
           <Reveal delay={0.1}>
-            <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-              <div className="p-6">
-                <div className="flex items-center gap-2 mb-6">
-                  <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                  <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                  <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                  <span className="ml-2 text-2xs text-text-muted font-mono">Admin Panel</span>
-                </div>
-
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center text-2xs font-semibold text-primary">JD</div>
-                      <div>
-                        <p className="text-xs font-medium">Jane Doe</p>
-                        <p className="text-2xs text-text-muted">jane@company.com</p>
-                      </div>
-                    </div>
-                    <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">Admin</span>
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <div className="p-6">
+                  <div className="flex items-center gap-2 mb-6">
+                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                    <span className="ml-2 text-2xs text-text-muted font-mono">
+                      Admin Panel
+                    </span>
                   </div>
 
-                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-accent-blue/15 flex items-center justify-center text-2xs font-semibold text-accent-blue">MS</div>
-                      <div>
-                        <p className="text-xs font-medium">Mike Smith</p>
-                        <p className="text-2xs text-text-muted">mike@company.com</p>
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                      <div className="flex items-center gap-3">
+                        <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center text-2xs font-semibold text-primary">
+                          JD
+                        </div>
+                        <div>
+                          <p className="text-xs font-medium">Jane Doe</p>
+                          <p className="text-2xs text-text-muted">
+                            jane@company.com
+                          </p>
+                        </div>
                       </div>
+                      <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                        Admin
+                      </span>
                     </div>
-                    <span className="px-2 py-0.5 text-2xs font-mono bg-primary/10 text-primary border border-primary/20 rounded-full">Operator</span>
+
+                    <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                      <div className="flex items-center gap-3">
+                        <div className="w-8 h-8 rounded-full bg-accent-blue/15 flex items-center justify-center text-2xs font-semibold text-accent-blue">
+                          MS
+                        </div>
+                        <div>
+                          <p className="text-xs font-medium">Mike Smith</p>
+                          <p className="text-2xs text-text-muted">
+                            mike@company.com
+                          </p>
+                        </div>
+                      </div>
+                      <span className="px-2 py-0.5 text-2xs font-mono bg-primary/10 text-primary border border-primary/20 rounded-full">
+                        Operator
+                      </span>
+                    </div>
+
+                    <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                      <div className="flex items-center gap-3">
+                        <div className="w-8 h-8 rounded-full bg-accent-cyan/15 flex items-center justify-center text-2xs font-semibold text-accent-cyan">
+                          AL
+                        </div>
+                        <div>
+                          <p className="text-xs font-medium">Ana Lima</p>
+                          <p className="text-2xs text-text-muted">
+                            ana@company.com
+                          </p>
+                        </div>
+                      </div>
+                      <span className="px-2 py-0.5 text-2xs font-mono bg-white/[0.04] text-text-muted border border-border rounded-full">
+                        Viewer
+                      </span>
+                    </div>
                   </div>
 
-                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-accent-cyan/15 flex items-center justify-center text-2xs font-semibold text-accent-cyan">AL</div>
-                      <div>
-                        <p className="text-xs font-medium">Ana Lima</p>
-                        <p className="text-2xs text-text-muted">ana@company.com</p>
-                      </div>
-                    </div>
-                    <span className="px-2 py-0.5 text-2xs font-mono bg-white/[0.04] text-text-muted border border-border rounded-full">Viewer</span>
+                  <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                    <span className="text-2xs text-text-muted">
+                      3 users in production namespace
+                    </span>
+                    <span className="text-2xs text-primary font-medium">
+                      Manage &rarr;
+                    </span>
                   </div>
                 </div>
-
-                <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                  <span className="text-2xs text-text-muted">3 users in production namespace</span>
-                  <span className="text-2xs text-primary font-medium">Manage &rarr;</span>
-                </div>
-              </div>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>

--- a/ui/apps/website/src/pages/enterprise/DeploymentOptions.tsx
+++ b/ui/apps/website/src/pages/enterprise/DeploymentOptions.tsx
@@ -1,3 +1,4 @@
+import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 export function DeploymentOptions() {
@@ -12,7 +13,8 @@ export function DeploymentOptions() {
             Your infrastructure, your rules
           </h2>
           <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            Choose the deployment model that fits your organization. Fully managed or on your own infrastructure.
+            Choose the deployment model that fits your organization. Fully
+            managed or on your own infrastructure.
           </p>
         </Reveal>
 
@@ -23,19 +25,30 @@ export function DeploymentOptions() {
                 <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
                 <div className="relative">
                   <div className="flex items-center gap-3 mb-4">
-                    <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
-                      <svg className="w-5 h-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15z" />
+                    <IconBadge color="primary">
+                      <svg
+                        className="w-5 h-5 text-primary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15z"
+                        />
                       </svg>
-                    </div>
-                    <span className="px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                    </IconBadge>
+                    <Badge shape="pill" color="green">
                       Recommended
-                    </span>
+                    </Badge>
                   </div>
 
                   <h3 className="text-lg font-bold mb-2">Managed Cloud</h3>
                   <p className="text-sm text-text-secondary leading-relaxed mb-6">
-                    We handle the infrastructure. Dedicated servers, automatic updates, and guaranteed uptime.
+                    We handle the infrastructure. Dedicated servers, automatic
+                    updates, and guaranteed uptime.
                   </p>
 
                   <ul className="space-y-2.5">
@@ -46,9 +59,22 @@ export function DeploymentOptions() {
                       "Daily backups with point-in-time recovery",
                       "Global edge network for low latency",
                     ].map((item) => (
-                      <li key={item} className="flex items-center gap-2.5 text-sm text-text-secondary">
-                        <svg className="w-4 h-4 text-accent-green shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                      <li
+                        key={item}
+                        className="flex items-center gap-2.5 text-sm text-text-secondary"
+                      >
+                        <svg
+                          className="w-4 h-4 text-accent-green shrink-0"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="m4.5 12.75 6 6 9-13.5"
+                          />
                         </svg>
                         {item}
                       </li>
@@ -61,18 +87,29 @@ export function DeploymentOptions() {
 
           <Reveal delay={0.1}>
             <ShimmerCard className="h-full">
-              <div className="bg-card border border-border rounded-xl p-8 flex flex-col h-full hover:border-border-light transition-colors duration-300">
+              <Card hover className="p-8 flex flex-col h-full">
                 <div className="flex items-center gap-3 mb-4">
-                  <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
-                    <svg className="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 17.25v-.228a4.5 4.5 0 0 0-.12-1.03l-2.268-9.64a3.375 3.375 0 0 0-3.285-2.602H7.923a3.375 3.375 0 0 0-3.285 2.602l-2.268 9.64a4.5 4.5 0 0 0-.12 1.03v.228m19.5 0a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3m19.5 0a3 3 0 0 0-3-3H5.25a3 3 0 0 0-3 3m16.5 0h.008v.008h-.008v-.008Zm-3 0h.008v.008h-.008v-.008Z" />
+                  <IconBadge color="neutral">
+                    <svg
+                      className="w-5 h-5 text-text-secondary"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M21.75 17.25v-.228a4.5 4.5 0 0 0-.12-1.03l-2.268-9.64a3.375 3.375 0 0 0-3.285-2.602H7.923a3.375 3.375 0 0 0-3.285 2.602l-2.268 9.64a4.5 4.5 0 0 0-.12 1.03v.228m19.5 0a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3m19.5 0a3 3 0 0 0-3-3H5.25a3 3 0 0 0-3 3m16.5 0h.008v.008h-.008v-.008Zm-3 0h.008v.008h-.008v-.008Z"
+                      />
                     </svg>
-                  </div>
+                  </IconBadge>
                 </div>
 
                 <h3 className="text-lg font-bold mb-2">On-Premises</h3>
                 <p className="text-sm text-text-secondary leading-relaxed mb-6">
-                  Run ShellHub on your own infrastructure. Full data sovereignty and compliance control.
+                  Run ShellHub on your own infrastructure. Full data sovereignty
+                  and compliance control.
                 </p>
 
                 <ul className="space-y-2.5">
@@ -83,15 +120,28 @@ export function DeploymentOptions() {
                     "Air-gapped environment support",
                     "Custom integration with your toolchain",
                   ].map((item) => (
-                    <li key={item} className="flex items-center gap-2.5 text-sm text-text-secondary">
-                      <svg className="w-4 h-4 text-text-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                    <li
+                      key={item}
+                      className="flex items-center gap-2.5 text-sm text-text-secondary"
+                    >
+                      <svg
+                        className="w-4 h-4 text-text-muted shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m4.5 12.75 6 6 9-13.5"
+                        />
                       </svg>
                       {item}
                     </li>
                   ))}
                 </ul>
-              </div>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>

--- a/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
+++ b/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge } from "@shellhub/design-system/primitives";
 import { Reveal, ConnectionGrid } from "../landing/components";
 
 export function HeroEnterprise() {
@@ -10,9 +11,9 @@ export function HeroEnterprise() {
 
       <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
         <Reveal>
-          <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20 rounded-full mb-6">
+          <Badge shape="pill" color="yellow" className="mb-6">
             Enterprise
-          </span>
+          </Badge>
         </Reveal>
         <Reveal>
           <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-3xl mx-auto">

--- a/ui/apps/website/src/pages/enterprise/SecurityFeatures.tsx
+++ b/ui/apps/website/src/pages/enterprise/SecurityFeatures.tsx
@@ -1,10 +1,19 @@
+import { Card } from "@shellhub/design-system/primitives";
 import { Reveal, ShimmerCard } from "../landing/components";
 import { C } from "../landing/constants";
 
 const features = [
   {
     icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={C.primary}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      >
         <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
         <polyline points="10 17 15 12 10 7" />
         <line x1="15" y1="12" x2="3" y2="12" />
@@ -16,7 +25,15 @@ const features = [
   },
   {
     icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.cyan} strokeWidth="1.5" strokeLinecap="round">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={C.cyan}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      >
         <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
         <circle cx="9" cy="7" r="4" />
         <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
@@ -29,7 +46,15 @@ const features = [
   },
   {
     icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.yellow} strokeWidth="1.5" strokeLinecap="round">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={C.yellow}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      >
         <rect x="3" y="11" width="18" height="11" rx="2" />
         <path d="M7 11V7a5 5 0 0 1 10 0v4" />
         <circle cx="12" cy="16" r="1" />
@@ -41,7 +66,15 @@ const features = [
   },
   {
     icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.green} strokeWidth="1.5" strokeLinecap="round">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={C.green}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      >
         <path d="M12 20h9" />
         <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
       </svg>
@@ -52,7 +85,15 @@ const features = [
   },
   {
     icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.red} strokeWidth="1.5" strokeLinecap="round">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={C.red}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      >
         <circle cx="12" cy="12" r="10" />
         <polygon points="10 8 16 12 10 16 10 8" />
       </svg>
@@ -63,7 +104,15 @@ const features = [
   },
   {
     icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.blue} strokeWidth="1.5" strokeLinecap="round">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={C.blue}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      >
         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
       </svg>
     ),
@@ -85,22 +134,30 @@ export function SecurityFeatures() {
             Enterprise-grade security, built in
           </h2>
           <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            Meet compliance requirements with SSO, MFA enforcement, session recording, and complete audit logging.
+            Meet compliance requirements with SSO, MFA enforcement, session
+            recording, and complete audit logging.
           </p>
         </Reveal>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {features.map((f, i) => (
             <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{ background: `${f.color}15`, borderColor: `${f.color}25` }}
-                >
-                  {f.icon}
-                </div>
-                <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                <p className="text-xs text-text-secondary leading-relaxed">{f.desc}</p>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${f.color}15`,
+                      borderColor: `${f.color}25`,
+                    }}
+                  >
+                    {f.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {f.desc}
+                  </p>
+                </Card>
               </ShimmerCard>
             </Reveal>
           ))}

--- a/ui/apps/website/src/pages/enterprise/SupportSection.tsx
+++ b/ui/apps/website/src/pages/enterprise/SupportSection.tsx
@@ -1,3 +1,4 @@
+import { Card, IconBadge } from "@shellhub/design-system/primitives";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 export function SupportSection() {
@@ -12,23 +13,36 @@ export function SupportSection() {
             Support that matches your needs
           </h2>
           <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            From community forums to dedicated account managers, choose the level of support your team needs.
+            From community forums to dedicated account managers, choose the
+            level of support your team needs.
           </p>
         </Reveal>
 
         <div className="grid md:grid-cols-2 gap-6">
           <Reveal delay={0}>
             <ShimmerCard className="h-full">
-              <div className="bg-card border border-border rounded-xl p-8 h-full hover:border-border-light transition-colors duration-300">
+              <Card hover className="p-8 h-full">
                 <div className="flex items-center gap-3 mb-6">
                   <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
-                    <svg className="w-5 h-5 text-text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 0 1-.825-.242m9.345-8.334a2.126 2.126 0 0 0-.476-.095 48.64 48.64 0 0 0-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0 0 11.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155" />
+                    <svg
+                      className="w-5 h-5 text-text-secondary"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 0 1-.825-.242m9.345-8.334a2.126 2.126 0 0 0-.476-.095 48.64 48.64 0 0 0-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0 0 11.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155"
+                      />
                     </svg>
                   </div>
                   <div>
                     <h3 className="text-sm font-bold">Community</h3>
-                    <p className="text-2xs text-text-muted">Free & Open Source</p>
+                    <p className="text-2xs text-text-muted">
+                      Free & Open Source
+                    </p>
                   </div>
                 </div>
 
@@ -39,15 +53,28 @@ export function SupportSection() {
                     "Public documentation",
                     "Community-driven bug fixes",
                   ].map((item) => (
-                    <li key={item} className="flex items-center gap-2.5 text-sm text-text-secondary">
-                      <svg className="w-4 h-4 text-text-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                    <li
+                      key={item}
+                      className="flex items-center gap-2.5 text-sm text-text-secondary"
+                    >
+                      <svg
+                        className="w-4 h-4 text-text-muted shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m4.5 12.75 6 6 9-13.5"
+                        />
                       </svg>
                       {item}
                     </li>
                   ))}
                 </ul>
-              </div>
+              </Card>
             </ShimmerCard>
           </Reveal>
 
@@ -57,11 +84,21 @@ export function SupportSection() {
                 <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
                 <div className="relative">
                   <div className="flex items-center gap-3 mb-6">
-                    <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
-                      <svg className="w-5 h-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+                    <IconBadge color="primary">
+                      <svg
+                        className="w-5 h-5 text-primary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
+                        />
                       </svg>
-                    </div>
+                    </IconBadge>
                     <div>
                       <h3 className="text-sm font-bold">Enterprise</h3>
                       <p className="text-2xs text-primary">Priority Support</p>
@@ -77,9 +114,22 @@ export function SupportSection() {
                       "Custom integration support",
                       "Quarterly business reviews",
                     ].map((item) => (
-                      <li key={item} className="flex items-center gap-2.5 text-sm text-text-secondary">
-                        <svg className="w-4 h-4 text-accent-green shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                      <li
+                        key={item}
+                        className="flex items-center gap-2.5 text-sm text-text-secondary"
+                      >
+                        <svg
+                          className="w-4 h-4 text-accent-green shrink-0"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="m4.5 12.75 6 6 9-13.5"
+                          />
                         </svg>
                         {item}
                       </li>

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card } from "@shellhub/design-system/primitives";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -14,7 +15,7 @@ function TerminalChrome({
   accent?: string;
 }) {
   return (
-    <div className="bg-card border border-border rounded-xl overflow-hidden">
+    <Card className="overflow-hidden">
       <div className="px-4 py-3 border-b border-border flex items-center gap-2">
         <div className="w-3 h-3 rounded-full bg-accent-red/60" />
         <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
@@ -26,7 +27,7 @@ function TerminalChrome({
         />
       </div>
       <div className="p-5 font-mono text-xs leading-relaxed">{children}</div>
-    </div>
+    </Card>
   );
 }
 
@@ -39,7 +40,7 @@ function BrowserChrome({
   children: React.ReactNode;
 }) {
   return (
-    <div className="bg-card border border-border rounded-xl overflow-hidden">
+    <Card className="overflow-hidden">
       <div className="px-4 py-3 border-b border-border flex items-center gap-2">
         <div className="w-3 h-3 rounded-full bg-accent-red/60" />
         <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
@@ -62,7 +63,7 @@ function BrowserChrome({
         </div>
       </div>
       <div className="p-5">{children}</div>
-    </div>
+    </Card>
   );
 }
 
@@ -109,9 +110,9 @@ function Hero() {
 
       <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
         <Reveal>
-          <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-primary/10 text-primary border border-primary/20 rounded-full mb-6">
+          <Badge shape="pill" color="primary" className="mb-6 tracking-label">
             Features
-          </span>
+          </Badge>
         </Reveal>
         <Reveal>
           <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-3xl mx-auto">
@@ -237,37 +238,39 @@ function NativeSSH() {
 
           {/* Terminal Mockup */}
           <Reveal delay={0.1}>
-            <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-              <TerminalChrome title="Terminal — ssh" accent={C.green}>
-                <Line
-                  prompt="$"
-                  cmd="ssh admin@rpi-gateway.production.shellhub"
-                />
-                <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
-                  <span className="text-accent-green">Connected to</span>{" "}
-                  <span className="text-primary">rpi-gateway</span>
-                  <span className="text-text-muted"> (production)</span>
-                </div>
-                <Line
-                  prompt="$"
-                  cmd="ssh deploy@sensor-node-04.staging.shellhub"
-                />
-                <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
-                  <span className="text-accent-green">Connected to</span>{" "}
-                  <span className="text-primary">sensor-node-04</span>
-                  <span className="text-text-muted"> (staging)</span>
-                </div>
-                <Line
-                  prompt="$"
-                  cmd="ssh root@edge-server.iot-fleet.shellhub"
-                />
-                <div className="mt-2 flex items-center gap-2">
-                  <div className="w-1.5 h-1.5 rounded-full bg-accent-green animate-pulse" />
-                  <span className="text-text-muted text-2xs">
-                    Connecting via ShellHub gateway...
-                  </span>
-                </div>
-              </TerminalChrome>
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <TerminalChrome title="Terminal — ssh" accent={C.green}>
+                  <Line
+                    prompt="$"
+                    cmd="ssh admin@rpi-gateway.production.shellhub"
+                  />
+                  <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
+                    <span className="text-accent-green">Connected to</span>{" "}
+                    <span className="text-primary">rpi-gateway</span>
+                    <span className="text-text-muted"> (production)</span>
+                  </div>
+                  <Line
+                    prompt="$"
+                    cmd="ssh deploy@sensor-node-04.staging.shellhub"
+                  />
+                  <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
+                    <span className="text-accent-green">Connected to</span>{" "}
+                    <span className="text-primary">sensor-node-04</span>
+                    <span className="text-text-muted"> (staging)</span>
+                  </div>
+                  <Line
+                    prompt="$"
+                    cmd="ssh root@edge-server.iot-fleet.shellhub"
+                  />
+                  <div className="mt-2 flex items-center gap-2">
+                    <div className="w-1.5 h-1.5 rounded-full bg-accent-green animate-pulse" />
+                    <span className="text-text-muted text-2xs">
+                      Connecting via ShellHub gateway...
+                    </span>
+                  </div>
+                </TerminalChrome>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>
@@ -286,139 +289,151 @@ function SessionRecording() {
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           {/* Playback Mockup (left on this one for visual variety) */}
           <Reveal delay={0.1}>
-            <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-              <div className="p-6">
-                {/* Header bar */}
-                <div className="flex items-center justify-between mb-5">
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <div className="p-6">
+                  {/* Header bar */}
+                  <div className="flex items-center justify-between mb-5">
+                    <div className="flex items-center gap-3">
+                      <div className="w-8 h-8 rounded-lg bg-accent-cyan/15 border border-accent-cyan/20 flex items-center justify-center">
+                        <svg
+                          className="w-4 h-4 text-accent-cyan"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={1.5}
+                        >
+                          <circle cx="12" cy="12" r="10" />
+                          <polygon points="10 8 16 12 10 16 10 8" />
+                        </svg>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold">Session #a7f3c2</p>
+                        <p className="text-2xs text-text-muted font-mono">
+                          admin@rpi-gateway &middot; production
+                        </p>
+                      </div>
+                    </div>
+                    <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                      Recorded
+                    </span>
+                  </div>
+
+                  {/* Fake terminal playback area */}
+                  <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs mb-4">
+                    <div className="text-text-muted mb-1">
+                      <span className="text-accent-green">
+                        admin@rpi-gateway
+                      </span>
+                      :<span className="text-accent-blue">~</span>$ systemctl
+                      status nginx
+                    </div>
+                    <div className="text-text-secondary mb-1">
+                      ● nginx.service - A high performance web server
+                    </div>
+                    <div className="text-text-secondary mb-1">
+                      &nbsp;&nbsp;&nbsp;Active:{" "}
+                      <span className="text-accent-green">
+                        active (running)
+                      </span>{" "}
+                      since Mon 2026-02-14 09:31:04 UTC
+                    </div>
+                    <div className="text-text-secondary mb-1">
+                      &nbsp;&nbsp;Process: 1247 ExecStartPre=/usr/sbin/nginx -t
+                      (code=exited, status=0/SUCCESS)
+                    </div>
+                    <div className="text-text-muted mt-2">
+                      <span className="text-accent-green">
+                        admin@rpi-gateway
+                      </span>
+                      :<span className="text-accent-blue">~</span>${" "}
+                      <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
+                    </div>
+                  </div>
+
+                  {/* Playback controls */}
                   <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-lg bg-accent-cyan/15 border border-accent-cyan/20 flex items-center justify-center">
+                    <button className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
                       <svg
-                        className="w-4 h-4 text-accent-cyan"
+                        className="w-4 h-4 text-text-secondary"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
-                        strokeWidth={1.5}
+                        strokeWidth={2}
                       >
-                        <circle cx="12" cy="12" r="10" />
-                        <polygon points="10 8 16 12 10 16 10 8" />
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M21 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 0 1 0-1.953l7.108-4.062A1.125 1.125 0 0 1 21 8.688v8.123ZM11.25 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 0 1 0-1.953l7.108-4.062a1.125 1.125 0 0 1 1.683.977v8.123Z"
+                        />
                       </svg>
-                    </div>
-                    <div>
-                      <p className="text-xs font-semibold">Session #a7f3c2</p>
-                      <p className="text-2xs text-text-muted font-mono">
-                        admin@rpi-gateway &middot; production
-                      </p>
-                    </div>
-                  </div>
-                  <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
-                    Recorded
-                  </span>
-                </div>
+                    </button>
+                    <button className="w-10 h-10 rounded-lg bg-accent-cyan/15 border border-accent-cyan/25 flex items-center justify-center hover:bg-accent-cyan/25 transition-colors">
+                      <svg
+                        className="w-5 h-5 text-accent-cyan"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M15.75 5.25v13.5m-7.5-13.5v13.5"
+                        />
+                      </svg>
+                    </button>
+                    <button className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
+                      <svg
+                        className="w-4 h-4 text-text-secondary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M3 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 0 1 0 1.953l-7.108 4.062A1.125 1.125 0 0 1 3 16.81V8.688ZM12.75 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 0 1 0 1.953l-7.108 4.062a1.125 1.125 0 0 1-1.683-.977V8.688Z"
+                        />
+                      </svg>
+                    </button>
 
-                {/* Fake terminal playback area */}
-                <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs mb-4">
-                  <div className="text-text-muted mb-1">
-                    <span className="text-accent-green">admin@rpi-gateway</span>
-                    :<span className="text-accent-blue">~</span>$ systemctl
-                    status nginx
-                  </div>
-                  <div className="text-text-secondary mb-1">
-                    ● nginx.service - A high performance web server
-                  </div>
-                  <div className="text-text-secondary mb-1">
-                    &nbsp;&nbsp;&nbsp;Active:{" "}
-                    <span className="text-accent-green">active (running)</span>{" "}
-                    since Mon 2026-02-14 09:31:04 UTC
-                  </div>
-                  <div className="text-text-secondary mb-1">
-                    &nbsp;&nbsp;Process: 1247 ExecStartPre=/usr/sbin/nginx -t
-                    (code=exited, status=0/SUCCESS)
-                  </div>
-                  <div className="text-text-muted mt-2">
-                    <span className="text-accent-green">admin@rpi-gateway</span>
-                    :<span className="text-accent-blue">~</span>${" "}
-                    <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
-                  </div>
-                </div>
-
-                {/* Playback controls */}
-                <div className="flex items-center gap-3">
-                  <button className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
-                    <svg
-                      className="w-4 h-4 text-text-secondary"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M21 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 0 1 0-1.953l7.108-4.062A1.125 1.125 0 0 1 21 8.688v8.123ZM11.25 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 0 1 0-1.953l7.108-4.062a1.125 1.125 0 0 1 1.683.977v8.123Z"
-                      />
-                    </svg>
-                  </button>
-                  <button className="w-10 h-10 rounded-lg bg-accent-cyan/15 border border-accent-cyan/25 flex items-center justify-center hover:bg-accent-cyan/25 transition-colors">
-                    <svg
-                      className="w-5 h-5 text-accent-cyan"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M15.75 5.25v13.5m-7.5-13.5v13.5"
-                      />
-                    </svg>
-                  </button>
-                  <button className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
-                    <svg
-                      className="w-4 h-4 text-text-secondary"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M3 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 0 1 0 1.953l-7.108 4.062A1.125 1.125 0 0 1 3 16.81V8.688ZM12.75 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 0 1 0 1.953l-7.108 4.062a1.125 1.125 0 0 1-1.683-.977V8.688Z"
-                      />
-                    </svg>
-                  </button>
-
-                  {/* Timeline */}
-                  <div className="flex-1 mx-2">
-                    <div className="h-1.5 bg-surface rounded-full overflow-hidden border border-border">
-                      <div className="h-full w-[62%] bg-gradient-to-r from-accent-cyan to-primary rounded-full relative">
-                        <div className="absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full shadow-[0_0_8px_rgba(78,154,163,0.6)]" />
+                    {/* Timeline */}
+                    <div className="flex-1 mx-2">
+                      <div className="h-1.5 bg-surface rounded-full overflow-hidden border border-border">
+                        <div className="h-full w-[62%] bg-gradient-to-r from-accent-cyan to-primary rounded-full relative">
+                          <div className="absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full shadow-[0_0_8px_rgba(78,154,163,0.6)]" />
+                        </div>
                       </div>
                     </div>
+
+                    <span className="text-2xs text-text-muted font-mono whitespace-nowrap">
+                      04:32 / 07:15
+                    </span>
                   </div>
 
-                  <span className="text-2xs text-text-muted font-mono whitespace-nowrap">
-                    04:32 / 07:15
-                  </span>
+                  {/* Session metadata */}
+                  <div className="mt-4 pt-4 border-t border-border grid grid-cols-3 gap-4">
+                    <div>
+                      <p className="text-2xs text-text-muted mb-0.5">
+                        Duration
+                      </p>
+                      <p className="text-xs font-mono font-medium">7m 15s</p>
+                    </div>
+                    <div>
+                      <p className="text-2xs text-text-muted mb-0.5">
+                        Commands
+                      </p>
+                      <p className="text-xs font-mono font-medium">23</p>
+                    </div>
+                    <div>
+                      <p className="text-2xs text-text-muted mb-0.5">Size</p>
+                      <p className="text-xs font-mono font-medium">1.2 MB</p>
+                    </div>
+                  </div>
                 </div>
-
-                {/* Session metadata */}
-                <div className="mt-4 pt-4 border-t border-border grid grid-cols-3 gap-4">
-                  <div>
-                    <p className="text-2xs text-text-muted mb-0.5">Duration</p>
-                    <p className="text-xs font-mono font-medium">7m 15s</p>
-                  </div>
-                  <div>
-                    <p className="text-2xs text-text-muted mb-0.5">Commands</p>
-                    <p className="text-xs font-mono font-medium">23</p>
-                  </div>
-                  <div>
-                    <p className="text-2xs text-text-muted mb-0.5">Size</p>
-                    <p className="text-xs font-mono font-medium">1.2 MB</p>
-                  </div>
-                </div>
-              </div>
+              </Card>
             </ShimmerCard>
           </Reveal>
 
@@ -566,62 +581,68 @@ function WebTerminal() {
 
           {/* Browser Mockup */}
           <Reveal delay={0.1}>
-            <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-              <BrowserChrome url="shellhub.io/devices/rpi-gateway/terminal">
-                {/* Fake tabs row */}
-                <div className="flex items-center gap-1 mb-4">
-                  <div className="px-3 py-1.5 bg-surface border border-border rounded-t-lg text-2xs font-mono text-text-primary flex items-center gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                    rpi-gateway
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <BrowserChrome url="shellhub.io/devices/rpi-gateway/terminal">
+                  {/* Fake tabs row */}
+                  <div className="flex items-center gap-1 mb-4">
+                    <div className="px-3 py-1.5 bg-surface border border-border rounded-t-lg text-2xs font-mono text-text-primary flex items-center gap-2">
+                      <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                      rpi-gateway
+                    </div>
+                    <div className="px-3 py-1.5 bg-card border border-border/50 rounded-t-lg text-2xs font-mono text-text-muted flex items-center gap-2">
+                      <div className="w-1.5 h-1.5 rounded-full bg-text-muted" />
+                      sensor-node-04
+                    </div>
                   </div>
-                  <div className="px-3 py-1.5 bg-card border border-border/50 rounded-t-lg text-2xs font-mono text-text-muted flex items-center gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full bg-text-muted" />
-                    sensor-node-04
-                  </div>
-                </div>
 
-                {/* Terminal area inside browser */}
-                <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs">
-                  <div className="text-text-muted mb-1.5">
-                    <span className="text-accent-green">admin@rpi-gateway</span>
-                    :<span className="text-accent-blue">~</span>$ docker ps
-                    --format &quot;table {"{{.Names}}"}\t{"{{.Status}}"}&quot;
+                  {/* Terminal area inside browser */}
+                  <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs">
+                    <div className="text-text-muted mb-1.5">
+                      <span className="text-accent-green">
+                        admin@rpi-gateway
+                      </span>
+                      :<span className="text-accent-blue">~</span>$ docker ps
+                      --format &quot;table {"{{.Names}}"}\t{"{{.Status}}"}&quot;
+                    </div>
+                    <div className="text-text-secondary mb-0.5">
+                      NAMES&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;STATUS
+                    </div>
+                    <div className="text-text-secondary mb-0.5">
+                      nginx-proxy&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
+                      days
+                    </div>
+                    <div className="text-text-secondary mb-0.5">
+                      app-backend&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
+                      days
+                    </div>
+                    <div className="text-text-secondary mb-0.5">
+                      redis-cache&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
+                      days
+                    </div>
+                    <div className="text-text-secondary mb-1.5">
+                      postgres-db&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
+                      days
+                    </div>
+                    <div className="text-text-muted">
+                      <span className="text-accent-green">
+                        admin@rpi-gateway
+                      </span>
+                      :<span className="text-accent-blue">~</span>${" "}
+                      <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
+                    </div>
                   </div>
-                  <div className="text-text-secondary mb-0.5">
-                    NAMES&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;STATUS
-                  </div>
-                  <div className="text-text-secondary mb-0.5">
-                    nginx-proxy&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                    days
-                  </div>
-                  <div className="text-text-secondary mb-0.5">
-                    app-backend&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                    days
-                  </div>
-                  <div className="text-text-secondary mb-0.5">
-                    redis-cache&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                    days
-                  </div>
-                  <div className="text-text-secondary mb-1.5">
-                    postgres-db&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                    days
-                  </div>
-                  <div className="text-text-muted">
-                    <span className="text-accent-green">admin@rpi-gateway</span>
-                    :<span className="text-accent-blue">~</span>${" "}
-                    <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
-                  </div>
-                </div>
 
-                {/* Status bar */}
-                <div className="mt-3 flex items-center justify-between text-2xs text-text-muted">
-                  <div className="flex items-center gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                    <span>Connected &middot; WebSocket</span>
+                  {/* Status bar */}
+                  <div className="mt-3 flex items-center justify-between text-2xs text-text-muted">
+                    <div className="flex items-center gap-2">
+                      <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                      <span>Connected &middot; WebSocket</span>
+                    </div>
+                    <span className="font-mono">80x24</span>
                   </div>
-                  <span className="font-mono">80x24</span>
-                </div>
-              </BrowserChrome>
+                </BrowserChrome>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>
@@ -770,20 +791,22 @@ function SecurityGrid() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {securityFeatures.map((f, i) => (
             <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{
-                    background: `${f.color}15`,
-                    borderColor: `${f.color}25`,
-                  }}
-                >
-                  {f.icon}
-                </div>
-                <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                <p className="text-xs text-text-secondary leading-relaxed">
-                  {f.desc}
-                </p>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${f.color}15`,
+                      borderColor: `${f.color}25`,
+                    }}
+                  >
+                    {f.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {f.desc}
+                  </p>
+                </Card>
               </ShimmerCard>
             </Reveal>
           ))}
@@ -803,52 +826,54 @@ function FileTransfer() {
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           {/* Terminal Mockup */}
           <Reveal delay={0.1}>
-            <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-              <TerminalChrome title="Terminal — scp / sftp" accent={C.cyan}>
-                <div className="mb-4">
-                  <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
-                    SCP &mdash; Copy files to device
-                  </p>
-                  <Line
-                    prompt="$"
-                    cmd="scp firmware-v2.4.bin admin@rpi-gateway.production.shellhub:/opt/firmware/"
-                  />
-                  <div className="mt-1 flex items-center gap-3">
-                    <div className="flex-1 h-1.5 bg-surface rounded-full overflow-hidden border border-border">
-                      <div className="h-full w-full bg-gradient-to-r from-accent-cyan to-primary rounded-full" />
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <TerminalChrome title="Terminal — scp / sftp" accent={C.cyan}>
+                  <div className="mb-4">
+                    <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
+                      SCP &mdash; Copy files to device
+                    </p>
+                    <Line
+                      prompt="$"
+                      cmd="scp firmware-v2.4.bin admin@rpi-gateway.production.shellhub:/opt/firmware/"
+                    />
+                    <div className="mt-1 flex items-center gap-3">
+                      <div className="flex-1 h-1.5 bg-surface rounded-full overflow-hidden border border-border">
+                        <div className="h-full w-full bg-gradient-to-r from-accent-cyan to-primary rounded-full" />
+                      </div>
+                      <span className="text-accent-green text-2xs">100%</span>
                     </div>
-                    <span className="text-accent-green text-2xs">100%</span>
-                  </div>
-                  <p className="text-text-muted text-2xs mt-1">
-                    firmware-v2.4.bin &nbsp; 24.3 MB &nbsp; 12.1MB/s &nbsp;
-                    00:02
-                  </p>
-                </div>
-
-                <div className="pt-4 border-t border-border">
-                  <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
-                    SFTP &mdash; Interactive session
-                  </p>
-                  <Line prompt="sftp>" cmd="ls /var/log/" />
-                  <div className="text-text-secondary ml-0">
-                    <p>
-                      syslog &nbsp;&nbsp; auth.log &nbsp;&nbsp; kern.log
-                      &nbsp;&nbsp; nginx/
+                    <p className="text-text-muted text-2xs mt-1">
+                      firmware-v2.4.bin &nbsp; 24.3 MB &nbsp; 12.1MB/s &nbsp;
+                      00:02
                     </p>
                   </div>
-                  <Line
-                    prompt="sftp>"
-                    cmd="get /var/log/syslog ./diagnostics/"
-                  />
-                  <p className="text-text-muted text-2xs mt-1">
-                    Fetching /var/log/syslog to ./diagnostics/syslog
-                  </p>
-                  <p className="text-accent-green text-2xs">
-                    /var/log/syslog &nbsp; 100% &nbsp; 847KB &nbsp; 4.2MB/s
-                    &nbsp; 00:00
-                  </p>
-                </div>
-              </TerminalChrome>
+
+                  <div className="pt-4 border-t border-border">
+                    <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
+                      SFTP &mdash; Interactive session
+                    </p>
+                    <Line prompt="sftp>" cmd="ls /var/log/" />
+                    <div className="text-text-secondary ml-0">
+                      <p>
+                        syslog &nbsp;&nbsp; auth.log &nbsp;&nbsp; kern.log
+                        &nbsp;&nbsp; nginx/
+                      </p>
+                    </div>
+                    <Line
+                      prompt="sftp>"
+                      cmd="get /var/log/syslog ./diagnostics/"
+                    />
+                    <p className="text-text-muted text-2xs mt-1">
+                      Fetching /var/log/syslog to ./diagnostics/syslog
+                    </p>
+                    <p className="text-accent-green text-2xs">
+                      /var/log/syslog &nbsp; 100% &nbsp; 847KB &nbsp; 4.2MB/s
+                      &nbsp; 00:00
+                    </p>
+                  </div>
+                </TerminalChrome>
+              </Card>
             </ShimmerCard>
           </Reveal>
 
@@ -1340,7 +1365,7 @@ function DeviceOrganization() {
           {/* Tags card */}
           <Reveal delay={0}>
             <ShimmerCard className="h-full">
-              <div className="bg-card border border-border rounded-xl p-8 h-full hover:border-border-light transition-all duration-300">
+              <Card hover className="p-8 h-full">
                 <div className="flex items-center gap-3 mb-6">
                   <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
                     <svg
@@ -1449,7 +1474,7 @@ function DeviceOrganization() {
                     </li>
                   ))}
                 </ul>
-              </div>
+              </Card>
             </ShimmerCard>
           </Reveal>
 

--- a/ui/apps/website/src/pages/getting-started/StepPath.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepPath.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 interface StepPathProps {
@@ -17,12 +18,15 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
               <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.08] via-primary/[0.02] to-transparent pointer-events-none" />
               <div className="absolute top-0 right-0 w-40 h-40 bg-primary/[0.08] rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl pointer-events-none" />
               <div className="relative flex items-center gap-3 mb-4">
-                <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center shadow-[0_0_12px_rgba(102,122,204,0.15)]">
+                <IconBadge
+                  color="primary"
+                  className="shadow-[0_0_12px_rgba(102,122,204,0.15)]"
+                >
                   <img src="/cloud-icon.svg" alt="" className="h-5" />
-                </div>
-                <span className="px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                </IconBadge>
+                <Badge shape="pill" color="green">
                   Recommended
-                </span>
+                </Badge>
               </div>
 
               <h3 className="text-lg font-bold mb-2">ShellHub Cloud</h3>
@@ -163,8 +167,8 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
 
       {/* Enterprise card — full width below */}
       <Reveal delay={0.2}>
-        <div className="bg-card border border-border rounded-xl p-6 flex flex-col sm:flex-row items-start sm:items-center gap-5 hover:border-primary/30 transition-colors duration-300">
-          <div className="w-10 h-10 rounded-lg bg-accent-yellow/10 border border-accent-yellow/20 flex items-center justify-center shrink-0">
+        <Card className="p-6 flex flex-col sm:flex-row items-start sm:items-center gap-5 hover:border-primary/30 transition-colors duration-300">
+          <IconBadge color="yellow">
             <svg
               className="w-5 h-5 text-accent-yellow"
               fill="none"
@@ -178,7 +182,7 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
                 d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3H21m-3.75 3H21"
               />
             </svg>
-          </div>
+          </IconBadge>
           <div className="flex-1 min-w-0">
             <h3 className="text-sm font-bold mb-1">Enterprise</h3>
             <p className="text-xs text-text-secondary leading-relaxed">
@@ -205,7 +209,7 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
               />
             </svg>
           </Link>
-        </div>
+        </Card>
       </Reveal>
     </div>
   );

--- a/ui/apps/website/src/pages/getting-started/StepSetup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSetup.tsx
@@ -1,3 +1,4 @@
+import { Card } from "@shellhub/design-system/primitives";
 import { docsUrl } from "@/links";
 import { Reveal, CopyBtn } from "../landing/components";
 
@@ -11,7 +12,7 @@ export function StepSetup({ onBack }: StepSetupProps) {
   return (
     <div className="max-w-xl mx-auto w-full">
       <Reveal>
-        <div className="bg-card border border-border rounded-xl overflow-hidden mb-6">
+        <Card className="overflow-hidden mb-6">
           <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border bg-surface">
             <span className="w-2.5 h-2.5 rounded-full bg-accent-red/70" />
             <span className="w-2.5 h-2.5 rounded-full bg-accent-yellow/70" />
@@ -27,7 +28,7 @@ export function StepSetup({ onBack }: StepSetupProps) {
             </code>
             <CopyBtn text={DOCKER_CMD} />
           </div>
-        </div>
+        </Card>
       </Reveal>
 
       <Reveal delay={0.1}>

--- a/ui/apps/website/src/pages/getting-started/StepSignup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSignup.tsx
@@ -1,4 +1,5 @@
 import { useState, FormEvent } from "react";
+import { Card } from "@shellhub/design-system/primitives";
 import { Reveal } from "../landing/components";
 import apiClient from "../../api/client";
 import { loginUrl } from "@/links";
@@ -131,7 +132,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
     return (
       <div className="max-w-md mx-auto w-full">
         <Reveal>
-          <div className="bg-card border border-border rounded-xl p-8 text-center">
+          <Card className="p-8 text-center">
             <div className="w-12 h-12 rounded-full bg-accent-green/10 border border-accent-green/20 flex items-center justify-center mx-auto mb-4">
               <svg
                 className="w-6 h-6 text-accent-green"
@@ -158,7 +159,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
             >
               Go to Login
             </a>
-          </div>
+          </Card>
         </Reveal>
       </div>
     );
@@ -167,7 +168,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
   return (
     <div className="max-w-md mx-auto w-full">
       <Reveal>
-        <div className="bg-card border border-border rounded-xl overflow-hidden">
+        <Card className="overflow-hidden">
           {/* Header */}
           <div className="px-6 pt-6 pb-5 border-b border-border bg-surface/50">
             <div className="flex items-center gap-3">
@@ -496,7 +497,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
               Back to options
             </button>
           </form>
-        </div>
+        </Card>
       </Reveal>
     </div>
   );

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -163,9 +164,9 @@ export default function HowItWorks() {
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>
-            <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-primary/10 text-primary border border-primary/20 rounded-full mb-6">
+            <Badge shape="pill" color="primary" className="mb-6 tracking-label">
               How It Works
-            </span>
+            </Badge>
           </Reveal>
           <Reveal>
             <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-3xl mx-auto">
@@ -233,502 +234,504 @@ export default function HowItWorks() {
           </Reveal>
 
           <Reveal>
-            <ShimmerCard className="bg-card border border-border rounded-xl p-6 lg:p-10 overflow-x-auto">
-              <svg
-                viewBox="0 0 960 340"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                className="w-full h-auto min-w-[720px]"
-              >
-                <defs>
-                  <marker
-                    id="hw-a-pri"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.primary} />
-                  </marker>
-                  <marker
-                    id="hw-a-grn"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.green} />
-                  </marker>
-                  <marker
-                    id="hw-a-dim"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={`${C.primary}60`} />
-                  </marker>
-                </defs>
-
-                {/* ── User ── */}
-                <text
-                  x="70"
-                  y="24"
-                  fontFamily="IBM Plex Sans"
-                  fontSize="11"
-                  fill={C.textMuted}
-                  textAnchor="middle"
-                  letterSpacing=".1em"
-                >
-                  YOU
-                </text>
-                <rect
-                  x="20"
-                  y="36"
-                  width="100"
-                  height="90"
-                  rx="12"
-                  fill={C.card}
-                  stroke={C.border}
-                  strokeWidth="1.2"
-                />
-                <circle
-                  cx="70"
-                  cy="62"
-                  r="14"
-                  stroke={C.primary}
-                  strokeWidth="1.5"
+            <ShimmerCard>
+              <Card className="p-6 lg:p-10 overflow-x-auto">
+                <svg
+                  viewBox="0 0 960 340"
                   fill="none"
-                />
-                <circle cx="70" cy="58" r="4.5" fill={C.primary} />
-                <path
-                  d="M70 63 L70 67 M63 65 L77 65"
-                  stroke={C.primary}
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                />
-                <text
-                  x="70"
-                  y="100"
-                  fontFamily="IBM Plex Mono"
-                  fontSize="9"
-                  fill={C.textSec}
-                  textAnchor="middle"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-full h-auto min-w-[720px]"
                 >
-                  Any location
-                </text>
-                <text
-                  x="70"
-                  y="114"
-                  fontFamily="IBM Plex Mono"
-                  fontSize="8"
-                  fill={C.textMuted}
-                  textAnchor="middle"
-                >
-                  laptop / browser
-                </text>
-
-                {/* ── Arrow: User to Gateway ── */}
-                <line
-                  x1="125"
-                  y1="80"
-                  x2="260"
-                  y2="80"
-                  stroke={C.primary}
-                  strokeWidth="1.5"
-                  strokeDasharray="6 4"
-                  markerEnd="url(#hw-a-pri)"
-                />
-                <rect
-                  x="155"
-                  y="58"
-                  width="68"
-                  height="16"
-                  rx="4"
-                  fill={C.bg}
-                />
-                <text
-                  x="189"
-                  y="70"
-                  fontFamily="IBM Plex Mono"
-                  fontSize="8"
-                  fill={C.primary}
-                  textAnchor="middle"
-                >
-                  SSH / HTTPS
-                </text>
-
-                {/* ── ShellHub Cloud ── */}
-                <rect
-                  x="265"
-                  y="20"
-                  width="330"
-                  height="290"
-                  rx="16"
-                  fill={`${C.primary}08`}
-                  stroke={C.primary}
-                  strokeWidth="1.5"
-                />
-                <text
-                  x="430"
-                  y="14"
-                  fontFamily="IBM Plex Sans"
-                  fontSize="12"
-                  fill={C.primary}
-                  textAnchor="middle"
-                  fontWeight="600"
-                  letterSpacing=".1em"
-                >
-                  SHELLHUB CLOUD
-                </text>
-
-                {/* Logo badge */}
-                <rect
-                  x="395"
-                  y="38"
-                  width="70"
-                  height="36"
-                  rx="10"
-                  fill={C.primaryDim}
-                  stroke={C.primary}
-                  strokeWidth="1"
-                />
-                <text
-                  x="430"
-                  y="62"
-                  fontFamily="IBM Plex Mono"
-                  fontSize="16"
-                  fill={C.primary}
-                  textAnchor="middle"
-                  fontWeight="700"
-                >
-                  SH
-                </text>
-
-                {/* Internal modules */}
-                {[
-                  {
-                    x: 285,
-                    y: 100,
-                    label: "Authentication",
-                    color: C.primary,
-                    icon: "lock",
-                  },
-                  {
-                    x: 285,
-                    y: 140,
-                    label: "TLS Encryption",
-                    color: C.primary,
-                    icon: "shield",
-                  },
-                  {
-                    x: 285,
-                    y: 180,
-                    label: "Session Recording",
-                    color: C.cyan,
-                    icon: "rec",
-                  },
-                  {
-                    x: 285,
-                    y: 220,
-                    label: "Connection Router",
-                    color: C.green,
-                    icon: "route",
-                  },
-                  {
-                    x: 445,
-                    y: 100,
-                    label: "Firewall Rules",
-                    color: C.yellow,
-                    icon: "fire",
-                  },
-                  {
-                    x: 445,
-                    y: 140,
-                    label: "Audit Logging",
-                    color: C.green,
-                    icon: "log",
-                  },
-                  {
-                    x: 445,
-                    y: 180,
-                    label: "Team RBAC",
-                    color: C.primary,
-                    icon: "team",
-                  },
-                  {
-                    x: 445,
-                    y: 220,
-                    label: "Device Registry",
-                    color: C.blue,
-                    icon: "device",
-                  },
-                ].map((m, i) => (
-                  <g key={i}>
-                    <rect
-                      x={m.x}
-                      y={m.y}
-                      width="130"
-                      height="30"
-                      rx="6"
-                      fill={C.card}
-                      stroke={C.border}
-                    />
-                    <circle
-                      cx={m.x + 16}
-                      cy={m.y + 15}
-                      r="5"
-                      fill={`${m.color}30`}
-                      stroke={m.color}
-                      strokeWidth=".8"
-                    />
-                    <text
-                      x={m.x + 32}
-                      y={m.y + 19}
-                      fontFamily="IBM Plex Sans"
-                      fontSize="9"
-                      fill={C.textSec}
+                  <defs>
+                    <marker
+                      id="hw-a-pri"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
                     >
-                      {m.label}
-                    </text>
-                  </g>
-                ))}
-
-                {/* Gateway label */}
-                <text
-                  x="430"
-                  y="278"
-                  fontFamily="IBM Plex Mono"
-                  fontSize="8"
-                  fill={C.textMuted}
-                  textAnchor="middle"
-                >
-                  CLOUD OR SELF-HOSTED
-                </text>
-
-                {/* ── NAT Wall ── */}
-                <rect
-                  x="630"
-                  y="30"
-                  width="8"
-                  height="270"
-                  rx="4"
-                  fill={C.border}
-                />
-                <rect
-                  x="630"
-                  y="30"
-                  width="8"
-                  height="270"
-                  rx="4"
-                  fill={`${C.red}12`}
-                />
-                <text
-                  x="634"
-                  y="22"
-                  fontFamily="IBM Plex Mono"
-                  fontSize="9"
-                  fill={C.textMuted}
-                  textAnchor="middle"
-                >
-                  NAT
-                </text>
-
-                {/* ── Arrow: Gateway to NAT ── */}
-                <line
-                  x1="600"
-                  y1="115"
-                  x2="626"
-                  y2="115"
-                  stroke={C.green}
-                  strokeWidth="1.5"
-                  markerEnd="url(#hw-a-grn)"
-                />
-
-                {/* ── Arrows: NAT to Devices ── */}
-                <line
-                  x1="642"
-                  y1="85"
-                  x2="678"
-                  y2="65"
-                  stroke={`${C.primary}60`}
-                  strokeWidth="1.2"
-                  strokeDasharray="4 3"
-                  markerEnd="url(#hw-a-dim)"
-                />
-                <line
-                  x1="642"
-                  y1="125"
-                  x2="678"
-                  y2="140"
-                  stroke={`${C.primary}60`}
-                  strokeWidth="1.2"
-                  strokeDasharray="4 3"
-                  markerEnd="url(#hw-a-dim)"
-                />
-                <line
-                  x1="642"
-                  y1="175"
-                  x2="678"
-                  y2="215"
-                  stroke={`${C.primary}60`}
-                  strokeWidth="1.2"
-                  strokeDasharray="4 3"
-                  markerEnd="url(#hw-a-dim)"
-                />
-                <line
-                  x1="642"
-                  y1="220"
-                  x2="678"
-                  y2="280"
-                  stroke={`${C.primary}60`}
-                  strokeWidth="1.2"
-                  strokeDasharray="4 3"
-                  markerEnd="url(#hw-a-dim)"
-                />
-
-                <text
-                  x="658"
-                  y="170"
-                  fontFamily="IBM Plex Mono"
-                  fontSize="7"
-                  fill={`${C.primary}50`}
-                  textAnchor="middle"
-                  transform="rotate(-90,658,170)"
-                >
-                  NAT Traversal
-                </text>
-
-                {/* ── YOUR DEVICES label ── */}
-                <text
-                  x="790"
-                  y="22"
-                  fontFamily="IBM Plex Sans"
-                  fontSize="11"
-                  fill={C.textMuted}
-                  textAnchor="middle"
-                  letterSpacing=".1em"
-                >
-                  YOUR DEVICES
-                </text>
-
-                {/* ── Devices ── */}
-                {[
-                  {
-                    y: 36,
-                    icon: "Pi",
-                    iconBg: C.green,
-                    label: "Raspberry Pi",
-                    sub: "armv7 / aarch64",
-                    begin: "0s",
-                  },
-                  {
-                    y: 112,
-                    icon: "srv",
-                    iconBg: C.primary,
-                    label: "Linux Server",
-                    sub: "Ubuntu / Debian / RHEL",
-                    begin: ".5s",
-                  },
-                  {
-                    y: 188,
-                    icon: "dk",
-                    iconBg: C.blue,
-                    label: "Docker Host",
-                    sub: "container agent",
-                    begin: "1s",
-                  },
-                  {
-                    y: 264,
-                    icon: "iot",
-                    iconBg: C.yellow,
-                    label: "IoT Gateway",
-                    sub: "OpenWrt / Yocto",
-                    begin: "1.5s",
-                  },
-                ].map((d, i) => (
-                  <g key={i}>
-                    <rect
-                      x="682"
-                      y={d.y}
-                      width="160"
-                      height="60"
-                      rx="10"
-                      fill={C.card}
-                      stroke={C.border}
-                    />
-                    {/* icon box */}
-                    <rect
-                      x="696"
-                      y={d.y + 12}
-                      width="28"
-                      height="20"
-                      rx="4"
-                      fill={`${d.iconBg}15`}
-                      stroke={d.iconBg}
-                      strokeWidth=".8"
-                    />
-                    <text
-                      x="710"
-                      y={d.y + 26}
-                      fontSize="9"
-                      fill={d.iconBg}
-                      textAnchor="middle"
-                      fontFamily="IBM Plex Mono"
-                      fontWeight="600"
+                      <path d="M0,0 L8,3 L0,6" fill={C.primary} />
+                    </marker>
+                    <marker
+                      id="hw-a-grn"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
                     >
-                      {d.icon === "Pi"
-                        ? "Pi"
-                        : d.icon === "srv"
-                          ? ">_"
-                          : d.icon === "dk"
-                            ? "dk"
-                            : "IoT"}
-                    </text>
-                    {/* labels */}
-                    <text
-                      x="736"
-                      y={d.y + 24}
-                      fontFamily="IBM Plex Sans"
-                      fontSize="10"
-                      fill={C.text}
+                      <path d="M0,0 L8,3 L0,6" fill={C.green} />
+                    </marker>
+                    <marker
+                      id="hw-a-dim"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
                     >
-                      {d.label}
-                    </text>
-                    <text
-                      x="736"
-                      y={d.y + 38}
-                      fontFamily="IBM Plex Mono"
-                      fontSize="7"
-                      fill={C.textMuted}
-                    >
-                      {d.sub}
-                    </text>
-                    <text
-                      x="736"
-                      y={d.y + 50}
-                      fontFamily="IBM Plex Mono"
-                      fontSize="7"
-                      fill={C.textMuted}
-                    >
-                      agent running
-                    </text>
-                    {/* animated status dot */}
-                    <circle cx="834" cy={d.y + 10} r="3.5" fill={C.green}>
-                      <animate
-                        attributeName="opacity"
-                        values="1;.3;1"
-                        dur="2s"
-                        repeatCount="indefinite"
-                        begin={d.begin}
+                      <path d="M0,0 L8,3 L0,6" fill={`${C.primary}60`} />
+                    </marker>
+                  </defs>
+
+                  {/* ── User ── */}
+                  <text
+                    x="70"
+                    y="24"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                    letterSpacing=".1em"
+                  >
+                    YOU
+                  </text>
+                  <rect
+                    x="20"
+                    y="36"
+                    width="100"
+                    height="90"
+                    rx="12"
+                    fill={C.card}
+                    stroke={C.border}
+                    strokeWidth="1.2"
+                  />
+                  <circle
+                    cx="70"
+                    cy="62"
+                    r="14"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    fill="none"
+                  />
+                  <circle cx="70" cy="58" r="4.5" fill={C.primary} />
+                  <path
+                    d="M70 63 L70 67 M63 65 L77 65"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                  <text
+                    x="70"
+                    y="100"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Any location
+                  </text>
+                  <text
+                    x="70"
+                    y="114"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="8"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                  >
+                    laptop / browser
+                  </text>
+
+                  {/* ── Arrow: User to Gateway ── */}
+                  <line
+                    x1="125"
+                    y1="80"
+                    x2="260"
+                    y2="80"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    strokeDasharray="6 4"
+                    markerEnd="url(#hw-a-pri)"
+                  />
+                  <rect
+                    x="155"
+                    y="58"
+                    width="68"
+                    height="16"
+                    rx="4"
+                    fill={C.bg}
+                  />
+                  <text
+                    x="189"
+                    y="70"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="8"
+                    fill={C.primary}
+                    textAnchor="middle"
+                  >
+                    SSH / HTTPS
+                  </text>
+
+                  {/* ── ShellHub Cloud ── */}
+                  <rect
+                    x="265"
+                    y="20"
+                    width="330"
+                    height="290"
+                    rx="16"
+                    fill={`${C.primary}08`}
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                  />
+                  <text
+                    x="430"
+                    y="14"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="12"
+                    fill={C.primary}
+                    textAnchor="middle"
+                    fontWeight="600"
+                    letterSpacing=".1em"
+                  >
+                    SHELLHUB CLOUD
+                  </text>
+
+                  {/* Logo badge */}
+                  <rect
+                    x="395"
+                    y="38"
+                    width="70"
+                    height="36"
+                    rx="10"
+                    fill={C.primaryDim}
+                    stroke={C.primary}
+                    strokeWidth="1"
+                  />
+                  <text
+                    x="430"
+                    y="62"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="16"
+                    fill={C.primary}
+                    textAnchor="middle"
+                    fontWeight="700"
+                  >
+                    SH
+                  </text>
+
+                  {/* Internal modules */}
+                  {[
+                    {
+                      x: 285,
+                      y: 100,
+                      label: "Authentication",
+                      color: C.primary,
+                      icon: "lock",
+                    },
+                    {
+                      x: 285,
+                      y: 140,
+                      label: "TLS Encryption",
+                      color: C.primary,
+                      icon: "shield",
+                    },
+                    {
+                      x: 285,
+                      y: 180,
+                      label: "Session Recording",
+                      color: C.cyan,
+                      icon: "rec",
+                    },
+                    {
+                      x: 285,
+                      y: 220,
+                      label: "Connection Router",
+                      color: C.green,
+                      icon: "route",
+                    },
+                    {
+                      x: 445,
+                      y: 100,
+                      label: "Firewall Rules",
+                      color: C.yellow,
+                      icon: "fire",
+                    },
+                    {
+                      x: 445,
+                      y: 140,
+                      label: "Audit Logging",
+                      color: C.green,
+                      icon: "log",
+                    },
+                    {
+                      x: 445,
+                      y: 180,
+                      label: "Team RBAC",
+                      color: C.primary,
+                      icon: "team",
+                    },
+                    {
+                      x: 445,
+                      y: 220,
+                      label: "Device Registry",
+                      color: C.blue,
+                      icon: "device",
+                    },
+                  ].map((m, i) => (
+                    <g key={i}>
+                      <rect
+                        x={m.x}
+                        y={m.y}
+                        width="130"
+                        height="30"
+                        rx="6"
+                        fill={C.card}
+                        stroke={C.border}
                       />
-                    </circle>
-                  </g>
-                ))}
-              </svg>
+                      <circle
+                        cx={m.x + 16}
+                        cy={m.y + 15}
+                        r="5"
+                        fill={`${m.color}30`}
+                        stroke={m.color}
+                        strokeWidth=".8"
+                      />
+                      <text
+                        x={m.x + 32}
+                        y={m.y + 19}
+                        fontFamily="IBM Plex Sans"
+                        fontSize="9"
+                        fill={C.textSec}
+                      >
+                        {m.label}
+                      </text>
+                    </g>
+                  ))}
+
+                  {/* Gateway label */}
+                  <text
+                    x="430"
+                    y="278"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="8"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                  >
+                    CLOUD OR SELF-HOSTED
+                  </text>
+
+                  {/* ── NAT Wall ── */}
+                  <rect
+                    x="630"
+                    y="30"
+                    width="8"
+                    height="270"
+                    rx="4"
+                    fill={C.border}
+                  />
+                  <rect
+                    x="630"
+                    y="30"
+                    width="8"
+                    height="270"
+                    rx="4"
+                    fill={`${C.red}12`}
+                  />
+                  <text
+                    x="634"
+                    y="22"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                  >
+                    NAT
+                  </text>
+
+                  {/* ── Arrow: Gateway to NAT ── */}
+                  <line
+                    x1="600"
+                    y1="115"
+                    x2="626"
+                    y2="115"
+                    stroke={C.green}
+                    strokeWidth="1.5"
+                    markerEnd="url(#hw-a-grn)"
+                  />
+
+                  {/* ── Arrows: NAT to Devices ── */}
+                  <line
+                    x1="642"
+                    y1="85"
+                    x2="678"
+                    y2="65"
+                    stroke={`${C.primary}60`}
+                    strokeWidth="1.2"
+                    strokeDasharray="4 3"
+                    markerEnd="url(#hw-a-dim)"
+                  />
+                  <line
+                    x1="642"
+                    y1="125"
+                    x2="678"
+                    y2="140"
+                    stroke={`${C.primary}60`}
+                    strokeWidth="1.2"
+                    strokeDasharray="4 3"
+                    markerEnd="url(#hw-a-dim)"
+                  />
+                  <line
+                    x1="642"
+                    y1="175"
+                    x2="678"
+                    y2="215"
+                    stroke={`${C.primary}60`}
+                    strokeWidth="1.2"
+                    strokeDasharray="4 3"
+                    markerEnd="url(#hw-a-dim)"
+                  />
+                  <line
+                    x1="642"
+                    y1="220"
+                    x2="678"
+                    y2="280"
+                    stroke={`${C.primary}60`}
+                    strokeWidth="1.2"
+                    strokeDasharray="4 3"
+                    markerEnd="url(#hw-a-dim)"
+                  />
+
+                  <text
+                    x="658"
+                    y="170"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={`${C.primary}50`}
+                    textAnchor="middle"
+                    transform="rotate(-90,658,170)"
+                  >
+                    NAT Traversal
+                  </text>
+
+                  {/* ── YOUR DEVICES label ── */}
+                  <text
+                    x="790"
+                    y="22"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                    letterSpacing=".1em"
+                  >
+                    YOUR DEVICES
+                  </text>
+
+                  {/* ── Devices ── */}
+                  {[
+                    {
+                      y: 36,
+                      icon: "Pi",
+                      iconBg: C.green,
+                      label: "Raspberry Pi",
+                      sub: "armv7 / aarch64",
+                      begin: "0s",
+                    },
+                    {
+                      y: 112,
+                      icon: "srv",
+                      iconBg: C.primary,
+                      label: "Linux Server",
+                      sub: "Ubuntu / Debian / RHEL",
+                      begin: ".5s",
+                    },
+                    {
+                      y: 188,
+                      icon: "dk",
+                      iconBg: C.blue,
+                      label: "Docker Host",
+                      sub: "container agent",
+                      begin: "1s",
+                    },
+                    {
+                      y: 264,
+                      icon: "iot",
+                      iconBg: C.yellow,
+                      label: "IoT Gateway",
+                      sub: "OpenWrt / Yocto",
+                      begin: "1.5s",
+                    },
+                  ].map((d, i) => (
+                    <g key={i}>
+                      <rect
+                        x="682"
+                        y={d.y}
+                        width="160"
+                        height="60"
+                        rx="10"
+                        fill={C.card}
+                        stroke={C.border}
+                      />
+                      {/* icon box */}
+                      <rect
+                        x="696"
+                        y={d.y + 12}
+                        width="28"
+                        height="20"
+                        rx="4"
+                        fill={`${d.iconBg}15`}
+                        stroke={d.iconBg}
+                        strokeWidth=".8"
+                      />
+                      <text
+                        x="710"
+                        y={d.y + 26}
+                        fontSize="9"
+                        fill={d.iconBg}
+                        textAnchor="middle"
+                        fontFamily="IBM Plex Mono"
+                        fontWeight="600"
+                      >
+                        {d.icon === "Pi"
+                          ? "Pi"
+                          : d.icon === "srv"
+                            ? ">_"
+                            : d.icon === "dk"
+                              ? "dk"
+                              : "IoT"}
+                      </text>
+                      {/* labels */}
+                      <text
+                        x="736"
+                        y={d.y + 24}
+                        fontFamily="IBM Plex Sans"
+                        fontSize="10"
+                        fill={C.text}
+                      >
+                        {d.label}
+                      </text>
+                      <text
+                        x="736"
+                        y={d.y + 38}
+                        fontFamily="IBM Plex Mono"
+                        fontSize="7"
+                        fill={C.textMuted}
+                      >
+                        {d.sub}
+                      </text>
+                      <text
+                        x="736"
+                        y={d.y + 50}
+                        fontFamily="IBM Plex Mono"
+                        fontSize="7"
+                        fill={C.textMuted}
+                      >
+                        agent running
+                      </text>
+                      {/* animated status dot */}
+                      <circle cx="834" cy={d.y + 10} r="3.5" fill={C.green}>
+                        <animate
+                          attributeName="opacity"
+                          values="1;.3;1"
+                          dur="2s"
+                          repeatCount="indefinite"
+                          begin={d.begin}
+                        />
+                      </circle>
+                    </g>
+                  ))}
+                </svg>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>
@@ -807,40 +810,43 @@ export default function HowItWorks() {
                 </div>
 
                 <div className="md:pl-12">
-                  <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-                    <div className="p-5">
-                      <div className="flex items-center gap-2 mb-4">
-                        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                        <span className="ml-2 text-2xs text-text-muted font-mono">
-                          Terminal
-                        </span>
-                      </div>
-                      <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
-                        <p>
-                          <span className="text-accent-green">$</span>{" "}
-                          <span className="text-text-secondary">
-                            curl -sSf https://cloud.shellhub.io/install.sh | sh
+                  <ShimmerCard>
+                    <Card className="overflow-hidden">
+                      <div className="p-5">
+                        <div className="flex items-center gap-2 mb-4">
+                          <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                          <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                          <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                          <span className="ml-2 text-2xs text-text-muted font-mono">
+                            Terminal
                           </span>
-                        </p>
-                        <p className="text-text-muted">
-                          # Downloading ShellHub agent v0.17.2...
-                        </p>
-                        <p className="text-text-muted">
-                          # Installing to /usr/local/bin/shellhub-agent
-                        </p>
-                        <p className="text-text-muted">
-                          # Registering systemd service...
-                        </p>
-                        <p className="text-accent-green">
-                          # Agent installed and running.
-                        </p>
-                        <p className="text-accent-green">
-                          # Device ID: a1b2c3d4-e5f6-7890
-                        </p>
+                        </div>
+                        <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
+                          <p>
+                            <span className="text-accent-green">$</span>{" "}
+                            <span className="text-text-secondary">
+                              curl -sSf https://cloud.shellhub.io/install.sh |
+                              sh
+                            </span>
+                          </p>
+                          <p className="text-text-muted">
+                            # Downloading ShellHub agent v0.17.2...
+                          </p>
+                          <p className="text-text-muted">
+                            # Installing to /usr/local/bin/shellhub-agent
+                          </p>
+                          <p className="text-text-muted">
+                            # Registering systemd service...
+                          </p>
+                          <p className="text-accent-green">
+                            # Agent installed and running.
+                          </p>
+                          <p className="text-accent-green">
+                            # Device ID: a1b2c3d4-e5f6-7890
+                          </p>
+                        </div>
                       </div>
-                    </div>
+                    </Card>
                   </ShimmerCard>
                 </div>
               </div>
@@ -851,7 +857,7 @@ export default function HowItWorks() {
               <div className="relative grid md:grid-cols-2 gap-8 mb-16">
                 <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-cyan border-2 border-background z-10 hidden md:block" />
 
-                <div className="md:pr-12 md:text-right md:order-last md:text-left md:pl-12 md:pr-0">
+                <div className="md:order-last md:text-left md:pl-12">
                   <div className="flex items-center gap-3 mb-4">
                     <span className="w-10 h-10 rounded-xl bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center text-sm font-bold font-mono text-accent-cyan">
                       02
@@ -899,222 +905,224 @@ export default function HowItWorks() {
                 </div>
 
                 <div className="md:pr-12">
-                  <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-                    <div className="p-5">
-                      <svg
-                        viewBox="0 0 400 200"
-                        fill="none"
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="w-full h-auto"
-                      >
-                        <defs>
-                          <marker
-                            id="hw-s2-a"
-                            markerWidth="7"
-                            markerHeight="5"
-                            refX="7"
-                            refY="2.5"
-                            orient="auto"
-                          >
-                            <path d="M0,0 L7,2.5 L0,5" fill={C.cyan} />
-                          </marker>
-                        </defs>
+                  <ShimmerCard>
+                    <Card className="overflow-hidden">
+                      <div className="p-5">
+                        <svg
+                          viewBox="0 0 400 200"
+                          fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="w-full h-auto"
+                        >
+                          <defs>
+                            <marker
+                              id="hw-s2-a"
+                              markerWidth="7"
+                              markerHeight="5"
+                              refX="7"
+                              refY="2.5"
+                              orient="auto"
+                            >
+                              <path d="M0,0 L7,2.5 L0,5" fill={C.cyan} />
+                            </marker>
+                          </defs>
 
-                        {/* Device */}
-                        <rect
-                          x="20"
-                          y="60"
-                          width="90"
-                          height="80"
-                          rx="10"
-                          fill={C.card}
-                          stroke={C.border}
-                        />
-                        <rect
-                          x="35"
-                          y="74"
-                          width="24"
-                          height="16"
-                          rx="3"
-                          fill={`${C.green}15`}
-                          stroke={C.green}
-                          strokeWidth=".8"
-                        />
-                        <text
-                          x="47"
-                          y="86"
-                          fontSize="8"
-                          fill={C.green}
-                          textAnchor="middle"
-                          fontFamily="IBM Plex Mono"
-                          fontWeight="600"
-                        >
-                          Pi
-                        </text>
-                        <text
-                          x="65"
-                          y="110"
-                          fontFamily="IBM Plex Sans"
-                          fontSize="9"
-                          fill={C.textSec}
-                          textAnchor="middle"
-                        >
-                          Device
-                        </text>
-                        <text
-                          x="65"
-                          y="124"
-                          fontFamily="IBM Plex Mono"
-                          fontSize="7"
-                          fill={C.textMuted}
-                          textAnchor="middle"
-                        >
-                          agent
-                        </text>
-                        <circle cx="100" cy="68" r="3" fill={C.green}>
-                          <animate
-                            attributeName="opacity"
-                            values="1;.3;1"
-                            dur="2s"
-                            repeatCount="indefinite"
+                          {/* Device */}
+                          <rect
+                            x="20"
+                            y="60"
+                            width="90"
+                            height="80"
+                            rx="10"
+                            fill={C.card}
+                            stroke={C.border}
                           />
-                        </circle>
+                          <rect
+                            x="35"
+                            y="74"
+                            width="24"
+                            height="16"
+                            rx="3"
+                            fill={`${C.green}15`}
+                            stroke={C.green}
+                            strokeWidth=".8"
+                          />
+                          <text
+                            x="47"
+                            y="86"
+                            fontSize="8"
+                            fill={C.green}
+                            textAnchor="middle"
+                            fontFamily="IBM Plex Mono"
+                            fontWeight="600"
+                          >
+                            Pi
+                          </text>
+                          <text
+                            x="65"
+                            y="110"
+                            fontFamily="IBM Plex Sans"
+                            fontSize="9"
+                            fill={C.textSec}
+                            textAnchor="middle"
+                          >
+                            Device
+                          </text>
+                          <text
+                            x="65"
+                            y="124"
+                            fontFamily="IBM Plex Mono"
+                            fontSize="7"
+                            fill={C.textMuted}
+                            textAnchor="middle"
+                          >
+                            agent
+                          </text>
+                          <circle cx="100" cy="68" r="3" fill={C.green}>
+                            <animate
+                              attributeName="opacity"
+                              values="1;.3;1"
+                              dur="2s"
+                              repeatCount="indefinite"
+                            />
+                          </circle>
 
-                        {/* NAT Wall */}
-                        <rect
-                          x="145"
-                          y="40"
-                          width="6"
-                          height="120"
-                          rx="3"
-                          fill={C.border}
-                        />
-                        <rect
-                          x="145"
-                          y="40"
-                          width="6"
-                          height="120"
-                          rx="3"
-                          fill={`${C.red}15`}
-                        />
-                        <text
-                          x="148"
-                          y="34"
-                          fontFamily="IBM Plex Mono"
-                          fontSize="8"
-                          fill={C.textMuted}
-                          textAnchor="middle"
-                        >
-                          NAT
-                        </text>
+                          {/* NAT Wall */}
+                          <rect
+                            x="145"
+                            y="40"
+                            width="6"
+                            height="120"
+                            rx="3"
+                            fill={C.border}
+                          />
+                          <rect
+                            x="145"
+                            y="40"
+                            width="6"
+                            height="120"
+                            rx="3"
+                            fill={`${C.red}15`}
+                          />
+                          <text
+                            x="148"
+                            y="34"
+                            fontFamily="IBM Plex Mono"
+                            fontSize="8"
+                            fill={C.textMuted}
+                            textAnchor="middle"
+                          >
+                            NAT
+                          </text>
 
-                        {/* Outbound arrow: Device through NAT to Cloud */}
-                        <line
-                          x1="115"
-                          y1="100"
-                          x2="142"
-                          y2="100"
-                          stroke={C.cyan}
-                          strokeWidth="1.5"
-                          markerEnd="url(#hw-s2-a)"
-                        />
-                        <line
-                          x1="154"
-                          y1="100"
-                          x2="225"
-                          y2="100"
-                          stroke={C.cyan}
-                          strokeWidth="1.5"
-                          strokeDasharray="6 4"
-                          markerEnd="url(#hw-s2-a)"
-                        />
-                        <text
-                          x="190"
-                          y="92"
-                          fontFamily="IBM Plex Mono"
-                          fontSize="7"
-                          fill={C.cyan}
-                          textAnchor="middle"
-                        >
-                          outbound :443
-                        </text>
+                          {/* Outbound arrow: Device through NAT to Cloud */}
+                          <line
+                            x1="115"
+                            y1="100"
+                            x2="142"
+                            y2="100"
+                            stroke={C.cyan}
+                            strokeWidth="1.5"
+                            markerEnd="url(#hw-s2-a)"
+                          />
+                          <line
+                            x1="154"
+                            y1="100"
+                            x2="225"
+                            y2="100"
+                            stroke={C.cyan}
+                            strokeWidth="1.5"
+                            strokeDasharray="6 4"
+                            markerEnd="url(#hw-s2-a)"
+                          />
+                          <text
+                            x="190"
+                            y="92"
+                            fontFamily="IBM Plex Mono"
+                            fontSize="7"
+                            fill={C.cyan}
+                            textAnchor="middle"
+                          >
+                            outbound :443
+                          </text>
 
-                        {/* Cloud */}
-                        <rect
-                          x="230"
-                          y="50"
-                          width="150"
-                          height="100"
-                          rx="14"
-                          fill={`${C.primary}08`}
-                          stroke={C.primary}
-                          strokeWidth="1.2"
-                        />
-                        <rect
-                          x="278"
-                          y="68"
-                          width="54"
-                          height="28"
-                          rx="8"
-                          fill={C.primaryDim}
-                          stroke={C.primary}
-                          strokeWidth=".8"
-                        />
-                        <text
-                          x="305"
-                          y="87"
-                          fontFamily="IBM Plex Mono"
-                          fontSize="12"
-                          fill={C.primary}
-                          textAnchor="middle"
-                          fontWeight="700"
-                        >
-                          SH
-                        </text>
-                        <text
-                          x="305"
-                          y="118"
-                          fontFamily="IBM Plex Sans"
-                          fontSize="9"
-                          fill={C.textSec}
-                          textAnchor="middle"
-                        >
-                          ShellHub Gateway
-                        </text>
-                        <text
-                          x="305"
-                          y="132"
-                          fontFamily="IBM Plex Mono"
-                          fontSize="7"
-                          fill={C.textMuted}
-                          textAnchor="middle"
-                        >
-                          Auth + Encryption
-                        </text>
+                          {/* Cloud */}
+                          <rect
+                            x="230"
+                            y="50"
+                            width="150"
+                            height="100"
+                            rx="14"
+                            fill={`${C.primary}08`}
+                            stroke={C.primary}
+                            strokeWidth="1.2"
+                          />
+                          <rect
+                            x="278"
+                            y="68"
+                            width="54"
+                            height="28"
+                            rx="8"
+                            fill={C.primaryDim}
+                            stroke={C.primary}
+                            strokeWidth=".8"
+                          />
+                          <text
+                            x="305"
+                            y="87"
+                            fontFamily="IBM Plex Mono"
+                            fontSize="12"
+                            fill={C.primary}
+                            textAnchor="middle"
+                            fontWeight="700"
+                          >
+                            SH
+                          </text>
+                          <text
+                            x="305"
+                            y="118"
+                            fontFamily="IBM Plex Sans"
+                            fontSize="9"
+                            fill={C.textSec}
+                            textAnchor="middle"
+                          >
+                            ShellHub Gateway
+                          </text>
+                          <text
+                            x="305"
+                            y="132"
+                            fontFamily="IBM Plex Mono"
+                            fontSize="7"
+                            fill={C.textMuted}
+                            textAnchor="middle"
+                          >
+                            Auth + Encryption
+                          </text>
 
-                        {/* Labels */}
-                        <text
-                          x="65"
-                          y="170"
-                          fontFamily="IBM Plex Mono"
-                          fontSize="7"
-                          fill={C.textMuted}
-                          textAnchor="middle"
-                        >
-                          PRIVATE NETWORK
-                        </text>
-                        <text
-                          x="305"
-                          y="170"
-                          fontFamily="IBM Plex Mono"
-                          fontSize="7"
-                          fill={C.textMuted}
-                          textAnchor="middle"
-                        >
-                          PUBLIC CLOUD
-                        </text>
-                      </svg>
-                    </div>
+                          {/* Labels */}
+                          <text
+                            x="65"
+                            y="170"
+                            fontFamily="IBM Plex Mono"
+                            fontSize="7"
+                            fill={C.textMuted}
+                            textAnchor="middle"
+                          >
+                            PRIVATE NETWORK
+                          </text>
+                          <text
+                            x="305"
+                            y="170"
+                            fontFamily="IBM Plex Mono"
+                            fontSize="7"
+                            fill={C.textMuted}
+                            textAnchor="middle"
+                          >
+                            PUBLIC CLOUD
+                          </text>
+                        </svg>
+                      </div>
+                    </Card>
                   </ShimmerCard>
                 </div>
               </div>
@@ -1173,56 +1181,58 @@ export default function HowItWorks() {
                 </div>
 
                 <div className="md:pl-12">
-                  <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-                    <div className="p-5">
-                      <div className="flex items-center gap-2 mb-4">
-                        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                        <span className="ml-2 text-2xs text-text-muted font-mono">
-                          Terminal
-                        </span>
+                  <ShimmerCard>
+                    <Card className="overflow-hidden">
+                      <div className="p-5">
+                        <div className="flex items-center gap-2 mb-4">
+                          <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                          <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                          <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                          <span className="ml-2 text-2xs text-text-muted font-mono">
+                            Terminal
+                          </span>
+                        </div>
+                        <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
+                          <p>
+                            <span className="text-accent-green">$</span>{" "}
+                            <span className="text-text-secondary">
+                              ssh pi@a1b2c3d4-e5f6-7890.mycompany.shellhub.io
+                            </span>
+                          </p>
+                          <p className="text-text-muted">
+                            # Connecting through ShellHub gateway...
+                          </p>
+                          <p className="text-text-muted">
+                            # Authenticating with public key...
+                          </p>
+                          <p className="text-text-muted">
+                            # Session recording enabled.
+                          </p>
+                          <p>&nbsp;</p>
+                          <p>
+                            <span className="text-accent-green">
+                              pi@raspberrypi
+                            </span>
+                            :<span className="text-accent-blue">~</span>
+                            <span className="text-text-secondary">
+                              $ uname -a
+                            </span>
+                          </p>
+                          <p className="text-text-secondary">
+                            Linux raspberrypi 6.1.0-rpi7 armv7l GNU/Linux
+                          </p>
+                          <p>
+                            <span className="text-accent-green">
+                              pi@raspberrypi
+                            </span>
+                            :<span className="text-accent-blue">~</span>
+                            <span className="text-text-muted animate-pulse">
+                              _
+                            </span>
+                          </p>
+                        </div>
                       </div>
-                      <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
-                        <p>
-                          <span className="text-accent-green">$</span>{" "}
-                          <span className="text-text-secondary">
-                            ssh pi@a1b2c3d4-e5f6-7890.mycompany.shellhub.io
-                          </span>
-                        </p>
-                        <p className="text-text-muted">
-                          # Connecting through ShellHub gateway...
-                        </p>
-                        <p className="text-text-muted">
-                          # Authenticating with public key...
-                        </p>
-                        <p className="text-text-muted">
-                          # Session recording enabled.
-                        </p>
-                        <p>&nbsp;</p>
-                        <p>
-                          <span className="text-accent-green">
-                            pi@raspberrypi
-                          </span>
-                          :<span className="text-accent-blue">~</span>
-                          <span className="text-text-secondary">
-                            $ uname -a
-                          </span>
-                        </p>
-                        <p className="text-text-secondary">
-                          Linux raspberrypi 6.1.0-rpi7 armv7l GNU/Linux
-                        </p>
-                        <p>
-                          <span className="text-accent-green">
-                            pi@raspberrypi
-                          </span>
-                          :<span className="text-accent-blue">~</span>
-                          <span className="text-text-muted animate-pulse">
-                            _
-                          </span>
-                        </p>
-                      </div>
-                    </div>
+                    </Card>
                   </ShimmerCard>
                 </div>
               </div>
@@ -1256,7 +1266,7 @@ export default function HowItWorks() {
                   <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
                   <div className="relative">
                     <div className="flex items-center gap-3 mb-6">
-                      <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                      <IconBadge color="primary">
                         <svg
                           className="w-5 h-5 text-primary"
                           fill="none"
@@ -1270,16 +1280,16 @@ export default function HowItWorks() {
                             d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
                           />
                         </svg>
-                      </div>
+                      </IconBadge>
                       <div>
                         <h3 className="text-sm font-bold">ShellHub</h3>
                         <p className="text-2xs text-primary">
                           Purpose-built for device access
                         </p>
                       </div>
-                      <span className="ml-auto px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                      <Badge shape="pill" color="green" className="ml-auto">
                         Recommended
-                      </span>
+                      </Badge>
                     </div>
 
                     <ul className="space-y-3">
@@ -1313,7 +1323,7 @@ export default function HowItWorks() {
             {/* VPN Side */}
             <Reveal delay={0.1}>
               <ShimmerCard className="h-full">
-                <div className="bg-card border border-border rounded-xl p-8 flex flex-col h-full hover:border-border-light transition-colors duration-300">
+                <Card hover className="p-8 flex flex-col h-full">
                   <div className="flex items-center gap-3 mb-6">
                     <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
                       <svg
@@ -1361,7 +1371,7 @@ export default function HowItWorks() {
                       </li>
                     ))}
                   </ul>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
           </div>
@@ -1387,20 +1397,22 @@ export default function HowItWorks() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {techDetails.map((f, i) => (
               <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
+                <ShimmerCard>
+                  <Card hover className="p-6 h-full">
+                    <div
+                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                      style={{
+                        background: `${f.color}15`,
+                        borderColor: `${f.color}25`,
+                      }}
+                    >
+                      {f.icon}
+                    </div>
+                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {f.desc}
+                    </p>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
 import { SiteLayout } from "@/components/SiteLayout";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
@@ -15,16 +16,20 @@ function TerminalChrome({
   children: React.ReactNode;
 }) {
   return (
-    <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-      <div className="flex items-center gap-2 px-5 py-3 border-b border-border bg-surface/60">
-        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-        <span className="ml-2 text-2xs text-text-muted font-mono">{title}</span>
-      </div>
-      <div className="p-5 font-mono text-2xs leading-[1.7] overflow-x-auto">
-        {children}
-      </div>
+    <ShimmerCard>
+      <Card className="overflow-hidden">
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-border bg-surface/60">
+          <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+          <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+          <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+          <span className="ml-2 text-2xs text-text-muted font-mono">
+            {title}
+          </span>
+        </div>
+        <div className="p-5 font-mono text-2xs leading-[1.7] overflow-x-auto">
+          {children}
+        </div>
+      </Card>
     </ShimmerCard>
   );
 }
@@ -74,9 +79,9 @@ export default function Integrations() {
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>
-            <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-accent-cyan/10 text-accent-cyan border border-accent-cyan/20 rounded-full mb-6">
+            <Badge shape="pill" color="cyan" className="mb-6 tracking-label">
               Integrations
-            </span>
+            </Badge>
           </Reveal>
           <Reveal>
             <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-3xl mx-auto">
@@ -305,9 +310,9 @@ export default function Integrations() {
                       .github/workflows/deploy.yml
                     </span>
                     <div className="ml-auto flex items-center gap-1.5">
-                      <span className="px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                      <Badge shape="pill" color="green">
                         Passing
-                      </span>
+                      </Badge>
                     </div>
                   </div>
 
@@ -633,7 +638,7 @@ export default function Integrations() {
                     {/* Header */}
                     <div className="px-6 pt-6 pb-4">
                       <div className="flex items-center gap-3 mb-3">
-                        <div className="w-10 h-10 rounded-lg bg-accent-yellow/10 border border-accent-yellow/20 flex items-center justify-center">
+                        <IconBadge color="yellow">
                           <svg
                             className="w-5 h-5 text-accent-yellow"
                             fill="none"
@@ -647,7 +652,7 @@ export default function Integrations() {
                               d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Z"
                             />
                           </svg>
-                        </div>
+                        </IconBadge>
                         <div>
                           <h3 className="text-sm font-bold">Embedded Linux</h3>
                           <p className="text-2xs text-text-muted">
@@ -741,7 +746,7 @@ export default function Integrations() {
             {/* Left: diagram */}
             <Reveal>
               <ShimmerCard>
-                <div className="bg-card border border-border rounded-xl p-8 overflow-hidden">
+                <Card className="p-8 overflow-hidden">
                   <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-6">
                     Connection Flow
                   </p>
@@ -877,7 +882,7 @@ export default function Integrations() {
                       </div>
                     </div>
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
 
@@ -913,7 +918,7 @@ export default function Integrations() {
                     <Dim>curl localhost:8080/health</Dim>
                   </Ln>
                   <Ln>
-                    <Str>{"{\"status\":\"healthy\",\"uptime\":\"14d 6h\"}"}</Str>
+                    <Str>{'{"status":"healthy","uptime":"14d 6h"}'}</Str>
                   </Ln>
                 </TerminalChrome>
               </Reveal>
@@ -941,12 +946,12 @@ export default function Integrations() {
 
           <Reveal delay={0.1}>
             <ShimmerCard className="max-w-4xl mx-auto">
-              <div className="bg-card border border-border rounded-xl overflow-hidden">
+              <Card className="overflow-hidden">
                 {/* API tabs */}
                 <div className="flex items-center gap-1 px-5 py-3 border-b border-border bg-surface/60">
-                  <span className="px-3 py-1 text-2xs font-mono font-semibold bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                  <Badge shape="pill" color="green">
                     GET
-                  </span>
+                  </Badge>
                   <span className="text-2xs font-mono text-text-secondary ml-2">
                     /api/devices
                   </span>
@@ -1097,7 +1102,7 @@ export default function Integrations() {
                     </span>
                   ))}
                 </div>
-              </div>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>
@@ -1181,7 +1186,7 @@ export default function Integrations() {
             ].map((b, i) => (
               <Reveal key={i} delay={i * 0.06}>
                 <ShimmerCard className="h-full">
-                  <div className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
+                  <Card hover className="p-6 h-full">
                     <div
                       className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
                       style={{
@@ -1195,7 +1200,7 @@ export default function Integrations() {
                     <p className="text-xs text-text-secondary leading-relaxed">
                       {b.desc}
                     </p>
-                  </div>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}

--- a/ui/apps/website/src/pages/landing/FeatureGrid.tsx
+++ b/ui/apps/website/src/pages/landing/FeatureGrid.tsx
@@ -1,3 +1,4 @@
+import { Card } from "@shellhub/design-system/primitives";
 import { Reveal, ShimmerCard } from "./components";
 import { C } from "./constants";
 
@@ -6,26 +7,163 @@ export function FeatureGrid() {
     <section className="py-24">
       <div className="max-w-7xl mx-auto px-8">
         <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">Features</p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight">Everything you need to manage remote devices.</h2>
+          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
+            Features
+          </p>
+          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight">
+            Everything you need to manage remote devices.
+          </h2>
         </Reveal>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[
-            { icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round"><polyline points="4 17 10 11 4 5" /><line x1="12" y1="19" x2="20" y2="19" /></svg>, color: C.primary, title: "Native SSH Support", desc: "Use your standard SSH client. No proprietary tools or plugins required.", delay: 0 },
-            { icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.cyan} strokeWidth="1.5" strokeLinecap="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" /></svg>, color: C.cyan, title: "SCP/SFTP File Transfer", desc: "Transfer files to and from remote devices with SCP and SFTP.", delay: 0.06 },
-            { icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.yellow} strokeWidth="1.5" strokeLinecap="round"><rect x="3" y="11" width="18" height="11" rx="2" /><path d="M7 11V7a5 5 0 0110 0v4" /><circle cx="12" cy="16" r="1" /></svg>, color: C.yellow, title: "Multi-Factor Auth", desc: "Require TOTP-based MFA for SSH connections. Works with any authenticator app.", delay: 0.12 },
-            { icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.green} strokeWidth="1.5" strokeLinecap="round"><path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" /></svg>, color: C.green, title: "Audit Logging", desc: "Full audit trail of every connection, command, and session. Export logs for compliance.", delay: 0 },
-            { icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 00-3-3.87" /><path d="M16 3.13a4 4 0 010 7.75" /></svg>, color: C.primary, title: "Team Management & RBAC", desc: "Invite team members, assign roles, and control who can access which devices.", delay: 0.06 },
-            { icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={C.blue} strokeWidth="1.5" strokeLinecap="round"><rect x="2" y="6" width="20" height="12" rx="2" /><path d="M12 12h.01" /><path d="M17 12h.01" /><path d="M7 12h.01" /></svg>, color: C.blue, title: "Docker Container Access", desc: "SSH directly into Docker containers running on remote hosts. No docker exec needed.", delay: 0.12 },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <polyline points="4 17 10 11 4 5" />
+                  <line x1="12" y1="19" x2="20" y2="19" />
+                </svg>
+              ),
+              color: C.primary,
+              title: "Native SSH Support",
+              desc: "Use your standard SSH client. No proprietary tools or plugins required.",
+              delay: 0,
+            },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.cyan}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="16" y1="13" x2="8" y2="13" />
+                  <line x1="16" y1="17" x2="8" y2="17" />
+                </svg>
+              ),
+              color: C.cyan,
+              title: "SCP/SFTP File Transfer",
+              desc: "Transfer files to and from remote devices with SCP and SFTP.",
+              delay: 0.06,
+            },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.yellow}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <rect x="3" y="11" width="18" height="11" rx="2" />
+                  <path d="M7 11V7a5 5 0 0110 0v4" />
+                  <circle cx="12" cy="16" r="1" />
+                </svg>
+              ),
+              color: C.yellow,
+              title: "Multi-Factor Auth",
+              desc: "Require TOTP-based MFA for SSH connections. Works with any authenticator app.",
+              delay: 0.12,
+            },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.green}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
+                </svg>
+              ),
+              color: C.green,
+              title: "Audit Logging",
+              desc: "Full audit trail of every connection, command, and session. Export logs for compliance.",
+              delay: 0,
+            },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+                  <circle cx="9" cy="7" r="4" />
+                  <path d="M23 21v-2a4 4 0 00-3-3.87" />
+                  <path d="M16 3.13a4 4 0 010 7.75" />
+                </svg>
+              ),
+              color: C.primary,
+              title: "Team Management & RBAC",
+              desc: "Invite team members, assign roles, and control who can access which devices.",
+              delay: 0.06,
+            },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.blue}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <rect x="2" y="6" width="20" height="12" rx="2" />
+                  <path d="M12 12h.01" />
+                  <path d="M17 12h.01" />
+                  <path d="M7 12h.01" />
+                </svg>
+              ),
+              color: C.blue,
+              title: "Docker Container Access",
+              desc: "SSH directly into Docker containers running on remote hosts. No docker exec needed.",
+              delay: 0.12,
+            },
           ].map((f, i) => (
             <Reveal key={i} delay={f.delay}>
-              <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                <div className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border" style={{ background: `${f.color}15`, borderColor: `${f.color}25` }}>
-                  {f.icon}
-                </div>
-                <h4 className="text-sm font-semibold mb-2 group-hover:text-primary transition-colors">{f.title}</h4>
-                <p className="text-xs text-text-secondary leading-relaxed">{f.desc}</p>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${f.color}15`,
+                      borderColor: `${f.color}25`,
+                    }}
+                  >
+                    {f.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2 group-hover:text-primary transition-colors">
+                    {f.title}
+                  </h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {f.desc}
+                  </p>
+                </Card>
               </ShimmerCard>
             </Reveal>
           ))}

--- a/ui/apps/website/src/pages/landing/HowItWorks.tsx
+++ b/ui/apps/website/src/pages/landing/HowItWorks.tsx
@@ -1,3 +1,4 @@
+import { Card } from "@shellhub/design-system/primitives";
 import { Reveal, ShimmerCard } from "./components";
 import { C } from "./constants";
 
@@ -6,183 +7,1328 @@ export function HowItWorks() {
     <section className="py-24 border-t border-border">
       <div className="max-w-7xl mx-auto px-8">
         <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">How It Works</p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">From anywhere to any device.</h2>
-          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">Instead of juggling VPNs, public IPs, and firewall rules, connect to all your devices through one secure gateway.</p>
+          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
+            How It Works
+          </p>
+          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
+            From anywhere to any device.
+          </h2>
+          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
+            Instead of juggling VPNs, public IPs, and firewall rules, connect to
+            all your devices through one secure gateway.
+          </p>
         </Reveal>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           {/* Card 1: Remote SSH Access */}
           <Reveal>
-            <ShimmerCard className="bg-card border border-border rounded-xl p-6 lg:p-8 hover:border-primary/30 transition-all duration-300">
-              <div className="flex items-center gap-3 mb-5">
-                <span className="text-2xs font-mono font-semibold text-[#7B8EDB] border border-primary/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">Remote Access</span>
-                <span className="text-2xs font-mono font-bold text-text-secondary">01</span>
-              </div>
-              <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">SSH into any device, from anywhere</h3>
-              <svg viewBox="0 0 520 200" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
-                <defs><marker id="arrow-pri" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill={C.primary} /></marker></defs>
-                <rect x="10" y="65" width="80" height="70" rx="10" fill={C.card} stroke={C.border} />
-                <circle cx="50" cy="85" r="12" stroke={C.primary} strokeWidth="1.5" fill="none" />
-                <path d="M50 80 L50 83 M46 82 L54 82" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round" />
-                <circle cx="50" cy="78" r="3" fill={C.primary} />
-                <text x="50" y="125" fontFamily="IBM Plex Sans" fontSize="11" fill={C.textSec} textAnchor="middle">User</text>
-                <line x1="95" y1="100" x2="148" y2="100" stroke={C.primary} strokeWidth="1.5" strokeDasharray="4 3" markerEnd="url(#arrow-pri)" />
-                <text x="122" y="92" fontFamily="IBM Plex Mono" fontSize="9" fill={C.primaryGlow} textAnchor="middle" letterSpacing=".05em">SSH</text>
-                <rect x="152" y="65" width="90" height="70" rx="10" fill={C.card} stroke={C.border} />
-                <rect x="165" y="78" width="64" height="40" rx="4" fill={C.surface} stroke={C.border} />
-                <text x="197" y="95" fontFamily="IBM Plex Mono" fontSize="8" fill={C.primary} textAnchor="middle">$ ssh</text>
-                <text x="197" y="107" fontFamily="IBM Plex Mono" fontSize="7" fill={C.textMuted} textAnchor="middle">user@device</text>
-                <text x="197" y="125" fontFamily="IBM Plex Sans" fontSize="11" fill={C.textSec} textAnchor="middle">Terminal</text>
-                <line x1="247" y1="100" x2="290" y2="100" stroke={C.primary} strokeWidth="1.5" markerEnd="url(#arrow-pri)" />
-                <rect x="294" y="50" width="100" height="100" rx="12" fill={C.primaryDim} stroke={C.primary} strokeWidth="1.5" />
-                <rect x="322" y="72" width="44" height="28" rx="6" fill={`${C.primary}30`} />
-                <text x="344" y="89" fontFamily="IBM Plex Mono" fontSize="9" fill={C.primary} textAnchor="middle" fontWeight="600">SH</text>
-                <text x="344" y="115" fontFamily="IBM Plex Sans" fontSize="11" fill={C.primary} textAnchor="middle" fontWeight="600">ShellHub</text>
-                <text x="344" y="130" fontFamily="IBM Plex Sans" fontSize="9" fill={C.textSec} textAnchor="middle">Cloud</text>
-                <line x1="399" y1="100" x2="428" y2="100" stroke={C.primary} strokeWidth="1.5" markerEnd="url(#arrow-pri)" />
-                <rect x="432" y="60" width="8" height="80" rx="2" fill={C.border} /><rect x="432" y="60" width="8" height="80" rx="2" fill={`${C.primary}15`} />
-                <text x="436" y="55" fontFamily="IBM Plex Mono" fontSize="9" fill={C.textMuted} textAnchor="middle" letterSpacing=".05em">NAT</text>
-                <line x1="444" y1="100" x2="460" y2="100" stroke={C.primary} strokeWidth="1.5" markerEnd="url(#arrow-pri)" />
-                <rect x="464" y="65" width="50" height="70" rx="10" fill={C.card} stroke={C.border} />
-                <rect x="474" y="78" width="30" height="22" rx="3" fill={C.surface} stroke={C.primaryGlow} />
-                <rect x="480" y="104" width="18" height="4" rx="2" fill={C.border} /><circle cx="489" cy="111" r="1.5" fill={C.primary} />
-                <text x="489" y="125" fontFamily="IBM Plex Sans" fontSize="11" fill={C.textSec} textAnchor="middle">Device</text>
-              </svg>
+            <ShimmerCard>
+              <Card className="p-6 lg:p-8 hover:border-primary/30 transition-all duration-300">
+                <div className="flex items-center gap-3 mb-5">
+                  <span className="text-2xs font-mono font-semibold text-[#7B8EDB] border border-primary/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
+                    Remote Access
+                  </span>
+                  <span className="text-2xs font-mono font-bold text-text-secondary">
+                    01
+                  </span>
+                </div>
+                <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
+                  SSH into any device, from anywhere
+                </h3>
+                <svg
+                  viewBox="0 0 520 200"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-full h-auto"
+                >
+                  <defs>
+                    <marker
+                      id="arrow-pri"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
+                    >
+                      <path d="M0,0 L8,3 L0,6" fill={C.primary} />
+                    </marker>
+                  </defs>
+                  <rect
+                    x="10"
+                    y="65"
+                    width="80"
+                    height="70"
+                    rx="10"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <circle
+                    cx="50"
+                    cy="85"
+                    r="12"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    fill="none"
+                  />
+                  <path
+                    d="M50 80 L50 83 M46 82 L54 82"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                  <circle cx="50" cy="78" r="3" fill={C.primary} />
+                  <text
+                    x="50"
+                    y="125"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    User
+                  </text>
+                  <line
+                    x1="95"
+                    y1="100"
+                    x2="148"
+                    y2="100"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    strokeDasharray="4 3"
+                    markerEnd="url(#arrow-pri)"
+                  />
+                  <text
+                    x="122"
+                    y="92"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.primaryGlow}
+                    textAnchor="middle"
+                    letterSpacing=".05em"
+                  >
+                    SSH
+                  </text>
+                  <rect
+                    x="152"
+                    y="65"
+                    width="90"
+                    height="70"
+                    rx="10"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <rect
+                    x="165"
+                    y="78"
+                    width="64"
+                    height="40"
+                    rx="4"
+                    fill={C.surface}
+                    stroke={C.border}
+                  />
+                  <text
+                    x="197"
+                    y="95"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="8"
+                    fill={C.primary}
+                    textAnchor="middle"
+                  >
+                    $ ssh
+                  </text>
+                  <text
+                    x="197"
+                    y="107"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                  >
+                    user@device
+                  </text>
+                  <text
+                    x="197"
+                    y="125"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Terminal
+                  </text>
+                  <line
+                    x1="247"
+                    y1="100"
+                    x2="290"
+                    y2="100"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    markerEnd="url(#arrow-pri)"
+                  />
+                  <rect
+                    x="294"
+                    y="50"
+                    width="100"
+                    height="100"
+                    rx="12"
+                    fill={C.primaryDim}
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                  />
+                  <rect
+                    x="322"
+                    y="72"
+                    width="44"
+                    height="28"
+                    rx="6"
+                    fill={`${C.primary}30`}
+                  />
+                  <text
+                    x="344"
+                    y="89"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.primary}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    SH
+                  </text>
+                  <text
+                    x="344"
+                    y="115"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.primary}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    ShellHub
+                  </text>
+                  <text
+                    x="344"
+                    y="130"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="9"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Cloud
+                  </text>
+                  <line
+                    x1="399"
+                    y1="100"
+                    x2="428"
+                    y2="100"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    markerEnd="url(#arrow-pri)"
+                  />
+                  <rect
+                    x="432"
+                    y="60"
+                    width="8"
+                    height="80"
+                    rx="2"
+                    fill={C.border}
+                  />
+                  <rect
+                    x="432"
+                    y="60"
+                    width="8"
+                    height="80"
+                    rx="2"
+                    fill={`${C.primary}15`}
+                  />
+                  <text
+                    x="436"
+                    y="55"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                    letterSpacing=".05em"
+                  >
+                    NAT
+                  </text>
+                  <line
+                    x1="444"
+                    y1="100"
+                    x2="460"
+                    y2="100"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    markerEnd="url(#arrow-pri)"
+                  />
+                  <rect
+                    x="464"
+                    y="65"
+                    width="50"
+                    height="70"
+                    rx="10"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <rect
+                    x="474"
+                    y="78"
+                    width="30"
+                    height="22"
+                    rx="3"
+                    fill={C.surface}
+                    stroke={C.primaryGlow}
+                  />
+                  <rect
+                    x="480"
+                    y="104"
+                    width="18"
+                    height="4"
+                    rx="2"
+                    fill={C.border}
+                  />
+                  <circle cx="489" cy="111" r="1.5" fill={C.primary} />
+                  <text
+                    x="489"
+                    y="125"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Device
+                  </text>
+                </svg>
+              </Card>
             </ShimmerCard>
           </Reveal>
 
           {/* Card 2: Session Recording */}
           <Reveal delay={0.08}>
-            <ShimmerCard className="bg-card border border-border rounded-xl p-6 lg:p-8 hover:border-accent-cyan/30 transition-all duration-300">
-              <div className="flex items-center gap-3 mb-5">
-                <span className="text-2xs font-mono font-semibold text-accent-cyan border border-accent-cyan/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">Audit</span>
-                <span className="text-2xs font-mono font-bold text-text-secondary">02</span>
-              </div>
-              <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">Record and replay every session</h3>
-              <svg viewBox="0 0 520 200" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
-                <defs><marker id="arrow-cyan" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill={C.cyan} /></marker></defs>
-                <rect x="10" y="65" width="100" height="70" rx="10" fill={C.card} stroke={C.border} />
-                <rect x="22" y="78" width="76" height="36" rx="4" fill={C.surface} stroke={C.border} />
-                <text x="60" y="94" fontFamily="IBM Plex Mono" fontSize="7" fill={C.cyan} textAnchor="middle">session_01</text>
-                <text x="60" y="106" fontFamily="IBM Plex Mono" fontSize="6" fill={C.textMuted} textAnchor="middle">recording...</text>
-                <circle cx="90" cy="82" r="4" fill={C.cyan} opacity=".6"><animate attributeName="opacity" values=".3;1;.3" dur="1.5s" repeatCount="indefinite" /></circle>
-                <text x="60" y="125" fontFamily="IBM Plex Sans" fontSize="11" fill={C.textSec} textAnchor="middle">SSH Session</text>
-                <line x1="115" y1="100" x2="165" y2="100" stroke={C.cyan} strokeWidth="1.5" markerEnd="url(#arrow-cyan)" />
-                <rect x="170" y="55" width="100" height="90" rx="12" fill={C.cyanDim} stroke={C.cyan} strokeWidth="1.5" />
-                <rect x="196" y="72" width="48" height="28" rx="6" fill={`${C.cyan}30`} />
-                <text x="220" y="89" fontFamily="IBM Plex Mono" fontSize="9" fill={C.cyan} textAnchor="middle" fontWeight="600">SH</text>
-                <text x="220" y="115" fontFamily="IBM Plex Sans" fontSize="11" fill={C.cyan} textAnchor="middle" fontWeight="600">ShellHub</text>
-                <text x="220" y="130" fontFamily="IBM Plex Sans" fontSize="9" fill={C.textSec} textAnchor="middle">Gateway</text>
-                <line x1="275" y1="85" x2="340" y2="70" stroke={C.cyan} strokeWidth="1.5" markerEnd="url(#arrow-cyan)" />
-                <line x1="275" y1="115" x2="340" y2="135" stroke={C.cyan} strokeWidth="1.5" strokeDasharray="4 3" markerEnd="url(#arrow-cyan)" />
-                <rect x="345" y="38" width="100" height="64" rx="10" fill={C.card} stroke={C.border} />
-                <ellipse cx="395" cy="55" rx="20" ry="8" fill="none" stroke={C.cyan} strokeWidth="1.2" />
-                <path d="M375 55 L375 72 Q375 80 395 80 Q415 80 415 72 L415 55" fill="none" stroke={C.cyan} strokeWidth="1.2" />
-                <text x="395" y="93" fontFamily="IBM Plex Sans" fontSize="11" fill={C.textSec} textAnchor="middle">Storage</text>
-                <line x1="450" y1="70" x2="470" y2="70" stroke={C.cyan} strokeWidth="1.2" strokeDasharray="3 2" markerEnd="url(#arrow-cyan)" />
-                <rect x="474" y="50" width="40" height="40" rx="8" fill={`${C.cyan}20`} stroke={C.cyan} strokeWidth="1" />
-                <polygon points="488,63 488,77 500,70" fill={C.cyan} />
-                <text x="494" y="103" fontFamily="IBM Plex Sans" fontSize="9" fill={C.textSec} textAnchor="middle">Replay</text>
-                <rect x="345" y="115" width="100" height="50" rx="10" fill={C.card} stroke={C.border} />
-                <rect x="358" y="126" width="74" height="26" rx="4" fill={C.surface} />
-                <text x="395" y="137" fontFamily="IBM Plex Mono" fontSize="7" fill={C.cyan} textAnchor="middle">$ ls -la</text>
-                <text x="395" y="147" fontFamily="IBM Plex Mono" fontSize="6" fill={C.textMuted} textAnchor="middle">drwxr-xr-x</text>
-                <text x="395" y="175" fontFamily="IBM Plex Sans" fontSize="11" fill={C.textSec} textAnchor="middle">Live View</text>
-              </svg>
+            <ShimmerCard>
+              <Card className="p-6 lg:p-8 hover:border-accent-cyan/30 transition-all duration-300">
+                <div className="flex items-center gap-3 mb-5">
+                  <span className="text-2xs font-mono font-semibold text-accent-cyan border border-accent-cyan/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
+                    Audit
+                  </span>
+                  <span className="text-2xs font-mono font-bold text-text-secondary">
+                    02
+                  </span>
+                </div>
+                <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
+                  Record and replay every session
+                </h3>
+                <svg
+                  viewBox="0 0 520 200"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-full h-auto"
+                >
+                  <defs>
+                    <marker
+                      id="arrow-cyan"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
+                    >
+                      <path d="M0,0 L8,3 L0,6" fill={C.cyan} />
+                    </marker>
+                  </defs>
+                  <rect
+                    x="10"
+                    y="65"
+                    width="100"
+                    height="70"
+                    rx="10"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <rect
+                    x="22"
+                    y="78"
+                    width="76"
+                    height="36"
+                    rx="4"
+                    fill={C.surface}
+                    stroke={C.border}
+                  />
+                  <text
+                    x="60"
+                    y="94"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={C.cyan}
+                    textAnchor="middle"
+                  >
+                    session_01
+                  </text>
+                  <text
+                    x="60"
+                    y="106"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="6"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                  >
+                    recording...
+                  </text>
+                  <circle cx="90" cy="82" r="4" fill={C.cyan} opacity=".6">
+                    <animate
+                      attributeName="opacity"
+                      values=".3;1;.3"
+                      dur="1.5s"
+                      repeatCount="indefinite"
+                    />
+                  </circle>
+                  <text
+                    x="60"
+                    y="125"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    SSH Session
+                  </text>
+                  <line
+                    x1="115"
+                    y1="100"
+                    x2="165"
+                    y2="100"
+                    stroke={C.cyan}
+                    strokeWidth="1.5"
+                    markerEnd="url(#arrow-cyan)"
+                  />
+                  <rect
+                    x="170"
+                    y="55"
+                    width="100"
+                    height="90"
+                    rx="12"
+                    fill={C.cyanDim}
+                    stroke={C.cyan}
+                    strokeWidth="1.5"
+                  />
+                  <rect
+                    x="196"
+                    y="72"
+                    width="48"
+                    height="28"
+                    rx="6"
+                    fill={`${C.cyan}30`}
+                  />
+                  <text
+                    x="220"
+                    y="89"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.cyan}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    SH
+                  </text>
+                  <text
+                    x="220"
+                    y="115"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.cyan}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    ShellHub
+                  </text>
+                  <text
+                    x="220"
+                    y="130"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="9"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Gateway
+                  </text>
+                  <line
+                    x1="275"
+                    y1="85"
+                    x2="340"
+                    y2="70"
+                    stroke={C.cyan}
+                    strokeWidth="1.5"
+                    markerEnd="url(#arrow-cyan)"
+                  />
+                  <line
+                    x1="275"
+                    y1="115"
+                    x2="340"
+                    y2="135"
+                    stroke={C.cyan}
+                    strokeWidth="1.5"
+                    strokeDasharray="4 3"
+                    markerEnd="url(#arrow-cyan)"
+                  />
+                  <rect
+                    x="345"
+                    y="38"
+                    width="100"
+                    height="64"
+                    rx="10"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <ellipse
+                    cx="395"
+                    cy="55"
+                    rx="20"
+                    ry="8"
+                    fill="none"
+                    stroke={C.cyan}
+                    strokeWidth="1.2"
+                  />
+                  <path
+                    d="M375 55 L375 72 Q375 80 395 80 Q415 80 415 72 L415 55"
+                    fill="none"
+                    stroke={C.cyan}
+                    strokeWidth="1.2"
+                  />
+                  <text
+                    x="395"
+                    y="93"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Storage
+                  </text>
+                  <line
+                    x1="450"
+                    y1="70"
+                    x2="470"
+                    y2="70"
+                    stroke={C.cyan}
+                    strokeWidth="1.2"
+                    strokeDasharray="3 2"
+                    markerEnd="url(#arrow-cyan)"
+                  />
+                  <rect
+                    x="474"
+                    y="50"
+                    width="40"
+                    height="40"
+                    rx="8"
+                    fill={`${C.cyan}20`}
+                    stroke={C.cyan}
+                    strokeWidth="1"
+                  />
+                  <polygon points="488,63 488,77 500,70" fill={C.cyan} />
+                  <text
+                    x="494"
+                    y="103"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="9"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Replay
+                  </text>
+                  <rect
+                    x="345"
+                    y="115"
+                    width="100"
+                    height="50"
+                    rx="10"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <rect
+                    x="358"
+                    y="126"
+                    width="74"
+                    height="26"
+                    rx="4"
+                    fill={C.surface}
+                  />
+                  <text
+                    x="395"
+                    y="137"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={C.cyan}
+                    textAnchor="middle"
+                  >
+                    $ ls -la
+                  </text>
+                  <text
+                    x="395"
+                    y="147"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="6"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                  >
+                    drwxr-xr-x
+                  </text>
+                  <text
+                    x="395"
+                    y="175"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Live View
+                  </text>
+                </svg>
+              </Card>
             </ShimmerCard>
           </Reveal>
 
           {/* Card 3: Firewall Rules */}
           <Reveal delay={0.16}>
-            <ShimmerCard className="bg-card border border-border rounded-xl p-6 lg:p-8 hover:border-accent-yellow/30 transition-all duration-300">
-              <div className="flex items-center gap-3 mb-5">
-                <span className="text-2xs font-mono font-semibold text-accent-yellow border border-accent-yellow/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">Security</span>
-                <span className="text-2xs font-mono font-bold text-text-secondary">03</span>
-              </div>
-              <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">Control access with firewall rules</h3>
-              <svg viewBox="0 0 520 200" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
-                <defs>
-                  <marker id="arrow-yel" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill={C.yellow} /></marker>
-                  <marker id="arrow-grn" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill={C.green} /></marker>
-                  <marker id="arrow-red" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill={C.red} /></marker>
-                </defs>
-                <rect x="10" y="55" width="100" height="90" rx="10" fill={C.card} stroke={C.border} />
-                <text x="60" y="80" fontFamily="IBM Plex Sans" fontSize="11" fill={C.text} textAnchor="middle" fontWeight="600">Connection</text>
-                <text x="60" y="95" fontFamily="IBM Plex Sans" fontSize="11" fill={C.text} textAnchor="middle" fontWeight="600">Requests</text>
-                <rect x="22" y="108" width="76" height="10" rx="3" fill={C.yellowDim} /><circle cx="30" cy="113" r="3" fill={C.green} /><text x="56" y="116" fontFamily="IBM Plex Mono" fontSize="6" fill={C.textMuted}>192.168.1.10</text>
-                <rect x="22" y="122" width="76" height="10" rx="3" fill={C.yellowDim} /><circle cx="30" cy="127" r="3" fill={C.red} /><text x="56" y="130" fontFamily="IBM Plex Mono" fontSize="6" fill={C.textMuted}>10.0.0.55</text>
-                <line x1="115" y1="100" x2="178" y2="100" stroke={C.yellow} strokeWidth="1.5" markerEnd="url(#arrow-yel)" />
-                <rect x="182" y="40" width="140" height="120" rx="12" fill={C.yellowDim} stroke={C.yellow} strokeWidth="1.5" />
-                <text x="252" y="62" fontFamily="IBM Plex Mono" fontSize="9" fill={C.yellow} textAnchor="middle" letterSpacing=".05em">RULES ENGINE</text>
-                <rect x="196" y="72" width="112" height="22" rx="5" fill={C.card} stroke={C.border} />
-                <circle cx="210" cy="83" r="5" fill={`${C.green}30`} stroke={C.green} /><text x="210" y="86" fontSize="8" fill={C.green} textAnchor="middle">&#10003;</text>
-                <text x="252" y="86" fontFamily="IBM Plex Mono" fontSize="7" fill={C.textSec} textAnchor="middle">Allow 192.168.*</text>
-                <rect x="196" y="100" width="112" height="22" rx="5" fill={C.card} stroke={C.border} />
-                <circle cx="210" cy="111" r="5" fill={C.redDim} stroke={C.red} /><text x="210" y="114" fontSize="8" fill={C.red} textAnchor="middle">&#10005;</text>
-                <text x="252" y="114" fontFamily="IBM Plex Mono" fontSize="7" fill={C.textSec} textAnchor="middle">Deny 10.0.0.*</text>
-                <rect x="196" y="128" width="112" height="22" rx="5" fill={C.card} stroke={C.border} />
-                <circle cx="210" cy="139" r="5" fill={`${C.green}30`} stroke={C.green} /><text x="210" y="142" fontSize="8" fill={C.green} textAnchor="middle">&#10003;</text>
-                <text x="252" y="142" fontFamily="IBM Plex Mono" fontSize="7" fill={C.textSec} textAnchor="middle">Allow port 22</text>
-                <line x1="327" y1="80" x2="380" y2="60" stroke={C.green} strokeWidth="1.5" markerEnd="url(#arrow-grn)" />
-                <line x1="327" y1="120" x2="380" y2="150" stroke={C.red} strokeWidth="1.5" strokeDasharray="4 3" markerEnd="url(#arrow-red)" />
-                <rect x="384" y="35" width="80" height="55" rx="10" fill={C.greenDim} stroke={C.green} strokeWidth="1" />
-                <text x="424" y="57" fontFamily="IBM Plex Sans" fontSize="11" fill={C.green} textAnchor="middle" fontWeight="600">Allowed</text>
-                <rect x="400" y="67" width="48" height="14" rx="4" fill={C.card} stroke={C.border} />
-                <circle cx="408" cy="74" r="2" fill={C.green} /><text x="430" y="77" fontSize="6" fill={C.textMuted} textAnchor="middle">&rarr; Device</text>
-                <rect x="384" y="125" width="80" height="55" rx="10" fill={C.redDim} stroke={C.red} strokeWidth="1" />
-                <text x="424" y="148" fontFamily="IBM Plex Sans" fontSize="11" fill={C.red} textAnchor="middle" fontWeight="600">Denied</text>
-                <line x1="410" y1="160" x2="438" y2="170" stroke={C.red} strokeWidth="1.5" />
-                <line x1="438" y1="160" x2="410" y2="170" stroke={C.red} strokeWidth="1.5" />
-              </svg>
+            <ShimmerCard>
+              <Card className="p-6 lg:p-8 hover:border-accent-yellow/30 transition-all duration-300">
+                <div className="flex items-center gap-3 mb-5">
+                  <span className="text-2xs font-mono font-semibold text-accent-yellow border border-accent-yellow/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
+                    Security
+                  </span>
+                  <span className="text-2xs font-mono font-bold text-text-secondary">
+                    03
+                  </span>
+                </div>
+                <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
+                  Control access with firewall rules
+                </h3>
+                <svg
+                  viewBox="0 0 520 200"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-full h-auto"
+                >
+                  <defs>
+                    <marker
+                      id="arrow-yel"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
+                    >
+                      <path d="M0,0 L8,3 L0,6" fill={C.yellow} />
+                    </marker>
+                    <marker
+                      id="arrow-grn"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
+                    >
+                      <path d="M0,0 L8,3 L0,6" fill={C.green} />
+                    </marker>
+                    <marker
+                      id="arrow-red"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
+                    >
+                      <path d="M0,0 L8,3 L0,6" fill={C.red} />
+                    </marker>
+                  </defs>
+                  <rect
+                    x="10"
+                    y="55"
+                    width="100"
+                    height="90"
+                    rx="10"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <text
+                    x="60"
+                    y="80"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.text}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    Connection
+                  </text>
+                  <text
+                    x="60"
+                    y="95"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.text}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    Requests
+                  </text>
+                  <rect
+                    x="22"
+                    y="108"
+                    width="76"
+                    height="10"
+                    rx="3"
+                    fill={C.yellowDim}
+                  />
+                  <circle cx="30" cy="113" r="3" fill={C.green} />
+                  <text
+                    x="56"
+                    y="116"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="6"
+                    fill={C.textMuted}
+                  >
+                    192.168.1.10
+                  </text>
+                  <rect
+                    x="22"
+                    y="122"
+                    width="76"
+                    height="10"
+                    rx="3"
+                    fill={C.yellowDim}
+                  />
+                  <circle cx="30" cy="127" r="3" fill={C.red} />
+                  <text
+                    x="56"
+                    y="130"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="6"
+                    fill={C.textMuted}
+                  >
+                    10.0.0.55
+                  </text>
+                  <line
+                    x1="115"
+                    y1="100"
+                    x2="178"
+                    y2="100"
+                    stroke={C.yellow}
+                    strokeWidth="1.5"
+                    markerEnd="url(#arrow-yel)"
+                  />
+                  <rect
+                    x="182"
+                    y="40"
+                    width="140"
+                    height="120"
+                    rx="12"
+                    fill={C.yellowDim}
+                    stroke={C.yellow}
+                    strokeWidth="1.5"
+                  />
+                  <text
+                    x="252"
+                    y="62"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.yellow}
+                    textAnchor="middle"
+                    letterSpacing=".05em"
+                  >
+                    RULES ENGINE
+                  </text>
+                  <rect
+                    x="196"
+                    y="72"
+                    width="112"
+                    height="22"
+                    rx="5"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <circle
+                    cx="210"
+                    cy="83"
+                    r="5"
+                    fill={`${C.green}30`}
+                    stroke={C.green}
+                  />
+                  <text
+                    x="210"
+                    y="86"
+                    fontSize="8"
+                    fill={C.green}
+                    textAnchor="middle"
+                  >
+                    &#10003;
+                  </text>
+                  <text
+                    x="252"
+                    y="86"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Allow 192.168.*
+                  </text>
+                  <rect
+                    x="196"
+                    y="100"
+                    width="112"
+                    height="22"
+                    rx="5"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <circle
+                    cx="210"
+                    cy="111"
+                    r="5"
+                    fill={C.redDim}
+                    stroke={C.red}
+                  />
+                  <text
+                    x="210"
+                    y="114"
+                    fontSize="8"
+                    fill={C.red}
+                    textAnchor="middle"
+                  >
+                    &#10005;
+                  </text>
+                  <text
+                    x="252"
+                    y="114"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Deny 10.0.0.*
+                  </text>
+                  <rect
+                    x="196"
+                    y="128"
+                    width="112"
+                    height="22"
+                    rx="5"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <circle
+                    cx="210"
+                    cy="139"
+                    r="5"
+                    fill={`${C.green}30`}
+                    stroke={C.green}
+                  />
+                  <text
+                    x="210"
+                    y="142"
+                    fontSize="8"
+                    fill={C.green}
+                    textAnchor="middle"
+                  >
+                    &#10003;
+                  </text>
+                  <text
+                    x="252"
+                    y="142"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Allow port 22
+                  </text>
+                  <line
+                    x1="327"
+                    y1="80"
+                    x2="380"
+                    y2="60"
+                    stroke={C.green}
+                    strokeWidth="1.5"
+                    markerEnd="url(#arrow-grn)"
+                  />
+                  <line
+                    x1="327"
+                    y1="120"
+                    x2="380"
+                    y2="150"
+                    stroke={C.red}
+                    strokeWidth="1.5"
+                    strokeDasharray="4 3"
+                    markerEnd="url(#arrow-red)"
+                  />
+                  <rect
+                    x="384"
+                    y="35"
+                    width="80"
+                    height="55"
+                    rx="10"
+                    fill={C.greenDim}
+                    stroke={C.green}
+                    strokeWidth="1"
+                  />
+                  <text
+                    x="424"
+                    y="57"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.green}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    Allowed
+                  </text>
+                  <rect
+                    x="400"
+                    y="67"
+                    width="48"
+                    height="14"
+                    rx="4"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <circle cx="408" cy="74" r="2" fill={C.green} />
+                  <text
+                    x="430"
+                    y="77"
+                    fontSize="6"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                  >
+                    &rarr; Device
+                  </text>
+                  <rect
+                    x="384"
+                    y="125"
+                    width="80"
+                    height="55"
+                    rx="10"
+                    fill={C.redDim}
+                    stroke={C.red}
+                    strokeWidth="1"
+                  />
+                  <text
+                    x="424"
+                    y="148"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.red}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    Denied
+                  </text>
+                  <line
+                    x1="410"
+                    y1="160"
+                    x2="438"
+                    y2="170"
+                    stroke={C.red}
+                    strokeWidth="1.5"
+                  />
+                  <line
+                    x1="438"
+                    y1="160"
+                    x2="410"
+                    y2="170"
+                    stroke={C.red}
+                    strokeWidth="1.5"
+                  />
+                </svg>
+              </Card>
             </ShimmerCard>
           </Reveal>
 
           {/* Card 4: Web Terminal */}
           <Reveal delay={0.24}>
-            <ShimmerCard className="bg-card border border-border rounded-xl p-6 lg:p-8 hover:border-accent-green/30 transition-all duration-300">
-              <div className="flex items-center gap-3 mb-5">
-                <span className="text-2xs font-mono font-semibold text-accent-green border border-accent-green/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">Web Terminal</span>
-                <span className="text-2xs font-mono font-bold text-text-secondary">04</span>
-              </div>
-              <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">Access devices from your browser</h3>
-              <svg viewBox="0 0 520 200" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
-                <defs><marker id="arrow-green" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill={C.green} /></marker></defs>
-                <rect x="10" y="50" width="110" height="100" rx="10" fill={C.card} stroke={C.border} />
-                <rect x="10" y="50" width="110" height="24" rx="10" fill={C.surface} /><rect x="10" y="64" width="110" height="10" fill={C.surface} />
-                <circle cx="25" cy="62" r="4" fill={C.red} opacity=".7" /><circle cx="37" cy="62" r="4" fill={C.yellow} opacity=".7" /><circle cx="49" cy="62" r="4" fill={C.green} opacity=".7" />
-                <rect x="60" y="58" width="50" height="8" rx="4" fill={C.bg} />
-                <rect x="20" y="82" width="90" height="56" rx="3" fill={C.bg} />
-                <text x="65" y="98" fontFamily="IBM Plex Mono" fontSize="7" fill={C.green} textAnchor="middle">shellhub.io</text>
-                <text x="65" y="112" fontFamily="IBM Plex Mono" fontSize="6" fill={C.textMuted} textAnchor="middle">Web Terminal</text>
-                <rect x="30" y="118" width="60" height="3" rx="1" fill={`${C.green}20`} /><rect x="30" y="124" width="40" height="3" rx="1" fill={`${C.green}10`} />
-                <text x="65" y="157" fontFamily="IBM Plex Sans" fontSize="11" fill={C.textSec} textAnchor="middle">Browser</text>
-                <line x1="125" y1="100" x2="172" y2="100" stroke={C.green} strokeWidth="1.5" markerEnd="url(#arrow-green)" />
-                <text x="148" y="92" fontFamily="IBM Plex Mono" fontSize="9" fill={`${C.green}60`} textAnchor="middle" letterSpacing=".05em">HTTPS</text>
-                <rect x="176" y="50" width="110" height="100" rx="12" fill={C.greenDim} stroke={C.green} strokeWidth="1.5" />
-                <rect x="204" y="68" width="54" height="28" rx="6" fill={`${C.green}30`} />
-                <text x="231" y="85" fontFamily="IBM Plex Mono" fontSize="9" fill={C.green} textAnchor="middle" fontWeight="600">SH</text>
-                <text x="231" y="115" fontFamily="IBM Plex Sans" fontSize="11" fill={C.green} textAnchor="middle" fontWeight="600">ShellHub</text>
-                <text x="231" y="130" fontFamily="IBM Plex Sans" fontSize="9" fill={C.textSec} textAnchor="middle">Gateway</text>
-                <line x1="291" y1="75" x2="340" y2="45" stroke={C.green} strokeWidth="1.2" markerEnd="url(#arrow-green)" />
-                <line x1="291" y1="100" x2="340" y2="100" stroke={C.green} strokeWidth="1.2" markerEnd="url(#arrow-green)" />
-                <line x1="291" y1="125" x2="340" y2="155" stroke={C.green} strokeWidth="1.2" markerEnd="url(#arrow-green)" />
-                <text x="318" y="68" fontFamily="IBM Plex Mono" fontSize="7" fill={`${C.green}40`} textAnchor="middle">SSH</text>
-                <text x="318" y="94" fontFamily="IBM Plex Mono" fontSize="7" fill={`${C.green}40`} textAnchor="middle">SSH</text>
-                <text x="318" y="142" fontFamily="IBM Plex Mono" fontSize="7" fill={`${C.green}40`} textAnchor="middle">SSH</text>
-                <rect x="344" y="20" width="100" height="50" rx="8" fill={C.card} stroke={C.border} />
-                <rect x="356" y="30" width="20" height="14" rx="3" fill={`${C.green}20`} stroke={C.green} strokeWidth=".8" /><text x="366" y="40" fontSize="8" fill={C.green} textAnchor="middle">Pi</text>
-                <text x="415" y="42" fontFamily="IBM Plex Sans" fontSize="9" fill={C.textSec} textAnchor="middle">Raspberry Pi</text>
-                <text x="415" y="55" fontFamily="IBM Plex Mono" fontSize="9" fill={C.textMuted} textAnchor="middle" letterSpacing=".05em">192.168.1.10</text>
-                <rect x="344" y="78" width="100" height="50" rx="8" fill={C.card} stroke={C.border} />
-                <rect x="356" y="88" width="20" height="14" rx="2" fill={`${C.green}20`} stroke={C.green} strokeWidth=".8" /><rect x="360" y="92" width="12" height="6" rx="1" fill={`${C.green}40`} />
-                <text x="415" y="100" fontFamily="IBM Plex Sans" fontSize="9" fill={C.textSec} textAnchor="middle">Linux Server</text>
-                <text x="415" y="113" fontFamily="IBM Plex Mono" fontSize="9" fill={C.textMuted} textAnchor="middle" letterSpacing=".05em">10.0.0.5</text>
-                <rect x="344" y="136" width="100" height="50" rx="8" fill={C.card} stroke={C.border} />
-                <circle cx="366" cy="155" r="8" fill="none" stroke={C.green} strokeWidth=".8" /><circle cx="366" cy="155" r="3" fill={`${C.green}40`} />
-                <text x="415" y="158" fontFamily="IBM Plex Sans" fontSize="9" fill={C.textSec} textAnchor="middle">IoT Device</text>
-                <text x="415" y="171" fontFamily="IBM Plex Mono" fontSize="9" fill={C.textMuted} textAnchor="middle" letterSpacing=".05em">172.16.0.8</text>
-              </svg>
+            <ShimmerCard>
+              <Card className="p-6 lg:p-8 hover:border-accent-green/30 transition-all duration-300">
+                <div className="flex items-center gap-3 mb-5">
+                  <span className="text-2xs font-mono font-semibold text-accent-green border border-accent-green/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
+                    Web Terminal
+                  </span>
+                  <span className="text-2xs font-mono font-bold text-text-secondary">
+                    04
+                  </span>
+                </div>
+                <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
+                  Access devices from your browser
+                </h3>
+                <svg
+                  viewBox="0 0 520 200"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="w-full h-auto"
+                >
+                  <defs>
+                    <marker
+                      id="arrow-green"
+                      markerWidth="8"
+                      markerHeight="6"
+                      refX="8"
+                      refY="3"
+                      orient="auto"
+                    >
+                      <path d="M0,0 L8,3 L0,6" fill={C.green} />
+                    </marker>
+                  </defs>
+                  <rect
+                    x="10"
+                    y="50"
+                    width="110"
+                    height="100"
+                    rx="10"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <rect
+                    x="10"
+                    y="50"
+                    width="110"
+                    height="24"
+                    rx="10"
+                    fill={C.surface}
+                  />
+                  <rect
+                    x="10"
+                    y="64"
+                    width="110"
+                    height="10"
+                    fill={C.surface}
+                  />
+                  <circle cx="25" cy="62" r="4" fill={C.red} opacity=".7" />
+                  <circle cx="37" cy="62" r="4" fill={C.yellow} opacity=".7" />
+                  <circle cx="49" cy="62" r="4" fill={C.green} opacity=".7" />
+                  <rect
+                    x="60"
+                    y="58"
+                    width="50"
+                    height="8"
+                    rx="4"
+                    fill={C.bg}
+                  />
+                  <rect
+                    x="20"
+                    y="82"
+                    width="90"
+                    height="56"
+                    rx="3"
+                    fill={C.bg}
+                  />
+                  <text
+                    x="65"
+                    y="98"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={C.green}
+                    textAnchor="middle"
+                  >
+                    shellhub.io
+                  </text>
+                  <text
+                    x="65"
+                    y="112"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="6"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                  >
+                    Web Terminal
+                  </text>
+                  <rect
+                    x="30"
+                    y="118"
+                    width="60"
+                    height="3"
+                    rx="1"
+                    fill={`${C.green}20`}
+                  />
+                  <rect
+                    x="30"
+                    y="124"
+                    width="40"
+                    height="3"
+                    rx="1"
+                    fill={`${C.green}10`}
+                  />
+                  <text
+                    x="65"
+                    y="157"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Browser
+                  </text>
+                  <line
+                    x1="125"
+                    y1="100"
+                    x2="172"
+                    y2="100"
+                    stroke={C.green}
+                    strokeWidth="1.5"
+                    markerEnd="url(#arrow-green)"
+                  />
+                  <text
+                    x="148"
+                    y="92"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={`${C.green}60`}
+                    textAnchor="middle"
+                    letterSpacing=".05em"
+                  >
+                    HTTPS
+                  </text>
+                  <rect
+                    x="176"
+                    y="50"
+                    width="110"
+                    height="100"
+                    rx="12"
+                    fill={C.greenDim}
+                    stroke={C.green}
+                    strokeWidth="1.5"
+                  />
+                  <rect
+                    x="204"
+                    y="68"
+                    width="54"
+                    height="28"
+                    rx="6"
+                    fill={`${C.green}30`}
+                  />
+                  <text
+                    x="231"
+                    y="85"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.green}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    SH
+                  </text>
+                  <text
+                    x="231"
+                    y="115"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="11"
+                    fill={C.green}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    ShellHub
+                  </text>
+                  <text
+                    x="231"
+                    y="130"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="9"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Gateway
+                  </text>
+                  <line
+                    x1="291"
+                    y1="75"
+                    x2="340"
+                    y2="45"
+                    stroke={C.green}
+                    strokeWidth="1.2"
+                    markerEnd="url(#arrow-green)"
+                  />
+                  <line
+                    x1="291"
+                    y1="100"
+                    x2="340"
+                    y2="100"
+                    stroke={C.green}
+                    strokeWidth="1.2"
+                    markerEnd="url(#arrow-green)"
+                  />
+                  <line
+                    x1="291"
+                    y1="125"
+                    x2="340"
+                    y2="155"
+                    stroke={C.green}
+                    strokeWidth="1.2"
+                    markerEnd="url(#arrow-green)"
+                  />
+                  <text
+                    x="318"
+                    y="68"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={`${C.green}40`}
+                    textAnchor="middle"
+                  >
+                    SSH
+                  </text>
+                  <text
+                    x="318"
+                    y="94"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={`${C.green}40`}
+                    textAnchor="middle"
+                  >
+                    SSH
+                  </text>
+                  <text
+                    x="318"
+                    y="142"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="7"
+                    fill={`${C.green}40`}
+                    textAnchor="middle"
+                  >
+                    SSH
+                  </text>
+                  <rect
+                    x="344"
+                    y="20"
+                    width="100"
+                    height="50"
+                    rx="8"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <rect
+                    x="356"
+                    y="30"
+                    width="20"
+                    height="14"
+                    rx="3"
+                    fill={`${C.green}20`}
+                    stroke={C.green}
+                    strokeWidth=".8"
+                  />
+                  <text
+                    x="366"
+                    y="40"
+                    fontSize="8"
+                    fill={C.green}
+                    textAnchor="middle"
+                  >
+                    Pi
+                  </text>
+                  <text
+                    x="415"
+                    y="42"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="9"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Raspberry Pi
+                  </text>
+                  <text
+                    x="415"
+                    y="55"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                    letterSpacing=".05em"
+                  >
+                    192.168.1.10
+                  </text>
+                  <rect
+                    x="344"
+                    y="78"
+                    width="100"
+                    height="50"
+                    rx="8"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <rect
+                    x="356"
+                    y="88"
+                    width="20"
+                    height="14"
+                    rx="2"
+                    fill={`${C.green}20`}
+                    stroke={C.green}
+                    strokeWidth=".8"
+                  />
+                  <rect
+                    x="360"
+                    y="92"
+                    width="12"
+                    height="6"
+                    rx="1"
+                    fill={`${C.green}40`}
+                  />
+                  <text
+                    x="415"
+                    y="100"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="9"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    Linux Server
+                  </text>
+                  <text
+                    x="415"
+                    y="113"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                    letterSpacing=".05em"
+                  >
+                    10.0.0.5
+                  </text>
+                  <rect
+                    x="344"
+                    y="136"
+                    width="100"
+                    height="50"
+                    rx="8"
+                    fill={C.card}
+                    stroke={C.border}
+                  />
+                  <circle
+                    cx="366"
+                    cy="155"
+                    r="8"
+                    fill="none"
+                    stroke={C.green}
+                    strokeWidth=".8"
+                  />
+                  <circle cx="366" cy="155" r="3" fill={`${C.green}40`} />
+                  <text
+                    x="415"
+                    y="158"
+                    fontFamily="IBM Plex Sans"
+                    fontSize="9"
+                    fill={C.textSec}
+                    textAnchor="middle"
+                  >
+                    IoT Device
+                  </text>
+                  <text
+                    x="415"
+                    y="171"
+                    fontFamily="IBM Plex Mono"
+                    fontSize="9"
+                    fill={C.textMuted}
+                    textAnchor="middle"
+                    letterSpacing=".05em"
+                  >
+                    172.16.0.8
+                  </text>
+                </svg>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>

--- a/ui/apps/website/src/pages/landing/QuickStart.tsx
+++ b/ui/apps/website/src/pages/landing/QuickStart.tsx
@@ -1,3 +1,4 @@
+import { Card } from "@shellhub/design-system/primitives";
 import { Reveal, CopyBtn } from "./components";
 import { docsUrl } from "@/links";
 
@@ -18,7 +19,7 @@ export function QuickStart() {
         </Reveal>
 
         <Reveal>
-          <div className="max-w-xl mx-auto bg-card border border-border rounded-xl overflow-hidden">
+          <Card className="max-w-xl mx-auto overflow-hidden">
             <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border bg-surface">
               <span className="w-2.5 h-2.5 rounded-full bg-accent-red/70" />
               <span className="w-2.5 h-2.5 rounded-full bg-accent-yellow/70" />
@@ -36,7 +37,7 @@ export function QuickStart() {
               </code>
               <CopyBtn text="docker run -d -p 80:80 shellhubio/shellhub" />
             </div>
-          </div>
+          </Card>
         </Reveal>
 
         <Reveal className="text-center mt-5">

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -503,9 +504,9 @@ export default function ContainerManagement() {
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>
-            <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-accent-cyan/10 text-accent-cyan border border-accent-cyan/20 rounded-full mb-6">
+            <Badge shape="pill" color="cyan" className="mb-6 tracking-label">
               Use Case
-            </span>
+            </Badge>
           </Reveal>
           <Reveal>
             <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-3xl mx-auto">
@@ -579,7 +580,7 @@ export default function ContainerManagement() {
             {/* Without ShellHub */}
             <Reveal delay={0}>
               <ShimmerCard className="h-full">
-                <div className="bg-card border border-border rounded-xl p-8 flex flex-col h-full hover:border-border-light transition-colors duration-300">
+                <Card hover className="p-8 flex flex-col h-full">
                   <div className="flex items-center gap-3 mb-6">
                     <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
                       <svg
@@ -659,7 +660,7 @@ export default function ContainerManagement() {
                       </p>
                     </div>
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
 
@@ -670,7 +671,7 @@ export default function ContainerManagement() {
                   <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
                   <div className="relative flex-1 flex flex-col">
                     <div className="flex items-center gap-3 mb-6">
-                      <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                      <IconBadge color="primary">
                         <svg
                           className="w-5 h-5 text-primary"
                           fill="none"
@@ -684,10 +685,10 @@ export default function ContainerManagement() {
                             d="m4.5 12.75 6 6 9-13.5"
                           />
                         </svg>
-                      </div>
-                      <span className="px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                      </IconBadge>
+                      <Badge shape="pill" color="green">
                         Recommended
-                      </span>
+                      </Badge>
                     </div>
 
                     <h3 className="text-sm font-bold mb-1">With ShellHub</h3>
@@ -784,9 +785,9 @@ export default function ContainerManagement() {
 
           <Reveal>
             <ShimmerCard>
-              <div className="bg-card border border-border rounded-xl p-6 sm:p-8 overflow-hidden hover:border-border-light transition-colors duration-300">
+              <Card hover className="p-6 sm:p-8 overflow-hidden">
                 <ArchitectureDiagram />
-              </div>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>
@@ -812,7 +813,7 @@ export default function ContainerManagement() {
             {painPoints.map((p, i) => (
               <Reveal key={i} delay={i * 0.06}>
                 <ShimmerCard className="h-full">
-                  <div className="bg-card border border-border rounded-xl p-6 h-full hover:border-border-light transition-all duration-300">
+                  <Card hover className="p-6 h-full">
                     <div className="flex items-start gap-4">
                       <div
                         className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
@@ -843,7 +844,7 @@ export default function ContainerManagement() {
                         </p>
                       </div>
                     </div>
-                  </div>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}
@@ -875,7 +876,7 @@ export default function ContainerManagement() {
                 <div className="relative grid lg:grid-cols-2 gap-8 p-8">
                   {/* Left: description */}
                   <div className="flex flex-col justify-center">
-                    <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center mb-4">
+                    <IconBadge color="primary" className="mb-4">
                       <svg
                         width="20"
                         height="20"
@@ -890,7 +891,7 @@ export default function ContainerManagement() {
                         <path d="M23 21v-2a4 4 0 00-3-3.87" />
                         <path d="M16 3.13a4 4 0 010 7.75" />
                       </svg>
-                    </div>
+                    </IconBadge>
                     <h3 className="text-lg font-bold mb-2">
                       Per-Container Access Control
                     </h3>
@@ -996,7 +997,7 @@ export default function ContainerManagement() {
             {smallFeatures.map((f, i) => (
               <Reveal key={i} delay={i * 0.04}>
                 <ShimmerCard className="h-full">
-                  <div className="bg-card border border-border rounded-xl p-6 h-full hover:border-border-light transition-all duration-300">
+                  <Card hover className="p-6 h-full">
                     <div
                       className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
                       style={{
@@ -1010,7 +1011,7 @@ export default function ContainerManagement() {
                     <p className="text-xs text-text-secondary leading-relaxed">
                       {f.desc}
                     </p>
-                  </div>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}
@@ -1059,12 +1060,12 @@ export default function ContainerManagement() {
                     {s.num}
                   </div>
                   <ShimmerCard>
-                    <div className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300">
+                    <Card hover className="p-6">
                       <h4 className="text-sm font-semibold mb-2">{s.title}</h4>
                       <p className="text-xs text-text-secondary leading-relaxed">
                         {s.desc}
                       </p>
-                    </div>
+                    </Card>
                   </ShimmerCard>
                 </div>
               </Reveal>

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card } from "@shellhub/design-system/primitives";
 import { SiteLayout } from "@/components/SiteLayout";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
@@ -317,9 +318,9 @@ export default function DevopsCiCd() {
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>
-            <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full mb-6">
+            <Badge shape="pill" color="green" className="mb-6 tracking-label">
               Use Case
-            </span>
+            </Badge>
           </Reveal>
           <Reveal>
             <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-4xl mx-auto">
@@ -440,14 +441,16 @@ export default function DevopsCiCd() {
             </div>
 
             <Reveal delay={0.1}>
-              <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-                <TerminalChrome title="ansible-playbook">
-                  <div className="space-y-0">
-                    {ansibleLines.map((line, i) => (
-                      <CodeLine key={i} {...line} />
-                    ))}
-                  </div>
-                </TerminalChrome>
+              <ShimmerCard>
+                <Card className="overflow-hidden">
+                  <TerminalChrome title="ansible-playbook">
+                    <div className="space-y-0">
+                      {ansibleLines.map((line, i) => (
+                        <CodeLine key={i} {...line} />
+                      ))}
+                    </div>
+                  </TerminalChrome>
+                </Card>
               </ShimmerCard>
             </Reveal>
           </div>
@@ -459,14 +462,16 @@ export default function DevopsCiCd() {
         <div className="max-w-7xl mx-auto px-8">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <Reveal delay={0.1} className="order-2 lg:order-1">
-              <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-                <TerminalChrome title="main.tf">
-                  <div className="space-y-0">
-                    {terraformLines.map((line, i) => (
-                      <CodeLine key={i} {...line} />
-                    ))}
-                  </div>
-                </TerminalChrome>
+              <ShimmerCard>
+                <Card className="overflow-hidden">
+                  <TerminalChrome title="main.tf">
+                    <div className="space-y-0">
+                      {terraformLines.map((line, i) => (
+                        <CodeLine key={i} {...line} />
+                      ))}
+                    </div>
+                  </TerminalChrome>
+                </Card>
               </ShimmerCard>
             </Reveal>
 
@@ -647,15 +652,17 @@ export default function DevopsCiCd() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {painPoints.map((p, i) => (
               <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                  <div
-                    className="w-2 h-2 rounded-full mb-4"
-                    style={{ background: p.color }}
-                  />
-                  <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {p.desc}
-                  </p>
+                <ShimmerCard>
+                  <Card hover className="p-6 h-full">
+                    <div
+                      className="w-2 h-2 rounded-full mb-4"
+                      style={{ background: p.color }}
+                    />
+                    <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {p.desc}
+                    </p>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}
@@ -682,20 +689,22 @@ export default function DevopsCiCd() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {features.map((f, i) => (
               <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
+                <ShimmerCard>
+                  <Card hover className="p-6 h-full">
+                    <div
+                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                      style={{
+                        background: `${f.color}15`,
+                        borderColor: `${f.color}25`,
+                      }}
+                    >
+                      {f.icon}
+                    </div>
+                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {f.desc}
+                    </p>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import { C } from "../landing/constants";
@@ -214,9 +215,9 @@ export default function EdgeComputing() {
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>
-            <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-accent-blue/10 text-accent-blue border border-accent-blue/20 rounded-full mb-6">
+            <Badge shape="pill" color="blue" className="mb-6 tracking-label">
               Use Case
-            </span>
+            </Badge>
           </Reveal>
           <Reveal>
             <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-3xl mx-auto">
@@ -486,24 +487,28 @@ export default function EdgeComputing() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {painPoints.map((p, i) => (
               <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                  <div className="flex items-start gap-4">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
-                      style={{
-                        background: `${p.color}15`,
-                        borderColor: `${p.color}25`,
-                      }}
-                    >
-                      {p.icon}
+                <ShimmerCard>
+                  <Card hover className="p-6 h-full">
+                    <div className="flex items-start gap-4">
+                      <div
+                        className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
+                        style={{
+                          background: `${p.color}15`,
+                          borderColor: `${p.color}25`,
+                        }}
+                      >
+                        {p.icon}
+                      </div>
+                      <div>
+                        <h4 className="text-sm font-semibold mb-2">
+                          {p.title}
+                        </h4>
+                        <p className="text-xs text-text-secondary leading-relaxed">
+                          {p.desc}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {p.desc}
-                      </p>
-                    </div>
-                  </div>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}
@@ -535,7 +540,7 @@ export default function EdgeComputing() {
                 <div className="relative grid lg:grid-cols-2 gap-8 items-center">
                   <div>
                     <div className="flex items-center gap-2 mb-4">
-                      <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                      <IconBadge color="primary">
                         <svg
                           width="20"
                           height="20"
@@ -549,10 +554,10 @@ export default function EdgeComputing() {
                           <polyline points="4 17 10 11 4 5" />
                           <line x1="12" y1="19" x2="20" y2="19" />
                         </svg>
-                      </div>
-                      <span className="px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                      </IconBadge>
+                      <Badge shape="pill" color="green">
                         Core Feature
-                      </span>
+                      </Badge>
                     </div>
                     <h3 className="text-lg font-bold mb-2">
                       Instant Remote Access
@@ -650,7 +655,7 @@ export default function EdgeComputing() {
           <div className="grid md:grid-cols-2 gap-4 mb-4">
             <Reveal delay={0.05}>
               <ShimmerCard className="h-full">
-                <div className="bg-card border border-border rounded-xl p-6 h-full hover:border-border-light transition-all duration-300">
+                <Card hover className="p-6 h-full">
                   <div
                     className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
                     style={{
@@ -722,13 +727,13 @@ export default function EdgeComputing() {
                       </div>
                     </div>
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
 
             <Reveal delay={0.1}>
               <ShimmerCard className="h-full">
-                <div className="bg-card border border-border rounded-xl p-6 h-full hover:border-border-light transition-all duration-300">
+                <Card hover className="p-6 h-full">
                   <div
                     className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
                     style={{
@@ -801,7 +806,7 @@ export default function EdgeComputing() {
                       </div>
                     </div>
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
           </div>
@@ -810,7 +815,7 @@ export default function EdgeComputing() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <Reveal delay={0.05}>
               <ShimmerCard className="h-full">
-                <div className="bg-card border border-border rounded-xl p-6 h-full hover:border-border-light transition-all duration-300">
+                <Card hover className="p-6 h-full">
                   <div
                     className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
                     style={{
@@ -857,13 +862,13 @@ export default function EdgeComputing() {
                       </span>
                     ))}
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
 
             <Reveal delay={0.1}>
               <ShimmerCard className="h-full">
-                <div className="bg-card border border-border rounded-xl p-6 h-full hover:border-border-light transition-all duration-300">
+                <Card hover className="p-6 h-full">
                   <div
                     className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
                     style={{
@@ -919,13 +924,13 @@ export default function EdgeComputing() {
                       </div>
                     ))}
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
 
             <Reveal delay={0.15}>
               <ShimmerCard className="h-full">
-                <div className="bg-card border border-border rounded-xl p-6 h-full hover:border-border-light transition-all duration-300">
+                <Card hover className="p-6 h-full">
                   <div
                     className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
                     style={{
@@ -997,7 +1002,7 @@ export default function EdgeComputing() {
                       </div>
                     ))}
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
           </div>
@@ -1024,7 +1029,7 @@ export default function EdgeComputing() {
             {scenarios.map((s, i) => (
               <Reveal key={i} delay={i * 0.08}>
                 <ShimmerCard className="h-full">
-                  <div className="bg-card border border-border rounded-xl p-6 h-full hover:border-border-light transition-all duration-300">
+                  <Card hover className="p-6 h-full">
                     <div
                       className="w-2 h-2 rounded-full mb-4"
                       style={{ background: s.color }}
@@ -1034,7 +1039,7 @@ export default function EdgeComputing() {
                       {s.desc}
                     </p>
                     {s.mockup}
-                  </div>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -146,9 +147,9 @@ export default function IotEmbedded() {
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>
-            <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full mb-6">
+            <Badge shape="pill" color="green" className="mb-6 tracking-label">
               Use Case
-            </span>
+            </Badge>
           </Reveal>
           <Reveal>
             <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-4xl mx-auto">
@@ -267,91 +268,93 @@ export default function IotEmbedded() {
 
             {/* Fake dashboard panel */}
             <Reveal delay={0.1}>
-              <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-                <div className="p-6">
-                  {/* Window chrome */}
-                  <div className="flex items-center gap-2 mb-6">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Device Fleet
-                    </span>
-                  </div>
-
-                  {/* Table header */}
-                  <div className="flex items-center gap-3 px-3 py-2 mb-1">
-                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-5">
-                      St
-                    </span>
-                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1">
-                      Hostname
-                    </span>
-                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-24 hidden sm:block">
-                      IP
-                    </span>
-                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1 text-right">
-                      Tags
-                    </span>
-                  </div>
-
-                  {/* Device rows */}
-                  <div className="space-y-2">
-                    {fleetDevices.map((d, i) => (
-                      <div
-                        key={i}
-                        className="flex items-center gap-3 p-3 bg-surface rounded-lg border border-border hover:border-border-light transition-colors duration-200"
-                      >
-                        <div
-                          className="w-2 h-2 rounded-full shrink-0"
-                          style={{
-                            background:
-                              d.status === "online" ? C.green : C.textMuted,
-                          }}
-                        />
-                        <div className="flex-1 min-w-0">
-                          <p className="text-xs font-mono font-medium truncate">
-                            {d.name}
-                          </p>
-                        </div>
-                        <span className="text-2xs text-text-muted font-mono w-24 hidden sm:block">
-                          {d.ip}
-                        </span>
-                        <div className="flex items-center gap-1.5 flex-wrap justify-end">
-                          {d.tags.map((t, j) => (
-                            <span
-                              key={j}
-                              className="px-1.5 py-0.5 text-2xs font-mono rounded-full border"
-                              style={{
-                                background: `${t.color}10`,
-                                color: t.color,
-                                borderColor: `${t.color}20`,
-                              }}
-                            >
-                              {t.label}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-
-                  {/* Footer */}
-                  <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-2 h-2 rounded-full"
-                        style={{ background: C.green }}
-                      />
-                      <span className="text-2xs text-text-muted">
-                        24 devices online
+              <ShimmerCard>
+                <Card className="overflow-hidden">
+                  <div className="p-6">
+                    {/* Window chrome */}
+                    <div className="flex items-center gap-2 mb-6">
+                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                      <span className="ml-2 text-2xs text-text-muted font-mono">
+                        Device Fleet
                       </span>
                     </div>
-                    <span className="text-2xs text-primary font-medium">
-                      View all &rarr;
-                    </span>
+
+                    {/* Table header */}
+                    <div className="flex items-center gap-3 px-3 py-2 mb-1">
+                      <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-5">
+                        St
+                      </span>
+                      <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1">
+                        Hostname
+                      </span>
+                      <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-24 hidden sm:block">
+                        IP
+                      </span>
+                      <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1 text-right">
+                        Tags
+                      </span>
+                    </div>
+
+                    {/* Device rows */}
+                    <div className="space-y-2">
+                      {fleetDevices.map((d, i) => (
+                        <div
+                          key={i}
+                          className="flex items-center gap-3 p-3 bg-surface rounded-lg border border-border hover:border-border-light transition-colors duration-200"
+                        >
+                          <div
+                            className="w-2 h-2 rounded-full shrink-0"
+                            style={{
+                              background:
+                                d.status === "online" ? C.green : C.textMuted,
+                            }}
+                          />
+                          <div className="flex-1 min-w-0">
+                            <p className="text-xs font-mono font-medium truncate">
+                              {d.name}
+                            </p>
+                          </div>
+                          <span className="text-2xs text-text-muted font-mono w-24 hidden sm:block">
+                            {d.ip}
+                          </span>
+                          <div className="flex items-center gap-1.5 flex-wrap justify-end">
+                            {d.tags.map((t, j) => (
+                              <span
+                                key={j}
+                                className="px-1.5 py-0.5 text-2xs font-mono rounded-full border"
+                                style={{
+                                  background: `${t.color}10`,
+                                  color: t.color,
+                                  borderColor: `${t.color}20`,
+                                }}
+                              >
+                                {t.label}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+
+                    {/* Footer */}
+                    <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="w-2 h-2 rounded-full"
+                          style={{ background: C.green }}
+                        />
+                        <span className="text-2xs text-text-muted">
+                          24 devices online
+                        </span>
+                      </div>
+                      <span className="text-2xs text-primary font-medium">
+                        View all &rarr;
+                      </span>
+                    </div>
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
           </div>
@@ -377,26 +380,28 @@ export default function IotEmbedded() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {painPoints.map((p, i) => (
               <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                  <div className="flex items-start gap-4">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
-                      style={{
-                        background: `${p.color}15`,
-                        borderColor: `${p.color}25`,
-                      }}
-                    >
-                      {p.icon}
+                <ShimmerCard>
+                  <Card hover className="p-6 h-full">
+                    <div className="flex items-start gap-4">
+                      <div
+                        className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
+                        style={{
+                          background: `${p.color}15`,
+                          borderColor: `${p.color}25`,
+                        }}
+                      >
+                        {p.icon}
+                      </div>
+                      <div>
+                        <h4 className="text-sm font-semibold mb-1.5">
+                          {p.title}
+                        </h4>
+                        <p className="text-xs text-text-secondary leading-relaxed">
+                          {p.desc}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <h4 className="text-sm font-semibold mb-1.5">
-                        {p.title}
-                      </h4>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {p.desc}
-                      </p>
-                    </div>
-                  </div>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}
@@ -429,7 +434,7 @@ export default function IotEmbedded() {
                   {/* Left: text */}
                   <div className="flex flex-col justify-center">
                     <div className="flex items-center gap-3 mb-4">
-                      <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                      <IconBadge color="primary">
                         <svg
                           width="20"
                           height="20"
@@ -441,10 +446,10 @@ export default function IotEmbedded() {
                         >
                           <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
                         </svg>
-                      </div>
-                      <span className="px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] bg-primary/10 text-primary border border-primary/20 rounded-full">
+                      </IconBadge>
+                      <Badge shape="pill" color="primary">
                         Core
-                      </span>
+                      </Badge>
                     </div>
                     <h3 className="text-lg font-bold mb-3">NAT Traversal</h3>
                     <p className="text-sm text-text-secondary leading-relaxed mb-4">
@@ -782,20 +787,22 @@ export default function IotEmbedded() {
               },
             ].map((f, i) => (
               <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
+                <ShimmerCard>
+                  <Card hover className="p-6 h-full">
+                    <div
+                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                      style={{
+                        background: `${f.color}15`,
+                        borderColor: `${f.color}25`,
+                      }}
+                    >
+                      {f.icon}
+                    </div>
+                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {f.desc}
+                    </p>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}
@@ -810,7 +817,7 @@ export default function IotEmbedded() {
                   <div className="grid lg:grid-cols-[1fr_auto] gap-8 items-center">
                     <div>
                       <div className="flex items-center gap-3 mb-4">
-                        <div className="w-10 h-10 rounded-lg bg-accent-green/10 border border-accent-green/20 flex items-center justify-center">
+                        <IconBadge color="green">
                           <svg
                             width="20"
                             height="20"
@@ -823,10 +830,10 @@ export default function IotEmbedded() {
                             <polyline points="4 17 10 11 4 5" />
                             <line x1="12" y1="19" x2="20" y2="19" />
                           </svg>
-                        </div>
-                        <span className="px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                        </IconBadge>
+                        <Badge shape="pill" color="green">
                           Agent
-                        </span>
+                        </Badge>
                       </div>
                       <h3 className="text-lg font-bold mb-3">
                         Lightweight Agent

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { Badge, Card } from "@shellhub/design-system/primitives";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -227,9 +228,9 @@ export default function RemoteSupport() {
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>
-            <span className="inline-block px-3 py-1 text-2xs font-mono font-semibold uppercase tracking-[0.15em] bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20 rounded-full mb-6">
+            <Badge shape="pill" color="yellow" className="mb-6">
               Use Case
-            </span>
+            </Badge>
           </Reveal>
           <Reveal>
             <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-6 max-w-3xl mx-auto">
@@ -349,112 +350,114 @@ export default function RemoteSupport() {
 
             {/* Session player mockup */}
             <Reveal delay={0.1}>
-              <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-                <div className="p-6">
-                  {/* Window chrome */}
-                  <div className="flex items-center gap-2 mb-4">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Session Replay
-                    </span>
-                  </div>
-
-                  {/* Terminal area */}
-                  <div className="bg-[#111214] rounded-lg border border-border p-4 font-mono text-2xs leading-relaxed mb-4">
-                    <p className="text-accent-green">
-                      john@prod-server-03:~$
-                      <span className="text-text-primary ml-2">
-                        ls -la /var/log/nginx/
+              <ShimmerCard>
+                <Card className="overflow-hidden">
+                  <div className="p-6">
+                    {/* Window chrome */}
+                    <div className="flex items-center gap-2 mb-4">
+                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                      <span className="ml-2 text-2xs text-text-muted font-mono">
+                        Session Replay
                       </span>
-                    </p>
-                    <p className="text-text-muted mt-1">total 2184</p>
-                    <p className="text-text-muted">
-                      drwxr-xr-x 2 root root 4096 Feb 14 09:00 .
-                    </p>
-                    <p className="text-text-muted">
-                      -rw-r----- 1 root adm 842560 Feb 14 14:31 access.log
-                    </p>
-                    <p className="text-text-muted">
-                      -rw-r----- 1 root adm 194720 Feb 14 14:28 error.log
-                    </p>
-                    <p className="text-accent-green mt-2">
-                      john@prod-server-03:~$
-                      <span className="text-text-primary ml-2">
-                        systemctl status nginx
-                      </span>
-                    </p>
-                    <p className="text-text-muted mt-1">
-                      <span className="text-accent-green">●</span> nginx.service
-                      - A high performance web server
-                    </p>
-                    <p className="text-text-muted">
-                      {"   "}Loaded: loaded (/lib/systemd/system/nginx.service;
-                      enabled)
-                    </p>
-                    <p className="text-text-muted">
-                      {"   "}Active:{" "}
-                      <span className="text-accent-green">
-                        active (running)
-                      </span>{" "}
-                      since Fri 2026-02-14 09:00:12 UTC
-                    </p>
-                    <p className="text-accent-green mt-2">
-                      john@prod-server-03:~$
-                      <span className="text-text-primary ml-2 animate-pulse">
-                        _
-                      </span>
-                    </p>
-                  </div>
-
-                  {/* Playback controls */}
-                  <div className="flex items-center gap-3 bg-surface rounded-lg border border-border p-3">
-                    <button className="w-8 h-8 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center shrink-0">
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill={C.cyan}
-                        stroke="none"
-                      >
-                        <polygon points="6 4 20 12 6 20 6 4" />
-                      </svg>
-                    </button>
-
-                    {/* Timeline */}
-                    <div className="flex-1 relative">
-                      <div className="h-1.5 bg-border rounded-full overflow-hidden">
-                        <div
-                          className="h-full rounded-full bg-gradient-to-r from-accent-cyan to-primary"
-                          style={{ width: "30%" }}
-                        />
-                      </div>
                     </div>
 
-                    <span className="text-2xs text-text-muted font-mono shrink-0">
-                      00:03:42 / 00:12:15
-                    </span>
-                  </div>
+                    {/* Terminal area */}
+                    <div className="bg-[#111214] rounded-lg border border-border p-4 font-mono text-2xs leading-relaxed mb-4">
+                      <p className="text-accent-green">
+                        john@prod-server-03:~$
+                        <span className="text-text-primary ml-2">
+                          ls -la /var/log/nginx/
+                        </span>
+                      </p>
+                      <p className="text-text-muted mt-1">total 2184</p>
+                      <p className="text-text-muted">
+                        drwxr-xr-x 2 root root 4096 Feb 14 09:00 .
+                      </p>
+                      <p className="text-text-muted">
+                        -rw-r----- 1 root adm 842560 Feb 14 14:31 access.log
+                      </p>
+                      <p className="text-text-muted">
+                        -rw-r----- 1 root adm 194720 Feb 14 14:28 error.log
+                      </p>
+                      <p className="text-accent-green mt-2">
+                        john@prod-server-03:~$
+                        <span className="text-text-primary ml-2">
+                          systemctl status nginx
+                        </span>
+                      </p>
+                      <p className="text-text-muted mt-1">
+                        <span className="text-accent-green">●</span>{" "}
+                        nginx.service - A high performance web server
+                      </p>
+                      <p className="text-text-muted">
+                        {"   "}Loaded: loaded
+                        (/lib/systemd/system/nginx.service; enabled)
+                      </p>
+                      <p className="text-text-muted">
+                        {"   "}Active:{" "}
+                        <span className="text-accent-green">
+                          active (running)
+                        </span>{" "}
+                        since Fri 2026-02-14 09:00:12 UTC
+                      </p>
+                      <p className="text-accent-green mt-2">
+                        john@prod-server-03:~$
+                        <span className="text-text-primary ml-2 animate-pulse">
+                          _
+                        </span>
+                      </p>
+                    </div>
 
-                  {/* Metadata */}
-                  <div className="mt-4 pt-4 border-t border-border">
-                    <p className="text-2xs text-text-muted font-mono">
-                      User:{" "}
-                      <span className="text-text-secondary">
-                        john@company.com
+                    {/* Playback controls */}
+                    <div className="flex items-center gap-3 bg-surface rounded-lg border border-border p-3">
+                      <button className="w-8 h-8 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center shrink-0">
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill={C.cyan}
+                          stroke="none"
+                        >
+                          <polygon points="6 4 20 12 6 20 6 4" />
+                        </svg>
+                      </button>
+
+                      {/* Timeline */}
+                      <div className="flex-1 relative">
+                        <div className="h-1.5 bg-border rounded-full overflow-hidden">
+                          <div
+                            className="h-full rounded-full bg-gradient-to-r from-accent-cyan to-primary"
+                            style={{ width: "30%" }}
+                          />
+                        </div>
+                      </div>
+
+                      <span className="text-2xs text-text-muted font-mono shrink-0">
+                        00:03:42 / 00:12:15
                       </span>
-                      <span className="mx-2 text-border">|</span>
-                      Device:{" "}
-                      <span className="text-text-secondary">
-                        prod-server-03
-                      </span>
-                      <span className="mx-2 text-border">|</span>
-                      Duration:{" "}
-                      <span className="text-text-secondary">12m 15s</span>
-                    </p>
+                    </div>
+
+                    {/* Metadata */}
+                    <div className="mt-4 pt-4 border-t border-border">
+                      <p className="text-2xs text-text-muted font-mono">
+                        User:{" "}
+                        <span className="text-text-secondary">
+                          john@company.com
+                        </span>
+                        <span className="mx-2 text-border">|</span>
+                        Device:{" "}
+                        <span className="text-text-secondary">
+                          prod-server-03
+                        </span>
+                        <span className="mx-2 text-border">|</span>
+                        Duration:{" "}
+                        <span className="text-text-secondary">12m 15s</span>
+                      </p>
+                    </div>
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
           </div>
@@ -467,86 +470,88 @@ export default function RemoteSupport() {
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             {/* Audit log table mockup */}
             <Reveal delay={0.1} className="order-2 lg:order-1">
-              <ShimmerCard className="bg-card border border-border rounded-xl overflow-hidden">
-                <div className="p-6">
-                  {/* Window chrome */}
-                  <div className="flex items-center gap-2 mb-5">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Audit Log
-                    </span>
-                  </div>
+              <ShimmerCard>
+                <Card className="overflow-hidden">
+                  <div className="p-6">
+                    {/* Window chrome */}
+                    <div className="flex items-center gap-2 mb-5">
+                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                      <span className="ml-2 text-2xs text-text-muted font-mono">
+                        Audit Log
+                      </span>
+                    </div>
 
-                  {/* Table header */}
-                  <div className="grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2 mb-1">
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      Time
-                    </span>
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      User
-                    </span>
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      Action
-                    </span>
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      Device
-                    </span>
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      Duration
-                    </span>
-                  </div>
+                    {/* Table header */}
+                    <div className="grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2 mb-1">
+                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                        Time
+                      </span>
+                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                        User
+                      </span>
+                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                        Action
+                      </span>
+                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                        Device
+                      </span>
+                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                        Duration
+                      </span>
+                    </div>
 
-                  {/* Rows */}
-                  <div className="space-y-1">
-                    {auditRows.map((row, i) => (
-                      <div
-                        key={i}
-                        className={`grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2.5 rounded-lg items-center ${
-                          i % 2 === 0 ? "bg-surface" : "bg-transparent"
-                        }`}
-                      >
-                        <span className="text-2xs font-mono text-text-muted">
-                          {row.time}
-                        </span>
-                        <div className="flex items-center gap-2 min-w-0">
-                          <div
-                            className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-semibold shrink-0"
-                            style={{
-                              background: `${row.color}20`,
-                              color: row.color,
-                            }}
-                          >
-                            {row.initials}
+                    {/* Rows */}
+                    <div className="space-y-1">
+                      {auditRows.map((row, i) => (
+                        <div
+                          key={i}
+                          className={`grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2.5 rounded-lg items-center ${
+                            i % 2 === 0 ? "bg-surface" : "bg-transparent"
+                          }`}
+                        >
+                          <span className="text-2xs font-mono text-text-muted">
+                            {row.time}
+                          </span>
+                          <div className="flex items-center gap-2 min-w-0">
+                            <div
+                              className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-semibold shrink-0"
+                              style={{
+                                background: `${row.color}20`,
+                                color: row.color,
+                              }}
+                            >
+                              {row.initials}
+                            </div>
+                            <span className="text-2xs text-text-secondary truncate">
+                              {row.name}
+                            </span>
                           </div>
-                          <span className="text-2xs text-text-secondary truncate">
-                            {row.name}
+                          <span className="text-2xs text-text-secondary font-mono">
+                            {row.action}
+                          </span>
+                          <span className="text-2xs text-text-secondary font-mono truncate">
+                            {row.device}
+                          </span>
+                          <span className="text-2xs text-text-muted font-mono">
+                            {row.duration}
                           </span>
                         </div>
-                        <span className="text-2xs text-text-secondary font-mono">
-                          {row.action}
-                        </span>
-                        <span className="text-2xs text-text-secondary font-mono truncate">
-                          {row.device}
-                        </span>
-                        <span className="text-2xs text-text-muted font-mono">
-                          {row.duration}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
+                      ))}
+                    </div>
 
-                  {/* Footer */}
-                  <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                    <span className="text-2xs text-text-muted">
-                      Showing 4 of 1,247 entries
-                    </span>
-                    <span className="text-2xs text-primary font-medium">
-                      View all &rarr;
-                    </span>
+                    {/* Footer */}
+                    <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                      <span className="text-2xs text-text-muted">
+                        Showing 4 of 1,247 entries
+                      </span>
+                      <span className="text-2xs text-primary font-medium">
+                        View all &rarr;
+                      </span>
+                    </div>
                   </div>
-                </div>
+                </Card>
               </ShimmerCard>
             </Reveal>
 
@@ -638,7 +643,7 @@ export default function RemoteSupport() {
             {painPoints.map((p, i) => (
               <Reveal key={i} delay={i * 0.06}>
                 <ShimmerCard className="h-full">
-                  <div className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
+                  <Card hover className="p-6 h-full">
                     <div
                       className="w-2 h-2 rounded-full mb-4"
                       style={{ background: p.color }}
@@ -647,7 +652,7 @@ export default function RemoteSupport() {
                     <p className="text-xs text-text-secondary leading-relaxed">
                       {p.desc}
                     </p>
-                  </div>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}
@@ -675,20 +680,22 @@ export default function RemoteSupport() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {features.map((f, i) => (
               <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard className="bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
+                <ShimmerCard>
+                  <Card hover className="p-6 h-full">
+                    <div
+                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                      style={{
+                        background: `${f.color}15`,
+                        borderColor: `${f.color}25`,
+                      }}
+                    >
+                      {f.icon}
+                    </div>
+                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {f.desc}
+                    </p>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}
@@ -747,7 +754,7 @@ export default function RemoteSupport() {
             {workflowSteps.map((step, i) => (
               <Reveal key={i} delay={i * 0.08}>
                 <ShimmerCard className="h-full">
-                  <div className="relative bg-card border border-border rounded-xl p-6 hover:border-border-light transition-all duration-300 h-full overflow-hidden">
+                  <Card hover className="relative p-6 h-full overflow-hidden">
                     <div
                       className="absolute top-0 left-0 w-full h-0.5"
                       style={{
@@ -770,7 +777,7 @@ export default function RemoteSupport() {
                     <p className="text-xs text-text-secondary leading-relaxed">
                       {step.desc}
                     </p>
-                  </div>
+                  </Card>
                 </ShimmerCard>
               </Reveal>
             ))}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12552,6 +12552,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "license": "MIT",
@@ -13927,7 +13937,11 @@
     },
     "packages/design-system": {
       "name": "@shellhub/design-system",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "tailwind-merge": "^2.6.0"
+      }
     }
   }
 }

--- a/ui/packages/design-system/__tests__/Badge.test.tsx
+++ b/ui/packages/design-system/__tests__/Badge.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Badge } from "../primitives/Badge";
+
+describe("Badge", () => {
+  describe("defaults", () => {
+    it("renders with primary color and rounded shape by default", () => {
+      render(<Badge data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-primary/10");
+      expect(el.className).toContain("text-primary");
+      expect(el.className).toContain("rounded");
+      expect(el.className).toContain("px-1.5");
+      expect(el.className).toContain("py-0.5");
+      expect(el.className).toContain("font-medium");
+    });
+
+    it("always includes base inline-flex items-center gap-1 text-2xs", () => {
+      render(<Badge data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("inline-flex");
+      expect(el.className).toContain("items-center");
+      expect(el.className).toContain("gap-1");
+      expect(el.className).toContain("text-2xs");
+    });
+  });
+
+  describe("shape=rounded (console chips)", () => {
+    it("includes px-1.5 py-0.5 rounded font-medium", () => {
+      render(<Badge shape="rounded" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("px-1.5");
+      expect(el.className).toContain("py-0.5");
+      expect(el.className).toContain("rounded");
+      expect(el.className).toContain("font-medium");
+    });
+
+    it("does NOT include pill-only classes (font-semibold uppercase tracking-compact border)", () => {
+      render(<Badge shape="rounded" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).not.toContain("font-semibold");
+      expect(el.className).not.toContain("uppercase");
+      expect(el.className).not.toContain("tracking-compact");
+      // border is not part of rounded shape
+      expect(el.className).not.toContain("border");
+    });
+  });
+
+  describe("shape=pill (website)", () => {
+    it("includes px-2 py-0.5 rounded-full font-mono font-semibold uppercase tracking-compact border", () => {
+      render(<Badge shape="pill" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("px-2");
+      expect(el.className).toContain("py-0.5");
+      expect(el.className).toContain("rounded-full");
+      expect(el.className).toContain("font-mono");
+      expect(el.className).toContain("font-semibold");
+      expect(el.className).toContain("uppercase");
+      expect(el.className).toContain("tracking-compact");
+      expect(el.className).toContain("border");
+    });
+
+    it("does NOT include rounded-chip classes (rounded without -full, font-medium)", () => {
+      render(<Badge shape="pill" color="primary" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      // rounded-full is present; plain "rounded" class should NOT be present without -full suffix
+      // (we check rounded-full is present, and that "rounded " standalone is absent)
+      expect(el.className).toContain("rounded-full");
+      expect(el.className).not.toContain("font-medium");
+    });
+  });
+
+  describe("colors — rounded shape", () => {
+    it("primary uses bg-primary/10 text-primary", () => {
+      render(<Badge color="primary" shape="rounded" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-primary/10");
+      expect(el.className).toContain("text-primary");
+    });
+
+    it("green resolves to accent-green prefix: bg-accent-green/10 text-accent-green", () => {
+      render(<Badge color="green" shape="rounded" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-green/10");
+      expect(el.className).toContain("text-accent-green");
+    });
+
+    it("red resolves to accent-red prefix: bg-accent-red/10 text-accent-red", () => {
+      render(<Badge color="red" shape="rounded" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-red/10");
+      expect(el.className).toContain("text-accent-red");
+    });
+
+    it("yellow resolves to accent-yellow prefix: bg-accent-yellow/10 text-accent-yellow", () => {
+      render(<Badge color="yellow" shape="rounded" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-yellow/10");
+      expect(el.className).toContain("text-accent-yellow");
+    });
+
+    it("blue resolves to accent-blue prefix: bg-accent-blue/10 text-accent-blue", () => {
+      render(<Badge color="blue" shape="rounded" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-blue/10");
+      expect(el.className).toContain("text-accent-blue");
+    });
+
+    it("cyan resolves to accent-cyan prefix: bg-accent-cyan/10 text-accent-cyan", () => {
+      render(<Badge color="cyan" shape="rounded" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-cyan/10");
+      expect(el.className).toContain("text-accent-cyan");
+    });
+  });
+
+  describe("colors — pill shape (also includes border color)", () => {
+    it("primary pill uses bg-primary/10 text-primary border-primary/20", () => {
+      render(<Badge color="primary" shape="pill" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-primary/10");
+      expect(el.className).toContain("text-primary");
+      expect(el.className).toContain("border-primary/20");
+    });
+
+    it("green pill uses bg-accent-green/10 text-accent-green border-accent-green/20", () => {
+      render(<Badge color="green" shape="pill" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-green/10");
+      expect(el.className).toContain("text-accent-green");
+      expect(el.className).toContain("border-accent-green/20");
+    });
+
+    it("red pill uses bg-accent-red/10 text-accent-red border-accent-red/20", () => {
+      render(<Badge color="red" shape="pill" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-red/10");
+      expect(el.className).toContain("text-accent-red");
+      expect(el.className).toContain("border-accent-red/20");
+    });
+  });
+
+  describe("className override", () => {
+    it('className="font-semibold" wins over base font-medium (same tailwind-merge group)', () => {
+      render(
+        <Badge className="font-semibold" shape="rounded" data-testid="badge" />,
+      );
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("font-semibold");
+      expect(el.className).not.toContain("font-medium");
+    });
+
+    it("forwards custom className", () => {
+      render(<Badge className="custom-class" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("custom-class");
+    });
+  });
+
+  describe("children", () => {
+    it("renders children", () => {
+      render(<Badge>status</Badge>);
+      expect(screen.getByText("status")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/packages/design-system/__tests__/Card.test.tsx
+++ b/ui/packages/design-system/__tests__/Card.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Card } from "../primitives/Card";
+
+describe("Card", () => {
+  it("renders children", () => {
+    render(<Card>hello card</Card>);
+    expect(screen.getByText("hello card")).toBeInTheDocument();
+  });
+
+  it('as="a" renders an <a> element and forwards href', () => {
+    render(
+      <Card as="a" href="https://example.com">
+        link card
+      </Card>,
+    );
+    const el = screen.getByText("link card");
+    expect(el.tagName.toLowerCase()).toBe("a");
+    expect(el).toHaveAttribute("href", "https://example.com");
+  });
+
+  it("hover prop adds hover classes", () => {
+    render(<Card hover data-testid="card" />);
+    const el = screen.getByTestId("card");
+    expect(el.className).toContain("transition-all");
+    expect(el.className).toContain("duration-300");
+    expect(el.className).toContain("hover:border-border-light");
+  });
+
+  it('className="rounded-lg" override removes rounded-xl via cn merge', () => {
+    render(<Card className="rounded-lg" data-testid="card" />);
+    const el = screen.getByTestId("card");
+    expect(el.className).toContain("rounded-lg");
+    expect(el.className).not.toContain("rounded-xl");
+  });
+});

--- a/ui/packages/design-system/__tests__/IconBadge.test.tsx
+++ b/ui/packages/design-system/__tests__/IconBadge.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { IconBadge } from "../primitives/IconBadge";
+
+describe("IconBadge", () => {
+  describe("defaults", () => {
+    it("renders with default primary/md classes", () => {
+      render(<IconBadge data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-primary/10");
+      expect(el.className).toContain("border-primary/20");
+      expect(el.className).toContain("text-primary");
+      expect(el.className).toContain("w-10");
+      expect(el.className).toContain("h-10");
+    });
+  });
+
+  describe("colors", () => {
+    it("primary uses bg-primary/10 border-primary/20 text-primary", () => {
+      render(<IconBadge color="primary" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-primary/10");
+      expect(el.className).toContain("border-primary/20");
+      expect(el.className).toContain("text-primary");
+    });
+
+    it("green uses bg-accent-green/10 border-accent-green/20 text-accent-green", () => {
+      render(<IconBadge color="green" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-green/10");
+      expect(el.className).toContain("border-accent-green/20");
+      expect(el.className).toContain("text-accent-green");
+    });
+
+    it("red uses bg-accent-red/10 border-accent-red/20 text-accent-red", () => {
+      render(<IconBadge color="red" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-red/10");
+      expect(el.className).toContain("border-accent-red/20");
+      expect(el.className).toContain("text-accent-red");
+    });
+
+    it("yellow uses bg-accent-yellow/10 border-accent-yellow/20 text-accent-yellow", () => {
+      render(<IconBadge color="yellow" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-yellow/10");
+      expect(el.className).toContain("border-accent-yellow/20");
+      expect(el.className).toContain("text-accent-yellow");
+    });
+
+    it("blue uses bg-accent-blue/10 border-accent-blue/20 text-accent-blue", () => {
+      render(<IconBadge color="blue" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-blue/10");
+      expect(el.className).toContain("border-accent-blue/20");
+      expect(el.className).toContain("text-accent-blue");
+    });
+
+    it("cyan uses bg-accent-cyan/10 border-accent-cyan/20 text-accent-cyan", () => {
+      render(<IconBadge color="cyan" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-accent-cyan/10");
+      expect(el.className).toContain("border-accent-cyan/20");
+      expect(el.className).toContain("text-accent-cyan");
+    });
+
+    it("neutral uses bg-white/[0.04] border-border text-text-secondary", () => {
+      render(<IconBadge color="neutral" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("bg-white/[0.04]");
+      expect(el.className).toContain("border-border");
+      expect(el.className).toContain("text-text-secondary");
+    });
+  });
+
+  describe("sizes", () => {
+    it("sm produces w-8 h-8 rounded-lg", () => {
+      render(<IconBadge size="sm" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("w-8");
+      expect(el.className).toContain("h-8");
+      expect(el.className).toContain("rounded-lg");
+    });
+
+    it("md produces w-10 h-10 rounded-lg", () => {
+      render(<IconBadge size="md" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("w-10");
+      expect(el.className).toContain("h-10");
+      expect(el.className).toContain("rounded-lg");
+    });
+
+    it("lg produces w-12 h-12 rounded-lg", () => {
+      render(<IconBadge size="lg" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("w-12");
+      expect(el.className).toContain("h-12");
+      expect(el.className).toContain("rounded-lg");
+    });
+  });
+
+  describe("base classes", () => {
+    it("always includes flex items-center justify-center border", () => {
+      render(<IconBadge data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("flex");
+      expect(el.className).toContain("items-center");
+      expect(el.className).toContain("justify-center");
+      expect(el.className).toContain("border");
+      expect(el.className).toContain("shrink-0");
+    });
+  });
+
+  describe("children", () => {
+    it("renders children", () => {
+      render(<IconBadge>icon-content</IconBadge>);
+      expect(screen.getByText("icon-content")).toBeInTheDocument();
+    });
+  });
+
+  describe("className forwarding", () => {
+    it("forwards custom className", () => {
+      render(<IconBadge className="extra-class" data-testid="badge" />);
+      const el = screen.getByTestId("badge");
+      expect(el.className).toContain("extra-class");
+    });
+  });
+});

--- a/ui/packages/design-system/__tests__/StatusDot.test.tsx
+++ b/ui/packages/design-system/__tests__/StatusDot.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusDot } from "../primitives/StatusDot";
+
+describe("StatusDot", () => {
+  describe("online (default)", () => {
+    it("has aria-label Online and role img", () => {
+      render(<StatusDot data-testid="dot" />);
+      const el = screen.getByRole("img", { name: "Online" });
+      expect(el).toBeInTheDocument();
+    });
+
+    it("contains animate-ping child (halo)", () => {
+      render(<StatusDot data-testid="dot" />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      const halo = outer.querySelector(".animate-ping");
+      expect(halo).not.toBeNull();
+    });
+
+    it("applies green glow shadow by default", () => {
+      render(<StatusDot data-testid="dot" />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      // The solid dot (second child) carries the glow
+      const solidDot = outer.children[1] as HTMLElement;
+      expect(solidDot.className).toContain(
+        "shadow-[0_0_6px_rgba(130,165,104,0.4)]",
+      );
+    });
+
+    it("applies primary glow shadow when color=primary", () => {
+      render(<StatusDot color="primary" />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      const solidDot = outer.children[1] as HTMLElement;
+      expect(solidDot.className).toContain(
+        "shadow-[0_0_6px_rgba(102,122,204,0.4)]",
+      );
+    });
+
+    it("applies yellow glow shadow when color=yellow", () => {
+      render(<StatusDot color="yellow" />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      const solidDot = outer.children[1] as HTMLElement;
+      expect(solidDot.className).toContain(
+        "shadow-[0_0_6px_rgba(191,140,93,0.4)]",
+      );
+    });
+
+    it("halo has opacity-40 and no glow", () => {
+      render(<StatusDot />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      const halo = outer.children[0] as HTMLElement;
+      expect(halo.className).toContain("opacity-40");
+      expect(halo.className).not.toContain("shadow-[");
+    });
+
+    it("forwards className to outer span", () => {
+      render(<StatusDot className="mx-auto" />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      expect(outer.className).toContain("mx-auto");
+    });
+
+    it("outer span has relative flex classes", () => {
+      render(<StatusDot />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      expect(outer.className).toContain("relative");
+      expect(outer.className).toContain("flex");
+    });
+
+    it("size sm applies h-1.5 w-1.5", () => {
+      render(<StatusDot size="sm" />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      expect(outer.className).toContain("h-1.5");
+      expect(outer.className).toContain("w-1.5");
+    });
+
+    it("size md applies h-2.5 w-2.5", () => {
+      render(<StatusDot size="md" />);
+      const outer = screen.getByRole("img", { name: "Online" });
+      expect(outer.className).toContain("h-2.5");
+      expect(outer.className).toContain("w-2.5");
+    });
+  });
+
+  describe("offline", () => {
+    it("has aria-label Offline and role img", () => {
+      render(<StatusDot online={false} />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      expect(el).toBeInTheDocument();
+    });
+
+    it("has block class (required for mx-auto centering)", () => {
+      render(<StatusDot online={false} />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      expect(el.className).toContain("block");
+    });
+
+    it("has bg-text-muted/30 class", () => {
+      render(<StatusDot online={false} />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      expect(el.className).toContain("bg-text-muted/30");
+    });
+
+    it("does NOT contain animate-ping", () => {
+      render(<StatusDot online={false} />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      const halo = el.querySelector(".animate-ping");
+      expect(halo).toBeNull();
+    });
+
+    it("forwards className to the single span", () => {
+      render(<StatusDot online={false} className="mx-auto" />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      expect(el.className).toContain("mx-auto");
+    });
+
+    it("size sm applies h-1.5 w-1.5", () => {
+      render(<StatusDot online={false} size="sm" />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      expect(el.className).toContain("h-1.5");
+      expect(el.className).toContain("w-1.5");
+    });
+
+    it("size md applies h-2.5 w-2.5", () => {
+      render(<StatusDot online={false} size="md" />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      expect(el.className).toContain("h-2.5");
+      expect(el.className).toContain("w-2.5");
+    });
+
+    it("is a single span (no children)", () => {
+      render(<StatusDot online={false} />);
+      const el = screen.getByRole("img", { name: "Offline" });
+      expect(el.children).toHaveLength(0);
+    });
+  });
+});

--- a/ui/packages/design-system/__tests__/cn.test.ts
+++ b/ui/packages/design-system/__tests__/cn.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "../primitives/cn";
+
+describe("cn", () => {
+  it("merges tailwind classes — last conflicting class wins", () => {
+    expect(cn("rounded-xl", "rounded-lg")).toBe("rounded-lg");
+  });
+
+  it("concatenates non-conflicting classes", () => {
+    expect(cn("flex", "items-center")).toBe("flex items-center");
+  });
+
+  it("handles falsy values", () => {
+    expect(cn("flex", false, undefined, null, "gap-4")).toBe("flex gap-4");
+  });
+
+  it("handles conditional objects", () => {
+    expect(cn("flex", { "items-center": true, "items-start": false })).toBe(
+      "flex items-center",
+    );
+  });
+
+  it("merges custom font-size — text-2xs wins over text-xs", () => {
+    expect(cn("text-xs", "text-2xs")).toBe("text-2xs");
+  });
+});

--- a/ui/packages/design-system/package.json
+++ b/ui/packages/design-system/package.json
@@ -7,10 +7,15 @@
     "./tailwind.preset": "./tailwind.preset.js",
     "./css/base.css": "./css/base.css",
     "./components": "./components/index.ts",
-    "./constants": "./constants.ts"
+    "./constants": "./constants.ts",
+    "./primitives": "./primitives/index.ts"
   },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.6.0"
   }
 }

--- a/ui/packages/design-system/primitives/Badge.tsx
+++ b/ui/packages/design-system/primitives/Badge.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import type { Palette } from "./IconBadge";
+import { cn } from "./cn";
+
+export type BadgeColor = Exclude<Palette, "neutral">;
+export type BadgeShape = "rounded" | "pill";
+
+export interface BadgeProps {
+  color?: BadgeColor;
+  shape?: BadgeShape;
+  className?: string;
+  children?: ReactNode;
+  [key: string]: unknown;
+}
+
+const roundedColorClasses: Record<BadgeColor, string> = {
+  primary: "bg-primary/10 text-primary",
+  green: "bg-accent-green/10 text-accent-green",
+  red: "bg-accent-red/10 text-accent-red",
+  yellow: "bg-accent-yellow/10 text-accent-yellow",
+  blue: "bg-accent-blue/10 text-accent-blue",
+  cyan: "bg-accent-cyan/10 text-accent-cyan",
+};
+
+const pillColorClasses: Record<BadgeColor, string> = {
+  primary: "bg-primary/10 text-primary border-primary/20",
+  green: "bg-accent-green/10 text-accent-green border-accent-green/20",
+  red: "bg-accent-red/10 text-accent-red border-accent-red/20",
+  yellow: "bg-accent-yellow/10 text-accent-yellow border-accent-yellow/20",
+  blue: "bg-accent-blue/10 text-accent-blue border-accent-blue/20",
+  cyan: "bg-accent-cyan/10 text-accent-cyan border-accent-cyan/20",
+};
+
+export function Badge({
+  color = "primary",
+  shape = "rounded",
+  className,
+  children,
+  ...rest
+}: BadgeProps) {
+  const isRounded = shape === "rounded";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 text-2xs",
+        isRounded
+          ? cn("px-1.5 py-0.5 rounded font-medium", roundedColorClasses[color])
+          : cn(
+              "px-2 py-0.5 rounded-full font-mono font-semibold uppercase tracking-compact border",
+              pillColorClasses[color],
+            ),
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
+}

--- a/ui/packages/design-system/primitives/Card.tsx
+++ b/ui/packages/design-system/primitives/Card.tsx
@@ -1,0 +1,32 @@
+import type { ElementType, ComponentPropsWithoutRef, ReactNode } from "react";
+import { cn } from "./cn";
+
+type CardProps<T extends ElementType> = {
+  as?: T;
+  hover?: boolean;
+  className?: string;
+  children?: ReactNode;
+} & Omit<ComponentPropsWithoutRef<T>, "as" | "className" | "children">;
+
+export function Card<T extends ElementType = "div">({
+  as,
+  hover,
+  className,
+  children,
+  ...rest
+}: CardProps<T>) {
+  const Component = (as ?? "div") as ElementType;
+
+  return (
+    <Component
+      className={cn(
+        "bg-card border border-border rounded-xl",
+        hover && "transition-all duration-300 hover:border-border-light",
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/ui/packages/design-system/primitives/IconBadge.tsx
+++ b/ui/packages/design-system/primitives/IconBadge.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+import { cn } from "./cn";
+
+export type Palette =
+  | "primary"
+  | "green"
+  | "red"
+  | "yellow"
+  | "blue"
+  | "cyan"
+  | "neutral";
+export type IconBadgeSize = "sm" | "md" | "lg";
+
+export interface IconBadgeProps {
+  color?: Palette;
+  size?: IconBadgeSize;
+  className?: string;
+  children?: ReactNode;
+  [key: string]: unknown;
+}
+
+const colorClasses: Record<Palette, string> = {
+  primary: "bg-primary/10 border-primary/20 text-primary",
+  green: "bg-accent-green/10 border-accent-green/20 text-accent-green",
+  red: "bg-accent-red/10 border-accent-red/20 text-accent-red",
+  yellow: "bg-accent-yellow/10 border-accent-yellow/20 text-accent-yellow",
+  blue: "bg-accent-blue/10 border-accent-blue/20 text-accent-blue",
+  cyan: "bg-accent-cyan/10 border-accent-cyan/20 text-accent-cyan",
+  neutral: "bg-white/[0.04] border-border text-text-secondary",
+};
+
+const sizeClasses: Record<IconBadgeSize, string> = {
+  sm: "w-8 h-8",
+  md: "w-10 h-10",
+  lg: "w-12 h-12",
+};
+
+export function IconBadge({
+  color = "primary",
+  size = "md",
+  className,
+  children,
+  ...rest
+}: IconBadgeProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center border rounded-lg shrink-0",
+        sizeClasses[size],
+        colorClasses[color],
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/ui/packages/design-system/primitives/StatusDot.tsx
+++ b/ui/packages/design-system/primitives/StatusDot.tsx
@@ -1,0 +1,74 @@
+import { cn } from "./cn";
+
+export type StatusDotColor = "green" | "primary" | "yellow";
+export type StatusDotSize = "sm" | "md";
+
+export interface StatusDotProps {
+  online?: boolean;
+  color?: StatusDotColor;
+  size?: StatusDotSize;
+  className?: string;
+}
+
+const sizeClasses: Record<StatusDotSize, string> = {
+  sm: "h-1.5 w-1.5",
+  md: "h-2.5 w-2.5",
+};
+
+const glowClasses: Record<StatusDotColor, string> = {
+  green: "shadow-[0_0_6px_rgba(130,165,104,0.4)]",
+  primary: "shadow-[0_0_6px_rgba(102,122,204,0.4)]",
+  yellow: "shadow-[0_0_6px_rgba(191,140,93,0.4)]",
+};
+
+const bgClasses: Record<StatusDotColor, string> = {
+  green: "bg-accent-green",
+  primary: "bg-primary",
+  yellow: "bg-accent-yellow",
+};
+
+export function StatusDot({
+  online = true,
+  color = "green",
+  size = "md",
+  className,
+}: StatusDotProps) {
+  const sizeClass = sizeClasses[size];
+
+  if (!online) {
+    return (
+      <span
+        className={cn(
+          "block rounded-full",
+          sizeClass,
+          "bg-text-muted/30",
+          className,
+        )}
+        aria-label="Offline"
+        role="img"
+      />
+    );
+  }
+
+  return (
+    <span
+      className={cn("relative flex", sizeClass, className)}
+      aria-label="Online"
+      role="img"
+    >
+      <span
+        className={cn(
+          "animate-ping absolute inline-flex h-full w-full rounded-full opacity-40",
+          bgClasses[color],
+        )}
+      />
+      <span
+        className={cn(
+          "relative inline-flex rounded-full h-full w-full",
+          bgClasses[color],
+          glowClasses[color],
+        )}
+      />
+    </span>
+  );
+}

--- a/ui/packages/design-system/primitives/cn.ts
+++ b/ui/packages/design-system/primitives/cn.ts
@@ -1,0 +1,14 @@
+import { clsx, type ClassValue } from "clsx";
+import { extendTailwindMerge } from "tailwind-merge";
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [{ text: ["2xs", "3xs"] }],
+    },
+  },
+});
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/ui/packages/design-system/primitives/index.ts
+++ b/ui/packages/design-system/primitives/index.ts
@@ -1,0 +1,14 @@
+// primitives/index.ts — public surface of the design-system primitives.
+// cn is intentionally NOT exported here; import it directly from "./cn" within the package.
+
+export { Badge } from "./Badge";
+export type { BadgeColor, BadgeShape, BadgeProps } from "./Badge";
+export { Card } from "./Card";
+export { IconBadge } from "./IconBadge";
+export type { Palette, IconBadgeSize, IconBadgeProps } from "./IconBadge";
+export { StatusDot } from "./StatusDot";
+export type {
+  StatusDotColor,
+  StatusDotSize,
+  StatusDotProps,
+} from "./StatusDot";

--- a/ui/packages/design-system/test/setup.ts
+++ b/ui/packages/design-system/test/setup.ts
@@ -1,0 +1,5 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(cleanup);

--- a/ui/packages/design-system/tsconfig.json
+++ b/ui/packages/design-system/tsconfig.json
@@ -21,6 +21,8 @@
     "constants.ts",
     "tailwind.preset.js",
     "vitest.config.ts",
-    "__tests__"
+    "__tests__",
+    "primitives",
+    "test"
   ]
 }

--- a/ui/packages/design-system/vitest.config.ts
+++ b/ui/packages/design-system/vitest.config.ts
@@ -1,3 +1,10 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
-export default defineConfig({ test: { environment: "node" } });
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./test/setup.ts"],
+  },
+});


### PR DESCRIPTION
## What

Introduces four shared UI primitives in `@shellhub/design-system` — `Card`, `IconBadge`, `Badge`, and `StatusDot` — and replaces the duplicated inline Tailwind token markup that rendered those elements across the console and website apps with them.

## Why

The same card, badge, icon-badge, and status-dot class strings were copy-pasted across dozens of files in both apps, with no single source of truth — restyling any of them meant editing every call site. Consolidating them into the design-system package gives one canonical implementation and removes the duplication. Part of the shared-components extraction (`shellhub-io/team#114`).

## Changes

- **Primitives** (`packages/design-system/primitives/`): `Card` (polymorphic via `as`, optional `hover`), `IconBadge` (size + token-palette color), `Badge` (`rounded`/`pill` shapes), and `StatusDot` (online/offline), exposed through a new `./primitives` export.
- **`cn()` helper**: `clsx` + `tailwind-merge`, with `text-2xs`/`text-3xs` registered as font-size classes so conflicting overrides merge correctly; adds `clsx` and `tailwind-merge` as dependencies.
- **Package test infra**: jsdom `vitest` config, `test/setup.ts` (jest-dom), and unit tests for each primitive.
- **Console adoption**: swapped inline markup for the primitives across pages and common components (cards, page headers, stat cards, icon badges, online dots, filter/platform/session-type badges); promoted `ActiveBadge` into `components/common` so both firewall-rule pages share it.
- **Website adoption**: swapped inline cards, pill badges, and icon badges for the primitives across the landing, enterprise, use-case, getting-started, and how-it-works pages.

## Notes for reviewers

- The migration is intentionally near-lossless, but it normalizes a few badges onto the design-system's canonical style: `pill` badges render uppercase with `rounded-full`, and a handful of bordered/`font-mono` inline badges now follow the primitive's style. This is intended.
- A few website equal-height grids that wrapped a `ShimmerCard` now nest a `Card`; the stretch behavior shifts slightly there.
- Several website files show large line-count diffs because their dense single-line SVG/JSX was reformatted when edited — the substantive change in those files is just the primitive swap.

## Testing

Design-system unit tests plus both app suites pass: `design-system` 87, `console` 2218, `website` 26. Worth eyeballing the firewall-rule pages, dashboards, and a couple of website grids for visual parity.
