### PR TITLE
refactor(ui): extract reusable NoticeBanner from layout banners

### DIFF
--- a/ui/apps/console/src/components/common/ConnectivityBanner.tsx
+++ b/ui/apps/console/src/components/common/ConnectivityBanner.tsx
@@ -1,22 +1,16 @@
+import NoticeBanner from "@/components/common/NoticeBanner";
 import { useConnectivityStore } from "@/stores/connectivityStore";
 
 export default function ConnectivityBanner() {
   const apiReachable = useConnectivityStore((s) => s.apiReachable);
 
   return (
-    <div
-      className={`grid transition-[grid-template-rows] duration-300 ease-out ${
-        apiReachable ? "grid-rows-[0fr]" : "grid-rows-[1fr]"
-      }`}
+    <NoticeBanner
+      visible={!apiReachable}
+      severity="error"
+      align="center"
     >
-      <div className="overflow-hidden">
-        <div className="bg-accent-red/[0.06] border-b border-accent-red/10 px-5 py-1.5 flex items-center justify-center gap-2">
-          <span className="inline-flex rounded-full h-1.5 w-1.5 bg-accent-red shrink-0" />
-          <p className="text-2xs font-mono text-accent-red whitespace-nowrap">
-            API unreachable — reconnecting automatically
-          </p>
-        </div>
-      </div>
-    </div>
+      API unreachable — reconnecting automatically
+    </NoticeBanner>
   );
 }

--- a/ui/apps/console/src/components/common/DeviceLimitBanner.tsx
+++ b/ui/apps/console/src/components/common/DeviceLimitBanner.tsx
@@ -1,3 +1,4 @@
+import NoticeBanner from "@/components/common/NoticeBanner";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
 import { useAdminStats } from "@/hooks/useAdminStats";
 
@@ -39,36 +40,15 @@ export default function DeviceLimitBanner() {
     license != null &&
     (over || approaching);
 
-  const isErrorSeverity = over;
+  const severity = over ? "error" : "warning";
 
   const message = over
-    ? "Your licensed device limit has been reached — new devices can't connect until you remove devices or contact ShellHub sales to raise the limit."
-    : "You're approaching your licensed device limit — contact ShellHub sales to raise it before new devices are blocked.";
+    ? "You've reached your licensed device limit. New devices can't connect until you contact the ShellHub team to raise the limit or remove some."
+    : "You're approaching your licensed device limit. Contact the ShellHub team to raise it before new devices are blocked.";
 
   return (
-    <div
-      aria-hidden={!visible ? true : undefined}
-      {...(!visible ? { inert: "" } : {})}
-      className={`grid transition-[grid-template-rows] duration-300 ease-out ${
-        visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
-      }`}
-    >
-      <div className="overflow-hidden">
-        <div
-          className={`${isErrorSeverity ? "bg-accent-red/[0.06] border-accent-red/10" : "bg-accent-yellow/[0.06] border-accent-yellow/10"} px-5 py-1.5 flex items-center gap-2 border-b`}
-          role={isErrorSeverity ? "alert" : "status"}
-          aria-live={isErrorSeverity ? "assertive" : "polite"}
-        >
-          <span
-            className={`inline-flex rounded-full h-1.5 w-1.5 shrink-0 ${isErrorSeverity ? "bg-accent-red" : "bg-accent-yellow"}`}
-          />
-          <p
-            className={`text-xs font-mono ${isErrorSeverity ? "text-accent-red" : "text-accent-yellow"}`}
-          >
-            {message}
-          </p>
-        </div>
-      </div>
-    </div>
+    <NoticeBanner visible={visible} severity={severity}>
+      {message}
+    </NoticeBanner>
   );
 }

--- a/ui/apps/console/src/components/common/LicenseBanner.tsx
+++ b/ui/apps/console/src/components/common/LicenseBanner.tsx
@@ -1,10 +1,9 @@
 import { useMemo } from "react";
