### PR TITLE
refactor(api): replace UserConflicts pre-check with native duplicate detection

### DIFF
--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -76,6 +76,7 @@ var (
 	ErrUserNotFound                    = errors.New("user not found", ErrLayer, ErrCodeNotFound)
 	ErrUserInvalid                     = errors.New("user invalid", ErrLayer, ErrCodeInvalid)
 	ErrUserDuplicated                  = errors.New("user duplicated", ErrLayer, ErrCodeDuplicated)
+	ErrUserUnhandledDuplicate          = errors.New("unhandled duplicated field for the user", ErrLayer, ErrCodeDuplicated)
 	ErrUserPasswordInvalid             = errors.New("user password invalid", ErrLayer, ErrCodeInvalid)
 	ErrUserPasswordDuplicated          = errors.New("user password is equal to new password", ErrLayer, ErrCodeDuplicated)
 	ErrUserPasswordNotMatch            = errors.New("user password does not match to the current password", ErrLayer, ErrCodeInvalid)
@@ -247,6 +248,13 @@ func NewErrUserInvalid(data map[string]interface{}, next error) error {
 // NewErrUserDuplicated returns an error when the user is duplicated.
 func NewErrUserDuplicated(values []string, next error) error {
 	return NewErrDuplicated(ErrUserDuplicated, values, next)
+}
+
+// NewErrUserUnhandledDuplicate returns an error to be used when a duplicate-key violation
+// is returned by the store for a user field that is not explicitly handled by the caller.
+// It carries ErrCodeDuplicated so the echo handler maps it to HTTP 409.
+func NewErrUserUnhandledDuplicate() error {
+	return errors.Wrap(ErrUserUnhandledDuplicate, nil)
 }
 
 // NewErrUserPasswordInvalid returns an error when the user's password is invalid.

--- a/api/services/errors_test.go
+++ b/api/services/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	pkgerrors "github.com/shellhub-io/shellhub/pkg/errors"
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
 
@@ -27,4 +28,35 @@ func TestErrDeviceLicenseLimit(t *testing.T) {
 	if errors.Is(ErrDeviceLicenseLimit, ErrDeviceLimit) {
 		t.Error("ErrDeviceLicenseLimit must NOT match ErrDeviceLimit via errors.Is")
 	}
+}
+
+// TestErrUserUnhandledDuplicate verifies that ErrUserUnhandledDuplicate is a sentinel
+// with ErrCodeDuplicated so the echo handler maps it to HTTP 409, and that
+// NewErrUserUnhandledDuplicate returns an error that wraps that sentinel.
+func TestErrUserUnhandledDuplicate(t *testing.T) {
+	t.Run("sentinel has ErrCodeDuplicated code", func(t *testing.T) {
+		var e pkgerrors.Error
+		if !pkgerrors.As(ErrUserUnhandledDuplicate, &e) {
+			t.Fatal("ErrUserUnhandledDuplicate is not a pkgerrors.Error")
+		}
+
+		if e.Code != ErrCodeDuplicated {
+			t.Errorf("expected code %d (ErrCodeDuplicated), got %d", ErrCodeDuplicated, e.Code)
+		}
+
+		if e.Layer != ErrLayer {
+			t.Errorf("expected layer %q, got %q", ErrLayer, e.Layer)
+		}
+	})
+
+	t.Run("NewErrUserUnhandledDuplicate wraps ErrUserUnhandledDuplicate", func(t *testing.T) {
+		err := NewErrUserUnhandledDuplicate()
+		if err == nil {
+			t.Fatal("NewErrUserUnhandledDuplicate returned nil")
+		}
+
+		if !errors.Is(err, ErrUserUnhandledDuplicate) {
+			t.Error("NewErrUserUnhandledDuplicate result does not wrap ErrUserUnhandledDuplicate")
+		}
+	})
 }

--- a/api/services/setup.go
+++ b/api/services/setup.go
@@ -64,7 +64,7 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) error {
 				return NewErrUserDuplicated([]string{field}, err)
 			}
 
-			return NewErrUserDuplicated([]string{req.Username}, err)
+			return NewErrUserUnhandledDuplicate()
 		}
 
 		return err

--- a/api/services/setup.go
+++ b/api/services/setup.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"errors"
 
