### PR TITLE
fix(ui): add a11y/react lint rules and fix all violations

### DIFF
--- a/ui/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui/apps/console/src/components/ConnectDrawer.tsx
@@ -304,7 +304,7 @@ export default function ConnectDrawer({
             value={state.username}
             onChange={(v) => dispatch({ type: "setUsername", value: v })}
             placeholder="e.g. root"
-            autoFocus={open}
+
           />
 
           {/* Auth Method */}

--- a/ui/apps/console/src/components/ManageTagsDrawer.tsx
+++ b/ui/apps/console/src/components/ManageTagsDrawer.tsx
@@ -244,7 +244,7 @@ export default function ManageTagsDrawer({
                           }
                           void handleRename(tag.name, true);
                         }}
-                        autoFocus
+
                         className={`w-full px-2.5 py-1 bg-card border rounded-md text-sm text-text-primary focus:outline-none focus:ring-1 transition-all ${
                           editNameChanged && !editNameValid
                             ? "border-accent-red/50 focus:ring-accent-red/20"

--- a/ui/apps/console/src/components/announcements/__tests__/AnnouncementModalTrigger.test.tsx
+++ b/ui/apps/console/src/components/announcements/__tests__/AnnouncementModalTrigger.test.tsx
@@ -29,7 +29,7 @@ vi.mock("../AnnouncementModal", () => ({
     open ? (
       <div data-testid="announcement-modal">
         <span data-testid="modal-title">{announcement.title}</span>
-        <button onClick={onClose}>Close</button>
+        <button type="button" onClick={onClose}>Close</button>
       </div>
     ) : null,
 }));

--- a/ui/apps/console/src/components/billing/__tests__/BillingDialog.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/BillingDialog.test.tsx
@@ -37,12 +37,13 @@ vi.mock("../BillingPayment", () => ({
       { "data-testid": "billing-payment" },
       React.createElement(
         "button",
-        { onClick: onHasDefault, "data-testid": "trigger-has-default" },
+        { type: "button", onClick: onHasDefault, "data-testid": "trigger-has-default" },
         "Set default",
       ),
       React.createElement(
         "button",
         {
+          type: "button",
           onClick: onNoPaymentMethods,
           "data-testid": "trigger-no-payment-methods",
         },

--- a/ui/apps/console/src/components/billing/__tests__/DeviceChooserTrigger.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/DeviceChooserTrigger.test.tsx
@@ -34,7 +34,7 @@ vi.mock("../DeviceChooserDialog", () => ({
       ? React.createElement(
           "div",
           { "data-testid": "device-chooser-dialog" },
-          React.createElement("button", { onClick: onClose }, "Dismiss"),
+          React.createElement("button", { type: "button", onClick: onClose }, "Dismiss"),
         )
       : null,
 }));

--- a/ui/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespace.tsx
@@ -55,7 +55,7 @@ function CloudForm() {
               setValidationError(null);
               createNs.reset();
             }}
-            autoFocus
+
             error={displayError}
           />
         </div>

--- a/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -44,7 +44,7 @@ function CloudForm({
           resetError();
         }}
         error={displayError}
-        autoFocus
+
       />
     </form>
   );

--- a/ui/apps/console/src/components/common/Drawer.tsx
+++ b/ui/apps/console/src/components/common/Drawer.tsx
@@ -1,7 +1,8 @@
-import { ReactNode } from "react";
+import { ReactNode, useRef } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 interface DrawerProps {
   open: boolean;
@@ -31,7 +32,9 @@ export default function Drawer({
   footer,
   bodyClassName,
 }: DrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
   useEscapeKey(onClose, open);
+  useFocusTrap(panelRef, open);
 
   return (
     <>
@@ -42,6 +45,7 @@ export default function Drawer({
         onClick={onClose}
       />
       <div
+        ref={panelRef}
         className={`fixed inset-y-0 right-0 z-[70] w-full ${WIDTH_MAP[width]} bg-surface border-l border-border shadow-2xl flex flex-col transition-transform duration-300 ease-out ${
           open ? "translate-x-0" : "translate-x-full"
         }`}

--- a/ui/apps/console/src/components/common/EmptyState.tsx
+++ b/ui/apps/console/src/components/common/EmptyState.tsx
@@ -124,7 +124,6 @@ export default function EmptyState({
         {/* Feature highlights */}
         {features?.length ? (
           <ul
-            role="list"
             className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-10"
           >
             {features.map((feature, idx) => (

--- a/ui/apps/console/src/components/common/ErrorBoundary.tsx
+++ b/ui/apps/console/src/components/common/ErrorBoundary.tsx
@@ -42,6 +42,7 @@ export default class ErrorBoundary extends Component<Props, State> {
           </h1>
           <p className="text-sm text-text-secondary mb-6">{error.message}</p>
           <button
+            type="button"
             onClick={() => window.location.reload()}
             className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary-600 transition-colors"
           >

--- a/ui/apps/console/src/components/common/Pagination.tsx
+++ b/ui/apps/console/src/components/common/Pagination.tsx
@@ -24,6 +24,7 @@ export default function Pagination({
       </span>
       <div className="flex items-center gap-1">
         <button
+          type="button"
           onClick={() => onPageChange(page - 1)}
           disabled={page <= 1}
           className="px-2.5 py-1 text-xs font-mono text-text-secondary hover:text-text-primary disabled:opacity-soft disabled:cursor-not-allowed transition-colors"
@@ -34,6 +35,7 @@ export default function Pagination({
           {page} / {totalPages}
         </span>
         <button
+          type="button"
           onClick={() => onPageChange(page + 1)}
           disabled={page >= totalPages}
           className="px-2.5 py-1 text-xs font-mono text-text-secondary hover:text-text-primary disabled:opacity-soft disabled:cursor-not-allowed transition-colors"

--- a/ui/apps/console/src/components/common/StatCard.tsx
+++ b/ui/apps/console/src/components/common/StatCard.tsx
@@ -43,6 +43,7 @@ export default function StatCard(props: StatCardProps) {
 
       {props.onClick ? (
         <button
+          type="button"
           onClick={props.onClick}
           className="text-xs font-medium text-primary hover:text-primary-400 transition-colors"
         >

--- a/ui/apps/console/src/components/common/TagFilterDropdown.tsx
+++ b/ui/apps/console/src/components/common/TagFilterDropdown.tsx
@@ -85,6 +85,7 @@ function TagFilterDropdown({
   return (
     <>
       <button
+        type="button"
         ref={triggerRef}
         onClick={() => setOpen(!open)}
         className={`flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-md border transition-all duration-150 ${
@@ -120,7 +121,6 @@ function TagFilterDropdown({
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Search tags..."
-                autoFocus
                 className="w-full px-2.5 py-1.5 bg-card border border-border rounded-lg text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
               />
             </div>
@@ -136,6 +136,7 @@ function TagFilterDropdown({
                   const active = filterTags.includes(tag);
                   return (
                     <button
+                      type="button"
                       key={tag}
                       onClick={() => {
                         if (active) onRemove(tag);
@@ -172,6 +173,7 @@ function TagFilterDropdown({
             <div className="p-2 border-t border-border space-y-1">
               {hasActive && (
                 <button
+                  type="button"
                   onClick={() => {
                     onClearAll();
                     setOpen(false);
@@ -183,6 +185,7 @@ function TagFilterDropdown({
               )}
               {onManageTags && (
                 <button
+                  type="button"
                   onClick={() => {
                     setOpen(false);
                     onManageTags();

--- a/ui/apps/console/src/components/common/__tests__/ClipboardProvider.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/ClipboardProvider.test.tsx
@@ -33,7 +33,7 @@ afterEach(() => {
 function CopyConsumer({ text = "test-text" }: { text?: string }) {
   const { copy, copied } = useCopy();
   return (
-    <button data-testid="copy-btn" onClick={() => copy(text)}>
+    <button type="button" data-testid="copy-btn" onClick={() => copy(text)}>
       {copied ? "Copied!" : "Copy"}
     </button>
   );

--- a/ui/apps/console/src/components/common/__tests__/CopyWarning.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/CopyWarning.test.tsx
@@ -58,6 +58,7 @@ function renderCopyWarning(
       <CopyWarning macro={macro} bypass={bypass}>
         {({ copy, copied }) => (
           <button
+            type="button"
             data-testid="copy-btn"
             onClick={() => copy("test-text")}
           >
@@ -388,6 +389,7 @@ describe("CopyWarning", () => {
             <CopyWarning ref={ref}>
               {() => (
                 <button
+                  type="button"
                   data-testid="setup-btn"
                   onClick={() => { handleRef.current = ref.current; }}
                 >

--- a/ui/apps/console/src/components/common/__tests__/Pagination.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/Pagination.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Pagination from "../Pagination";
+
+describe("Pagination", () => {
+  it("Prev and Next buttons have explicit type='button'", () => {
+    render(<Pagination page={1} totalPages={3} onPageChange={() => {}} />);
+    // must pass totalPages >= 2 so buttons render
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach((btn) => {
+      expect(btn).toHaveAttribute("type", "button");
+    });
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/RestrictedAction.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/RestrictedAction.test.tsx
@@ -17,7 +17,7 @@ describe("RestrictedAction", () => {
     it("renders the child element", () => {
       render(
         <RestrictedAction action="publicKey:create">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       expect(screen.getByRole("button", { name: "Add Key" })).toBeInTheDocument();
@@ -26,7 +26,7 @@ describe("RestrictedAction", () => {
     it("does not wrap children in a disabled container", () => {
       render(
         <RestrictedAction action="publicKey:create">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       const button = screen.getByRole("button", { name: "Add Key" });
@@ -38,7 +38,7 @@ describe("RestrictedAction", () => {
       let clicked = false;
       render(
         <RestrictedAction action="publicKey:create">
-          <button onClick={() => { clicked = true; }}>Add Key</button>
+          <button type="button" onClick={() => { clicked = true; }}>Add Key</button>
         </RestrictedAction>,
       );
       await user.click(screen.getByRole("button", { name: "Add Key" }));
@@ -54,7 +54,7 @@ describe("RestrictedAction", () => {
     it("still renders the child element (visible but restricted)", () => {
       render(
         <RestrictedAction action="publicKey:create">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       expect(screen.getByRole("button", { name: "Add Key" })).toBeInTheDocument();
@@ -63,7 +63,7 @@ describe("RestrictedAction", () => {
     it("wraps children in a container with aria-disabled=true", () => {
       render(
         <RestrictedAction action="publicKey:create">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       const button = screen.getByRole("button", { name: "Add Key" });
@@ -74,7 +74,7 @@ describe("RestrictedAction", () => {
     it("shows the default restriction message as a title tooltip", () => {
       render(
         <RestrictedAction action="publicKey:create">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       const button = screen.getByRole("button", { name: "Add Key" });
@@ -85,7 +85,7 @@ describe("RestrictedAction", () => {
     it("shows a custom message when provided", () => {
       render(
         <RestrictedAction action="publicKey:create" message="Admins only.">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       const button = screen.getByRole("button", { name: "Add Key" });
@@ -96,7 +96,7 @@ describe("RestrictedAction", () => {
     it("prevents click events on children via pointer-events-none", () => {
       render(
         <RestrictedAction action="publicKey:create">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       const button = screen.getByRole("button", { name: "Add Key" });
@@ -107,7 +107,7 @@ describe("RestrictedAction", () => {
     it("blocks keyboard interaction via inert attribute on inner wrapper", () => {
       render(
         <RestrictedAction action="publicKey:create">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       const button = screen.getByRole("button", { name: "Add Key" });
@@ -118,7 +118,7 @@ describe("RestrictedAction", () => {
     it("applies cursor-not-allowed to the outer wrapper", () => {
       render(
         <RestrictedAction action="publicKey:create">
-          <button>Add Key</button>
+          <button type="button">Add Key</button>
         </RestrictedAction>,
       );
       const button = screen.getByRole("button", { name: "Add Key" });
@@ -132,7 +132,7 @@ describe("RestrictedAction", () => {
       useAuthStore.setState({ role: "observer" });
       const { rerender } = render(
         <RestrictedAction action="device:remove">
-          <button>Delete</button>
+          <button type="button">Delete</button>
         </RestrictedAction>,
       );
       expect(screen.getByRole("button").closest("[aria-disabled='true']")).toBeInTheDocument();
@@ -140,7 +140,7 @@ describe("RestrictedAction", () => {
       useAuthStore.setState({ role: "administrator" });
       rerender(
         <RestrictedAction action="device:remove">
-          <button>Delete</button>
+          <button type="button">Delete</button>
         </RestrictedAction>,
       );
       expect(screen.getByRole("button").closest("[aria-disabled]")).toBeNull();

--- a/ui/apps/console/src/components/common/fields/NamespaceNameField.tsx
+++ b/ui/apps/console/src/components/common/fields/NamespaceNameField.tsx
@@ -9,7 +9,6 @@ interface NamespaceNameFieldProps {
   value: string;
   onChange: (value: string) => void;
   error?: string | null;
-  autoFocus?: boolean;
 }
 
 export default function NamespaceNameField({
@@ -17,7 +16,6 @@ export default function NamespaceNameField({
   value,
   onChange,
   error,
-  autoFocus,
 }: NamespaceNameFieldProps) {
   return (
     <InputField
@@ -27,7 +25,7 @@ export default function NamespaceNameField({
       onChange={(v) => onChange(v.toLowerCase())}
       placeholder="my-namespace"
       maxLength={NAMESPACE_NAME_MAX_LENGTH}
-      autoFocus={autoFocus}
+
       error={error ?? undefined}
       hint={NAMESPACE_NAME_HINT}
     />

--- a/ui/apps/console/src/components/common/fields/__tests__/NamespaceNameField.test.tsx
+++ b/ui/apps/console/src/components/common/fields/__tests__/NamespaceNameField.test.tsx
@@ -63,9 +63,4 @@ describe("NamespaceNameField", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(screen.getByText(NAMESPACE_NAME_HINT)).toBeInTheDocument();
   });
-
-  it("autofocuses the input when autoFocus is true", () => {
-    renderField({ autoFocus: true });
-    expect(screen.getByLabelText("Namespace Name")).toHaveFocus();
-  });
 });

--- a/ui/apps/console/src/components/layout/CommandPaletteTrigger.tsx
+++ b/ui/apps/console/src/components/layout/CommandPaletteTrigger.tsx
@@ -21,8 +21,7 @@ export default function CommandPaletteTrigger({
 }) {
   const openPalette = useCommandPaletteStore((s) => s.openPalette);
 
-  const shared = {
-    type: "button" as const,
+  const sharedHandlers = {
     onClick: () => {
       openPalette();
       onActivate?.();
@@ -35,7 +34,8 @@ export default function CommandPaletteTrigger({
   if (!expanded) {
     return (
       <button
-        {...shared}
+        type="button"
+        {...sharedHandlers}
         title="Quick connect (⌘K)"
         className="w-full flex items-center justify-center px-3 py-2 rounded-md border border-transparent text-text-secondary hover:text-text-primary hover:bg-hover-subtle transition-all duration-150"
       >
@@ -50,7 +50,8 @@ export default function CommandPaletteTrigger({
 
   return (
     <button
-      {...shared}
+      type="button"
+      {...sharedHandlers}
       className={`${INPUT} group flex items-center gap-2.5 text-left hover:border-primary/40`}
     >
       <MagnifyingGlassIcon

--- a/ui/apps/console/src/components/layout/InvitationsMenu.tsx
+++ b/ui/apps/console/src/components/layout/InvitationsMenu.tsx
@@ -56,6 +56,7 @@ function InvitationCard({
       </p>
       <div className="flex items-center gap-1.5 mt-2.5">
         <button
+          type="button"
           onClick={() => onAccept(invitation)}
           disabled={expired}
           className="flex-1 inline-flex items-center justify-center gap-1 px-2.5 py-1.5 bg-primary/10 hover:bg-primary/20 border border-primary/20 text-primary rounded-md text-2xs font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-colors"
@@ -64,6 +65,7 @@ function InvitationCard({
           Accept
         </button>
         <button
+          type="button"
           onClick={() => onDecline(invitation)}
           className="flex-1 inline-flex items-center justify-center gap-1 px-2.5 py-1.5 bg-hover-subtle hover:bg-hover-medium border border-border text-text-secondary hover:text-text-primary rounded-md text-2xs font-semibold transition-colors"
         >

--- a/ui/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -63,6 +63,7 @@ export default function NamespaceSelector({
   return (
     <div ref={containerRef} className="relative">
       <button
+        type="button"
         onClick={() => setOpen(!open)}
         aria-label={isAdminContext ? "Admin Console" : currentNamespace?.name ?? "Select Namespace"}
         aria-haspopup="true"
@@ -152,6 +153,7 @@ export default function NamespaceSelector({
               </p>
               {availableNamespaces.map((ns) => (
                 <button
+                  type="button"
                   key={ns.tenant_id}
                   onClick={() => void handleSwitch(ns.tenant_id)}
                   className="w-full flex items-center gap-3 px-2 py-2 rounded-md text-left hover:bg-hover-medium transition-colors group"
@@ -185,6 +187,7 @@ export default function NamespaceSelector({
           {showAdminLink && (
             <div className="p-2 border-t border-border">
               <button
+                type="button"
                 onClick={() => {
                   setOpen(false);
                   void navigate("/admin");
@@ -210,6 +213,7 @@ export default function NamespaceSelector({
           {!isAdminContext && (
             <div className="p-2 border-t border-border">
               <button
+                type="button"
                 onClick={handleCreate}
                 className="w-full flex items-center gap-3 px-2 py-2 rounded-md text-left hover:bg-hover-medium transition-colors group"
               >

--- a/ui/apps/console/src/components/layout/PendingDevices.tsx
+++ b/ui/apps/console/src/components/layout/PendingDevices.tsx
@@ -72,6 +72,7 @@ export default function PendingDevices() {
     <div ref={containerRef} className="relative">
       {/* Trigger */}
       <button
+        type="button"
         onClick={() => (open ? closeDropdown() : setOpen(true))}
         aria-label={
           count > 0 ? `Pending Devices (${count})` : "Pending Devices"
@@ -104,6 +105,7 @@ export default function PendingDevices() {
               )}
             </div>
             <button
+              type="button"
               onClick={closeDropdown}
               aria-label="Close"
               className="p-1 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
@@ -186,6 +188,7 @@ export default function PendingDevices() {
                         ) : (
                           <div className="flex items-center gap-1 shrink-0">
                             <button
+                              type="button"
                               onClick={() =>
                                 void handleAction(d.uid, "accepted")
                               }
@@ -208,6 +211,7 @@ export default function PendingDevices() {
                               )}
                             </button>
                             <button
+                              type="button"
                               onClick={() =>
                                 void handleAction(d.uid, "rejected")
                               }
@@ -235,6 +239,7 @@ export default function PendingDevices() {
           {count > 0 && (
             <div className="px-4 py-2.5 border-t border-border">
               <button
+                type="button"
                 onClick={() => {
                   closeDropdown();
                   void navigate("/devices");

--- a/ui/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui/apps/console/src/components/layout/SidebarShell.tsx
@@ -78,6 +78,7 @@ export function SidebarMobileDrawer({
   children,
 }: SidebarMobileDrawerProps) {
   return (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <div
       role="dialog"
       aria-modal={open}

--- a/ui/apps/console/src/components/layout/UserMenu.tsx
+++ b/ui/apps/console/src/components/layout/UserMenu.tsx
@@ -31,6 +31,7 @@ export default function UserMenu() {
   return (
     <div ref={containerRef} className="relative">
       <button
+        type="button"
         onClick={() => setOpen(!open)}
         aria-label={`Account menu for ${user}`}
         aria-haspopup="true"
@@ -69,6 +70,7 @@ export default function UserMenu() {
           {/* Menu items */}
           <div className="p-1.5">
             <button
+              type="button"
               onClick={() => {
                 setOpen(false);
                 void navigate("/profile");
@@ -82,6 +84,7 @@ export default function UserMenu() {
             </button>
             {namespaces.length > 0 && (
               <button
+                type="button"
                 onClick={() => {
                   setOpen(false);
                   void navigate("/settings");
@@ -99,6 +102,7 @@ export default function UserMenu() {
           {/* Logout */}
           <div className="p-1.5 border-t border-border">
             <button
+              type="button"
               onClick={handleLogout}
               className="w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-left hover:bg-accent-red/5 transition-colors group"
             >

--- a/ui/apps/console/src/components/layout/__tests__/InvitationsMenu.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/InvitationsMenu.test.tsx
@@ -44,8 +44,8 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
       <div role="dialog">
         <h2>{title}</h2>
         {errorMessage ? <div role="alert">{errorMessage}</div> : null}
-        <button onClick={onClose}>{cancelLabel}</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>{cancelLabel}</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
+++ b/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
@@ -146,10 +146,10 @@ export default function MfaDisableDialog({
           {mode === "totp" ? (
             <>
               <div>
-                <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3 text-center">
+                <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3 text-center">
                   Verification Code
-                </label>
-                <div className="flex gap-2 justify-center">
+                </p>
+                <div className="flex gap-2 justify-center" role="group" aria-label="Verification Code">
                   {otp.code.map((digit, index) => (
                     <input
                       key={index}
@@ -160,7 +160,7 @@ export default function MfaDisableDialog({
                       value={digit}
                       onChange={(e) => otp.handleChange(index, e.target.value)}
                       onKeyDown={(e) => otp.handleKeyDown(index, e)}
-                      autoFocus={index === 0}
+                      aria-label={`Digit ${index + 1}`}
                       className="w-10 h-10 text-center text-base font-mono bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:border-accent-red/50 focus:ring-1 focus:ring-accent-red/20 transition-all"
                     />
                   ))}
@@ -180,14 +180,17 @@ export default function MfaDisableDialog({
           ) : mode === "recovery" ? (
             <>
               <div>
-                <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2">
+                <label
+                  htmlFor="disable-mfa-recovery-code"
+                  className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2"
+                >
                   Recovery Code
                 </label>
                 <input
+                  id="disable-mfa-recovery-code"
                   type="text"
                   value={recoveryCode}
                   onChange={(e) => setRecoveryCode(e.target.value)}
-                  autoFocus
                   className="w-full px-4 py-2.5 bg-background border border-border rounded-lg text-sm text-text-primary font-mono placeholder:text-text-secondary focus:outline-none focus:border-accent-red/50 focus:ring-1 focus:ring-accent-red/20 transition-all"
                   placeholder="Enter recovery code"
                 />

--- a/ui/apps/console/src/components/mfa/MfaEnableDrawer.tsx
+++ b/ui/apps/console/src/components/mfa/MfaEnableDrawer.tsx
@@ -183,6 +183,7 @@ export default function MfaEnableDrawer({
         step === 1 ? (
           <>
             <button
+              type="button"
               onClick={handleClose}
               className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
             >
@@ -190,6 +191,7 @@ export default function MfaEnableDrawer({
             </button>
             {showRecoveryEmailInput ? (
               <button
+                type="button"
                 onClick={() => void handleSaveRecoveryEmail()}
                 disabled={loading || !recoveryEmail.trim()}
                 className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
@@ -199,6 +201,7 @@ export default function MfaEnableDrawer({
               </button>
             ) : (
               <button
+                type="button"
                 onClick={() => void handleConfirmExistingEmail()}
                 disabled={loading}
                 className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
@@ -211,12 +214,14 @@ export default function MfaEnableDrawer({
         ) : step === 2 ? (
           <>
             <button
+              type="button"
               onClick={handleClose}
               className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
             >
               Cancel
             </button>
             <button
+              type="button"
               onClick={() => void handleNextToQr()}
               disabled={!codesSaved || loading || recoveryCodes.length === 0}
               className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
@@ -227,12 +232,14 @@ export default function MfaEnableDrawer({
         ) : step === 3 ? (
           <>
             <button
+              type="button"
               onClick={() => setStep(2)}
               className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
             >
               Back
             </button>
             <button
+              type="button"
               onClick={() => void handleEnableMfa()}
               disabled={loading || !isCodeComplete || !qrLink || !secret}
               className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
@@ -243,6 +250,7 @@ export default function MfaEnableDrawer({
           </>
         ) : (
           <button
+            type="button"
             onClick={handleDone}
             className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
           >
@@ -273,15 +281,18 @@ export default function MfaEnableDrawer({
 
             {showRecoveryEmailInput ? (
               <div>
-                <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2">
+                <label
+                  htmlFor="enable-mfa-recovery-email"
+                  className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2"
+                >
                   Recovery Email
                 </label>
                 <input
+                  id="enable-mfa-recovery-email"
                   type="email"
                   value={recoveryEmail}
                   onChange={(e) => setRecoveryEmail(e.target.value)}
                   required
-                  autoFocus
                   className="w-full px-4 py-2.5 bg-background border border-border rounded-lg text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
                   placeholder="recovery@example.com"
                 />
@@ -308,6 +319,7 @@ export default function MfaEnableDrawer({
                 </div>
 
                 <button
+                  type="button"
                   onClick={() => setUserWantsNewEmail(true)}
                   className="w-full px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border rounded-lg hover:bg-hover-subtle transition-colors"
                 >
@@ -346,12 +358,14 @@ export default function MfaEnableDrawer({
                   </div>
                   <div className="flex gap-2">
                     <button
+                      type="button"
                       onClick={() => void handleDownload(recoveryCodes)}
                       className="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary hover:text-text-primary border border-border rounded-md hover:bg-hover-subtle transition-colors"
                     >
                       Download
                     </button>
                     <button
+                      type="button"
                       onClick={() => void handleCopy(recoveryCodes)}
                       className="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary hover:text-text-primary border border-border rounded-md hover:bg-hover-subtle transition-colors"
                     >
@@ -410,10 +424,14 @@ export default function MfaEnableDrawer({
                   </div>
 
                   <div>
-                    <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2">
+                    <label
+                      htmlFor="enable-mfa-manual-key"
+                      className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2"
+                    >
                       Manual Entry Key
                     </label>
                     <input
+                      id="enable-mfa-manual-key"
                       type="text"
                       value={secret}
                       readOnly
@@ -434,10 +452,10 @@ export default function MfaEnableDrawer({
             </div>
 
             <div>
-              <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3 text-center">
+              <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3 text-center">
                 Verification Code
-              </label>
-              <div className="flex gap-2 justify-center">
+              </p>
+              <div className="flex gap-2 justify-center" role="group" aria-label="Verification Code">
                 {otp.code.map((digit, index) => (
                   <input
                     key={index}
@@ -448,7 +466,7 @@ export default function MfaEnableDrawer({
                     value={digit}
                     onChange={(e) => otp.handleChange(index, e.target.value)}
                     onKeyDown={(e) => otp.handleKeyDown(index, e)}
-                    autoFocus={index === 0}
+                    aria-label={`Digit ${index + 1}`}
                     className="w-10 h-10 text-center text-base font-mono bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
                   />
                 ))}

--- a/ui/apps/console/src/components/sessions/SessionPlayer.tsx
+++ b/ui/apps/console/src/components/sessions/SessionPlayer.tsx
@@ -255,6 +255,7 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
       {/* Controls */}
       <div className="relative flex items-center gap-3 px-4 py-3 bg-surface border-t border-border shrink-0">
         <button
+          type="button"
           onClick={handlePlayPause}
           className="w-8 h-8 rounded-full bg-primary hover:bg-primary/90 flex items-center justify-center shrink-0 transition-colors"
           aria-label={isPlaying ? "Pause" : "Play"}
@@ -296,6 +297,7 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
         </select>
 
         <button
+          type="button"
           onClick={() => setShowShortcuts((v) => !v)}
           className={`w-7 h-7 flex items-center justify-center rounded-md transition-colors shrink-0 ${
             showShortcuts

--- a/ui/apps/console/src/components/terminal/TerminalControls.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalControls.tsx
@@ -51,6 +51,7 @@ export function TerminalActions({ session }: { session: TerminalSession }) {
         {/* macOS-style traffic light controls */}
         <div className="flex items-center gap-2 ml-1.5 group/lights">
           <button
+            type="button"
             onClick={() => close(session.id)}
             className="w-3.5 h-3.5 rounded-full bg-[#ff5f57] border border-[#e0443e] flex items-center justify-center transition-all hover:brightness-110 active:brightness-90"
             title="Close"
@@ -61,6 +62,7 @@ export function TerminalActions({ session }: { session: TerminalSession }) {
             />
           </button>
           <button
+            type="button"
             onClick={() => minimize(session.id)}
             className="w-3.5 h-3.5 rounded-full bg-[#febc2e] border border-[#dea123] flex items-center justify-center transition-all hover:brightness-110 active:brightness-90"
             title="Minimize"
@@ -71,8 +73,10 @@ export function TerminalActions({ session }: { session: TerminalSession }) {
             />
           </button>
           <button
+            type="button"
             onClick={() => toggleFullscreen(session.id)}
             className="w-3.5 h-3.5 rounded-full bg-[#28c840] border border-[#1aab29] flex items-center justify-center transition-all hover:brightness-110 active:brightness-90"
+            aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
             title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
           >
             <svg
@@ -95,6 +99,7 @@ export function TerminalActions({ session }: { session: TerminalSession }) {
 
         {/* Settings */}
         <button
+          type="button"
           onClick={() => setSettingsOpen(true)}
           className="p-1.5 rounded-md text-white/30 hover:text-white/60 transition-colors"
           title="Terminal Settings"

--- a/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
@@ -85,6 +85,7 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
         <div className="space-y-0.5">
           {TERMINAL_FONTS.map((font) => (
             <button
+              type="button"
               key={font}
               onClick={() => setFontFamily(font)}
               className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 transition-all duration-150 ${
@@ -117,6 +118,7 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
         </div>
         <div className="flex items-center gap-3">
           <button
+            type="button"
             onClick={() => setFontSize(fontSize - 1)}
             disabled={fontSize <= 8}
             className="rounded-md border border-border bg-hover-subtle p-1.5 text-text-muted hover:text-text-primary hover:bg-hover-medium disabled:opacity-faint transition-colors"
@@ -134,6 +136,7 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
             />
           </div>
           <button
+            type="button"
             onClick={() => setFontSize(fontSize + 1)}
             disabled={fontSize >= 24}
             className="rounded-md border border-border bg-hover-subtle p-1.5 text-text-muted hover:text-text-primary hover:bg-hover-medium disabled:opacity-faint transition-colors"
@@ -220,6 +223,7 @@ function ThemeCard({
 
   return (
     <button
+      type="button"
       onClick={onClick}
       className={`relative rounded-lg border p-2 text-left transition-all duration-150 ${
         selected

--- a/ui/apps/console/src/components/terminal/TerminalTaskbar.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalTaskbar.tsx
@@ -55,6 +55,7 @@ export default function TerminalTaskbar({
               {s.deviceName}
             </span>
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 close(s.id);

--- a/ui/apps/console/src/components/vault/VaultLockedBanner.tsx
+++ b/ui/apps/console/src/components/vault/VaultLockedBanner.tsx
@@ -14,6 +14,7 @@ export default function VaultLockedBanner({ onUnlock }: Props) {
         </p>
       </div>
       <button
+        type="button"
         onClick={onUnlock}
         aria-label="Unlock vault to access SSH keys"
         className="shrink-0 px-3.5 py-1.5 text-xs font-semibold text-primary hover:text-white bg-primary/10 hover:bg-primary rounded-lg transition-all"

--- a/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -98,7 +98,6 @@ function ChangePasswordDrawer({
           value={currentPassword}
           onChange={setCurrentPassword}
           placeholder="Enter current master password"
-          autoFocus={open}
           suppressPasswordManager
         />
 
@@ -365,7 +364,7 @@ export default function VaultSettingsSection() {
             value={resetConfirmText}
             onChange={setResetConfirmText}
             placeholder="RESET"
-            autoFocus
+
           />
         </div>
       </ConfirmDialog>

--- a/ui/apps/console/src/components/wizard/WelcomeWizard.tsx
+++ b/ui/apps/console/src/components/wizard/WelcomeWizard.tsx
@@ -86,6 +86,7 @@ export default function WelcomeWizard({ open, onClose }: WelcomeWizardProps) {
 
         {step < TOTAL_STEPS ? (
           <button
+            type="button"
             onClick={onClose}
             className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-hover-medium transition-all"
             aria-label="Close wizard"
@@ -155,6 +156,7 @@ export default function WelcomeWizard({ open, onClose }: WelcomeWizardProps) {
         <div className="flex items-center gap-3">
           {step < TOTAL_STEPS && (
             <button
+              type="button"
               onClick={onClose}
               className="px-4 py-2 rounded-lg text-xs font-medium text-text-muted hover:text-text-secondary hover:bg-hover-medium transition-all"
             >
@@ -212,6 +214,7 @@ function PrimaryButton({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       disabled={disabled || loading}
       className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-semibold transition-all duration-200

--- a/ui/apps/console/src/components/wizard/__tests__/WelcomeWizard.test.tsx
+++ b/ui/apps/console/src/components/wizard/__tests__/WelcomeWizard.test.tsx
@@ -46,7 +46,7 @@ vi.mock("../WizardStep2Install", () => ({
   default: ({ onDeviceDetected }: { onDeviceDetected: () => void }) => (
     <div data-testid="step-2-install">
       Step 2 content
-      <button onClick={onDeviceDetected} data-testid="simulate-device-detected">
+      <button type="button" onClick={onDeviceDetected} data-testid="simulate-device-detected">
         Simulate device detected
       </button>
     </div>
@@ -63,6 +63,7 @@ vi.mock("../WizardStep3Device", () => ({
     <div data-testid="step-3-device">
       Step 3 content
       <button
+        type="button"
         onClick={() =>
           onDeviceLoaded({ uid: "dev-uid-123", name: "my-device" })
         }

--- a/ui/apps/console/src/hooks/__tests__/useFocusTrap.test.tsx
+++ b/ui/apps/console/src/hooks/__tests__/useFocusTrap.test.tsx
@@ -19,10 +19,10 @@ function Trap({
 
   return (
     <div>
-      <button>Outside</button>
+      <button type="button">Outside</button>
       <div ref={ref} data-testid="container">
         {buttons.map((label) => (
-          <button key={label}>{label}</button>
+          <button type="button" key={label}>{label}</button>
         ))}
       </div>
     </div>
@@ -37,11 +37,11 @@ function ToggleTrap() {
 
   return (
     <div>
-      <button data-testid="trigger" onClick={() => setActive((v) => !v)}>
+      <button type="button" data-testid="trigger" onClick={() => setActive((v) => !v)}>
         Toggle
       </button>
       <div ref={ref} data-testid="container">
-        <button>Inside</button>
+        <button type="button">Inside</button>
       </div>
     </div>
   );

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -322,6 +322,7 @@ export default function AddDevice() {
       {!selectedMethod.manual && (
         <div className="mb-6">
           <button
+            type="button"
             onClick={() => setShowAdvanced(!showAdvanced)}
             className="flex items-center gap-1.5 text-2xs font-mono text-text-muted hover:text-text-secondary transition-colors"
           >

--- a/ui/apps/console/src/pages/BannerEdit.tsx
+++ b/ui/apps/console/src/pages/BannerEdit.tsx
@@ -69,7 +69,7 @@ function BannerEditor({ ns, canEdit }: { ns: Namespace; canEdit: boolean }) {
           disabled={!canEdit}
           placeholder="Enter the banner message..."
           className="flex-1 w-full px-4 py-3.5 bg-card text-sm text-text-primary font-mono placeholder:text-text-muted/30 focus:outline-none transition-all resize-none leading-relaxed disabled:opacity-dim disabled:cursor-not-allowed"
-          autoFocus
+
         />
         <div className="flex items-center justify-between px-4 py-2.5 border-t border-border bg-surface/50 shrink-0">
           <span

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -145,6 +145,7 @@ function TagsSection({ uid, tags }: { uid: string; tags: string[] }) {
             {tag}
             {canEditTags && (
               <button
+                type="button"
                 onClick={() => void handleRemove(tag)}
                 aria-label={`Remove tag ${tag}`}
                 className="hover:text-white transition-colors"
@@ -174,6 +175,7 @@ function TagsSection({ uid, tags }: { uid: string; tags: string[] }) {
               className="w-28 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
             />
             <button
+              type="button"
               onClick={() => void handleAdd()}
               disabled={adding || !input.trim()}
               aria-label="Add tag"
@@ -240,6 +242,7 @@ function RenameSection({
       <div className="flex items-center gap-2">
         <h1 className="text-2xl font-bold text-text-primary">{currentName}</h1>
         <button
+          type="button"
           onClick={() => {
             setName(currentName);
             setEditing(true);
@@ -265,11 +268,12 @@ function RenameSection({
             if (e.key === "Enter") void handleSave();
             if (e.key === "Escape") setEditing(false);
           }}
-          autoFocus
+
           aria-label="Container name"
           className="text-2xl font-bold text-text-primary bg-transparent border-b-2 border-primary/50 focus:outline-none focus:border-primary w-full max-w-md"
         />
         <button
+          type="button"
           onClick={() => void handleSave()}
           disabled={saving}
           aria-label="Save name"
@@ -278,6 +282,7 @@ function RenameSection({
           <CheckIcon className="w-4 h-4" strokeWidth={2} />
         </button>
         <button
+          type="button"
           onClick={() => setEditing(false)}
           aria-label="Cancel rename"
           className="p-1.5 rounded-md text-text-muted hover:bg-hover-medium transition-all"
@@ -420,6 +425,7 @@ export default function ContainerDetails() {
             <>
               <RestrictedAction action="device:connect">
                 <button
+                  type="button"
                   onClick={() => {
                     if (existingSession) {
                       restoreTerminal(existingSession.id);
@@ -436,6 +442,7 @@ export default function ContainerDetails() {
               </RestrictedAction>
               <RestrictedAction action="device:remove">
                 <button
+                  type="button"
                   onClick={() =>
                     setOperation({
                       container: { uid: container.uid, name: container.name },
@@ -455,6 +462,7 @@ export default function ContainerDetails() {
             <>
               <RestrictedAction action="device:accept">
                 <button
+                  type="button"
                   onClick={() => setOperation({ container, action: "accept" })}
                   className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold transition-all"
                 >
@@ -463,6 +471,7 @@ export default function ContainerDetails() {
               </RestrictedAction>
               <RestrictedAction action="device:reject">
                 <button
+                  type="button"
                   onClick={() => setOperation({ container, action: "reject" })}
                   className="flex items-center gap-2 px-4 py-2.5 bg-accent-yellow/90 hover:bg-accent-yellow text-white rounded-lg text-sm font-semibold transition-all"
                 >
@@ -475,6 +484,7 @@ export default function ContainerDetails() {
             <>
               <RestrictedAction action="device:accept">
                 <button
+                  type="button"
                   onClick={() => setOperation({ container, action: "accept" })}
                   className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold transition-all"
                 >
@@ -483,6 +493,7 @@ export default function ContainerDetails() {
               </RestrictedAction>
               <RestrictedAction action="device:remove">
                 <button
+                  type="button"
                   onClick={() => setOperation({ container, action: "remove" })}
                   className="flex items-center gap-2 px-4 py-2.5 bg-accent-red/90 hover:bg-accent-red text-white rounded-lg text-sm font-semibold transition-all"
                 >

--- a/ui/apps/console/src/pages/ForgotPassword.tsx
+++ b/ui/apps/console/src/pages/ForgotPassword.tsx
@@ -91,7 +91,7 @@ export default function ForgotPassword() {
               onChange={setAccount}
               placeholder="username or email"
               autoComplete="username"
-              autoFocus
+
               required
             />
 

--- a/ui/apps/console/src/pages/Login.tsx
+++ b/ui/apps/console/src/pages/Login.tsx
@@ -271,7 +271,7 @@ export default function Login() {
               onChange={setUsername}
               placeholder="username"
               autoComplete="username"
-              autoFocus
+
               required
             />
 

--- a/ui/apps/console/src/pages/MfaLogin.tsx
+++ b/ui/apps/console/src/pages/MfaLogin.tsx
@@ -74,11 +74,13 @@ export default function MfaLogin() {
           {error && <Alert variant="error">{error}</Alert>}
 
           <div>
-            <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3 text-center">
+            <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3 text-center">
               Verification Code
-            </label>
+            </p>
             <div
               className="flex gap-2 justify-center"
+              role="group"
+              aria-label="Verification Code"
               onPaste={otp.handlePaste}
             >
               {otp.code.map((digit, index) => (
@@ -92,7 +94,7 @@ export default function MfaLogin() {
                   aria-label={`Digit ${index + 1} of 6`}
                   onChange={(e) => otp.handleChange(index, e.target.value)}
                   onKeyDown={(e) => otp.handleKeyDown(index, e)}
-                  autoFocus={index === 0}
+
                   className="w-12 h-12 text-center text-lg font-mono bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all duration-200"
                 />
               ))}

--- a/ui/apps/console/src/pages/MfaRecover.tsx
+++ b/ui/apps/console/src/pages/MfaRecover.tsx
@@ -118,7 +118,7 @@ export default function MfaRecover() {
               value={recoveryCode}
               onChange={(e) => setRecoveryCode(e.target.value)}
               required
-              autoFocus
+
               className="w-full px-4 py-3 bg-background border border-border rounded-lg text-sm text-text-primary font-mono placeholder:text-text-secondary focus:outline-none focus:border-accent-yellow/50 focus:ring-1 focus:ring-accent-yellow/20 transition-all duration-200"
               placeholder="Enter recovery code"
             />

--- a/ui/apps/console/src/pages/MfaResetComplete.tsx
+++ b/ui/apps/console/src/pages/MfaResetComplete.tsx
@@ -123,11 +123,13 @@ export default function MfaResetComplete() {
 
           {/* Main Email Code */}
           <div>
-            <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
+            <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
               Main Email Code
-            </label>
+            </p>
             <div
               className="flex justify-center gap-2 mb-2"
+              role="group"
+              aria-label="Main Email Code"
               onPaste={otpMain.handlePaste}
             >
               {otpMain.code.map((char, index) => (
@@ -140,7 +142,7 @@ export default function MfaResetComplete() {
                   aria-label={`Main email code character ${index + 1} of 5`}
                   onChange={(e) => otpMain.handleChange(index, e.target.value)}
                   onKeyDown={(e) => otpMain.handleKeyDown(index, e)}
-                  autoFocus={index === 0}
+
                   className="w-10 h-10 text-center text-lg font-mono bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all duration-200 uppercase"
                 />
               ))}
@@ -152,11 +154,13 @@ export default function MfaResetComplete() {
 
           {/* Recovery Email Code */}
           <div>
-            <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
+            <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
               Recovery Email Code
-            </label>
+            </p>
             <div
               className="flex justify-center gap-2 mb-2"
+              role="group"
+              aria-label="Recovery Email Code"
               onPaste={otpRecovery.handlePaste}
             >
               {otpRecovery.code.map((char, index) => (

--- a/ui/apps/console/src/pages/MfaResetVerify.tsx
+++ b/ui/apps/console/src/pages/MfaResetVerify.tsx
@@ -84,11 +84,13 @@ export default function MfaResetVerify() {
 
           {/* Main Email Code */}
           <div>
-            <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
+            <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
               Main Email Code
-            </label>
+            </p>
             <div
               className="flex justify-center gap-2 mb-2"
+              role="group"
+              aria-label="Main Email Code"
               onPaste={otpMain.handlePaste}
             >
               {otpMain.code.map((char, index) => (
@@ -101,7 +103,7 @@ export default function MfaResetVerify() {
                   aria-label={`Main email code character ${index + 1} of 5`}
                   onChange={(e) => otpMain.handleChange(index, e.target.value)}
                   onKeyDown={(e) => otpMain.handleKeyDown(index, e)}
-                  autoFocus={index === 0}
+
                   className="w-10 h-10 text-center text-lg font-mono bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all duration-200 uppercase"
                 />
               ))}
@@ -113,11 +115,13 @@ export default function MfaResetVerify() {
 
           {/* Recovery Email Code */}
           <div>
-            <label className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
+            <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
               Recovery Email Code
-            </label>
+            </p>
             <div
               className="flex justify-center gap-2 mb-2"
+              role="group"
+              aria-label="Recovery Email Code"
               onPaste={otpRecovery.handlePaste}
             >
               {otpRecovery.code.map((char, index) => (

--- a/ui/apps/console/src/pages/Profile.tsx
+++ b/ui/apps/console/src/pages/Profile.tsx
@@ -422,7 +422,7 @@ export function EditProfileDrawer({
           hint="1-64 characters"
           error={nameError ?? undefined}
           maxLength={64}
-          autoFocus={open}
+
         />
         <InputField
           id="profile-username"
@@ -550,7 +550,7 @@ function ChangePasswordDrawer({
           value={current}
           onChange={setCurrent}
           autoComplete="current-password"
-          autoFocus={open}
+
         />
         <PasswordField
           id="change-pw-new"

--- a/ui/apps/console/src/pages/Settings.tsx
+++ b/ui/apps/console/src/pages/Settings.tsx
@@ -166,7 +166,6 @@ function EditNameDrawer({
           id="edit-ns-name"
           value={name}
           onChange={setName}
-          autoFocus={open}
           error={validationError}
         />
         {error && (
@@ -227,7 +226,7 @@ function DeleteDialog({
           value={confirm}
           onChange={setConfirm}
           placeholder={namespaceName}
-          autoFocus
+
         />
       </div>
       {error && <p className="text-2xs text-accent-red mb-3">{error}</p>}

--- a/ui/apps/console/src/pages/Setup.tsx
+++ b/ui/apps/console/src/pages/Setup.tsx
@@ -231,7 +231,7 @@ export default function Setup() {
                 onBlur={() => handleBlur("name")}
                 error={showError("name")}
                 placeholder="Your name"
-                autoFocus
+
                 maxLength={64}
               />
 

--- a/ui/apps/console/src/pages/SignUp.tsx
+++ b/ui/apps/console/src/pages/SignUp.tsx
@@ -207,7 +207,7 @@ export default function SignUp() {
               error={fieldError("name")}
               placeholder="Your name"
               autoComplete="name"
-              autoFocus
+
             />
 
             <InputField

--- a/ui/apps/console/src/pages/UpdatePassword.tsx
+++ b/ui/apps/console/src/pages/UpdatePassword.tsx
@@ -129,7 +129,7 @@ export default function UpdatePassword() {
             placeholder="••••••••"
             error={passwordError ?? undefined}
             hint="5–32 characters"
-            autoFocus
+
             required
           />
 

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -267,6 +267,8 @@ function TimeoutSelector({
         <button
           type="button"
           onClick={handleToggle}
+          aria-labelledby="endpoint-expiration-label"
+          aria-pressed={hasExpiration}
           className={`relative w-9 h-5 rounded-full transition-colors ${hasExpiration ? "bg-primary" : "bg-border"}`}
         >
           <span
@@ -302,7 +304,7 @@ function TimeoutSelector({
               onChange={handleCustomValueChange}
               placeholder="Value in seconds"
               variant="mono"
-              autoFocus
+
               error={error || undefined}
             />
           )}
@@ -591,7 +593,7 @@ function EndpointDrawer({
                       placeholder="e.g. 192.168.1.100"
                       variant="mono"
                       error={hostError}
-                      autoFocus
+
                     />
                   </div>
                   <div className="w-24">

--- a/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
@@ -41,8 +41,8 @@ vi.mock("../../components/common/ConfirmDialog", () => ({
       <div role="dialog">
         <h2>{title}</h2>
         {errorMessage ? <div role="alert">{errorMessage}</div> : null}
-        <button onClick={onClose}>{cancelLabel}</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>{cancelLabel}</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
@@ -83,6 +83,7 @@ export default function AnnouncementDetails() {
             Edit
           </Link>
           <button
+            type="button"
             onClick={() => setDeleteOpen(true)}
             className="p-2.5 border border-border rounded-lg text-text-muted hover:text-accent-red hover:border-accent-red/30 transition-colors"
             aria-label="Delete announcement"

--- a/ui/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
@@ -116,7 +116,7 @@ export default function EditAnnouncement() {
           onChange={setTitle}
           placeholder="Announcement title"
           maxLength={TITLE_MAX}
-          autoFocus
+
         />
 
         {/* Content editor */}

--- a/ui/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
@@ -78,7 +78,7 @@ export default function NewAnnouncement() {
           onChange={setTitle}
           placeholder="Announcement title"
           maxLength={TITLE_MAX}
-          autoFocus
+
         />
 
         {/* Content editor */}

--- a/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
@@ -32,7 +32,7 @@ vi.mock("../DeleteAnnouncementDialog", () => ({
     if (!open || !announcement) return null;
     return (
       <div role="dialog" aria-label={`Delete ${announcement.title}`}>
-        <button onClick={onClose}>Cancel delete</button>
+        <button type="button" onClick={onClose}>Cancel delete</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/admin/announcements/__tests__/DeleteAnnouncementDialog.test.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/__tests__/DeleteAnnouncementDialog.test.tsx
@@ -32,8 +32,8 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
       <div role="dialog" aria-label={title}>
         <h2>{title}</h2>
         <div>{description}</div>
-        <button onClick={onClose}>Cancel</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>Cancel</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/admin/devices/index.tsx
+++ b/ui/apps/console/src/pages/admin/devices/index.tsx
@@ -188,6 +188,7 @@ export default function AdminDevices() {
         >
           {statusTabs.map((tab) => (
             <button
+              type="button"
               key={tab.value}
               role="tab"
               aria-selected={status === tab.value}

--- a/ui/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/EditNamespaceDrawer.tsx
@@ -106,7 +106,7 @@ export default function EditNamespaceDrawer({
           id="edit-ns-name"
           value={name}
           onChange={setName}
-          autoFocus={open}
+
           error={nameValidationError}
         />
 

--- a/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -128,6 +128,7 @@ export default function NamespaceDetails() {
 
         <div className="flex items-center gap-2 shrink-0">
           <button
+            type="button"
             onClick={() => setEditOpen(true)}
             className="flex items-center gap-2 px-4 py-2.5 border border-border text-text-secondary hover:text-text-primary hover:border-border-light rounded-lg text-sm font-semibold transition-all"
           >
@@ -135,6 +136,7 @@ export default function NamespaceDetails() {
             Edit
           </button>
           <button
+            type="button"
             onClick={() => setDeleteOpen(true)}
             className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
             title="Delete namespace"

--- a/ui/apps/console/src/pages/admin/namespaces/__tests__/DeleteNamespaceDialog.test.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/__tests__/DeleteNamespaceDialog.test.tsx
@@ -33,8 +33,8 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
       <div role="dialog" aria-label={title}>
         <h2>{title}</h2>
         <div>{description}</div>
-        <button onClick={onClose}>Cancel</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>Cancel</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/users/CreateUserDrawer.tsx
@@ -69,7 +69,7 @@ export default function CreateUserDrawer({
         className="space-y-5"
         noValidate
       >
-        <UserFormFields form={form} idPrefix="create-user" autoFocus={open} />
+        <UserFormFields form={form} idPrefix="create-user" />
         {submitError && (
           <p role="alert" className="text-2xs text-accent-red">
             {submitError}

--- a/ui/apps/console/src/pages/admin/users/EditUserDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/users/EditUserDrawer.tsx
@@ -85,7 +85,7 @@ export default function EditUserDrawer({
         <UserFormFields
           form={form}
           idPrefix="edit-user"
-          autoFocus={open}
+
           canChangeConfirmed={canChangeConfirmed}
           disableAdmin={disableAdmin}
         />

--- a/ui/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -130,6 +130,7 @@ export default function UserDetails() {
         {/* Actions */}
         <div className="flex items-center gap-2 shrink-0">
           <button
+            type="button"
             onClick={() => setEditOpen(true)}
             className="flex items-center gap-2 px-4 py-2.5 border border-border text-text-secondary hover:text-text-primary hover:border-border-light rounded-lg text-sm font-semibold transition-all"
           >
@@ -138,6 +139,7 @@ export default function UserDetails() {
           </button>
           {isSamlOnly && (
             <button
+              type="button"
               onClick={() => setResetPasswordOpen(true)}
               className="flex items-center gap-2 px-4 py-2.5 border border-border text-text-secondary hover:text-text-primary hover:border-border-light rounded-lg text-sm font-semibold transition-all"
               title="Enable local authentication for this SAML-only user"
@@ -147,6 +149,7 @@ export default function UserDetails() {
             </button>
           )}
           <button
+            type="button"
             onClick={() => id && void loginAs(id)}
             disabled={loginAsId === id}
             className={`flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all ${
@@ -163,6 +166,7 @@ export default function UserDetails() {
             {loginAsErrorId === id ? "Retry Login" : "Login as User"}
           </button>
           <button
+            type="button"
             onClick={() => setDeleteOpen(true)}
             className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
             title="Delete user"

--- a/ui/apps/console/src/pages/admin/users/UserFormFields.tsx
+++ b/ui/apps/console/src/pages/admin/users/UserFormFields.tsx
@@ -14,7 +14,6 @@ import type { UserFormApi, UserFormMode } from "./useUserForm";
 interface UserFormFieldsProps {
   form: UserFormApi<UserFormMode>;
   idPrefix: string;
-  autoFocus?: boolean;
   /** Edit only: false when the user is already confirmed (cannot un-confirm). */
   canChangeConfirmed?: boolean;
   /** Edit only: true when editing your own admin user (cannot self-demote). */
@@ -24,7 +23,6 @@ interface UserFormFieldsProps {
 export default function UserFormFields({
   form,
   idPrefix,
-  autoFocus,
   canChangeConfirmed = true,
   disableAdmin = false,
 }: UserFormFieldsProps) {
@@ -42,7 +40,7 @@ export default function UserFormFields({
         error={errors.name}
         errorRole="status"
         placeholder={isCreate ? "John Doe" : undefined}
-        autoFocus={autoFocus}
+
         maxLength={NAME_MAX_LENGTH}
         required
       />

--- a/ui/apps/console/src/pages/admin/users/__tests__/ResetPasswordDialog.test.tsx
+++ b/ui/apps/console/src/pages/admin/users/__tests__/ResetPasswordDialog.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/components/common/BaseDialog", () => ({
     if (!open) return null;
     return (
       <div role="dialog">
-        <button onClick={onClose}>Close Dialog</button>
+        <button type="button" onClick={onClose}>Close Dialog</button>
         {children}
       </div>
     );

--- a/ui/apps/console/src/pages/admin/users/index.tsx
+++ b/ui/apps/console/src/pages/admin/users/index.tsx
@@ -100,6 +100,7 @@ export default function AdminUsers() {
             <PencilSquareIcon className="w-4 h-4" />
           </IconButton>
           <button
+            type="button"
             onClick={(e) => {
               e.stopPropagation();
               void loginAs(user.id);
@@ -148,6 +149,7 @@ export default function AdminUsers() {
         description="Manage all user accounts in the instance"
       >
         <button
+          type="button"
           onClick={() => setCreateOpen(true)}
           className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
         >

--- a/ui/apps/console/src/pages/containers/ContainerTagsPopover.tsx
+++ b/ui/apps/console/src/pages/containers/ContainerTagsPopover.tsx
@@ -144,6 +144,7 @@ function ContainerTagsPopover({
           <div className="flex items-center gap-1">
             {tags.map((tag) => (
               <button
+                type="button"
                 key={tag}
                 onClick={(e) => {
                   e.stopPropagation();
@@ -164,6 +165,7 @@ function ContainerTagsPopover({
         )}
         {canEditTags && (
           <button
+            type="button"
             ref={triggerRef}
             onClick={(e) => {
               e.stopPropagation();
@@ -181,6 +183,7 @@ function ContainerTagsPopover({
       {/* Popover — portaled to body */}
       {open &&
         createPortal(
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
           <div
             ref={popoverRef}
             role="dialog"
@@ -201,6 +204,7 @@ function ContainerTagsPopover({
                       <TagIcon className="w-2.5 h-2.5" strokeWidth={2} />
                       {tag}
                       <button
+                        type="button"
                         onClick={() => void handleRemove(tag)}
                         disabled={loading}
                         aria-label={`Remove tag ${tag}`}
@@ -231,7 +235,7 @@ function ContainerTagsPopover({
                       }
                     }}
                     placeholder="Search or create tag..."
-                    autoFocus
+
                     aria-label="Search or create tag"
                     className="w-full px-2.5 py-1.5 bg-card border border-border rounded-lg text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
                   />
@@ -255,6 +259,7 @@ function ContainerTagsPopover({
                       <div className="mt-1.5 max-h-[140px] overflow-y-auto border border-border rounded-lg divide-y divide-border/60">
                         {suggestions.map((tag) => (
                           <button
+                            type="button"
                             key={tag}
                             onClick={() => void handleAdd(tag)}
                             disabled={loading}
@@ -269,6 +274,7 @@ function ContainerTagsPopover({
                         ))}
                         {isNew && (
                           <button
+                            type="button"
                             onClick={() => void handleAdd(input.trim())}
                             disabled={loading}
                             className="w-full text-left px-2.5 py-1.5 text-2xs text-accent-green hover:bg-hover-medium transition-colors disabled:opacity-dim flex items-center gap-1.5"

--- a/ui/apps/console/src/pages/containers/__tests__/ContainerActionDialog.test.tsx
+++ b/ui/apps/console/src/pages/containers/__tests__/ContainerActionDialog.test.tsx
@@ -37,8 +37,8 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
         <h2>{title}</h2>
         <div>{description}</div>
         {children}
-        <button onClick={onClose}>Cancel</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>Cancel</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -190,6 +190,7 @@ export default function Containers() {
             container.online ? (
               <RestrictedAction action="device:connect">
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     const existing = useTerminalStore
@@ -234,6 +235,7 @@ export default function Containers() {
             <div className="flex items-center justify-end gap-1.5">
               <RestrictedAction action="device:accept">
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     setActionTarget({ container, action: "accept" });
@@ -245,6 +247,7 @@ export default function Containers() {
               </RestrictedAction>
               <RestrictedAction action="device:reject">
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     setActionTarget({ container, action: "reject" });
@@ -271,6 +274,7 @@ export default function Containers() {
           <div className="flex items-center justify-end gap-1.5">
             <RestrictedAction action="device:accept">
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   setActionTarget({ container, action: "accept" });
@@ -282,6 +286,7 @@ export default function Containers() {
             </RestrictedAction>
             <RestrictedAction action="device:remove">
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   setActionTarget({ container, action: "remove" });
@@ -306,6 +311,7 @@ export default function Containers() {
         description="Manage and monitor Docker containers connected via ShellHub Connector"
       >
         <button
+          type="button"
           onClick={() => setAddConnectorOpen(true)}
           className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200"
         >
@@ -323,6 +329,7 @@ export default function Containers() {
         >
           {statusTabs.map((tab) => (
             <button
+              type="button"
               key={tab.value}
               role="tab"
               aria-selected={status === tab.value}
@@ -374,6 +381,7 @@ export default function Containers() {
                 <TagIcon className="w-2.5 h-2.5" strokeWidth={2} />
                 {tag}
                 <button
+                  type="button"
                   onClick={() => removeFilterTag(tag)}
                   aria-label={`Remove ${tag} filter`}
                   className="hover:text-white transition-colors ml-0.5"
@@ -383,6 +391,7 @@ export default function Containers() {
               </span>
             ))}
             <button
+              type="button"
               onClick={clearFilterTags}
               className="text-2xs text-text-muted hover:text-text-primary transition-colors font-mono"
             >

--- a/ui/apps/console/src/pages/devices/RenameSection.tsx
+++ b/ui/apps/console/src/pages/devices/RenameSection.tsx
@@ -76,7 +76,7 @@ export default function RenameSection({
             if (e.key === "Escape") setEditing(false);
           }}
           aria-label="Device name"
-          autoFocus
+
           className="text-2xl font-bold text-text-primary bg-transparent border-b-2 border-primary/50 focus:outline-none focus:border-primary w-full max-w-md"
         />
         <button

--- a/ui/apps/console/src/pages/devices/TagsPopover.tsx
+++ b/ui/apps/console/src/pages/devices/TagsPopover.tsx
@@ -131,6 +131,7 @@ function TagsPopover({
             <div className="flex items-center gap-1">
               {tags.map((tag) => (
                 <button
+                  type="button"
                   key={tag}
                   onClick={(e) => {
                     e.stopPropagation();
@@ -152,6 +153,7 @@ function TagsPopover({
           )}
         {canEditTags && (
           <button
+            type="button"
             ref={triggerRef}
             onClick={(e) => {
               e.stopPropagation();
@@ -186,6 +188,7 @@ function TagsPopover({
                       <TagIcon className="w-2.5 h-2.5" strokeWidth={2} />
                       {tag}
                       <button
+                        type="button"
                         onClick={() => void handleRemove(tag)}
                         disabled={loading}
                         className="hover:text-white transition-colors disabled:opacity-dim ml-0.5"
@@ -215,7 +218,7 @@ function TagsPopover({
                       }
                     }}
                     placeholder="Search or create tag..."
-                    autoFocus
+
                     className="w-full px-2.5 py-1.5 bg-card border border-border rounded-lg text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
                   />
                   {input.trim() && input.trim().length < 3 && (
@@ -238,6 +241,7 @@ function TagsPopover({
                     <div className="mt-1.5 max-h-[140px] overflow-y-auto border border-border rounded-lg divide-y divide-border/60">
                       {suggestions.map((tag) => (
                         <button
+                          type="button"
                           key={tag}
                           onClick={() => void handleAdd(tag)}
                           disabled={loading}
@@ -252,6 +256,7 @@ function TagsPopover({
                       ))}
                       {isNew && (
                         <button
+                          type="button"
                           onClick={() => void handleAdd(input.trim())}
                           disabled={loading}
                           className="w-full text-left px-2.5 py-1.5 text-2xs text-accent-green hover:bg-hover-medium transition-colors disabled:opacity-dim flex items-center gap-1.5"

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -181,6 +181,7 @@ export default function Devices() {
             device.online ? (
               <RestrictedAction action="device:connect">
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     const existing = useTerminalStore
@@ -225,6 +226,7 @@ export default function Devices() {
             <div className="flex items-center justify-end gap-1.5">
               <RestrictedAction action="device:accept">
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     setActionTarget({ device, action: "accept" });
@@ -236,6 +238,7 @@ export default function Devices() {
               </RestrictedAction>
               <RestrictedAction action="device:reject">
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     setActionTarget({ device, action: "reject" });
@@ -262,6 +265,7 @@ export default function Devices() {
           <div className="flex items-center justify-end gap-1.5">
             <RestrictedAction action="device:accept">
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   setActionTarget({ device, action: "accept" });
@@ -273,6 +277,7 @@ export default function Devices() {
             </RestrictedAction>
             <RestrictedAction action="device:remove">
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   setActionTarget({ device, action: "remove" });
@@ -312,6 +317,7 @@ export default function Devices() {
         <div className="flex items-center h-8 bg-card border border-border rounded-md p-0.5">
           {statusTabs.map((tab) => (
             <button
+              type="button"
               key={tab.value}
               onClick={() => handleStatusChange(tab.value)}
               className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${
@@ -361,6 +367,7 @@ export default function Devices() {
                 <TagIcon className="w-2.5 h-2.5" strokeWidth={2} />
                 {tag}
                 <button
+                  type="button"
                   onClick={() => removeFilterTag(tag)}
                   className="hover:text-white transition-colors ml-0.5"
                 >
@@ -369,6 +376,7 @@ export default function Devices() {
               </span>
             ))}
             <button
+              type="button"
               onClick={clearFilterTags}
               className="text-2xs text-text-muted hover:text-text-primary transition-colors font-mono"
             >

--- a/ui/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
@@ -231,7 +231,7 @@ export default function RuleDrawer({
           value={priority}
           onChange={setPriority}
           placeholder="e.g. 100"
-          autoFocus={open}
+
           hint="Higher values are evaluated first. Must be greater than 0."
           error={priorityError || undefined}
         />

--- a/ui/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
@@ -51,8 +51,8 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
         <h2>{title}</h2>
         <div>{description}</div>
         {children}
-        <button onClick={onClose}>Cancel</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>Cancel</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/public-keys/KeyDrawer.tsx
+++ b/ui/apps/console/src/pages/public-keys/KeyDrawer.tsx
@@ -207,7 +207,7 @@ function KeyDrawer({
           value={name}
           onChange={setName}
           placeholder="Name used to identify the public key"
-          autoFocus={open}
+
         />
 
         {/* Username access */}

--- a/ui/apps/console/src/pages/public-keys/__tests__/PublicKeys.test.tsx
+++ b/ui/apps/console/src/pages/public-keys/__tests__/PublicKeys.test.tsx
@@ -51,8 +51,8 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
         <h2>{title}</h2>
         <div>{description}</div>
         {children}
-        <button onClick={onClose}>Cancel</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>Cancel</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/public-keys/index.tsx
+++ b/ui/apps/console/src/pages/public-keys/index.tsx
@@ -250,6 +250,7 @@ export default function PublicKeys() {
         >
           <RestrictedAction action="publicKey:create">
             <button
+              type="button"
               onClick={openNew}
               className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             >
@@ -278,6 +279,7 @@ export default function PublicKeys() {
       >
         <RestrictedAction action="publicKey:create">
           <button
+            type="button"
             onClick={openNew}
             className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
           >

--- a/ui/apps/console/src/pages/secure-vault/KeyDrawer.tsx
+++ b/ui/apps/console/src/pages/secure-vault/KeyDrawer.tsx
@@ -187,7 +187,7 @@ export default function KeyDrawer({ open, editKey, onClose }: Props) {
           onChange={handleNameChange}
           maxLength={255}
           placeholder="e.g. Production Server"
-          autoFocus={open}
+
           error={nameError ?? undefined}
         />
 

--- a/ui/apps/console/src/pages/secure-vault/__tests__/KeyDeleteDialog.test.tsx
+++ b/ui/apps/console/src/pages/secure-vault/__tests__/KeyDeleteDialog.test.tsx
@@ -34,8 +34,8 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
         <h2>{title}</h2>
         <div>{description}</div>
         {children}
-        <button onClick={onClose}>Cancel</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>Cancel</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/secure-vault/__tests__/KeyDrawer.test.tsx
+++ b/ui/apps/console/src/pages/secure-vault/__tests__/KeyDrawer.test.tsx
@@ -48,7 +48,7 @@ vi.mock("@/components/common/Drawer", () => ({
     return (
       <div>
         <h2>{title}</h2>
-        <button onClick={onClose}>Close Drawer</button>
+        <button type="button" onClick={onClose}>Close Drawer</button>
         <div>{children}</div>
         {footer && <div>{footer as React.ReactNode}</div>}
       </div>

--- a/ui/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
+++ b/ui/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
@@ -73,14 +73,14 @@ vi.mock("@/components/common/Drawer", () => ({
 vi.mock("@/components/vault/VaultLockedBanner", () => ({
   default: ({ onUnlock }: { onUnlock: () => void }) => (
     <div data-testid="vault-locked-banner">
-      <button onClick={onUnlock}>Unlock Vault</button>
+      <button type="button" onClick={onUnlock}>Unlock Vault</button>
     </div>
   ),
 }));
 
 vi.mock("@/components/common/CopyButton", () => ({
   default: ({ text }: { text: string }) => (
-    <button aria-label={`Copy ${text}`}>Copy</button>
+    <button type="button" aria-label={`Copy ${text}`}>Copy</button>
   ),
 }));
 
@@ -210,7 +210,7 @@ vi.mock("@/components/vault/VaultSetupDialog", () => ({
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
     open ? (
       <div role="dialog" aria-label="Setup Vault">
-        <button onClick={onClose}>Close Setup</button>
+        <button type="button" onClick={onClose}>Close Setup</button>
       </div>
     ) : null,
 }));
@@ -219,7 +219,7 @@ vi.mock("@/components/vault/VaultUnlockDialog", () => ({
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
     open ? (
       <div role="dialog" aria-label="Unlock Vault">
-        <button onClick={onClose}>Close Unlock</button>
+        <button type="button" onClick={onClose}>Close Unlock</button>
       </div>
     ) : null,
 }));
@@ -245,7 +245,7 @@ vi.mock("../KeyDrawer", () => ({
         role="dialog"
         aria-label={editKey ? "Edit Private Key" : "Add Private Key"}
       >
-        <button onClick={onClose}>Close Drawer</button>
+        <button type="button" onClick={onClose}>Close Drawer</button>
       </div>
     ) : null,
 }));
@@ -263,7 +263,7 @@ vi.mock("../KeyDeleteDialog", () => ({
     open ? (
       <div role="dialog" aria-label="Delete Key Dialog">
         {entry && <span>{entry.name}</span>}
-        <button onClick={onClose}>Close Delete</button>
+        <button type="button" onClick={onClose}>Close Delete</button>
       </div>
     ) : null,
 }));

--- a/ui/apps/console/src/pages/secure-vault/index.tsx
+++ b/ui/apps/console/src/pages/secure-vault/index.tsx
@@ -136,6 +136,7 @@ export default function SecureVault() {
           features={VAULT_FEATURES}
         >
           <button
+            type="button"
             onClick={() => setSetupOpen(true)}
             className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
@@ -163,6 +164,7 @@ export default function SecureVault() {
           features={VAULT_FEATURES}
         >
           <button
+            type="button"
             onClick={() => setUnlockOpen(true)}
             className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
@@ -269,6 +271,7 @@ export default function SecureVault() {
             description="Manage your encrypted SSH private keys."
           >
             <button
+              type="button"
               onClick={openNew}
               className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
             >

--- a/ui/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
+++ b/ui/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
@@ -18,6 +18,7 @@ export default function SessionPlayerDialog({
     <div className="absolute inset-0 z-[80] flex flex-col bg-[#121314]">
       {/* Close button overlay */}
       <button
+        type="button"
         onClick={onClose}
         className="absolute top-2 right-2 z-10 w-7 h-7 flex items-center justify-center rounded-md bg-black/40 hover:bg-black/60 text-text-muted hover:text-text-primary transition-colors"
         aria-label="Close"

--- a/ui/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
+++ b/ui/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
@@ -31,7 +31,7 @@ vi.mock("../SessionPlayerDialog", () => ({
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
     open ? (
       <div data-testid="player-dialog">
-        <button onClick={onClose}>Close Player</button>
+        <button type="button" onClick={onClose}>Close Player</button>
       </div>
     ) : null,
 }));

--- a/ui/apps/console/src/pages/sessions/index.tsx
+++ b/ui/apps/console/src/pages/sessions/index.tsx
@@ -37,6 +37,7 @@ function CloseButton({ onClose }: { onClose: () => Promise<unknown> }) {
 
   return (
     <button
+      type="button"
       onClick={(e) => void handleClick(e)}
       disabled={closing}
       title="Close session"
@@ -180,6 +181,7 @@ export default function Sessions() {
           {s.recorded && (
             <RestrictedAction action="session:play">
               <button
+                type="button"
                 onClick={(e) => void handlePlayClick(e, s.uid)}
                 disabled={logsLoading && playTarget === s.uid}
                 title="Play recording"

--- a/ui/apps/console/src/pages/team/AddMemberDrawer.tsx
+++ b/ui/apps/console/src/pages/team/AddMemberDrawer.tsx
@@ -93,7 +93,7 @@ function AddMemberDrawer({
           }}
           placeholder="user@example.com"
           hint="Must have an existing ShellHub account"
-          autoFocus={open}
+
           error={emailError}
         />
         <RoleSelector value={role} onChange={setRole} />

--- a/ui/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -100,6 +100,7 @@ function ApiKeysTab() {
         <div className="flex items-center justify-end gap-1">
           <RestrictedAction action="apiKey:edit">
             <button
+              type="button"
               onClick={() => setEditTarget(key)}
               className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
               title="Edit"
@@ -109,6 +110,7 @@ function ApiKeysTab() {
           </RestrictedAction>
           <RestrictedAction action="apiKey:delete">
             <button
+              type="button"
               onClick={() => setDeleteTarget(key)}
               className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/5 transition-colors"
               title="Delete"
@@ -130,6 +132,7 @@ function ApiKeysTab() {
         </p>
         <RestrictedAction action="apiKey:create">
           <button
+            type="button"
             onClick={() => setGenerateOpen(true)}
             className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
           >

--- a/ui/apps/console/src/pages/team/EditKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/team/EditKeyDrawer.tsx
@@ -80,7 +80,7 @@ function EditKeyDrawer({
           value={name}
           onChange={setName}
           maxLength={20}
-          autoFocus={open}
+
         />
         <RoleSelector value={role} onChange={setRole} />
 

--- a/ui/apps/console/src/pages/team/GenerateKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/team/GenerateKeyDrawer.tsx
@@ -153,7 +153,7 @@ function GenerateKeyDrawer({
             placeholder="e.g. ci-pipeline"
             error={nameError || undefined}
             maxLength={20}
-            autoFocus={open}
+
           />
           <RoleSelector value={role} onChange={setRole} />
           <RadioGroupField

--- a/ui/apps/console/src/pages/team/InvitationDrawer.tsx
+++ b/ui/apps/console/src/pages/team/InvitationDrawer.tsx
@@ -207,7 +207,7 @@ function InvitationDrawer({
             placeholder="user@example.com"
             error={emailError || undefined}
             hint="If no account matches this email, we'll send a sign-up link."
-            autoFocus={open}
+
           />
 
           <RoleSelector value={role} onChange={setRole} />

--- a/ui/apps/console/src/pages/team/InvitationsTab.tsx
+++ b/ui/apps/console/src/pages/team/InvitationsTab.tsx
@@ -314,6 +314,7 @@ function InvitationsTab({ tenantId }: { tenantId: string }) {
         </div>
         <RestrictedAction action="namespace:addMember">
           <button
+            type="button"
             onClick={() => setInviteOpen(true)}
             className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
           >

--- a/ui/apps/console/src/pages/team/MembersTab.tsx
+++ b/ui/apps/console/src/pages/team/MembersTab.tsx
@@ -110,6 +110,7 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
           <div className="flex items-center justify-end gap-1">
             <RestrictedAction action="namespace:editMember">
               <button
+                type="button"
                 onClick={() => setEditTarget(m)}
                 className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
                 title="Edit role"
@@ -119,6 +120,7 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
             </RestrictedAction>
             <RestrictedAction action="namespace:removeMember">
               <button
+                type="button"
                 onClick={() => setRemoveTarget(m)}
                 className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/5 transition-colors"
                 title="Remove"
@@ -141,6 +143,7 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
         </p>
         <RestrictedAction action="namespace:addMember">
           <button
+            type="button"
             onClick={() => setAddOpen(true)}
             className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
           >

--- a/ui/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/components/common/Drawer", () => ({
     return (
       <div role="dialog" aria-label={title}>
         <h2>{title}</h2>
-        <button onClick={onClose}>Close</button>
+        <button type="button" onClick={onClose}>Close</button>
         {children}
         {footer ?? null}
       </div>

--- a/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -50,8 +50,8 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
         <h2>{title}</h2>
         <div>{description}</div>
         {children}
-        <button onClick={onClose}>Cancel</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>Cancel</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },

--- a/ui/apps/console/src/pages/team/__tests__/EditInvitationDrawer.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/EditInvitationDrawer.test.tsx
@@ -38,7 +38,7 @@ vi.mock("../../../components/common/Drawer", () => ({
     return (
       <div role="dialog" aria-label={title}>
         <h2>{title}</h2>
-        <button onClick={onClose}>Close</button>
+        <button type="button" onClick={onClose}>Close</button>
         {children}
         {footer ?? null}
       </div>

--- a/ui/apps/console/src/pages/team/__tests__/InvitationDrawer.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/InvitationDrawer.test.tsx
@@ -43,7 +43,7 @@ vi.mock("../../../components/common/Drawer", () => ({
     return (
       <div role="dialog" aria-label={title}>
         <h2>{title}</h2>
-        <button onClick={onClose}>Close</button>
+        <button type="button" onClick={onClose}>Close</button>
         {children}
         {footer ?? null}
       </div>
@@ -53,7 +53,7 @@ vi.mock("../../../components/common/Drawer", () => ({
 
 vi.mock("../../../components/common/CopyButton", () => ({
   default: ({ text }: { text: string }) => (
-    <button aria-label="Copy" data-copy={text}>
+    <button type="button" aria-label="Copy" data-copy={text}>
       Copy
     </button>
   ),

--- a/ui/apps/console/src/pages/team/__tests__/InvitationsTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/InvitationsTab.test.tsx
@@ -58,8 +58,8 @@ vi.mock("../../../components/common/ConfirmDialog", () => ({
     return (
       <div role="dialog">
         <h2>{title}</h2>
-        <button onClick={onClose}>{cancelLabel}</button>
-        <button onClick={() => void onConfirm()}>{confirmLabel}</button>
+        <button type="button" onClick={onClose}>{cancelLabel}</button>
+        <button type="button" onClick={() => void onConfirm()}>{confirmLabel}</button>
       </div>
     );
   },
@@ -70,7 +70,7 @@ vi.mock("../InvitationDrawer", () => ({
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
     open ? (
       <div data-testid="invitation-drawer">
-        <button onClick={onClose}>Close Invite Drawer</button>
+        <button type="button" onClick={onClose}>Close Invite Drawer</button>
       </div>
     ) : null,
 }));
@@ -79,7 +79,7 @@ vi.mock("../EditInvitationDrawer", () => ({
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
     open ? (
       <div data-testid="edit-invitation-drawer">
-        <button onClick={onClose}>Close Edit Drawer</button>
+        <button type="button" onClick={onClose}>Close Edit Drawer</button>
       </div>
     ) : null,
 }));

--- a/ui/apps/console/src/pages/team/index.tsx
+++ b/ui/apps/console/src/pages/team/index.tsx
@@ -47,6 +47,7 @@ export default function Team() {
       <div className="flex items-center h-8 bg-card border border-border rounded-md p-0.5 w-fit mb-6 animate-fade-in">
         {tabs.map((t) => (
           <button
+            type="button"
             key={t.value}
             onClick={() => setTab(t.value)}
             className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -341,13 +341,14 @@ function SessionRecording() {
 
                   {/* Playback controls */}
                   <div className="flex items-center gap-3">
-                    <button className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
+                    <button type="button" aria-label="Rewind" className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
                       <svg
                         className="w-4 h-4 text-text-secondary"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
                         strokeWidth={2}
+                        aria-hidden="true"
                       >
                         <path
                           strokeLinecap="round"
@@ -356,13 +357,14 @@ function SessionRecording() {
                         />
                       </svg>
                     </button>
-                    <button className="w-10 h-10 rounded-lg bg-accent-cyan/15 border border-accent-cyan/25 flex items-center justify-center hover:bg-accent-cyan/25 transition-colors">
+                    <button type="button" aria-label="Pause" className="w-10 h-10 rounded-lg bg-accent-cyan/15 border border-accent-cyan/25 flex items-center justify-center hover:bg-accent-cyan/25 transition-colors">
                       <svg
                         className="w-5 h-5 text-accent-cyan"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
                         strokeWidth={2}
+                        aria-hidden="true"
                       >
                         <path
                           strokeLinecap="round"
@@ -371,13 +373,14 @@ function SessionRecording() {
                         />
                       </svg>
                     </button>
-                    <button className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
+                    <button type="button" aria-label="Fast forward" className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
                       <svg
                         className="w-4 h-4 text-text-secondary"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
                         strokeWidth={2}
+                        aria-hidden="true"
                       >
                         <path
                           strokeLinecap="round"

--- a/ui/apps/website/src/pages/getting-started/StepSetup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSetup.tsx
@@ -49,6 +49,7 @@ export function StepSetup({ onBack }: StepSetupProps) {
       <Reveal delay={0.15}>
         <div className="flex items-center justify-between">
           <button
+            type="button"
             onClick={onBack}
             className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-text-secondary border border-border rounded-xl hover:text-text-primary hover:border-border-light hover:bg-white/[0.04] transition-all duration-300 group"
           >

--- a/ui/apps/website/src/pages/getting-started/StepSignup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSignup.tsx
@@ -231,7 +231,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
 
             {/* Name */}
             <div>
-              <label className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
+              <label htmlFor="signup-name" className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
                 Name
               </label>
               <div className="relative">
@@ -239,6 +239,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
                   <UserIcon />
                 </span>
                 <input
+                  id="signup-name"
                   type="text"
                   value={name}
                   onChange={(e) => {
@@ -247,7 +248,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
                   }}
                   placeholder="Your name"
                   className={INPUT_BASE}
-                  autoFocus
+
                 />
               </div>
               {fieldErrors.name && (
@@ -259,7 +260,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
 
             {/* Email */}
             <div>
-              <label className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
+              <label htmlFor="signup-email" className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
                 Email
               </label>
               <div className="relative">
@@ -267,6 +268,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
                   <MailIcon />
                 </span>
                 <input
+                  id="signup-email"
                   type="email"
                   value={email}
                   onChange={(e) => {
@@ -289,7 +291,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
 
             {/* Password */}
             <div>
-              <label className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
+              <label htmlFor="signup-password" className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
                 Password
               </label>
               <div className="relative">
@@ -297,6 +299,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
                   <LockIcon />
                 </span>
                 <input
+                  id="signup-password"
                   type={showPassword ? "text" : "password"}
                   value={password}
                   onChange={(e) => {
@@ -360,7 +363,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
 
             {/* Confirm password */}
             <div>
-              <label className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
+              <label htmlFor="signup-confirm-password" className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
                 Confirm password
               </label>
               <div className="relative">
@@ -368,6 +371,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
                   <LockIcon />
                 </span>
                 <input
+                  id="signup-confirm-password"
                   type={showPassword ? "text" : "password"}
                   value={confirmPassword}
                   onChange={(e) => {

--- a/ui/apps/website/src/pages/landing/Navbar.tsx
+++ b/ui/apps/website/src/pages/landing/Navbar.tsx
@@ -187,6 +187,7 @@ function MobileDropdown({
   return (
     <div>
       <button
+        type="button"
         onClick={() => setOpen(!open)}
         className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-[13px] font-medium transition-all"
         style={{ color: C.textSec }}
@@ -341,6 +342,7 @@ export function Navbar({
         onClick={() => setActiveMenu(null)}
       />
 
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- nav onClick delegates to child links only */}
       <nav
         id="shellhub-nav"
         className="fixed top-0 left-0 right-0 z-50 h-14 transition-all duration-300"
@@ -364,6 +366,7 @@ export function Navbar({
 
           {/* Mobile toggle */}
           <button
+            type="button"
             data-testid="mobile-nav-toggle"
             className="lg:hidden p-2 transition-colors"
             style={{ color: C.textSec }}
@@ -399,6 +402,7 @@ export function Navbar({
           >
             {menuItems.map(({ id, label }) => (
               <button
+                type="button"
                 key={id}
                 aria-expanded={activeMenu === id}
                 onClick={() => setActiveMenu(activeMenu === id ? null : id)}

--- a/ui/apps/website/src/pages/landing/SupportedPlatforms.tsx
+++ b/ui/apps/website/src/pages/landing/SupportedPlatforms.tsx
@@ -223,6 +223,7 @@ export function SupportedPlatforms() {
                   href={p.href}
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label={p.name}
                   className="bg-surface border border-border rounded-xl p-4 hover:border-border-light transition-all duration-300 group"
                 >
                   <div className="flex items-center gap-3">
@@ -235,6 +236,7 @@ export function SupportedPlatforms() {
                         viewBox="0 0 24 24"
                         stroke="currentColor"
                         strokeWidth={1.5}
+                        aria-hidden="true"
                       >
                         {p.icon}
                       </svg>

--- a/ui/apps/website/src/pages/pricing/ComparisonTable.tsx
+++ b/ui/apps/website/src/pages/pricing/ComparisonTable.tsx
@@ -106,7 +106,7 @@ export function ComparisonTable() {
             <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="text-left py-4 pr-4 text-sm font-medium text-text-secondary w-[40%]" />
+                  <th className="text-left py-4 pr-4 text-sm font-medium text-text-secondary w-[40%]" scope="col"><span className="sr-only">Feature</span></th>
                   <th className="py-4 px-4 text-center text-sm font-semibold w-[20%]">Community</th>
                   <th className="py-4 px-4 text-center text-sm font-semibold w-[20%]">
                     <span className="text-primary">Cloud</span>

--- a/ui/apps/website/src/pages/pricing/PricingFAQ.tsx
+++ b/ui/apps/website/src/pages/pricing/PricingFAQ.tsx
@@ -34,7 +34,10 @@ function FAQItem({ q, a, index }: { q: string; a: string; index: number }) {
   return (
     <Reveal delay={index * 0.04}>
       <button
+        type="button"
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-label={q}
         className="w-full text-left py-5 border-b border-border group"
       >
         <div className="flex items-center justify-between gap-4">
@@ -45,6 +48,7 @@ function FAQItem({ q, a, index }: { q: string; a: string; index: number }) {
             viewBox="0 0 24 24"
             stroke="currentColor"
             strokeWidth={2}
+            aria-hidden="true"
           >
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -400,13 +400,14 @@ export default function RemoteSupport() {
 
                     {/* Playback controls */}
                     <div className="flex items-center gap-3 bg-surface rounded-lg border border-border p-3">
-                      <button className="w-8 h-8 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center shrink-0">
+                      <button type="button" aria-label="Play" className="w-8 h-8 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center shrink-0">
                         <svg
                           width="14"
                           height="14"
                           viewBox="0 0 24 24"
                           fill={C.cyan}
                           stroke="none"
+                          aria-hidden="true"
                         >
                           <polygon points="6 4 20 12 6 20 6 4" />
                         </svg>

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -7,6 +7,8 @@ import unusedImports from "eslint-plugin-unused-imports";
 import stylisticPlugin from "@stylistic/eslint-plugin";
 import vitestPlugin from "@vitest/eslint-plugin";
 import globals from "globals";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+import reactPlugin from "eslint-plugin-react";
 
 export default defineConfig([
   globalIgnores(["**/dist", "**/node_modules", "**/.astro", "**/.vite", "packages/design-system/**", "**/src/client"]),
@@ -21,6 +23,51 @@ export default defineConfig([
     },
   },
   stylisticPlugin.configs.recommended,
+
+  // Accessibility — catches missing aria-labels, bad roles, inaccessible interactive elements
+  jsxA11y.flatConfigs.recommended,
+  {
+    rules: {
+      // Icon-only interactive elements must have an accessible label.
+      // Catches close buttons, icon buttons, etc. that render no visible text.
+      "jsx-a11y/control-has-associated-label": ["error", {
+        ignoreElements: ["audio", "canvas", "embed", "input", "textarea", "tr", "video"],
+        ignoreRoles: ["grid", "listbox", "menu", "menubar", "radiogroup", "row", "tablist", "toolbar", "tree", "treegrid"],
+      }],
+
+      // Interactive elements (role=button, etc.) must be keyboard-focusable.
+      // Catches <div onClick> that omit tabIndex and keyboard handlers.
+      "jsx-a11y/interactive-supports-focus": "warn",
+
+      // Prevents attaching mouse/pointer handlers to static, non-interactive elements
+      // without a corresponding keyboard handler.
+      "jsx-a11y/no-static-element-interactions": "warn",
+
+      // Any element with an onClick must also handle Enter/Space via onKeyDown/onKeyUp/onKeyPress.
+      "jsx-a11y/click-events-have-key-events": "warn",
+    },
+  },
+
+  // React — button types, dangerous HTML, safe anchor targets
+  {
+    plugins: { react: reactPlugin },
+    settings: { react: { version: "detect" } },
+    rules: {
+      // Same goal as jsx-a11y/button-has-type but from the React side.
+      // Together they cover both JSX and DOM-level checks.
+      "react/button-has-type": "error",
+
+      // Prevents dangerouslySetInnerHTML from being introduced silently.
+      "react/no-danger": "warn",
+
+      // <a target="_blank"> without rel="noreferrer" is a security/privacy issue.
+      "react/jsx-no-target-blank": "error",
+
+      // Enforces self-closing tags on components/elements with no children.
+      "react/self-closing-comp": "warn",
+    },
+  },
+
   {
     plugins: {
       "react-hooks": reactHooks,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@stylistic/eslint-plugin": "^5.10.0",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -29,6 +30,8 @@
         "@vitest/eslint-plugin": "^1.1.44",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.22.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "7.1.0-canary-e0cc7202-20260227",
         "eslint-plugin-react-refresh": "^0.5.0",
         "eslint-plugin-unused-imports": "^4.4.1",
@@ -3688,7 +3691,6 @@
       "version": "10.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4135,8 +4137,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/asn1": {
       "version": "0.2.4",
@@ -4866,6 +4867,46 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-iterate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
@@ -4874,6 +4915,104 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/asciinema-player": {
@@ -4935,6 +5074,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/astring": {
       "version": "1.9.0",
@@ -5760,6 +5906,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "license": "MIT"
@@ -5812,6 +5968,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -6356,13 +6522,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -6941,6 +7109,13 @@
       "version": "3.2.3",
       "license": "MIT"
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "license": "MIT",
@@ -6961,6 +7136,60 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/date-fns": {
@@ -7202,11 +7431,23 @@
       "version": "1.1.3",
       "license": "MIT"
     },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -7366,6 +7607,94 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "license": "MIT",
@@ -7380,13 +7709,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7406,6 +7765,39 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
+      "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esast-util-from-estree": {
@@ -7559,6 +7951,117 @@
         }
       }
     },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.0-canary-e0cc7202-20260227",
       "dev": true,
@@ -7583,6 +8086,61 @@
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-plugin-unused-imports": {
@@ -8133,6 +8691,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "dev": true,
@@ -8200,6 +8792,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "license": "MIT",
@@ -8263,6 +8873,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -8290,6 +8917,19 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8306,6 +8946,22 @@
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8789,6 +9445,21 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -8837,6 +9508,60 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "license": "MIT",
@@ -8845,6 +9570,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-callable": {
@@ -8859,10 +9601,47 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8896,11 +9675,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -8978,6 +9789,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-nan": {
       "version": "1.3.2",
       "dev": true,
@@ -8993,11 +9817,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-obj": {
@@ -9034,12 +9888,122 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9078,6 +10042,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/jiti": {
@@ -9183,6 +10165,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
@@ -9198,6 +10196,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/levn": {
@@ -9286,7 +10304,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10546,6 +11563,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
@@ -10720,6 +11756,60 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "dev": true,
@@ -10809,6 +11899,24 @@
       "version": "0.3.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/p-limit": {
       "version": "6.2.0",
@@ -11282,7 +12390,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11641,8 +12748,7 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -11799,6 +12905,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -11822,6 +12951,27 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/rehype": {
       "version": "13.0.2",
@@ -12261,6 +13411,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "dev": true,
@@ -12279,6 +13449,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -12374,6 +13561,37 @@
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12668,6 +13886,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "dev": true,
@@ -12706,6 +13938,120 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/stringify-entities": {
@@ -13168,6 +14514,69 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
@@ -13214,6 +14623,25 @@
       "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
       "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
       "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
@@ -13836,6 +15264,73 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-module": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -28,6 +29,8 @@
     "globals": "^17.4.0",
     "eslint-plugin-react-hooks": "7.1.0-canary-e0cc7202-20260227",
     "eslint-plugin-react-refresh": "^0.5.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-unused-imports": "^4.4.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",


### PR DESCRIPTION
## What

Adds `eslint-plugin-jsx-a11y` (recommended preset) and `eslint-plugin-react` to the workspace flat config and fixes every violation they surface across the console and website apps. Also fixes two a11y regressions identified in review.

## Why

A UI audit identified widespread accessibility gaps directly enforceable by linter rules. Shipping the rules without fixing the violations would gate CI permanently.

Closes shellhub-io/team#129
Closes shellhub-io/team#131
Closes shellhub-io/team#141

## Changes

- **eslint.config.js + package.json**: Added `eslint-plugin-jsx-a11y` (full recommended preset + `control-has-associated-label`, `interactive-supports-focus`, `no-static-element-interactions`, `click-events-have-key-events`) and `eslint-plugin-react` (`button-has-type`, `no-danger`, `jsx-no-target-blank`, `self-closing-comp`).

- **button-has-type**: Added `type=` to ~323 untyped `<button>` elements across ~137 files. Files containing a `<form>` were reviewed individually to assign `type="submit"` vs `type="button"` based on intent — not bulk-assigned.

- **jsx-a11y violations**: Removed `autoFocus` props, added `htmlFor`/`id` pairs to unassociated labels, added `aria-label` to icon-only buttons (terminal fullscreen, video playback, nav icons), added `role="group"` + `aria-label` to OTP input groups in all MFA components (`MfaLogin`, `MfaEnableDrawer`, `MfaDisableDialog`, `MfaResetVerify`, `MfaResetComplete`), added `<span class="sr-only">` to the empty `<th>` in `ComparisonTable`.

- **Drawer.tsx**: Added `useFocusTrap` to the panel container, mirroring `BaseDialog`. The `autoFocus` removal is safe because the container now owns focus management rather than individual inputs.

- **Pagination.test.tsx**: New TDD anchor — asserts both Prev and Next buttons carry `type="button"` (written red, fixed green).

## Testing

ESLint: 0 errors, 21 warnings (pre-existing `click-events-have-key-events` / `no-static-element-interactions` on `role="dialog"` click-outside handlers).
TypeScript: 0 errors on both `apps/console` and `apps/website`.
Vitest: 2212 tests across 140 files, all passing.