-import { getConfig } from "@/env";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
+import NoticeBanner from "@/components/common/NoticeBanner";
 
 export default function LicenseBanner() {
   const { data, isLoading, isError, dataUpdatedAt } = useAdminLicense();
-  const isEnterprise = getConfig().enterprise && !getConfig().cloud;
 
   // data === undefined: query not enabled (non-admin) — banner stays hidden
   // data === null:      no license installed (400 normalized by hook)
@@ -16,68 +15,36 @@ export default function LicenseBanner() {
 
   const daysUntilExpiration = useMemo(() => {
     if (data == null || data.expires_at <= 0) return null;
-    return Math.ceil((data.expires_at - dataUpdatedAt / 1000) / 86400);
+    const days = Math.ceil((data.expires_at - dataUpdatedAt / 1000) / 86400);
+    // treat zero or negative as null so the fallback copy is shown
+    return days > 0 ? days : null;
   }, [data, dataUpdatedAt]);
 
-  const visible = isEnterprise && !isLoading && !isError
-    && (noLicense || expired || gracePeriod || aboutToExpire);
+  const visible =
+    !isLoading &&
+    !isError &&
+    (noLicense || expired || gracePeriod || aboutToExpire);
 
-  const isErrorSeverity = noLicense;
+  const severity = noLicense || expired ? "error" : "warning";
 
   const message = (() => {
-    if (noLicense) return "No license uploaded. This instance requires a valid license to operate properly.";
-    if (expired) return "Your license has expired. The instance will not function properly until a new license is uploaded.";
-    if (gracePeriod) return "Your license has expired and is in the grace period. Upload a new license before it stops working.";
+    if (noLicense)
+      return "No license installed. This instance needs a valid license to run properly — contact the ShellHub team to get one.";
+    if (expired)
+      return "Your license has expired. This instance won't function properly until it's renewed — contact the ShellHub team.";
+    if (gracePeriod)
+      return "Your license has expired and is in its grace period. Contact the ShellHub team to renew it before this instance stops working.";
     if (aboutToExpire) {
       return daysUntilExpiration !== null
-        ? `Your license expires in ${daysUntilExpiration} day${daysUntilExpiration === 1 ? "" : "s"}. Upload a new license soon to avoid interruption.`
-        : "Your license is about to expire. Upload a new license soon to avoid interruption.";
+        ? `Your license expires in ${daysUntilExpiration} day${daysUntilExpiration === 1 ? "" : "s"}. Contact the ShellHub team to renew it before it lapses.`
+        : "Your license is about to expire. Contact the ShellHub team to renew it before it lapses.";
     }
     return "";
   })();
 
   return (
-    <div
-      aria-hidden={!visible ? true : undefined}
-      {...(!visible ? { inert: "" } : {})}
-      className={`grid transition-[grid-template-rows] duration-300 ease-out ${
-        visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
-      }`}
-    >
-      <div className="overflow-hidden">
-        <div
-          className={`${
-            isErrorSeverity
-              ? "bg-accent-red/[0.06] border-b border-accent-red/10"
-              : "bg-accent-yellow/[0.06] border-b border-accent-yellow/10"
-          } px-5 py-1.5 flex items-center justify-between gap-2`}
-          role={isErrorSeverity ? "alert" : "status"}
-          aria-live={isErrorSeverity ? "assertive" : "polite"}
-        >
-          <div className="flex items-center gap-2 min-w-0">
-            <span
-              className={`inline-flex rounded-full h-1.5 w-1.5 shrink-0 ${
-                isErrorSeverity ? "bg-accent-red" : "bg-accent-yellow"
-              }`}
-            />
-            <p
-              className={`text-2xs font-mono ${
-                isErrorSeverity ? "text-accent-red" : "text-accent-yellow"
-              }`}
-            >
-              {message}
-            </p>
-          </div>
-          <a
-            href="/admin/license"
-            className={`text-2xs font-mono font-semibold underline shrink-0 ${
-              isErrorSeverity ? "text-accent-red" : "text-accent-yellow"
-            }`}
-          >
-            Upload license
-          </a>
-        </div>
-      </div>
-    </div>
+    <NoticeBanner visible={visible} severity={severity}>
+      {message}
+    </NoticeBanner>
   );
 }

--- a/ui/apps/console/src/components/common/NoticeBanner.tsx
+++ b/ui/apps/console/src/components/common/NoticeBanner.tsx
@@ -1,0 +1,87 @@
+import { ReactNode } from "react";
+
+export interface NoticeBannerProps {
+  visible: boolean;
+  severity: "error" | "warning";
+  align?: "start" | "center";
+  children: ReactNode;
+}
+
+type SeverityConfig = {
+  surface: string;
+  text: string;
+  dot: string;
+  role: "alert" | "status";
+  ariaLive: "assertive" | "polite";
+};
+
+const SEVERITY: Record<"error" | "warning", SeverityConfig> = {
+  error: {
+    surface: "bg-accent-red/[0.06] border-accent-red/10",
+    text: "text-accent-red",
+    dot: "bg-accent-red",
+    role: "alert",
+    ariaLive: "assertive",
+  },
+  warning: {
+    surface: "bg-accent-yellow/[0.06] border-accent-yellow/10",
+    text: "text-accent-yellow",
+    dot: "bg-accent-yellow",
+    role: "status",
+    ariaLive: "polite",
+  },
+};
+
+export default function NoticeBanner({
+  visible,
+  severity,
+  align = "start",
+  children,
+}: NoticeBannerProps) {
+  const { surface, text, dot, role, ariaLive } = SEVERITY[severity];
+  const justifyClass = align === "center" ? "justify-center" : "justify-start";
+
+  return (
+    <div
+      aria-hidden={!visible ? true : undefined}
+      {...(!visible ? { inert: "" } : {})}
+      className={`grid transition-[grid-template-rows] duration-300 ease-out ${
+        visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+      }`}
+    >
+      <div className="overflow-hidden">
+        {/*
+         * The strip container is always mounted so the overflow-hidden clip
+         * layer has content to collapse into, producing the smooth
+         * grid-rows 1fr→0fr transition on hide. The live region (role +
+         * aria-live) is registered on this always-present element so the
+         * browser tracks it from the start.
+         *
+         * Children are conditionally rendered: screen readers fire live-region
+         * announcements on content insertion, NOT on aria-hidden removal. By
+         * mounting children only when visible=true, the text node is freshly
+         * inserted into the registered live region each time the banner
+         * becomes visible, which reliably triggers an AT announcement.
+         *
+         * aria-hidden + inert on the outer wrapper suppress AT access when
+         * the banner is not visible; focusable children are also absent from
+         * the DOM at that point.
+         */}
+        <div
+          role={role}
+          aria-live={ariaLive}
+          className={`${surface} ${text} ${justifyClass} px-5 py-1.5 flex items-center gap-2 border-b`}
+        >
+          {visible && (
+            <>
+              <span
+                className={`inline-flex rounded-full h-1.5 w-1.5 shrink-0 ${dot}`}
+              />
+              <p className="text-xs font-mono">{children}</p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/apps/console/src/components/common/__tests__/ConnectivityBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/ConnectivityBanner.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import ConnectivityBanner from "@/components/common/ConnectivityBanner";
+import { useConnectivityStore } from "@/stores/connectivityStore";
+
+beforeEach(() => useConnectivityStore.setState({ apiReachable: true }));
+afterEach(cleanup);
+
+describe("ConnectivityBanner", () => {
+  it("is hidden when api is reachable", () => {
+    useConnectivityStore.setState({ apiReachable: true });
+    render(<ConnectivityBanner />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("delegates to NoticeBanner: renders role=alert when api is unreachable", () => {
+    useConnectivityStore.setState({ apiReachable: false });
+    render(<ConnectivityBanner />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("shows the unreachable message text when api is unreachable", () => {
+    useConnectivityStore.setState({ apiReachable: false });
+    render(<ConnectivityBanner />);
+    expect(
+      screen.getByText(/API unreachable — reconnecting automatically/),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/DeviceLimitBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/DeviceLimitBanner.test.tsx
@@ -110,9 +110,11 @@ describe("DeviceLimitBanner", () => {
       render(<DeviceLimitBanner />);
       expect(screen.getByRole("alert")).toBeInTheDocument();
       expect(
-        screen.getByText(/your licensed device limit has been reached/i),
+        screen.getByText(/you've reached your licensed device limit/i),
       ).toBeInTheDocument();
-      expect(screen.getByText(/contact ShellHub sales/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/contact the ShellHub team/i),
+      ).toBeInTheDocument();
     });
 
     it("shows RED (role=alert) when cap=10 and registered=10", () => {
@@ -153,7 +155,9 @@ describe("DeviceLimitBanner", () => {
       expect(
         screen.getByText(/you're approaching your licensed device limit/i),
       ).toBeInTheDocument();
-      expect(screen.getByText(/contact ShellHub sales/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/contact the ShellHub team/i),
+      ).toBeInTheDocument();
     });
 
     it("shows YELLOW (role=status) when cap=10 and registered=9 (90% boundary)", () => {
@@ -216,9 +220,15 @@ describe("DeviceLimitBanner", () => {
       expect(screen.queryByRole("status")).not.toBeInTheDocument();
     });
 
-    it("is absent while license is loading", () => {
+    it("is absent while license is loading (even when over-limit data is present)", () => {
+      // data present + over-limit would normally show the banner; isLoading must suppress it.
+      // Using data: undefined would hide the banner via the license != null guard, not the
+      // licenseLoading guard — so the guard under test would never actually be exercised.
       mockUseAdminLicense.mockReturnValue(
-        makeLicenseQueryResult({ data: undefined, isLoading: true }),
+        makeLicenseQueryResult({ data: makeLicense(100), isLoading: true }),
+      );
+      mockUseAdminStats.mockReturnValue(
+        makeStatsResult({ stats: { registered_devices: 100 } }),
       );
       render(<DeviceLimitBanner />);
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();

--- a/ui/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
@@ -5,32 +5,27 @@ import type { GetLicenseResponse } from "@/client/types.gen";
 
 // ── Dependency mocks ──────────────────────────────────────────────────────────
 
-vi.mock("@/env", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/env")>();
-  return { ...actual, getConfig: vi.fn() };
-});
-
 vi.mock("@/hooks/useAdminLicense", () => ({
   useAdminLicense: vi.fn(),
 }));
 
-import { getConfig, defaultConfig } from "@/env";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
 import LicenseBanner from "../LicenseBanner";
 
 // ── Typed mocks ───────────────────────────────────────────────────────────────
 
-const mockGetConfig = vi.mocked(getConfig);
 const mockUseAdminLicense = vi.mocked(useAdminLicense);
 
 type LicenseData = GetLicenseResponse | null;
 
-function makeQueryResult(overrides: {
-  data?: LicenseData;
-  isLoading?: boolean;
-  isError?: boolean;
-  dataUpdatedAt?: number;
-} = {}) {
+function makeQueryResult(
+  overrides: {
+    data?: LicenseData;
+    isLoading?: boolean;
+    isError?: boolean;
+    dataUpdatedAt?: number;
+  } = {},
+) {
   return {
     data: undefined,
     isLoading: false,
@@ -40,7 +35,9 @@ function makeQueryResult(overrides: {
   } as unknown as UseQueryResult<LicenseData, Error>;
 }
 
-function makeLicense(overrides: Partial<GetLicenseResponse> = {}): GetLicenseResponse {
+function makeLicense(
+  overrides: Partial<GetLicenseResponse> = {},
+): GetLicenseResponse {
   return {
     expired: false,
     grace_period: false,
@@ -66,7 +63,6 @@ function makeLicense(overrides: Partial<GetLicenseResponse> = {}): GetLicenseRes
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
   // Default: admin with no license installed
   mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: null }));
 });
@@ -75,22 +71,10 @@ beforeEach(() => {
 
 describe("LicenseBanner", () => {
   describe("visibility", () => {
-    it("is hidden when enterprise is false, even if cloud is true", () => {
-      mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: false, cloud: true });
-      render(<LicenseBanner />);
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
-    });
-
-    it("is hidden when cloud is true, even if enterprise is true", () => {
-      mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true, cloud: true });
-      render(<LicenseBanner />);
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
-    });
-
     it("is hidden while the license check is in progress", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: null, isLoading: true }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({ data: null, isLoading: true }),
+      );
       render(<LicenseBanner />);
       // Both roles must be absent — checking only one would miss regressions that
       // make the banner visible but switch it from error to warning severity.
@@ -106,46 +90,63 @@ describe("LicenseBanner", () => {
     });
 
     it("is hidden when the query fails unexpectedly", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: null, isError: true }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({ data: null, isError: true }),
+      );
       render(<LicenseBanner />);
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       expect(screen.queryByRole("status")).not.toBeInTheDocument();
     });
 
-    it("is hidden when enterprise and license is valid", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: makeLicense() }));
+    it("is hidden when license is valid", () => {
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({ data: makeLicense() }),
+      );
       render(<LicenseBanner />);
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       expect(screen.queryByRole("status")).not.toBeInTheDocument();
     });
 
-    it("is shown when enterprise and no license is installed", () => {
+    it("is shown when no license is installed", () => {
       render(<LicenseBanner />);
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
 
-    it("is shown when enterprise and license is expired", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ expired: true, grace_period: false }),
-      }));
+    it("is shown when license is expired", () => {
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ expired: true, grace_period: false }),
+        }),
+      );
       render(<LicenseBanner />);
-      expect(screen.getByText(/your license has expired\./i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/your license has expired\./i),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
     });
 
-    it("is shown when enterprise and license is in the grace period", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ expired: true, grace_period: true }),
-      }));
+    it("is shown when license is in the grace period", () => {
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ expired: true, grace_period: true }),
+        }),
+      );
       render(<LicenseBanner />);
       expect(screen.getByText(/grace period/i)).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
     });
 
-    it("is shown when enterprise and license is about to expire", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ about_to_expire: true }),
-      }));
+    it("is shown when license is about to expire", () => {
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ about_to_expire: true }),
+        }),
+      );
       render(<LicenseBanner />);
-      expect(screen.getByText(/about to expire|expires in/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/about to expire|expires in/i),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeInTheDocument();
     });
   });
 
