### PR TITLE
feat(ui): server-side storage for the SSH key vault

### DIFF
--- a/openapi/spec/components/schemas/vaultResponse.yaml
+++ b/openapi/spec/components/schemas/vaultResponse.yaml
@@ -1,0 +1,33 @@
+type: object
+description: |
+  The user's encrypted SSH key vault. `meta`, `data` and `settings` are opaque
+  strings produced by the client: all encryption happens in the browser and
+  the server never parses their contents.
+properties:
+  meta:
+    description: Vault metadata (KDF parameters and verifier), as an opaque JSON string.
+    type: string
+    example: '{"version":1,"salt":"c2FsdA==","iterations":600000,"verifier":"dg==","verifierIv":"aXY="}'
+  data:
+    description: Encrypted vault data (IV and ciphertext), as an opaque JSON string.
+    type: string
+    example: '{"iv":"aXY=","ciphertext":"Y2lwaGVydGV4dA=="}'
+  settings:
+    description: Vault settings, as an opaque JSON string.
+    type: string
+    example: '{"autoLockTimeoutMinutes":5,"lockOnHidden":true}'
+  version:
+    description: |
+      Vault version, incremented on every write. Used for optimistic
+      concurrency when saving data.
+    type: integer
+    format: int64
+    example: 2
+  created_at:
+    description: Vault's creation date.
+    type: string
+    format: date-time
+  updated_at:
+    description: Vault's last update date.
+    type: string
+    format: date-time

--- a/openapi/spec/components/schemas/vaultVersionResponse.yaml
+++ b/openapi/spec/components/schemas/vaultVersionResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+description: Current vault version after a write.
+properties:
+  version:
+    description: Vault version, incremented on every write.
+    type: integer
+    format: int64
+    example: 2

--- a/openapi/spec/openapi.yaml
+++ b/openapi/spec/openapi.yaml
@@ -86,6 +86,8 @@ tags:
     description: Routes related to announcements resource
   - name: mfa
     description: Routes related to MFA
+  - name: vault
+    description: Routes related to the user's encrypted SSH key vault.
 
 paths:
   /info:
@@ -186,6 +188,14 @@ paths:
     $ref: paths/api@firewall@rules.yaml
   /api/firewall/rules/{id}:
     $ref: paths/api@firewall@rules@{id}.yaml
+  /api/vault:
+    $ref: paths/api@vault.yaml
+  /api/vault/meta:
+    $ref: paths/api@vault@meta.yaml
+  /api/vault/data:
+    $ref: paths/api@vault@data.yaml
+  /api/vault/settings:
+    $ref: paths/api@vault@settings.yaml
   /api/register:
     $ref: paths/api@register.yaml
   /api/user/resend_email:

--- a/openapi/spec/paths/api@vault.yaml
+++ b/openapi/spec/paths/api@vault.yaml
@@ -1,0 +1,48 @@
+get:
+  operationId: getVault
+  summary: Get vault
+  description: |
+    Get the authenticated user's vault in the current namespace. Returns 404
+    when the user has not created a vault yet.
+  tags:
+    - cloud
+
+    - vault
+  security:
+    - jwt: []
+  responses:
+    '200':
+      description: Success to get the vault.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/vaultResponse.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '404':
+      $ref: ../components/responses/404.yaml
+    '500':
+      $ref: ../components/responses/500.yaml
+delete:
+  operationId: deleteVault
+  summary: Delete vault
+  description: Delete the authenticated user's vault in the current namespace.
+  tags:
+    - cloud
+
+    - vault
+  security:
+    - jwt: []
+  responses:
+    '200':
+      $ref: ../components/responses/200.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '404':
+      $ref: ../components/responses/404.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/api@vault@data.yaml
+++ b/openapi/spec/paths/api@vault@data.yaml
@@ -1,0 +1,51 @@
+put:
+  operationId: saveVaultData
+  summary: Save vault data
+  description: |
+    Save the encrypted vault data for the authenticated user in the current
+    namespace. The vault must already exist and `version` must match the
+    current vault version; a stale version is rejected with 409 and the
+    client should reload the vault.
+  tags:
+    - cloud
+
+    - vault
+  security:
+    - jwt: []
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data:
+              description: Encrypted vault data, as an opaque JSON string.
+              type: string
+              example: '{"iv":"aXY=","ciphertext":"Y2lwaGVydGV4dA=="}'
+            version:
+              description: The vault version this write is based on.
+              type: integer
+              format: int64
+              example: 1
+          required:
+            - data
+            - version
+  responses:
+    '200':
+      description: Success to save the vault data.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/vaultVersionResponse.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '404':
+      $ref: ../components/responses/404.yaml
+    '409':
+      $ref: ../components/responses/409.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/api@vault@meta.yaml
+++ b/openapi/spec/paths/api@vault@meta.yaml
@@ -1,0 +1,40 @@
+put:
+  operationId: saveVaultMeta
+  summary: Save vault metadata
+  description: |
+    Save the vault metadata (KDF parameters and verifier) for the
+    authenticated user in the current namespace, creating the vault when it
+    does not exist yet.
+  tags:
+    - cloud
+
+    - vault
+  security:
+    - jwt: []
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            meta:
+              description: Vault metadata, as an opaque JSON string.
+              type: string
+              example: '{"version":1,"salt":"c2FsdA==","iterations":600000,"verifier":"dg==","verifierIv":"aXY="}'
+          required:
+            - meta
+  responses:
+    '200':
+      description: Success to save the vault metadata.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/vaultVersionResponse.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/api@vault@settings.yaml
+++ b/openapi/spec/paths/api@vault@settings.yaml
@@ -1,0 +1,39 @@
+put:
+  operationId: saveVaultSettings
+  summary: Save vault settings
+  description: |
+    Save the vault settings for the authenticated user in the current
+    namespace, creating the vault when it does not exist yet.
+  tags:
+    - cloud
+
+    - vault
+  security:
+    - jwt: []
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            settings:
+              description: Vault settings, as an opaque JSON string.
+              type: string
+              example: '{"autoLockTimeoutMinutes":5,"lockOnHidden":true}'
+          required:
+            - settings
+  responses:
+    '200':
+      description: Success to save the vault settings.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/vaultVersionResponse.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/ui/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui/apps/console/src/components/ConnectDrawer.tsx
@@ -114,7 +114,7 @@ export default function ConnectDrawer({
   useEffect(() => {
     if (!open) return;
     dispatch({ type: "reset" });
-    refreshVault();
+    void refreshVault();
   }, [open, refreshVault]);
 
   const hasVaultKeys = vaultStatus === "unlocked" && vaultKeys.length > 0;

--- a/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -5,8 +5,11 @@ import {
   ExclamationTriangleIcon,
   ExclamationCircleIcon,
   ChevronDownIcon,
+  ServerStackIcon,
 } from "@heroicons/react/24/outline";
 import { useVaultStore } from "@/stores/vaultStore";
+import { isVaultServerEnabled } from "@/utils/vault-backend-factory";
+import VaultSyncDialog from "@/components/vault/VaultSyncDialog";
 import { ALLOWED_TIMEOUT_MINUTES } from "@/types/vault";
 import type { AllowedTimeoutMinutes } from "@/types/vault";
 import { useClickOutside } from "@/hooks/useClickOutside";
@@ -211,9 +214,11 @@ export default function VaultSettingsSection() {
   const autoLockTimeoutMinutes = useVaultStore((s) => s.autoLockTimeoutMinutes);
   const lockOnHidden = useVaultStore((s) => s.lockOnHidden);
   const updateAutoLockSettings = useVaultStore((s) => s.updateAutoLockSettings);
+  const storageMode = useVaultStore((s) => s.storageMode);
   const [changeOpen, setChangeOpen] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
   const [resetConfirmText, setResetConfirmText] = useState("");
+  const [syncOpen, setSyncOpen] = useState(false);
 
   if (status !== "unlocked") return null;
 
@@ -253,7 +258,7 @@ export default function VaultSettingsSection() {
             <AutoLockTimeoutSelect
               value={autoLockTimeoutMinutes}
               onChange={(minutes) =>
-                updateAutoLockSettings({ autoLockTimeoutMinutes: minutes })
+                void updateAutoLockSettings({ autoLockTimeoutMinutes: minutes })
               }
             />
           </div>
@@ -266,11 +271,29 @@ export default function VaultSettingsSection() {
                 description="Locks the vault about a minute after you switch away or minimize."
                 checked={lockOnHidden}
                 onChange={(checked) =>
-                  updateAutoLockSettings({ lockOnHidden: checked })
+                  void updateAutoLockSettings({ lockOnHidden: checked })
                 }
               />
             </div>
           </div>
+
+          {isVaultServerEnabled() && (
+            <button
+              type="button"
+              onClick={() => setSyncOpen(true)}
+              className="flex items-center gap-3 w-full px-4 py-3.5 text-left hover:bg-hover-subtle transition-colors"
+            >
+              <ServerStackIcon className="w-4 h-4 text-text-muted shrink-0" />
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-text-primary">Storage</p>
+                <p className="text-2xs text-text-muted">
+                  {storageMode === "server"
+                    ? "Synced with the ShellHub server. Click to move it to this device."
+                    : "Stored in this browser only. Click to sync it to the ShellHub server."}
+                </p>
+              </div>
+            </button>
+          )}
 
           <button
             type="button"
@@ -319,7 +342,7 @@ export default function VaultSettingsSection() {
           setResetOpen(false);
         }}
         onConfirm={() => {
-          resetVault();
+          void resetVault();
           setResetOpen(false);
         }}
         title="Reset Secure Vault"
@@ -347,6 +370,12 @@ export default function VaultSettingsSection() {
           />
         </div>
       </ConfirmDialog>
+
+      <VaultSyncDialog
+        open={syncOpen}
+        onClose={() => setSyncOpen(false)}
+        direction={storageMode === "server" ? "to-local" : "to-server"}
+      />
     </>
   );
 }

--- a/ui/apps/console/src/components/vault/VaultSetupDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultSetupDialog.tsx
@@ -2,10 +2,16 @@ import { useState, FormEvent, useEffect, useId, useMemo } from "react";
 import {
   ShieldCheckIcon,
   ExclamationTriangleIcon,
+  ComputerDesktopIcon,
+  ServerStackIcon,
+  CheckCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useVaultStore } from "@/stores/vaultStore";
-import { getVaultBackend } from "@/utils/vault-backend-factory";
-import { useAuthStore } from "@/stores/authStore";
+import { loadLegacyKeysFromStorage } from "@/utils/vault-backend-local";
+import {
+  isVaultServerEnabled,
+  type VaultStorageMode,
+} from "@/utils/vault-backend-factory";
 import BaseDialog from "@/components/common/BaseDialog";
 import PasswordField from "@/components/common/fields/PasswordField";
 import Spinner from "@/components/common/Spinner";
@@ -19,29 +25,52 @@ interface FormProps extends Props {
   instanceId: string;
 }
 
+const STORAGE_OPTIONS: {
+  mode: VaultStorageMode;
+  icon: typeof ServerStackIcon;
+  title: string;
+  description: string;
+}[] = [
+  {
+    mode: "server",
+    icon: ServerStackIcon,
+    title: "Sync to the ShellHub server",
+    description:
+      "Use your keys on any machine you sign in to. Stored encrypted — the server never sees them.",
+  },
+  {
+    mode: "local",
+    icon: ComputerDesktopIcon,
+    title: "This device only",
+    description:
+      "Keys stay in this browser. Clearing its data deletes them, and other machines can't reach them.",
+  },
+];
+
 function SetupForm({ open, onClose, instanceId }: FormProps) {
   const loading = useVaultStore((s) => s.loading);
   const error = useVaultStore((s) => s.error);
   const initialize = useVaultStore((s) => s.initialize);
   const clearError = useVaultStore((s) => s.clearError);
-  const user = useAuthStore((s) => s.user);
-  const tenant = useAuthStore((s) => s.tenant);
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
+  // Server-backed deployments default to syncing — the value of the feature.
+  const [mode, setMode] = useState<VaultStorageMode>("server");
 
+  const serverEnabled = isVaultServerEnabled();
   const titleId = `vault-setup-title-${instanceId}`;
 
   useEffect(() => {
     if (open) clearError();
   }, [open, clearError]);
 
-  // Compute once per open/user/tenant change — avoids a localStorage read
-  // on every render and ensures the component subscribes to auth changes.
+  // Compute once per open change — avoids a localStorage read on every
+  // render. Legacy keys predate the vault and always live in localStorage,
+  // regardless of which vault backend is active.
   const legacyCount = useMemo(() => {
     if (!open) return 0;
-    const scope = user && tenant ? { user, tenant } : undefined;
-    return getVaultBackend(scope).loadLegacyKeys().length;
-  }, [open, user, tenant]);
+    return loadLegacyKeysFromStorage().length;
+  }, [open]);
 
   const passwordTooShort = password.length > 0 && password.length < 8;
   const passwordsMismatch = confirm.length > 0 && password !== confirm;
@@ -50,7 +79,7 @@ function SetupForm({ open, onClose, instanceId }: FormProps) {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!canSubmit) return;
-    await initialize(password);
+    await initialize(password, serverEnabled ? mode : "local");
     if (!useVaultStore.getState().error && !useVaultStore.getState().loading) {
       onClose();
     }
@@ -93,6 +122,59 @@ function SetupForm({ open, onClose, instanceId }: FormProps) {
       )}
 
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        {serverEnabled && (
+          <fieldset className="space-y-2">
+            <legend className="text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2">
+              Where to store it
+            </legend>
+            {STORAGE_OPTIONS.map((option) => {
+              const selected = mode === option.mode;
+              const Icon = option.icon;
+              return (
+                <label
+                  key={option.mode}
+                  className={`flex items-start gap-3 px-3.5 py-3 rounded-lg border cursor-pointer transition-colors ${
+                    selected
+                      ? "border-primary bg-primary/[0.06]"
+                      : "border-border hover:border-border-light hover:bg-hover-subtle"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name={`${instanceId}-storage`}
+                    value={option.mode}
+                    checked={selected}
+                    onChange={() => setMode(option.mode)}
+                    className="sr-only"
+                  />
+                  <Icon
+                    className={`w-5 h-5 shrink-0 mt-0.5 ${
+                      selected ? "text-primary" : "text-text-muted"
+                    }`}
+                    strokeWidth={2}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-sm font-medium text-text-primary">
+                        {option.title}
+                      </span>
+                      {selected && (
+                        <CheckCircleIcon
+                          className="w-4 h-4 text-primary shrink-0"
+                          strokeWidth={2}
+                        />
+                      )}
+                    </div>
+                    <p className="text-2xs text-text-muted mt-0.5">
+                      {option.description}
+                    </p>
+                  </div>
+                </label>
+              );
+            })}
+          </fieldset>
+        )}
+
         <PasswordField
           id={`${instanceId}-password`}
           label="Master Password"
@@ -136,9 +218,7 @@ function SetupForm({ open, onClose, instanceId }: FormProps) {
             disabled={!canSubmit}
             className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
-            {loading && (
-              <Spinner tone="onPrimary" />
-            )}
+            {loading && <Spinner tone="onPrimary" />}
             Create Vault
           </button>
         </div>

--- a/ui/apps/console/src/components/vault/VaultSyncDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultSyncDialog.tsx
@@ -1,0 +1,243 @@
+import { useState, useEffect, useId, useMemo } from "react";
+import {
+  ServerStackIcon,
+  ComputerDesktopIcon,
+} from "@heroicons/react/24/outline";
+import { useVaultStore } from "@/stores/vaultStore";
+import { useAuthStore } from "@/stores/authStore";
+import {
+  serverVaultExists,
+  migrateLocalToServer,
+  adoptServerVault,
+  migrateServerToLocal,
+} from "@/utils/vault-migrate";
+import BaseDialog from "@/components/common/BaseDialog";
+import Alert from "@/components/common/Alert";
+import Spinner from "@/components/common/Spinner";
+
+type Direction = "to-server" | "to-local";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  direction: Direction;
+}
+
+function useScope() {
+  const user = useAuthStore((s) => s.user);
+  const tenant = useAuthStore((s) => s.tenant);
+  return useMemo(
+    () => (user && tenant ? { user, tenant } : undefined),
+    [user, tenant],
+  );
+}
+
+function SyncForm({
+  open,
+  onClose,
+  direction,
+  instanceId,
+}: Props & { instanceId: string }) {
+  const refreshStatus = useVaultStore((s) => s.refreshStatus);
+  const lock = useVaultStore((s) => s.lock);
+  const scope = useScope();
+
+  const [checking, setChecking] = useState(direction === "to-server");
+  const [conflict, setConflict] = useState(false);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || direction !== "to-server") return undefined;
+    let cancelled = false;
+    serverVaultExists(scope)
+      .then((exists) => {
+        if (!cancelled) setConflict(exists);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Could not reach the server. Try again.");
+      })
+      .finally(() => {
+        if (!cancelled) setChecking(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, direction, scope]);
+
+  const run = async (action: () => Promise<void>) => {
+    setWorking(true);
+    setError(null);
+    try {
+      await action();
+      // Same vault, new home: lock so the next unlock reads from it.
+      lock();
+      await refreshStatus();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to move the vault");
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const titleId = `vault-sync-title-${instanceId}`;
+  const toServer = direction === "to-server";
+
+  return (
+    <div className="p-6">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+          {toServer ? (
+            <ServerStackIcon className="w-5 h-5 text-primary" />
+          ) : (
+            <ComputerDesktopIcon className="w-5 h-5 text-primary" />
+          )}
+        </div>
+        <div>
+          <h2
+            id={titleId}
+            className="text-base font-semibold text-text-primary"
+          >
+            {toServer
+              ? "Sync vault to the ShellHub server"
+              : "Move vault to this device"}
+          </h2>
+          <p className="text-2xs text-text-muted mt-0.5">
+            {toServer
+              ? "Use your keys from any machine"
+              : "Keep your keys in this browser only"}
+          </p>
+        </div>
+      </div>
+
+      {checking ? (
+        <div className="flex items-center justify-center gap-2 py-6 text-sm text-text-secondary">
+          <Spinner />
+          Checking the server
+        </div>
+      ) : toServer && conflict ? (
+        <>
+          <Alert variant="warning" className="mb-4">
+            The ShellHub server already has a synced vault, created on another
+            machine. Pick the vault to keep. The other one is deleted.
+          </Alert>
+          <div
+            className="space-y-2"
+            role="group"
+            aria-label="Choose which vault to keep"
+          >
+            <button
+              type="button"
+              disabled={working}
+              onClick={() => void run(() => adoptServerVault(scope))}
+              className="w-full text-left px-4 py-3 rounded-lg border border-border hover:border-border-light hover:bg-hover-subtle transition-colors disabled:opacity-dim disabled:cursor-not-allowed"
+            >
+              <span className="block text-sm font-medium text-text-primary">
+                Keep the synced vault
+              </span>
+              <span className="block text-2xs text-text-muted mt-0.5">
+                Deletes the keys stored in this browser.
+              </span>
+            </button>
+            <button
+              type="button"
+              disabled={working}
+              onClick={() => void run(() => migrateLocalToServer(scope))}
+              className="w-full text-left px-4 py-3 rounded-lg border border-border hover:border-border-light hover:bg-hover-subtle transition-colors disabled:opacity-dim disabled:cursor-not-allowed"
+            >
+              <span className="block text-sm font-medium text-text-primary">
+                Keep this device's vault
+              </span>
+              <span className="block text-2xs text-text-muted mt-0.5">
+                Replaces the synced vault on the server.
+              </span>
+            </button>
+          </div>
+        </>
+      ) : (
+        <div className="text-sm text-text-secondary space-y-3 mb-1">
+          {toServer ? (
+            <>
+              <p>
+                Your encrypted vault moves to the ShellHub server and is removed
+                from this browser. Unlock it with the same master password from
+                any machine you sign in to.
+              </p>
+              <p className="text-xs text-text-muted">
+                Encryption stays in your browser. The server never sees your
+                keys or your master password.
+              </p>
+            </>
+          ) : (
+            <>
+              <p>
+                Your encrypted vault moves to this browser and is removed from
+                the ShellHub server. Other machines lose access to it.
+              </p>
+              <p className="text-xs text-text-muted">
+                Clearing this browser's data deletes the vault permanently.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="error" className="mt-4">
+          {error}
+        </Alert>
+      )}
+
+      <div className="flex justify-end gap-2 pt-4">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={working}
+          className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
+        >
+          Cancel
+        </button>
+        {!checking && !(toServer && conflict) && (
+          <button
+            type="button"
+            disabled={working || (toServer && !!error)}
+            onClick={() =>
+              void run(() =>
+                toServer
+                  ? migrateLocalToServer(scope)
+                  : migrateServerToLocal(scope),
+              )
+            }
+            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
+          >
+            {working && <Spinner tone="onPrimary" />}
+            {toServer ? "Sync vault" : "Move vault"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function VaultSyncDialog({ open, onClose, direction }: Props) {
+  const instanceId = useId();
+  const titleId = `vault-sync-title-${instanceId}`;
+
+  return (
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      size="sm"
+      aria-labelledby={titleId}
+    >
+      <SyncForm
+        key={String(open)}
+        open={open}
+        onClose={onClose}
+        direction={direction}
+        instanceId={instanceId}
+      />
+    </BaseDialog>
+  );
+}

--- a/ui/apps/console/src/components/vault/VaultSyncPromoDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultSyncPromoDialog.tsx
@@ -1,0 +1,109 @@
+import { useState, useId } from "react";
+import {
+  ServerStackIcon,
+  GlobeAltIcon,
+  ShieldCheckIcon,
+  ArrowPathIcon,
+} from "@heroicons/react/24/outline";
+import { useAuthStore } from "@/stores/authStore";
+import { dismissVaultSyncPromo } from "@/utils/vault-backend-factory";
+import BaseDialog from "@/components/common/BaseDialog";
+import CheckboxField from "@/components/common/fields/CheckboxField";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Called when the user chooses to sync; opens the sync flow. */
+  onSync: () => void;
+}
+
+const BENEFITS = [
+  {
+    icon: GlobeAltIcon,
+    text: "Unlock your keys from any machine you sign in to",
+  },
+  {
+    icon: ShieldCheckIcon,
+    text: "End-to-end encrypted. The server never sees your keys",
+  },
+  {
+    icon: ArrowPathIcon,
+    text: "Survives clearing this browser's data",
+  },
+];
+
+export default function VaultSyncPromoDialog({ open, onClose, onSync }: Props) {
+  const instanceId = useId();
+  const titleId = `vault-sync-promo-title-${instanceId}`;
+  const user = useAuthStore((s) => s.user);
+  const tenant = useAuthStore((s) => s.tenant);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  const close = () => {
+    if (dontShowAgain) {
+      dismissVaultSyncPromo(user && tenant ? { user, tenant } : undefined);
+    }
+    onClose();
+  };
+
+  return (
+    <BaseDialog open={open} onClose={close} size="sm" aria-labelledby={titleId}>
+      <div className="p-6">
+        <div className="flex flex-col items-center text-center mb-5">
+          <div className="relative w-14 h-14 rounded-2xl bg-primary/10 flex items-center justify-center mb-4">
+            <div className="absolute inset-0 rounded-2xl bg-primary/20 blur-xl -z-10" />
+            <ServerStackIcon className="w-7 h-7 text-primary" />
+          </div>
+          <h2
+            id={titleId}
+            className="text-base font-semibold text-text-primary"
+          >
+            Take your vault anywhere
+          </h2>
+          <p className="text-sm text-text-secondary mt-1.5 max-w-xs">
+            This vault lives in this browser only. Sync it to the ShellHub
+            server and it follows you.
+          </p>
+        </div>
+
+        <ul className="space-y-2.5 mb-5">
+          {BENEFITS.map(({ icon: Icon, text }) => (
+            <li key={text} className="flex items-center gap-3">
+              <Icon className="w-4 h-4 text-primary shrink-0" strokeWidth={2} />
+              <span className="text-xs text-text-secondary">{text}</span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              onClose();
+              onSync();
+            }}
+            className="w-full px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+          >
+            Sync vault
+          </button>
+          <button
+            type="button"
+            onClick={close}
+            className="w-full px-5 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
+          >
+            Keep it on this device
+          </button>
+        </div>
+
+        <div className="flex justify-center mt-4">
+          <CheckboxField
+            id={`${instanceId}-dont-show`}
+            label="Don't show this again"
+            checked={dontShowAgain}
+            onChange={setDontShowAgain}
+          />
+        </div>
+      </div>
+    </BaseDialog>
+  );
+}

--- a/ui/apps/console/src/components/vault/VaultUnlockDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultUnlockDialog.tsx
@@ -93,9 +93,7 @@ function UnlockForm({ open, onClose, onReset, instanceId }: FormProps) {
               disabled={!canSubmit}
               className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
-              {loading && (
-                <Spinner tone="onPrimary" />
-              )}
+              {loading && <Spinner tone="onPrimary" />}
               Unlock
             </button>
           </div>

--- a/ui/apps/console/src/components/vault/__tests__/VaultSettingsSection.test.tsx
+++ b/ui/apps/console/src/components/vault/__tests__/VaultSettingsSection.test.tsx
@@ -30,6 +30,7 @@ vi.mock("@/utils/vault-backend-factory", () => ({
     clearLegacyKeys: vi.fn(),
     clear: vi.fn(),
   })),
+  isVaultServerEnabled: vi.fn(() => false),
 }));
 
 vi.mock("@/stores/authStore", () => ({

--- a/ui/apps/console/src/pages/secure-vault/index.tsx
+++ b/ui/apps/console/src/pages/secure-vault/index.tsx
@@ -17,6 +17,13 @@ import CopyButton from "@/components/common/CopyButton";
 import VaultSetupDialog from "@/components/vault/VaultSetupDialog";
 import VaultUnlockDialog from "@/components/vault/VaultUnlockDialog";
 import VaultSettingsSection from "@/components/vault/VaultSettingsSection";
+import VaultSyncDialog from "@/components/vault/VaultSyncDialog";
+import VaultSyncPromoDialog from "@/components/vault/VaultSyncPromoDialog";
+import { useAuthStore } from "@/stores/authStore";
+import {
+  isVaultServerEnabled,
+  isVaultSyncPromoDismissed,
+} from "@/utils/vault-backend-factory";
 import DataTable, { type Column } from "@/components/common/DataTable";
 import SearchField from "@/components/common/fields/SearchField";
 import KeyDrawer from "./KeyDrawer";
@@ -50,15 +57,20 @@ export default function SecureVault() {
   const keys = useVaultStore((s) => s.keys);
   const refreshStatus = useVaultStore((s) => s.refreshStatus);
   const autoLockNonce = useVaultStore((s) => s.autoLockNonce);
+  const storageMode = useVaultStore((s) => s.storageMode);
+  const user = useAuthStore((s) => s.user);
+  const tenant = useAuthStore((s) => s.tenant);
   const [setupOpen, setSetupOpen] = useState(false);
   const [unlockOpen, setUnlockOpen] = useState(false);
+  const [syncOpen, setSyncOpen] = useState(false);
+  const [promoOpen, setPromoOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<VaultKeyEntry | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<VaultKeyEntry | null>(null);
   const [search, setSearch] = useState("");
 
   useEffect(() => {
-    refreshStatus();
+    void refreshStatus();
   }, [refreshStatus]);
 
   const seenNonce = useRef(autoLockNonce);
@@ -68,6 +80,28 @@ export default function SecureVault() {
       setUnlockOpen(true);
     }
   }, [autoLockNonce]);
+
+  // Offer syncing a local vault to the ShellHub server right after the user
+  // unlocks it: they just proved ownership and are looking at their keys, so
+  // it's the natural moment to pitch portability. Fires only on the
+  // locked -> unlocked transition (a real unlock), never on setup
+  // (uninitialized -> unlocked, where the user just picked a location) nor on
+  // a plain page open of an already-unlocked vault.
+  const prevStatus = useRef(status);
+  useEffect(() => {
+    const cameFromLocked = prevStatus.current === "locked";
+    prevStatus.current = status;
+
+    if (
+      cameFromLocked &&
+      status === "unlocked" &&
+      isVaultServerEnabled() &&
+      storageMode === "local" &&
+      !isVaultSyncPromoDismissed(user && tenant ? { user, tenant } : undefined)
+    ) {
+      setPromoOpen(true);
+    }
+  }, [status, storageMode, user, tenant]);
 
   const openNew = () => {
     setEditTarget(null);
@@ -273,6 +307,16 @@ export default function SecureVault() {
         open={!!deleteTarget}
         entry={deleteTarget}
         onClose={() => setDeleteTarget(null)}
+      />
+      <VaultSyncPromoDialog
+        open={promoOpen}
+        onClose={() => setPromoOpen(false)}
+        onSync={() => setSyncOpen(true)}
+      />
+      <VaultSyncDialog
+        open={syncOpen}
+        onClose={() => setSyncOpen(false)}
+        direction="to-server"
       />
     </div>
   );

--- a/ui/apps/console/src/stores/__tests__/vaultStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/vaultStore.test.ts
@@ -14,6 +14,8 @@ vi.mock("@/utils/vault-crypto", () => ({
 
 vi.mock("@/utils/vault-backend-factory", () => ({
   getVaultBackend: vi.fn(),
+  getVaultStorageMode: vi.fn(() => "local"),
+  setVaultStorageMode: vi.fn(),
 }));
 
 vi.mock("../authStore", () => ({
@@ -82,15 +84,15 @@ function makeVaultData(): VaultData {
 
 function makeFakeBackend() {
   return {
-    loadMeta: vi.fn().mockReturnValue(null),
-    saveMeta: vi.fn(),
-    loadData: vi.fn().mockReturnValue(null),
-    saveData: vi.fn(),
-    clear: vi.fn(),
-    loadLegacyKeys: vi.fn().mockReturnValue([]),
-    clearLegacyKeys: vi.fn(),
-    loadSettings: vi.fn().mockReturnValue(DEFAULT_VAULT_SETTINGS),
-    saveSettings: vi.fn(),
+    loadMeta: vi.fn().mockResolvedValue(null),
+    saveMeta: vi.fn().mockResolvedValue(undefined),
+    loadData: vi.fn().mockResolvedValue(null),
+    saveData: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    loadLegacyKeys: vi.fn().mockResolvedValue([]),
+    clearLegacyKeys: vi.fn().mockResolvedValue(undefined),
+    loadSettings: vi.fn().mockResolvedValue(DEFAULT_VAULT_SETTINGS),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -118,39 +120,39 @@ beforeEach(() => {
 
 describe("vaultStore", () => {
   describe("refreshStatus", () => {
-    it("sets status to uninitialized when backend has no meta", () => {
+    it("sets status to uninitialized when backend has no meta", async () => {
       const backend = makeFakeBackend();
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(null);
 
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(useVaultStore.getState().status).toBe("uninitialized");
     });
 
-    it("sets status to locked when meta exists but no session key", () => {
+    it("sets status to locked when meta exists but no session key", async () => {
       const backend = makeFakeBackend();
       backend.loadMeta.mockReturnValue(makeMeta());
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(null);
 
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(useVaultStore.getState().status).toBe("locked");
     });
 
-    it("sets status to unlocked when meta exists and session key is present", () => {
+    it("sets status to unlocked when meta exists and session key is present", async () => {
       const backend = makeFakeBackend();
       backend.loadMeta.mockReturnValue(makeMeta());
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(makeFakeCryptoKey());
 
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(useVaultStore.getState().status).toBe("unlocked");
     });
 
-    it("loads settings from backend ONLY when meta exists", () => {
+    it("loads settings from backend ONLY when meta exists", async () => {
       const backend = makeFakeBackend();
       const customSettings = { autoLockTimeoutMinutes: 30, lockOnHidden: true };
       backend.loadMeta.mockReturnValue(makeMeta());
@@ -158,70 +160,70 @@ describe("vaultStore", () => {
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(null);
 
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(backend.loadSettings).toHaveBeenCalled();
       expect(useVaultStore.getState().autoLockTimeoutMinutes).toBe(30);
       expect(useVaultStore.getState().lockOnHidden).toBe(true);
     });
 
-    it("does NOT call loadSettings when meta is absent (uninitialized)", () => {
+    it("does NOT call loadSettings when meta is absent (uninitialized)", async () => {
       const backend = makeFakeBackend();
       backend.loadMeta.mockReturnValue(null);
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(null);
 
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(backend.loadSettings).not.toHaveBeenCalled();
     });
 
-    it("does not change autoLockNonce on any refreshStatus call", () => {
+    it("does not change autoLockNonce on any refreshStatus call", async () => {
       const backend = makeFakeBackend();
       backend.loadMeta.mockReturnValue(makeMeta());
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(null);
 
       useVaultStore.setState({ autoLockNonce: 5 });
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(useVaultStore.getState().autoLockNonce).toBe(5);
     });
 
-    it("calls activityTracker.stop() when no meta (uninitialized return)", () => {
+    it("calls activityTracker.stop() when no meta (uninitialized return)", async () => {
       const backend = makeFakeBackend();
       backend.loadMeta.mockReturnValue(null);
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(null);
 
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(mockTrackerStop).toHaveBeenCalled();
     });
 
-    it("calls activityTracker.stop() when meta exists but no session key (locked)", () => {
+    it("calls activityTracker.stop() when meta exists but no session key (locked)", async () => {
       const backend = makeFakeBackend();
       backend.loadMeta.mockReturnValue(makeMeta());
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(null);
 
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(mockTrackerStop).toHaveBeenCalled();
     });
 
-    it("does NOT call activityTracker.start() on the unlocked branch", () => {
+    it("does NOT call activityTracker.start() on the unlocked branch", async () => {
       const backend = makeFakeBackend();
       backend.loadMeta.mockReturnValue(makeMeta());
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(makeFakeCryptoKey());
 
-      useVaultStore.getState().refreshStatus();
+      await useVaultStore.getState().refreshStatus();
 
       expect(mockTrackerStart).not.toHaveBeenCalled();
     });
 
-    it("does not throw when backend.loadSettings throws (exception-safe)", () => {
+    it("does not throw when backend.loadSettings throws (exception-safe)", async () => {
       const backend = makeFakeBackend();
       backend.loadMeta.mockReturnValue(makeMeta());
       backend.loadSettings.mockImplementation(() => {
@@ -230,7 +232,9 @@ describe("vaultStore", () => {
       mockGetBackend.mockReturnValue(backend);
       mockGetSession.mockReturnValue(null);
 
-      expect(() => useVaultStore.getState().refreshStatus()).not.toThrow();
+      await expect(
+        useVaultStore.getState().refreshStatus(),
+      ).resolves.toBeUndefined();
       // Status should still be set despite settings load failure
       expect(useVaultStore.getState().status).toBe("locked");
     });
@@ -563,7 +567,7 @@ describe("vaultStore", () => {
   });
 
   describe("updateAutoLockSettings", () => {
-    it("saves settings to backend, updates state, and restarts tracker when unlocked", () => {
+    it("saves settings to backend, updates state, and restarts tracker when unlocked", async () => {
       const backend = makeFakeBackend();
       mockGetBackend.mockReturnValue(backend);
       useVaultStore.setState({
@@ -572,7 +576,7 @@ describe("vaultStore", () => {
         lockOnHidden: false,
       });
 
-      useVaultStore.getState().updateAutoLockSettings({
+      await useVaultStore.getState().updateAutoLockSettings({
         autoLockTimeoutMinutes: 30,
         lockOnHidden: true,
       });
@@ -590,7 +594,7 @@ describe("vaultStore", () => {
       expect(startArg.lockOnHidden).toBe(true);
     });
 
-    it("saves settings and updates state but does NOT restart tracker when locked", () => {
+    it("saves settings and updates state but does NOT restart tracker when locked", async () => {
       const backend = makeFakeBackend();
       mockGetBackend.mockReturnValue(backend);
       useVaultStore.setState({
@@ -599,7 +603,7 @@ describe("vaultStore", () => {
         lockOnHidden: false,
       });
 
-      useVaultStore
+      await useVaultStore
         .getState()
         .updateAutoLockSettings({ autoLockTimeoutMinutes: 60 });
 
@@ -611,7 +615,7 @@ describe("vaultStore", () => {
       expect(mockTrackerStart).not.toHaveBeenCalled();
     });
 
-    it("can update only lockOnHidden (partial update)", () => {
+    it("can update only lockOnHidden (partial update)", async () => {
       const backend = makeFakeBackend();
       mockGetBackend.mockReturnValue(backend);
       useVaultStore.setState({
@@ -620,7 +624,9 @@ describe("vaultStore", () => {
         lockOnHidden: false,
       });
 
-      useVaultStore.getState().updateAutoLockSettings({ lockOnHidden: true });
+      await useVaultStore
+        .getState()
+        .updateAutoLockSettings({ lockOnHidden: true });
 
       expect(backend.saveSettings).toHaveBeenCalledWith({
         autoLockTimeoutMinutes: 15,
@@ -1066,7 +1072,10 @@ describe("vaultStore", () => {
         .getState()
         .changeMasterPassword("current-pass", "new-pass");
 
-      // Vault locks while createVaultMeta is in flight
+      // Wait until loadMeta + verifyPassword have resolved and execution is
+      // suspended inside createVaultMeta, then simulate the vault locking
+      // while it is in flight.
+      await vi.waitFor(() => expect(mockCrypto).toHaveBeenCalled());
       useVaultStore.setState({ status: "locked", keys: [] });
       mockGetSession.mockReturnValue(null);
 
@@ -1089,7 +1098,7 @@ describe("vaultStore", () => {
   });
 
   describe("resetVault", () => {
-    it("clears backend, session key, and resets state to uninitialized", () => {
+    it("clears backend, session key, and resets state to uninitialized", async () => {
       const backend = makeFakeBackend();
       mockGetBackend.mockReturnValue(backend);
 
@@ -1099,7 +1108,7 @@ describe("vaultStore", () => {
         error: "previous error",
       });
 
-      useVaultStore.getState().resetVault();
+      await useVaultStore.getState().resetVault();
 
       const state = useVaultStore.getState();
       expect(state.status).toBe("uninitialized");
@@ -1109,17 +1118,17 @@ describe("vaultStore", () => {
       expect(mockClearSession).toHaveBeenCalled();
     });
 
-    it("calls activityTracker.stop() on resetVault", () => {
+    it("calls activityTracker.stop() on resetVault", async () => {
       const backend = makeFakeBackend();
       mockGetBackend.mockReturnValue(backend);
       useVaultStore.setState({ status: "unlocked", keys: [] });
 
-      useVaultStore.getState().resetVault();
+      await useVaultStore.getState().resetVault();
 
       expect(mockTrackerStop).toHaveBeenCalled();
     });
 
-    it("resets autoLockTimeoutMinutes and lockOnHidden to defaults", () => {
+    it("resets autoLockTimeoutMinutes and lockOnHidden to defaults", async () => {
       const backend = makeFakeBackend();
       mockGetBackend.mockReturnValue(backend);
 
@@ -1129,7 +1138,7 @@ describe("vaultStore", () => {
         lockOnHidden: true,
       });
 
-      useVaultStore.getState().resetVault();
+      await useVaultStore.getState().resetVault();
 
       const state = useVaultStore.getState();
       expect(state.autoLockTimeoutMinutes).toBe(

--- a/ui/apps/console/src/stores/vaultStore.ts
+++ b/ui/apps/console/src/stores/vaultStore.ts
@@ -15,15 +15,24 @@ import {
   getSessionKey,
   clearSessionKey,
 } from "@/utils/vault-crypto";
-import { getVaultBackend } from "@/utils/vault-backend-factory";
+import {
+  getVaultBackend,
+  getVaultStorageMode,
+  setVaultStorageMode,
+  type VaultStorageMode,
+} from "@/utils/vault-backend-factory";
 import type { IVaultBackend } from "@/utils/vault-backend";
 import * as activityTracker from "@/utils/vault-activity-tracker";
 import { useAuthStore } from "@/stores/authStore";
 import { generateRandomUUID } from "@/utils/random-uuid";
 
-function getBackend() {
+function getScope() {
   const { user, tenant } = useAuthStore.getState();
-  return getVaultBackend(user && tenant ? { user, tenant } : undefined);
+  return user && tenant ? { user, tenant } : undefined;
+}
+
+function getBackend() {
+  return getVaultBackend(getScope());
 }
 
 export type DuplicateField = "name" | "private_key" | "both";
@@ -44,9 +53,14 @@ interface VaultState {
   autoLockTimeoutMinutes: number;
   lockOnHidden: boolean;
   autoLockNonce: number;
+  /** Where the vault lives for the current user ("local" or "server"). */
+  storageMode: VaultStorageMode;
 
-  refreshStatus: () => void;
-  initialize: (masterPassword: string) => Promise<void>;
+  refreshStatus: () => Promise<void>;
+  initialize: (
+    masterPassword: string,
+    mode?: VaultStorageMode,
+  ) => Promise<void>;
   unlock: (masterPassword: string) => Promise<void>;
   lock: () => void;
   addKey: (
@@ -69,9 +83,9 @@ interface VaultState {
     currentPassword: string,
     newPassword: string,
   ) => Promise<void>;
-  resetVault: () => void;
+  resetVault: () => Promise<void>;
   clearError: () => void;
-  updateAutoLockSettings: (updates: Partial<VaultSettings>) => void;
+  updateAutoLockSettings: (updates: Partial<VaultSettings>) => Promise<void>;
 }
 
 async function persistKeys(
@@ -83,7 +97,7 @@ async function persistKeys(
 
   const backend = be ?? getBackend();
   const data = await encrypt(key, JSON.stringify(keys));
-  backend.saveData(data);
+  await backend.saveData(data);
 }
 
 function checkDuplicates(
@@ -119,10 +133,10 @@ function migrateLegacyKeys(legacy: LegacyPrivateKey[]): VaultKeyEntry[] {
 }
 
 export const useVaultStore = create<VaultState>((set, get) => {
-  function loadSettingsIntoState(): void {
+  async function loadSettingsIntoState(): Promise<void> {
     try {
       const backend = getBackend();
-      const settings = backend.loadSettings();
+      const settings = await backend.loadSettings();
       set({
         autoLockTimeoutMinutes: settings.autoLockTimeoutMinutes,
         lockOnHidden: settings.lockOnHidden,
@@ -161,10 +175,24 @@ export const useVaultStore = create<VaultState>((set, get) => {
     autoLockTimeoutMinutes: DEFAULT_VAULT_SETTINGS.autoLockTimeoutMinutes,
     lockOnHidden: DEFAULT_VAULT_SETTINGS.lockOnHidden,
     autoLockNonce: 0,
+    storageMode: "local",
 
-    refreshStatus: () => {
-      const backend = getBackend();
-      const meta = backend.loadMeta();
+    refreshStatus: async () => {
+      set({ storageMode: getVaultStorageMode(getScope()) });
+
+      let meta;
+      try {
+        const backend = getBackend();
+        meta = await backend.loadMeta();
+      } catch (err) {
+        // Keep the current status: with a server-backed vault a transient
+        // network error must not present the setup screen (which could lead
+        // to overwriting an existing vault).
+        const msg =
+          err instanceof Error ? err.message : "Failed to load the vault";
+        set({ error: msg });
+        return;
+      }
 
       if (!meta) {
         activityTracker.stop();
@@ -172,7 +200,7 @@ export const useVaultStore = create<VaultState>((set, get) => {
         return;
       }
 
-      loadSettingsIntoState();
+      await loadSettingsIntoState();
 
       if (!getSessionKey()) {
         activityTracker.stop();
@@ -183,30 +211,36 @@ export const useVaultStore = create<VaultState>((set, get) => {
       set({ status: "unlocked" });
     },
 
-    initialize: async (masterPassword) => {
+    initialize: async (masterPassword, mode) => {
       set({ loading: true, error: null });
+      // Persist the chosen storage location before picking the backend so the
+      // vault is created where the user asked (local or server).
+      if (mode) {
+        setVaultStorageMode(mode, getScope());
+        set({ storageMode: mode });
+      }
       const backend = getBackend();
       try {
         const { meta, derivedKey } = await createVaultMeta(masterPassword);
-        backend.saveMeta(meta);
+        await backend.saveMeta(meta);
 
         setSessionKey(derivedKey);
 
-        const legacyKeys = backend.loadLegacyKeys();
+        const legacyKeys = await backend.loadLegacyKeys();
         const keys = legacyKeys.length > 0 ? migrateLegacyKeys(legacyKeys) : [];
 
         await persistKeys(keys);
 
         if (legacyKeys.length > 0) {
-          backend.clearLegacyKeys();
+          await backend.clearLegacyKeys();
         }
 
         set({ status: "unlocked", keys, loading: false });
-        loadSettingsIntoState();
+        await loadSettingsIntoState();
         startTracker();
       } catch (err) {
         // Rollback saved meta so the vault returns to "uninitialized"
-        backend.clear();
+        await backend.clear().catch(() => undefined);
         clearSessionKey();
         const msg =
           err instanceof Error ? err.message : "Failed to create vault";
@@ -218,7 +252,7 @@ export const useVaultStore = create<VaultState>((set, get) => {
       set({ loading: true, error: null });
       try {
         const backend = getBackend();
-        const meta = backend.loadMeta();
+        const meta = await backend.loadMeta();
         if (!meta) {
           set({ loading: false, error: "No vault found" });
           return;
@@ -235,7 +269,7 @@ export const useVaultStore = create<VaultState>((set, get) => {
         setSessionKey(derivedKey);
 
         try {
-          const vaultData = backend.loadData();
+          const vaultData = await backend.loadData();
           const parsed: unknown = vaultData
             ? JSON.parse(await decrypt(derivedKey, vaultData))
             : [];
@@ -259,7 +293,7 @@ export const useVaultStore = create<VaultState>((set, get) => {
           const keys = parsed as VaultKeyEntry[];
 
           set({ status: "unlocked", keys, loading: false });
-          loadSettingsIntoState();
+          await loadSettingsIntoState();
           startTracker();
         } catch {
           clearSessionKey();
@@ -328,7 +362,7 @@ export const useVaultStore = create<VaultState>((set, get) => {
       set({ loading: true, error: null });
       try {
         const backend = getBackend();
-        const meta = backend.loadMeta();
+        const meta = await backend.loadMeta();
         if (!meta) {
           set({ loading: false, error: "No vault found" });
           return;
@@ -356,18 +390,18 @@ export const useVaultStore = create<VaultState>((set, get) => {
         }
 
         // Save current encrypted data and meta for rollback before re-encrypting.
-        const oldData = backend.loadData();
+        const oldData = await backend.loadData();
         const oldMeta = meta;
 
         setSessionKey(newKey);
         try {
           await persistKeys(get().keys, backend);
-          backend.saveMeta(newMeta);
+          await backend.saveMeta(newMeta);
         } catch (err) {
           // Restore old session key, encrypted data, and meta
           setSessionKey(oldKey);
-          if (oldData) backend.saveData(oldData);
-          backend.saveMeta(oldMeta);
+          if (oldData) await backend.saveData(oldData).catch(() => undefined);
+          await backend.saveMeta(oldMeta).catch(() => undefined);
           throw err;
         }
 
@@ -383,9 +417,16 @@ export const useVaultStore = create<VaultState>((set, get) => {
       }
     },
 
-    resetVault: () => {
+    resetVault: async () => {
       const backend = getBackend();
-      backend.clear();
+      try {
+        await backend.clear();
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to reset the vault";
+        set({ error: msg });
+        return;
+      }
       clearSessionKey();
       activityTracker.stop();
       set({
@@ -399,7 +440,7 @@ export const useVaultStore = create<VaultState>((set, get) => {
 
     clearError: () => set({ error: null }),
 
-    updateAutoLockSettings: (updates) => {
+    updateAutoLockSettings: async (updates) => {
       const current = get();
       const newSettings: VaultSettings = {
         autoLockTimeoutMinutes:
@@ -408,7 +449,14 @@ export const useVaultStore = create<VaultState>((set, get) => {
       };
 
       const backend = getBackend();
-      backend.saveSettings(newSettings);
+      try {
+        await backend.saveSettings(newSettings);
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to save vault settings";
+        set({ error: msg });
+        return;
+      }
       set(newSettings);
 
       if (get().status === "unlocked") {

--- a/ui/apps/console/src/utils/__tests__/vault-backend-factory.test.ts
+++ b/ui/apps/console/src/utils/__tests__/vault-backend-factory.test.ts
@@ -30,7 +30,7 @@ describe("getVaultBackend", () => {
     expect(typeof backend.saveSettings).toBe("function");
   });
 
-  it("scopes storage keys when scope is provided", () => {
+  it("scopes storage keys when scope is provided", async () => {
     const backend = getVaultBackend({
       user: "testuser",
       tenant: "test-tenant",
@@ -42,14 +42,14 @@ describe("getVaultBackend", () => {
       verifier: "dmVyaWZpZXI=",
       verifierIv: "aXY=",
     };
-    backend.saveMeta(meta);
+    await backend.saveMeta(meta);
     expect(
       localStorage.getItem("shellhub-vault-meta:testuser:test-tenant"),
     ).toBe(JSON.stringify(meta));
     expect(localStorage.getItem("shellhub-vault-meta")).toBeNull();
   });
 
-  it("uses unscoped keys when no scope is provided", () => {
+  it("uses unscoped keys when no scope is provided", async () => {
     const backend = getVaultBackend();
     const meta = {
       version: 1 as const,
@@ -58,7 +58,7 @@ describe("getVaultBackend", () => {
       verifier: "dmVyaWZpZXI=",
       verifierIv: "aXY=",
     };
-    backend.saveMeta(meta);
+    await backend.saveMeta(meta);
     expect(localStorage.getItem("shellhub-vault-meta")).toBe(
       JSON.stringify(meta),
     );

--- a/ui/apps/console/src/utils/__tests__/vault-backend-local.test.ts
+++ b/ui/apps/console/src/utils/__tests__/vault-backend-local.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { LocalVaultBackend } from "../vault-backend-local";
+import { LocalVaultBackend, localVaultExists } from "../vault-backend-local";
 import type { VaultMeta, VaultData, LegacyPrivateKey } from "@/types/vault";
 import { DEFAULT_VAULT_SETTINGS } from "@/types/vault";
 
@@ -40,169 +40,169 @@ describe("LocalVaultBackend", () => {
   });
 
   describe("meta", () => {
-    it("returns null when no meta is stored", () => {
-      expect(backend.loadMeta()).toBeNull();
+    it("returns null when no meta is stored", async () => {
+      expect(await backend.loadMeta()).toBeNull();
     });
 
-    it("saves and loads meta correctly", () => {
-      backend.saveMeta(META);
-      expect(backend.loadMeta()).toEqual(META);
+    it("saves and loads meta correctly", async () => {
+      await backend.saveMeta(META);
+      expect(await backend.loadMeta()).toEqual(META);
     });
 
-    it("persists meta under the correct localStorage key", () => {
-      backend.saveMeta(META);
+    it("persists meta under the correct localStorage key", async () => {
+      await backend.saveMeta(META);
       expect(localStorage.getItem(VAULT_META_KEY)).toBe(JSON.stringify(META));
     });
 
-    it("returns null after meta is cleared via clear()", () => {
-      backend.saveMeta(META);
-      backend.clear();
-      expect(backend.loadMeta()).toBeNull();
+    it("returns null after meta is cleared via clear()", async () => {
+      await backend.saveMeta(META);
+      await backend.clear();
+      expect(await backend.loadMeta()).toBeNull();
     });
 
-    it("returns null when stored meta is invalid JSON", () => {
+    it("returns null when stored meta is invalid JSON", async () => {
       localStorage.setItem(VAULT_META_KEY, "not-json{{{");
-      expect(backend.loadMeta()).toBeNull();
+      expect(await backend.loadMeta()).toBeNull();
     });
 
-    it("overwrites existing meta on repeated saves", () => {
-      backend.saveMeta(META);
+    it("overwrites existing meta on repeated saves", async () => {
+      await backend.saveMeta(META);
       const updated: VaultMeta = { ...META, iterations: 100000 };
-      backend.saveMeta(updated);
-      expect(backend.loadMeta()).toEqual(updated);
+      await backend.saveMeta(updated);
+      expect(await backend.loadMeta()).toEqual(updated);
     });
 
-    it("returns null when version is not 1", () => {
+    it("returns null when version is not 1", async () => {
       localStorage.setItem(
         VAULT_META_KEY,
         JSON.stringify({ ...META, version: 2 }),
       );
-      expect(backend.loadMeta()).toBeNull();
+      expect(await backend.loadMeta()).toBeNull();
     });
 
-    it("returns null when iterations is below minimum", () => {
+    it("returns null when iterations is below minimum", async () => {
       localStorage.setItem(
         VAULT_META_KEY,
         JSON.stringify({ ...META, iterations: 99_999 }),
       );
-      expect(backend.loadMeta()).toBeNull();
+      expect(await backend.loadMeta()).toBeNull();
     });
 
-    it("returns null when iterations exceeds maximum", () => {
+    it("returns null when iterations exceeds maximum", async () => {
       localStorage.setItem(
         VAULT_META_KEY,
         JSON.stringify({ ...META, iterations: 10_000_001 }),
       );
-      expect(backend.loadMeta()).toBeNull();
+      expect(await backend.loadMeta()).toBeNull();
     });
 
-    it("returns null when iterations is not an integer", () => {
+    it("returns null when iterations is not an integer", async () => {
       localStorage.setItem(
         VAULT_META_KEY,
         JSON.stringify({ ...META, iterations: 600000.5 }),
       );
-      expect(backend.loadMeta()).toBeNull();
+      expect(await backend.loadMeta()).toBeNull();
     });
 
-    it("returns null when salt is not a string", () => {
+    it("returns null when salt is not a string", async () => {
       localStorage.setItem(
         VAULT_META_KEY,
         JSON.stringify({ ...META, salt: 42 }),
       );
-      expect(backend.loadMeta()).toBeNull();
+      expect(await backend.loadMeta()).toBeNull();
     });
 
-    it("returns null when verifier is not a string", () => {
+    it("returns null when verifier is not a string", async () => {
       localStorage.setItem(
         VAULT_META_KEY,
         JSON.stringify({ ...META, verifier: null }),
       );
-      expect(backend.loadMeta()).toBeNull();
+      expect(await backend.loadMeta()).toBeNull();
     });
   });
 
   describe("data", () => {
-    it("returns null when no data is stored", () => {
-      expect(backend.loadData()).toBeNull();
+    it("returns null when no data is stored", async () => {
+      expect(await backend.loadData()).toBeNull();
     });
 
-    it("saves and loads data correctly", () => {
-      backend.saveData(DATA);
-      expect(backend.loadData()).toEqual(DATA);
+    it("saves and loads data correctly", async () => {
+      await backend.saveData(DATA);
+      expect(await backend.loadData()).toEqual(DATA);
     });
 
-    it("persists data under the correct localStorage key", () => {
-      backend.saveData(DATA);
+    it("persists data under the correct localStorage key", async () => {
+      await backend.saveData(DATA);
       expect(localStorage.getItem(VAULT_DATA_KEY)).toBe(JSON.stringify(DATA));
     });
 
-    it("returns null after data is cleared via clear()", () => {
-      backend.saveData(DATA);
-      backend.clear();
-      expect(backend.loadData()).toBeNull();
+    it("returns null after data is cleared via clear()", async () => {
+      await backend.saveData(DATA);
+      await backend.clear();
+      expect(await backend.loadData()).toBeNull();
     });
 
-    it("returns null when stored data is invalid JSON", () => {
+    it("returns null when stored data is invalid JSON", async () => {
       localStorage.setItem(VAULT_DATA_KEY, "!!!bad json!!!");
-      expect(backend.loadData()).toBeNull();
+      expect(await backend.loadData()).toBeNull();
     });
 
-    it("overwrites existing data on repeated saves", () => {
-      backend.saveData(DATA);
+    it("overwrites existing data on repeated saves", async () => {
+      await backend.saveData(DATA);
       const updated: VaultData = { iv: "bmV3SXY=", ciphertext: "bmV3Q2lwaA==" };
-      backend.saveData(updated);
-      expect(backend.loadData()).toEqual(updated);
+      await backend.saveData(updated);
+      expect(await backend.loadData()).toEqual(updated);
     });
   });
 
   describe("clear", () => {
-    it("removes both meta and data from localStorage", () => {
-      backend.saveMeta(META);
-      backend.saveData(DATA);
-      backend.clear();
+    it("removes both meta and data from localStorage", async () => {
+      await backend.saveMeta(META);
+      await backend.saveData(DATA);
+      await backend.clear();
       expect(localStorage.getItem(VAULT_META_KEY)).toBeNull();
       expect(localStorage.getItem(VAULT_DATA_KEY)).toBeNull();
     });
 
-    it("does not remove legacy keys", () => {
+    it("does not remove legacy keys", async () => {
       localStorage.setItem(LEGACY_KEYS_KEY, JSON.stringify(LEGACY_KEYS));
-      backend.clear();
+      await backend.clear();
       expect(localStorage.getItem(LEGACY_KEYS_KEY)).not.toBeNull();
     });
 
-    it("is idempotent when nothing is stored", () => {
-      expect(() => backend.clear()).not.toThrow();
+    it("is idempotent when nothing is stored", async () => {
+      await expect(backend.clear()).resolves.toBeUndefined();
     });
   });
 
   describe("legacy keys", () => {
-    it("returns an empty array when no legacy keys are stored", () => {
-      expect(backend.loadLegacyKeys()).toEqual([]);
+    it("returns an empty array when no legacy keys are stored", async () => {
+      expect(await backend.loadLegacyKeys()).toEqual([]);
     });
 
-    it("loads legacy keys stored by another mechanism", () => {
+    it("loads legacy keys stored by another mechanism", async () => {
       localStorage.setItem(LEGACY_KEYS_KEY, JSON.stringify(LEGACY_KEYS));
-      expect(backend.loadLegacyKeys()).toEqual(LEGACY_KEYS);
+      expect(await backend.loadLegacyKeys()).toEqual(LEGACY_KEYS);
     });
 
-    it("returns an empty array when legacy keys storage contains invalid JSON", () => {
+    it("returns an empty array when legacy keys storage contains invalid JSON", async () => {
       localStorage.setItem(LEGACY_KEYS_KEY, "oops{");
-      expect(backend.loadLegacyKeys()).toEqual([]);
+      expect(await backend.loadLegacyKeys()).toEqual([]);
     });
 
-    it("removes legacy keys from localStorage on clearLegacyKeys()", () => {
+    it("removes legacy keys from localStorage on clearLegacyKeys()", async () => {
       localStorage.setItem(LEGACY_KEYS_KEY, JSON.stringify(LEGACY_KEYS));
-      backend.clearLegacyKeys();
+      await backend.clearLegacyKeys();
       expect(localStorage.getItem(LEGACY_KEYS_KEY)).toBeNull();
     });
 
-    it("clearLegacyKeys is idempotent when nothing is stored", () => {
-      expect(() => backend.clearLegacyKeys()).not.toThrow();
+    it("clearLegacyKeys is idempotent when nothing is stored", async () => {
+      await expect(backend.clearLegacyKeys()).resolves.toBeUndefined();
     });
   });
 
   describe("storage quota exceeded error", () => {
-    it("throws a descriptive error when saving meta exceeds quota", () => {
+    it("throws a descriptive error when saving meta exceeds quota", async () => {
       const quotaError = new DOMException(
         "QuotaExceededError",
         "QuotaExceededError",
@@ -210,12 +210,12 @@ describe("LocalVaultBackend", () => {
       vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
         throw quotaError;
       });
-      expect(() => backend.saveMeta(META)).toThrow(
+      await expect(backend.saveMeta(META)).rejects.toThrow(
         "Storage quota exceeded. Free up space or reset the vault.",
       );
     });
 
-    it("throws a descriptive error when saving data exceeds quota", () => {
+    it("throws a descriptive error when saving data exceeds quota", async () => {
       const quotaError = new DOMException(
         "QuotaExceededError",
         "QuotaExceededError",
@@ -223,110 +223,138 @@ describe("LocalVaultBackend", () => {
       vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
         throw quotaError;
       });
-      expect(() => backend.saveData(DATA)).toThrow(
+      await expect(backend.saveData(DATA)).rejects.toThrow(
         "Storage quota exceeded. Free up space or reset the vault.",
       );
     });
 
-    it("re-throws non-quota errors as-is", () => {
+    it("re-throws non-quota errors as-is", async () => {
       const unknownError = new Error("disk failure");
       vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
         throw unknownError;
       });
-      expect(() => backend.saveMeta(META)).toThrow("disk failure");
+      await expect(backend.saveMeta(META)).rejects.toThrow("disk failure");
     });
   });
 
   describe("settings", () => {
-    it("returns DEFAULT_VAULT_SETTINGS when nothing is stored", () => {
-      expect(backend.loadSettings()).toEqual(DEFAULT_VAULT_SETTINGS);
+    it("returns DEFAULT_VAULT_SETTINGS when nothing is stored", async () => {
+      expect(await backend.loadSettings()).toEqual(DEFAULT_VAULT_SETTINGS);
     });
 
-    it("save->load round-trip returns the same settings", () => {
+    it("save->load round-trip returns the same settings", async () => {
       const settings = { autoLockTimeoutMinutes: 30, lockOnHidden: true };
-      backend.saveSettings(settings);
-      expect(backend.loadSettings()).toEqual(settings);
+      await backend.saveSettings(settings);
+      expect(await backend.loadSettings()).toEqual(settings);
     });
 
-    it("returns DEFAULT_VAULT_SETTINGS when stored JSON is invalid", () => {
+    it("returns DEFAULT_VAULT_SETTINGS when stored JSON is invalid", async () => {
       localStorage.setItem(VAULT_SETTINGS_KEY, "not-json{{{");
-      expect(backend.loadSettings()).toEqual(DEFAULT_VAULT_SETTINGS);
+      expect(await backend.loadSettings()).toEqual(DEFAULT_VAULT_SETTINGS);
     });
 
-    it("autoLockTimeoutMinutes:0 round-trips as 0 (valid member, not coerced)", () => {
-      backend.saveSettings({ autoLockTimeoutMinutes: 0, lockOnHidden: false });
-      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(0);
+    it("autoLockTimeoutMinutes:0 round-trips as 0 (valid member, not coerced)", async () => {
+      await backend.saveSettings({
+        autoLockTimeoutMinutes: 0,
+        lockOnHidden: false,
+      });
+      expect((await backend.loadSettings()).autoLockTimeoutMinutes).toBe(0);
     });
 
-    it("autoLockTimeoutMinutes:7 (not in allowed list) falls back to 15", () => {
+    it("autoLockTimeoutMinutes:7 (not in allowed list) falls back to 15", async () => {
       localStorage.setItem(
         VAULT_SETTINGS_KEY,
         JSON.stringify({ autoLockTimeoutMinutes: 7, lockOnHidden: false }),
       );
-      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+      expect((await backend.loadSettings()).autoLockTimeoutMinutes).toBe(15);
     });
 
-    it("autoLockTimeoutMinutes:999999 falls back to 15", () => {
+    it("autoLockTimeoutMinutes:999999 falls back to 15", async () => {
       localStorage.setItem(
         VAULT_SETTINGS_KEY,
         JSON.stringify({ autoLockTimeoutMinutes: 999999, lockOnHidden: false }),
       );
-      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+      expect((await backend.loadSettings()).autoLockTimeoutMinutes).toBe(15);
     });
 
-    it("autoLockTimeoutMinutes:15.5 (float, not a member) falls back to 15", () => {
+    it("autoLockTimeoutMinutes:15.5 (float, not a member) falls back to 15", async () => {
       localStorage.setItem(
         VAULT_SETTINGS_KEY,
         JSON.stringify({ autoLockTimeoutMinutes: 15.5, lockOnHidden: false }),
       );
-      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+      expect((await backend.loadSettings()).autoLockTimeoutMinutes).toBe(15);
     });
 
-    it("autoLockTimeoutMinutes as string '15' falls back to 15 (no coercion)", () => {
+    it("autoLockTimeoutMinutes as string '15' falls back to 15 (no coercion)", async () => {
       localStorage.setItem(
         VAULT_SETTINGS_KEY,
         JSON.stringify({ autoLockTimeoutMinutes: "15", lockOnHidden: false }),
       );
-      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+      expect((await backend.loadSettings()).autoLockTimeoutMinutes).toBe(15);
     });
 
-    it("autoLockTimeoutMinutes:null falls back to 15", () => {
+    it("autoLockTimeoutMinutes:null falls back to 15", async () => {
       localStorage.setItem(
         VAULT_SETTINGS_KEY,
         JSON.stringify({ autoLockTimeoutMinutes: null, lockOnHidden: false }),
       );
-      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+      expect((await backend.loadSettings()).autoLockTimeoutMinutes).toBe(15);
     });
 
-    it("missing autoLockTimeoutMinutes falls back to 15", () => {
+    it("missing autoLockTimeoutMinutes falls back to 15", async () => {
       localStorage.setItem(
         VAULT_SETTINGS_KEY,
         JSON.stringify({ lockOnHidden: false }),
       );
-      expect(backend.loadSettings().autoLockTimeoutMinutes).toBe(15);
+      expect((await backend.loadSettings()).autoLockTimeoutMinutes).toBe(15);
     });
 
-    it("non-boolean lockOnHidden falls back to false", () => {
+    it("non-boolean lockOnHidden falls back to false", async () => {
       localStorage.setItem(
         VAULT_SETTINGS_KEY,
         JSON.stringify({ autoLockTimeoutMinutes: 15, lockOnHidden: "yes" }),
       );
-      expect(backend.loadSettings().lockOnHidden).toBe(false);
+      expect((await backend.loadSettings()).lockOnHidden).toBe(false);
     });
 
-    it("clear() removes the settings key", () => {
-      backend.saveSettings({ autoLockTimeoutMinutes: 30, lockOnHidden: true });
-      backend.clear();
+    it("clear() removes the settings key", async () => {
+      await backend.saveSettings({
+        autoLockTimeoutMinutes: 30,
+        lockOnHidden: true,
+      });
+      await backend.clear();
       expect(localStorage.getItem(VAULT_SETTINGS_KEY)).toBeNull();
     });
 
-    it("scoped backend uses prefixed settings key", () => {
+    it("scoped backend uses prefixed settings key", async () => {
       const scoped = new LocalVaultBackend({ user: "alice", tenant: "t1" });
-      scoped.saveSettings({ autoLockTimeoutMinutes: 60, lockOnHidden: true });
+      await scoped.saveSettings({
+        autoLockTimeoutMinutes: 60,
+        lockOnHidden: true,
+      });
       expect(localStorage.getItem(`${VAULT_SETTINGS_KEY}:alice:t1`)).toBe(
         JSON.stringify({ autoLockTimeoutMinutes: 60, lockOnHidden: true }),
       );
       expect(localStorage.getItem(VAULT_SETTINGS_KEY)).toBeNull();
+    });
+  });
+
+  describe("localVaultExists", () => {
+    it("is false when no vault meta is stored", () => {
+      expect(localVaultExists()).toBe(false);
+    });
+
+    it("is true after meta is saved", async () => {
+      await backend.saveMeta(META);
+      expect(localVaultExists()).toBe(true);
+    });
+
+    it("respects scoping", async () => {
+      const scoped = new LocalVaultBackend({ user: "alice", tenant: "t1" });
+      await scoped.saveMeta(META);
+      expect(localVaultExists({ user: "alice", tenant: "t1" })).toBe(true);
+      expect(localVaultExists({ user: "bob", tenant: "t1" })).toBe(false);
+      expect(localVaultExists()).toBe(false);
     });
   });
 });

--- a/ui/apps/console/src/utils/vault-backend-factory.ts
+++ b/ui/apps/console/src/utils/vault-backend-factory.ts
@@ -1,6 +1,72 @@
+import { getConfig } from "@/env";
 import type { IVaultBackend } from "@/utils/vault-backend";
-import { LocalVaultBackend } from "@/utils/vault-backend-local";
+import {
+  LocalVaultBackend,
+  localVaultExists,
+} from "@/utils/vault-backend-local";
+import { ServerVaultBackend } from "@/utils/vault-backend-server";
 
-export function getVaultBackend(scope?: { user: string; tenant: string }): IVaultBackend {
+export type VaultStorageMode = "local" | "server";
+export type VaultScope = { user: string; tenant: string };
+
+const VAULT_STORAGE_MODE_KEY = "shellhub-vault-storage";
+
+function modeKey(scope?: VaultScope): string {
+  return scope
+    ? `${VAULT_STORAGE_MODE_KEY}:${scope.user}:${scope.tenant}`
+    : VAULT_STORAGE_MODE_KEY;
+}
+
+/**
+ * Whether server-side vault storage is available in this deployment
+ * (Cloud/Enterprise). Community Edition is always local.
+ */
+export function isVaultServerEnabled(): boolean {
+  const config = getConfig();
+  return config.cloud || config.enterprise;
+}
+
+/**
+ * The storage mode in effect for the given scope. The user's explicit choice
+ * (persisted per user/namespace) wins; without one, an existing local vault
+ * keeps using local storage — switching to the server is an explicit
+ * migration — and new vaults default to the server when available.
+ */
+export function getVaultStorageMode(scope?: VaultScope): VaultStorageMode {
+  if (!isVaultServerEnabled()) return "local";
+
+  const stored = localStorage.getItem(modeKey(scope));
+  if (stored === "local" || stored === "server") return stored;
+
+  return localVaultExists(scope) ? "local" : "server";
+}
+
+export function setVaultStorageMode(
+  mode: VaultStorageMode,
+  scope?: VaultScope,
+): void {
+  localStorage.setItem(modeKey(scope), mode);
+}
+
+const VAULT_SYNC_PROMO_KEY = "shellhub-vault-sync-promo-dismissed";
+
+function promoKey(scope?: VaultScope): string {
+  return scope
+    ? `${VAULT_SYNC_PROMO_KEY}:${scope.user}:${scope.tenant}`
+    : VAULT_SYNC_PROMO_KEY;
+}
+
+/** Whether the user opted out of the "sync your vault" prompt shown on lock. */
+export function isVaultSyncPromoDismissed(scope?: VaultScope): boolean {
+  return localStorage.getItem(promoKey(scope)) === "true";
+}
+
+export function dismissVaultSyncPromo(scope?: VaultScope): void {
+  localStorage.setItem(promoKey(scope), "true");
+}
+
+export function getVaultBackend(scope?: VaultScope): IVaultBackend {
+  if (getVaultStorageMode(scope) === "server")
+    return new ServerVaultBackend(scope);
   return new LocalVaultBackend(scope);
 }

--- a/ui/apps/console/src/utils/vault-backend-local.ts
+++ b/ui/apps/console/src/utils/vault-backend-local.ts
@@ -4,8 +4,12 @@ import type {
   LegacyPrivateKey,
   VaultSettings,
 } from "@/types/vault";
-import { ALLOWED_TIMEOUT_MINUTES, DEFAULT_VAULT_SETTINGS } from "@/types/vault";
 import type { IVaultBackend } from "@/utils/vault-backend";
+import {
+  parseVaultMeta,
+  parseVaultData,
+  parseVaultSettings,
+} from "@/utils/vault-parse";
 
 const VAULT_META_KEY = "shellhub-vault-meta";
 const VAULT_DATA_KEY = "shellhub-vault-data";
@@ -14,6 +18,18 @@ const LEGACY_KEYS_KEY = "privateKeys";
 
 function prefixKey(base: string, prefix?: string): string {
   return prefix ? `${base}:${prefix}` : base;
+}
+
+/**
+ * Whether an initialized vault exists in this browser's localStorage for the
+ * given scope. Vault meta presence is what defines an initialized vault.
+ */
+export function localVaultExists(scope?: {
+  user: string;
+  tenant: string;
+}): boolean {
+  const prefix = scope ? `${scope.user}:${scope.tenant}` : undefined;
+  return localStorage.getItem(prefixKey(VAULT_META_KEY, prefix)) !== null;
 }
 
 function safeSetItem(key: string, value: string): void {
@@ -30,13 +46,41 @@ function safeSetItem(key: string, value: string): void {
   }
 }
 
-function safeParse<T>(raw: string | null, fallback: T): T {
-  if (!raw) return fallback;
+// Runs a synchronous storage write and surfaces any throw as a rejected
+// promise, so the async IVaultBackend contract holds (a synchronous throw
+// would escape `await` and bypass `.catch`).
+function settle(write: () => void): Promise<void> {
   try {
-    return JSON.parse(raw) as T;
-  } catch {
-    return fallback;
+    write();
+    return Promise.resolve();
+  } catch (err) {
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
   }
+}
+
+export function loadLegacyKeysFromStorage(): LegacyPrivateKey[] {
+  let raw: unknown[];
+  try {
+    raw = JSON.parse(
+      localStorage.getItem(LEGACY_KEYS_KEY) ?? "[]",
+    ) as unknown[];
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (item): item is LegacyPrivateKey =>
+      typeof item === "object" &&
+      item !== null &&
+      typeof (item as Record<string, unknown>).name === "string" &&
+      typeof (item as Record<string, unknown>).data === "string" &&
+      typeof (item as Record<string, unknown>).hasPassphrase === "boolean" &&
+      typeof (item as Record<string, unknown>).fingerprint === "string",
+  );
+}
+
+export function clearLegacyKeysFromStorage(): void {
+  localStorage.removeItem(LEGACY_KEYS_KEY);
 }
 
 export class LocalVaultBackend implements IVaultBackend {
@@ -46,98 +90,64 @@ export class LocalVaultBackend implements IVaultBackend {
     this.prefix = scope ? `${scope.user}:${scope.tenant}` : undefined;
   }
 
-  loadMeta(): VaultMeta | null {
-    const raw = safeParse<Record<string, unknown> | null>(
-      localStorage.getItem(prefixKey(VAULT_META_KEY, this.prefix)),
-      null,
+  loadMeta(): Promise<VaultMeta | null> {
+    return Promise.resolve(
+      parseVaultMeta(
+        localStorage.getItem(prefixKey(VAULT_META_KEY, this.prefix)),
+      ),
     );
-    if (
-      !raw ||
-      raw.version !== 1 ||
-      typeof raw.salt !== "string" ||
-      typeof raw.iterations !== "number" ||
-      !Number.isInteger(raw.iterations) ||
-      raw.iterations < 100_000 ||
-      raw.iterations > 10_000_000 ||
-      typeof raw.verifier !== "string" ||
-      typeof raw.verifierIv !== "string"
-    )
-      return null;
-    return raw as unknown as VaultMeta;
   }
 
-  saveMeta(meta: VaultMeta): void {
-    safeSetItem(prefixKey(VAULT_META_KEY, this.prefix), JSON.stringify(meta));
-  }
-
-  loadData(): VaultData | null {
-    const raw = safeParse<Record<string, unknown> | null>(
-      localStorage.getItem(prefixKey(VAULT_DATA_KEY, this.prefix)),
-      null,
+  saveMeta(meta: VaultMeta): Promise<void> {
+    return settle(() =>
+      safeSetItem(prefixKey(VAULT_META_KEY, this.prefix), JSON.stringify(meta)),
     );
-    if (
-      !raw ||
-      typeof raw.iv !== "string" ||
-      typeof raw.ciphertext !== "string"
-    )
-      return null;
-    return raw as unknown as VaultData;
   }
 
-  saveData(data: VaultData): void {
-    safeSetItem(prefixKey(VAULT_DATA_KEY, this.prefix), JSON.stringify(data));
+  loadData(): Promise<VaultData | null> {
+    return Promise.resolve(
+      parseVaultData(
+        localStorage.getItem(prefixKey(VAULT_DATA_KEY, this.prefix)),
+      ),
+    );
   }
 
-  clear(): void {
+  saveData(data: VaultData): Promise<void> {
+    return settle(() =>
+      safeSetItem(prefixKey(VAULT_DATA_KEY, this.prefix), JSON.stringify(data)),
+    );
+  }
+
+  clear(): Promise<void> {
     localStorage.removeItem(prefixKey(VAULT_META_KEY, this.prefix));
     localStorage.removeItem(prefixKey(VAULT_DATA_KEY, this.prefix));
     localStorage.removeItem(prefixKey(VAULT_SETTINGS_KEY, this.prefix));
+    return Promise.resolve();
   }
 
-  loadSettings(): VaultSettings {
-    const raw = safeParse<Record<string, unknown> | null>(
-      localStorage.getItem(prefixKey(VAULT_SETTINGS_KEY, this.prefix)),
-      null,
-    );
-    if (!raw) return { ...DEFAULT_VAULT_SETTINGS };
-
-    const rawTimeout = raw.autoLockTimeoutMinutes;
-    const autoLockTimeoutMinutes =
-      typeof rawTimeout === "number" &&
-      (ALLOWED_TIMEOUT_MINUTES as readonly number[]).includes(rawTimeout)
-        ? rawTimeout
-        : DEFAULT_VAULT_SETTINGS.autoLockTimeoutMinutes;
-
-    const lockOnHidden =
-      typeof raw.lockOnHidden === "boolean"
-        ? raw.lockOnHidden
-        : DEFAULT_VAULT_SETTINGS.lockOnHidden;
-
-    return { autoLockTimeoutMinutes, lockOnHidden };
-  }
-
-  saveSettings(settings: VaultSettings): void {
-    safeSetItem(
-      prefixKey(VAULT_SETTINGS_KEY, this.prefix),
-      JSON.stringify(settings),
+  loadSettings(): Promise<VaultSettings> {
+    return Promise.resolve(
+      parseVaultSettings(
+        localStorage.getItem(prefixKey(VAULT_SETTINGS_KEY, this.prefix)),
+      ),
     );
   }
 
-  loadLegacyKeys(): LegacyPrivateKey[] {
-    const raw = safeParse<unknown[]>(localStorage.getItem(LEGACY_KEYS_KEY), []);
-    if (!Array.isArray(raw)) return [];
-    return raw.filter(
-      (item): item is LegacyPrivateKey =>
-        typeof item === "object" &&
-        item !== null &&
-        typeof (item as Record<string, unknown>).name === "string" &&
-        typeof (item as Record<string, unknown>).data === "string" &&
-        typeof (item as Record<string, unknown>).hasPassphrase === "boolean" &&
-        typeof (item as Record<string, unknown>).fingerprint === "string",
+  saveSettings(settings: VaultSettings): Promise<void> {
+    return settle(() =>
+      safeSetItem(
+        prefixKey(VAULT_SETTINGS_KEY, this.prefix),
+        JSON.stringify(settings),
+      ),
     );
   }
 
-  clearLegacyKeys(): void {
-    localStorage.removeItem(LEGACY_KEYS_KEY);
+  loadLegacyKeys(): Promise<LegacyPrivateKey[]> {
+    return Promise.resolve(loadLegacyKeysFromStorage());
+  }
+
+  clearLegacyKeys(): Promise<void> {
+    clearLegacyKeysFromStorage();
+    return Promise.resolve();
   }
 }

--- a/ui/apps/console/src/utils/vault-backend-server.ts
+++ b/ui/apps/console/src/utils/vault-backend-server.ts
@@ -1,0 +1,144 @@
+import {
+  getVault,
+  saveVaultMeta,
+  saveVaultData,
+  saveVaultSettings,
+  deleteVault,
+} from "@/client";
+import type { VaultResponse } from "@/client";
+import type {
+  VaultMeta,
+  VaultData,
+  LegacyPrivateKey,
+  VaultSettings,
+} from "@/types/vault";
+import type { IVaultBackend } from "@/utils/vault-backend";
+import {
+  loadLegacyKeysFromStorage,
+  clearLegacyKeysFromStorage,
+} from "@/utils/vault-backend-local";
+import {
+  parseVaultMeta,
+  parseVaultData,
+  parseVaultSettings,
+} from "@/utils/vault-parse";
+import type { VaultScope } from "@/utils/vault-backend-factory";
+
+// Last-seen vault version, keyed by scope. It lives at module scope (not on
+// the instance) because the store creates a fresh ServerVaultBackend per
+// operation; a per-instance counter would reset to 0 between saveMeta and the
+// following saveData, sending a stale version and tripping the server's
+// optimistic-concurrency check on every write.
+const versionRegistry = new Map<string, number>();
+
+function scopeKey(scope?: VaultScope): string {
+  return scope ? `${scope.user}:${scope.tenant}` : "";
+}
+
+/**
+ * Vault backend that stores the encrypted vault on the ShellHub server
+ * (Cloud/Enterprise). The server is the single source of truth: every load
+ * hits the API and every save writes through. Encryption stays in the
+ * browser — the server only ever sees opaque strings.
+ *
+ * Writes to vault data carry the last seen `version` so a concurrent write
+ * from another session is detected by the server (409) instead of silently
+ * overwritten.
+ */
+export class ServerVaultBackend implements IVaultBackend {
+  private readonly key: string;
+
+  constructor(scope?: VaultScope) {
+    this.key = scopeKey(scope);
+  }
+
+  /** Vault version from the last successful read or write for this scope. */
+  private get version(): number {
+    return versionRegistry.get(this.key) ?? 0;
+  }
+
+  private track(vault: { version?: number } | undefined): void {
+    if (typeof vault?.version === "number")
+      versionRegistry.set(this.key, vault.version);
+  }
+
+  /** Fetches the vault, returning null when it does not exist yet (404). */
+  private async fetch(): Promise<VaultResponse | null> {
+    const { data, error, response } = await getVault();
+    if (response.status === 404) return null;
+    if (error || !data)
+      throw new Error("Failed to load the vault from the server.");
+    this.track(data);
+    return data;
+  }
+
+  async loadMeta(): Promise<VaultMeta | null> {
+    const vault = await this.fetch();
+    return parseVaultMeta(vault?.meta);
+  }
+
+  async saveMeta(meta: VaultMeta): Promise<void> {
+    const { data, error } = await saveVaultMeta({
+      body: { meta: JSON.stringify(meta) },
+    });
+    if (error || !data)
+      throw new Error("Failed to save the vault to the server.");
+    this.track(data);
+  }
+
+  async loadData(): Promise<VaultData | null> {
+    const vault = await this.fetch();
+    return parseVaultData(vault?.data);
+  }
+
+  async saveData(data: VaultData): Promise<void> {
+    const res = await saveVaultData({
+      body: { data: JSON.stringify(data), version: this.version },
+    });
+    if (res.response.status === 409) {
+      // Another session changed the vault since we last read it. Refresh the
+      // version so a retry (after the user reloads) can succeed.
+      await this.fetch().catch(() => null);
+      throw new Error(
+        "The vault was changed in another session. Reload the vault and try again.",
+      );
+    }
+    if (res.error || !res.data)
+      throw new Error("Failed to save the vault to the server.");
+    this.track(res.data);
+  }
+
+  async clear(): Promise<void> {
+    const { error, response } = await deleteVault();
+    // Resetting a vault that does not exist is a no-op, not an error.
+    if (error && response.status !== 404)
+      throw new Error("Failed to reset the vault on the server.");
+    versionRegistry.delete(this.key);
+  }
+
+  async loadSettings(): Promise<VaultSettings> {
+    const vault = await this.fetch().catch(() => null);
+    return parseVaultSettings(vault?.settings);
+  }
+
+  async saveSettings(settings: VaultSettings): Promise<void> {
+    const { data, error } = await saveVaultSettings({
+      body: { settings: JSON.stringify(settings) },
+    });
+    if (error || !data)
+      throw new Error("Failed to save the vault settings to the server.");
+    this.track(data);
+  }
+
+  // Legacy keys predate the vault and only ever lived in this browser's
+  // localStorage, so they are read locally even when the vault is on the
+  // server: initializing a vault migrates them into the encrypted blob.
+  loadLegacyKeys(): Promise<LegacyPrivateKey[]> {
+    return Promise.resolve(loadLegacyKeysFromStorage());
+  }
+
+  clearLegacyKeys(): Promise<void> {
+    clearLegacyKeysFromStorage();
+    return Promise.resolve();
+  }
+}

--- a/ui/apps/console/src/utils/vault-backend.ts
+++ b/ui/apps/console/src/utils/vault-backend.ts
@@ -6,13 +6,13 @@ import type {
 } from "@/types/vault";
 
 export interface IVaultBackend {
-  loadMeta(): VaultMeta | null;
-  saveMeta(meta: VaultMeta): void;
-  loadData(): VaultData | null;
-  saveData(data: VaultData): void;
-  clear(): void;
-  loadLegacyKeys(): LegacyPrivateKey[];
-  clearLegacyKeys(): void;
-  loadSettings(): VaultSettings;
-  saveSettings(settings: VaultSettings): void;
+  loadMeta(): Promise<VaultMeta | null>;
+  saveMeta(meta: VaultMeta): Promise<void>;
+  loadData(): Promise<VaultData | null>;
+  saveData(data: VaultData): Promise<void>;
+  clear(): Promise<void>;
+  loadLegacyKeys(): Promise<LegacyPrivateKey[]>;
+  clearLegacyKeys(): Promise<void>;
+  loadSettings(): Promise<VaultSettings>;
+  saveSettings(settings: VaultSettings): Promise<void>;
 }

--- a/ui/apps/console/src/utils/vault-migrate.ts
+++ b/ui/apps/console/src/utils/vault-migrate.ts
@@ -1,0 +1,81 @@
+import { LocalVaultBackend } from "@/utils/vault-backend-local";
+import { ServerVaultBackend } from "@/utils/vault-backend-server";
+import {
+  setVaultStorageMode,
+  type VaultScope,
+} from "@/utils/vault-backend-factory";
+
+export { localVaultExists } from "@/utils/vault-backend-local";
+
+/**
+ * Vault migration between local and server storage.
+ *
+ * The vault is an opaque encrypted blob, so moving it is a plain copy: no
+ * master password and no decryption involved. Migration always preserves a
+ * single source of truth — after copying, the origin is cleared and the
+ * storage mode preference flips.
+ */
+
+/** Whether a vault already exists on the server for the current user. */
+export async function serverVaultExists(scope?: VaultScope): Promise<boolean> {
+  const server = new ServerVaultBackend(scope);
+  return (await server.loadMeta()) !== null;
+}
+
+/**
+ * Copies the local vault to the server, clears the local copy, and switches
+ * the storage mode to "server". When the server already has a vault it is
+ * replaced — callers must get explicit confirmation for that first (see
+ * [serverVaultExists]).
+ */
+export async function migrateLocalToServer(scope?: VaultScope): Promise<void> {
+  const local = new LocalVaultBackend(scope);
+  const server = new ServerVaultBackend(scope);
+
+  const meta = await local.loadMeta();
+  if (!meta) throw new Error("No local vault to migrate.");
+  const data = await local.loadData();
+  const settings = await local.loadSettings();
+
+  // Drop any existing server vault so the upload starts from version 1.
+  await server.clear();
+
+  await server.saveMeta(meta);
+  if (data) await server.saveData(data);
+  await server.saveSettings(settings);
+
+  await local.clear();
+  setVaultStorageMode("server", scope);
+}
+
+/**
+ * Adopts the existing server vault, discarding the local one, and switches
+ * the storage mode to "server". Used when migrating and the user chooses the
+ * vault that already exists on their account.
+ */
+export async function adoptServerVault(scope?: VaultScope): Promise<void> {
+  const local = new LocalVaultBackend(scope);
+  await local.clear();
+  setVaultStorageMode("server", scope);
+}
+
+/**
+ * Copies the server vault to local storage, removes it from the server, and
+ * switches the storage mode to "local".
+ */
+export async function migrateServerToLocal(scope?: VaultScope): Promise<void> {
+  const local = new LocalVaultBackend(scope);
+  const server = new ServerVaultBackend(scope);
+
+  const meta = await server.loadMeta();
+  if (!meta) throw new Error("No synced vault to migrate.");
+  const data = await server.loadData();
+  const settings = await server.loadSettings();
+
+  await local.saveMeta(meta);
+  if (data) await local.saveData(data);
+  await local.saveSettings(settings);
+
+  await server.clear();
+  setVaultStorageMode("local", scope);
+}

--- a/ui/apps/console/src/utils/vault-parse.ts
+++ b/ui/apps/console/src/utils/vault-parse.ts
@@ -1,0 +1,64 @@
+import type { VaultMeta, VaultData, VaultSettings } from "@/types/vault";
+import { ALLOWED_TIMEOUT_MINUTES, DEFAULT_VAULT_SETTINGS } from "@/types/vault";
+
+function safeParse(raw: string | null | undefined): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function parseVaultMeta(
+  raw: string | null | undefined,
+): VaultMeta | null {
+  const parsed = safeParse(raw) as Record<string, unknown> | null;
+  if (
+    !parsed ||
+    parsed.version !== 1 ||
+    typeof parsed.salt !== "string" ||
+    typeof parsed.iterations !== "number" ||
+    !Number.isInteger(parsed.iterations) ||
+    parsed.iterations < 100_000 ||
+    parsed.iterations > 10_000_000 ||
+    typeof parsed.verifier !== "string" ||
+    typeof parsed.verifierIv !== "string"
+  )
+    return null;
+  return parsed as unknown as VaultMeta;
+}
+
+export function parseVaultData(
+  raw: string | null | undefined,
+): VaultData | null {
+  const parsed = safeParse(raw) as Record<string, unknown> | null;
+  if (
+    !parsed ||
+    typeof parsed.iv !== "string" ||
+    typeof parsed.ciphertext !== "string"
+  )
+    return null;
+  return parsed as unknown as VaultData;
+}
+
+export function parseVaultSettings(
+  raw: string | null | undefined,
+): VaultSettings {
+  const parsed = safeParse(raw) as Record<string, unknown> | null;
+  if (!parsed) return { ...DEFAULT_VAULT_SETTINGS };
+
+  const rawTimeout = parsed.autoLockTimeoutMinutes;
+  const autoLockTimeoutMinutes =
+    typeof rawTimeout === "number" &&
+    (ALLOWED_TIMEOUT_MINUTES as readonly number[]).includes(rawTimeout)
+      ? rawTimeout
+      : DEFAULT_VAULT_SETTINGS.autoLockTimeoutMinutes;
+
+  const lockOnHidden =
+    typeof parsed.lockOnHidden === "boolean"
+      ? parsed.lockOnHidden
+      : DEFAULT_VAULT_SETTINGS.lockOnHidden;
+
+  return { autoLockTimeoutMinutes, lockOnHidden };
+}


### PR DESCRIPTION
## What

Adds optional server-side storage for the SSH key vault. Until now the
vault was local-only: the encrypted blob lived in `localStorage`, so it
was tied to a single browser and lost on a cache clear. On
Cloud/Enterprise the vault can now live on the server and follow the user
across machines.

Encryption stays in the browser — the server only ever stores an opaque
encrypted blob, so zero-knowledge is preserved.

- `IVaultBackend` is now async; new `ServerVaultBackend` talks to
  `/api/vault` through the generated client, selected by a per-scope
  storage mode (CE stays local).
- The setup dialog lets the user choose where the vault lives (this
  device vs the ShellHub server).
- A sync flow migrates an existing vault between local and server, with
  an explicit choice when both sides already hold a vault.
- The vault version is tracked in a module registry keyed by scope, so
  optimistic concurrency holds even though the store builds a fresh
  backend per operation.
- Adds the OpenAPI spec for `/api/vault` under the enterprise/cloud
  edition tag.

## Why

The vault is only useful if the keys are there when you need them. Local
storage made it fragile (clear cache, lose keys) and non-portable (new
machine, empty vault). Server storage fixes both without weakening the
zero-knowledge model.

Depends on the backend in shellhub-io/cloud#2399 — keep
`do-not-merge` until that lands and the flow is verified end to end.

## How to test

1. Bring up the stack in enterprise mode with a valid license.
2. Open the vault, create it, and pick "Sync to the ShellHub server".
3. Add a key, open another browser profile, unlock with the same master
   password — the key is there.
4. Switch storage back to this device from vault settings and confirm the
   vault moves back to local.
