### PR TITLE
refactor(validator): use named constants for api-key and member_role tags

### DIFF
--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -41,6 +41,12 @@ const (
 	// PrivateKeyPEMTag contains the rule to validate a private key.
 	PrivateKeyPEMTag = "privateKeyPEM"
 	CertPEMTag       = "certPEM"
+	// APIKeyNameTag contains the rule to validate an API key's name.
+	APIKeyNameTag = "api-key_name"
+	// APIKeyExpiresAtTag contains the rule to validate an API key's expiration value.
+	APIKeyExpiresAtTag = "api-key_expires-at" //nolint:gosec // G101: not a credential, this is a validator tag name
+	// MemberRoleTag contains the rule to validate a namespace member's role.
+	MemberRoleTag = "member_role"
 )
 
 // Rules is a slice that contains all validation rules.
@@ -87,7 +93,7 @@ var Rules = []Rule{
 	// and `_`. URL-reserved characters (e.g. @, /, #) are intentionally excluded
 	// because the name is used as a path parameter in PATCH and DELETE endpoints.
 	{
-		Tag: "api-key_name",
+		Tag: APIKeyNameTag,
 		Handler: func(field validator.FieldLevel) bool {
 			return regexp.MustCompile(`^[a-zA-Z0-9_-]{3,20}$`).MatchString(field.Field().String())
 		},
@@ -95,7 +101,7 @@ var Rules = []Rule{
 	},
 	// api-key_expires-at reports whether a given int is in [ 30 60 90 365 -1 ].
 	{
-		Tag: "api-key_expires-at",
+		Tag: APIKeyExpiresAtTag,
 		Handler: func(field validator.FieldLevel) bool {
 			if !field.Field().CanInt() {
 				return false
@@ -109,7 +115,7 @@ var Rules = []Rule{
 	},
 	// member_role reports whether a given string is a valid role or not
 	{
-		Tag: "member_role",
+		Tag: MemberRoleTag,
 		Handler: func(field validator.FieldLevel) bool {
 			return authorizer.RoleFromString(field.Field().String()) != authorizer.RoleInvalid
 		},

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -461,6 +461,122 @@ func TestAPIKeyName(t *testing.T) {
 	}
 }
 
+func TestAPIKeyExpiresAt(t *testing.T) {
+	tests := []struct {
+		description string
+		value       int
+		want        bool
+	}{
+		{
+			description: "fails when expires_at is 0",
+			value:       0,
+			want:        false,
+		},
+		{
+			description: "fails when expires_at is 7",
+			value:       7,
+			want:        false,
+		},
+		{
+			description: "fails when expires_at is 1000",
+			value:       1000,
+			want:        false,
+		},
+		{
+			description: "succeeds when expires_at is -1 (never expires)",
+			value:       -1,
+			want:        true,
+		},
+		{
+			description: "succeeds when expires_at is 30",
+			value:       30,
+			want:        true,
+		},
+		{
+			description: "succeeds when expires_at is 60",
+			value:       60,
+			want:        true,
+		},
+		{
+			description: "succeeds when expires_at is 90",
+			value:       90,
+			want:        true,
+		},
+		{
+			description: "succeeds when expires_at is 365",
+			value:       365,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			data := struct {
+				ExpiresAt int `validate:"api-key_expires-at"`
+			}{
+				ExpiresAt: tt.value,
+			}
+
+			ok, _ := New().Struct(data)
+
+			assert.Equal(t, tt.want, ok)
+		})
+	}
+}
+
+func TestMemberRole(t *testing.T) {
+	tests := []struct {
+		description string
+		value       string
+		want        bool
+	}{
+		{
+			description: "fails when role is empty",
+			value:       "",
+			want:        false,
+		},
+		{
+			description: "fails when role is superuser",
+			value:       "superuser",
+			want:        false,
+		},
+		{
+			description: "succeeds when role is owner",
+			value:       "owner",
+			want:        true,
+		},
+		{
+			description: "succeeds when role is administrator",
+			value:       "administrator",
+			want:        true,
+		},
+		{
+			description: "succeeds when role is operator",
+			value:       "operator",
+			want:        true,
+		},
+		{
+			description: "succeeds when role is observer",
+			value:       "observer",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			data := struct {
+				Role string `validate:"member_role"`
+			}{
+				Role: tt.value,
+			}
+
+			ok, _ := New().Struct(data)
+
+			assert.Equal(t, tt.want, ok)
+		})
+	}
+}
+
 func TestCertPEM(t *testing.T) {
 	tests := []struct {
 		description string


### PR DESCRIPTION
## What

Extract the `api-key_name`, `api-key_expires-at` and `member_role` validation
tags into named constants (`APIKeyNameTag`, `APIKeyExpiresAtTag`,
`MemberRoleTag`) in `pkg/validator/validator.go`, so all tag definitions in
the `Rules` slice follow the same pattern as the older rules (`NameTag`,
`DeviceNameTag`, etc.). Pure refactor with no behavior change.

## Why

These three rules were the odd ones out, declaring their tag as a raw string
literal while every other rule used a named constant. The constant values are
byte-for-byte identical to the previous literals, so rule registration
(`RegisterValidation`) and struct-tag matching are unchanged: a no-op at
runtime.

Struct field tags (e.g. `validate:"required,api-key_name"`) keep using the raw
strings, because Go struct tags cannot reference constants. This is the same
situation as the existing constants, which are likewise referenced only within
`validator.go`, so this change removes an inconsistency rather than introducing
one.

## Changes

- `pkg/validator/validator.go`: add the three constants and reference them in
  the `Rules` slice instead of the raw literals.
- `pkg/validator/validator_test.go`: add `TestAPIKeyExpiresAt` and
  `TestMemberRole`, which previously had no coverage.

## Testing

- `go test ./pkg/validator/...`: passes, including the two new tests.
- `golangci-lint`: clean.