@@ -156,28 +157,34 @@ describe("LicenseBanner", () => {
       expect(screen.queryByRole("status")).not.toBeInTheDocument();
     });
 
-    it("uses warning (role=status) when license is expired — not an error", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ expired: true, grace_period: false }),
-      }));
+    it("uses error (role=alert) when license is expired", () => {
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ expired: true, grace_period: false }),
+        }),
+      );
       render(<LicenseBanner />);
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
     });
 
     it("uses warning (role=status) when license is in the grace period", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ expired: true, grace_period: true }),
-      }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ expired: true, grace_period: true }),
+        }),
+      );
       render(<LicenseBanner />);
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       expect(screen.getByRole("status")).toBeInTheDocument();
     });
 
     it("uses warning (role=status) when license is about to expire", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ about_to_expire: true }),
-      }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ about_to_expire: true }),
+        }),
+      );
       render(<LicenseBanner />);
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       expect(screen.getByRole("status")).toBeInTheDocument();
@@ -187,60 +194,121 @@ describe("LicenseBanner", () => {
   describe("messages", () => {
     it("shows the no-license message", () => {
       render(<LicenseBanner />);
-      expect(screen.getByText(/no license uploaded/i)).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText(/no license installed/i)).toBeInTheDocument();
     });
 
     it("shows the expired message", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ expired: true, grace_period: false }),
-      }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ expired: true, grace_period: false }),
+        }),
+      );
       render(<LicenseBanner />);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
       expect(
-        screen.getByText(/your license has expired\. the instance will not function/i),
+        screen.getByText(
+          /your license has expired\. this instance won't function/i,
+        ),
       ).toBeInTheDocument();
     });
 
     it("shows the grace period message", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ expired: true, grace_period: true }),
