### PR TITLE
ci: bump sigstore/cosign-installer to v4

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -132,7 +132,7 @@ jobs:
           path: sbom-agent-*.cdx.json
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Attach SBOM to agent image
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,7 +65,7 @@ jobs:
           path: sbom-${{ matrix.project }}-*.cdx.json
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Attach SBOM to '${{ matrix.project }}' image
         run: |
@@ -137,7 +137,7 @@ jobs:
           path: sbom-api-enterprise-*.cdx.json
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Attach SBOM to api-enterprise image
         run: |


### PR DESCRIPTION
Updates `sigstore/cosign-installer` from v3 to v4 (latest) in `build-agent.yml` and `docker-publish.yml`.

Part of a workspace-wide GitHub Actions version audit.