### PR TITLE
ci: disable experimental Claude agent-teams in review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -228,12 +228,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           trigger_phrase: "/review"
-          settings: |
-            {
-              "env": {
-                "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-              }
-            }
           prompt: |
             You are the lead reviewer for this PR in shellhub-io/shellhub (Community Edition).
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -118,9 +118,3 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "@claude"
-          settings: |
-            {
-              "env": {
-                "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-              }
-            }


### PR DESCRIPTION
## What

Removes `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` from the Claude review workflow(s), so the action runs on the standard runtime instead of the experimental agent-teams path.

## Why

The experimental agent-teams runtime produced highly variable latency and cost for the multi-agent review fan-out. A recent `/review` on shellhub PR #6505 ran **21m 51s / 38 turns / $9.52**, versus a prior run on the same prompt at **~3 min / 28 turns / $3.41**. The long run also left the tracking comment frozen at "5 agents running…" for ~20 minutes, which read as a stalled/crashed review.

## Notes

The review prompts are unchanged — they still spawn their reviewer agents via the normal `Task` tool, which is how the fast prior run executed. This only drops the experimental runtime flag.