-      }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ expired: true, grace_period: true }),
+        }),
+      );
       render(<LicenseBanner />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
       expect(screen.getByText(/grace period/i)).toBeInTheDocument();
     });
 
     it("shows days remaining when about to expire and days are known", () => {
       const expiresAt = Math.floor(Date.now() / 1000) + 1 * 86400;
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ about_to_expire: true, expires_at: expiresAt }),
-      }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ about_to_expire: true, expires_at: expiresAt }),
+        }),
+      );
       render(<LicenseBanner />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
       expect(screen.getByText(/expires in 1 day\b/i)).toBeInTheDocument();
     });
 
     it("uses the plural form when more than one day remains", () => {
       const expiresAt = Math.floor(Date.now() / 1000) + 5 * 86400;
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ about_to_expire: true, expires_at: expiresAt }),
-      }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ about_to_expire: true, expires_at: expiresAt }),
+        }),
+      );
       render(<LicenseBanner />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
       expect(screen.getByText(/expires in 5 days/i)).toBeInTheDocument();
     });
 
     it("shows the fallback about-to-expire message when expires_at is not set", () => {
-      mockUseAdminLicense.mockReturnValue(makeQueryResult({
-        data: makeLicense({ about_to_expire: true, expires_at: -1 }),
-      }));
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ about_to_expire: true, expires_at: -1 }),
+        }),
+      );
       render(<LicenseBanner />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText(/is about to expire/i)).toBeInTheDocument();
