### PR TITLE
test(api): add route handler tests for tag endpoints

### DIFF
--- a/api/routes/tags_test.go
+++ b/api/routes/tags_test.go
@@ -1,17 +1,23 @@
 package routes
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
+	svc "github.com/shellhub-io/shellhub/api/services"
 	"github.com/shellhub-io/shellhub/api/services/mocks"
+	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	gomock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTags(t *testing.T) {
@@ -118,4 +124,755 @@ func TestGetTags(t *testing.T) {
 	}
 
 	svcMock.AssertExpectations(t)
+}
+
+func TestDeleteTag(t *testing.T) {
+	// Only observer lacks tag permissions; operator, administrator, and owner all hold them — do not test those as forbidden.
+	cases := []struct {
+		description    string
+		url            string
+		headers        map[string]string
+		requiredMocks  func(svcMock *mocks.Service)
+		expectedStatus int
+	}{
+		{
+			description: "fails when role is observer (new URL)",
+			url:         "/api/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleObserver.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks:  func(_ *mocks.Service) {},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			description: "fails when role is observer (legacy URL)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/tags/production",
+			headers: map[string]string{
+				"X-Role": authorizer.RoleObserver.String(),
+				"X-ID":   "000000000000000000000000",
+			},
+			requiredMocks:  func(_ *mocks.Service) {},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			description: "fails when service returns ErrNamespaceNotFound",
+			url:         "/api/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleOwner.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("DeleteTag", gomock.Anything, &requests.DeleteTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+					}).
+					Return(svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
+					Once()
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description: "succeeds with 200 and no body (new URL)",
+			url:         "/api/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleOwner.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("DeleteTag", gomock.Anything, &requests.DeleteTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+					}).
+					Return(nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			description: "succeeds via legacy URL (tenant from path param)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/tags/production",
+			headers: map[string]string{
+				"X-Role": authorizer.RoleOwner.String(),
+				"X-ID":   "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("DeleteTag", gomock.Anything, &requests.DeleteTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+					}).
+					Return(nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			svcMock := new(mocks.Service)
+			tc.requiredMocks(svcMock)
+
+			req := httptest.NewRequest(http.MethodDelete, tc.url, nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+
+			e := NewRouter(svcMock)
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+
+			svcMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCreateTag(t *testing.T) {
+	type Expected struct {
+		status     int
+		insertedID string
+		conflicts  []string
+	}
+
+	// Only observer lacks tag permissions; operator, administrator, and owner all hold them — do not test those as forbidden.
+	cases := []struct {
+		description   string
+		url           string
+		headers       map[string]string
+		body          map[string]interface{}
+		requiredMocks func(svcMock *mocks.Service)
+		expected      Expected
+	}{
+		{
+			description: "fails when role is observer (new URL)",
+			url:         "/api/tags",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleObserver.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "production",
+			},
+			requiredMocks: func(_ *mocks.Service) {},
+			expected:      Expected{status: http.StatusForbidden},
+		},
+		{
+			description: "fails when role is observer (legacy URL)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/tags",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Role":       authorizer.RoleObserver.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "production",
+			},
+			requiredMocks: func(_ *mocks.Service) {},
+			expected:      Expected{status: http.StatusForbidden},
+		},
+		{
+			description: "fails when name is too short (< 3 chars)",
+			url:         "/api/tags",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "a",
+			},
+			requiredMocks: func(_ *mocks.Service) {},
+			expected:      Expected{status: http.StatusBadRequest},
+		},
+		{
+			description: "fails when service returns ErrNamespaceNotFound",
+			url:         "/api/tags",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "production",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("CreateTag", gomock.Anything, &requests.CreateTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+					}).
+					Return("", []string{}, svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
+					Once()
+			},
+			expected: Expected{status: http.StatusNotFound},
+		},
+		{
+			description: "succeeds with 200 and X-Inserted-ID header (new URL)",
+			url:         "/api/tags",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "production",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("CreateTag", gomock.Anything, &requests.CreateTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+					}).
+					Return("000000000000000000000001", []string{}, nil).
+					Once()
+			},
+			expected: Expected{
+				status:     http.StatusOK,
+				insertedID: "000000000000000000000001",
+			},
+		},
+		{
+			description: "returns 409 with conflicts JSON body",
+			url:         "/api/tags",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "production",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("CreateTag", gomock.Anything, &requests.CreateTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+					}).
+					Return("", []string{"name"}, nil).
+					Once()
+			},
+			expected: Expected{
+				status:    http.StatusConflict,
+				conflicts: []string{"name"},
+			},
+		},
+		{
+			description: "succeeds via legacy URL (tenant from path param)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/tags",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "production",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("CreateTag", gomock.Anything, &requests.CreateTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+					}).
+					Return("000000000000000000000002", []string{}, nil).
+					Once()
+			},
+			expected: Expected{
+				status:     http.StatusOK,
+				insertedID: "000000000000000000000002",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			svcMock := new(mocks.Service)
+			tc.requiredMocks(svcMock)
+
+			data, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, tc.url, strings.NewReader(string(data)))
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+
+			e := NewRouter(svcMock)
+			e.ServeHTTP(rec, req)
+
+			res := rec.Result()
+			assert.Equal(t, tc.expected.status, res.StatusCode)
+
+			if tc.expected.insertedID != "" {
+				assert.Equal(t, tc.expected.insertedID, res.Header.Get("X-Inserted-ID"))
+			}
+
+			if tc.expected.conflicts != nil {
+				var body map[string][]string
+				require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+				assert.Equal(t, tc.expected.conflicts, body["conflicts"])
+			}
+
+			svcMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestUpdateTag(t *testing.T) {
+	type Expected struct {
+		status    int
+		conflicts []string
+	}
+
+	// Only observer lacks tag permissions; operator, administrator, and owner all hold them — do not test those as forbidden.
+	cases := []struct {
+		description   string
+		url           string
+		headers       map[string]string
+		body          map[string]interface{}
+		requiredMocks func(svcMock *mocks.Service)
+		expected      Expected
+	}{
+		{
+			description: "fails when role is observer (new URL)",
+			url:         "/api/tags/production",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleObserver.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "staging",
+			},
+			requiredMocks: func(_ *mocks.Service) {},
+			expected:      Expected{status: http.StatusForbidden},
+		},
+		{
+			description: "fails when role is observer (legacy URL)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/tags/production",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Role":       authorizer.RoleObserver.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "staging",
+			},
+			requiredMocks: func(_ *mocks.Service) {},
+			expected:      Expected{status: http.StatusForbidden},
+		},
+		{
+			description: "fails when NewName is too short (< 3 chars)",
+			url:         "/api/tags/production",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "ab",
+			},
+			requiredMocks: func(_ *mocks.Service) {},
+			expected:      Expected{status: http.StatusBadRequest},
+		},
+		{
+			description: "fails when service returns ErrNamespaceNotFound",
+			url:         "/api/tags/production",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "staging",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("UpdateTag", gomock.Anything, &requests.UpdateTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						NewName:  "staging",
+					}).
+					Return([]string{}, svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
+					Once()
+			},
+			expected: Expected{status: http.StatusNotFound},
+		},
+		{
+			description: "succeeds with 200 and no body (new URL)",
+			url:         "/api/tags/production",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "staging",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("UpdateTag", gomock.Anything, &requests.UpdateTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						NewName:  "staging",
+					}).
+					Return([]string{}, nil).
+					Once()
+			},
+			expected: Expected{status: http.StatusOK},
+		},
+		{
+			description: "succeeds via legacy URL (tenant from path param)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/tags/production",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "staging",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("UpdateTag", gomock.Anything, &requests.UpdateTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						NewName:  "staging",
+					}).
+					Return([]string{}, nil).
+					Once()
+			},
+			expected: Expected{status: http.StatusOK},
+		},
+		{
+			description: "returns 409 with conflicts JSON body",
+			url:         "/api/tags/production",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       authorizer.RoleOwner.String(),
+				"X-ID":         "000000000000000000000000",
+			},
+			body: map[string]interface{}{
+				"name": "staging",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("UpdateTag", gomock.Anything, &requests.UpdateTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						NewName:  "staging",
+					}).
+					Return([]string{"name"}, nil).
+					Once()
+			},
+			expected: Expected{
+				status:    http.StatusConflict,
+				conflicts: []string{"name"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			svcMock := new(mocks.Service)
+			tc.requiredMocks(svcMock)
+
+			data, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPatch, tc.url, strings.NewReader(string(data)))
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+
+			e := NewRouter(svcMock)
+			e.ServeHTTP(rec, req)
+
+			res := rec.Result()
+			assert.Equal(t, tc.expected.status, res.StatusCode)
+
+			if tc.expected.conflicts != nil {
+				var body map[string][]string
+				require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+				assert.Equal(t, tc.expected.conflicts, body["conflicts"])
+			}
+
+			svcMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestPushTagToDevice(t *testing.T) {
+	const deviceUID = "aabbccddee00112233445566778899aabbccddee"
+
+	// Only observer lacks tag permissions; operator, administrator, and owner all hold them — do not test those as forbidden.
+	cases := []struct {
+		description    string
+		url            string
+		headers        map[string]string
+		requiredMocks  func(svcMock *mocks.Service)
+		expectedStatus int
+	}{
+		{
+			description: "fails when role is observer (new URL)",
+			url:         "/api/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleObserver.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks:  func(_ *mocks.Service) {},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			description: "fails when role is observer (legacy URL)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Role": authorizer.RoleObserver.String(),
+				"X-ID":   "000000000000000000000000",
+			},
+			requiredMocks:  func(_ *mocks.Service) {},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			description: "fails when tag name is too short (< 3 chars)",
+			url:         "/api/devices/" + deviceUID + "/tags/ab",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleOwner.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks:  func(_ *mocks.Service) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			description: "fails when service returns ErrNamespaceNotFound",
+			url:         "/api/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleOwner.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("PushTagTo", gomock.Anything, store.TagTargetDevice, &requests.PushTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						TargetID: deviceUID,
+					}).
+					Return(svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
+					Once()
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description: "succeeds with 200 and no body (new URL)",
+			url:         "/api/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleOwner.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("PushTagTo", gomock.Anything, store.TagTargetDevice, &requests.PushTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						TargetID: deviceUID,
+					}).
+					Return(nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			description: "succeeds via legacy URL (tenant from path param)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Role": authorizer.RoleOwner.String(),
+				"X-ID":   "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("PushTagTo", gomock.Anything, store.TagTargetDevice, &requests.PushTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						TargetID: deviceUID,
+					}).
+					Return(nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			svcMock := new(mocks.Service)
+			tc.requiredMocks(svcMock)
+
+			req := httptest.NewRequest(http.MethodPost, tc.url, nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+
+			e := NewRouter(svcMock)
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+
+			svcMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestPullTagFromDevice(t *testing.T) {
+	const deviceUID = "aabbccddee00112233445566778899aabbccddee"
+
+	// Only observer lacks tag permissions; operator, administrator, and owner all hold them — do not test those as forbidden.
+	cases := []struct {
+		description    string
+		url            string
+		headers        map[string]string
+		requiredMocks  func(svcMock *mocks.Service)
+		expectedStatus int
+	}{
+		{
+			description: "fails when role is observer (new URL)",
+			url:         "/api/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleObserver.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks:  func(_ *mocks.Service) {},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			description: "fails when role is observer (legacy URL)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Role": authorizer.RoleObserver.String(),
+				"X-ID":   "000000000000000000000000",
+			},
+			requiredMocks:  func(_ *mocks.Service) {},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
+			description: "fails when tag name is too short (< 3 chars)",
+			url:         "/api/devices/" + deviceUID + "/tags/ab",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleOwner.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks:  func(_ *mocks.Service) {},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			description: "fails when service returns ErrNamespaceNotFound",
+			url:         "/api/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleOwner.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("PullTagFrom", gomock.Anything, store.TagTargetDevice, &requests.PullTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						TargetID: deviceUID,
+					}).
+					Return(svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
+					Once()
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			description: "succeeds with 200 and no body (new URL)",
+			url:         "/api/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Tenant-ID": "00000000-0000-4000-0000-000000000000",
+				"X-Role":      authorizer.RoleOwner.String(),
+				"X-ID":        "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("PullTagFrom", gomock.Anything, store.TagTargetDevice, &requests.PullTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						TargetID: deviceUID,
+					}).
+					Return(nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			description: "succeeds via legacy URL (tenant from path param)",
+			url:         "/api/namespaces/00000000-0000-4000-0000-000000000000/devices/" + deviceUID + "/tags/production",
+			headers: map[string]string{
+				"X-Role": authorizer.RoleOwner.String(),
+				"X-ID":   "000000000000000000000000",
+			},
+			requiredMocks: func(svcMock *mocks.Service) {
+				svcMock.
+					On("PullTagFrom", gomock.Anything, store.TagTargetDevice, &requests.PullTag{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "production",
+						TargetID: deviceUID,
+					}).
+					Return(nil).
+					Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			svcMock := new(mocks.Service)
+			tc.requiredMocks(svcMock)
+
+			req := httptest.NewRequest(http.MethodDelete, tc.url, nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+
+			e := NewRouter(svcMock)
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+
+			svcMock.AssertExpectations(t)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Adds route-layer tests for the five tag HTTP handlers that previously had no coverage. They are appended to the existing `api/routes/tags_test.go` (which already holds `TestGetTags`). Addresses shellhub-io/team#116.

The route layer enforces HTTP concerns the service tests (`api/services/tags_test.go`) don't reach: authorization enforcement, request binding/validation, status-code mapping, and response shape (the `X-Inserted-ID` header, the `{"conflicts":[...]}` body).

Each handler is exercised over **both** the new header-based URLs (`/tags`, `/devices/:uid/tags/:name`) and the legacy `/namespaces/:tenant/...` URLs:

| Handler | Cases |
|---|---|
| `CreateTag` | observer→403, validation→400, service err→404, success→200 + `X-Inserted-ID`, conflict→409 `{"conflicts":[...]}` |
| `UpdateTag` | observer→403, validation→400, service err→404, success→200, conflict→409 `{"conflicts":[...]}` |
| `DeleteTag` | observer→403, service err→404, success→200 |
| `PushTagToDevice` | observer→403, validation→400, service err→404, success→200 (asserts `TargetID` bound from `:uid` + `store.TagTargetDevice`) |
| `PullTagFromDevice` | observer→403, validation→400, service err→404, success→200 |

`GetTags` was already covered on `master` and is left unchanged.

## Notes

- Only `observer` is exercised as the unauthorized role — `operator`, `administrator`, and `owner` all hold tag permissions.
- Role headers use the `authorizer.Role*.String()` constants, matching the existing `TestGetTags`.
- Each sub-test uses an isolated mock with `AssertExpectations`, which also confirms forbidden/validation cases make **zero** service calls.
- Test-only change — no production code touched.

Fixes: shellhub-io/team#116