### PR TITLE
fix(ui): restore muted resting tone for ghost and icon buttons

### DIFF
--- a/ui/apps/console/src/components/ManageTagsDrawer.tsx
+++ b/ui/apps/console/src/components/ManageTagsDrawer.tsx
@@ -159,7 +159,7 @@ export default function ManageTagsDrawer({
             />
             <IconButton
               type="submit"
-              variant="primary"
+              variant="filled"
               size="lg"
               loading={submitting}
               disabled={!newNameValid}

--- a/ui/packages/design-system/__tests__/Button.test.tsx
+++ b/ui/packages/design-system/__tests__/Button.test.tsx
@@ -38,7 +38,7 @@ describe("Button — variants", () => {
     );
     const el = screen.getByTestId("btn");
     expect(el.className).toContain("bg-transparent");
-    expect(el.className).toContain("text-text-primary");
+    expect(el.className).toContain("text-text-secondary");
   });
 
   it("variant=destructive renders destructive classes", () => {

--- a/ui/packages/design-system/__tests__/IconButton.test.tsx
+++ b/ui/packages/design-system/__tests__/IconButton.test.tsx
@@ -32,6 +32,28 @@ describe("IconButton — base classes", () => {
     expect(el.className).toContain("shrink-0");
   });
 
+  it("includes default bg and text color classes", () => {
+    render(<IconButton data-testid="btn">X</IconButton>);
+    const el = screen.getByTestId("btn");
+    expect(el.className).toContain("bg-transparent");
+    expect(el.className).toContain("text-text-muted");
+  });
+
+  it("includes shared transition, selection, focus, and disabled classes", () => {
+    render(<IconButton data-testid="btn">X</IconButton>);
+    const el = screen.getByTestId("btn");
+    expect(el.className).toContain("transition-all");
+    expect(el.className).toContain("duration-150");
+    expect(el.className).toContain("select-none");
+    expect(el.className).toContain("focus-visible:outline-none");
+    expect(el.className).toContain("focus-visible:ring-2");
+    expect(el.className).toContain("focus-visible:ring-offset-2");
+    expect(el.className).toContain("focus-visible:ring-offset-background");
+    expect(el.className).toContain("focus-visible:ring-primary");
+    expect(el.className).toContain("disabled:opacity-50");
+    expect(el.className).toContain("disabled:cursor-not-allowed");
+  });
+
   it("includes focus-visible:ring-2", () => {
     render(<IconButton data-testid="btn">X</IconButton>);
     expect(screen.getByTestId("btn").className).toContain(
@@ -105,29 +127,46 @@ describe("IconButton — variants", () => {
   it("variant=ghost (default) adds ghost classes", () => {
     render(<IconButton data-testid="btn">X</IconButton>);
     const el = screen.getByTestId("btn");
-    expect(el.className).toContain("bg-transparent");
-    expect(el.className).toContain("text-text-primary");
+    expect(el.className).toContain("hover:text-text-primary");
+    expect(el.className).toContain("hover:bg-hover-subtle");
   });
 
-  it("variant=primary adds primary classes", () => {
+  it("variant=primary adds subtle muted-to-blue classes (row edit convention)", () => {
     render(
       <IconButton data-testid="btn" variant="primary">
         X
       </IconButton>,
     );
     const el = screen.getByTestId("btn");
-    expect(el.className).toContain("bg-primary");
-    expect(el.className).toContain("text-white");
+    expect(el.className).toContain("hover:text-primary");
+    expect(el.className).toContain("hover:bg-primary/10");
   });
 
-  it("variant=danger adds danger classes", () => {
+  it("variant=danger adds subtle muted-to-red classes (row delete convention)", () => {
     render(
       <IconButton data-testid="btn" variant="danger">
         X
       </IconButton>,
     );
     const el = screen.getByTestId("btn");
-    expect(el.className).toContain("text-accent-red");
+    expect(el.className).toContain("hover:text-accent-red");
+    expect(el.className).toContain("hover:bg-accent-red/10");
+    expect(el.className).toContain("focus-visible:ring-accent-red");
+    expect(el.className).not.toContain("focus-visible:ring-primary");
+  });
+
+  it("variant=filled adds filled primary classes (prominent button convention)", () => {
+    render(
+      <IconButton data-testid="btn" variant="filled">
+        X
+      </IconButton>,
+    );
+    const el = screen.getByTestId("btn");
+    expect(el.className).toContain("bg-primary");
+    expect(el.className).toContain("text-white");
+    expect(el.className).toContain("hover:bg-primary/90");
+    expect(el.className).not.toContain("bg-transparent");
+    expect(el.className).not.toContain("text-text-muted");
   });
 });
 
@@ -295,6 +334,34 @@ describe("IconButton — loading", () => {
       </IconButton>,
     );
     expect(screen.getByTestId("btn")).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("variant=filled loading uses onPrimary spinner tone (white border classes)", () => {
+    render(
+      <IconButton data-testid="btn" variant="filled" loading aria-label="x">
+        X
+      </IconButton>,
+    );
+    const spinner = screen
+      .getByTestId("btn")
+      .querySelector("[class*='animate-spin']");
+    expect(spinner).not.toBeNull();
+    expect(spinner!.className).toContain("border-white/30");
+    expect(spinner!.className).toContain("border-t-white");
+  });
+
+  it("non-filled loading variant uses onSurface spinner tone (primary border classes)", () => {
+    render(
+      <IconButton data-testid="btn" variant="primary" loading aria-label="x">
+        X
+      </IconButton>,
+    );
+    const spinner = screen
+      .getByTestId("btn")
+      .querySelector("[class*='animate-spin']");
+    expect(spinner).not.toBeNull();
+    expect(spinner!.className).toContain("border-primary/30");
+    expect(spinner!.className).toContain("border-t-primary");
   });
 });
 

--- a/ui/packages/design-system/primitives/Button.tsx
+++ b/ui/packages/design-system/primitives/Button.tsx
@@ -30,7 +30,7 @@ const VARIANT: Record<ButtonVariant, string> = {
   surface:
     "bg-surface border border-border text-text-primary hover:border-border-light hover:bg-white/[0.04] focus-visible:ring-primary",
   ghost:
-    "bg-transparent text-text-primary hover:bg-hover-subtle focus-visible:ring-primary",
+    "bg-transparent text-text-secondary hover:text-text-primary hover:bg-hover-subtle focus-visible:ring-primary",
   destructive:
     "bg-accent-red text-white hover:bg-accent-red/90 focus-visible:ring-accent-red",
   dangerSoft:

--- a/ui/packages/design-system/primitives/IconButton.tsx
+++ b/ui/packages/design-system/primitives/IconButton.tsx
@@ -6,20 +6,24 @@ import { cn } from "./cn";
 // Public types
 // ---------------------------------------------------------------------------
 
-export type IconButtonVariant = "ghost" | "primary" | "danger";
+export type IconButtonVariant = "ghost" | "primary" | "danger" | "filled";
 export type IconButtonSize = "sm" | "md" | "lg";
 
 // ---------------------------------------------------------------------------
 // Static maps
 // ---------------------------------------------------------------------------
 
+// Icon-button variants intentionally rest at text-text-muted and accent on hover,
+// so `primary` and `danger` here differ from the always-filled Button variants of the same name.
 const VARIANT: Record<IconButtonVariant, string> = {
   ghost:
-    "bg-transparent text-text-primary hover:bg-hover-subtle focus-visible:ring-primary",
+    "hover:text-text-primary hover:bg-hover-subtle",
   primary:
-    "bg-primary text-white hover:bg-primary/90 focus-visible:ring-primary",
+    "hover:text-primary hover:bg-primary/10",
   danger:
-    "bg-transparent text-accent-red hover:bg-accent-red/10 focus-visible:ring-accent-red",
+    "hover:text-accent-red hover:bg-accent-red/10 focus-visible:ring-accent-red",
+  filled:
+    "bg-primary text-white hover:bg-primary/90",
 };
 
 const SIZE: Record<IconButtonSize, string> = {
@@ -29,8 +33,8 @@ const SIZE: Record<IconButtonSize, string> = {
 };
 
 const BASE =
-  "inline-flex items-center justify-center shrink-0 transition-all duration-150 select-none" +
-  " focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background" +
+  "inline-flex items-center justify-center shrink-0 transition-all duration-150 select-none text-text-muted bg-transparent" +
+  " focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:ring-primary" +
   " disabled:opacity-50 disabled:cursor-not-allowed";
 
 // ---------------------------------------------------------------------------
@@ -111,7 +115,7 @@ export function IconButton<T extends ElementType = "button">({
       {loading ? (
         <Spinner
           size="sm"
-          tone={variant === "primary" ? "onPrimary" : "onSurface"}
+          tone={variant === "filled" ? "onPrimary" : "onSurface"}
         />
       ) : (
         children


### PR DESCRIPTION
## What

Restore the muted resting tone of the design-system `ghost` and `IconButton` controls, and add a dedicated `filled` `IconButton` variant for the rare solid case, so the UI stops rendering louder than it did before the Button migration.

## Why

PR #6485 adopted `Button`/`IconButton` across the apps, but the primitives' variants didn't preserve the visual weight of the markup they replaced. `ghost` rested at `text-text-primary` (near-white) instead of the muted gray used everywhere (e.g. the `ConfirmDialog` cancel was `text-text-secondary`), and `IconButton`'s `primary`/`danger` were filled-blue / always-red — so subtle table-row edit and delete actions rendered as solid colored squares. The result was a visibly louder interface than before the migration. Part of the design-system consolidation tracked in shellhub-io/team#114.

## Changes

- **`Button`**: `ghost` now rests at `text-text-secondary` and brightens to `text-text-primary` on hover, matching the pre-migration cancel/close treatment. No other variant changed.
- **`IconButton`**: variants now rest muted and accent on hover. The shared rest state (`text-text-muted bg-transparent`) and `focus-visible:ring-primary` moved into the base classes; `ghost`/`primary`/`danger` carry only their hover accents (`primary` muted→blue, `danger` muted→red). Added a `filled` variant (`bg-primary text-white`) — the only solid icon-button style — and keyed the loading spinner's `onPrimary` tone off it. A comment documents that these `primary`/`danger` semantics intentionally differ from the always-filled `Button` variants of the same name.
- **`ManageTagsDrawer`**: the one genuinely prominent icon action (the add-tag submit) moved from `primary` to the new `filled` so it stays solid.
- **tests**: updated the `Button`/`IconButton` specs for the new rest tones and added coverage for `filled` and the muted-at-rest behavior, including the `filled`-vs-other loading-spinner tone.

## Testing

Run the design-system and console suites and lint via `./bin/docker-compose`. Visually confirm: table-row edit (pencil) and delete (trash) icons rest muted gray and accent blue/red on hover rather than rendering as filled squares; dialog/drawer Cancel/Close buttons rest muted gray, not near-white; the add-tag "+" in Manage Tags stays solid blue.