+    });
+
+    it("shows fallback about-to-expire copy when expires_at is in the past and about_to_expire is true (negative days)", () => {
+      // expires_at is in the past: daysUntilExpiration will be < 0
+      const expiredAt = Math.floor(Date.now() / 1000) - 1;
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ about_to_expire: true, expires_at: expiredAt }),
+        }),
+      );
+      render(<LicenseBanner />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText(/is about to expire/i)).toBeInTheDocument();
+    });
+
+    it("shows fallback about-to-expire copy when Math.ceil yields exactly 0 (days===0 boundary)", () => {
+      // expires_at exactly equal to dataUpdatedAt/1000 → Math.ceil(0/86400) = 0
+      // The guard `days > 0 ? days : null` must return null so the fallback is shown.
+      const now = Date.now();
+      const nowSeconds = Math.floor(now / 1000);
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ about_to_expire: true, expires_at: nowSeconds }),
+          dataUpdatedAt: now,
+        }),
+      );
+      render(<LicenseBanner />);
+      // days = Math.ceil((nowSeconds - now/1000) / 86400) = Math.ceil(0) = 0
+      // → null → fallback copy shown, NOT "expires in 0 days"
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.queryByText(/expires in 0 day/i)).not.toBeInTheDocument();
       expect(screen.getByText(/is about to expire/i)).toBeInTheDocument();
     });
   });
 
