### PR TITLE
feat(ui): increase `BillingPayment` error message text size

### DIFF
--- a/ui/apps/console/src/components/billing/BillingPayment.tsx
+++ b/ui/apps/console/src/components/billing/BillingPayment.tsx
@@ -414,7 +414,7 @@ function BillingPaymentInner({
       )}
 
       {error && (
-        <p role="alert" className="text-2xs text-accent-red">
+        <p role="alert" className="text-xs text-accent-red">
           {error}
         </p>
       )}


### PR DESCRIPTION
## What 

Increase the `BillingPayment` error message text size to `text-xs`.

## Why

The readability of that message was very bad due to the small size and red color. Increasing the text size improves it.