### PR TITLE
fix(api): scope device name conflict check to namespace

### DIFF
--- a/api/services/device.go
+++ b/api/services/device.go
@@ -383,9 +383,11 @@ func (s *service) UpdateDevice(ctx context.Context, req *requests.DeviceUpdate) 
 		return nil
 	}
 
-	conflictsTarget := &models.DeviceConflicts{Name: req.Name}
+	// Device names are stored lower-cased, so match on the lower-cased value. Scope the lookup
+	// to the device's namespace: a name used in another namespace is not a conflict.
+	conflictsTarget := &models.DeviceConflicts{Name: strings.ToLower(req.Name)}
 	conflictsTarget.Distinct(device)
-	if _, has, err := s.store.DeviceConflicts(ctx, conflictsTarget); err != nil || has {
+	if _, has, err := s.store.DeviceConflicts(ctx, conflictsTarget, s.store.Options().InNamespace(req.TenantID)); err != nil || has {
 		return NewErrDeviceDuplicated(req.Name, err)
 	}
 

--- a/api/services/device_test.go
+++ b/api/services/device_test.go
@@ -2261,13 +2261,13 @@ func TestDeviceUpdate(t *testing.T) {
 				queryOptionsMock.
 					On("InNamespace", "00000000-0000-0000-0000-000000000000").
 					Return(nil).
-					Once()
+					Twice()
 				storeMock.
 					On("DeviceResolve", ctx, store.DeviceUIDResolver, "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e", mock.AnythingOfType("store.QueryOption")).
 					Return(device, nil).
 					Once()
 				storeMock.
-					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: "name"}).
+					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: "name"}, mock.AnythingOfType("store.QueryOption")).
 					Return([]string{"name"}, true, nil).
 					Once()
 			},
@@ -2318,13 +2318,13 @@ func TestDeviceUpdate(t *testing.T) {
 				queryOptionsMock.
 					On("InNamespace", "00000000-0000-0000-0000-000000000000").
 					Return(nil).
-					Once()
+					Twice()
 				storeMock.
 					On("DeviceResolve", ctx, store.DeviceUIDResolver, "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e", mock.AnythingOfType("store.QueryOption")).
 					Return(device, nil).
 					Once()
 				storeMock.
-					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: "newname"}).
+					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: "newname"}, mock.AnythingOfType("store.QueryOption")).
 					Return([]string{}, false, nil).
 					Once()
 				storeMock.
@@ -2355,13 +2355,13 @@ func TestDeviceUpdate(t *testing.T) {
 				queryOptionsMock.
 					On("InNamespace", "00000000-0000-0000-0000-000000000000").
 					Return(nil).
-					Once()
+					Twice()
 				storeMock.
 					On("DeviceResolve", ctx, store.DeviceUIDResolver, "d6c6a5e97217bbe4467eae46ab004695a766c5c43f70b95efd4b6a4d32b33c6e", mock.AnythingOfType("store.QueryOption")).
 					Return(device, nil).
 					Once()
 				storeMock.
-					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: "NewName"}).
+					On("DeviceConflicts", ctx, &models.DeviceConflicts{Name: "newname"}, mock.AnythingOfType("store.QueryOption")).
 					Return([]string{}, false, nil).
 					Once()
 				storeMock.

