### PR TITLE
docs(openapi): bound vault request field sizes

### DIFF
--- a/openapi/spec/paths/api@vault@data.yaml
+++ b/openapi/spec/paths/api@vault@data.yaml
@@ -21,11 +21,13 @@ put:
             data:
               description: Encrypted vault data, as an opaque JSON string.
               type: string
+              maxLength: 1048576
               example: '{"iv":"aXY=","ciphertext":"Y2lwaGVydGV4dA=="}'
             version:
               description: The vault version this write is based on.
               type: integer
               format: int64
+              minimum: 1
               example: 1
           required:
             - data

--- a/openapi/spec/paths/api@vault@meta.yaml
+++ b/openapi/spec/paths/api@vault@meta.yaml
@@ -20,6 +20,7 @@ put:
             meta:
               description: Vault metadata, as an opaque JSON string.
               type: string
+              maxLength: 4096
               example: '{"version":1,"salt":"c2FsdA==","iterations":600000,"verifier":"dg==","verifierIv":"aXY="}'
           required:
             - meta

--- a/openapi/spec/paths/api@vault@settings.yaml
+++ b/openapi/spec/paths/api@vault@settings.yaml
@@ -19,6 +19,7 @@ put:
             settings:
               description: Vault settings, as an opaque JSON string.
               type: string
+              maxLength: 4096
               example: '{"autoLockTimeoutMinutes":5,"lockOnHidden":true}'
           required:
             - settings


### PR DESCRIPTION
## What

Adds `maxLength` to the vault `PUT` request bodies in the OpenAPI spec —
`meta` and `settings` at 4 KiB, `data` at 1 MiB — and `minimum: 1` on the
data `version`.

## Why

The vault server-side store (#6478) landed without these bounds in the
spec. shellhub-io/cloud#2399 adds the matching `max=`/`min=` validation
on the server; this keeps the published contract in sync so consumers see
the real limits.

Spec-only change, no code. Pairs with shellhub-io/cloud#2399 —
`do-not-merge` until that lands.