### PR TITLE
fix(api): use a dedicated forbidden error for role-authority denials

### DIFF
--- a/api/routes/api-key_test.go
+++ b/api/routes/api-key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shellhub-io/shellhub/api/services"
 	servicemock "github.com/shellhub-io/shellhub/api/services/mocks"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
@@ -677,6 +678,35 @@ func TestUpdateAPIKey(t *testing.T) {
 			requiredMocks: func() {
 			},
 			expected: Expected{status: http.StatusBadRequest},
+		},
+		{
+			description: "fails when member is not found",
+			name:        "dev",
+			headers: map[string]string{
+				"Content-Type": "application/json",
+				"X-ID":         "000000000000000000000000",
+				"X-Tenant-ID":  "00000000-0000-4000-0000-000000000000",
+				"X-Role":       "owner",
+			},
+			body: map[string]string{
+				"name": "prod",
+				"role": "administrator",
+			},
+			requiredMocks: func() {
+				svcMock.On(
+					"UpdateAPIKey",
+					mock.Anything,
+					&requests.UpdateAPIKey{
+						UserID:      "000000000000000000000000",
+						TenantID:    "00000000-0000-4000-0000-000000000000",
+						CurrentName: "dev",
+						Name:        "prod",
+						Role:        "administrator",
+					}).
+					Return(services.NewErrNamespaceMemberNotFound("000000000000000000000000", nil)).
+					Once()
+			},
+			expected: Expected{status: http.StatusNotFound},
 		},
 		{
 			description: "succeeds",

--- a/api/services/api-key.go
+++ b/api/services/api-key.go
@@ -54,7 +54,7 @@ func (s *service) CreateAPIKey(ctx context.Context, req *requests.CreateAPIKey) 
 
 	if req.OptRole != "" {
 		if !req.Role.HasAuthority(req.OptRole) {
-			return nil, NewErrRoleInvalid()
+			return nil, NewErrRoleForbidden()
 		}
 
 		req.Role = req.OptRole
@@ -114,10 +114,16 @@ func (s *service) UpdateAPIKey(ctx context.Context, req *requests.UpdateAPIKey) 
 		return NewErrNamespaceNotFound(req.TenantID, err)
 	}
 
-	// If req.Role is not empty, it must be lower than the user's role.
+	// If req.Role is not empty, the requesting user must be a namespace member
+	// with sufficient authority to assign that role.
 	if req.Role != "" {
-		if m, ok := ns.FindMember(req.UserID); !ok || !m.Role.HasAuthority(req.Role) {
-			return NewErrRoleInvalid()
+		m, ok := ns.FindMember(req.UserID)
+		if !ok {
+			return NewErrNamespaceMemberNotFound(req.UserID, nil)
+		}
+
+		if !m.Role.HasAuthority(req.Role) {
+			return NewErrRoleForbidden()
 		}
 	}
 

--- a/api/services/api-key_test.go
+++ b/api/services/api-key_test.go
@@ -123,7 +123,7 @@ func TestCreateAPIKey(t *testing.T) {
 			},
 			expected: Expected{
 				res: nil,
-				err: NewErrRoleInvalid(),
+				err: NewErrRoleForbidden(),
 			},
 		},
 		{
@@ -540,6 +540,23 @@ func TestUpdateAPIKey(t *testing.T) {
 			expected: NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", errors.New("error")),
 		},
 		{
+			description: "fails when user is not a member of the namespace",
+			req: &requests.UpdateAPIKey{
+				UserID:      "000000000000000000000000",
+				TenantID:    "00000000-0000-4000-0000-000000000000",
+				CurrentName: "dev",
+				Name:        "newName",
+				Role:        "administrator",
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{Members: []models.Member{}}, nil).
+					Once()
+			},
+			expected: NewErrNamespaceMemberNotFound("000000000000000000000000", nil),
+		},
+		{
 			description: "fails when role is greater than user's role",
 			req: &requests.UpdateAPIKey{
 				UserID:      "000000000000000000000000",
@@ -554,7 +571,7 @@ func TestUpdateAPIKey(t *testing.T) {
 					Return(&models.Namespace{Members: []models.Member{{ID: "000000000000000000000000", Role: "administrator"}}}, nil).
 					Once()
 			},
-			expected: NewErrRoleInvalid(),
+			expected: NewErrRoleForbidden(),
 		},
 		{
 			description: "fails when api key does not exist for resolve",

--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -130,17 +130,13 @@ var (
 	ErrAPIKeyNotFound                  = errors.New("APIKey not found", ErrLayer, ErrCodeNotFound)
 	ErrAPIKeyDuplicated                = errors.New("APIKey duplicated", ErrLayer, ErrCodeDuplicated)
 	ErrAuthForbidden                   = errors.New("user is authenticated but cannot access this resource", ErrLayer, ErrCodeForbidden)
-	ErrRoleInvalid                     = errors.New("role is invalid", ErrLayer, ErrCodeForbidden)
+	ErrRoleForbidden                   = errors.New("role is forbidden", ErrLayer, ErrCodeForbidden)
 	ErrUserDelete                      = errors.New("user couldn't be deleted", ErrLayer, ErrCodeInvalid)
 	ErrSetupForbidden                  = errors.New("setup isn't allowed anymore", ErrLayer, ErrCodeForbidden)
 	ErrAuthMethodNotAllowed            = errors.New("auth method not allowed", ErrLayer, ErrCodeNotImplemented)
 	ErrAuthDeviceNoIdentityAndHostname = errors.New("device doesn't have identity neither hostname defined", ErrLayer, ErrCodeInvalid)
 	ErruthDeviceNoIdentity             = errors.New("device doesn't have identity defined", ErrLayer, ErrCodeInvalid)
 )
-
-func NewErrRoleInvalid() error {
-	return ErrRoleInvalid
-}
 
 // NewErrNotFound returns an error with the ErrDataNotFound and wrap an error.
 func NewErrNoContentChange(err error, next error) error {
@@ -470,6 +466,10 @@ func NewErrDeviceMaxDevicesReached(count int) error {
 
 func NewErrAuthForbidden() error {
 	return NewErrForbidden(ErrAuthForbidden, nil)
+}
+
+func NewErrRoleForbidden() error {
+	return NewErrForbidden(ErrRoleForbidden, nil)
 }
 
 func NewErrUserDelete(err error) error {

--- a/api/services/member.go
+++ b/api/services/member.go
@@ -67,7 +67,7 @@ func (s *service) AddNamespaceMember(ctx context.Context, req *requests.Namespac
 	}
 
 	if !active.Role.HasAuthority(req.MemberRole) {
-		return nil, NewErrRoleInvalid()
+		return nil, NewErrRoleForbidden()
 	}
 
 	if len(memberAddHooks) > 0 {
@@ -140,12 +140,12 @@ func (s *service) UpdateNamespaceMember(ctx context.Context, req *requests.Names
 	// allows the owner (or any higher-ranked member) to repair or remove such a record
 	// via the normal API path instead of requiring direct DB intervention.
 	if !active.Role.HasAuthority(member.Role) {
-		return NewErrRoleInvalid()
+		return NewErrRoleForbidden()
 	}
 
 	if req.MemberRole != authorizer.RoleInvalid {
 		if !active.Role.HasAuthority(req.MemberRole) {
-			return NewErrRoleInvalid()
+			return NewErrRoleForbidden()
 		}
 
 		member.Role = req.MemberRole
@@ -189,7 +189,7 @@ func (s *service) RemoveNamespaceMember(ctx context.Context, req *requests.Names
 	}
 
 	if !active.Role.HasAuthority(passive.Role) {
-		return nil, NewErrRoleInvalid()
+		return nil, NewErrRoleForbidden()
 	}
 
 	if err := s.removeMember(ctx, namespace, passive); err != nil { //nolint:revive

--- a/api/services/member_test.go
+++ b/api/services/member_test.go
@@ -150,7 +150,7 @@ func TestService_AddNamespaceMember(t *testing.T) {
 			},
 			expected: Expected{
 				namespace: nil,
-				err:       NewErrRoleInvalid(),
+				err:       NewErrRoleForbidden(),
 			},
 		},
 		{
@@ -187,7 +187,7 @@ func TestService_AddNamespaceMember(t *testing.T) {
 			},
 			expected: Expected{
 				namespace: nil,
-				err:       NewErrRoleInvalid(),
+				err:       NewErrRoleForbidden(),
 			},
 		},
 		{
@@ -573,7 +573,7 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 			},
-			expected: NewErrRoleInvalid(),
+			expected: NewErrRoleForbidden(),
 		},
 		{
 			// The current-role guard catches any attempt by a lower-privileged actor to
@@ -620,7 +620,7 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 			},
-			expected: NewErrRoleInvalid(),
+			expected: NewErrRoleForbidden(),
 		},
 		{
 			description: "[community|enterprise|cloud] fails when cannot update the member",
@@ -747,7 +747,7 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 			},
-			expected: NewErrRoleInvalid(),
+			expected: NewErrRoleForbidden(),
 		},
 		{
 			// An admin acting on an equal-rank admin with a lower new role (demotion) is
@@ -806,7 +806,7 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 		{
 			// An owner must not be able to self-demote. The self-target guard (active.ID ==
 			// member.ID) runs before the BFLA current-role guard, so this now returns
-			// NewErrAuthForbidden() instead of NewErrRoleInvalid().
+			// NewErrAuthForbidden() instead of NewErrRoleForbidden().
 			description: "[community|enterprise|cloud] BFLA: fails when owner tries to self-demote",
 			req: &requests.NamespaceUpdateMember{
 				UserID:     "000000000000000000000000",
@@ -881,7 +881,7 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 			},
-			expected: NewErrRoleInvalid(),
+			expected: NewErrRoleForbidden(),
 		},
 		{
 			// A member record with an empty/invalid role (legacy or corrupted data) must
@@ -979,7 +979,7 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 			},
-			expected: NewErrRoleInvalid(),
+			expected: NewErrRoleForbidden(),
 		},
 		{
 			// An administrator self-targeting this endpoint must be rejected. A
@@ -1203,7 +1203,7 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 			},
 			expected: Expected{
 				namespace: nil,
-				err:       NewErrRoleInvalid(),
+				err:       NewErrRoleForbidden(),
 			},
 		},
 		{


### PR DESCRIPTION
## What
Replaces the misleading `NewErrRoleInvalid()` returned by role-authority guards
with a dedicated `NewErrRoleForbidden()` error, so an authorization denial is no
longer reported as a malformed-role-value error. HTTP status is unchanged (403).

## Why
The guards in `api/services` returned `NewErrRoleInvalid()` ("role is invalid")
when the **caller lacked authority** over the target role — a *forbidden*
condition, not a validation failure. This conflated two distinct failure modes
under one error, misleading API consumers and obscuring logs/telemetry.

Across both `shellhub` and `cloud`, every call site of `NewErrRoleInvalid()` was
an authority guard; there were no genuine "invalid role value" uses, so the
symbol is removed entirely.

Fixes: shellhub-io/team#155

## Changes
- **api/services/errors.go**: add `ErrRoleForbidden` + `NewErrRoleForbidden()`
  (`ErrCodeForbidden` → 403, matching the existing `ErrAuthForbidden` family);
  remove the now-dead `ErrRoleInvalid` / `NewErrRoleInvalid()`.
- **api/services/member.go**: migrate the four `HasAuthority` guards
  (`AddNamespaceMember`, `UpdateNamespaceMember` ×2, `RemoveNamespaceMember`).
- **api/services/api-key.go**: migrate the `CreateAPIKey` guard; split the
  `UpdateAPIKey` guard so a non-member returns `NewErrNamespaceMemberNotFound`
  (404) instead of conflating member-not-found with the authority denial (403).
- **tests**: update service + route assertions to the new error; add an
  `UpdateAPIKey` member-not-found case (service + route-layer 404).

## Coordination
This is the **primary** of two coordinated PRs. The companion is
shellhub-io/cloud#2407 (same branch name `fix/member-authority-error-semantics`)
and migrates cloud's call sites. **Merge this shellhub PR first** — cloud resolves
the `services` package from the shellhub module via a local `replace` directive,
so removing the symbol here breaks cloud's build until cloud is also merged.

## Testing
`go test ./api/services/ ./api/routes/ -run 'Member|APIKey|Errors' -tags docker`
— all authority cases assert `NewErrRoleForbidden()`; the new non-member case
returns 404.