-  describe("action", () => {
-    it("shows the Upload license link pointing to /admin/license", () => {
+  describe("no CTA link", () => {
+    it("never renders any link when no license is installed (error state)", () => {
       render(<LicenseBanner />);
-      const link = screen.getByRole("link", { name: /upload license/i });
-      expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute("href", "/admin/license");
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      expect(screen.queryByText(/upload license/i)).not.toBeInTheDocument();
+    });
+
+    it("never renders any link when license is about to expire (warning state)", () => {
+      const expiresAt = Math.floor(Date.now() / 1000) + 5 * 86400;
+      mockUseAdminLicense.mockReturnValue(
+        makeQueryResult({
+          data: makeLicense({ about_to_expire: true, expires_at: expiresAt }),
+        }),
+      );
+      render(<LicenseBanner />);
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+      expect(screen.queryByText(/upload license/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/apps/console/src/components/common/__tests__/NoticeBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/NoticeBanner.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import NoticeBanner from "@/components/common/NoticeBanner";
+
+const getStrip = (container: HTMLElement): HTMLElement =>
+  container.querySelector('[role="alert"],[role="status"]') as HTMLElement;
+
+describe("NoticeBanner", () => {
+  describe("visibility toggle", () => {
+    it("collapsed (visible=false) has grid-rows-[0fr], aria-hidden=true, and inert on the outer wrapper", () => {
+      const { container } = render(
+        <NoticeBanner visible={false} severity="error">
+          Message
+        </NoticeBanner>,
+      );
+      const outer = container.firstChild as HTMLElement;
+      expect(outer.className).toContain("grid-rows-[0fr]");
+      expect(outer).toHaveAttribute("aria-hidden", "true");
+      expect(outer).toHaveAttribute("inert");
+    });
+
+    it("expanded (visible=true) has grid-rows-[1fr], no aria-hidden, and no inert on the outer wrapper", () => {
+      const { container } = render(
+        <NoticeBanner visible={true} severity="error">
+          Message
+        </NoticeBanner>,
+      );
+      const outer = container.firstChild as HTMLElement;
+      expect(outer.className).toContain("grid-rows-[1fr]");
+      expect(outer).not.toHaveAttribute("aria-hidden");
+      expect(outer).not.toHaveAttribute("inert");
+    });
+  });
+
+  describe("severity color classes", () => {
+    it.each<["error" | "warning", string]>([
+      ["error", "bg-accent-red"],
+      ["warning", "bg-accent-yellow"],
+    ])(
+      "severity=%s applies the correct background class to the strip",
+      (severity, expected) => {
+        const { container } = render(
+          <NoticeBanner visible={true} severity={severity}>
+            Message
+          </NoticeBanner>,
+        );
+        const strip = getStrip(container);
+        expect(strip.className).toContain(expected);
+      },
+    );
+  });
+
+  describe("severity role / aria-live", () => {
+    it("severity=error uses role=alert and aria-live=assertive on the strip", () => {
+      const { container } = render(
+        <NoticeBanner visible={true} severity="error">
+          Message
+        </NoticeBanner>,
+      );
+      const strip = getStrip(container);
+      expect(strip).toHaveAttribute("role", "alert");
+      expect(strip).toHaveAttribute("aria-live", "assertive");
+    });
+
+    it("severity=warning uses role=status and aria-live=polite on the strip", () => {
+      const { container } = render(
+        <NoticeBanner visible={true} severity="warning">
+          Message
+        </NoticeBanner>,
+      );
+      const strip = getStrip(container);
+      expect(strip).toHaveAttribute("role", "status");
+      expect(strip).toHaveAttribute("aria-live", "polite");
+    });
+  });
+
+  describe("align prop", () => {
+    it("align defaults to start (justify-start on strip)", () => {
+      const { container } = render(
+        <NoticeBanner visible={true} severity="error">
+          Message
+        </NoticeBanner>,
+      );
+      const strip = getStrip(container);
+      expect(strip.className).toContain("justify-start");
+    });
+
+    it("align=center applies justify-center on strip", () => {
+      const { container } = render(
+        <NoticeBanner visible={true} severity="error" align="center">
+          Message
+        </NoticeBanner>,
+      );
+      const strip = getStrip(container);
+      expect(strip.className).toContain("justify-center");
+    });
+  });
+
+  describe("children rendering", () => {
+    it("renders plain string children", () => {
+      render(
+        <NoticeBanner visible={true} severity="error">
+          Something went wrong
+        </NoticeBanner>,
+      );
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
+  });
+
+  describe("message styling", () => {
+    it("message <p> always uses text-xs (flat size, no override possible)", () => {
+      const { container } = render(
+        <NoticeBanner visible={true} severity="error">
+          Message
+        </NoticeBanner>,
+      );
+      const strip = getStrip(container);
+      const p = strip.querySelector("p") as HTMLElement;
+      expect(p.className).toContain("text-xs");
+      expect(p.className).not.toContain("text-2xs");
+    });
+  });
+});

--- a/ui/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
@@ -60,8 +60,8 @@ vi.mock("@/terminal/TerminalManager", () => ({
   default: () => null,
 }));
 
-vi.mock("@/common/ConnectivityBanner", () => ({
-  default: () => null,
+vi.mock("@/components/common/ConnectivityBanner", () => ({
+  default: () => <div data-testid="connectivity-banner" />,
 }));
 
 vi.mock("@/components/common/DeviceLimitBanner", () => ({
@@ -134,6 +134,13 @@ describe("AppLayout", () => {
       renderLayout();
       expect(screen.getByTestId("app-bar")).toBeInTheDocument();
       expect(screen.getByTestId("sidebar")).toBeInTheDocument();
+    });
+  });
+
+  describe("ConnectivityBanner", () => {
+    it("is always mounted", () => {
+      renderLayout();
+      expect(screen.getByTestId("connectivity-banner")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## What
Extract the collapsing notice-strip markup duplicated across the three app-layout banners into one presentational `NoticeBanner`, leaving each banner as a thin wrapper around its own data and message.

## Why
`LicenseBanner`, `DeviceLimitBanner`, and `ConnectivityBanner` each hand-rolled the same strip — grid-rows collapse transition, `aria-hidden`/`inert` plumbing, severity→color/role/aria-live mapping, dot + message. The copies had already drifted: inconsistent text sizes and a missing `aria-hidden`/`inert` on `ConnectivityBanner`. Consolidating removes the drift and gives one place to evolve the pattern.

## Changes
- **`NoticeBanner`**: new presentational primitive with a minimal `{ visible, severity, align?, children }` API. Owns the collapse skeleton, the `surface`/`text`/`dot`/`role`/`aria-live` severity lookup (mirroring `Alert.tsx`'s Record pattern), and the visibility plumbing. No `className`/size/action escape hatches, by design.
- **Wrappers**: `LicenseBanner`, `DeviceLimitBanner`, `ConnectivityBanner` reduced to computing their own flags/message and delegating. `LicenseBanner` drops its redundant internal `isEnterprise` guard — `AppLayout` already gates it via `{isEnterprise && …}`, matching `DeviceLimitBanner`.
- **Behavioral**: expired non-grace licenses now render as `error` (red) instead of `warning`; the inline "Upload license" CTA is removed and copy directs admins to contact the ShellHub team; banner text standardized to `text-xs`; a non-positive `daysUntilExpiration` falls through to the about-to-expire fallback copy instead of rendering "expires in 0 days".
- **Tests**: new `NoticeBanner` and `ConnectivityBanner` suites; `LicenseBanner`/`DeviceLimitBanner` specs updated for the new copy and severity; fixed a dead `ConnectivityBanner` mock path in `AppLayout.test.tsx` (`@/common/…` → `@/components/common/…`) that silently never intercepted.

## Testing
Confirm the expired-license banner is intentionally red now (severity escalation) and that no banner renders an "Upload license" link. Full console suite green (2269 tests), lint clean.