+	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/clock"
@@ -57,7 +59,15 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) error {
 
 	insertedID, err := s.store.UserCreate(ctx, user)
 	if err != nil {
-		return NewErrUserDuplicated([]string{req.Username}, err)
+		if errors.Is(err, store.ErrDuplicate) {
+			if field, ok := store.DuplicatedField(err); ok {
+				return NewErrUserDuplicated([]string{field}, err)
+			}
+
+			return NewErrUserDuplicated([]string{req.Username}, err)
+		}
+
+		return err
 	}
 
 	namespace := &models.Namespace{

--- a/api/services/setup_test.go
+++ b/api/services/setup_test.go
@@ -123,6 +123,48 @@ func TestSetup(t *testing.T) {
 			),
 		},
 		{
+			description: "Fail when cannot create the user due to unhandled duplicate (no field info)",
+			req: requests.Setup{
+				Email:    "teste@google.com",
+				Name:     "userteste",
+				Username: "userteste",
+				Password: "secret",
+			},
+			requiredMocks: func() {
+				storeMock.On("SystemGet", ctx).Return(&models.System{
+					Setup: false,
+				}, nil).Once()
+
+				hashMock.
+					On("Do", "secret").
+					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
+					Once()
+
+				user := &models.User{
+					Origin:    models.UserOriginLocal,
+					Status:    models.UserStatusConfirmed,
+					CreatedAt: now,
+					UserData: models.UserData{
+						Name:     "userteste",
+						Email:    "teste@google.com",
+						Username: "userteste",
+					},
+					Password: models.UserPassword{
+						Plain: "secret",
+						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+					},
+					MaxNamespaces: -1,
+					Preferences: models.UserPreferences{
+						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+					Admin: true,
+				}
+
+				storeMock.On("UserCreate", ctx, user).Return("", store.ErrDuplicate).Once()
+			},
+			expected: NewErrUserUnhandledDuplicate(),
+		},
+		{
 			description: "Fail when cannot create the user due to a generic store error",
 			req: requests.Setup{
 				Email:    "teste@google.com",

--- a/api/services/setup_test.go
+++ b/api/services/setup_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	stderrors "errors"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestSetup(t *testing.T) {
 	uuid.DefaultBackend = uuidMock
 	uuidMock.On("Generate").Return(tenant)
 
-	now := time.Now()
+	now := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
 	clockMock.On("Now").Return(now)
 
 	ctx := context.TODO()
@@ -76,7 +77,7 @@ func TestSetup(t *testing.T) {
 			expected: NewErrUserPasswordInvalid(errors.New("error", "", 0)),
 		},
 		{
-			description: "Fail when cannot create the user",
+			description: "Fail when cannot create the user due to duplicate field",
 			req: requests.Setup{
 				Email:    "teste@google.com",
 				Name:     "userteste",
@@ -112,9 +113,56 @@ func TestSetup(t *testing.T) {
 					},
 					Admin: true,
 				}
-				storeMock.On("UserCreate", ctx, user).Return("", errors.New("error", "", 0)).Once()
+
+				dupErr := stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "username"})
+				storeMock.On("UserCreate", ctx, user).Return("", dupErr).Once()
 			},
-			expected: NewErrUserDuplicated([]string{"userteste"}, errors.New("error", "", 0)),
+			expected: NewErrUserDuplicated(
+				[]string{"username"},
+				stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "username"}),
+			),
+		},
+		{
+			description: "Fail when cannot create the user due to a generic store error",
+			req: requests.Setup{
+				Email:    "teste@google.com",
+				Name:     "userteste",
+				Username: "userteste",
+				Password: "secret",
+			},
+			requiredMocks: func() {
+				storeMock.On("SystemGet", ctx).Return(&models.System{
+					Setup: false,
+				}, nil).Once()
+
+				hashMock.
+					On("Do", "secret").
+					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
+					Once()
+
+				user := &models.User{
+					Origin:    models.UserOriginLocal,
+					Status:    models.UserStatusConfirmed,
+					CreatedAt: now,
+					UserData: models.UserData{
+						Name:     "userteste",
+						Email:    "teste@google.com",
+						Username: "userteste",
+					},
+					Password: models.UserPassword{
+						Plain: "secret",
+						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+					},
+					MaxNamespaces: -1,
+					Preferences: models.UserPreferences{
+						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+					Admin: true,
+				}
+
+				storeMock.On("UserCreate", ctx, user).Return("", store.ErrInternal).Once()
+			},
+			expected: store.ErrInternal,
 		},
 		{
 			description: "Fail when cannot create namespace, and user deletion fails",

--- a/api/services/user.go
+++ b/api/services/user.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/shellhub-io/shellhub/api/store"
@@ -32,18 +33,20 @@ func (s *service) UpdateUser(ctx context.Context, req *requests.UpdateUser) ([]s
 		return []string{"email", "recovery_email"}, NewErrBadRequest(nil)
 	}
 
-	conflictsTarget := &models.UserConflicts{Email: req.Email, Username: req.Username}
-	conflictsTarget.Distinct(user)
-	if conflicts, has, _ := s.store.UserConflicts(ctx, conflictsTarget); has {
-		return conflicts, NewErrUserDuplicated(conflicts, nil)
-	}
-
 	updatedUser, err := applyUserChanges(user, req)
 	if err != nil {
 		return []string{}, err
 	}
 
 	if err := s.store.UserUpdate(ctx, updatedUser); err != nil {
+		if errors.Is(err, store.ErrDuplicate) {
+			if field, ok := store.DuplicatedField(err); ok {
+				return []string{field}, NewErrUserDuplicated([]string{field}, err)
+			}
+
+			return []string{}, NewErrUserUnhandledDuplicate()
+		}
+
 		return []string{}, NewErrUserUpdate(user, err)
 	}
 

--- a/api/services/user_test.go
+++ b/api/services/user_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	stderrors "errors"
 	"testing"
 
 	"github.com/shellhub-io/shellhub/api/store"
@@ -172,41 +173,6 @@ func TestUpdateUser(t *testing.T) {
 			},
 		},
 		{
-			description: "Fail when conflict fields exists",
-			req: &requests.UpdateUser{
-				UserID:        "000000000000000000000000",
-				Name:          "John Doe",
-				Username:      "john_doe",
-				Email:         "john.doe@test.com",
-				RecoveryEmail: "recovery@test.com",
-			},
-			requiredMocks: func(ctx context.Context) {
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(
-						&models.User{
-							ID: "000000000000000000000000",
-							UserData: models.UserData{
-								Name:          "James Smith",
-								Username:      "james_smith",
-								Email:         "james.smith@test.com",
-								RecoveryEmail: "recover@test.com",
-							},
-						},
-						nil,
-					).
-					Once()
-				storeMock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{"email"}, true, nil).
-					Once()
-			},
-			expected: Expected{
-				conflicts: []string{"email"},
-				err:       NewErrUserDuplicated([]string{"email"}, nil),
-			},
-		},
-		{
 			description: "Fails when the current password doesn't match with user's password",
 			req: &requests.UpdateUser{
 				UserID:          "000000000000000000000000",
@@ -235,10 +201,6 @@ func TestUpdateUser(t *testing.T) {
 						},
 						nil,
 					).
-					Once()
-				storeMock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{}, false, nil).
 					Once()
 				hashMock.
 					On("CompareWith", "secret", "$2a$10$V/6N1wsjheBVvWosVVVV2uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi").
