### PR TITLE
fix(billing): show portal button in canceled/incomplete_expired

### DIFF
--- a/ui/apps/console/src/components/billing/BillingSection.tsx
+++ b/ui/apps/console/src/components/billing/BillingSection.tsx
@@ -237,7 +237,11 @@ export default function BillingSection({ sectionId }: BillingSectionProps) {
     isActiveLike ||
     status === "unpaid" ||
     status === "paused" ||
-    status === "incomplete";
+    status === "incomplete" ||
+    // canceled/incomplete_expired retain a Stripe customer_id and subscription_id;
+    // they may carry an open invoice the 402 re-subscribe path directs here to settle.
+    status === "canceled" ||
+    status === "incomplete_expired";
 
   const dateDescription = (() => {
     if (!endAt) return "—";

--- a/ui/apps/console/src/components/billing/__tests__/BillingSection.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/BillingSection.test.tsx
@@ -197,6 +197,22 @@ describe("BillingSection — Subscribe button visibility", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows portal button when status is 'canceled'", () => {
+    setStatus("canceled");
+    renderSection();
+    expect(
+      screen.getByRole("button", { name: /open portal/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows portal button when status is 'incomplete_expired'", () => {
+    setStatus("incomplete_expired");
+    renderSection();
+    expect(
+      screen.getByRole("button", { name: /open portal/i }),
+    ).toBeInTheDocument();
+  });
+
   it("does not show Subscribe button when status is 'active'", () => {
     setStatus("active");
     renderSection();


### PR DESCRIPTION
## What

Render the **Open portal** button in the console Billing section when the subscription is `canceled` or `incomplete_expired`.

## Why

`canReopenPortal` previously omitted `canceled` and `incomplete_expired`. In those states the namespace still holds a Stripe `customer_id` and `subscription_id` and may carry an open/unpaid invoice. When the user tries to re-subscribe, `CreateSubscription` returns HTTP `402` and the subscribe dialog instructs them to "open the billing portal to settle them" — but the portal button was hidden, leaving a dead-end on the failed-payment recovery path (Stripe dunning auto-cancels the subscription with reason `payment_failed`, while the open invoice remains).

## Changes

- **BillingSection**: add `canceled` and `incomplete_expired` to `canReopenPortal`, so the portal button is reachable exactly when the `402` re-subscribe error directs the user there. Safe because these states always retain a valid Stripe customer — a deleted customer surfaces as `inactive`, never `canceled`.
- **tests**: assert the **Open portal** button renders for both `canceled` and `incomplete_expired`.

## Testing

Reach a `canceled` subscription that still holds an open invoice (fail a renewal via a Stripe test clock, let dunning cancel it), then open Settings → Billing: the **Open portal** button should now appear alongside **Subscribe**. `eslint` and the full billing suite (125 tests) pass.
