### PR TITLE
refactor(ui): migrate raw buttons to design-system primitives

### DIFF
--- a/ui/apps/console/src/components/ManageTagsDrawer.tsx
+++ b/ui/apps/console/src/components/ManageTagsDrawer.tsx
@@ -190,13 +190,13 @@ export default function ManageTagsDrawer({
                 />
                 {error}
               </p>
-              <button
-                type="button"
+              <IconButton
+                size="sm"
+                aria-label="Dismiss error"
                 onClick={() => setError(null)}
-                className="p-0.5 rounded text-accent-red/60 hover:text-accent-red transition-colors shrink-0"
               >
                 <XMarkIcon className="w-3.5 h-3.5" strokeWidth={2} />
-              </button>
+              </IconButton>
             </div>
           </div>
         )}

--- a/ui/apps/console/src/components/announcements/AnnouncementModal.tsx
+++ b/ui/apps/console/src/components/announcements/AnnouncementModal.tsx
@@ -5,7 +5,11 @@ import Link from "@tiptap/extension-link";
 import Image from "@tiptap/extension-image";
 import { Markdown } from "@tiptap/markdown";
 import { MegaphoneIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { IconBadge } from "@shellhub/design-system/primitives";
+import {
+  Button,
+  IconBadge,
+  IconButton,
+} from "@shellhub/design-system/primitives";
 import BaseDialog from "@/components/common/BaseDialog";
 import { formatDateShort } from "@/utils/date";
 import { isAllowedUrl } from "@/utils/url";
@@ -82,14 +86,14 @@ export default function AnnouncementModal({
             </p>
           </div>
         </div>
-        <button
-          type="button"
+        <IconButton
+          size="sm"
           onClick={onClose}
-          className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-border/40 transition-colors shrink-0 -mt-0.5 -mr-1"
           aria-label="Close announcement"
+          className="-mt-0.5 -mr-1"
         >
           <XMarkIcon className="w-4 h-4" />
-        </button>
+        </IconButton>
       </div>
 
       <div className="p-6 overflow-y-auto max-h-[60vh]">
@@ -100,13 +104,9 @@ export default function AnnouncementModal({
       </div>
 
       <div className="flex justify-end gap-2 p-5 border-t border-border">
-        <button
-          type="button"
-          onClick={onClose}
-          className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary/90 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-        >
+        <Button variant="ghost" onClick={onClose}>
           Got it
-        </button>
+        </Button>
       </div>
     </BaseDialog>
   );

--- a/ui/apps/console/src/components/auth/AccountCreated.tsx
+++ b/ui/apps/console/src/components/auth/AccountCreated.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { ArrowRightIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import { useAuthStore } from "@/stores/authStore";
 import { useSignUpStore } from "@/stores/signUpStore";
+import { Button } from "@shellhub/design-system/primitives";
 
 export default function AccountCreated() {
   const navigate = useNavigate();
@@ -50,14 +51,12 @@ export default function AccountCreated() {
           the button below.
         </p>
 
-        <button
-          type="button"
+        <Button
+          iconRight={<ArrowRightIcon className="w-4 h-4" strokeWidth={2} />}
           onClick={handleRedirect}
-          className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all duration-200"
         >
           Redirect
-          <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/ui/apps/console/src/components/billing/BillingDialog.tsx
+++ b/ui/apps/console/src/components/billing/BillingDialog.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, startTransition, useCallback, useState } from "react";
+import { startTransition, useCallback, useState } from "react";
 import { isSdkError } from "@/api/errors";
 import {
   ArrowRightIcon,
@@ -11,7 +11,7 @@ import BillingLetter from "./BillingLetter";
 import BillingPayment from "./BillingPayment";
 import BillingCheckout from "./BillingCheckout";
 import BillingSuccessful from "./BillingSuccessful";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const STEPS = ["Overview", "Payment method", "Review", "Success"] as const;
 const TOTAL_STEPS = STEPS.length;
@@ -114,15 +114,13 @@ export default function BillingDialog({
         </div>
 
         {step < TOTAL_STEPS ? (
-          <button
-            type="button"
+          <IconButton
             onClick={handleClose}
             disabled={createSubscription.isPending}
-            className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-hover-medium transition-all disabled:opacity-40"
             aria-label="Close wizard"
           >
             <XMarkIcon className="w-4 h-4" />
-          </button>
+          </IconButton>
         ) : (
           <div className="w-7 h-7" aria-hidden="true" />
         )}
@@ -168,88 +166,75 @@ export default function BillingDialog({
       {/* Footer */}
       <footer className="px-6 py-4 mt-4 border-t border-border shrink-0 flex items-center justify-between">
         {step > 1 && step < TOTAL_STEPS ? (
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            icon={<ChevronLeftIcon className="w-3.5 h-3.5" strokeWidth={2.5} />}
             onClick={goBack}
             disabled={createSubscription.isPending}
-            className="inline-flex items-center gap-1 text-xs font-medium text-text-muted hover:text-text-secondary transition-colors disabled:opacity-40"
           >
-            <ChevronLeftIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
             Back
-          </button>
+          </Button>
         ) : (
           <span />
         )}
 
         <div className="flex items-center gap-3">
           {step < TOTAL_STEPS && (
-            <button
-              type="button"
+            <Button
+              variant="ghost"
               onClick={handleClose}
               disabled={createSubscription.isPending}
-              className="px-4 py-2 rounded-lg text-xs font-medium text-text-muted hover:text-text-secondary hover:bg-hover-medium transition-all disabled:opacity-40"
             >
               Close
-            </button>
+            </Button>
           )}
 
           {step === 1 && (
-            <PrimaryButton onClick={goNext}>
-              Next <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
-            </PrimaryButton>
+            <Button
+              onClick={goNext}
+              iconRight={
+                <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
+              }
+            >
+              Next
+            </Button>
           )}
 
           {step === 2 && (
-            <PrimaryButton onClick={goNext} disabled={!hasDefault}>
-              Next <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
-            </PrimaryButton>
+            <Button
+              onClick={goNext}
+              disabled={!hasDefault}
+              iconRight={
+                <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
+              }
+            >
+              Next
+            </Button>
           )}
 
           {step === 3 && (
-            <PrimaryButton
+            <Button
               onClick={() => void subscribe()}
-              disabled={createSubscription.isPending}
               loading={createSubscription.isPending}
             >
               {createSubscription.isPending
                 ? "Subscribing…"
                 : "Confirm subscription"}
-            </PrimaryButton>
+            </Button>
           )}
 
           {step === TOTAL_STEPS && (
-            <PrimaryButton onClick={handleClose}>
-              Done <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
-            </PrimaryButton>
+            <Button
+              onClick={handleClose}
+              iconRight={
+                <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
+              }
+            >
+              Done
+            </Button>
           )}
         </div>
       </footer>
     </BaseDialog>
-  );
-}
-
-function PrimaryButton({
-  children,
-  onClick,
-  disabled = false,
-  loading = false,
-}: {
-  children: ReactNode;
-  onClick?: () => void;
-  disabled?: boolean;
-  loading?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled || loading}
-      className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-semibold transition-all duration-200
-        bg-primary text-white hover:bg-primary-600 active:scale-[0.98]
-        disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary disabled:active:scale-100"
-    >
-      {loading && <Spinner size="sm" tone="onPrimary" />}
-      {children}
-    </button>
   );
 }

--- a/ui/apps/console/src/components/billing/BillingPayment.tsx
+++ b/ui/apps/console/src/components/billing/BillingPayment.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Card, Spinner } from "@shellhub/design-system/primitives";
+import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 import { isSdkError } from "@/api/errors";
 import {
   Elements,
@@ -237,8 +237,7 @@ function BillingPaymentInner({
         <p role="alert" className="text-sm text-accent-red text-center">
           {error}
         </p>
-        <button
-          type="button"
+        <Button
           onClick={() => {
             bootstrapRef.current = false;
             setError("");
@@ -246,10 +245,9 @@ function BillingPaymentInner({
             setRetryCount((c) => c + 1);
           }}
           disabled={createCustomer.isPending}
-          className="px-4 py-2 rounded-lg text-xs font-semibold bg-primary text-white hover:bg-primary-600 transition-all disabled:opacity-40 disabled:cursor-not-allowed"
         >
           Retry
-        </button>
+        </Button>
       </div>
     );
   }
@@ -326,29 +324,29 @@ function BillingPaymentInner({
                     <StarSolidIcon className="w-4 h-4" />
                   </span>
                 ) : (
-                  <button
+                  <IconButton
+                    variant="primary"
                     type="button"
-                    onClick={() => void handleSetDefault(pm.id)}
-                    disabled={setDefaultPm.isPending}
-                    className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors disabled:opacity-40"
-                    aria-label={`Set ${pm.brand} ending ${pm.number.slice(-4)} as default`}
                     title="Set as default"
+                    aria-label={`Set ${pm.brand} ending ${pm.number.slice(-4)} as default`}
+                    disabled={setDefaultPm.isPending}
+                    onClick={() => void handleSetDefault(pm.id)}
                   >
                     <StarOutlineIcon className="w-4 h-4" />
-                  </button>
+                  </IconButton>
                 )}
-                <button
+                <IconButton
+                  variant="danger"
                   type="button"
-                  onClick={() => void handleDetach(pm.id)}
-                  disabled={detachPm.isPending || pm.default}
-                  className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-colors disabled:opacity-40 disabled:hover:text-text-muted disabled:hover:bg-transparent"
-                  aria-label={`Remove ${pm.brand} ending ${pm.number.slice(-4)}`}
                   title={
                     pm.default ? "Cannot remove the default card" : "Remove"
                   }
+                  aria-label={`Remove ${pm.brand} ending ${pm.number.slice(-4)}`}
+                  disabled={detachPm.isPending || pm.default}
+                  onClick={() => void handleDetach(pm.id)}
                 >
                   <TrashIcon className="w-4 h-4" />
-                </button>
+                </IconButton>
               </div>
             </Card>
           ))}
@@ -356,14 +354,15 @@ function BillingPaymentInner({
       )}
 
       {!isAddingCard && (
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          fullWidth
+          icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
           onClick={() => setIsAddingCard(true)}
-          className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-card border border-dashed border-border hover:border-primary/40 rounded-lg text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
+          className="border border-dashed border-border hover:border-primary/40 bg-card"
         >
-          <PlusIcon className="w-4 h-4" strokeWidth={2} />
           Add payment method
-        </button>
+        </Button>
       )}
 
       {isAddingCard && (
@@ -388,27 +387,24 @@ function BillingPaymentInner({
           </div>
 
           <div className="flex justify-end gap-2">
-            <button
-              type="button"
+            <Button
+              variant="ghost"
               onClick={() => {
                 setIsAddingCard(false);
                 setCardComplete(false);
                 setError("");
               }}
               disabled={submitting}
-              className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors disabled:opacity-40"
             >
               Cancel
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
+              loading={submitting}
+              disabled={!stripe || !cardComplete}
               onClick={() => void handleAddCard()}
-              disabled={!stripe || !cardComplete || submitting}
-              className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
             >
-              {submitting && <Spinner tone="onPrimary" />}
               Save card
-            </button>
+            </Button>
           </div>
         </Card>
       )}

--- a/ui/apps/console/src/components/billing/BillingSection.tsx
+++ b/ui/apps/console/src/components/billing/BillingSection.tsx
@@ -15,7 +15,7 @@ import { useOpenBillingPortal, useSubscription } from "@/hooks/useBilling";
 import { useInvalidateByIds } from "@/hooks/useInvalidateQueries";
 import { formatExpiry } from "@/utils/date";
 import type { BillingStatus } from "@/client/types.gen";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 
 const BillingDialog = lazy(() => import("./BillingDialog"));
 
@@ -338,34 +338,29 @@ export default function BillingSection({ sectionId }: BillingSectionProps) {
             >
               <div className="flex items-center gap-2">
                 {canShowSubscribeButton && (
-                  <button
-                    type="button"
+                  <Button
                     onClick={() => setWizardOpen(true)}
                     onMouseEnter={preloadStripe}
                     onFocus={preloadStripe}
-                    className="px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
                   >
                     Subscribe
-                  </button>
+                  </Button>
                 )}
                 {canReopenPortal && (
                   <div className="flex flex-col items-end gap-1.5">
-                    <button
-                      type="button"
-                      onClick={() => openPortal.mutate()}
-                      disabled={openPortal.isPending}
-                      className="inline-flex items-center gap-1.5 px-4 py-2 bg-card hover:bg-hover-medium border border-border hover:border-border-light text-text-primary rounded-lg text-sm font-medium transition-all disabled:opacity-dim disabled:cursor-not-allowed"
-                    >
-                      {openPortal.isPending ? (
-                        <Spinner tone="subtle" />
-                      ) : (
+                    <Button
+                      variant="secondary"
+                      loading={openPortal.isPending}
+                      icon={
                         <ArrowTopRightOnSquareIcon
                           className="w-4 h-4"
                           strokeWidth={2}
                         />
-                      )}
+                      }
+                      onClick={() => openPortal.mutate()}
+                    >
                       Open portal
-                    </button>
+                    </Button>
                     {openPortal.isError && (
                       <p role="alert" className="text-2xs text-accent-red">
                         Couldn't open the billing portal. Please try again.

--- a/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
+++ b/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/hooks/useDeviceChooser";
 import { isSdkError } from "@/api/errors";
 import { FREE_TIER_DEVICE_LIMIT } from "./DeviceChooserTrigger";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 5;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -266,32 +266,23 @@ export default function DeviceChooserDialog({
       )}
 
       <footer className="px-6 py-4 mt-4 border-t border-border shrink-0 flex items-center justify-end gap-2">
-        <button
-          type="button"
-          onClick={onClose}
-          disabled={choice.isPending}
-          className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-        >
+        <Button variant="ghost" onClick={onClose} disabled={choice.isPending}>
           Cancel
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          variant="secondary"
           onClick={goSubscribe}
           disabled={choice.isPending}
-          className="px-4 py-2.5 rounded-lg text-sm font-semibold transition-all bg-card hover:bg-hover-medium border border-border hover:border-border-light text-text-primary disabled:opacity-40 disabled:cursor-not-allowed"
         >
           Subscribe
-        </button>
-        <button
-          type="button"
-          onClick={() => void accept()}
+        </Button>
+        <Button
+          loading={choice.isPending}
           disabled={acceptDisabled}
-          aria-disabled={acceptDisabled}
-          className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-lg text-sm font-semibold transition-all bg-primary text-white hover:bg-primary-600 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary disabled:active:scale-100"
+          onClick={() => void accept()}
         >
-          {choice.isPending && <Spinner size="sm" tone="onPrimary" />}
           {choice.isPending ? "Saving…" : "Accept"}
-        </button>
+        </Button>
       </footer>
     </BaseDialog>
   );
@@ -596,14 +587,13 @@ function SelectedChips({
           className="inline-flex items-center gap-1 bg-card border border-border rounded px-1.5 py-0.5 text-xs text-text-secondary"
         >
           <span className="truncate max-w-[180px]">{d.name}</span>
-          <button
-            type="button"
-            onClick={() => onRemove(d)}
+          <IconButton
+            size="sm"
             aria-label={`Remove ${d.name ?? "device"} from selection`}
-            className="text-text-muted hover:text-text-primary transition-colors rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/50"
+            onClick={() => onRemove(d)}
           >
             <XMarkIcon className="w-3 h-3" strokeWidth={2.5} />
-          </button>
+          </IconButton>
         </li>
       ))}
     </ul>

--- a/ui/apps/console/src/components/commandPalette/CommandRow.tsx
+++ b/ui/apps/console/src/components/commandPalette/CommandRow.tsx
@@ -1,4 +1,5 @@
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import { optionId, type BadgeVariant, type CommandItem } from "./items";
 
 const badgeStyles: Record<BadgeVariant, string> = {
@@ -77,20 +78,18 @@ export default function CommandRow({
         </kbd>
       )}
       {item.onDrillIn && (
-        <button
-          type="button"
+        <IconButton
+          size="sm"
           tabIndex={-1}
           aria-label={`Show actions for ${item.label}`}
           onClick={(e) => {
             e.stopPropagation();
             item.onDrillIn?.();
           }}
-          className={`shrink-0 p-0.5 rounded transition-colors hover:text-primary hover:bg-hover-medium ${
-            isActive ? "text-primary" : "text-text-muted/40"
-          }`}
+          className={isActive ? "text-primary" : "text-text-muted/40"}
         >
           <ChevronRightIcon className="w-4 h-4" />
-        </button>
+        </IconButton>
       )}
     </div>
   );

--- a/ui/apps/console/src/components/commandPalette/PaletteHeader.tsx
+++ b/ui/apps/console/src/components/commandPalette/PaletteHeader.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import type { NormalizedDevice } from "@/hooks/useDevices";
 import { LISTBOX_ID, icons } from "./items";
 
@@ -31,14 +32,14 @@ export default function PaletteHeader({
     <div className="flex items-center gap-3 px-4 border-b border-border shrink-0">
       {drillDevice ? (
         <>
-          <button
-            type="button"
+          <IconButton
+            size="sm"
             onClick={onBack}
             aria-label="Back to devices"
-            className="shrink-0 -ml-1 p-1 rounded text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
+            className="-ml-1"
           >
             <ChevronLeftIcon className="w-5 h-5" />
-          </button>
+          </IconButton>
           <div className="shrink-0 flex items-center gap-1.5 min-w-0">
             <span className="text-text-muted" aria-hidden="true">
               {icons.devices}

--- a/ui/apps/console/src/components/common/Alert.tsx
+++ b/ui/apps/console/src/components/common/Alert.tsx
@@ -6,6 +6,7 @@ import {
   InformationCircleIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 
 export type AlertVariant = "error" | "success" | "warning" | "info";
 
@@ -23,7 +24,10 @@ interface AlertProps {
   className?: string;
 }
 
-type IconComponent = (props: { className?: string; strokeWidth?: number }) => React.ReactElement | null;
+type IconComponent = (props: {
+  className?: string;
+  strokeWidth?: number;
+}) => React.ReactElement | null;
 
 type VariantConfig = {
   bg: string;
@@ -69,7 +73,12 @@ const VARIANT: Record<AlertVariant, VariantConfig> = {
   },
 };
 
-export default function Alert({ variant, children, onDismiss, className }: AlertProps) {
+export default function Alert({
+  variant,
+  children,
+  onDismiss,
+  className,
+}: AlertProps) {
   const { bg, border, text, Icon, role, ariaLive } = VARIANT[variant];
 
   return (
@@ -89,14 +98,14 @@ export default function Alert({ variant, children, onDismiss, className }: Alert
       <Icon className="w-3.5 h-3.5 shrink-0" strokeWidth={2} />
       <span className="flex-1 min-w-0">{children}</span>
       {onDismiss && (
-        <button
-          type="button"
+        <IconButton
+          size="sm"
           aria-label="Dismiss alert"
           onClick={onDismiss}
-          className="ml-1 hover:opacity-70 transition-opacity shrink-0 -mr-0.5"
+          className="ml-1 shrink-0 -mr-0.5"
         >
           <XMarkIcon className="w-3 h-3" />
-        </button>
+        </IconButton>
       )}
     </div>
   );

--- a/ui/apps/console/src/components/common/ClipboardProvider.tsx
+++ b/ui/apps/console/src/components/common/ClipboardProvider.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useCallback, useId, useMemo, useState } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { ClipboardContext } from "@/hooks/useCopy";
 import BaseDialog from "./BaseDialog";
+import { Button } from "@shellhub/design-system/primitives";
 
 /**
  * Mounts a single clipboard-warning dialog for the whole app.
@@ -33,7 +34,10 @@ export function ClipboardProvider({ children }: { children: ReactNode }) {
             className="w-5 h-5 flex-shrink-0 text-accent-yellow"
             aria-hidden="true"
           />
-          <h2 id={titleId} className="text-base font-semibold text-text-primary">
+          <h2
+            id={titleId}
+            className="text-base font-semibold text-text-primary"
+          >
             Copying is not allowed
           </h2>
         </div>
@@ -49,14 +53,9 @@ export function ClipboardProvider({ children }: { children: ReactNode }) {
 
         {/* Footer */}
         <div className="flex justify-end px-6 py-4 border-t border-border">
-          <button
-            type="button"
-            data-testid="copy-warning-ok-btn"
-            onClick={handleClose}
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
-          >
+          <Button data-testid="copy-warning-ok-btn" onClick={handleClose}>
             OK
-          </button>
+          </Button>
         </div>
       </BaseDialog>
     </ClipboardContext.Provider>

--- a/ui/apps/console/src/components/common/CopyButton.tsx
+++ b/ui/apps/console/src/components/common/CopyButton.tsx
@@ -1,4 +1,5 @@
 import { CheckIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outline";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 import { useCopy } from "@/hooks/useCopy";
 
 const sizes = {
@@ -22,54 +23,42 @@ export default function CopyButton({
 
   if (showLabel) {
     return (
-      <button
-        type="button"
+      <Button
+        size="sm"
+        variant={copied ? "successSoft" : "secondary"}
+        icon={
+          copied ? (
+            <CheckIcon className="w-3 h-3" strokeWidth={2.5} />
+          ) : (
+            <DocumentDuplicateIcon className="w-3 h-3" />
+          )
+        }
         onClick={(e) => {
           e.stopPropagation();
           copy(text);
         }}
-        className={`shrink-0 px-3 py-1.5 rounded-md text-2xs font-semibold transition-all ${
-          copied
-            ? "bg-accent-green/15 text-accent-green border border-accent-green/25"
-            : "bg-hover-medium text-text-muted hover:text-text-primary hover:bg-hover-strong border border-transparent"
-        } ${className}`}
+        className={`shrink-0 ${className}`}
       >
-        <span className="flex items-center gap-1">
-          {copied
-            ? (
-              <>
-                <CheckIcon className="w-3 h-3" strokeWidth={2.5} />
-                Copied
-              </>
-            )
-            : (
-              <>
-                <DocumentDuplicateIcon className="w-3 h-3" />
-                Copy
-              </>
-            )}
-        </span>
-      </button>
+        {copied ? "Copied" : "Copy"}
+      </Button>
     );
   }
 
   return (
-    <button
-      type="button"
+    <IconButton
+      size={size}
+      title="Copy"
       onClick={(e) => {
         e.stopPropagation();
         copy(text);
       }}
-      className={`${s.button} text-text-muted hover:text-text-primary hover:bg-hover-medium transition-all ${className}`}
-      title="Copy"
+      className={className}
     >
-      {copied
-        ? (
-          <CheckIcon className={`${s.icon} text-accent-green`} strokeWidth={2} />
-        )
-        : (
-          <DocumentDuplicateIcon className={s.icon} />
-        )}
-    </button>
+      {copied ? (
+        <CheckIcon className={`${s.icon} text-accent-green`} strokeWidth={2} />
+      ) : (
+        <DocumentDuplicateIcon className={s.icon} />
+      )}
+    </IconButton>
   );
 }

--- a/ui/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespace.tsx
@@ -18,7 +18,11 @@ import {
   NAMESPACE_NAME_MIN_LENGTH,
   validateNamespaceName,
 } from "@/utils/validation";
-import { Spinner } from "@shellhub/design-system/primitives";
+import {
+  Button,
+  IconButton,
+  Spinner,
+} from "@shellhub/design-system/primitives";
 
 /* ─── Cloud/Enterprise form ─── */
 function CloudForm() {
@@ -55,23 +59,19 @@ function CloudForm() {
               setValidationError(null);
               createNs.reset();
             }}
-
             error={displayError}
           />
         </div>
-        <button
+        <Button
           type="submit"
+          loading={createNs.isPending}
           disabled={
             createNs.isPending || name.length < NAMESPACE_NAME_MIN_LENGTH
           }
-          className="px-6 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 shrink-0"
+          className="shrink-0"
         >
-          {createNs.isPending ? (
-            <Spinner tone="onPrimary" className="block" />
-          ) : (
-            "Create"
-          )}
-        </button>
+          {createNs.isPending ? "Creating..." : "Create"}
+        </Button>
       </div>
     </form>
   );
@@ -91,11 +91,11 @@ function CopyBlock({ command }: { command: string }) {
     <div className="relative bg-background border border-border rounded-lg p-3.5 pr-11 font-mono text-xs text-text-secondary leading-relaxed">
       <span className="text-primary/60">$ </span>
       {command}
-      <button
-        type="button"
-        onClick={handleCopy}
-        className="absolute top-2.5 right-2.5 p-1.5 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 transition-all"
+      <IconButton
+        variant="primary"
         title="Copy command"
+        onClick={handleCopy}
+        className="absolute top-2.5 right-2.5"
       >
         {copied ? (
           <CheckIcon
@@ -105,7 +105,7 @@ function CopyBlock({ command }: { command: string }) {
         ) : (
           <ClipboardDocumentIcon className="w-3.5 h-3.5" strokeWidth={2} />
         )}
-      </button>
+      </IconButton>
     </div>
   );
 }
@@ -170,16 +170,7 @@ function CommunityInstructions() {
         </p>
       </div>
 
-      <button
-        type="button"
-        disabled={!ready}
-        onClick={handleContinue}
-        className={`w-full flex items-center justify-center gap-2.5 px-5 py-3 rounded-lg text-sm font-semibold transition-all duration-200 ${
-          ready
-            ? "bg-primary hover:bg-primary-600 text-white cursor-pointer"
-            : "bg-primary/30 text-white/50 cursor-not-allowed"
-        }`}
-      >
+      <Button fullWidth disabled={!ready} onClick={handleContinue}>
         {ready ? (
           "You're in! Go to dashboard"
         ) : (
@@ -188,7 +179,7 @@ function CommunityInstructions() {
             Waiting for namespace access...
           </>
         )}
-      </button>
+      </Button>
 
       {/* Upgrade tip */}
       <div className="flex items-start gap-2.5 bg-primary/5 border border-primary/10 rounded-lg p-3">

--- a/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -4,7 +4,12 @@ import {
   BookOpenIcon,
   FolderPlusIcon,
 } from "@heroicons/react/24/outline";
-import { Card, IconBadge, Spinner } from "@shellhub/design-system/primitives";
+import {
+  Button,
+  Card,
+  IconBadge,
+  IconButton,
+} from "@shellhub/design-system/primitives";
 import BaseDialog from "./BaseDialog";
 import CopyButton from "./CopyButton";
 import NamespaceNameField from "./fields/NamespaceNameField";
@@ -166,14 +171,9 @@ export default function CreateNamespaceDialog({
           </h2>
         </div>
 
-        <button
-          type="button"
-          onClick={onClose}
-          className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-hover-medium transition-all"
-          aria-label="Close dialog"
-        >
+        <IconButton onClick={onClose} aria-label="Close dialog">
           <XMarkIcon className="w-4 h-4" />
-        </button>
+        </IconButton>
       </header>
 
       {/* Body */}
@@ -205,28 +205,18 @@ export default function CreateNamespaceDialog({
         </a>
 
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2 rounded-lg text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-hover-medium transition-all"
-          >
+          <Button variant="ghost" onClick={onClose}>
             {isCloud ? "Cancel" : "Close"}
-          </button>
+          </Button>
           {isCloud && (
-            <button
+            <Button
               type="submit"
               form={FORM_ID}
-              disabled={
-                createNs.isPending || name.length < NAMESPACE_NAME_MIN_LENGTH
-              }
-              className="px-4 py-2 bg-primary hover:bg-primary/90 text-white rounded-lg text-xs font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+              loading={createNs.isPending}
+              disabled={name.length < NAMESPACE_NAME_MIN_LENGTH}
             >
-              {createNs.isPending ? (
-                <Spinner size="sm" tone="onPrimary" className="inline-block" />
-              ) : (
-                "Create"
-              )}
-            </button>
+              Create
+            </Button>
           )}
         </div>
       </footer>

--- a/ui/apps/console/src/components/common/ErrorBoundary.tsx
+++ b/ui/apps/console/src/components/common/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ReactNode } from "react";
+import { Button } from "@shellhub/design-system/primitives";
 
 interface Props {
   children: ReactNode;
@@ -41,13 +42,7 @@ export default class ErrorBoundary extends Component<Props, State> {
             Something went wrong
           </h1>
           <p className="text-sm text-text-secondary mb-6">{error.message}</p>
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            className="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary-600 transition-colors"
-          >
-            Reload page
-          </button>
+          <Button onClick={() => window.location.reload()}>Reload page</Button>
         </div>
       </div>
     );

--- a/ui/apps/console/src/components/common/FeatureGate.tsx
+++ b/ui/apps/console/src/components/common/FeatureGate.tsx
@@ -4,6 +4,7 @@ import {
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
 import { getConfig } from "@/env";
+import { Button } from "@shellhub/design-system/primitives";
 import EmptyState, {
   type EmptyStateFeature,
 } from "@/components/common/EmptyState";
@@ -35,15 +36,19 @@ export default function FeatureGate({
       features={highlights}
       footnote="Available on ShellHub Cloud and Enterprise editions."
     >
-      <a
+      <Button
+        as="a"
         href="https://www.shellhub.io/pricing"
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        size="lg"
+        glow
+        iconRight={
+          <ArrowTopRightOnSquareIcon className="w-4 h-4" strokeWidth={2} />
+        }
       >
         Pricing
-        <ArrowTopRightOnSquareIcon className="w-4 h-4" strokeWidth={2} />
-      </a>
+      </Button>
     </EmptyState>
   );
 }

--- a/ui/apps/console/src/components/common/NamespaceGuard.tsx
+++ b/ui/apps/console/src/components/common/NamespaceGuard.tsx
@@ -9,7 +9,7 @@ import { useConnectivityStore } from "@/stores/connectivityStore";
 import AmbientBackground from "./AmbientBackground";
 import CreateNamespace from "./CreateNamespace";
 import UserMenu from "../layout/UserMenu";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button, Spinner } from "@shellhub/design-system/primitives";
 
 function MinimalHeader() {
   return (
@@ -58,14 +58,12 @@ function FetchErrorPage({
           again.
         </p>
 
-        <button
-          type="button"
+        <Button
+          icon={<ArrowPathIcon className="w-4 h-4" strokeWidth={2} />}
           onClick={onRetry}
-          className="inline-flex items-center gap-2.5 px-5 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200"
         >
-          <ArrowPathIcon className="w-4 h-4" strokeWidth={2} />
           Try again
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/ui/apps/console/src/components/common/StatCard.tsx
+++ b/ui/apps/console/src/components/common/StatCard.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { Card } from "@shellhub/design-system/primitives";
+import { Button, Card } from "@shellhub/design-system/primitives";
 
 interface StatCardBaseProps {
   icon: ReactNode;
@@ -42,20 +42,13 @@ export default function StatCard(props: StatCardProps) {
       </p>
 
       {props.onClick ? (
-        <button
-          type="button"
-          onClick={props.onClick}
-          className="text-xs font-medium text-primary hover:text-primary-400 transition-colors"
-        >
+        <Button variant="ghost" size="sm" onClick={props.onClick}>
           {linkLabel} &rarr;
-        </button>
+        </Button>
       ) : (
-        <Link
-          to={props.linkTo}
-          className="text-xs font-medium text-primary hover:text-primary-400 transition-colors"
-        >
+        <Button variant="ghost" size="sm" as={Link} to={props.linkTo}>
           {linkLabel} &rarr;
-        </Link>
+        </Button>
       )}
     </Card>
   );

--- a/ui/apps/console/src/components/common/fields/TagsSelector.tsx
+++ b/ui/apps/console/src/components/common/fields/TagsSelector.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import { useTags } from "@/hooks/useTags";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import FieldLabel from "@/components/common/fields/FieldLabel";
@@ -61,16 +62,16 @@ export default function TagsSelector({
               className="inline-flex items-center gap-1 px-2 py-0.5 bg-primary/10 text-primary text-xs rounded-md font-medium"
             >
               {tag}
-              <button
-                type="button"
+              <IconButton
+                size="sm"
+                aria-label="Remove tag"
                 onClick={(e) => {
                   e.stopPropagation();
                   toggle(tag);
                 }}
-                className="hover:text-white transition-colors"
               >
                 <XMarkIcon className="w-3 h-3" strokeWidth={2} />
-              </button>
+              </IconButton>
             </span>
           ))}
           <input

--- a/ui/apps/console/src/components/layout/AdminAppBar.tsx
+++ b/ui/apps/console/src/components/layout/AdminAppBar.tsx
@@ -3,6 +3,7 @@ import {
   ArrowRightStartOnRectangleIcon,
   Bars3Icon,
 } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import { useAuthStore } from "@/stores/authStore";
 import { getInitials } from "@/utils/string";
 import NamespaceSelector from "./NamespaceSelector";
@@ -26,14 +27,13 @@ export default function AdminAppBar({ onMenuToggle }: AdminAppBarProps) {
     <header className="h-14 bg-surface border-b border-border px-3 sm:px-5 flex items-center justify-between shrink-0">
       <div className="flex items-center gap-1">
         {onMenuToggle && (
-          <button
-            type="button"
+          <IconButton
             onClick={onMenuToggle}
-            className="lg:hidden p-2 -ml-1 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-subtle transition-colors"
             aria-label="Open navigation menu"
+            className="lg:hidden -ml-1"
           >
             <Bars3Icon className="w-5 h-5" />
-          </button>
+          </IconButton>
         )}
         <NamespaceSelector isAdminContext />
       </div>

--- a/ui/apps/console/src/components/layout/AppBar.tsx
+++ b/ui/apps/console/src/components/layout/AppBar.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useState } from "react";
-import {
-  useTerminalStore,
-  type TerminalSession,
-} from "@/stores/terminalStore";
+import { useTerminalStore, type TerminalSession } from "@/stores/terminalStore";
 import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 import { Bars3Icon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import NamespaceSelector from "./NamespaceSelector";
 
 import UserMenu from "./UserMenu";
@@ -80,26 +78,23 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
       {/* Left: menu toggle + crossfade with vertical slide */}
       <div className="flex items-center gap-1 min-w-0">
         {onMenuToggle && (
-          <button
-            type="button"
+          <IconButton
             onClick={onMenuToggle}
-            className="lg:hidden p-2 -ml-1 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-subtle transition-colors"
             aria-label="Open navigation menu"
+            className="lg:hidden -ml-1"
           >
             <Bars3Icon className="w-5 h-5" />
-          </button>
+          </IconButton>
         )}
         <div
           onTransitionEnd={handleTransitionEnd}
           className={`min-w-0 transition-all duration-150 ease-out ${visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"}`}
         >
-          {displayed
-            ? (
-              <TerminalInfo session={displayed} />
-            )
-            : (
-              <NamespaceSelector />
-            )}
+          {displayed ? (
+            <TerminalInfo session={displayed} />
+          ) : (
+            <NamespaceSelector />
+          )}
         </div>
       </div>
 

--- a/ui/apps/console/src/components/layout/InvitationsMenu.tsx
+++ b/ui/apps/console/src/components/layout/InvitationsMenu.tsx
@@ -23,6 +23,7 @@ import { formatRelative } from "@/utils/date";
 import { RoleBadge } from "@/pages/team/constants";
 import { isInvitationExpired } from "@/utils/invitations";
 import PageLoader from "@/components/common/PageLoader";
+import { Button } from "@shellhub/design-system/primitives";
 
 function InvitationCard({
   invitation,
@@ -55,23 +56,24 @@ function InvitationCard({
         )}
       </p>
       <div className="flex items-center gap-1.5 mt-2.5">
-        <button
-          type="button"
-          onClick={() => onAccept(invitation)}
+        <Button
+          size="sm"
+          icon={<CheckIcon className="w-3 h-3" strokeWidth={2.5} />}
           disabled={expired}
-          className="flex-1 inline-flex items-center justify-center gap-1 px-2.5 py-1.5 bg-primary/10 hover:bg-primary/20 border border-primary/20 text-primary rounded-md text-2xs font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-colors"
+          className="flex-1"
+          onClick={() => onAccept(invitation)}
         >
-          <CheckIcon className="w-3 h-3" strokeWidth={2.5} />
           Accept
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={<XMarkIcon className="w-3 h-3" strokeWidth={2.5} />}
+          className="flex-1"
           onClick={() => onDecline(invitation)}
-          className="flex-1 inline-flex items-center justify-center gap-1 px-2.5 py-1.5 bg-hover-subtle hover:bg-hover-medium border border-border text-text-secondary hover:text-text-primary rounded-md text-2xs font-semibold transition-colors"
         >
-          <XMarkIcon className="w-3 h-3" strokeWidth={2.5} />
           Decline
-        </button>
+        </Button>
       </div>
     </li>
   );

--- a/ui/apps/console/src/components/layout/PendingDevices.tsx
+++ b/ui/apps/console/src/components/layout/PendingDevices.tsx
@@ -10,7 +10,7 @@ import {
 import { useDevices } from "@/hooks/useDevices";
 import { useAcceptDevice, useRejectDevice } from "@/hooks/useDeviceMutations";
 import { useClickOutside } from "@/hooks/useClickOutside";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 import PageLoader from "@/components/common/PageLoader";
 import { getAcceptDeviceErrorMessage } from "@/utils/deviceErrors";
 
@@ -63,7 +63,10 @@ export default function PendingDevices() {
       }, 600);
     } catch (err) {
       setActing(null);
-      const error = action === "accepted" ? getAcceptDeviceErrorMessage(err) : "Failed to reject device.";
+      const error =
+        action === "accepted"
+          ? getAcceptDeviceErrorMessage(err)
+          : "Failed to reject device.";
       setError(error);
     }
   };
@@ -104,14 +107,9 @@ export default function PendingDevices() {
                 </span>
               )}
             </div>
-            <button
-              type="button"
-              onClick={closeDropdown}
-              aria-label="Close"
-              className="p-1 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
-            >
+            <IconButton size="sm" onClick={closeDropdown} aria-label="Close">
               <XMarkIcon className="w-3.5 h-3.5" strokeWidth={2} />
-            </button>
+            </IconButton>
           </div>
 
           {/* Body */}
@@ -187,44 +185,32 @@ export default function PendingDevices() {
                           </span>
                         ) : (
                           <div className="flex items-center gap-1 shrink-0">
-                            <button
-                              type="button"
+                            <IconButton
+                              variant="primary"
+                              title="Accept"
+                              aria-label="Accept device"
+                              disabled={isActing}
+                              loading={isActing}
                               onClick={() =>
                                 void handleAction(d.uid, "accepted")
                               }
-                              disabled={isActing}
-                              aria-label="Accept"
-                              className="p-1.5 rounded-md text-text-muted hover:text-accent-green hover:bg-accent-green/10 transition-colors disabled:opacity-soft"
-                              title="Accept"
                             >
-                              {isActing ? (
-                                <Spinner
-                                  size="sm"
-                                  tone="subtle"
-                                  className="block"
-                                />
-                              ) : (
-                                <CheckIcon
-                                  className="w-3.5 h-3.5"
-                                  strokeWidth={2.5}
-                                />
-                              )}
-                            </button>
-                            <button
-                              type="button"
+                              <CheckIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
+                            </IconButton>
+                            <IconButton
+                              variant="danger"
+                              title="Reject"
+                              aria-label="Reject device"
+                              disabled={isActing}
                               onClick={() =>
                                 void handleAction(d.uid, "rejected")
                               }
-                              disabled={isActing}
-                              aria-label="Reject"
-                              className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-colors disabled:opacity-soft"
-                              title="Reject"
                             >
                               <XMarkIcon
                                 className="w-3.5 h-3.5"
                                 strokeWidth={2.5}
                               />
-                            </button>
+                            </IconButton>
                           </div>
                         )}
                       </div>
@@ -238,17 +224,20 @@ export default function PendingDevices() {
           {/* Footer */}
           {count > 0 && (
             <div className="px-4 py-2.5 border-t border-border">
-              <button
-                type="button"
+              <Button
+                size="sm"
+                variant="ghost"
+                fullWidth
+                iconRight={
+                  <ArrowRightIcon className="w-3 h-3" strokeWidth={2.5} />
+                }
                 onClick={() => {
                   closeDropdown();
                   void navigate("/devices");
                 }}
-                className="w-full flex items-center justify-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
               >
                 View all pending devices
-                <ArrowRightIcon className="w-3 h-3" strokeWidth={2.5} />
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/ui/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui/apps/console/src/components/layout/SidebarShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { NavLink } from "react-router-dom";
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 
 // ---- Shared nav style constants ----
 
@@ -189,19 +190,13 @@ export default function SidebarShell({
         >
           {footerLabel}
         </p>
-        <button
-          type="button"
+        <IconButton
+          size="sm"
           onClick={onToggle}
           tabIndex={expanded ? 0 : -1}
           aria-label={toggleLabel}
           title={toggleTitle}
-          className={`p-1 rounded-md transition-all duration-200 ${
-            expanded ? "opacity-100" : "opacity-0"
-          } ${
-            pinned
-              ? "text-primary bg-primary/10"
-              : "text-text-muted hover:text-text-primary hover:bg-hover-subtle"
-          }`}
+          className={`duration-200 ${expanded ? "opacity-100" : "opacity-0"} ${pinned ? "text-primary bg-primary/10" : ""}`}
         >
           <ChevronLeftIcon
             className={`w-3.5 h-3.5 transition-transform duration-200 ${
@@ -209,7 +204,7 @@ export default function SidebarShell({
             }`}
             strokeWidth={2}
           />
-        </button>
+        </IconButton>
       </div>
     </aside>
   );

--- a/ui/apps/console/src/components/layout/SupportButton.tsx
+++ b/ui/apps/console/src/components/layout/SupportButton.tsx
@@ -2,15 +2,9 @@ import { useState } from "react";
 import { LifebuoyIcon } from "@heroicons/react/24/outline";
 import { useChatwootContext } from "@/hooks/useChatwoot";
 import SupportPaywallDialog from "./SupportPaywallDialog";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Spinner, IconButton } from "@shellhub/design-system/primitives";
 
 const GITHUB_ISSUE_URL = "https://github.com/shellhub-io/shellhub/issues/new";
-
-const ICON_BUTTON_BASE =
-  "inline-flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50 focus-visible:outline-offset-2";
-
-const ICON_BUTTON_ENABLED =
-  "text-text-secondary hover:bg-hover-medium hover:text-text-primary border border-transparent hover:border-border";
 
 export default function SupportButton() {
   const { status, openWidget } = useChatwootContext();
@@ -25,7 +19,7 @@ export default function SupportButton() {
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Report an issue on GitHub"
-        className={`${ICON_BUTTON_BASE} ${ICON_BUTTON_ENABLED}`}
+        className="inline-flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50 focus-visible:outline-offset-2 text-text-secondary hover:bg-hover-medium hover:text-text-primary border border-transparent hover:border-border"
       >
         <LifebuoyIcon className="w-[18px] h-[18px]" aria-hidden="true" />
       </a>
@@ -51,21 +45,18 @@ export default function SupportButton() {
 
   return (
     <>
-      <button
-        type="button"
+      <IconButton
         onClick={handleClick}
         aria-disabled={isLoading || undefined}
         aria-label={ariaLabel}
-        className={`${ICON_BUTTON_BASE} ${
-          isLoading ? "text-text-muted cursor-wait" : ICON_BUTTON_ENABLED
-        }`}
+        className={isLoading ? "cursor-wait" : undefined}
       >
         {isLoading ? (
           <Spinner size="sm" tone="subtle" className="block" />
         ) : (
           <LifebuoyIcon className="w-[18px] h-[18px]" aria-hidden="true" />
         )}
-      </button>
+      </IconButton>
       <SupportPaywallDialog
         open={paywallOpen && status === "no-subscription"}
         onClose={() => setPaywallOpen(false)}

--- a/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
+++ b/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
@@ -8,7 +8,7 @@ import Alert from "@/components/common/Alert";
 import { useOtpInput } from "@/hooks/useOtpInput";
 import { useAuthStore } from "@/stores/authStore";
 import { useMfaResetStore } from "@/stores/mfaResetStore";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 import BaseDialog from "@/components/common/BaseDialog";
 
 interface MfaDisableDialogProps {
@@ -168,13 +168,13 @@ export default function MfaDisableDialog({
               </div>
 
               <div className="text-center">
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => setMode("recovery")}
-                  className="text-xs text-text-muted hover:text-text-secondary transition-colors"
                 >
                   Use recovery code instead
-                </button>
+                </Button>
               </div>
             </>
           ) : mode === "recovery" ? (
@@ -197,23 +197,25 @@ export default function MfaDisableDialog({
               </div>
 
               <div className="text-center space-y-2">
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  fullWidth
                   onClick={() => setMode("totp")}
-                  className="block w-full text-xs text-text-muted hover:text-text-secondary transition-colors"
                 >
                   ← Use authenticator code
-                </button>
-                <button
-                  type="button"
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  fullWidth
                   onClick={() => {
                     setMode("email-reset");
                     setEmailRequested(false);
                   }}
-                  className="block w-full text-xs text-text-muted hover:text-text-secondary transition-colors"
                 >
                   Lost recovery codes? Request email reset
-                </button>
+                </Button>
               </div>
             </>
           ) : (
@@ -227,24 +229,22 @@ export default function MfaDisableDialog({
                     </p>
                   </div>
 
-                  <button
-                    type="button"
+                  <Button
+                    fullWidth
+                    loading={requestingEmail}
                     onClick={() => void handleRequestEmailReset()}
-                    disabled={requestingEmail}
-                    className="w-full px-4 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all disabled:opacity-dim disabled:cursor-not-allowed flex items-center justify-center gap-2"
                   >
-                    {requestingEmail && <Spinner tone="onPrimary" />}
                     Send Verification Codes
-                  </button>
+                  </Button>
 
                   <div className="text-center">
-                    <button
-                      type="button"
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={() => setMode("recovery")}
-                      className="text-xs text-text-muted hover:text-text-secondary transition-colors"
                     >
                       ← Use recovery code
-                    </button>
+                    </Button>
                   </div>
                 </div>
               ) : (
@@ -278,13 +278,9 @@ export default function MfaDisableDialog({
                     </p>
                   </div>
 
-                  <button
-                    type="button"
-                    onClick={onClose}
-                    className="w-full px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
-                  >
+                  <Button fullWidth onClick={onClose}>
                     Close
-                  </button>
+                  </Button>
                 </div>
               )}
             </>
@@ -293,21 +289,17 @@ export default function MfaDisableDialog({
           {/* Actions */}
           {mode !== "email-reset" && (
             <div className="flex justify-end gap-2 pt-2">
-              <button
-                type="button"
-                onClick={onClose}
-                className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-              >
+              <Button variant="secondary" onClick={onClose}>
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
-                disabled={submitting || !isComplete}
-                className="px-5 py-2.5 bg-accent-red/90 hover:bg-accent-red text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
+                variant="destructive"
+                disabled={!isComplete}
+                loading={submitting}
               >
-                {submitting && <Spinner tone="onPrimary" />}
                 Disable MFA
-              </button>
+              </Button>
             </div>
           )}
         </form>

--- a/ui/apps/console/src/components/mfa/MfaEnableDrawer.tsx
+++ b/ui/apps/console/src/components/mfa/MfaEnableDrawer.tsx
@@ -4,7 +4,7 @@ import {
   CheckCircleIcon,
   EnvelopeIcon,
 } from "@heroicons/react/24/outline";
-import { IconBadge, Spinner } from "@shellhub/design-system/primitives";
+import { IconBadge, Button } from "@shellhub/design-system/primitives";
 import Alert from "@/components/common/Alert";
 import Drawer from "../common/Drawer";
 import CheckboxField from "@/components/common/fields/CheckboxField";
@@ -182,80 +182,54 @@ export default function MfaEnableDrawer({
       footer={
         step === 1 ? (
           <>
-            <button
-              type="button"
-              onClick={handleClose}
-              className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-            >
+            <Button variant="ghost" onClick={handleClose}>
               Cancel
-            </button>
+            </Button>
             {showRecoveryEmailInput ? (
-              <button
-                type="button"
+              <Button
                 onClick={() => void handleSaveRecoveryEmail()}
-                disabled={loading || !recoveryEmail.trim()}
-                className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
+                disabled={!recoveryEmail.trim()}
+                loading={loading}
               >
-                {loading && <Spinner size="sm" tone="onPrimary" />}
                 Save & Continue
-              </button>
+              </Button>
             ) : (
-              <button
-                type="button"
+              <Button
                 onClick={() => void handleConfirmExistingEmail()}
-                disabled={loading}
-                className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
+                loading={loading}
               >
-                {loading && <Spinner size="sm" tone="onPrimary" />}
                 Continue
-              </button>
+              </Button>
             )}
           </>
         ) : step === 2 ? (
           <>
-            <button
-              type="button"
-              onClick={handleClose}
-              className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-            >
+            <Button variant="ghost" onClick={handleClose}>
               Cancel
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
               onClick={() => void handleNextToQr()}
-              disabled={!codesSaved || loading || recoveryCodes.length === 0}
-              className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+              disabled={!codesSaved || recoveryCodes.length === 0}
+              loading={loading}
             >
               Next Step
-            </button>
+            </Button>
           </>
         ) : step === 3 ? (
           <>
-            <button
-              type="button"
-              onClick={() => setStep(2)}
-              className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-            >
+            <Button variant="ghost" onClick={() => setStep(2)}>
               Back
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
               onClick={() => void handleEnableMfa()}
-              disabled={loading || !isCodeComplete || !qrLink || !secret}
-              className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
+              disabled={!isCodeComplete || !qrLink || !secret}
+              loading={loading}
             >
-              {loading && <Spinner size="sm" tone="onPrimary" />}
               Verify & Enable
-            </button>
+            </Button>
           </>
         ) : (
-          <button
-            type="button"
-            onClick={handleDone}
-            className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
-          >
-            Done
-          </button>
+          <Button onClick={handleDone}>Done</Button>
         )
       }
     >
@@ -318,13 +292,13 @@ export default function MfaEnableDrawer({
                   </div>
                 </div>
 
-                <button
-                  type="button"
+                <Button
+                  variant="secondary"
+                  fullWidth
                   onClick={() => setUserWantsNewEmail(true)}
-                  className="w-full px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border rounded-lg hover:bg-hover-subtle transition-colors"
                 >
                   Use a different recovery email
-                </button>
+                </Button>
               </div>
             )}
           </div>
@@ -357,20 +331,20 @@ export default function MfaEnableDrawer({
                     ))}
                   </div>
                   <div className="flex gap-2">
-                    <button
-                      type="button"
+                    <Button
+                      variant="secondary"
                       onClick={() => void handleDownload(recoveryCodes)}
-                      className="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary hover:text-text-primary border border-border rounded-md hover:bg-hover-subtle transition-colors"
+                      className="flex-1"
                     >
                       Download
-                    </button>
-                    <button
-                      type="button"
+                    </Button>
+                    <Button
+                      variant="secondary"
                       onClick={() => void handleCopy(recoveryCodes)}
-                      className="flex-1 px-3 py-1.5 text-xs font-medium text-text-secondary hover:text-text-primary border border-border rounded-md hover:bg-hover-subtle transition-colors"
+                      className="flex-1"
                     >
                       Copy
-                    </button>
+                    </Button>
                   </div>
                 </>
               ) : (
@@ -455,7 +429,11 @@ export default function MfaEnableDrawer({
               <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3 text-center">
                 Verification Code
               </p>
-              <div className="flex gap-2 justify-center" role="group" aria-label="Verification Code">
+              <div
+                className="flex gap-2 justify-center"
+                role="group"
+                aria-label="Verification Code"
+              >
                 {otp.code.map((digit, index) => (
                   <input
                     key={index}

--- a/ui/apps/console/src/components/mfa/MfaRecoveryCodesModal.tsx
+++ b/ui/apps/console/src/components/mfa/MfaRecoveryCodesModal.tsx
@@ -1,7 +1,5 @@
-import {
-  KeyIcon,
-  ExclamationTriangleIcon,
-} from "@heroicons/react/24/outline";
+import { KeyIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { Button } from "@shellhub/design-system/primitives";
 import BaseDialog from "@/components/common/BaseDialog";
 
 interface MfaRecoveryCodesModalProps {
@@ -55,13 +53,9 @@ export default function MfaRecoveryCodesModal({
           </div>
 
           <div className="flex justify-end pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-5 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
-            >
+            <Button variant="ghost" onClick={onClose}>
               Close
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/ui/apps/console/src/components/mfa/MfaRecoveryTimeoutModal.tsx
+++ b/ui/apps/console/src/components/mfa/MfaRecoveryTimeoutModal.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { useCountdown } from "@/hooks/useCountdown";
 import CheckboxField from "@/components/common/fields/CheckboxField";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 import BaseDialog from "@/components/common/BaseDialog";
 
 interface MfaRecoveryTimeoutModalProps {
@@ -85,22 +85,17 @@ export default function MfaRecoveryTimeoutModal({
 
         {/* Actions */}
         <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-          >
+          <Button variant="ghost" onClick={onClose}>
             Close
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={hasAccess || isExpired}
+            loading={disabling}
             onClick={() => void handleDisable()}
-            disabled={hasAccess || disabling || isExpired}
-            className="px-5 py-2.5 bg-accent-red/90 hover:bg-accent-red text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
-            {disabling && <Spinner tone="onPrimary" />}
             Disable MFA
-          </button>
+          </Button>
         </div>
 
         {/* Explanation note */}

--- a/ui/apps/console/src/components/sessions/SessionPlayer.tsx
+++ b/ui/apps/console/src/components/sessions/SessionPlayer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { create, type AsciinemaPlayer } from "asciinema-player";
 import "asciinema-player/dist/bundle/asciinema-player.css";
 import { PlayIcon, PauseIcon } from "@heroicons/react/24/solid";
-import { Card } from "@shellhub/design-system/primitives";
+import { Card, IconButton } from "@shellhub/design-system/primitives";
 
 type Speed = 0.5 | 1 | 1.5 | 2;
 
@@ -254,18 +254,19 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
 
       {/* Controls */}
       <div className="relative flex items-center gap-3 px-4 py-3 bg-surface border-t border-border shrink-0">
-        <button
-          type="button"
-          onClick={handlePlayPause}
-          className="w-8 h-8 rounded-full bg-primary hover:bg-primary/90 flex items-center justify-center shrink-0 transition-colors"
+        <IconButton
+          variant="filled"
+          size="lg"
+          className="rounded-full"
           aria-label={isPlaying ? "Pause" : "Play"}
+          onClick={handlePlayPause}
         >
           {isPlaying ? (
             <PauseIcon className="w-3.5 h-3.5 text-white" />
           ) : (
             <PlayIcon className="w-3.5 h-3.5 text-white ml-0.5" />
           )}
-        </button>
+        </IconButton>
 
         <span className="text-xs font-mono tabular-nums text-text-secondary shrink-0">
           {formatTime(currentTime)} / {formatTime(duration)}
@@ -296,19 +297,19 @@ export default function SessionPlayer({ logs, onClose }: SessionPlayerProps) {
           <option value={2}>2x</option>
         </select>
 
-        <button
-          type="button"
-          onClick={() => setShowShortcuts((v) => !v)}
-          className={`w-7 h-7 flex items-center justify-center rounded-md transition-colors shrink-0 ${
+        <IconButton
+          variant={showShortcuts ? "primary" : "ghost"}
+          className={
             showShortcuts
               ? "bg-primary/10 text-primary border border-primary/20"
-              : "text-text-muted hover:text-text-primary hover:bg-card border border-transparent"
-          }`}
+              : "border border-transparent"
+          }
           aria-label="Keyboard shortcuts"
           title="Keyboard shortcuts"
+          onClick={() => setShowShortcuts((v) => !v)}
         >
           <KeyboardIcon className="w-4 h-4" />
-        </button>
+        </IconButton>
 
         {/* Shortcuts popover */}
         {showShortcuts && (

--- a/ui/apps/console/src/components/terminal/TerminalControls.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalControls.tsx
@@ -5,6 +5,7 @@ import {
   Cog6ToothIcon,
   MinusIcon,
 } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import { useTerminalStore } from "@/stores/terminalStore";
 import type { TerminalSession } from "@/stores/terminalStore";
 import TerminalSettingsDrawer from "./TerminalSettingsDrawer";
@@ -13,8 +14,8 @@ import TerminalSettingsDrawer from "./TerminalSettingsDrawer";
 export function TerminalInfo({ session }: { session: TerminalSession }) {
   const status = useTerminalStore(
     (s) =>
-      s.sessions.find((ss) => ss.id === session.id)?.connectionStatus
-      ?? "disconnected",
+      s.sessions.find((ss) => ss.id === session.id)?.connectionStatus ??
+      "disconnected",
   );
 
   return (
@@ -89,23 +90,25 @@ export function TerminalActions({ session }: { session: TerminalSession }) {
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                d={isFullscreen
-                  ? "M8 4v4H4M20 8h-4V4M16 20v-4h4M4 16h4v4"
-                  : "M4 8V4h4M16 4h4v4M20 16v4h-4M8 20H4v-4"}
+                d={
+                  isFullscreen
+                    ? "M8 4v4H4M20 8h-4V4M16 20v-4h4M4 16h4v4"
+                    : "M4 8V4h4M16 4h4v4M20 16v4h-4M8 20H4v-4"
+                }
               />
             </svg>
           </button>
         </div>
 
         {/* Settings */}
-        <button
-          type="button"
+        <IconButton
+          title="Terminal settings"
+          aria-label="Terminal settings"
           onClick={() => setSettingsOpen(true)}
-          className="p-1.5 rounded-md text-white/30 hover:text-white/60 transition-colors"
-          title="Terminal Settings"
+          className="text-white/30 hover:text-white/60"
         >
           <Cog6ToothIcon className="w-4 h-4" />
-        </button>
+        </IconButton>
       </div>
 
       {createPortal(

--- a/ui/apps/console/src/components/terminal/TerminalErrorBanner.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalErrorBanner.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { ExclamationCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 import { useTerminalStore } from "@/stores/terminalStore";
 import type { TerminalError } from "./terminalErrors";
 
@@ -49,27 +50,25 @@ export default function TerminalErrorBanner({
               <span className="w-px h-3.5 bg-border-light" />
             )}
             {error.reconnect && (
-              <button
-                type="button"
+              <Button
+                size="sm"
                 onClick={() => {
                   useTerminalStore.getState().closeAndReconnect(sessionId);
                 }}
-                className="px-2.5 py-1 bg-primary hover:bg-primary-600 text-white rounded text-xs font-semibold transition-colors"
               >
                 Retry
-              </button>
+              </Button>
             )}
           </div>
         )}
       </div>
-      <button
-        type="button"
-        aria-label="Close"
+      <IconButton
+        size="sm"
+        aria-label="Dismiss"
         onClick={() => useTerminalStore.getState().close(sessionId)}
-        className="text-text-muted hover:text-text-primary transition-colors p-0.5 shrink-0"
       >
         <XMarkIcon className="w-3.5 h-3.5" />
-      </button>
+      </IconButton>
     </div>
   );
 }

--- a/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { CheckIcon, MinusIcon, PlusIcon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import {
   useTerminalThemeStore,
   TERMINAL_FONTS,
@@ -46,19 +47,17 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
       title="Terminal Settings"
       width="sm"
       bodyClassName="flex-1 overflow-y-auto"
-      footer={(
+      footer={
         <>
           <span className="text-2xs font-mono text-text-muted mr-auto">
             {themeName}
           </span>
           <span className="text-2xs font-mono text-text-muted/60">
-            {fontFamily}
-            {" "}
-            {fontSize}
+            {fontFamily} {fontSize}
             px
           </span>
         </>
-      )}
+      }
     >
       {/* Theme Picker */}
       <div className="border-b border-border p-4">
@@ -117,14 +116,14 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
           Font Size
         </div>
         <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={() => setFontSize(fontSize - 1)}
+          <IconButton
+            aria-label="Decrease font size"
             disabled={fontSize <= 8}
-            className="rounded-md border border-border bg-hover-subtle p-1.5 text-text-muted hover:text-text-primary hover:bg-hover-medium disabled:opacity-faint transition-colors"
+            onClick={() => setFontSize(fontSize - 1)}
+            className="border border-border bg-hover-subtle"
           >
             <MinusIcon className="w-3.5 h-3.5" strokeWidth={2} />
-          </button>
+          </IconButton>
           <div className="flex-1">
             <input
               type="range"
@@ -135,14 +134,14 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
               className="w-full accent-primary h-1"
             />
           </div>
-          <button
-            type="button"
-            onClick={() => setFontSize(fontSize + 1)}
+          <IconButton
+            aria-label="Increase font size"
             disabled={fontSize >= 24}
-            className="rounded-md border border-border bg-hover-subtle p-1.5 text-text-muted hover:text-text-primary hover:bg-hover-medium disabled:opacity-faint transition-colors"
+            onClick={() => setFontSize(fontSize + 1)}
+            className="border border-border bg-hover-subtle"
           >
             <PlusIcon className="w-3.5 h-3.5" strokeWidth={2} />
-          </button>
+          </IconButton>
           <span className="font-mono text-[13px] text-text-secondary w-7 text-right">
             {fontSize}
           </span>
@@ -165,20 +164,15 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
         >
           <div style={{ color: theme.colors.green }}>$ ssh root@device</div>
           <div style={{ color: theme.colors.foreground }}>
-            <span style={{ color: theme.colors.cyan }}>ShellHub</span>
-            {" "}
+            <span style={{ color: theme.colors.cyan }}>ShellHub</span>{" "}
             <span style={{ color: theme.colors.yellow }}>
               {getConfig().version || "v0.0.0"}
-            </span>
-            {" "}
+            </span>{" "}
             <span style={{ color: theme.colors.green }}>connected</span>
           </div>
           <div style={{ color: theme.colors.foreground }}>
-            <span style={{ color: theme.colors.brightBlack }}>~</span>
-            {" "}
-            <span style={{ color: theme.colors.red }}>3</span>
-            {" "}
-            devices online
+            <span style={{ color: theme.colors.brightBlack }}>~</span>{" "}
+            <span style={{ color: theme.colors.red }}>3</span> devices online
           </div>
           <div className="mt-1">
             <span style={{ color: theme.colors.green }}>$</span>

--- a/ui/apps/console/src/components/terminal/TerminalTaskbar.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalTaskbar.tsx
@@ -1,4 +1,5 @@
 import { XMarkIcon, CommandLineIcon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import { useTerminalStore } from "@/stores/terminalStore";
 
 export default function TerminalTaskbar({
@@ -54,16 +55,16 @@ export default function TerminalTaskbar({
             >
               {s.deviceName}
             </span>
-            <button
-              type="button"
+            <IconButton
+              size="sm"
+              aria-label="Close"
               onClick={(e) => {
                 e.stopPropagation();
                 close(s.id);
               }}
-              className="p-0.5 rounded text-text-muted/50 hover:text-accent-red hover:bg-accent-red/10 transition-all duration-150"
             >
               <XMarkIcon className="w-3.5 h-3.5" strokeWidth={2} />
-            </button>
+            </IconButton>
           </div>
         );
       })}

--- a/ui/apps/console/src/components/vault/VaultLockedBanner.tsx
+++ b/ui/apps/console/src/components/vault/VaultLockedBanner.tsx
@@ -1,4 +1,5 @@
 import { LockClosedIcon } from "@heroicons/react/24/outline";
+import { Button } from "@shellhub/design-system/primitives";
 
 interface Props {
   onUnlock: () => void;
@@ -13,14 +14,14 @@ export default function VaultLockedBanner({ onUnlock }: Props) {
           Your vault is locked. Unlock it to view and manage your SSH keys.
         </p>
       </div>
-      <button
-        type="button"
+      <Button
+        size="sm"
         onClick={onUnlock}
         aria-label="Unlock vault to access SSH keys"
-        className="shrink-0 px-3.5 py-1.5 text-xs font-semibold text-primary hover:text-white bg-primary/10 hover:bg-primary rounded-lg transition-all"
+        className="shrink-0"
       >
         Unlock
-      </button>
+      </Button>
     </div>
   );
 }

--- a/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, FormEvent } from "react";
-import { Card, Spinner } from "@shellhub/design-system/primitives";
+import { Card, Button } from "@shellhub/design-system/primitives";
 import {
   KeyIcon,
   LockClosedIcon,
@@ -72,22 +72,17 @@ function ChangePasswordDrawer({
       title="Change Master Password"
       footer={
         <>
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-          >
+          <Button variant="ghost" onClick={onClose}>
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
             onClick={() => void handleSubmit()}
             disabled={!canSubmit}
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
+            loading={loading}
           >
-            {loading && <Spinner size="sm" tone="onPrimary" />}
             Update Password
-          </button>
+          </Button>
         </>
       }
     >

--- a/ui/apps/console/src/components/vault/VaultSetupDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultSetupDialog.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/utils/vault-backend-factory";
 import BaseDialog from "@/components/common/BaseDialog";
 import PasswordField from "@/components/common/fields/PasswordField";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 
 interface Props {
   open: boolean;
@@ -206,21 +206,12 @@ function SetupForm({ open, onClose, instanceId }: FormProps) {
         )}
 
         <div className="flex justify-end gap-2 pt-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-          >
+          <Button variant="ghost" onClick={onClose}>
             Cancel
-          </button>
-          <button
-            type="submit"
-            disabled={!canSubmit}
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
-          >
-            {loading && <Spinner tone="onPrimary" />}
+          </Button>
+          <Button type="submit" disabled={!canSubmit} loading={loading}>
             Create Vault
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/ui/apps/console/src/components/vault/VaultSyncDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultSyncDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/utils/vault-migrate";
 import BaseDialog from "@/components/common/BaseDialog";
 import Alert from "@/components/common/Alert";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button, Spinner } from "@shellhub/design-system/primitives";
 
 type Direction = "to-server" | "to-local";
 
@@ -127,11 +127,12 @@ function SyncForm({
             role="group"
             aria-label="Choose which vault to keep"
           >
-            <button
-              type="button"
+            <Button
+              variant="outline"
+              fullWidth
+              className="flex-col items-start justify-start"
               disabled={working}
               onClick={() => void run(() => adoptServerVault(scope))}
-              className="w-full text-left px-4 py-3 rounded-lg border border-border hover:border-border-light hover:bg-hover-subtle transition-colors disabled:opacity-dim disabled:cursor-not-allowed"
             >
               <span className="block text-sm font-medium text-text-primary">
                 Keep the synced vault
@@ -139,12 +140,13 @@ function SyncForm({
               <span className="block text-2xs text-text-muted mt-0.5">
                 Deletes the keys stored in this browser.
               </span>
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
+              variant="outline"
+              fullWidth
+              className="flex-col items-start justify-start"
               disabled={working}
               onClick={() => void run(() => migrateLocalToServer(scope))}
-              className="w-full text-left px-4 py-3 rounded-lg border border-border hover:border-border-light hover:bg-hover-subtle transition-colors disabled:opacity-dim disabled:cursor-not-allowed"
             >
               <span className="block text-sm font-medium text-text-primary">
                 Keep this device's vault
@@ -152,7 +154,7 @@ function SyncForm({
               <span className="block text-2xs text-text-muted mt-0.5">
                 Replaces the synced vault on the server.
               </span>
-            </button>
+            </Button>
           </div>
         </>
       ) : (
@@ -190,18 +192,13 @@ function SyncForm({
       )}
 
       <div className="flex justify-end gap-2 pt-4">
-        <button
-          type="button"
-          onClick={onClose}
-          disabled={working}
-          className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-        >
+        <Button variant="ghost" onClick={onClose} disabled={working}>
           Cancel
-        </button>
+        </Button>
         {!checking && !(toServer && conflict) && (
-          <button
-            type="button"
-            disabled={working || (toServer && !!error)}
+          <Button
+            disabled={toServer && !!error}
+            loading={working}
             onClick={() =>
               void run(() =>
                 toServer
@@ -209,11 +206,9 @@ function SyncForm({
                   : migrateServerToLocal(scope),
               )
             }
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
           >
-            {working && <Spinner tone="onPrimary" />}
             {toServer ? "Sync vault" : "Move vault"}
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/ui/apps/console/src/components/vault/VaultSyncPromoDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultSyncPromoDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useId } from "react";
+import { Button } from "@shellhub/design-system/primitives";
 import {
   ServerStackIcon,
   GlobeAltIcon,
@@ -76,23 +77,18 @@ export default function VaultSyncPromoDialog({ open, onClose, onSync }: Props) {
         </ul>
 
         <div className="flex flex-col gap-3">
-          <button
-            type="button"
+          <Button
+            fullWidth
             onClick={() => {
               onClose();
               onSync();
             }}
-            className="w-full px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
           >
             Sync vault
-          </button>
-          <button
-            type="button"
-            onClick={close}
-            className="w-full px-5 py-2 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-          >
+          </Button>
+          <Button variant="ghost" fullWidth onClick={close}>
             Keep it on this device
-          </button>
+          </Button>
         </div>
 
         <div className="flex justify-center mt-4">

--- a/ui/apps/console/src/components/vault/VaultUnlockDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultUnlockDialog.tsx
@@ -3,7 +3,7 @@ import { LockClosedIcon } from "@heroicons/react/24/outline";
 import { useVaultStore } from "@/stores/vaultStore";
 import BaseDialog from "@/components/common/BaseDialog";
 import PasswordField from "@/components/common/fields/PasswordField";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 
 interface Props {
   open: boolean;
@@ -70,32 +70,19 @@ function UnlockForm({ open, onClose, onReset, instanceId }: FormProps) {
 
         <div className="flex items-center justify-between pt-2">
           {onReset ? (
-            <button
-              type="button"
-              onClick={onReset}
-              className="text-2xs text-text-muted hover:text-accent-red transition-colors"
-            >
+            <Button variant="ghost" size="sm" onClick={onReset}>
               Forgot password? Reset vault
-            </button>
+            </Button>
           ) : (
             <div />
           )}
           <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-            >
+            <Button variant="ghost" onClick={onClose}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={!canSubmit}
-              className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
-            >
-              {loading && <Spinner tone="onPrimary" />}
+            </Button>
+            <Button type="submit" disabled={!canSubmit} loading={loading}>
               Unlock
-            </button>
+            </Button>
           </div>
         </div>
       </form>

--- a/ui/apps/console/src/components/wizard/WelcomeWizard.tsx
+++ b/ui/apps/console/src/components/wizard/WelcomeWizard.tsx
@@ -4,6 +4,7 @@ import {
   ArrowRightIcon,
   BookOpenIcon,
 } from "@heroicons/react/24/outline";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { useAcceptDevice } from "@/hooks/useDeviceMutations";
 import type { NormalizedDevice } from "@/hooks/useDevices";
@@ -85,14 +86,9 @@ export default function WelcomeWizard({ open, onClose }: WelcomeWizardProps) {
         </div>
 
         {step < TOTAL_STEPS ? (
-          <button
-            type="button"
-            onClick={onClose}
-            className="p-1.5 rounded-lg text-text-muted hover:text-text-primary hover:bg-hover-medium transition-all"
-            aria-label="Close wizard"
-          >
+          <IconButton onClick={onClose} aria-label="Close wizard">
             <XMarkIcon className="w-4 h-4" />
-          </button>
+          </IconButton>
         ) : (
           // Spacer preserves the justify-between layout on the final step
           // without placing a focusable or ARIA-hidden interactive element in the tree.
@@ -155,73 +151,58 @@ export default function WelcomeWizard({ open, onClose }: WelcomeWizardProps) {
 
         <div className="flex items-center gap-3">
           {step < TOTAL_STEPS && (
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 rounded-lg text-xs font-medium text-text-muted hover:text-text-secondary hover:bg-hover-medium transition-all"
-            >
+            <Button variant="ghost" onClick={onClose}>
               Close
-            </button>
+            </Button>
           )}
 
           {step === 1 && (
-            <PrimaryButton onClick={() => setStep(2)}>
-              Next <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
-            </PrimaryButton>
+            <Button
+              onClick={() => setStep(2)}
+              iconRight={
+                <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
+              }
+            >
+              Next
+            </Button>
           )}
 
           {step === 2 && (
             // Disabled — polling in WizardStep2Install auto-advances to step 3
-            <PrimaryButton disabled>
-              Next <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
-            </PrimaryButton>
+            <Button
+              disabled
+              iconRight={
+                <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
+              }
+            >
+              Next
+            </Button>
           )}
 
           {step === 3 && (
-            <PrimaryButton
+            <Button
               onClick={() => void handleAccept()}
-              disabled={!pendingDevice || accepting}
+              disabled={!pendingDevice}
               loading={accepting}
             >
               {accepting ? "Accepting…" : "Accept"}
-            </PrimaryButton>
+            </Button>
           )}
 
           {step === TOTAL_STEPS && (
             // Finish always closes directly. canClose blocks ESC/backdrop on
             // earlier steps; the Finish button is intentionally unrestricted.
-            <PrimaryButton onClick={onClose}>
-              Finish{" "}
-              <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
-            </PrimaryButton>
+            <Button
+              onClick={onClose}
+              iconRight={
+                <ArrowRightIcon className="w-3.5 h-3.5" strokeWidth={2.5} />
+              }
+            >
+              Finish
+            </Button>
           )}
         </div>
       </footer>
     </BaseDialog>
-  );
-}
-
-function PrimaryButton({
-  children,
-  onClick,
-  disabled = false,
-  loading = false,
-}: {
-  children: React.ReactNode;
-  onClick?: () => void;
-  disabled?: boolean;
-  loading?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled || loading}
-      className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-semibold transition-all duration-200
-        bg-primary text-white hover:bg-primary-600 active:scale-[0.98]
-        disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-primary disabled:active:scale-100"
-    >
-      {children}
-    </button>
   );
 }

--- a/ui/apps/console/src/components/wizard/WizardStep4Complete.tsx
+++ b/ui/apps/console/src/components/wizard/WizardStep4Complete.tsx
@@ -1,22 +1,29 @@
-import { CheckCircleIcon, BookOpenIcon, ChatBubbleLeftRightIcon } from "@heroicons/react/24/outline";
+import {
+  CheckCircleIcon,
+  BookOpenIcon,
+  ChatBubbleLeftRightIcon,
+} from "@heroicons/react/24/outline";
 import { useAuthStore } from "@/stores/authStore";
 import { useNamespace } from "@/hooks/useNamespaces";
 import type { NormalizedDevice } from "@/hooks/useDevices";
 import CopyButton from "@/components/common/CopyButton";
+import { Button } from "@shellhub/design-system/primitives";
 
 interface WizardStep4CompleteProps {
   device: NormalizedDevice | null;
 }
 
-export default function WizardStep4Complete({ device }: WizardStep4CompleteProps) {
+export default function WizardStep4Complete({
+  device,
+}: WizardStep4CompleteProps) {
   const username = useAuthStore((s) => s.username);
   const tenantId = useAuthStore((s) => s.tenant) ?? "";
   const { namespace: ns } = useNamespace(tenantId);
   const namespace = ns?.name;
   const hostname = window.location.hostname;
 
-  const sshCmd
-    = device && username && namespace
+  const sshCmd =
+    device && username && namespace
       ? `ssh ${username}@${namespace}.${device.name}@${hostname}`
       : null;
 
@@ -25,13 +32,14 @@ export default function WizardStep4Complete({ device }: WizardStep4CompleteProps
       {/* Success card */}
       <div className="bg-accent-green/8 border border-accent-green/20 rounded-xl px-5 py-6 flex flex-col items-center text-center gap-3">
         <div className="w-12 h-12 rounded-full bg-accent-green/15 border border-accent-green/25 flex items-center justify-center">
-          <CheckCircleIcon className="w-6 h-6 text-accent-green" strokeWidth={1.5} />
+          <CheckCircleIcon
+            className="w-6 h-6 text-accent-green"
+            strokeWidth={1.5}
+          />
         </div>
         <div>
           <p className="text-base font-mono font-bold text-text-primary">
-            {device?.name ?? "Your device"}
-            {" "}
-            is online.
+            {device?.name ?? "Your device"} is online.
           </p>
           <p className="text-xs text-text-muted mt-1">
             Accepted and ready for SSH connections.
@@ -58,25 +66,32 @@ export default function WizardStep4Complete({ device }: WizardStep4CompleteProps
       )}
 
       {/* Resource links */}
-      <nav aria-label="Resources" className="flex flex-wrap items-center justify-center gap-4">
-        <a
+      <nav
+        aria-label="Resources"
+        className="flex flex-wrap items-center justify-center gap-4"
+      >
+        <Button
+          variant="secondary"
+          as="a"
+          size="sm"
           href="https://docs.shellhub.io"
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-background border border-border text-xs text-text-secondary hover:text-text-primary hover:border-border-light transition-all duration-200"
+          icon={<BookOpenIcon className="w-4 h-4" />}
         >
-          <BookOpenIcon className="w-4 h-4" />
           Documentation
-        </a>
-        <a
+        </Button>
+        <Button
+          variant="secondary"
+          as="a"
+          size="sm"
           href="https://gitter.im/shellhub-io/community"
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-background border border-border text-xs text-text-secondary hover:text-text-primary hover:border-border-light transition-all duration-200"
+          icon={<ChatBubbleLeftRightIcon className="w-4 h-4" />}
         >
-          <ChatBubbleLeftRightIcon className="w-4 h-4" />
           Community
-        </a>
+        </Button>
       </nav>
     </div>
   );

--- a/ui/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui/apps/console/src/pages/AcceptInvite.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/hooks/useInvitationMutations";
 import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button, Spinner } from "@shellhub/design-system/primitives";
 
 type Branch =
   | { kind: "loading" }
@@ -195,13 +195,15 @@ export default function AcceptInvite() {
             title="Invalid Invitation"
             description="This invitation link is missing required parameters. Please use the link from the original email."
             action={
-              <Link
+              <Button
+                as={Link}
                 to="/login"
-                className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all"
+                iconRight={
+                  <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
+                }
               >
                 Back to Login
-                <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-              </Link>
+              </Button>
             }
           />
         )}
@@ -218,13 +220,15 @@ export default function AcceptInvite() {
             title="Invitation Unavailable"
             description={branch.message}
             action={
-              <Link
+              <Button
+                as={Link}
                 to="/login"
-                className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all"
+                iconRight={
+                  <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
+                }
               >
                 Back to Login
-                <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-              </Link>
+              </Button>
             }
           />
         )}
@@ -249,14 +253,14 @@ export default function AcceptInvite() {
               </>
             }
             action={
-              <button
-                type="button"
+              <Button
                 onClick={handleSignOut}
-                className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all"
+                iconRight={
+                  <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
+                }
               >
                 Sign Out
-                <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-              </button>
+              </Button>
             }
           />
         )}
@@ -277,21 +281,15 @@ export default function AcceptInvite() {
               be automatically switched to it after accepting.
             </p>
             <div className="flex items-center justify-center gap-2">
-              <button
-                type="button"
-                onClick={() => setConfirmKind("decline")}
-                className="px-5 py-2.5 text-sm font-semibold text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-              >
+              <Button variant="ghost" onClick={() => setConfirmKind("decline")}>
                 Decline
-              </button>
-              <button
-                type="button"
+              </Button>
+              <Button
+                icon={<CheckCircleIcon className="w-4 h-4" strokeWidth={2} />}
                 onClick={() => setConfirmKind("accept")}
-                className="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all"
               >
-                <CheckCircleIcon className="w-4 h-4" strokeWidth={2} />
                 Accept
-              </button>
+              </Button>
             </div>
           </div>
         )}

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -26,7 +26,7 @@ import NumericInput from "@/components/common/fields/NumericInput";
 import RadioCard from "@/components/common/fields/RadioCard";
 import RadioGroupField from "@/components/common/fields/RadioGroupField";
 import { LABEL_BASE } from "@/utils/styles";
-import { Card } from "@shellhub/design-system/primitives";
+import { Button, Card } from "@shellhub/design-system/primitives";
 
 /* ─── Types ─── */
 type Method =
@@ -278,18 +278,22 @@ export default function AddDevice() {
                   {selectedMethod.label} requires manual setup. Follow the
                   platform-specific documentation for step-by-step instructions.
                 </p>
-                <a
+                <Button
+                  variant="warningSoft"
+                  as="a"
+                  size="sm"
                   href={selectedMethod.docsUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 px-3.5 py-2 bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20 rounded-lg text-xs font-medium hover:bg-accent-yellow/15 transition-all"
+                  iconRight={
+                    <ArrowTopRightOnSquareIcon
+                      className="w-3 h-3"
+                      strokeWidth={2}
+                    />
+                  }
                 >
                   View {selectedMethod.label} guide
-                  <ArrowTopRightOnSquareIcon
-                    className="w-3 h-3"
-                    strokeWidth={2}
-                  />
-                </a>
+                </Button>
               </div>
             </div>
           </Card>

--- a/ui/apps/console/src/pages/ConfirmAccount.tsx
+++ b/ui/apps/console/src/pages/ConfirmAccount.tsx
@@ -4,7 +4,7 @@ import { EnvelopeIcon } from "@heroicons/react/24/outline";
 import Alert from "@/components/common/Alert";
 import { useSignUpStore } from "../stores/signUpStore";
 import { useResendEmail } from "../hooks/useResendEmail";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 
 export default function ConfirmAccount() {
   const [searchParams] = useSearchParams();
@@ -56,23 +56,19 @@ export default function ConfirmAccount() {
           </Alert>
         )}
 
-        <button
-          type="button"
-          onClick={() => void handleResend()}
+        <Button
+          fullWidth
+          loading={resendLoading}
           disabled={resendLoading || resendCooldown > 0}
-          className="w-full bg-primary hover:bg-primary/90 text-white py-2.5 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mb-5 flex items-center justify-center gap-2"
+          onClick={() => void handleResend()}
+          className="mb-5"
         >
-          {resendLoading ? (
-            <>
-              <Spinner size="sm" tone="onPrimary" />
-              Sending...
-            </>
-          ) : resendCooldown > 0 ? (
-            `Resend Email (${resendCooldown}s)`
-          ) : (
-            "Resend Email"
-          )}
-        </button>
+          {resendLoading
+            ? "Sending..."
+            : resendCooldown > 0
+              ? `Resend Email (${resendCooldown}s)`
+              : "Resend Email"}
+        </Button>
 
         <p className="text-xs text-text-muted">
           Back to{" "}

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -38,7 +38,7 @@ import { buildSshid } from "../utils/sshid";
 import { useHasPermission } from "../hooks/useHasPermission";
 import RestrictedAction from "../components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
-import { Card } from "@shellhub/design-system/primitives";
+import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -174,15 +174,15 @@ function TagsSection({ uid, tags }: { uid: string; tags: string[] }) {
               aria-label="Add tag"
               className="w-28 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
             />
-            <button
-              type="button"
-              onClick={() => void handleAdd()}
+            <IconButton
+              variant="primary"
+              size="sm"
               disabled={adding || !input.trim()}
               aria-label="Add tag"
-              className="p-1 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 disabled:opacity-soft transition-all"
+              onClick={() => void handleAdd()}
             >
               <PlusIcon className="w-4 h-4" strokeWidth={2} />
-            </button>
+            </IconButton>
           </div>
         )}
       </div>
@@ -241,18 +241,17 @@ function RenameSection({
     return (
       <div className="flex items-center gap-2">
         <h1 className="text-2xl font-bold text-text-primary">{currentName}</h1>
-        <button
-          type="button"
+        <IconButton
+          variant="primary"
+          title="Rename container"
+          aria-label="Rename container"
           onClick={() => {
             setName(currentName);
             setEditing(true);
           }}
-          className="p-1.5 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 transition-all"
-          title="Rename container"
-          aria-label="Rename container"
         >
           <PencilSquareIcon className="w-4 h-4" />
-        </button>
+        </IconButton>
       </div>
     );
   }
@@ -268,27 +267,23 @@ function RenameSection({
             if (e.key === "Enter") void handleSave();
             if (e.key === "Escape") setEditing(false);
           }}
-
           aria-label="Container name"
           className="text-2xl font-bold text-text-primary bg-transparent border-b-2 border-primary/50 focus:outline-none focus:border-primary w-full max-w-md"
         />
-        <button
-          type="button"
-          onClick={() => void handleSave()}
-          disabled={saving}
+        <IconButton
+          variant="primary"
           aria-label="Save name"
-          className="p-1.5 rounded-md text-accent-green hover:bg-accent-green/10 transition-all"
+          disabled={saving}
+          onClick={() => void handleSave()}
         >
           <CheckIcon className="w-4 h-4" strokeWidth={2} />
-        </button>
-        <button
-          type="button"
-          onClick={() => setEditing(false)}
+        </IconButton>
+        <IconButton
           aria-label="Cancel rename"
-          className="p-1.5 rounded-md text-text-muted hover:bg-hover-medium transition-all"
+          onClick={() => setEditing(false)}
         >
           <XMarkIcon className="w-4 h-4" strokeWidth={2} />
-        </button>
+        </IconButton>
       </div>
       {error && (
         <p role="alert" className="text-2xs text-accent-red mt-1">
@@ -424,8 +419,8 @@ export default function ContainerDetails() {
           {container.status === "accepted" && (
             <>
               <RestrictedAction action="device:connect">
-                <button
-                  type="button"
+                <Button
+                  variant="success"
                   onClick={() => {
                     if (existingSession) {
                       restoreTerminal(existingSession.id);
@@ -434,71 +429,72 @@ export default function ContainerDetails() {
                     }
                   }}
                   disabled={!container.online}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+                  icon={
+                    <ChevronDoubleRightIcon
+                      className="w-4 h-4"
+                      strokeWidth={2}
+                    />
+                  }
                 >
-                  <ChevronDoubleRightIcon className="w-4 h-4" strokeWidth={2} />
                   Connect
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="device:remove">
-                <button
-                  type="button"
+                <IconButton
+                  variant="danger"
+                  size="lg"
+                  title="Remove container"
+                  aria-label="Remove container"
+                  className="border border-border"
                   onClick={() =>
                     setOperation({
                       container: { uid: container.uid, name: container.name },
                       action: "remove",
                     })
                   }
-                  className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
-                  title="Remove container"
-                  aria-label="Remove container"
                 >
                   <TrashIcon className="w-4 h-4" />
-                </button>
+                </IconButton>
               </RestrictedAction>
             </>
           )}
           {container.status === "pending" && (
             <>
               <RestrictedAction action="device:accept">
-                <button
-                  type="button"
+                <Button
+                  variant="success"
                   onClick={() => setOperation({ container, action: "accept" })}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold transition-all"
                 >
                   Accept
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="device:reject">
-                <button
-                  type="button"
+                <Button
+                  variant="warning"
                   onClick={() => setOperation({ container, action: "reject" })}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-yellow/90 hover:bg-accent-yellow text-white rounded-lg text-sm font-semibold transition-all"
                 >
                   Reject
-                </button>
+                </Button>
               </RestrictedAction>
             </>
           )}
           {container.status === "rejected" && (
             <>
               <RestrictedAction action="device:accept">
-                <button
-                  type="button"
+                <Button
+                  variant="success"
                   onClick={() => setOperation({ container, action: "accept" })}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold transition-all"
                 >
                   Accept
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="device:remove">
-                <button
-                  type="button"
+                <Button
+                  variant="destructive"
                   onClick={() => setOperation({ container, action: "remove" })}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-red/90 hover:bg-accent-red text-white rounded-lg text-sm font-semibold transition-all"
                 >
                   Remove
-                </button>
+                </Button>
               </RestrictedAction>
             </>
           )}

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -29,7 +29,7 @@ import InfoItem from "./devices/InfoItem";
 import TagsSection from "./devices/TagsSection";
 import RenameSection from "./devices/RenameSection";
 import CustomFieldsSection from "./devices/CustomFieldsSection";
-import { Card } from "@shellhub/design-system/primitives";
+import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -171,8 +171,8 @@ export default function DeviceDetails() {
           {device.status === "accepted" && (
             <>
               <RestrictedAction action="device:connect">
-                <button
-                  type="button"
+                <Button
+                  variant="success"
                   onClick={() => {
                     if (existingSession) {
                       restoreTerminal(existingSession.id);
@@ -181,66 +181,68 @@ export default function DeviceDetails() {
                     }
                   }}
                   disabled={!device.online}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+                  icon={
+                    <ChevronDoubleRightIcon
+                      className="w-4 h-4"
+                      strokeWidth={2}
+                    />
+                  }
                 >
-                  <ChevronDoubleRightIcon className="w-4 h-4" strokeWidth={2} />
                   Connect
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="device:remove">
-                <button
+                <IconButton
+                  variant="danger"
+                  size="lg"
                   type="button"
-                  onClick={() => setShowDelete(true)}
-                  className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
-                  aria-label="Delete device"
                   title="Delete device"
+                  aria-label="Delete device"
+                  className="border border-border"
+                  onClick={() => setShowDelete(true)}
                 >
                   <TrashIcon className="w-4 h-4" />
-                </button>
+                </IconButton>
               </RestrictedAction>
             </>
           )}
           {device.status === "pending" && (
             <>
               <RestrictedAction action="device:accept">
-                <button
-                  type="button"
+                <Button
+                  variant="success"
                   onClick={() => setOperation({ device, action: "accept" })}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold transition-all"
                 >
                   Accept
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="device:reject">
-                <button
-                  type="button"
+                <Button
+                  variant="warning"
                   onClick={() => setOperation({ device, action: "reject" })}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-yellow/90 hover:bg-accent-yellow text-white rounded-lg text-sm font-semibold transition-all"
                 >
                   Reject
-                </button>
+                </Button>
               </RestrictedAction>
             </>
           )}
           {device.status === "rejected" && (
             <>
               <RestrictedAction action="device:accept">
-                <button
-                  type="button"
+                <Button
+                  variant="success"
                   onClick={() => setOperation({ device, action: "accept" })}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-green/90 hover:bg-accent-green text-white rounded-lg text-sm font-semibold transition-all"
                 >
                   Accept
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="device:remove">
-                <button
-                  type="button"
+                <Button
+                  variant="destructive"
                   onClick={() => setOperation({ device, action: "remove" })}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-accent-red/90 hover:bg-accent-red text-white rounded-lg text-sm font-semibold transition-all"
                 >
                   Remove
-                </button>
+                </Button>
               </RestrictedAction>
             </>
           )}

--- a/ui/apps/console/src/pages/Login.tsx
+++ b/ui/apps/console/src/pages/Login.tsx
@@ -271,7 +271,6 @@ export default function Login() {
               onChange={setUsername}
               placeholder="username"
               autoComplete="username"
-
               required
             />
 
@@ -327,24 +326,17 @@ export default function Login() {
             </div>
           )}
 
-          <button
-            type="button"
-            onClick={() => void handleSsoLogin()}
+          <Button
+            variant={ssoOnly ? "primary" : "secondary"}
+            fullWidth
+            loading={ssoLoading}
             disabled={ssoLoading}
+            icon={<ArrowRightEndOnRectangleIcon className="w-4 h-4" />}
             data-testid="sso-btn"
-            className={`w-full py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 flex items-center justify-center gap-2 ${
-              ssoOnly
-                ? "bg-primary hover:bg-primary-600 text-white"
-                : "bg-card border border-border hover:border-border-light text-text-primary"
-            }`}
+            onClick={() => void handleSsoLogin()}
           >
-            {ssoLoading ? (
-              <Spinner size="sm" tone={ssoOnly ? "onPrimary" : "onSurface"} />
-            ) : (
-              <ArrowRightEndOnRectangleIcon className="w-4 h-4" />
-            )}
             Login with SSO
-          </button>
+          </Button>
         </div>
       )}
 

--- a/ui/apps/console/src/pages/MfaRecover.tsx
+++ b/ui/apps/console/src/pages/MfaRecover.tsx
@@ -6,7 +6,7 @@ import { useAuthStore } from "../stores/authStore";
 import { disableMfa } from "../client";
 import MfaRecoveryTimeoutModal from "../components/mfa/MfaRecoveryTimeoutModal";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 
 export default function MfaRecover() {
   const {
@@ -118,7 +118,6 @@ export default function MfaRecover() {
               value={recoveryCode}
               onChange={(e) => setRecoveryCode(e.target.value)}
               required
-
               className="w-full px-4 py-3 bg-background border border-border rounded-lg text-sm text-text-primary font-mono placeholder:text-text-secondary focus:outline-none focus:border-accent-yellow/50 focus:ring-1 focus:ring-accent-yellow/20 transition-all duration-200"
               placeholder="Enter recovery code"
             />
@@ -127,20 +126,15 @@ export default function MfaRecover() {
             </p>
           </div>
 
-          <button
+          <Button
+            variant="warning"
+            fullWidth
             type="submit"
+            loading={loading}
             disabled={loading || !recoveryCode.trim()}
-            className="w-full bg-accent-yellow hover:bg-accent-yellow/80 text-background py-3 px-4 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 mt-1 flex items-center justify-center gap-2"
           >
-            {loading ? (
-              <>
-                <Spinner size="sm" tone="onPrimary" />
-                Recovering...
-              </>
-            ) : (
-              "Recover Account"
-            )}
-          </button>
+            {loading ? "Recovering..." : "Recover Account"}
+          </Button>
 
           <div className="text-center pt-2 space-y-2">
             <Link

--- a/ui/apps/console/src/pages/Profile.tsx
+++ b/ui/apps/console/src/pages/Profile.tsx
@@ -684,7 +684,6 @@ export default function Profile() {
             description="Credentials used to authenticate into your account"
           >
             <Button
-              size="sm"
               variant="secondary"
               onClick={() => setPwDrawerOpen(true)}
             >
@@ -707,7 +706,6 @@ export default function Profile() {
             >
               {mfaEnabled ? (
                 <Button
-                  size="sm"
                   variant="secondary"
                   onClick={() => setMfaDisableOpen(true)}
                 >
@@ -715,7 +713,6 @@ export default function Profile() {
                 </Button>
               ) : (
                 <Button
-                  size="sm"
                   variant="secondary"
                   onClick={() => setMfaEnableOpen(true)}
                 >

--- a/ui/apps/console/src/pages/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/SessionDetails.tsx
@@ -36,7 +36,12 @@ import type { Session } from "../client";
 import RestrictedAction from "../components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
 import ConfirmDialog from "../components/common/ConfirmDialog";
-import { Badge, Card } from "@shellhub/design-system/primitives";
+import {
+  Badge,
+  Button,
+  Card,
+  IconButton,
+} from "@shellhub/design-system/primitives";
 import SessionTypeBadge from "./sessions/SessionTypeBadge";
 
 /* ── timeline builder ────────────────────────────── */
@@ -406,14 +411,14 @@ export default function SessionDetails() {
               />
               {session.active && (
                 <RestrictedAction action="session:close">
-                  <button
-                    type="button"
+                  <Button
+                    variant="dangerSoft"
+                    size="sm"
+                    icon={<XCircleIcon className="w-3 h-3" strokeWidth={2} />}
                     onClick={() => setShowClose(true)}
-                    className="flex items-center gap-1.5 px-2.5 py-1 border border-accent-red/30 text-accent-red hover:bg-accent-red/10 rounded-md text-2xs font-mono font-medium transition-all"
                   >
-                    <XCircleIcon className="w-3 h-3" strokeWidth={2} />
                     close
-                  </button>
+                  </Button>
                 </RestrictedAction>
               )}
             </div>
@@ -425,38 +430,39 @@ export default function SessionDetails() {
           {session.recorded && (
             <>
               <RestrictedAction action="session:play">
-                <button
-                  type="button"
-                  onClick={() => void handlePlayRecording()}
+                <Button
+                  icon={<PlayIcon className="w-4 h-4" />}
+                  loading={logsLoading}
                   disabled={logsLoading}
-                  className="flex items-center gap-2 px-4 py-2.5 bg-primary/90 hover:bg-primary text-white rounded-lg text-sm font-semibold disabled:opacity-dim transition-all"
+                  onClick={() => void handlePlayRecording()}
                 >
-                  <PlayIcon className="w-4 h-4" />
                   {logsLoading ? "Loading…" : "Play Recording"}
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="session:removeRecord">
-                <button
+                <IconButton
+                  variant="danger"
+                  size="lg"
                   type="button"
-                  onClick={() => setShowDeleteLogs(true)}
-                  className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
                   title="Delete recording"
+                  aria-label="Delete recording"
+                  className="border border-border"
+                  onClick={() => setShowDeleteLogs(true)}
                 >
                   <TrashIcon className="w-4 h-4" />
-                </button>
+                </IconButton>
               </RestrictedAction>
             </>
           )}
           {session.active && (
             <RestrictedAction action="session:close">
-              <button
-                type="button"
+              <Button
+                variant="dangerSoft"
+                icon={<XCircleIcon className="w-4 h-4" strokeWidth={2} />}
                 onClick={() => setShowClose(true)}
-                className="flex items-center gap-2 px-4 py-2.5 bg-surface hover:bg-hover-subtle text-accent-red border border-accent-red/30 rounded-lg text-sm font-semibold transition-all"
               >
-                <XCircleIcon className="w-4 h-4" strokeWidth={2} />
                 Close Session
-              </button>
+              </Button>
             </RestrictedAction>
           )}
         </div>

--- a/ui/apps/console/src/pages/Settings.tsx
+++ b/ui/apps/console/src/pages/Settings.tsx
@@ -33,7 +33,7 @@ import InputField from "@/components/common/fields/InputField";
 import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
 import { validateNamespaceName } from "@/utils/validation";
 import { getConfig } from "../env";
-import { Button } from "@shellhub/design-system/primitives";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 import PageLoader from "@/components/common/PageLoader";
 
 /* ─── Settings Card ─── */
@@ -226,7 +226,6 @@ function DeleteDialog({
           value={confirm}
           onChange={setConfirm}
           placeholder={namespaceName}
-
         />
       </div>
       {error && <p className="text-2xs text-accent-red mb-3">{error}</p>}
@@ -287,13 +286,14 @@ function BannerPreview({
         description="Message shown when users connect via SSH"
       >
         {canEdit && (
-          <Link
+          <IconButton
+            as={Link}
             to="/settings/banner"
-            className="inline-flex p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
             title="Edit"
+            aria-label="Edit"
           >
             <PencilSquareIcon className="w-4 h-4" />
-          </Link>
+          </IconButton>
         )}
       </SettingsRow>
     );
@@ -320,13 +320,14 @@ function BannerPreview({
         </button>
         <div className="flex items-center gap-1 shrink-0">
           {canEdit && (
-            <Link
+            <IconButton
+              as={Link}
               to="/settings/banner"
-              className="inline-flex p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
               title="Edit"
+              aria-label="Edit"
             >
               <PencilSquareIcon className="w-4 h-4" />
-            </Link>
+            </IconButton>
           )}
           <button
             type="button"
@@ -462,14 +463,15 @@ export default function Settings() {
                 {ns.name}
               </span>
               {canRename && (
-                <button
+                <IconButton
+                  variant="primary"
                   type="button"
-                  onClick={() => setEditNameOpen(true)}
-                  className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
                   title="Rename"
+                  aria-label="Rename namespace"
+                  onClick={() => setEditNameOpen(true)}
                 >
                   <PencilSquareIcon className="w-4 h-4" />
-                </button>
+                </IconButton>
               )}
             </div>
           </SettingsRow>

--- a/ui/apps/console/src/pages/Setup.tsx
+++ b/ui/apps/console/src/pages/Setup.tsx
@@ -7,7 +7,7 @@ import { getConfig } from "../env";
 import { validate, type FormErrors } from "./setup/validate";
 import InputField from "@/components/common/fields/InputField";
 import PasswordField from "@/components/common/fields/PasswordField";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 
 const STEP_ONBOARDING = 1;
 const STEP_ACCOUNT = 2;
@@ -206,14 +206,13 @@ export default function Setup() {
                 />
               </div>
 
-              <button
-                type="button"
+              <Button
+                fullWidth
                 disabled={!surveyCompleted}
                 onClick={() => setStep(STEP_ACCOUNT)}
-                className="w-full bg-primary hover:bg-primary-600 text-white py-2.5 px-4 rounded-md text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200"
               >
                 Continue
-              </button>
+              </Button>
             </div>
           )}
 
@@ -231,7 +230,6 @@ export default function Setup() {
                 onBlur={() => handleBlur("name")}
                 error={showError("name")}
                 placeholder="Your name"
-
                 maxLength={64}
               />
 
@@ -279,28 +277,22 @@ export default function Setup() {
 
               <div className="flex gap-3 pt-1">
                 {showOnboarding && (
-                  <button
-                    type="button"
+                  <Button
+                    variant="secondary"
+                    className="flex-1"
                     onClick={() => setStep(STEP_ONBOARDING)}
-                    className="flex-1 bg-card hover:bg-border/50 border border-border text-text-secondary py-2.5 px-4 rounded-md text-sm font-semibold transition-all duration-200"
                   >
                     Back
-                  </button>
+                  </Button>
                 )}
-                <button
+                <Button
                   type="submit"
+                  loading={loading}
                   disabled={disableCreateAccountButton}
-                  className={`${showOnboarding ? "flex-[2]" : "w-full"} bg-primary hover:bg-primary-600 text-white py-2.5 px-4 rounded-md text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all duration-200 flex items-center justify-center gap-2`}
+                  className={showOnboarding ? "flex-[2]" : "w-full"}
                 >
-                  {loading ? (
-                    <>
-                      <Spinner size="sm" tone="onPrimary" />
-                      Creating...
-                    </>
-                  ) : (
-                    "Create Account"
-                  )}
-                </button>
+                  {loading ? "Creating..." : "Create Account"}
+                </Button>
               </div>
             </form>
           )}

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -36,7 +36,7 @@ import {
 } from "@heroicons/react/24/outline";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
-import { Badge, Spinner } from "@shellhub/design-system/primitives";
+import { Badge, Button, IconButton } from "@shellhub/design-system/primitives";
 
 /* ─── Constants ─── */
 
@@ -142,17 +142,18 @@ function DeviceSelector({
             <span className="text-sm text-text-primary truncate">
               {selected.name}
             </span>
-            <button
-              type="button"
+            <IconButton
+              size="sm"
+              aria-label="Clear selected device"
+              className="ml-auto"
               onClick={(e) => {
                 e.stopPropagation();
                 onChange(null);
                 setSearch("");
               }}
-              className="ml-auto shrink-0 p-0.5 text-text-muted hover:text-text-primary transition-colors"
             >
               <XMarkIcon className="w-3.5 h-3.5" strokeWidth={2} />
-            </button>
+            </IconButton>
           </div>
         ) : (
           <input
@@ -304,7 +305,6 @@ function TimeoutSelector({
               onChange={handleCustomValueChange}
               placeholder="Value in seconds"
               variant="mono"
-
               error={error || undefined}
             />
           )}
@@ -425,28 +425,17 @@ function EndpointDrawer({
       subtitle="Tunnel HTTP traffic to a service on your device."
       footer={
         <>
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary rounded-lg hover:bg-hover-subtle transition-colors"
-          >
+          <Button variant="ghost" onClick={onClose}>
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
-            onClick={() => void handleSubmit()}
+            loading={submitting}
             disabled={submitting || confirmDisabled}
-            className="px-5 py-2.5 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all flex items-center gap-2"
+            onClick={() => void handleSubmit()}
           >
-            {submitting ? (
-              <>
-                <Spinner size="sm" tone="onPrimary" />
-                Creating...
-              </>
-            ) : (
-              "Create Endpoint"
-            )}
-          </button>
+            {submitting ? "Creating..." : "Create Endpoint"}
+          </Button>
         </>
       }
     >
@@ -593,7 +582,6 @@ function EndpointDrawer({
                       placeholder="e.g. 192.168.1.100"
                       variant="mono"
                       error={hostError}
-
                     />
                   </div>
                   <div className="w-24">
@@ -798,15 +786,15 @@ function EndpointCard({
         {/* Right: delete action */}
         <div className="flex items-center shrink-0">
           <RestrictedAction action="webEndpoint:delete">
-            <button
+            <IconButton
+              variant="danger"
               type="button"
-              onClick={onDelete}
-              className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-red/50"
-              aria-label={`Delete web endpoint ${endpoint.full_address}`}
               title="Delete"
+              aria-label={`Delete web endpoint ${endpoint.full_address}`}
+              onClick={onDelete}
             >
               <TrashIcon className="w-4 h-4" aria-hidden="true" />
-            </button>
+            </IconButton>
           </RestrictedAction>
         </div>
       </div>
@@ -902,18 +890,19 @@ function WebEndpointsContent() {
           footnote="No VPN, no SSH port forwarding — just a URL."
         >
           <RestrictedAction action="webEndpoint:create">
-            <button
-              type="button"
+            <Button
+              size="lg"
               onClick={openNew}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              icon={
+                <PlusIcon
+                  className="w-4 h-4"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+              }
             >
-              <PlusIcon
-                className="w-4 h-4"
-                strokeWidth={2}
-                aria-hidden="true"
-              />
               Create your first endpoint
-            </button>
+            </Button>
           </RestrictedAction>
         </EmptyState>
       ) : (
@@ -925,18 +914,18 @@ function WebEndpointsContent() {
             description="Unique URLs that tunnel HTTP traffic to services on your devices."
           >
             <RestrictedAction action="webEndpoint:create">
-              <button
-                type="button"
+              <Button
                 onClick={openNew}
-                className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                icon={
+                  <PlusIcon
+                    className="w-4 h-4"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  />
+                }
               >
-                <PlusIcon
-                  className="w-4 h-4"
-                  strokeWidth={2}
-                  aria-hidden="true"
-                />
                 New Endpoint
-              </button>
+              </Button>
             </RestrictedAction>
           </PageHeader>
 

--- a/ui/apps/console/src/pages/admin/License.tsx
+++ b/ui/apps/console/src/pages/admin/License.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/utils/license";
 import type { GetLicenseResponse } from "@/client/types.gen";
 import PageLoader from "@/components/common/PageLoader";
-import { Card, Spinner } from "@shellhub/design-system/primitives";
+import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 type HeroIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
@@ -370,14 +370,14 @@ function LicenseUpload() {
 
             {/* Sibling of the drop zone — clicking it does NOT re-open the file picker */}
             {file && (
-              <button
-                type="button"
+              <IconButton
+                size="sm"
+                aria-label="Remove file"
                 onClick={clearFile}
-                aria-label="Remove selected file"
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-text-muted hover:text-text-primary hover:bg-hover-strong transition-colors"
+                className="absolute right-2.5 top-1/2 -translate-y-1/2"
               >
                 <XMarkIcon className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
+              </IconButton>
             )}
           </div>
 
@@ -396,25 +396,18 @@ function LicenseUpload() {
         </div>
 
         <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={() => void handleUpload()}
+          <Button
+            loading={upload.isPending}
             disabled={!canUpload}
-            aria-busy={upload.isPending}
             aria-label={
               upload.isPending
                 ? "Uploading license file"
                 : "Upload license file"
             }
-            className="inline-flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
+            onClick={() => void handleUpload()}
           >
-            {upload.isPending ? (
-              <Spinner size="md" tone="onPrimary" />
-            ) : (
-              <ArrowUpTrayIcon className="w-4 h-4" aria-hidden="true" />
-            )}
             {upload.isPending ? "Uploading..." : "Upload"}
-          </button>
+          </Button>
           {feedback && (
             <p
               role={feedback.type === "error" ? "alert" : "status"}

--- a/ui/apps/console/src/pages/admin/Unauthorized.tsx
+++ b/ui/apps/console/src/pages/admin/Unauthorized.tsx
@@ -11,6 +11,7 @@ import { useAuthStore } from "@/stores/authStore";
 import EmptyState, {
   type EmptyStateFeature,
 } from "@/components/common/EmptyState";
+import { Button } from "@shellhub/design-system/primitives";
 
 const highlights: EmptyStateFeature[] = [
   {
@@ -53,25 +54,26 @@ export default function AdminUnauthorized() {
       footnote="If you believe you should have admin access, contact your system administrator."
     >
       <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-        <button
-          type="button"
+        <Button
+          size="lg"
+          icon={<ArrowLeftIcon className="w-4 h-4" aria-hidden="true" />}
           onClick={() => void navigate("/dashboard")}
-          className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
-          <ArrowLeftIcon className="w-4 h-4" aria-hidden="true" />
           Go to ShellHub
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          size="lg"
+          variant="outline"
+          icon={
+            <ArrowRightStartOnRectangleIcon
+              className="w-4 h-4"
+              aria-hidden="true"
+            />
+          }
           onClick={handleLogout}
-          className="inline-flex items-center gap-2 px-6 py-3 border border-border rounded-lg text-sm font-medium text-text-secondary hover:bg-hover-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
-          <ArrowRightStartOnRectangleIcon
-            className="w-4 h-4"
-            aria-hidden="true"
-          />
           Logout
-        </button>
+        </Button>
       </div>
     </EmptyState>
   );

--- a/ui/apps/console/src/pages/admin/__tests__/License.test.tsx
+++ b/ui/apps/console/src/pages/admin/__tests__/License.test.tsx
@@ -28,12 +28,28 @@ const validLicense = {
   starts_at: 1704110400,
   expires_at: 1735732800,
   allowed_regions: [] as string[],
-  customer: { id: "cust-xxx", name: "Test Customer", email: "test@example.com", company: "Test Co" },
-  features: { devices: -1, session_recording: true, firewall_rules: true, reports: false, login_link: false, billing: false },
+  customer: {
+    id: "cust-xxx",
+    name: "Test Customer",
+    email: "test@example.com",
+    company: "Test Co",
+  },
+  features: {
+    devices: -1,
+    session_recording: true,
+    firewall_rules: true,
+    reports: false,
+    login_link: false,
+    billing: false,
+  },
 };
 const expiredLicense = { ...validLicense, expired: true, grace_period: false };
 const aboutToExpireLicense = { ...validLicense, about_to_expire: true };
-const gracePeriodLicense = { ...validLicense, expired: true, grace_period: true };
+const gracePeriodLicense = {
+  ...validLicense,
+  expired: true,
+  grace_period: true,
+};
 const regionalLicense = { ...validLicense, allowed_regions: ["BR", "US"] };
 
 const mockMutateAsync = vi.fn();
@@ -51,8 +67,16 @@ function setupHooks({
   error?: object;
   isPending?: boolean;
 }) {
-  vi.mocked(useAdminLicense).mockReturnValue({ data, isLoading, isError, error } as never);
-  vi.mocked(useUploadLicense).mockReturnValue({ mutateAsync: mockMutateAsync, isPending } as never);
+  vi.mocked(useAdminLicense).mockReturnValue({
+    data,
+    isLoading,
+    isError,
+    error,
+  } as never);
+  vi.mocked(useUploadLicense).mockReturnValue({
+    mutateAsync: mockMutateAsync,
+    isPending,
+  } as never);
 }
 
 function renderPage() {
@@ -63,7 +87,8 @@ function renderPage() {
       </MemoryRouter>
     </ClipboardProvider>,
   );
-  const fileInput = () => result.container.querySelector<HTMLInputElement>("#license-file")!;
+  const fileInput = () =>
+    result.container.querySelector<HTMLInputElement>("#license-file")!;
   return { ...result, fileInput };
 }
 
@@ -85,15 +110,23 @@ describe("AdminLicense", () => {
       setupHooks({ isError: true, error: { status: 500 } });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Failed to load license information")).toBeInTheDocument();
+      expect(
+        screen.getByText("Failed to load license information"),
+      ).toBeInTheDocument();
     });
 
     it("shows no-license info alert and upload section when license data is null", () => {
       setupHooks({ data: null });
       renderPage();
-      expect(screen.getByText("You do not have an installed license")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /choose a \.dat file/i })).toBeInTheDocument();
-      expect(screen.queryByText("Failed to load license information")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("You do not have an installed license"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /choose a \.dat file/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Failed to load license information"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -101,7 +134,9 @@ describe("AdminLicense", () => {
     it("renders upload section but no license details", () => {
       setupHooks({ data: undefined });
       renderPage();
-      expect(screen.getByRole("button", { name: /choose a \.dat file/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /choose a \.dat file/i }),
+      ).toBeInTheDocument();
       expect(screen.queryByText("License Information")).not.toBeInTheDocument();
     });
   });
@@ -111,14 +146,18 @@ describe("AdminLicense", () => {
       setupHooks({ data: {} });
       renderPage();
       expect(screen.getByRole("status")).toBeInTheDocument();
-      expect(screen.getByText("You do not have an installed license")).toBeInTheDocument();
+      expect(
+        screen.getByText("You do not have an installed license"),
+      ).toBeInTheDocument();
     });
 
     it("shows info alert when about_to_expire", () => {
       setupHooks({ data: aboutToExpireLicense });
       renderPage();
       expect(screen.getByRole("status")).toBeInTheDocument();
-      expect(screen.getByText("Your license is about to expire!")).toBeInTheDocument();
+      expect(
+        screen.getByText("Your license is about to expire!"),
+      ).toBeInTheDocument();
     });
 
     it("shows warning when expired + grace period", () => {
@@ -138,9 +177,13 @@ describe("AdminLicense", () => {
     it("shows no alert when license is valid", () => {
       setupHooks({ data: validLicense });
       renderPage();
-      expect(screen.queryByText(/license has expired/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/license has expired/i),
+      ).not.toBeInTheDocument();
       expect(screen.queryByText(/about to expire/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/do not have an installed license/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/do not have an installed license/i),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -233,7 +276,9 @@ describe("AdminLicense", () => {
     it("renders drop zone and hidden file input", () => {
       setupHooks({ data: {} });
       const { fileInput } = renderPage();
-      expect(screen.getByRole("button", { name: /choose a \.dat file/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /choose a \.dat file/i }),
+      ).toBeInTheDocument();
       expect(fileInput()).toBeInTheDocument();
     });
 
@@ -246,17 +291,23 @@ describe("AdminLicense", () => {
     it("shows validation error for wrong file extension", () => {
       setupHooks({ data: {} });
       const { fileInput } = renderPage();
-      const badFile = new File(["content"], "license.txt", { type: "text/plain" });
+      const badFile = new File(["content"], "license.txt", {
+        type: "text/plain",
+      });
       fireEvent.change(fileInput(), { target: { files: [badFile] } });
-      expect(screen.getByText("Only .dat files are allowed")).toBeInTheDocument();
+      expect(
+        screen.getByText("Only .dat files are allowed"),
+      ).toBeInTheDocument();
     });
 
     it("shows remove button and clears file on click", async () => {
       setupHooks({ data: {} });
       const { fileInput } = renderPage();
-      const validFile = new File(["content"], "license.dat", { type: "application/octet-stream" });
+      const validFile = new File(["content"], "license.dat", {
+        type: "application/octet-stream",
+      });
       await userEvent.upload(fileInput(), validFile);
-      const removeBtn = screen.getByRole("button", { name: /remove selected file/i });
+      const removeBtn = screen.getByRole("button", { name: /remove file/i });
       expect(removeBtn).toBeInTheDocument();
       await userEvent.click(removeBtn);
       expect(screen.getByRole("button", { name: /upload/i })).toBeDisabled();
@@ -266,23 +317,31 @@ describe("AdminLicense", () => {
       mockMutateAsync.mockResolvedValue(undefined);
       setupHooks({ data: {} });
       const { fileInput } = renderPage();
-      const validFile = new File(["license-content"], "license.dat", { type: "application/octet-stream" });
+      const validFile = new File(["license-content"], "license.dat", {
+        type: "application/octet-stream",
+      });
       await userEvent.upload(fileInput(), validFile);
       const uploadBtn = screen.getByRole("button", { name: /upload/i });
       expect(uploadBtn).not.toBeDisabled();
       await userEvent.click(uploadBtn);
-      expect(mockMutateAsync).toHaveBeenCalledWith({ body: { file: validFile } });
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        body: { file: validFile },
+      });
     });
 
     it("shows success message after upload", async () => {
       mockMutateAsync.mockResolvedValue(undefined);
       setupHooks({ data: {} });
       const { fileInput } = renderPage();
-      const validFile = new File(["license-content"], "license.dat", { type: "application/octet-stream" });
+      const validFile = new File(["license-content"], "license.dat", {
+        type: "application/octet-stream",
+      });
       await userEvent.upload(fileInput(), validFile);
       await userEvent.click(screen.getByRole("button", { name: /upload/i }));
       await waitFor(() =>
-        expect(screen.getByText("License uploaded successfully.")).toBeInTheDocument(),
+        expect(
+          screen.getByText("License uploaded successfully."),
+        ).toBeInTheDocument(),
       );
     });
 
@@ -290,11 +349,15 @@ describe("AdminLicense", () => {
       mockMutateAsync.mockRejectedValue(new Error("upload failed"));
       setupHooks({ data: {} });
       const { fileInput } = renderPage();
-      const validFile = new File(["license-content"], "license.dat", { type: "application/octet-stream" });
+      const validFile = new File(["license-content"], "license.dat", {
+        type: "application/octet-stream",
+      });
       await userEvent.upload(fileInput(), validFile);
       await userEvent.click(screen.getByRole("button", { name: /upload/i }));
       await waitFor(() =>
-        expect(screen.getByText("Failed to upload the license.")).toBeInTheDocument(),
+        expect(
+          screen.getByText("Failed to upload the license."),
+        ).toBeInTheDocument(),
       );
     });
   });

--- a/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
@@ -13,7 +13,7 @@ import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import AnnouncementContent from "./AnnouncementContent";
 import { formatDateFull } from "@/utils/date";
 import PageLoader from "@/components/common/PageLoader";
-import { Card } from "@shellhub/design-system/primitives";
+import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -75,21 +75,23 @@ export default function AnnouncementDetails() {
           </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          <Link
+          <Button
+            variant="outline"
+            as={Link}
             to={`/admin/announcements/${announcement.uuid}/edit`}
-            className="flex items-center gap-2 px-4 py-2.5 border border-border rounded-lg text-sm text-text-secondary hover:text-text-primary hover:border-border-light transition-colors"
+            icon={<PencilSquareIcon className="w-4 h-4" />}
           >
-            <PencilSquareIcon className="w-4 h-4" />
             Edit
-          </Link>
-          <button
-            type="button"
-            onClick={() => setDeleteOpen(true)}
-            className="p-2.5 border border-border rounded-lg text-text-muted hover:text-accent-red hover:border-accent-red/30 transition-colors"
+          </Button>
+          <IconButton
+            variant="danger"
+            size="lg"
             aria-label="Delete announcement"
+            className="border border-border hover:border-accent-red/30"
+            onClick={() => setDeleteOpen(true)}
           >
             <TrashIcon className="w-4 h-4" />
-          </button>
+          </IconButton>
         </div>
       </div>
 

--- a/ui/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
@@ -9,7 +9,7 @@ import Breadcrumb from "@/components/common/Breadcrumb";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
 import PageLoader from "@/components/common/PageLoader";
-import { Card, Spinner } from "@shellhub/design-system/primitives";
+import { Button, Card } from "@shellhub/design-system/primitives";
 
 const TITLE_MAX = 90;
 
@@ -116,7 +116,6 @@ export default function EditAnnouncement() {
           onChange={setTitle}
           placeholder="Announcement title"
           maxLength={TITLE_MAX}
-
         />
 
         {/* Content editor */}
@@ -137,16 +136,13 @@ export default function EditAnnouncement() {
           >
             Cancel
           </Link>
-          <button
+          <Button
             type="submit"
+            loading={updateAnnouncement.isPending}
             disabled={!canSubmit || updateAnnouncement.isPending}
-            className="flex items-center gap-2 px-4 py-2.5 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {updateAnnouncement.isPending && (
-              <Spinner size="sm" tone="onPrimary" />
-            )}
             Save
-          </button>
+          </Button>
         </div>
       </Card>
     </div>

--- a/ui/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/NewAnnouncement.tsx
@@ -6,7 +6,7 @@ import AnnouncementEditor from "./AnnouncementEditor";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
-import { Card, Spinner } from "@shellhub/design-system/primitives";
+import { Button, Card } from "@shellhub/design-system/primitives";
 
 const TITLE_MAX = 90;
 
@@ -78,7 +78,6 @@ export default function NewAnnouncement() {
           onChange={setTitle}
           placeholder="Announcement title"
           maxLength={TITLE_MAX}
-
         />
 
         {/* Content editor */}
@@ -95,16 +94,13 @@ export default function NewAnnouncement() {
           >
             Cancel
           </Link>
-          <button
+          <Button
             type="submit"
+            loading={createAnnouncement.isPending}
             disabled={!canSubmit || createAnnouncement.isPending}
-            className="flex items-center gap-2 px-4 py-2.5 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {createAnnouncement.isPending && (
-              <Spinner size="sm" tone="onPrimary" />
-            )}
             Create
-          </button>
+          </Button>
         </div>
       </Card>
     </div>

--- a/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -16,7 +16,12 @@ import DeleteNamespaceDialog from "./DeleteNamespaceDialog";
 import { formatDateFull } from "@/utils/date";
 import { formatMaxDevices } from "./utils";
 import PageLoader from "@/components/common/PageLoader";
-import { Badge, Card } from "@shellhub/design-system/primitives";
+import {
+  Badge,
+  Button,
+  Card,
+  IconButton,
+} from "@shellhub/design-system/primitives";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -127,23 +132,23 @@ export default function NamespaceDetails() {
         </div>
 
         <div className="flex items-center gap-2 shrink-0">
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            icon={<PencilSquareIcon className="w-4 h-4" />}
             onClick={() => setEditOpen(true)}
-            className="flex items-center gap-2 px-4 py-2.5 border border-border text-text-secondary hover:text-text-primary hover:border-border-light rounded-lg text-sm font-semibold transition-all"
           >
-            <PencilSquareIcon className="w-4 h-4" />
             Edit
-          </button>
-          <button
-            type="button"
-            onClick={() => setDeleteOpen(true)}
-            className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
+          </Button>
+          <IconButton
+            variant="danger"
+            size="lg"
             title="Delete namespace"
             aria-label={`Delete ${namespace.name}`}
+            className="border border-border"
+            onClick={() => setDeleteOpen(true)}
           >
             <TrashIcon className="w-4 h-4" />
-          </button>
+          </IconButton>
         </div>
       </div>
 

--- a/ui/apps/console/src/pages/admin/settings/Authentication.tsx
+++ b/ui/apps/console/src/pages/admin/settings/Authentication.tsx
@@ -15,7 +15,7 @@ import PageHeader from "../../../components/common/PageHeader";
 import CopyButton from "../../../components/common/CopyButton";
 import SamlConfigDrawer from "./SamlConfigDrawer";
 import PageLoader from "@/components/common/PageLoader";
-import { Card } from "@shellhub/design-system/primitives";
+import { Button, Card } from "@shellhub/design-system/primitives";
 
 type AuthSettings = GetAuthenticationSettingsResponse;
 
@@ -284,28 +284,28 @@ export default function AdminAuthentication() {
               {/* Actions */}
               <div className="flex items-center gap-3 pt-1">
                 {saml.auth_url && (
-                  <a
+                  <Button
+                    variant="outline"
+                    as="a"
+                    size="sm"
                     href={saml.auth_url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-text-secondary border border-border hover:border-border-light hover:text-text-primary rounded-lg transition-all"
                     title="Opens a new window directly calling the authentication URL"
+                    icon={
+                      <ArrowTopRightOnSquareIcon
+                        className="w-3.5 h-3.5"
+                        strokeWidth={2}
+                      />
+                    }
                   >
-                    <ArrowTopRightOnSquareIcon
-                      className="w-3.5 h-3.5"
-                      strokeWidth={2}
-                    />
                     Test Auth Integration
-                  </a>
+                  </Button>
                 )}
 
-                <button
-                  type="button"
-                  onClick={() => setDrawerOpen(true)}
-                  className="flex items-center gap-1.5 px-3 py-1.5 bg-primary hover:bg-primary-600 text-white text-xs font-semibold rounded-lg transition-all"
-                >
+                <Button size="sm" onClick={() => setDrawerOpen(true)}>
                   Edit Configuration
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/ui/apps/console/src/pages/admin/settings/SamlConfigDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/settings/SamlConfigDrawer.tsx
@@ -11,7 +11,7 @@ import InputField from "@/components/common/fields/InputField";
 import CheckboxField from "@/components/common/fields/CheckboxField";
 import { INPUT } from "@/utils/styles";
 import FieldLabel from "@/components/common/fields/FieldLabel";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 
 type SamlSettings = NonNullable<GetAuthenticationSettingsResponse>["saml"];
 
@@ -205,22 +205,16 @@ export default function SamlConfigDrawer({
 
   const footer = (
     <>
-      <button
-        type="button"
-        onClick={onClose}
-        className="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border hover:border-border-light rounded-lg transition-all"
-      >
+      <Button variant="ghost" onClick={onClose}>
         Cancel
-      </button>
-      <button
-        type="button"
+      </Button>
+      <Button
+        loading={saving}
+        disabled={hasErrors}
         onClick={() => void handleSave()}
-        disabled={hasErrors || saving}
-        className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all"
       >
-        {saving && <Spinner size="sm" tone="onPrimary" />}
         Save Configuration
-      </button>
+      </Button>
     </>
   );
 

--- a/ui/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -19,7 +19,12 @@ import ResetPasswordDialog from "./ResetPasswordDialog";
 import DeleteUserDialog from "./DeleteUserDialog";
 import { formatDateFull } from "@/utils/date";
 import PageLoader from "@/components/common/PageLoader";
-import { Badge, Card, Spinner } from "@shellhub/design-system/primitives";
+import {
+  Badge,
+  Button,
+  Card,
+  IconButton,
+} from "@shellhub/design-system/primitives";
 
 const LABEL =
   "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
@@ -129,51 +134,42 @@ export default function UserDetails() {
 
         {/* Actions */}
         <div className="flex items-center gap-2 shrink-0">
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            icon={<PencilSquareIcon className="w-4 h-4" />}
             onClick={() => setEditOpen(true)}
-            className="flex items-center gap-2 px-4 py-2.5 border border-border text-text-secondary hover:text-text-primary hover:border-border-light rounded-lg text-sm font-semibold transition-all"
           >
-            <PencilSquareIcon className="w-4 h-4" />
             Edit
-          </button>
+          </Button>
           {isSamlOnly && (
-            <button
-              type="button"
-              onClick={() => setResetPasswordOpen(true)}
-              className="flex items-center gap-2 px-4 py-2.5 border border-border text-text-secondary hover:text-text-primary hover:border-border-light rounded-lg text-sm font-semibold transition-all"
+            <Button
+              variant="secondary"
+              icon={<KeyIcon className="w-4 h-4" />}
               title="Enable local authentication for this SAML-only user"
+              onClick={() => setResetPasswordOpen(true)}
             >
-              <KeyIcon className="w-4 h-4" />
               Set Password
-            </button>
+            </Button>
           )}
-          <button
-            type="button"
-            onClick={() => id && void loginAs(id)}
+          <Button
+            variant={loginAsErrorId === id ? "destructive" : "primary"}
+            icon={<ArrowRightStartOnRectangleIcon className="w-4 h-4" />}
+            loading={loginAsId === id}
             disabled={loginAsId === id}
-            className={`flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold disabled:opacity-dim disabled:cursor-not-allowed transition-all ${
-              loginAsErrorId === id
-                ? "bg-accent-red hover:bg-accent-red/80 text-white"
-                : "bg-primary hover:bg-primary-600 text-white"
-            }`}
+            onClick={() => id && void loginAs(id)}
           >
-            {loginAsId === id ? (
-              <Spinner tone="onPrimary" />
-            ) : (
-              <ArrowRightStartOnRectangleIcon className="w-4 h-4" />
-            )}
             {loginAsErrorId === id ? "Retry Login" : "Login as User"}
-          </button>
-          <button
-            type="button"
-            onClick={() => setDeleteOpen(true)}
-            className="p-2.5 rounded-lg text-text-muted hover:text-accent-red hover:bg-accent-red/10 border border-border transition-all"
+          </Button>
+          <IconButton
+            variant="danger"
+            size="lg"
             title="Delete user"
             aria-label={`Delete ${user.name}`}
+            className="border border-border"
+            onClick={() => setDeleteOpen(true)}
           >
             <TrashIcon className="w-4 h-4" />
-          </button>
+          </IconButton>
         </div>
       </div>
 

--- a/ui/apps/console/src/pages/admin/users/index.tsx
+++ b/ui/apps/console/src/pages/admin/users/index.tsx
@@ -19,7 +19,7 @@ import UserStatusChip from "./UserStatusChip";
 import CreateUserDrawer from "./CreateUserDrawer";
 import EditUserDrawer from "./EditUserDrawer";
 import DeleteUserDialog from "./DeleteUserDialog";
-import { Badge, IconButton, Spinner } from "@shellhub/design-system/primitives";
+import { Badge, Button, IconButton } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -99,31 +99,28 @@ export default function AdminUsers() {
           >
             <PencilSquareIcon className="w-4 h-4" />
           </IconButton>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              void loginAs(user.id);
-            }}
+          <IconButton
+            variant="primary"
+            loading={loginAsId === user.id}
             disabled={loginAsId === user.id}
-            className={`p-1.5 rounded-md transition-colors disabled:opacity-dim disabled:cursor-not-allowed ${
+            className={
               loginAsError === user.id
                 ? "text-accent-red hover:text-accent-red hover:bg-accent-red/5"
-                : "text-text-muted hover:text-primary hover:bg-primary/5"
-            }`}
+                : undefined
+            }
             title={
               loginAsError === user.id
                 ? "Login failed \u2014 click to retry"
                 : "Login as user"
             }
             aria-label={`Login as ${user.name}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              void loginAs(user.id);
+            }}
           >
-            {loginAsId === user.id ? (
-              <Spinner className="block" />
-            ) : (
-              <ArrowRightStartOnRectangleIcon className="w-4 h-4" />
-            )}
-          </button>
+            <ArrowRightStartOnRectangleIcon className="w-4 h-4" />
+          </IconButton>
           <IconButton
             variant="danger"
             title="Delete user"
@@ -148,14 +145,12 @@ export default function AdminUsers() {
         title="Users"
         description="Manage all user accounts in the instance"
       >
-        <button
-          type="button"
+        <Button
           onClick={() => setCreateOpen(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+          icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
         >
-          <PlusIcon className="w-4 h-4" strokeWidth={2} />
           Create User
-        </button>
+        </Button>
       </PageHeader>
 
       <SearchField

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -29,6 +29,7 @@ import {
 } from "@heroicons/react/24/outline";
 import Alert from "@/components/common/Alert";
 import RestrictedAction from "@/components/common/RestrictedAction";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const statusTabs: { label: string; value: DeviceStatus }[] = [
   { label: "Accepted", value: "accepted" },
@@ -189,8 +190,9 @@ export default function Containers() {
           render: (container) =>
             container.online ? (
               <RestrictedAction action="device:connect">
-                <button
-                  type="button"
+                <Button
+                  variant="successSoft"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     const existing = useTerminalStore
@@ -209,11 +211,15 @@ export default function Containers() {
                       });
                     }
                   }}
-                  className="inline-flex items-center gap-1 px-2.5 py-1 bg-accent-green/10 text-accent-green text-2xs font-semibold rounded-md hover:bg-accent-green/20 border border-accent-green/20 transition-all"
+                  icon={
+                    <ChevronDoubleRightIcon
+                      className="w-3 h-3"
+                      strokeWidth={2}
+                    />
+                  }
                 >
-                  <ChevronDoubleRightIcon className="w-3 h-3" strokeWidth={2} />
                   Connect
-                </button>
+                </Button>
               </RestrictedAction>
             ) : (
               <span className="text-2xs text-text-muted/30 font-mono">
@@ -234,28 +240,28 @@ export default function Containers() {
           render: (container) => (
             <div className="flex items-center justify-end gap-1.5">
               <RestrictedAction action="device:accept">
-                <button
-                  type="button"
+                <Button
+                  variant="successSoft"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     setActionTarget({ container, action: "accept" });
                   }}
-                  className="px-2.5 py-1 text-2xs font-semibold rounded-md bg-accent-green/10 text-accent-green hover:bg-accent-green/20 border border-accent-green/20 transition-all"
                 >
                   Accept
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="device:reject">
-                <button
-                  type="button"
+                <Button
+                  variant="warningSoft"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     setActionTarget({ container, action: "reject" });
                   }}
-                  className="px-2.5 py-1 text-2xs font-semibold rounded-md bg-accent-yellow/10 text-accent-yellow hover:bg-accent-yellow/20 border border-accent-yellow/20 transition-all"
                 >
                   Reject
-                </button>
+                </Button>
               </RestrictedAction>
             </div>
           ),
@@ -273,28 +279,28 @@ export default function Containers() {
         render: (container) => (
           <div className="flex items-center justify-end gap-1.5">
             <RestrictedAction action="device:accept">
-              <button
-                type="button"
+              <Button
+                variant="successSoft"
+                size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
                   setActionTarget({ container, action: "accept" });
                 }}
-                className="px-2.5 py-1 text-2xs font-semibold rounded-md bg-accent-green/10 text-accent-green hover:bg-accent-green/20 border border-accent-green/20 transition-all"
               >
                 Accept
-              </button>
+              </Button>
             </RestrictedAction>
             <RestrictedAction action="device:remove">
-              <button
-                type="button"
+              <Button
+                variant="dangerSoft"
+                size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
                   setActionTarget({ container, action: "remove" });
                 }}
-                className="px-2.5 py-1 text-2xs font-semibold rounded-md bg-accent-red/10 text-accent-red hover:bg-accent-red/20 border border-accent-red/20 transition-all"
               >
                 Remove
-              </button>
+              </Button>
             </RestrictedAction>
           </div>
         ),
@@ -310,14 +316,12 @@ export default function Containers() {
         title="Containers"
         description="Manage and monitor Docker containers connected via ShellHub Connector"
       >
-        <button
-          type="button"
+        <Button
           onClick={() => setAddConnectorOpen(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200"
+          icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
         >
-          <PlusIcon className="w-4 h-4" strokeWidth={2} />
           Add Docker Host
-        </button>
+        </Button>
       </PageHeader>
 
       {/* Filter bar */}
@@ -380,23 +384,19 @@ export default function Containers() {
               >
                 <TagIcon className="w-2.5 h-2.5" strokeWidth={2} />
                 {tag}
-                <button
-                  type="button"
-                  onClick={() => removeFilterTag(tag)}
+                <IconButton
+                  size="sm"
                   aria-label={`Remove ${tag} filter`}
-                  className="hover:text-white transition-colors ml-0.5"
+                  className="ml-0.5"
+                  onClick={() => removeFilterTag(tag)}
                 >
                   <XMarkIcon className="w-2.5 h-2.5" strokeWidth={2.5} />
-                </button>
+                </IconButton>
               </span>
             ))}
-            <button
-              type="button"
-              onClick={clearFilterTags}
-              className="text-2xs text-text-muted hover:text-text-primary transition-colors font-mono"
-            >
+            <Button variant="ghost" size="sm" onClick={clearFilterTags}>
               Clear all
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/ui/apps/console/src/pages/devices/CustomFieldsSection.tsx
+++ b/ui/apps/console/src/pages/devices/CustomFieldsSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { PlusIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import {
   useSetDeviceCustomField,
   useDeleteDeviceCustomField,
@@ -97,14 +98,15 @@ export default function CustomFieldsSection({
                   </button>
                 </div>
               ) : (
-                <button
+                <IconButton
+                  variant="danger"
+                  size="sm"
                   type="button"
-                  onClick={() => setConfirmKey(key)}
                   aria-label={`Remove custom field ${key}`}
-                  className="shrink-0 p-1 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-all"
+                  onClick={() => setConfirmKey(key)}
                 >
                   <XMarkIcon className="w-3 h-3" strokeWidth={2} />
-                </button>
+                </IconButton>
               ))}
           </div>
         ))}
@@ -146,15 +148,15 @@ export default function CustomFieldsSection({
             aria-label="Custom field value"
             className="w-32 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
           />
-          <button
-            type="button"
-            onClick={() => void handleAdd()}
+          <IconButton
+            variant="primary"
+            size="sm"
             disabled={adding || !keyInput.trim() || !valueInput.trim()}
             aria-label="Add custom field"
-            className="p-1 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 disabled:opacity-soft transition-all"
+            onClick={() => void handleAdd()}
           >
             <PlusIcon className="w-4 h-4" strokeWidth={2} />
-          </button>
+          </IconButton>
         </div>
       )}
       {error && <p className="text-2xs text-accent-red mt-1.5">{error}</p>}

--- a/ui/apps/console/src/pages/devices/RenameSection.tsx
+++ b/ui/apps/console/src/pages/devices/RenameSection.tsx
@@ -4,6 +4,7 @@ import {
   CheckIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import { useRenameDevice } from "@/hooks/useDeviceMutations";
 import { useHasPermission } from "@/hooks/useHasPermission";
 
@@ -47,18 +48,17 @@ export default function RenameSection({
       <div className="flex items-center gap-2">
         <h1 className="text-2xl font-bold text-text-primary">{currentName}</h1>
         {canRename && (
-          <button
-            type="button"
+          <IconButton
+            variant="primary"
+            aria-label="Rename device"
+            title="Rename"
             onClick={() => {
               setName(currentName);
               setEditing(true);
             }}
-            className="p-1.5 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 transition-all"
-            aria-label="Rename device"
-            title="Rename"
           >
             <PencilSquareIcon className="w-4 h-4" />
-          </button>
+          </IconButton>
         )}
       </div>
     );
@@ -76,26 +76,24 @@ export default function RenameSection({
             if (e.key === "Escape") setEditing(false);
           }}
           aria-label="Device name"
-
           className="text-2xl font-bold text-text-primary bg-transparent border-b-2 border-primary/50 focus:outline-none focus:border-primary w-full max-w-md"
         />
-        <button
+        <IconButton
+          variant="primary"
           type="button"
-          onClick={() => void handleSave()}
-          disabled={saving}
           aria-label="Save device name"
-          className="p-1.5 rounded-md text-accent-green hover:bg-accent-green/10 transition-all"
+          disabled={saving}
+          onClick={() => void handleSave()}
         >
           <CheckIcon className="w-4 h-4" strokeWidth={2} />
-        </button>
-        <button
+        </IconButton>
+        <IconButton
           type="button"
-          onClick={() => setEditing(false)}
           aria-label="Cancel rename"
-          className="p-1.5 rounded-md text-text-muted hover:bg-hover-medium transition-all"
+          onClick={() => setEditing(false)}
         >
           <XMarkIcon className="w-4 h-4" strokeWidth={2} />
-        </button>
+        </IconButton>
       </div>
       {error && <p className="text-2xs text-accent-red mt-1">{error}</p>}
     </div>

--- a/ui/apps/console/src/pages/devices/TagsPopover.tsx
+++ b/ui/apps/console/src/pages/devices/TagsPopover.tsx
@@ -7,7 +7,10 @@ import {
   PencilIcon,
 } from "@heroicons/react/24/outline";
 import { useTags } from "@/hooks/useTags";
-import { useAddDeviceTag, useRemoveDeviceTag } from "@/hooks/useDeviceMutations";
+import {
+  useAddDeviceTag,
+  useRemoveDeviceTag,
+} from "@/hooks/useDeviceMutations";
 import type { NormalizedDevice } from "@/hooks/useDevices";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useHasPermission } from "@/hooks/useHasPermission";
@@ -72,10 +75,10 @@ function TagsPopover({
     if (!open) return;
     const handler = (e: MouseEvent) => {
       if (
-        popoverRef.current
-        && !popoverRef.current.contains(e.target as Node)
-        && triggerRef.current
-        && !triggerRef.current.contains(e.target as Node)
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target as Node) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target as Node)
       ) {
         setOpen(false);
       }
@@ -113,44 +116,42 @@ function TagsPopover({
   const suggestions = allTags.filter(
     (t) => !tags.includes(t) && t.toLowerCase().includes(input.toLowerCase()),
   );
-  const isNew
-    = input.trim().length >= 3
-      && input.trim().length <= 255
-      && !allTags.includes(input.trim())
-      && !tags.includes(input.trim());
-  const inputValid
-    = !input.trim()
-      || (/^[a-zA-Z0-9]+$/.test(input.trim()) && input.trim().length <= 255);
+  const isNew =
+    input.trim().length >= 3 &&
+    input.trim().length <= 255 &&
+    !allTags.includes(input.trim()) &&
+    !tags.includes(input.trim());
+  const inputValid =
+    !input.trim() ||
+    (/^[a-zA-Z0-9]+$/.test(input.trim()) && input.trim().length <= 255);
 
   return (
     <>
       {/* Trigger — inline in the table cell */}
       <div className="flex items-center gap-1 min-h-[28px] group/tags">
-        {tags.length > 0
-          ? (
-            <div className="flex items-center gap-1">
-              {tags.map((tag) => (
-                <button
-                  type="button"
-                  key={tag}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onFilterTag(tag);
-                  }}
-                  title={`Filter by "${tag}"`}
-                  className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-primary/10 text-primary text-2xs rounded font-medium hover:bg-primary/20 transition-all cursor-pointer"
-                >
-                  <TagIcon className="w-2 h-2" strokeWidth={2} />
-                  {tag}
-                </button>
-              ))}
-            </div>
-          )
-          : (
-            <span className="text-2xs text-text-muted/30 group-hover/tags:text-text-muted transition-colors">
-              No tags
-            </span>
-          )}
+        {tags.length > 0 ? (
+          <div className="flex items-center gap-1">
+            {tags.map((tag) => (
+              <button
+                type="button"
+                key={tag}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onFilterTag(tag);
+                }}
+                title={`Filter by "${tag}"`}
+                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 bg-primary/10 text-primary text-2xs rounded font-medium hover:bg-primary/20 transition-all cursor-pointer"
+              >
+                <TagIcon className="w-2 h-2" strokeWidth={2} />
+                {tag}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <span className="text-2xs text-text-muted/30 group-hover/tags:text-text-muted transition-colors">
+            No tags
+          </span>
+        )}
         {canEditTags && (
           <button
             type="button"
@@ -161,6 +162,7 @@ function TagsPopover({
             }}
             className="p-0.5 rounded text-text-muted/20 group-hover/tags:text-text-muted hover:!text-primary hover:bg-primary/10 transition-all shrink-0"
             title="Manage tags"
+            aria-label="Manage tags"
           >
             <PencilIcon className="w-3 h-3" strokeWidth={2} />
           </button>
@@ -168,8 +170,8 @@ function TagsPopover({
       </div>
 
       {/* Popover — portaled to body */}
-      {open
-        && createPortal(
+      {open &&
+        createPortal(
           <div
             ref={popoverRef}
             className="fixed z-50 w-[300px] bg-surface border border-border rounded-xl shadow-2xl animate-fade-in"
@@ -191,6 +193,7 @@ function TagsPopover({
                         type="button"
                         onClick={() => void handleRemove(tag)}
                         disabled={loading}
+                        aria-label={`Remove tag ${tag}`}
                         className="hover:text-white transition-colors disabled:opacity-dim ml-0.5"
                       >
                         <XMarkIcon className="w-2.5 h-2.5" strokeWidth={2} />
@@ -209,16 +212,15 @@ function TagsPopover({
                     onChange={(e) => setInput(e.target.value)}
                     onKeyDown={(e) => {
                       if (
-                        e.key === "Enter"
-                        && input.trim().length >= 3
-                        && inputValid
+                        e.key === "Enter" &&
+                        input.trim().length >= 3 &&
+                        inputValid
                       ) {
                         e.preventDefault();
                         void handleAdd(input.trim());
                       }
                     }}
                     placeholder="Search or create tag..."
-
                     className="w-full px-2.5 py-1.5 bg-card border border-border rounded-lg text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all"
                   />
                   {input.trim() && input.trim().length < 3 && (
@@ -235,43 +237,43 @@ function TagsPopover({
                   )}
 
                   {/* Suggestions dropdown */}
-                  {(suggestions.length > 0 || isNew)
-                    && input.trim()
-                    && inputValid && (
-                    <div className="mt-1.5 max-h-[140px] overflow-y-auto border border-border rounded-lg divide-y divide-border/60">
-                      {suggestions.map((tag) => (
-                        <button
-                          type="button"
-                          key={tag}
-                          onClick={() => void handleAdd(tag)}
-                          disabled={loading}
-                          className="w-full text-left px-2.5 py-1.5 text-2xs text-text-primary hover:bg-hover-medium transition-colors disabled:opacity-dim flex items-center gap-1.5"
-                        >
-                          <TagIcon
-                            className="w-2.5 h-2.5 text-primary shrink-0"
-                            strokeWidth={2}
-                          />
-                          {tag}
-                        </button>
-                      ))}
-                      {isNew && (
-                        <button
-                          type="button"
-                          onClick={() => void handleAdd(input.trim())}
-                          disabled={loading}
-                          className="w-full text-left px-2.5 py-1.5 text-2xs text-accent-green hover:bg-hover-medium transition-colors disabled:opacity-dim flex items-center gap-1.5"
-                        >
-                          <PlusIcon
-                            className="w-2.5 h-2.5 shrink-0"
-                            strokeWidth={2}
-                          />
-                          Create &ldquo;
-                          {input.trim()}
-                          &rdquo;
-                        </button>
-                      )}
-                    </div>
-                  )}
+                  {(suggestions.length > 0 || isNew) &&
+                    input.trim() &&
+                    inputValid && (
+                      <div className="mt-1.5 max-h-[140px] overflow-y-auto border border-border rounded-lg divide-y divide-border/60">
+                        {suggestions.map((tag) => (
+                          <button
+                            type="button"
+                            key={tag}
+                            onClick={() => void handleAdd(tag)}
+                            disabled={loading}
+                            className="w-full text-left px-2.5 py-1.5 text-2xs text-text-primary hover:bg-hover-medium transition-colors disabled:opacity-dim flex items-center gap-1.5"
+                          >
+                            <TagIcon
+                              className="w-2.5 h-2.5 text-primary shrink-0"
+                              strokeWidth={2}
+                            />
+                            {tag}
+                          </button>
+                        ))}
+                        {isNew && (
+                          <button
+                            type="button"
+                            onClick={() => void handleAdd(input.trim())}
+                            disabled={loading}
+                            className="w-full text-left px-2.5 py-1.5 text-2xs text-accent-green hover:bg-hover-medium transition-colors disabled:opacity-dim flex items-center gap-1.5"
+                          >
+                            <PlusIcon
+                              className="w-2.5 h-2.5 shrink-0"
+                              strokeWidth={2}
+                            />
+                            Create &ldquo;
+                            {input.trim()}
+                            &rdquo;
+                          </button>
+                        )}
+                      </div>
+                    )}
                 </div>
               ) : (
                 <p className="text-2xs text-text-muted">

--- a/ui/apps/console/src/pages/devices/TagsSection.tsx
+++ b/ui/apps/console/src/pages/devices/TagsSection.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { TagIcon, XMarkIcon, PlusIcon } from "@heroicons/react/24/outline";
-import { useAddDeviceTag, useRemoveDeviceTag } from "@/hooks/useDeviceMutations";
+import { IconButton } from "@shellhub/design-system/primitives";
+import {
+  useAddDeviceTag,
+  useRemoveDeviceTag,
+} from "@/hooks/useDeviceMutations";
 import { useHasPermission } from "@/hooks/useHasPermission";
 
 const LABEL =
@@ -103,15 +107,15 @@ export default function TagsSection({ uid, tags }: TagsSectionProps) {
               aria-label="New tag"
               className="w-28 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
             />
-            <button
-              type="button"
-              onClick={() => void handleAdd()}
+            <IconButton
+              variant="primary"
+              size="sm"
               disabled={adding || !input.trim()}
               aria-label="Add tag"
-              className="p-1 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 disabled:opacity-soft transition-all"
+              onClick={() => void handleAdd()}
             >
               <PlusIcon className="w-4 h-4" strokeWidth={2} />
-            </button>
+            </IconButton>
           </div>
         )}
       </div>

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "@heroicons/react/24/outline";
 import Alert from "@/components/common/Alert";
 import RestrictedAction from "@/components/common/RestrictedAction";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const statusTabs: { label: string; value: DeviceStatus }[] = [
   { label: "Accepted", value: "accepted" },
@@ -180,8 +181,15 @@ export default function Devices() {
           render: (device) =>
             device.online ? (
               <RestrictedAction action="device:connect">
-                <button
-                  type="button"
+                <Button
+                  variant="successSoft"
+                  size="sm"
+                  icon={
+                    <ChevronDoubleRightIcon
+                      className="w-3 h-3"
+                      strokeWidth={2}
+                    />
+                  }
                   onClick={(e) => {
                     e.stopPropagation();
                     const existing = useTerminalStore
@@ -200,11 +208,9 @@ export default function Devices() {
                       });
                     }
                   }}
-                  className="inline-flex items-center gap-1 px-2.5 py-1 bg-accent-green/10 text-accent-green text-2xs font-semibold rounded-md hover:bg-accent-green/20 border border-accent-green/20 transition-all"
                 >
-                  <ChevronDoubleRightIcon className="w-3 h-3" strokeWidth={2} />
                   Connect
-                </button>
+                </Button>
               </RestrictedAction>
             ) : (
               <span className="text-2xs text-text-muted/30 font-mono">
@@ -225,28 +231,28 @@ export default function Devices() {
           render: (device) => (
             <div className="flex items-center justify-end gap-1.5">
               <RestrictedAction action="device:accept">
-                <button
-                  type="button"
+                <Button
+                  variant="successSoft"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     setActionTarget({ device, action: "accept" });
                   }}
-                  className="px-2.5 py-1 text-2xs font-semibold rounded-md bg-accent-green/10 text-accent-green hover:bg-accent-green/20 border border-accent-green/20 transition-all"
                 >
                   Accept
-                </button>
+                </Button>
               </RestrictedAction>
               <RestrictedAction action="device:reject">
-                <button
-                  type="button"
+                <Button
+                  variant="warningSoft"
+                  size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     setActionTarget({ device, action: "reject" });
                   }}
-                  className="px-2.5 py-1 text-2xs font-semibold rounded-md bg-accent-yellow/10 text-accent-yellow hover:bg-accent-yellow/20 border border-accent-yellow/20 transition-all"
                 >
                   Reject
-                </button>
+                </Button>
               </RestrictedAction>
             </div>
           ),
@@ -264,28 +270,28 @@ export default function Devices() {
         render: (device) => (
           <div className="flex items-center justify-end gap-1.5">
             <RestrictedAction action="device:accept">
-              <button
-                type="button"
+              <Button
+                variant="successSoft"
+                size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
                   setActionTarget({ device, action: "accept" });
                 }}
-                className="px-2.5 py-1 text-2xs font-semibold rounded-md bg-accent-green/10 text-accent-green hover:bg-accent-green/20 border border-accent-green/20 transition-all"
               >
                 Accept
-              </button>
+              </Button>
             </RestrictedAction>
             <RestrictedAction action="device:remove">
-              <button
-                type="button"
+              <Button
+                variant="dangerSoft"
+                size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
                   setActionTarget({ device, action: "remove" });
                 }}
-                className="px-2.5 py-1 text-2xs font-semibold rounded-md bg-accent-red/10 text-accent-red hover:bg-accent-red/20 border border-accent-red/20 transition-all"
               >
                 Remove
-              </button>
+              </Button>
             </RestrictedAction>
           </div>
         ),
@@ -302,13 +308,13 @@ export default function Devices() {
         description="Manage and monitor all devices connected to your namespace"
       >
         <RestrictedAction action="device:add">
-          <Link
+          <Button
+            as={Link}
             to="/devices/add"
-            className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200"
+            icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
           >
-            <PlusIcon className="w-4 h-4" strokeWidth={2} />
             Add Device
-          </Link>
+          </Button>
         </RestrictedAction>
       </PageHeader>
 
@@ -366,22 +372,19 @@ export default function Devices() {
               >
                 <TagIcon className="w-2.5 h-2.5" strokeWidth={2} />
                 {tag}
-                <button
-                  type="button"
+                <IconButton
+                  size="sm"
+                  aria-label="Remove tag filter"
+                  className="ml-0.5"
                   onClick={() => removeFilterTag(tag)}
-                  className="hover:text-white transition-colors ml-0.5"
                 >
                   <XMarkIcon className="w-2.5 h-2.5" strokeWidth={2.5} />
-                </button>
+                </IconButton>
               </span>
             ))}
-            <button
-              type="button"
-              onClick={clearFilterTags}
-              className="text-2xs text-text-muted hover:text-text-primary transition-colors font-mono"
-            >
+            <Button variant="ghost" size="sm" onClick={clearFilterTags}>
               Clear all
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/ui/apps/console/src/pages/firewall-rules/index.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/index.tsx
@@ -21,7 +21,7 @@ import {
   TrashIcon,
 } from "@heroicons/react/24/outline";
 import { type FirewallRulesResponse as FirewallRule } from "@/client";
-import { Badge, IconButton } from "@shellhub/design-system/primitives";
+import { Badge, Button, IconButton } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 
@@ -210,18 +210,19 @@ export default function FirewallRules() {
           footnote="Rules are evaluated by priority before connections reach devices."
         >
           <RestrictedAction action="firewall:create">
-            <button
-              type="button"
+            <Button
+              size="lg"
               onClick={openNew}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              icon={
+                <PlusIcon
+                  className="w-4 h-4"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+              }
             >
-              <PlusIcon
-                className="w-4 h-4"
-                strokeWidth={2}
-                aria-hidden="true"
-              />
               Add your first rule
-            </button>
+            </Button>
           </RestrictedAction>
         </EmptyState>
 
@@ -243,14 +244,18 @@ export default function FirewallRules() {
         description="Control SSH connections to your devices with allow and deny rules evaluated by priority."
       >
         <RestrictedAction action="firewall:create">
-          <button
-            type="button"
+          <Button
             onClick={openNew}
-            className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            icon={
+              <PlusIcon
+                className="w-4 h-4"
+                strokeWidth={2}
+                aria-hidden="true"
+              />
+            }
           >
-            <PlusIcon className="w-4 h-4" strokeWidth={2} aria-hidden="true" />
             Add Rule
-          </button>
+          </Button>
         </RestrictedAction>
       </PageHeader>
 

--- a/ui/apps/console/src/pages/public-keys/index.tsx
+++ b/ui/apps/console/src/pages/public-keys/index.tsx
@@ -24,7 +24,7 @@ import {
   TrashIcon,
 } from "@heroicons/react/24/outline";
 import { PublicKeyResponse as PublicKey } from "@/client";
-import { IconButton } from "@shellhub/design-system/primitives";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 
@@ -249,14 +249,13 @@ export default function PublicKeys() {
           footnote="Supports RSA, DSA, ECDSA, and ED25519 key types."
         >
           <RestrictedAction action="publicKey:create">
-            <button
-              type="button"
+            <Button
+              size="lg"
               onClick={openNew}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
             >
-              <PlusIcon className="w-4 h-4" strokeWidth={2} />
               Add your first key
-            </button>
+            </Button>
           </RestrictedAction>
         </EmptyState>
 
@@ -278,14 +277,12 @@ export default function PublicKeys() {
         description="Manage SSH public keys for passwordless authentication to your devices."
       >
         <RestrictedAction action="publicKey:create">
-          <button
-            type="button"
+          <Button
             onClick={openNew}
-            className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+            icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
           >
-            <PlusIcon className="w-4 h-4" strokeWidth={2} />
             Add Public Key
-          </button>
+          </Button>
         </RestrictedAction>
       </PageHeader>
 

--- a/ui/apps/console/src/pages/secure-vault/index.tsx
+++ b/ui/apps/console/src/pages/secure-vault/index.tsx
@@ -30,7 +30,7 @@ import KeyDrawer from "./KeyDrawer";
 import KeyDeleteDialog from "./KeyDeleteDialog";
 import { formatDate } from "@/utils/date";
 import type { VaultKeyEntry } from "@/types/vault";
-import { IconButton } from "@shellhub/design-system/primitives";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const VAULT_FEATURES: EmptyStateFeature[] = [
   {
@@ -135,14 +135,13 @@ export default function SecureVault() {
           description="Store and encrypt your SSH private keys with a master password. Your keys never leave your browser and are protected at rest."
           features={VAULT_FEATURES}
         >
-          <button
-            type="button"
+          <Button
+            size="lg"
             onClick={() => setSetupOpen(true)}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            icon={<ShieldCheckIcon className="w-4 h-4" strokeWidth={2} />}
           >
-            <ShieldCheckIcon className="w-4 h-4" strokeWidth={2} />
             Set Up Secure Vault
-          </button>
+          </Button>
         </EmptyState>
         <VaultSetupDialog
           open={setupOpen}
@@ -163,14 +162,13 @@ export default function SecureVault() {
           description="Enter your master password to access your SSH keys and connect to devices."
           features={VAULT_FEATURES}
         >
-          <button
-            type="button"
+          <Button
+            size="lg"
             onClick={() => setUnlockOpen(true)}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all duration-200 shadow-lg shadow-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            icon={<LockClosedIcon className="w-4 h-4" strokeWidth={2} />}
           >
-            <LockClosedIcon className="w-4 h-4" strokeWidth={2} />
             Unlock Vault
-          </button>
+          </Button>
         </EmptyState>
         <VaultUnlockDialog
           open={unlockOpen}
@@ -270,14 +268,12 @@ export default function SecureVault() {
             title="Secure Vault"
             description="Manage your encrypted SSH private keys."
           >
-            <button
-              type="button"
+            <Button
               onClick={openNew}
-              className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+              icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
             >
-              <PlusIcon className="w-4 h-4" strokeWidth={2} />
               Add Private Key
-            </button>
+            </Button>
           </PageHeader>
 
           <SearchField

--- a/ui/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
+++ b/ui/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
@@ -1,4 +1,5 @@
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { IconButton } from "@shellhub/design-system/primitives";
 import SessionPlayer from "@/components/sessions/SessionPlayer";
 
 interface SessionPlayerDialogProps {
@@ -17,14 +18,13 @@ export default function SessionPlayerDialog({
   return (
     <div className="absolute inset-0 z-[80] flex flex-col bg-[#121314]">
       {/* Close button overlay */}
-      <button
-        type="button"
+      <IconButton
         onClick={onClose}
-        className="absolute top-2 right-2 z-10 w-7 h-7 flex items-center justify-center rounded-md bg-black/40 hover:bg-black/60 text-text-muted hover:text-text-primary transition-colors"
         aria-label="Close"
+        className="absolute top-2 right-2 z-10 bg-black/40 hover:bg-black/60"
       >
         <XMarkIcon className="w-4 h-4" strokeWidth={2} />
-      </button>
+      </IconButton>
 
       {/* Player */}
       <div className="flex-1 min-h-0">

--- a/ui/apps/console/src/pages/sessions/index.tsx
+++ b/ui/apps/console/src/pages/sessions/index.tsx
@@ -18,7 +18,7 @@ import SessionPlayerDialog from "./SessionPlayerDialog";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import { formatDate, formatDuration } from "@/utils/date";
 import { sessionType } from "@/utils/session";
-import { Spinner } from "@shellhub/design-system/primitives";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 
@@ -36,15 +36,15 @@ function CloseButton({ onClose }: { onClose: () => Promise<unknown> }) {
   };
 
   return (
-    <button
-      type="button"
-      onClick={(e) => void handleClick(e)}
-      disabled={closing}
+    <IconButton
+      variant="danger"
       title="Close session"
-      className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/10 transition-colors disabled:opacity-dim"
+      aria-label="Close session"
+      disabled={closing}
+      onClick={(e) => void handleClick(e)}
     >
       <XCircleIcon className="w-4 h-4" strokeWidth={2} />
-    </button>
+    </IconButton>
   );
 }
 
@@ -180,20 +180,16 @@ export default function Sessions() {
         <div className="flex items-center justify-end gap-1">
           {s.recorded && (
             <RestrictedAction action="session:play">
-              <button
-                type="button"
-                onClick={(e) => void handlePlayClick(e, s.uid)}
+              <Button
+                size="sm"
+                icon={<PlayIcon className="w-3 h-3" />}
+                loading={logsLoading && playTarget === s.uid}
                 disabled={logsLoading && playTarget === s.uid}
                 title="Play recording"
-                className="inline-flex items-center gap-1 px-2.5 py-1 bg-primary/10 text-primary text-2xs font-semibold rounded-md hover:bg-primary/20 border border-primary/20 transition-all disabled:opacity-dim"
+                onClick={(e) => void handlePlayClick(e, s.uid)}
               >
-                {logsLoading && playTarget === s.uid ? (
-                  <Spinner size="xs" tone="onSurface" />
-                ) : (
-                  <PlayIcon className="w-3 h-3" />
-                )}
                 Play
-              </button>
+              </Button>
             </RestrictedAction>
           )}
           {s.active && (

--- a/ui/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -4,6 +4,7 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 import { useApiKeys } from "@/hooks/useApiKeys";
 import { useDeleteApiKey } from "@/hooks/useApiKeyMutations";
 import { type ApiKey } from "@/client";
@@ -99,24 +100,24 @@ function ApiKeysTab() {
       render: (key) => (
         <div className="flex items-center justify-end gap-1">
           <RestrictedAction action="apiKey:edit">
-            <button
-              type="button"
-              onClick={() => setEditTarget(key)}
-              className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
+            <IconButton
+              variant="primary"
               title="Edit"
+              aria-label="Edit API key"
+              onClick={() => setEditTarget(key)}
             >
               <PencilSquareIcon className="w-4 h-4" />
-            </button>
+            </IconButton>
           </RestrictedAction>
           <RestrictedAction action="apiKey:delete">
-            <button
-              type="button"
-              onClick={() => setDeleteTarget(key)}
-              className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/5 transition-colors"
+            <IconButton
+              variant="danger"
               title="Delete"
+              aria-label="Delete API key"
+              onClick={() => setDeleteTarget(key)}
             >
               <TrashIcon className="w-4 h-4" />
-            </button>
+            </IconButton>
           </RestrictedAction>
         </div>
       ),
@@ -131,14 +132,12 @@ function ApiKeysTab() {
           {totalCount !== 1 ? "s" : ""}
         </p>
         <RestrictedAction action="apiKey:create">
-          <button
-            type="button"
+          <Button
             onClick={() => setGenerateOpen(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+            icon={<KeyIcon className="w-4 h-4" strokeWidth={2} />}
           >
-            <KeyIcon className="w-4 h-4" strokeWidth={2} />
             Generate Key
-          </button>
+          </Button>
         </RestrictedAction>
       </div>
 

--- a/ui/apps/console/src/pages/team/InvitationsTab.tsx
+++ b/ui/apps/console/src/pages/team/InvitationsTab.tsx
@@ -25,7 +25,7 @@ import {
 import { ExpiredBadge, RoleBadge } from "./constants";
 import InvitationDrawer from "./InvitationDrawer";
 import EditInvitationDrawer from "./EditInvitationDrawer";
-import { IconButton } from "@shellhub/design-system/primitives";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 
@@ -313,14 +313,12 @@ function InvitationsTab({ tenantId }: { tenantId: string }) {
           </div>
         </div>
         <RestrictedAction action="namespace:addMember">
-          <button
-            type="button"
+          <Button
             onClick={() => setInviteOpen(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+            icon={<UserPlusIcon className="w-4 h-4" strokeWidth={2} />}
           >
-            <UserPlusIcon className="w-4 h-4" strokeWidth={2} />
             Invite Member
-          </button>
+          </Button>
         </RestrictedAction>
       </div>
 

--- a/ui/apps/console/src/pages/team/MembersTab.tsx
+++ b/ui/apps/console/src/pages/team/MembersTab.tsx
@@ -5,6 +5,7 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline";
+import { Button, IconButton } from "@shellhub/design-system/primitives";
 import { useAuthStore } from "@/stores/authStore";
 import { useNamespace, type NamespaceMember } from "@/hooks/useNamespaces";
 import { useRemoveMember } from "@/hooks/useMemberMutations";
@@ -109,24 +110,24 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
         return (
           <div className="flex items-center justify-end gap-1">
             <RestrictedAction action="namespace:editMember">
-              <button
-                type="button"
-                onClick={() => setEditTarget(m)}
-                className="p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
+              <IconButton
+                variant="primary"
                 title="Edit role"
+                aria-label="Edit role"
+                onClick={() => setEditTarget(m)}
               >
                 <PencilSquareIcon className="w-4 h-4" />
-              </button>
+              </IconButton>
             </RestrictedAction>
             <RestrictedAction action="namespace:removeMember">
-              <button
-                type="button"
-                onClick={() => setRemoveTarget(m)}
-                className="p-1.5 rounded-md text-text-muted hover:text-accent-red hover:bg-accent-red/5 transition-colors"
+              <IconButton
+                variant="danger"
                 title="Remove"
+                aria-label="Remove member"
+                onClick={() => setRemoveTarget(m)}
               >
                 <TrashIcon className="w-4 h-4" />
-              </button>
+              </IconButton>
             </RestrictedAction>
           </div>
         );
@@ -142,14 +143,12 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
           {sorted.length !== 1 ? "s" : ""}
         </p>
         <RestrictedAction action="namespace:addMember">
-          <button
-            type="button"
+          <Button
             onClick={() => setAddOpen(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-600 text-white rounded-lg text-sm font-semibold transition-all"
+            icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
           >
-            <PlusIcon className="w-4 h-4" strokeWidth={2} />
             Add Member
-          </button>
+          </Button>
         </RestrictedAction>
       </div>
 

--- a/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -99,7 +99,7 @@ describe("ApiKeysTab — delete error handling", () => {
   async function openDeleteDialog() {
     const user = userEvent.setup();
     render(<ApiKeysTab />);
-    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete API key" }));
     return user;
   }
 

--- a/ui/apps/website/src/pages/getting-started/StepSetup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSetup.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@shellhub/design-system/primitives";
+import { Button, Card } from "@shellhub/design-system/primitives";
 import { docsUrl } from "@/links";
 import { Reveal, CopyBtn } from "../landing/components";
 
@@ -48,26 +48,28 @@ export function StepSetup({ onBack }: StepSetupProps) {
 
       <Reveal delay={0.15}>
         <div className="flex items-center justify-between">
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            className="group"
             onClick={onBack}
-            className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium text-text-secondary border border-border rounded-xl hover:text-text-primary hover:border-border-light hover:bg-white/[0.04] transition-all duration-300 group"
+            icon={
+              <svg
+                className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform duration-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+                />
+              </svg>
+            }
           >
-            <svg
-              className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform duration-300"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-              />
-            </svg>
             Back
-          </button>
+          </Button>
 
           <a
             href={`${docsUrl}/getting-started`}

--- a/ui/apps/website/src/pages/getting-started/StepSignup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSignup.tsx
@@ -231,7 +231,10 @@ export function StepSignup({ onBack }: StepSignupProps) {
 
             {/* Name */}
             <div>
-              <label htmlFor="signup-name" className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
+              <label
+                htmlFor="signup-name"
+                className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5"
+              >
                 Name
               </label>
               <div className="relative">
@@ -248,7 +251,6 @@ export function StepSignup({ onBack }: StepSignupProps) {
                   }}
                   placeholder="Your name"
                   className={INPUT_BASE}
-
                 />
               </div>
               {fieldErrors.name && (
@@ -260,7 +262,10 @@ export function StepSignup({ onBack }: StepSignupProps) {
 
             {/* Email */}
             <div>
-              <label htmlFor="signup-email" className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
+              <label
+                htmlFor="signup-email"
+                className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5"
+              >
                 Email
               </label>
               <div className="relative">
@@ -291,7 +296,10 @@ export function StepSignup({ onBack }: StepSignupProps) {
 
             {/* Password */}
             <div>
-              <label htmlFor="signup-password" className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
+              <label
+                htmlFor="signup-password"
+                className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5"
+              >
                 Password
               </label>
               <div className="relative">
@@ -363,7 +371,10 @@ export function StepSignup({ onBack }: StepSignupProps) {
 
             {/* Confirm password */}
             <div>
-              <label htmlFor="signup-confirm-password" className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5">
+              <label
+                htmlFor="signup-confirm-password"
+                className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5"
+              >
                 Confirm password
               </label>
               <div className="relative">
@@ -479,26 +490,30 @@ export function StepSignup({ onBack }: StepSignupProps) {
             </Button>
 
             {/* Back */}
-            <button
-              type="button"
+            <Button
+              variant="ghost"
+              size="sm"
+              fullWidth
+              className="group"
               onClick={onBack}
-              className="w-full inline-flex items-center justify-center gap-2 px-5 py-1.5 text-xs font-medium text-text-muted hover:text-text-secondary transition-colors group"
+              icon={
+                <svg
+                  className="w-3.5 h-3.5 group-hover:-translate-x-0.5 transition-transform duration-300"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+                  />
+                </svg>
+              }
             >
-              <svg
-                className="w-3.5 h-3.5 group-hover:-translate-x-0.5 transition-transform duration-300"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2.5}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-                />
-              </svg>
               Back to options
-            </button>
+            </Button>
           </form>
         </Card>
       </Reveal>

--- a/ui/packages/design-system/components/CopyBtn.tsx
+++ b/ui/packages/design-system/components/CopyBtn.tsx
@@ -1,15 +1,44 @@
 import { useState } from "react";
+import { IconButton } from "../primitives";
 
 export function CopyBtn({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
-  const handleCopy = () => { navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 1500); };
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
   return (
-    <button onClick={handleCopy} className="p-1.5 rounded-md text-text-muted hover:text-primary hover:bg-primary/10 transition-all" title="Copy">
+    <IconButton variant="primary" onClick={handleCopy} title="Copy">
       {copied ? (
-        <svg className="w-4 h-4 text-accent-green" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+        <svg
+          className="w-4 h-4 text-accent-green"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m4.5 12.75 6 6 9-13.5"
+          />
+        </svg>
       ) : (
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184" /></svg>
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9.75a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184"
+          />
+        </svg>
       )}
-    </button>
+    </IconButton>
   );
 }

--- a/ui/packages/design-system/primitives/Button.tsx
+++ b/ui/packages/design-system/primitives/Button.tsx
@@ -13,6 +13,8 @@ export type ButtonVariant =
   | "ghost"
   | "destructive"
   | "dangerSoft"
+  | "warningSoft"
+  | "successSoft"
   | "success"
   | "warning"
   | "outline";
@@ -35,6 +37,10 @@ const VARIANT: Record<ButtonVariant, string> = {
     "bg-accent-red text-white hover:bg-accent-red/90 focus-visible:ring-accent-red",
   dangerSoft:
     "bg-accent-red/10 hover:bg-accent-red/20 text-accent-red border border-accent-red/20 focus-visible:ring-accent-red",
+  warningSoft:
+    "bg-accent-yellow/10 hover:bg-accent-yellow/20 text-accent-yellow border border-accent-yellow/20 focus-visible:ring-accent-yellow",
+  successSoft:
+    "bg-accent-green/10 hover:bg-accent-green/20 text-accent-green border border-accent-green/20 focus-visible:ring-accent-green",
   success:
     "bg-accent-green/90 hover:bg-accent-green text-white focus-visible:ring-accent-green",
   warning:
@@ -51,7 +57,7 @@ const SIZE: Record<ButtonSize, string> = {
 };
 
 const BASE =
-  "inline-flex items-center justify-center gap-2 font-medium transition-all duration-150 select-none" +
+  "inline-flex items-center justify-center gap-2 font-medium transition-all duration-300 select-none" +
   " focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background" +
   " disabled:opacity-50 disabled:cursor-not-allowed";
 


### PR DESCRIPTION
## What
Consolidate ad-hoc button styling across the console and website apps onto the shared `@shellhub/design-system` `Button` and `IconButton` primitives, so variant, sizing, focus/disabled/loading, and accessibility behavior are defined once rather than re-implemented at each call site. Net -100 lines across 84 files.

## Why
Raw `<button>`/`<a>`/`<Link>` elements throughout the UI carried hand-rolled Tailwind for color, size, spinner/disabled states, and focus rings, which had drifted in visual weight and a11y coverage. Routing them through the primitives removes the duplication and yields consistent keyboard/`aria` handling and loading semantics.

## Changes
- **primitives**: added `successSoft` and `warningSoft` `Button` variants (mirrors of `dangerSoft`) so soft-tinted accept/warn actions resolve to a variant instead of bespoke classes.
- **console**: migrated page CTAs, dialog/drawer footers, empty-state heroes, row/detail icon actions, device/container status actions, and assorted banner/copy/error controls to `Button`/`IconButton`; button-styled `<Link>`/`<a>` use the polymorphic `as` prop. The raw copy `<button>` inside the design-system's own `CopyBtn` was converted too.
- **website**: migrated the getting-started back buttons.
- **kept raw (intentional)**: structural controls the primitives don't model — tabs, `role="switch"` toggles, dropdown triggers and their menu/listbox options, accordions/disclosures, pagination, segmented controls, full-row card targets, password-reveal field appends, styled-pill tag chips, and the docs `.astro` markup.
- **deferred**: the two manage-tags pencils (`TagsPopover`/`ContainerTagsPopover`) stay raw pending `ref` forwarding on the primitives.

## Testing
No behavior change is intended. Worth probing the loading states (submit buttons swap their leading icon for a spinner while keeping the label) and the conditional-variant actions (admin login-as error/retry styling; device/container accept/reject/remove).