### PR TITLE
docs(api): fix copy-pasted doc comment on NewErrNoContentChange

### DIFF
--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -138,7 +138,7 @@ var (
 	ErruthDeviceNoIdentity             = errors.New("device doesn't have identity defined", ErrLayer, ErrCodeInvalid)
 )
 
-// NewErrNotFound returns an error with the ErrDataNotFound and wrap an error.
+// NewErrNoContentChange returns an error to be used when an operation results in no content change.
 func NewErrNoContentChange(err error, next error) error {
 	return errors.Wrap(err, next)
 }


### PR DESCRIPTION
## What
Corrects the doc comment above `NewErrNoContentChange` in
`api/services/errors.go`, which described `NewErrNotFound` instead.

## Why
A copy-paste leftover: the identical `NewErrNotFound` comment was pasted
above `NewErrNoContentChange`. The real `NewErrNotFound` a few lines down
keeps its (correct) comment. Spotted while reviewing the team#155 change.

## Changes
- **api/services/errors.go**: the comment now documents
  `NewErrNoContentChange` (error signalling that an operation resulted in
  no content change → `ErrCodeNoContentChange`/204).

Comment-only; no behavior change.