@@ -284,10 +246,6 @@ func TestUpdateUser(t *testing.T) {
 					Return(user, nil).
 					Once()
 				storeMock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{}, false, nil).
-					Once()
-				storeMock.
 					On("UserUpdate", ctx, updatedUser).
 					Return(errors.New("error", "", 0)).
 					Once()
@@ -306,6 +264,135 @@ func TestUpdateUser(t *testing.T) {
 					},
 					errors.New("error", "", 0),
 				),
+			},
+		},
+		{
+			description: "Fail when UserUpdate returns duplicate email",
+			req: &requests.UpdateUser{
+				UserID:        "000000000000000000000000",
+				Name:          "John Doe",
+				Username:      "john_doe",
+				Email:         "john.doe@test.com",
+				RecoveryEmail: "recovery@test.com",
+			},
+			requiredMocks: func(ctx context.Context) {
+				user := &models.User{
+					ID: "000000000000000000000000",
+					UserData: models.UserData{
+						Name:          "James Smith",
+						Username:      "james_smith",
+						Email:         "james.smith@shellhub.io",
+						RecoveryEmail: "recover@test.com",
+					},
+				}
+				updatedUser := &models.User{
+					ID: "000000000000000000000000",
+					UserData: models.UserData{
+						Name:          "John Doe",
+						Username:      "john_doe",
+						Email:         "john.doe@test.com",
+						RecoveryEmail: "recovery@test.com",
+					},
+				}
+
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(user, nil).
+					Once()
+				storeMock.
+					On("UserUpdate", ctx, updatedUser).
+					Return(stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "email"})).
+					Once()
+			},
+			expected: Expected{
+				conflicts: []string{"email"},
+				err:       NewErrUserDuplicated([]string{"email"}, stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "email"})),
+			},
+		},
+		{
+			description: "Fail when UserUpdate returns duplicate username",
+			req: &requests.UpdateUser{
+				UserID:        "000000000000000000000000",
+				Name:          "John Doe",
+				Username:      "john_doe",
+				Email:         "john.doe@test.com",
+				RecoveryEmail: "recovery@test.com",
+			},
+			requiredMocks: func(ctx context.Context) {
+				user := &models.User{
+					ID: "000000000000000000000000",
+					UserData: models.UserData{
+						Name:          "James Smith",
+						Username:      "james_smith",
+						Email:         "james.smith@shellhub.io",
+						RecoveryEmail: "recover@test.com",
+					},
+				}
+				updatedUser := &models.User{
+					ID: "000000000000000000000000",
+					UserData: models.UserData{
+						Name:          "John Doe",
+						Username:      "john_doe",
+						Email:         "john.doe@test.com",
+						RecoveryEmail: "recovery@test.com",
+					},
+				}
+
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(user, nil).
+					Once()
+				storeMock.
+					On("UserUpdate", ctx, updatedUser).
+					Return(stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "username"})).
+					Once()
+			},
+			expected: Expected{
+				conflicts: []string{"username"},
+				err:       NewErrUserDuplicated([]string{"username"}, stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "username"})),
+			},
+		},
+		{
+			description: "Fail when UserUpdate returns unhandled duplicate (no field info)",
+			req: &requests.UpdateUser{
+				UserID:        "000000000000000000000000",
+				Name:          "John Doe",
+				Username:      "john_doe",
+				Email:         "john.doe@test.com",
+				RecoveryEmail: "recovery@test.com",
+			},
+			requiredMocks: func(ctx context.Context) {
+				user := &models.User{
+					ID: "000000000000000000000000",
+					UserData: models.UserData{
+						Name:          "James Smith",
+						Username:      "james_smith",
+						Email:         "james.smith@shellhub.io",
+						RecoveryEmail: "recover@test.com",
+					},
+				}
+				updatedUser := &models.User{
+					ID: "000000000000000000000000",
+					UserData: models.UserData{
+						Name:          "John Doe",
+						Username:      "john_doe",
+						Email:         "john.doe@test.com",
+						RecoveryEmail: "recovery@test.com",
+					},
+				}
+
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(user, nil).
+					Once()
+				storeMock.
+					On("UserUpdate", ctx, updatedUser).
+					Return(store.ErrDuplicate).
+					Once()
+			},
+			expected: Expected{
+				conflicts: []string{},
+				err:       NewErrUserUnhandledDuplicate(),
 			},
 		},
 		{
@@ -332,10 +419,6 @@ func TestUpdateUser(t *testing.T) {
 				storeMock.
 					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(user, nil).
-					Once()
-				storeMock.
-					On("UserConflicts", ctx, &models.UserConflicts{}).
-					Return([]string{}, false, nil).
 					Once()
 				hashMock.
 					On("CompareWith", "secret", "$2a$10$V/6N1wsjheBVvWosVVVV2uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi").
@@ -394,10 +477,6 @@ func TestUpdateUser(t *testing.T) {
 				storeMock.
 					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
 					Return(user, nil).
-					Once()
-				storeMock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{}, false, nil).
 					Once()
 				storeMock.
 					On("UserUpdate", ctx, updatedUser).

--- a/api/store/errors.go
+++ b/api/store/errors.go
@@ -1,6 +1,11 @@
 package store
 
-import "github.com/shellhub-io/shellhub/pkg/errors"
+import (
+	stderrors "errors"
+	"fmt"
+
+	"github.com/shellhub-io/shellhub/pkg/errors"
+)
 
 // ErrLayer is an error level. Each error defined at this level, is container to it.
 // ErrLayer is the errors' level for store's error.
@@ -21,8 +26,24 @@ var (
 	ErrInternal         = errors.New("internal store error", ErrLayer, ErrCodeInternal)
 )
 
-// Errors used by Cloud.
-var (
-	ErrDuplicateUser  = errors.New("user already exists", ErrLayer, ErrCodeDuplicated)
-	ErrDuplicateEmail = errors.New("email address is already in use", ErrLayer, ErrCodeDuplicated)
-)
+// DuplicateFieldError carries the name of the field that caused a duplicate-key violation.
+// It is a plain Go error type (not a pkg/errors.Error) so that echo's error chain never
+// matches it directly; callers use DuplicatedField to extract the field name.
+type DuplicateFieldError struct {
+	Field string
+}
+
+func (e DuplicateFieldError) Error() string {
+	return fmt.Sprintf("duplicate field: %s", e.Field)
+}
+
+// DuplicatedField extracts the field name from a DuplicateFieldError wrapped inside err.
+// It returns ("", false) when no DuplicateFieldError is present or when Field is empty.
+func DuplicatedField(err error) (string, bool) {
+	var df DuplicateFieldError
+	if stderrors.As(err, &df) && df.Field != "" {
+		return df.Field, true
+	}
+
+	return "", false
+}

--- a/api/store/errors_test.go
+++ b/api/store/errors_test.go
@@ -1,9 +1,10 @@
 package store
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/shellhub-io/shellhub/pkg/errors"
+	pkgerrors "github.com/shellhub-io/shellhub/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,8 +14,8 @@ func TestErrInternal(t *testing.T) {
 	})
 
 	t.Run("has correct layer", func(t *testing.T) {
-		var e errors.Error
-		assert.True(t, errors.As(ErrInternal, &e))
+		var e pkgerrors.Error
+		assert.True(t, pkgerrors.As(ErrInternal, &e))
 		assert.Equal(t, ErrLayer, e.Layer)
 	})
 