--- a/api/store/device.go
+++ b/api/store/device.go
@@ -45,7 +45,10 @@ type DeviceStore interface {
 	//  conflicts, has, err := store.DeviceConflicts(ctx, &models.DeviceConflicts{Name: "mydevice"})
 	//
 	// It returns an array of conflicting attribute fields and an error, if any.
-	DeviceConflicts(ctx context.Context, target *models.DeviceConflicts) (conflicts []string, has bool, err error)
+	//
+	// Only accepted devices are considered conflicting. Scope the lookup to a namespace by
+	// passing the InNamespace query option; without it the check spans every namespace.
+	DeviceConflicts(ctx context.Context, target *models.DeviceConflicts, opts ...QueryOption) (conflicts []string, has bool, err error)
 
 	// DeviceUpdate updates a device. It returns [ErrNoDocuments] if none device is found.
 	DeviceUpdate(ctx context.Context, device *models.Device) error

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -284,9 +284,16 @@ func (_m *Store) ActiveSessionUpdate(ctx context.Context, activeSession *models.
 	return r0
 }
 
-// DeviceConflicts provides a mock function with given fields: ctx, target
-func (_m *Store) DeviceConflicts(ctx context.Context, target *models.DeviceConflicts) ([]string, bool, error) {
-	ret := _m.Called(ctx, target)
+// DeviceConflicts provides a mock function with given fields: ctx, target, opts
+func (_m *Store) DeviceConflicts(ctx context.Context, target *models.DeviceConflicts, opts ...store.QueryOption) ([]string, bool, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, target)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeviceConflicts")
@@ -295,25 +302,25 @@ func (_m *Store) DeviceConflicts(ctx context.Context, target *models.DeviceConfl
 	var r0 []string
 	var r1 bool
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, *models.DeviceConflicts) ([]string, bool, error)); ok {
-		return rf(ctx, target)
+	if rf, ok := ret.Get(0).(func(context.Context, *models.DeviceConflicts, ...store.QueryOption) ([]string, bool, error)); ok {
+		return rf(ctx, target, opts...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *models.DeviceConflicts) []string); ok {
-		r0 = rf(ctx, target)
+	if rf, ok := ret.Get(0).(func(context.Context, *models.DeviceConflicts, ...store.QueryOption) []string); ok {
+		r0 = rf(ctx, target, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *models.DeviceConflicts) bool); ok {
-		r1 = rf(ctx, target)
+	if rf, ok := ret.Get(1).(func(context.Context, *models.DeviceConflicts, ...store.QueryOption) bool); ok {
+		r1 = rf(ctx, target, opts...)
 	} else {
 		r1 = ret.Get(1).(bool)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, *models.DeviceConflicts) error); ok {
-		r2 = rf(ctx, target)
+	if rf, ok := ret.Get(2).(func(context.Context, *models.DeviceConflicts, ...store.QueryOption) error); ok {
+		r2 = rf(ctx, target, opts...)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/api/store/pg/device.go
+++ b/api/store/pg/device.go
@@ -25,25 +25,28 @@ func (pg *Pg) DeviceCreate(ctx context.Context, device *models.Device) (string, 
 	return e.ID, nil
 }
 
-func (pg *Pg) DeviceConflicts(ctx context.Context, target *models.DeviceConflicts) ([]string, bool, error) {
+func (pg *Pg) DeviceConflicts(ctx context.Context, target *models.DeviceConflicts, opts ...store.QueryOption) ([]string, bool, error) {
 	db := pg.GetConnection(ctx)
 
 	if target.Name == "" {
 		return []string{}, false, nil
 	}
 
+	// A name only conflicts with an accepted device; pending/rejected/removed don't hold a name.
+	// Namespace scoping comes from opts (InNamespace), so a name used in another namespace is not
+	// a conflict. Keep the predicates ANDed: chaining with WhereGroup(" OR ", ...) would let the
+	// name match satisfy the query on its own and silently disable the status filter.
 	devices := make([]entity.Device, 0)
 	query := db.NewSelect().
 		Model(&devices).
 		Column("name").
-		Where("status != ?", models.DeviceStatusRemoved).
-		WhereGroup(" OR ", func(q *bun.SelectQuery) *bun.SelectQuery {
-			if target.Name != "" {
-				q = q.Where("name = ?", target.Name)
-			}
+		Where("status = ?", models.DeviceStatusAccepted).
+		Where("name = ?", target.Name)
 
-			return q
-		})
+	var err error
+	if query, err = applyOptions(ctx, query, opts...); err != nil {
+		return nil, false, err
+	}
 
 	if err := query.Scan(ctx); err != nil {
 		return nil, false, fromSQLError(err)
@@ -51,7 +54,7 @@ func (pg *Pg) DeviceConflicts(ctx context.Context, target *models.DeviceConflict
 
 	seen := make(map[string]bool)
 	for _, device := range devices {
-		if target.Name != "" && device.Name == target.Name {
+		if device.Name == target.Name {
 			seen["name"] = true
 		}
 	}

--- a/api/store/storetest/device_tests.go
+++ b/api/store/storetest/device_tests.go
@@ -523,6 +523,46 @@ func (s *Suite) TestDeviceConflicts(t *testing.T) {
 		assert.ElementsMatch(t, []string{"name"}, conflicts)
 		assert.True(t, ok)
 	})
+
+	t.Run("no conflict when the same name lives in another namespace", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		nsA := s.CreateNamespace(t)
+		nsB := s.CreateNamespace(t)
+		s.CreateDevice(t, WithDeviceName("shared"), WithTenantID(nsA))
+
+		// Scoped to namespace B, an accepted "shared" in namespace A must not conflict.
+		conflicts, ok, err := st.DeviceConflicts(ctx, &models.DeviceConflicts{Name: "shared"}, st.Options().InNamespace(nsB))
+		require.NoError(t, err)
+		assert.Empty(t, conflicts)
+		assert.False(t, ok)
+	})
+
+	t.Run("conflict when the same name lives in the same namespace", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		nsA := s.CreateNamespace(t)
+		s.CreateDevice(t, WithDeviceName("shared"), WithTenantID(nsA))
+
+		conflicts, ok, err := st.DeviceConflicts(ctx, &models.DeviceConflicts{Name: "shared"}, st.Options().InNamespace(nsA))
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"name"}, conflicts)
+		assert.True(t, ok)
+	})
+
+	t.Run("no conflict when the matching device is not accepted", func(t *testing.T) {
+		for _, status := range []models.DeviceStatus{models.DeviceStatusPending, models.DeviceStatusRejected, models.DeviceStatusRemoved} {
+			require.NoError(t, s.provider.CleanDatabase(t))
+
+			nsA := s.CreateNamespace(t)
+			s.CreateDevice(t, WithDeviceName("not-accepted"), WithTenantID(nsA), WithDeviceStatus(status))
+
+			conflicts, ok, err := st.DeviceConflicts(ctx, &models.DeviceConflicts{Name: "not-accepted"}, st.Options().InNamespace(nsA))
+			require.NoError(t, err, status)
+			assert.Empty(t, conflicts, status)
+			assert.False(t, ok, status)
+		}
+	})
 }
 
 // TestDeviceUpdate tests device updates


### PR DESCRIPTION
## What

Fixes two regressions in `DeviceConflicts`, the check that blocks renaming a device to a name already in use:

- **Cross-namespace leak.** The lookup ran over every namespace, so renaming a device could fail because an unrelated tenant already used the name, and the error revealed whether a name existed in another tenant.
- **Dead status filter.** Chaining the status predicate with `WhereGroup(" OR ", ...)` let the name match satisfy the query on its own, so the status filter never applied and even a removed device still counted as a conflict.

## Why

`DeviceConflicts` was introduced in a refactor (`a5730fffe`) that replaced `DeviceGetByName(ctx, name, tenantID, statusAccepted)` with a generic conflict abstraction. The new struct-based API had no field for tenant or status, so both scoping constraints were silently dropped. A later patch tried to restore the status filter but did so with the `WhereGroup(" OR ", ...)` that turned it into dead code.

## Changes

- Rewrite the query as accepted-only `AND` name match (predicates ANDed, no `OR` group).
- Add a variadic `opts ...QueryOption` to `DeviceConflicts`; `UpdateDevice` passes `InNamespace(req.TenantID)`.
- Lower-case `req.Name` before matching, since names are stored lower-cased.
- Update interface docs, mocks, and add storetest coverage.

Restores the namespace- and accepted-scoped behavior that predated the `DeviceConflicts` refactor.