@@ -25,8 +26,35 @@ func TestErrInternal(t *testing.T) {
 	})
 
 	t.Run("ErrInternal carries ErrCodeInternal", func(t *testing.T) {
-		var e errors.Error
-		assert.True(t, errors.As(ErrInternal, &e))
+		var e pkgerrors.Error
+		assert.True(t, pkgerrors.As(ErrInternal, &e))
 		assert.Equal(t, ErrCodeInternal, e.Code)
+	})
+}
+
+func TestDuplicatedField(t *testing.T) {
+	t.Run("joined with ErrDuplicate returns field and true", func(t *testing.T) {
+		err := errors.Join(ErrDuplicate, DuplicateFieldError{Field: "email"})
+
+		field, ok := DuplicatedField(err)
+
+		assert.True(t, ok)
+		assert.Equal(t, "email", field)
+	})
+
+	t.Run("bare ErrDuplicate returns empty string and false", func(t *testing.T) {
+		field, ok := DuplicatedField(ErrDuplicate)
+
+		assert.False(t, ok)
+		assert.Equal(t, "", field)
+	})
+
+	t.Run("empty-field DuplicateFieldError returns empty string and false", func(t *testing.T) {
+		err := errors.Join(ErrDuplicate, DuplicateFieldError{Field: ""})
+
+		field, ok := DuplicatedField(err)
+
+		assert.False(t, ok)
+		assert.Equal(t, "", field)
 	})
 }

--- a/api/store/mocks/store.go
+++ b/api/store/mocks/store.go
@@ -1629,43 +1629,6 @@ func (_m *Store) TagUpdate(ctx context.Context, tag *models.Tag) error {
 	return r0
 }
 
-// UserConflicts provides a mock function with given fields: ctx, target
-func (_m *Store) UserConflicts(ctx context.Context, target *models.UserConflicts) ([]string, bool, error) {
-	ret := _m.Called(ctx, target)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UserConflicts")
-	}
-
-	var r0 []string
-	var r1 bool
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, *models.UserConflicts) ([]string, bool, error)); ok {
-		return rf(ctx, target)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *models.UserConflicts) []string); ok {
-		r0 = rf(ctx, target)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, *models.UserConflicts) bool); ok {
-		r1 = rf(ctx, target)
-	} else {
-		r1 = ret.Get(1).(bool)
-	}
-
-	if rf, ok := ret.Get(2).(func(context.Context, *models.UserConflicts) error); ok {
-		r2 = rf(ctx, target)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
 // UserCreate provides a mock function with given fields: ctx, user
 func (_m *Store) UserCreate(ctx context.Context, user *models.User) (string, error) {
 	ret := _m.Called(ctx, user)

--- a/api/store/pg/store_test.go
+++ b/api/store/pg/store_test.go
@@ -19,10 +19,11 @@ func TestPgStore(t *testing.T) {
 		suite.TestUserResolve(t)
 		suite.TestUserCreate(t)
 		suite.TestUserCreatePasswordRoundTrip(t)
-		suite.TestUserConflicts(t)
+		suite.TestUserCreateDuplicate(t)
 		suite.TestUserUpdate(t)
 		suite.TestUserDelete(t)
 		suite.TestUserGetInfo(t)
+		suite.TestUserConflictsRemoved(t)
 	})
 
 	runSubSuite(t, "NamespaceStore", func(suite *storetest.Suite, t *testing.T) {

--- a/api/store/pg/user.go
+++ b/api/store/pg/user.go
@@ -26,52 +26,6 @@ func (pg *Pg) UserCreate(ctx context.Context, user *models.User) (string, error)
 	return user.ID, nil
 }
 
-func (pg *Pg) UserConflicts(ctx context.Context, target *models.UserConflicts) ([]string, bool, error) {
-	db := pg.GetConnection(ctx)
-
-	if target.Email == "" && target.Username == "" {
-		return []string{}, false, nil
-	}
-
-	users := make([]entity.User, 0)
-	query := db.NewSelect().
-		Model(&users).
-		Column("email", "username").
-		WhereGroup(" OR ", func(q *bun.SelectQuery) *bun.SelectQuery {
-			if target.Email != "" {
-				q = q.Where("email = ?", target.Email)
-			}
-
-			if target.Username != "" {
-				q = q.Where("username = ?", target.Username)
-			}
-
-			return q
-		})
-
-	if err := query.Scan(ctx); err != nil {
-		return nil, false, fromSQLError(err)
-	}
-
-	seen := make(map[string]bool)
-	for _, user := range users {
-		if target.Email != "" && user.Email == target.Email {
-			seen["email"] = true
-		}
-
-		if target.Username != "" && user.Username == target.Username {
-			seen["username"] = true
-		}
-	}
-
-	conflicts := make([]string, 0, len(seen))
-	for field := range seen {
-		conflicts = append(conflicts, field)
-	}
-
-	return conflicts, len(conflicts) > 0, nil
-}
-
 func (pg *Pg) UserList(ctx context.Context, opts ...store.QueryOption) ([]models.User, int, error) {
 	db := pg.GetConnection(ctx)
 

--- a/api/store/pg/utils.go
+++ b/api/store/pg/utils.go
@@ -11,6 +11,32 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// constraintToField maps a PostgreSQL unique-constraint name on the users table to
+// the user-facing field name it protects. The constraint names here are defined in
+// migration 001_initial_schema — renaming those constraints silently breaks this mapping.
+//
+// Only constraints from the users table are listed; other tables' 23505 violations
+// will return an empty string and fall through to a bare store.ErrDuplicate.
+func constraintToField(constraint string) string {
+	switch constraint {
+	case constraintUsersEmailKey:
+		return "email"
+	case constraintUsersUsernameKey:
+		return "username"
+	default:
+		return ""
+	}
+}
+
+// constraintUsersEmailKey and constraintUsersUsernameKey are the PostgreSQL unique-constraint
+// names for the users table, as created by migration 001_initial_schema.
+// WARNING: renaming these constraints in a migration silently breaks the constraintToField
+// mapping — update both together.
+const (
+	constraintUsersEmailKey    = "users_email_key"
+	constraintUsersUsernameKey = "users_username_key"
+)
+
 func fromSQLError(err error) error {
 	switch err {
 	case nil:
@@ -21,6 +47,10 @@ func fromSQLError(err error) error {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			if pgErr.Code == "23505" { // unique_violation
+				if field := constraintToField(pgErr.ConstraintName); field != "" {
+					return errors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: field})
+				}
+
 				return store.ErrDuplicate
 			}
 		}

--- a/api/store/pg/utils_test.go
+++ b/api/store/pg/utils_test.go
@@ -44,6 +44,41 @@ func TestFromSQLError(t *testing.T) {
 			},
 		},
 		{
+			name:  "23505 with users_email_key joins DuplicateFieldError with email",
+			input: &pgconn.PgError{Code: "23505", ConstraintName: "users_email_key"},
+			check: func(t *testing.T, result error) {
+				require.Error(t, result)
+				assert.True(t, errors.Is(result, store.ErrDuplicate))
+
+				var df store.DuplicateFieldError
+				require.True(t, errors.As(result, &df))
+				assert.Equal(t, "email", df.Field)
+			},
+		},
+		{
+			name:  "23505 with users_username_key joins DuplicateFieldError with username",
+			input: &pgconn.PgError{Code: "23505", ConstraintName: "users_username_key"},
+			check: func(t *testing.T, result error) {
+				require.Error(t, result)
+				assert.True(t, errors.Is(result, store.ErrDuplicate))
+
+				var df store.DuplicateFieldError
+				require.True(t, errors.As(result, &df))
+				assert.Equal(t, "username", df.Field)
+			},
+		},
+		{
+			name:  "23505 with unrelated constraint returns bare ErrDuplicate without DuplicateFieldError",
+			input: &pgconn.PgError{Code: "23505", ConstraintName: "some_other_unique_key"},
+			check: func(t *testing.T, result error) {
+				require.Error(t, result)
+				assert.True(t, errors.Is(result, store.ErrDuplicate))
+
+				var df store.DuplicateFieldError
+				assert.False(t, errors.As(result, &df), "expected no DuplicateFieldError for unknown constraint")
+			},
+		},
+		{
 			name:  "generic unmapped error wraps with store.ErrInternal",
 			input: fmt.Errorf("some unexpected db error"),
 			check: func(t *testing.T, result error) {

--- a/api/store/storetest/suite.go
+++ b/api/store/storetest/suite.go
@@ -45,7 +45,6 @@ func (s *Suite) Run(t *testing.T) {
 		s.TestUserList(t)
 		s.TestUserResolve(t)
 		s.TestUserCreate(t)
-		s.TestUserConflicts(t)
 		s.TestUserUpdate(t)
 		s.TestUserDelete(t)
 		s.TestUserGetInfo(t)

--- a/api/store/storetest/user_tests.go
+++ b/api/store/storetest/user_tests.go
@@ -2,6 +2,7 @@ package storetest
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/shellhub-io/shellhub/api/store"
@@ -10,6 +11,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestUserConflictsRemoved asserts that UserConflicts has been deleted from the
+// UserStore interface. The method was replaced by the duplicate-detection path
+// inside UserCreate (ErrDuplicate / DuplicatedField).
+func (s *Suite) TestUserConflictsRemoved(t *testing.T) {
+	ifaceType := reflect.TypeOf((*store.UserStore)(nil)).Elem()
+	_, ok := ifaceType.MethodByName("UserConflicts")
+	assert.False(t, ok, "UserStore.UserConflicts must be removed from the interface")
+}
 
 func (s *Suite) TestUserList(t *testing.T) {
 	ctx := context.Background()
@@ -180,71 +190,51 @@ func (s *Suite) TestUserCreatePasswordRoundTrip(t *testing.T) {
 	})
 }
 
-func (s *Suite) TestUserConflicts(t *testing.T) {
+// TestUserCreateDuplicate verifies that UserCreate enforces unique constraints on
+// email and username at the real-database level, returning store.ErrDuplicate with
+// the correct field name reported by store.DuplicatedField.
+func (s *Suite) TestUserCreateDuplicate(t *testing.T) {
 	ctx := context.Background()
 	st := s.provider.Store()
 
-	t.Run("no conflicts when target is empty", func(t *testing.T) {
+	t.Run("duplicate email is rejected with ErrDuplicate and field=email", func(t *testing.T) {
 		require.NoError(t, s.provider.CleanDatabase(t))
-		s.CreateUser(t, WithUsername("john_doe"), WithEmail("john.doe@test.com"))
 
-		conflicts, ok, err := st.UserConflicts(ctx, &models.UserConflicts{})
-		require.NoError(t, err)
-		assert.Empty(t, conflicts)
-		assert.False(t, ok)
-	})
+		s.CreateUser(t, WithUsername("baseline_user"), WithEmail("shared@test.com"))
 
-	t.Run("no conflicts with non existing email", func(t *testing.T) {
-		require.NoError(t, s.provider.CleanDatabase(t))
-		s.CreateUser(t, WithUsername("john_doe"), WithEmail("john.doe@test.com"))
-
-		conflicts, ok, err := st.UserConflicts(ctx, &models.UserConflicts{Email: "other@test.com"})
-		require.NoError(t, err)
-		assert.Empty(t, conflicts)
-		assert.False(t, ok)
-	})
-
-	t.Run("no conflicts with non existing username", func(t *testing.T) {
-		require.NoError(t, s.provider.CleanDatabase(t))
-		s.CreateUser(t, WithUsername("john_doe"), WithEmail("john.doe@test.com"))
-
-		conflicts, ok, err := st.UserConflicts(ctx, &models.UserConflicts{Username: "other"})
-		require.NoError(t, err)
-		assert.Empty(t, conflicts)
-		assert.False(t, ok)
-	})
-
-	t.Run("conflict detected with existing email", func(t *testing.T) {
-		require.NoError(t, s.provider.CleanDatabase(t))
-		s.CreateUser(t, WithUsername("john_doe"), WithEmail("john.doe@test.com"))
-
-		conflicts, ok, err := st.UserConflicts(ctx, &models.UserConflicts{Email: "john.doe@test.com"})
-		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"email"}, conflicts)
-		assert.True(t, ok)
-	})
-
-	t.Run("conflict detected with existing username", func(t *testing.T) {
-		require.NoError(t, s.provider.CleanDatabase(t))
-		s.CreateUser(t, WithUsername("john_doe"), WithEmail("john.doe@test.com"))
-
-		conflicts, ok, err := st.UserConflicts(ctx, &models.UserConflicts{Username: "john_doe"})
-		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"username"}, conflicts)
-		assert.True(t, ok)
-	})
-
-	t.Run("conflict detected with existing username and email", func(t *testing.T) {
-		require.NoError(t, s.provider.CleanDatabase(t))
-		s.CreateUser(t, WithUsername("john_doe"), WithEmail("john.doe@test.com"))
-
-		conflicts, ok, err := st.UserConflicts(ctx, &models.UserConflicts{
-			Email:    "john.doe@test.com",
-			Username: "john_doe",
+		_, err := st.UserCreate(ctx, &models.User{
+			UserData: models.UserData{
+				Name:     "second user",
+				Username: "other_user",
+				Email:    "shared@test.com",
+			},
+			Password: models.UserPassword{Hash: "somehash"},
 		})
-		require.NoError(t, err)
-		assert.ElementsMatch(t, []string{"username", "email"}, conflicts)
+		assert.ErrorIs(t, err, store.ErrDuplicate)
+
+		field, ok := store.DuplicatedField(err)
 		assert.True(t, ok)
+		assert.Equal(t, "email", field)
+	})
+
+	t.Run("duplicate username is rejected with ErrDuplicate and field=username", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		s.CreateUser(t, WithUsername("shared_name"), WithEmail("first@test.com"))
+
+		_, err := st.UserCreate(ctx, &models.User{
+			UserData: models.UserData{
+				Name:     "second user",
+				Username: "shared_name",
+				Email:    "second@test.com",
+			},
+			Password: models.UserPassword{Hash: "somehash"},
+		})
+		assert.ErrorIs(t, err, store.ErrDuplicate)
+
+		field, ok := store.DuplicatedField(err)
+		assert.True(t, ok)
+		assert.Equal(t, "username", field)
 	})
 }
 

--- a/api/store/user.go
+++ b/api/store/user.go
@@ -28,15 +28,6 @@ type UserStore interface {
 	// It returns the resolved user if found and an error, if any.
 	UserResolve(ctx context.Context, resolver UserResolver, value string, opts ...QueryOption) (*models.User, error)
 
-	// UserConflicts reports whether the target contains conflicting attributes with the database. Pass zero values for
-	// attributes you do not wish to match on. For example, the following call checks for conflicts based on email only:
-	//
-	//  ctx := context.Background()
-	//  conflicts, has, err := store.UserConflicts(ctx, &models.UserConflicts{Email: "john.doe@test.com", Username: ""})
-	//
-	// It returns an array of conflicting attribute fields and an error, if any.
-	UserConflicts(ctx context.Context, target *models.UserConflicts) (conflicts []string, has bool, err error)
-
 	UserUpdate(ctx context.Context, user *models.User) error
 
 	// UserGetInfo retrieves the user's information, like the owned and associated namespaces.

--- a/cli/services/errors.go
+++ b/cli/services/errors.go
@@ -16,7 +16,6 @@ var (
 	ErrUserPasswordInvalid         = errors.New("user password is invalid")
 	ErrUserEmailExists             = errors.New("user email already exists")
 	ErrUserNameExists              = errors.New("user name already exists")
-	ErrUserNameAndEmailExists      = errors.New("user name and email already exists")
 	ErrFailedNamespaceAddMember    = errors.New("could not add this member to this namespace")
 	ErrUserUnhandledDuplicate      = errors.New("unhandled duplicated field for the user")
 	ErrFailedListNamespaces        = errors.New("failed to list namespaces")

--- a/cli/services/users.go
+++ b/cli/services/users.go
@@ -2,7 +2,7 @@ package services
 
 import (
 	"context"
-	"slices"
+	"errors"
 	"strings"
 
 	"github.com/shellhub-io/shellhub/api/store"
@@ -18,22 +18,6 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 		Name:     input.Username,
 		Email:    input.Email,
 		Username: input.Username,
-	}
-
-	if conflicts, has, _ := s.store.UserConflicts(ctx, &models.UserConflicts{Email: userData.Email, Username: userData.Username}); has {
-		containsEmail := slices.Contains(conflicts, "email")
-		containsUsername := slices.Contains(conflicts, "username")
-
-		switch {
-		case containsUsername && containsEmail:
-			return nil, ErrUserNameAndEmailExists
-		case containsUsername:
-			return nil, ErrUserNameExists
-		case containsEmail:
-			return nil, ErrUserEmailExists
-		default:
-			return nil, ErrUserUnhandledDuplicate
-		}
 	}
 
 	password, err := models.HashUserPassword(input.Password)
@@ -60,6 +44,22 @@ func (s *service) UserCreate(ctx context.Context, input *inputs.UserCreate) (*mo
 	}
 
 	if _, err := s.store.UserCreate(ctx, user); err != nil {
+		if errors.Is(err, store.ErrDuplicate) {
+			field, ok := store.DuplicatedField(err)
+			if !ok {
+				return nil, ErrUserUnhandledDuplicate
+			}
+
+			switch field {
+			case "email":
+				return nil, ErrUserEmailExists
+			case "username":
+				return nil, ErrUserNameExists
+			default:
+				return nil, ErrUserUnhandledDuplicate
+			}
+		}
+
 		return nil, ErrCreateNewUser
 	}
 

--- a/cli/services/users_test.go
+++ b/cli/services/users_test.go
@@ -42,54 +42,11 @@ func TestUserCreate(t *testing.T) {
 		expected      Expected
 	}{
 		{
-			description: "fails when email is duplicated",
-			username:    "john_doe",
-			email:       "john.doe@test.com",
-			password:    "secret",
-			requiredMocks: func() {
-				mock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{"email"}, true, nil).
-					Once()
-			},
-			expected: Expected{nil, ErrUserEmailExists},
-		},
-		{
-			description: "fails when username is duplicated",
-			username:    "john_doe",
-			email:       "john.doe@test.com",
-			password:    "secret",
-			requiredMocks: func() {
-				mock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{"username"}, true, nil).
-					Once()
-			},
-			expected: Expected{nil, ErrUserNameExists},
-		},
-		{
-			description: "fails when email and username is duplicated",
-			username:    "john_doe",
-			email:       "john.doe@test.com",
-			password:    "secret",
-			requiredMocks: func() {
-				mock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{"username", "email"}, true, nil).
-					Once()
-			},
-			expected: Expected{nil, ErrUserNameAndEmailExists},
-		},
-		{
 			description: "fails when the password is invalid",
 			username:    "john_doe",
 			email:       "john.doe@test.com",
 			password:    "secret",
 			requiredMocks: func() {
-				mock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{}, false, nil).
-					Once()
 				hashMock.
 					On("Do", "secret").
 					Return("", errors.New("error")).
@@ -103,10 +60,6 @@ func TestUserCreate(t *testing.T) {
 			email:       "john.doe@test.com",
 			password:    "secret",
 			requiredMocks: func() {
-				mock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{}, false, nil).
-					Once()
 				hashMock.
 					On("Do", "secret").
 					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
@@ -131,12 +84,134 @@ func TestUserCreate(t *testing.T) {
 					},
 					Admin: true,
 				}
-				mock.On("UserCreate", ctx, user).Return("", errors.New("error")).Once()
+
 				mock.On("SystemGet", ctx).
 					Return(&models.System{Setup: false}, nil).
 					Once()
+				mock.On("UserCreate", ctx, user).Return("", errors.New("error")).Once()
 			},
 			expected: Expected{nil, ErrCreateNewUser},
+		},
+		{
+			description: "fails when email is duplicated",
+			username:    "john_doe",
+			email:       "john.doe@test.com",
+			password:    "secret",
+			requiredMocks: func() {
+				hashMock.
+					On("Do", "secret").
+					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
+					Once()
+
+				user := &models.User{
+					Origin: models.UserOriginLocal,
+					UserData: models.UserData{
+						Name:     "john_doe",
+						Email:    "john.doe@test.com",
+						Username: "john_doe",
+					},
+					Password: models.UserPassword{
+						Plain: "secret",
+						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+					},
+					Status:        models.UserStatusConfirmed,
+					CreatedAt:     clock.Now(),
+					MaxNamespaces: MaxNumberNamespacesCommunity,
+					Preferences: models.UserPreferences{
+						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+					Admin: true,
+				}
+
+				mock.On("SystemGet", ctx).
+					Return(&models.System{Setup: false}, nil).
+					Once()
+				mock.On("UserCreate", ctx, user).
+					Return("", errors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "email"})).
+					Once()
+			},
+			expected: Expected{nil, ErrUserEmailExists},
+		},
+		{
+			description: "fails when username is duplicated",
+			username:    "john_doe",
+			email:       "john.doe@test.com",
+			password:    "secret",
+			requiredMocks: func() {
+				hashMock.
+					On("Do", "secret").
+					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
+					Once()
+
+				user := &models.User{
+					Origin: models.UserOriginLocal,
+					UserData: models.UserData{
+						Name:     "john_doe",
+						Email:    "john.doe@test.com",
+						Username: "john_doe",
+					},
+					Password: models.UserPassword{
+						Plain: "secret",
+						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+					},
+					Status:        models.UserStatusConfirmed,
+					CreatedAt:     clock.Now(),
+					MaxNamespaces: MaxNumberNamespacesCommunity,
+					Preferences: models.UserPreferences{
+						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+					Admin: true,
+				}
+
+				mock.On("SystemGet", ctx).
+					Return(&models.System{Setup: false}, nil).
+					Once()
+				mock.On("UserCreate", ctx, user).
+					Return("", errors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "username"})).
+					Once()
+			},
+			expected: Expected{nil, ErrUserNameExists},
+		},
+		{
+			description: "fails with ErrUserUnhandledDuplicate when duplicate field is not known",
+			username:    "john_doe",
+			email:       "john.doe@test.com",
+			password:    "secret",
+			requiredMocks: func() {
+				hashMock.
+					On("Do", "secret").
+					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
+					Once()
+
+				user := &models.User{
+					Origin: models.UserOriginLocal,
+					UserData: models.UserData{
+						Name:     "john_doe",
+						Email:    "john.doe@test.com",
+						Username: "john_doe",
+					},
+					Password: models.UserPassword{
+						Plain: "secret",
+						Hash:  "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi",
+					},
+					Status:        models.UserStatusConfirmed,
+					CreatedAt:     clock.Now(),
+					MaxNamespaces: MaxNumberNamespacesCommunity,
+					Preferences: models.UserPreferences{
+						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+					Admin: true,
+				}
+
+				mock.On("SystemGet", ctx).
+					Return(&models.System{Setup: false}, nil).
+					Once()
+				// bare ErrDuplicate with no field (ok==false)
+				mock.On("UserCreate", ctx, user).
+					Return("", store.ErrDuplicate).
+					Once()
+			},
+			expected: Expected{nil, ErrUserUnhandledDuplicate},
 		},
 		{
 			description: "successfully creates a user",
@@ -144,10 +219,6 @@ func TestUserCreate(t *testing.T) {
 			email:       "john.doe@test.com",
 			password:    "secret",
 			requiredMocks: func() {
-				mock.
-					On("UserConflicts", ctx, &models.UserConflicts{Username: "john_doe", Email: "john.doe@test.com"}).
-					Return([]string{}, false, nil).
-					Once()
 				hashMock.
 					On("Do", "secret").
 					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).
@@ -173,9 +244,8 @@ func TestUserCreate(t *testing.T) {
 					Admin: true,
 				}
 
-				mock.On("UserCreate", ctx, user).Return("000000000000000000000000", nil).Once()
-
 				mock.On("SystemGet", ctx).Return(&models.System{Setup: false}, nil).Once()
+				mock.On("UserCreate", ctx, user).Return("000000000000000000000000", nil).Once()
 				mock.On("SystemSet", ctx, &models.System{Setup: true}).Return(nil).Once()
 			},
 			expected: Expected{&models.User{
@@ -204,14 +274,6 @@ func TestUserCreate(t *testing.T) {
 			email:       "john.doe@test.com",
 			password:    "secret",
 			requiredMocks: func() {
-				mock.
-					On("UserConflicts", ctx, &models.UserConflicts{
-						Username: "john_doe",
-						Email:    "john.doe@test.com",
-					}).
-					Return([]string{}, false, nil).
-					Once()
-
 				hashMock.
 					On("Do", "secret").
 					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yi", nil).

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -192,24 +192,6 @@ type UserChanges struct {
 	AuthMethods        []UserAuthMethod `bson:"preferences.auth_methods,omitempty"`
 }
 
-// UserConflicts holds user attributes that must be unique for each itam and can be utilized in queries
-// to identify conflicts.
-type UserConflicts struct {
-	Email    string
-	Username string
-}
-
-// Distinct removes the c attributes whether it's equal to the user attribute.
-func (c *UserConflicts) Distinct(user *User) {
-	if c.Email == user.Email {
-		c.Email = ""
-	}
-
-	if c.Username == user.Username {
-		c.Username = ""
-	}
-}
-
 type UserInfo struct {
 	// OwnedNamespaces are the namespaces where the user is the owner.
 	OwnedNamespaces []Namespace


### PR DESCRIPTION
## What
Removes the MongoDB-era `UserConflicts` pre-check and detects user
uniqueness conflicts from PostgreSQL constraint violations instead.

## Why
`UserConflicts` ran an explicit `SELECT` before every user create/update to
discover which unique field (email/username) would collide. Postgres already
enforces this with separate unique constraints, making the pre-check
redundant. Stage-3 cleanup of the Mongo→Postgres migration.

Fixes: shellhub-io/team#158

## Changes
- **store (contract)**: added a driver-free `DuplicateFieldError` plus a
  `DuplicatedField(err)` helper so callers recover the conflicting field
  without importing the pg driver. Removed the dead `ErrDuplicateUser` /
  `ErrDuplicateEmail`.
- **store/pg**: `fromSQLError` maps the violated constraint name to a field
  via `constraintToField` and joins a `DuplicateFieldError` onto
  `store.ErrDuplicate` on `23505` — for the users table only, so every other
  table's duplicate path is byte-identical to before.
- **services/cli**: `UpdateUser`, the CLI `UserCreate`, and the setup flow
  attempt the write and translate `store.ErrDuplicate`, reporting one field
  at a time. Added `ErrUserUnhandledDuplicate` (409) for a duplicate whose
  constraint isn't field-mappable.
- **removal**: deleted the `UserConflicts` model/`Distinct`, the `UserStore`
  interface method, its pg implementation, and the generated mock.
- **tests**: replaced `TestUserConflicts` with `TestUserCreateDuplicate`,
  which pins the constraint-name→field mapping against a real Postgres
  instance (fails loudly if a future migration renames the constraints).

## Testing
Reviewer note: the constraint-name mapping (`users_email_key`,
`users_username_key`) is Postgres' default naming for the inline `UNIQUE`
constraints in migration 001 — `TestUserCreateDuplicate` is the guard.

Paired with a cloud PR on the same-named branch `refactor/remove-user-conflicts`.