### PR TITLE
refactor(ui): extract and adopt website marketing primitives

### DIFF
--- a/ui/apps/website/src/components/marketing/FeatureListItem.tsx
+++ b/ui/apps/website/src/components/marketing/FeatureListItem.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+import { cn } from "@shellhub/design-system/cn";
+
+type Color = "muted" | "green";
+
+const colorClasses: Record<Color, string> = {
+  muted: "text-text-muted",
+  green: "text-accent-green",
+};
+
+const DefaultIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={2}
+    stroke="currentColor"
+    className={cn("w-4 h-4 shrink-0", className)}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m4.5 12.75 6 6 9-13.5"
+    />
+  </svg>
+);
+
+export interface FeatureListItemProps {
+  children: ReactNode;
+  color?: Color;
+  className?: string;
+}
+
+export function FeatureListItem({
+  children,
+  color = "muted",
+  className,
+}: FeatureListItemProps) {
+  return (
+    <li
+      className={cn(
+        "flex gap-2.5 text-sm text-text-secondary items-center",
+        className,
+      )}
+    >
+      <DefaultIcon className={colorClasses[color]} />
+      {children}
+    </li>
+  );
+}

--- a/ui/apps/website/src/components/marketing/Section.tsx
+++ b/ui/apps/website/src/components/marketing/Section.tsx
@@ -1,0 +1,65 @@
+import type { ComponentPropsWithoutRef, ElementType } from "react";
+import { cn } from "@shellhub/design-system/cn";
+
+type Padding = "lg" | "md" | "none";
+type Background = "surface" | "none";
+
+export type SectionOwnProps<E extends ElementType = "section"> = {
+  as?: E;
+  bordered?: boolean;
+  padding?: Padding;
+  background?: Background;
+  centered?: boolean;
+  container?: boolean;
+  containerClassName?: string;
+};
+
+export type SectionProps<E extends ElementType = "section"> =
+  SectionOwnProps<E> &
+    Omit<ComponentPropsWithoutRef<E>, keyof SectionOwnProps<E>>;
+
+const paddingClasses: Record<Padding, string> = {
+  lg: "py-24",
+  md: "py-12",
+  none: "",
+};
+
+export function Section<E extends ElementType = "section">({
+  as,
+  bordered = true,
+  padding = "lg",
+  background = "none",
+  centered = false,
+  container = true,
+  className,
+  containerClassName,
+  children,
+  ...rest
+}: SectionProps<E>) {
+  const Tag: ElementType = as ?? "section";
+
+  const outerClass = cn(
+    bordered && "border-t border-border",
+    paddingClasses[padding],
+    background === "surface" && "bg-surface",
+    className,
+  );
+
+  return (
+    <Tag className={outerClass} {...rest}>
+      {container ? (
+        <div
+          className={cn(
+            "max-w-7xl mx-auto px-8",
+            centered && "text-center",
+            containerClassName,
+          )}
+        >
+          {children}
+        </div>
+      ) : (
+        children
+      )}
+    </Tag>
+  );
+}

--- a/ui/apps/website/src/components/marketing/SectionHeader.tsx
+++ b/ui/apps/website/src/components/marketing/SectionHeader.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+import { Reveal } from "@shellhub/design-system/components";
+import { cn } from "@shellhub/design-system/cn";
+
+type Size = "section" | "sub" | "cta";
+type Align = "center" | "left";
+type EyebrowColor = "primary" | "cyan" | "green";
+type Variant = "cta";
+
+const sizeClasses: Record<Size, string> = {
+  section: "text-[clamp(1.75rem,4vw,3rem)]",
+  sub: "text-[clamp(1.75rem,4vw,2.5rem)]",
+  cta: "text-[clamp(1.5rem,3vw,2.25rem)]",
+};
+
+const eyebrowColorClasses: Record<EyebrowColor, string> = {
+  primary: "text-primary",
+  cyan: "text-accent-cyan",
+  green: "text-accent-green",
+};
+
+export interface SectionHeaderProps {
+  title: ReactNode;
+  eyebrow?: ReactNode;
+  subtitle?: ReactNode;
+  size?: Size;
+  align?: Align;
+  eyebrowColor?: EyebrowColor;
+  variant?: Variant;
+  reveal?: boolean;
+  className?: string;
+  subtitleClassName?: string;
+}
+
+export function SectionHeader({
+  title,
+  eyebrow,
+  subtitle,
+  size,
+  align = "center",
+  eyebrowColor = "primary",
+  variant,
+  reveal,
+  className,
+  subtitleClassName,
+}: SectionHeaderProps) {
+  const isCenter = align === "center";
+  const isCta = variant === "cta";
+  const resolvedSize = size ?? (isCta ? "cta" : "section");
+  const resolvedReveal = reveal ?? !isCta;
+  const defaultMargin = isCta ? "mb-0" : "mb-14";
+
+  const content = (
+    <div
+      className={cn(
+        isCenter && "text-center mx-auto",
+        !resolvedReveal && cn(defaultMargin, className),
+      )}
+    >
+      {eyebrow && (
+        <p
+          className={cn(
+            "text-2xs font-mono font-semibold uppercase tracking-label mb-3",
+            eyebrowColorClasses[eyebrowColor],
+          )}
+        >
+          {eyebrow}
+        </p>
+      )}
+      <h2
+        className={cn(
+          "font-bold tracking-[-0.03em] leading-tight text-text-primary",
+          sizeClasses[resolvedSize],
+        )}
+      >
+        {title}
+      </h2>
+      {subtitle && (
+        <p
+          className={cn(
+            "mt-4 text-sm text-text-secondary leading-relaxed",
+            isCenter && (isCta ? "max-w-md mx-auto mb-8" : "max-w-lg mx-auto"),
+            subtitleClassName,
+          )}
+        >
+          {subtitle}
+        </p>
+      )}
+    </div>
+  );
+
+  if (!resolvedReveal) {
+    return content;
+  }
+
+  return <Reveal className={cn(defaultMargin, className)}>{content}</Reveal>;
+}

--- a/ui/apps/website/src/components/marketing/__tests__/FeatureListItem.test.tsx
+++ b/ui/apps/website/src/components/marketing/__tests__/FeatureListItem.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FeatureListItem } from "@/components/marketing/FeatureListItem";
+
+describe("FeatureListItem", () => {
+  it("renders an <li> with items-center and children", () => {
+    render(<FeatureListItem>My label</FeatureListItem>);
+    const li = screen.getByRole("listitem");
+    expect(li).toHaveClass("items-center");
+    expect(screen.getByText("My label")).toBeInTheDocument();
+  });
+
+  it("color='green' gives icon text-accent-green", () => {
+    render(<FeatureListItem color="green">Label</FeatureListItem>);
+    const li = screen.getByRole("listitem");
+    const svg = li.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveClass("text-accent-green");
+  });
+
+  it("color='muted' (default) gives icon text-text-muted", () => {
+    render(<FeatureListItem>Label</FeatureListItem>);
+    const li = screen.getByRole("listitem");
+    const svg = li.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveClass("text-text-muted");
+  });
+});

--- a/ui/apps/website/src/components/marketing/__tests__/Section.test.tsx
+++ b/ui/apps/website/src/components/marketing/__tests__/Section.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Section } from "@/components/marketing/Section";
+
+describe("Section", () => {
+  it("spreads id and className onto the outer element only", () => {
+    render(
+      <Section id="my-section" className="custom-outer" data-testid="outer">
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer).toHaveAttribute("id", "my-section");
+    expect(outer).toHaveClass("custom-outer");
+  });
+
+  it("renders inner container with containerClassName", () => {
+    render(
+      <Section data-testid="outer" containerClassName="custom-inner">
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    // containerClassName should NOT be on the outer element
+    expect(outer).not.toHaveClass("custom-inner");
+    // inner container should carry the class
+    const inner = outer.firstChild as HTMLElement;
+    expect(inner).toHaveClass("custom-inner");
+  });
+
+  it("containerClassName='max-w-3xl' overrides max-w-7xl via cn-merge", () => {
+    render(
+      <Section data-testid="outer" containerClassName="max-w-3xl">
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    const inner = outer.firstChild as HTMLElement;
+    expect(inner).toHaveClass("max-w-3xl");
+    expect(inner).not.toHaveClass("max-w-7xl");
+  });
+
+  it("container={false} removes inner wrapper", () => {
+    render(
+      <Section data-testid="outer" container={false}>
+        <span>child</span>
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    // direct child should be the span, not an inner div
+    expect(outer.firstChild).toHaveTextContent("child");
+    expect(outer.querySelector("div")).toBeNull();
+  });
+
+  it("container={false} makes containerClassName inert (not applied anywhere)", () => {
+    render(
+      <Section
+        data-testid="outer"
+        container={false}
+        containerClassName="should-not-appear"
+      >
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer.innerHTML).not.toContain("should-not-appear");
+  });
+
+  it("container={false} makes centered inert (text-center not applied)", () => {
+    render(
+      <Section data-testid="outer" container={false} centered>
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer).not.toHaveClass("text-center");
+    expect(outer.innerHTML).not.toContain("text-center");
+  });
+
+  it("bordered={false} removes border-t class from outer element", () => {
+    render(
+      <Section data-testid="outer" bordered={false}>
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer).not.toHaveClass("border-t");
+  });
+
+  it("bordered defaults to true and applies border-t border-border", () => {
+    render(<Section data-testid="outer">content</Section>);
+    const outer = screen.getByTestId("outer");
+    expect(outer).toHaveClass("border-t");
+    expect(outer).toHaveClass("border-border");
+  });
+
+  it("background='surface' adds bg-surface to outer element", () => {
+    render(
+      <Section data-testid="outer" background="surface">
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer).toHaveClass("bg-surface");
+  });
+
+  it("background='none' does not add bg-surface", () => {
+    render(
+      <Section data-testid="outer" background="none">
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer).not.toHaveClass("bg-surface");
+  });
+
+  it("polymorphic as='div' renders a <div> element", () => {
+    render(
+      <Section as="div" data-testid="outer">
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer.tagName.toLowerCase()).toBe("div");
+  });
+
+  it("renders as <section> by default", () => {
+    render(<Section data-testid="outer">content</Section>);
+    const outer = screen.getByTestId("outer");
+    expect(outer.tagName.toLowerCase()).toBe("section");
+  });
+
+  it("centered adds text-center to the inner container", () => {
+    render(
+      <Section data-testid="outer" centered>
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    const inner = outer.firstChild as HTMLElement;
+    expect(inner).toHaveClass("text-center");
+  });
+
+  it("padding='lg' applies py-24 (default)", () => {
+    render(<Section data-testid="outer">content</Section>);
+    const outer = screen.getByTestId("outer");
+    expect(outer).toHaveClass("py-24");
+  });
+
+  it("padding='md' applies py-12", () => {
+    render(
+      <Section data-testid="outer" padding="md">
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer).toHaveClass("py-12");
+  });
+
+  it("padding='none' applies no py- class", () => {
+    render(
+      <Section data-testid="outer" padding="none">
+        content
+      </Section>,
+    );
+    const outer = screen.getByTestId("outer");
+    expect(outer).not.toHaveClass("py-24");
+    expect(outer).not.toHaveClass("py-12");
+  });
+});

--- a/ui/apps/website/src/components/marketing/__tests__/SectionHeader.test.tsx
+++ b/ui/apps/website/src/components/marketing/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SectionHeader } from "@/components/marketing/SectionHeader";
+
+vi.mock("@shellhub/design-system/components", () => ({
+  Reveal: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="reveal-wrapper" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
+describe("SectionHeader", () => {
+  it("reveal=true wraps content in Reveal component", () => {
+    render(<SectionHeader title="Hello" reveal={true} />);
+    expect(screen.getByTestId("reveal-wrapper")).toBeInTheDocument();
+  });
+
+  it("reveal=false renders a plain div without Reveal", () => {
+    render(<SectionHeader title="Hello" reveal={false} />);
+    expect(screen.queryByTestId("reveal-wrapper")).toBeNull();
+    // Should still render a wrapper div
+    const h2 = screen.getByRole("heading", { level: 2 });
+    expect(h2).toBeInTheDocument();
+  });
+
+  it("title renders as an <h2>", () => {
+    render(<SectionHeader title="My Title" reveal={false} />);
+    const h2 = screen.getByRole("heading", { level: 2 });
+    expect(h2).toHaveTextContent("My Title");
+  });
+
+  it("title accepts ReactNode with inner <span>", () => {
+    render(
+      <SectionHeader
+        title={
+          <>
+            <span data-testid="inner-span">Inner</span> text
+          </>
+        }
+        reveal={false}
+      />,
+    );
+    expect(screen.getByTestId("inner-span")).toBeInTheDocument();
+    const h2 = screen.getByRole("heading", { level: 2 });
+    expect(h2).toContainElement(screen.getByTestId("inner-span"));
+  });
+
+  it("size='sub' emits exact class text-[clamp(1.75rem,4vw,2.5rem)]", () => {
+    render(<SectionHeader title="Sub" size="sub" reveal={false} />);
+    const h2 = screen.getByRole("heading", { level: 2 });
+    expect(h2.className).toContain("text-[clamp(1.75rem,4vw,2.5rem)]");
+  });
+
+  it("align='left' does not apply text-center or mx-auto to the wrapper", () => {
+    const { container } = render(
+      <SectionHeader title="Left" align="left" reveal={false} />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).not.toContain("text-center");
+    expect(wrapper.className).not.toContain("mx-auto");
+  });
+
+  it("eyebrow has the complete required class set and does not use text-sm", () => {
+    render(<SectionHeader title="T" eyebrow="Feature" reveal={false} />);
+    const eyebrow = screen.getByText("Feature");
+    expect(eyebrow).toHaveClass("text-2xs");
+    expect(eyebrow).toHaveClass("font-mono");
+    expect(eyebrow).toHaveClass("font-semibold");
+    expect(eyebrow).toHaveClass("uppercase");
+    expect(eyebrow).toHaveClass("tracking-label");
+    expect(eyebrow).toHaveClass("mb-3");
+    expect(eyebrow).toHaveClass("text-primary");
+    expect(eyebrow).not.toHaveClass("text-sm");
+  });
+
+  it("h2 has tracking-[-0.03em]", () => {
+    render(<SectionHeader title="My Title" reveal={false} />);
+    const h2 = screen.getByRole("heading", { level: 2 });
+    expect(h2.className).toContain("tracking-[-0.03em]");
+  });
+
+  it("className='mb-10' lands on the outer wrapper", () => {
+    render(<SectionHeader title="T" className="mb-10" reveal={false} />);
+    const wrapper =
+      screen.queryByTestId("reveal-wrapper") ??
+      document.querySelector(".mb-10");
+    expect(wrapper).not.toBeNull();
+    expect((wrapper as HTMLElement).className).toContain("mb-10");
+  });
+
+  it("subtitle has default text-sm max-w-lg mx-auto leading-relaxed and mt-4", () => {
+    render(<SectionHeader title="T" subtitle="Sub text" reveal={false} />);
+    const subtitle = screen.getByText("Sub text");
+    expect(subtitle).toHaveClass("text-sm");
+    expect(subtitle).toHaveClass("max-w-lg");
+    expect(subtitle).toHaveClass("mx-auto");
+    expect(subtitle).toHaveClass("leading-relaxed");
+    expect(subtitle).toHaveClass("mt-4");
+  });
+
+  it("outer wrapper has mb-14 by default (reveal=true)", () => {
+    render(<SectionHeader title="T" />);
+    const wrapper = screen.getByTestId("reveal-wrapper");
+    expect(wrapper.className).toContain("mb-14");
+  });
+
+  it("className='mb-10' overrides default mb-14 (reveal=false)", () => {
+    render(<SectionHeader title="T" className="mb-10" reveal={false} />);
+    const wrapper = document.querySelector(".mb-10") as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.className).toContain("mb-10");
+    expect(wrapper.className).not.toContain("mb-14");
+  });
+
+  it("align='left' subtitle drops max-w-lg and mx-auto", () => {
+    render(
+      <SectionHeader
+        title="T"
+        subtitle="Sub text"
+        align="left"
+        reveal={false}
+      />,
+    );
+    const subtitle = screen.getByText("Sub text");
+    expect(subtitle).toHaveClass("text-sm");
+    expect(subtitle).toHaveClass("leading-relaxed");
+    expect(subtitle).toHaveClass("mt-4");
+    expect(subtitle).not.toHaveClass("max-w-lg");
+    expect(subtitle).not.toHaveClass("mx-auto");
+  });
+
+  it("subtitleClassName='max-w-xl' overrides default max-w-lg", () => {
+    render(
+      <SectionHeader
+        title="T"
+        subtitle="Sub text"
+        subtitleClassName="max-w-xl"
+        reveal={false}
+      />,
+    );
+    const subtitle = screen.getByText("Sub text");
+    expect(subtitle).toHaveClass("max-w-xl");
+    expect(subtitle).not.toHaveClass("max-w-lg");
+  });
+
+  describe("variant='cta'", () => {
+    it("renders NO Reveal wrapper by default", () => {
+      render(<SectionHeader variant="cta" title="CTA Title" />);
+      expect(screen.queryByTestId("reveal-wrapper")).toBeNull();
+    });
+
+    it("h2 gets the cta clamp class", () => {
+      render(<SectionHeader variant="cta" title="CTA Title" />);
+      const h2 = screen.getByRole("heading", { level: 2 });
+      expect(h2.className).toContain("text-[clamp(1.5rem,3vw,2.25rem)]");
+    });
+
+    it("content wrapper has mb-0 and NOT mb-14", () => {
+      const { container } = render(
+        <SectionHeader variant="cta" title="CTA Title" />,
+      );
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.className).toContain("mb-0");
+      expect(wrapper.className).not.toContain("mb-14");
+    });
+
+    it("centered subtitle gets max-w-md, mx-auto, mb-8 and NOT max-w-lg", () => {
+      render(
+        <SectionHeader variant="cta" title="CTA Title" subtitle="CTA Sub" />,
+      );
+      const subtitle = screen.getByText("CTA Sub");
+      expect(subtitle).toHaveClass("max-w-md");
+      expect(subtitle).toHaveClass("mx-auto");
+      expect(subtitle).toHaveClass("mb-8");
+      expect(subtitle).not.toHaveClass("max-w-lg");
+    });
+
+    it("explicit reveal=true still renders the Reveal wrapper", () => {
+      render(<SectionHeader variant="cta" reveal={true} title="CTA Title" />);
+      expect(screen.getByTestId("reveal-wrapper")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/apps/website/src/components/marketing/__tests__/index.test.ts
+++ b/ui/apps/website/src/components/marketing/__tests__/index.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import * as marketing from "@/components/marketing";
+
+describe("marketing barrel (index.ts)", () => {
+  it("exports Section", () => {
+    expect(marketing.Section).toBeDefined();
+    expect(typeof marketing.Section).toBe("function");
+  });
+
+  it("exports SectionHeader", () => {
+    expect(marketing.SectionHeader).toBeDefined();
+    expect(typeof marketing.SectionHeader).toBe("function");
+  });
+
+  it("exports FeatureListItem", () => {
+    expect(marketing.FeatureListItem).toBeDefined();
+    expect(typeof marketing.FeatureListItem).toBe("function");
+  });
+});

--- a/ui/apps/website/src/components/marketing/index.ts
+++ b/ui/apps/website/src/components/marketing/index.ts
@@ -1,0 +1,6 @@
+export { Section } from "./Section";
+export type { SectionOwnProps, SectionProps } from "./Section";
+export { SectionHeader } from "./SectionHeader";
+export type { SectionHeaderProps } from "./SectionHeader";
+export { FeatureListItem } from "./FeatureListItem";
+export type { FeatureListItemProps } from "./FeatureListItem";

--- a/ui/apps/website/src/pages/enterprise/AdminPanel.tsx
+++ b/ui/apps/website/src/pages/enterprise/AdminPanel.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@shellhub/design-system/primitives";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 const capabilities = [
@@ -30,135 +31,128 @@ const capabilities = [
 
 export function AdminPanel() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          <div>
-            <Reveal>
-              <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                Admin Panel
-              </p>
-              <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                Manage everything from the browser
-              </h2>
-              <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                No more CLI commands for admin tasks. The Enterprise admin panel
-                gives your team a complete web interface for user management,
-                namespace administration, and security policies.
-              </p>
-            </Reveal>
+    <Section>
+      <div className="grid lg:grid-cols-2 gap-12 items-center">
+        <div>
+          <SectionHeader
+            align="left"
+            size="sub"
+            className="mb-8"
+            eyebrow="Admin Panel"
+            title="Manage everything from the browser"
+            subtitle="No more CLI commands for admin tasks. The Enterprise admin panel gives your team a complete web interface for user management, namespace administration, and security policies."
+          />
 
-            <div className="space-y-3">
-              {capabilities.map((cap, i) => (
-                <Reveal key={i} delay={i * 0.04}>
-                  <div className="flex items-start gap-3">
-                    <svg
-                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="m4.5 12.75 6 6 9-13.5"
-                      />
-                    </svg>
-                    <div>
-                      <p className="text-sm font-medium text-text-primary">
-                        {cap.label}
-                      </p>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {cap.desc}
-                      </p>
-                    </div>
+          <div className="space-y-3">
+            {capabilities.map((cap, i) => (
+              <Reveal key={i} delay={i * 0.04}>
+                <div className="flex items-start gap-3">
+                  <svg
+                    className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="m4.5 12.75 6 6 9-13.5"
+                    />
+                  </svg>
+                  <div>
+                    <p className="text-sm font-medium text-text-primary">
+                      {cap.label}
+                    </p>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {cap.desc}
+                    </p>
                   </div>
-                </Reveal>
-              ))}
-            </div>
+                </div>
+              </Reveal>
+            ))}
           </div>
+        </div>
 
-          <Reveal delay={0.1}>
-            <ShimmerCard>
-              <Card className="overflow-hidden">
-                <div className="p-6">
-                  <div className="flex items-center gap-2 mb-6">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Admin Panel
+        <Reveal delay={0.1}>
+          <ShimmerCard>
+            <Card className="overflow-hidden">
+              <div className="p-6">
+                <div className="flex items-center gap-2 mb-6">
+                  <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                  <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                  <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                  <span className="ml-2 text-2xs text-text-muted font-mono">
+                    Admin Panel
+                  </span>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                    <div className="flex items-center gap-3">
+                      <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center text-2xs font-semibold text-primary">
+                        JD
+                      </div>
+                      <div>
+                        <p className="text-xs font-medium">Jane Doe</p>
+                        <p className="text-2xs text-text-muted">
+                          jane@company.com
+                        </p>
+                      </div>
+                    </div>
+                    <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                      Admin
                     </span>
                   </div>
 
-                  <div className="space-y-3">
-                    <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                      <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center text-2xs font-semibold text-primary">
-                          JD
-                        </div>
-                        <div>
-                          <p className="text-xs font-medium">Jane Doe</p>
-                          <p className="text-2xs text-text-muted">
-                            jane@company.com
-                          </p>
-                        </div>
+                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                    <div className="flex items-center gap-3">
+                      <div className="w-8 h-8 rounded-full bg-accent-blue/15 flex items-center justify-center text-2xs font-semibold text-accent-blue">
+                        MS
                       </div>
-                      <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
-                        Admin
-                      </span>
-                    </div>
-
-                    <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                      <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 rounded-full bg-accent-blue/15 flex items-center justify-center text-2xs font-semibold text-accent-blue">
-                          MS
-                        </div>
-                        <div>
-                          <p className="text-xs font-medium">Mike Smith</p>
-                          <p className="text-2xs text-text-muted">
-                            mike@company.com
-                          </p>
-                        </div>
+                      <div>
+                        <p className="text-xs font-medium">Mike Smith</p>
+                        <p className="text-2xs text-text-muted">
+                          mike@company.com
+                        </p>
                       </div>
-                      <span className="px-2 py-0.5 text-2xs font-mono bg-primary/10 text-primary border border-primary/20 rounded-full">
-                        Operator
-                      </span>
                     </div>
-
-                    <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                      <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 rounded-full bg-accent-cyan/15 flex items-center justify-center text-2xs font-semibold text-accent-cyan">
-                          AL
-                        </div>
-                        <div>
-                          <p className="text-xs font-medium">Ana Lima</p>
-                          <p className="text-2xs text-text-muted">
-                            ana@company.com
-                          </p>
-                        </div>
-                      </div>
-                      <span className="px-2 py-0.5 text-2xs font-mono bg-white/[0.04] text-text-muted border border-border rounded-full">
-                        Viewer
-                      </span>
-                    </div>
+                    <span className="px-2 py-0.5 text-2xs font-mono bg-primary/10 text-primary border border-primary/20 rounded-full">
+                      Operator
+                    </span>
                   </div>
 
-                  <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                    <span className="text-2xs text-text-muted">
-                      3 users in production namespace
-                    </span>
-                    <span className="text-2xs text-primary font-medium">
-                      Manage &rarr;
+                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                    <div className="flex items-center gap-3">
+                      <div className="w-8 h-8 rounded-full bg-accent-cyan/15 flex items-center justify-center text-2xs font-semibold text-accent-cyan">
+                        AL
+                      </div>
+                      <div>
+                        <p className="text-xs font-medium">Ana Lima</p>
+                        <p className="text-2xs text-text-muted">
+                          ana@company.com
+                        </p>
+                      </div>
+                    </div>
+                    <span className="px-2 py-0.5 text-2xs font-mono bg-white/[0.04] text-text-muted border border-border rounded-full">
+                      Viewer
                     </span>
                   </div>
                 </div>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-        </div>
+
+                <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                  <span className="text-2xs text-text-muted">
+                    3 users in production namespace
+                  </span>
+                  <span className="text-2xs text-primary font-medium">
+                    Manage &rarr;
+                  </span>
+                </div>
+              </div>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/enterprise/DeploymentOptions.tsx
+++ b/ui/apps/website/src/pages/enterprise/DeploymentOptions.tsx
@@ -1,97 +1,27 @@
 import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
+import { Section, SectionHeader } from "@/components/marketing";
+import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 export function DeploymentOptions() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Deployment
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-            Your infrastructure, your rules
-          </h2>
-          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            Choose the deployment model that fits your organization. Fully
-            managed or on your own infrastructure.
-          </p>
-        </Reveal>
+    <Section>
+      <SectionHeader
+        eyebrow="Deployment"
+        title="Your infrastructure, your rules"
+        subtitle="Choose the deployment model that fits your organization. Fully managed or on your own infrastructure."
+      />
 
-        <div className="grid md:grid-cols-2 gap-6">
-          <Reveal delay={0}>
-            <ShimmerCard className="h-full">
-              <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-                <div className="relative">
-                  <div className="flex items-center gap-3 mb-4">
-                    <IconBadge color="primary">
-                      <svg
-                        className="w-5 h-5 text-primary"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={1.5}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15z"
-                        />
-                      </svg>
-                    </IconBadge>
-                    <Badge shape="pill" color="green">
-                      Recommended
-                    </Badge>
-                  </div>
-
-                  <h3 className="text-lg font-bold mb-2">Managed Cloud</h3>
-                  <p className="text-sm text-text-secondary leading-relaxed mb-6">
-                    We handle the infrastructure. Dedicated servers, automatic
-                    updates, and guaranteed uptime.
-                  </p>
-
-                  <ul className="space-y-2.5">
-                    {[
-                      "Dedicated servers for your organization",
-                      "Automatic updates and patches",
-                      "99.9% uptime SLA",
-                      "Daily backups with point-in-time recovery",
-                      "Global edge network for low latency",
-                    ].map((item) => (
-                      <li
-                        key={item}
-                        className="flex items-center gap-2.5 text-sm text-text-secondary"
-                      >
-                        <svg
-                          className="w-4 h-4 text-accent-green shrink-0"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m4.5 12.75 6 6 9-13.5"
-                          />
-                        </svg>
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </ShimmerCard>
-          </Reveal>
-
-          <Reveal delay={0.1}>
-            <ShimmerCard className="h-full">
-              <Card hover className="p-8 flex flex-col h-full">
+      <div className="grid md:grid-cols-2 gap-6">
+        <Reveal delay={0}>
+          <ShimmerCard className="h-full">
+            <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+              <div className="relative">
                 <div className="flex items-center gap-3 mb-4">
-                  <IconBadge color="neutral">
+                  <IconBadge color="primary">
                     <svg
-                      className="w-5 h-5 text-text-secondary"
+                      className="w-5 h-5 text-primary"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -100,52 +30,83 @@ export function DeploymentOptions() {
                       <path
                         strokeLinecap="round"
                         strokeLinejoin="round"
-                        d="M21.75 17.25v-.228a4.5 4.5 0 0 0-.12-1.03l-2.268-9.64a3.375 3.375 0 0 0-3.285-2.602H7.923a3.375 3.375 0 0 0-3.285 2.602l-2.268 9.64a4.5 4.5 0 0 0-.12 1.03v.228m19.5 0a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3m19.5 0a3 3 0 0 0-3-3H5.25a3 3 0 0 0-3 3m16.5 0h.008v.008h-.008v-.008Zm-3 0h.008v.008h-.008v-.008Z"
+                        d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15z"
                       />
                     </svg>
                   </IconBadge>
+                  <Badge shape="pill" color="green">
+                    Recommended
+                  </Badge>
                 </div>
 
-                <h3 className="text-lg font-bold mb-2">On-Premises</h3>
+                <h3 className="text-lg font-bold mb-2">Managed Cloud</h3>
                 <p className="text-sm text-text-secondary leading-relaxed mb-6">
-                  Run ShellHub on your own infrastructure. Full data sovereignty
-                  and compliance control.
+                  We handle the infrastructure. Dedicated servers, automatic
+                  updates, and guaranteed uptime.
                 </p>
 
                 <ul className="space-y-2.5">
                   {[
-                    "Complete data sovereignty",
-                    "Deploy on Kubernetes with Helm charts",
-                    "Docker Compose for simpler setups",
-                    "Air-gapped environment support",
-                    "Custom integration with your toolchain",
+                    "Dedicated servers for your organization",
+                    "Automatic updates and patches",
+                    "99.9% uptime SLA",
+                    "Daily backups with point-in-time recovery",
+                    "Global edge network for low latency",
                   ].map((item) => (
-                    <li
-                      key={item}
-                      className="flex items-center gap-2.5 text-sm text-text-secondary"
-                    >
-                      <svg
-                        className="w-4 h-4 text-text-muted shrink-0"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
+                    <FeatureListItem key={item} color="green">
                       {item}
-                    </li>
+                    </FeatureListItem>
                   ))}
                 </ul>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-        </div>
+              </div>
+            </div>
+          </ShimmerCard>
+        </Reveal>
+
+        <Reveal delay={0.1}>
+          <ShimmerCard className="h-full">
+            <Card hover className="p-8 flex flex-col h-full">
+              <div className="flex items-center gap-3 mb-4">
+                <IconBadge color="neutral">
+                  <svg
+                    className="w-5 h-5 text-text-secondary"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M21.75 17.25v-.228a4.5 4.5 0 0 0-.12-1.03l-2.268-9.64a3.375 3.375 0 0 0-3.285-2.602H7.923a3.375 3.375 0 0 0-3.285 2.602l-2.268 9.64a4.5 4.5 0 0 0-.12 1.03v.228m19.5 0a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3m19.5 0a3 3 0 0 0-3-3H5.25a3 3 0 0 0-3 3m16.5 0h.008v.008h-.008v-.008Zm-3 0h.008v.008h-.008v-.008Z"
+                    />
+                  </svg>
+                </IconBadge>
+              </div>
+
+              <h3 className="text-lg font-bold mb-2">On-Premises</h3>
+              <p className="text-sm text-text-secondary leading-relaxed mb-6">
+                Run ShellHub on your own infrastructure. Full data sovereignty
+                and compliance control.
+              </p>
+
+              <ul className="space-y-2.5">
+                {[
+                  "Complete data sovereignty",
+                  "Deploy on Kubernetes with Helm charts",
+                  "Docker Compose for simpler setups",
+                  "Air-gapped environment support",
+                  "Custom integration with your toolchain",
+                ].map((item) => (
+                  <FeatureListItem key={item} color="muted">
+                    {item}
+                  </FeatureListItem>
+                ))}
+              </ul>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/enterprise/EnterpriseCTA.tsx
+++ b/ui/apps/website/src/pages/enterprise/EnterpriseCTA.tsx
@@ -1,49 +1,43 @@
 import { Link } from "react-router-dom";
 import { Button } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ConnectionGrid } from "../landing/components";
 
 export function EnterpriseCTA() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
+    <Section>
+      <Reveal>
+        <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+          <ConnectionGrid />
+          <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
 
-            <div className="relative z-10">
-              <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                Ready to get started?
-              </p>
-              <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                Talk to our team
-              </h2>
-              <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                Get a demo, discuss your requirements, and find the right plan
-                for your organization. Our team typically responds within one
-                business day.
-              </p>
+          <div className="relative z-10">
+            <SectionHeader
+              variant="cta"
+              eyebrow="Ready to get started?"
+              title="Talk to our team"
+              subtitle="Get a demo, discuss your requirements, and find the right plan for your organization. Our team typically responds within one business day."
+            />
 
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as="a"
-                  href="mailto:sales@shellhub.io"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Contact Sales
-                </Button>
-                <Button as={Link} to="/pricing" variant="outline" size="xl">
-                  View Pricing
-                </Button>
-              </div>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+              <Button
+                as="a"
+                href="mailto:sales@shellhub.io"
+                variant="primary"
+                size="xl"
+                glow
+                iconRight={<ArrowRight />}
+              >
+                Contact Sales
+              </Button>
+              <Button as={Link} to="/pricing" variant="outline" size="xl">
+                View Pricing
+              </Button>
             </div>
           </div>
-        </Reveal>
-      </div>
-    </section>
+        </div>
+      </Reveal>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/enterprise/SecurityFeatures.tsx
+++ b/ui/apps/website/src/pages/enterprise/SecurityFeatures.tsx
@@ -1,4 +1,5 @@
 import { Card } from "@shellhub/design-system/primitives";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -124,45 +125,36 @@ const features = [
 
 export function SecurityFeatures() {
   return (
-    <section className="py-24">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Security & Authentication
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-            Enterprise-grade security, built in
-          </h2>
-          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            Meet compliance requirements with SSO, MFA enforcement, session
-            recording, and complete audit logging.
-          </p>
-        </Reveal>
+    <Section bordered={false}>
+      <SectionHeader
+        eyebrow="Security & Authentication"
+        title="Enterprise-grade security, built in"
+        subtitle="Meet compliance requirements with SSO, MFA enforcement, session recording, and complete audit logging."
+      />
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {features.map((f, i) => (
-            <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-          ))}
-        </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {features.map((f, i) => (
+          <Reveal key={i} delay={i * 0.04}>
+            <ShimmerCard>
+              <Card hover className="p-6 h-full">
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                  style={{
+                    background: `${f.color}15`,
+                    borderColor: `${f.color}25`,
+                  }}
+                >
+                  {f.icon}
+                </div>
+                <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                <p className="text-xs text-text-secondary leading-relaxed">
+                  {f.desc}
+                </p>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+        ))}
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/enterprise/SupportSection.tsx
+++ b/ui/apps/website/src/pages/enterprise/SupportSection.tsx
@@ -1,31 +1,68 @@
 import { Card, IconBadge } from "@shellhub/design-system/primitives";
+import { Section, SectionHeader } from "@/components/marketing";
+import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 export function SupportSection() {
   return (
-    <section className="py-24">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Support
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-            Support that matches your needs
-          </h2>
-          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            From community forums to dedicated account managers, choose the
-            level of support your team needs.
-          </p>
+    <Section bordered={false}>
+      <SectionHeader
+        eyebrow="Support"
+        title="Support that matches your needs"
+        subtitle="From community forums to dedicated account managers, choose the level of support your team needs."
+      />
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <Reveal delay={0}>
+          <ShimmerCard className="h-full">
+            <Card hover className="p-8 h-full">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
+                  <svg
+                    className="w-5 h-5 text-text-secondary"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 0 1-.825-.242m9.345-8.334a2.126 2.126 0 0 0-.476-.095 48.64 48.64 0 0 0-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0 0 11.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <h3 className="text-sm font-bold">Community</h3>
+                  <p className="text-2xs text-text-muted">Free & Open Source</p>
+                </div>
+              </div>
+
+              <ul className="space-y-3">
+                {[
+                  "GitHub Issues & Discussions",
+                  "Community Discord server",
+                  "Public documentation",
+                  "Community-driven bug fixes",
+                ].map((item) => (
+                  <FeatureListItem key={item} color="muted">
+                    {item}
+                  </FeatureListItem>
+                ))}
+              </ul>
+            </Card>
+          </ShimmerCard>
         </Reveal>
 
-        <div className="grid md:grid-cols-2 gap-6">
-          <Reveal delay={0}>
-            <ShimmerCard className="h-full">
-              <Card hover className="p-8 h-full">
+        <Reveal delay={0.1}>
+          <ShimmerCard className="h-full">
+            <div className="relative bg-card border border-primary/30 rounded-xl p-8 h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+              <div className="relative">
                 <div className="flex items-center gap-3 mb-6">
-                  <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
+                  <IconBadge color="primary">
                     <svg
-                      className="w-5 h-5 text-text-secondary"
+                      className="w-5 h-5 text-primary"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -34,113 +71,35 @@ export function SupportSection() {
                       <path
                         strokeLinecap="round"
                         strokeLinejoin="round"
-                        d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 0 1-.825-.242m9.345-8.334a2.126 2.126 0 0 0-.476-.095 48.64 48.64 0 0 0-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0 0 11.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155"
+                        d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
                       />
                     </svg>
-                  </div>
+                  </IconBadge>
                   <div>
-                    <h3 className="text-sm font-bold">Community</h3>
-                    <p className="text-2xs text-text-muted">
-                      Free & Open Source
-                    </p>
+                    <h3 className="text-sm font-bold">Enterprise</h3>
+                    <p className="text-2xs text-primary">Priority Support</p>
                   </div>
                 </div>
 
                 <ul className="space-y-3">
                   {[
-                    "GitHub Issues & Discussions",
-                    "Community Discord server",
-                    "Public documentation",
-                    "Community-driven bug fixes",
+                    "Dedicated account manager",
+                    "Priority ticket queue with SLA",
+                    "Private Slack or Teams channel",
+                    "Onboarding & migration assistance",
+                    "Custom integration support",
+                    "Quarterly business reviews",
                   ].map((item) => (
-                    <li
-                      key={item}
-                      className="flex items-center gap-2.5 text-sm text-text-secondary"
-                    >
-                      <svg
-                        className="w-4 h-4 text-text-muted shrink-0"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
+                    <FeatureListItem key={item} color="green">
                       {item}
-                    </li>
+                    </FeatureListItem>
                   ))}
                 </ul>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-
-          <Reveal delay={0.1}>
-            <ShimmerCard className="h-full">
-              <div className="relative bg-card border border-primary/30 rounded-xl p-8 h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-                <div className="relative">
-                  <div className="flex items-center gap-3 mb-6">
-                    <IconBadge color="primary">
-                      <svg
-                        className="w-5 h-5 text-primary"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={1.5}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
-                        />
-                      </svg>
-                    </IconBadge>
-                    <div>
-                      <h3 className="text-sm font-bold">Enterprise</h3>
-                      <p className="text-2xs text-primary">Priority Support</p>
-                    </div>
-                  </div>
-
-                  <ul className="space-y-3">
-                    {[
-                      "Dedicated account manager",
-                      "Priority ticket queue with SLA",
-                      "Private Slack or Teams channel",
-                      "Onboarding & migration assistance",
-                      "Custom integration support",
-                      "Quarterly business reviews",
-                    ].map((item) => (
-                      <li
-                        key={item}
-                        className="flex items-center gap-2.5 text-sm text-text-secondary"
-                      >
-                        <svg
-                          className="w-4 h-4 text-accent-green shrink-0"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m4.5 12.75 6 6 9-13.5"
-                          />
-                        </svg>
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
               </div>
-            </ShimmerCard>
-          </Reveal>
-        </div>
+            </div>
+          </ShimmerCard>
+        </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Badge, Button, Card } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -157,113 +158,106 @@ function Hero() {
 /* ═══════════════════════════════════════════════════════════════ */
 function NativeSSH() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          {/* Text */}
-          <div>
-            <Reveal>
-              <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                Core Feature
-              </p>
-              <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                Native SSH access, no agents required
-              </h2>
-              <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                Connect to any device using your existing SSH client. ShellHub
-                works transparently with OpenSSH, PuTTY, and any SSH-compatible
-                client. No proprietary plugins, no VPNs, no port forwarding.
-              </p>
-            </Reveal>
+    <Section>
+      <div className="grid lg:grid-cols-2 gap-12 items-center">
+        {/* Text */}
+        <div>
+          <SectionHeader
+            align="left"
+            size="sub"
+            className="mb-8"
+            eyebrow="Core Feature"
+            title="Native SSH access, no agents required"
+            subtitle="Connect to any device using your existing SSH client. ShellHub works transparently with OpenSSH, PuTTY, and any SSH-compatible client. No proprietary plugins, no VPNs, no port forwarding."
+          />
 
-            <div className="space-y-3">
-              {[
-                {
-                  label: "Standard SSH protocol",
-                  desc: "Use ssh, scp, sftp with zero modifications to your workflow",
-                },
-                {
-                  label: "SSHID addressing",
-                  desc: "Connect via user@device.namespace format for clear device targeting",
-                },
-                {
-                  label: "No agent installation",
-                  desc: "Devices run a lightweight ShellHub agent — nothing on your workstation",
-                },
-                {
-                  label: "Works behind NAT",
-                  desc: "Reach devices behind firewalls, NAT, or CGNAT without port forwarding",
-                },
-              ].map((item, i) => (
-                <Reveal key={i} delay={i * 0.04}>
-                  <div className="flex items-start gap-3">
-                    <svg
-                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="m4.5 12.75 6 6 9-13.5"
-                      />
-                    </svg>
-                    <div>
-                      <p className="text-sm font-medium text-text-primary">
-                        {item.label}
-                      </p>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {item.desc}
-                      </p>
-                    </div>
+          <div className="space-y-3">
+            {[
+              {
+                label: "Standard SSH protocol",
+                desc: "Use ssh, scp, sftp with zero modifications to your workflow",
+              },
+              {
+                label: "SSHID addressing",
+                desc: "Connect via user@device.namespace format for clear device targeting",
+              },
+              {
+                label: "No agent installation",
+                desc: "Devices run a lightweight ShellHub agent — nothing on your workstation",
+              },
+              {
+                label: "Works behind NAT",
+                desc: "Reach devices behind firewalls, NAT, or CGNAT without port forwarding",
+              },
+            ].map((item, i) => (
+              <Reveal key={i} delay={i * 0.04}>
+                <div className="flex items-start gap-3">
+                  <svg
+                    className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="m4.5 12.75 6 6 9-13.5"
+                    />
+                  </svg>
+                  <div>
+                    <p className="text-sm font-medium text-text-primary">
+                      {item.label}
+                    </p>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {item.desc}
+                    </p>
                   </div>
-                </Reveal>
-              ))}
-            </div>
+                </div>
+              </Reveal>
+            ))}
           </div>
-
-          {/* Terminal Mockup */}
-          <Reveal delay={0.1}>
-            <ShimmerCard>
-              <Card className="overflow-hidden">
-                <TerminalChrome title="Terminal — ssh" accent={C.green}>
-                  <Line
-                    prompt="$"
-                    cmd="ssh admin@rpi-gateway.production.shellhub"
-                  />
-                  <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
-                    <span className="text-accent-green">Connected to</span>{" "}
-                    <span className="text-primary">rpi-gateway</span>
-                    <span className="text-text-muted"> (production)</span>
-                  </div>
-                  <Line
-                    prompt="$"
-                    cmd="ssh deploy@sensor-node-04.staging.shellhub"
-                  />
-                  <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
-                    <span className="text-accent-green">Connected to</span>{" "}
-                    <span className="text-primary">sensor-node-04</span>
-                    <span className="text-text-muted"> (staging)</span>
-                  </div>
-                  <Line
-                    prompt="$"
-                    cmd="ssh root@edge-server.iot-fleet.shellhub"
-                  />
-                  <div className="mt-2 flex items-center gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full bg-accent-green animate-pulse" />
-                    <span className="text-text-muted text-2xs">
-                      Connecting via ShellHub gateway...
-                    </span>
-                  </div>
-                </TerminalChrome>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
         </div>
+
+        {/* Terminal Mockup */}
+        <Reveal delay={0.1}>
+          <ShimmerCard>
+            <Card className="overflow-hidden">
+              <TerminalChrome title="Terminal — ssh" accent={C.green}>
+                <Line
+                  prompt="$"
+                  cmd="ssh admin@rpi-gateway.production.shellhub"
+                />
+                <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
+                  <span className="text-accent-green">Connected to</span>{" "}
+                  <span className="text-primary">rpi-gateway</span>
+                  <span className="text-text-muted"> (production)</span>
+                </div>
+                <Line
+                  prompt="$"
+                  cmd="ssh deploy@sensor-node-04.staging.shellhub"
+                />
+                <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
+                  <span className="text-accent-green">Connected to</span>{" "}
+                  <span className="text-primary">sensor-node-04</span>
+                  <span className="text-text-muted"> (staging)</span>
+                </div>
+                <Line
+                  prompt="$"
+                  cmd="ssh root@edge-server.iot-fleet.shellhub"
+                />
+                <div className="mt-2 flex items-center gap-2">
+                  <div className="w-1.5 h-1.5 rounded-full bg-accent-green animate-pulse" />
+                  <span className="text-text-muted text-2xs">
+                    Connecting via ShellHub gateway...
+                  </span>
+                </div>
+              </TerminalChrome>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }
 
@@ -272,228 +266,223 @@ function NativeSSH() {
 /* ═══════════════════════════════════════════════════════════════ */
 function SessionRecording() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          {/* Playback Mockup (left on this one for visual variety) */}
-          <Reveal delay={0.1}>
-            <ShimmerCard>
-              <Card className="overflow-hidden">
-                <div className="p-6">
-                  {/* Header bar */}
-                  <div className="flex items-center justify-between mb-5">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-lg bg-accent-cyan/15 border border-accent-cyan/20 flex items-center justify-center">
-                        <svg
-                          className="w-4 h-4 text-accent-cyan"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        >
-                          <circle cx="12" cy="12" r="10" />
-                          <polygon points="10 8 16 12 10 16 10 8" />
-                        </svg>
-                      </div>
-                      <div>
-                        <p className="text-xs font-semibold">Session #a7f3c2</p>
-                        <p className="text-2xs text-text-muted font-mono">
-                          admin@rpi-gateway &middot; production
-                        </p>
-                      </div>
-                    </div>
-                    <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
-                      Recorded
-                    </span>
-                  </div>
-
-                  {/* Fake terminal playback area */}
-                  <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs mb-4">
-                    <div className="text-text-muted mb-1">
-                      <span className="text-accent-green">
-                        admin@rpi-gateway
-                      </span>
-                      :<span className="text-accent-blue">~</span>$ systemctl
-                      status nginx
-                    </div>
-                    <div className="text-text-secondary mb-1">
-                      ● nginx.service - A high performance web server
-                    </div>
-                    <div className="text-text-secondary mb-1">
-                      &nbsp;&nbsp;&nbsp;Active:{" "}
-                      <span className="text-accent-green">
-                        active (running)
-                      </span>{" "}
-                      since Mon 2026-02-14 09:31:04 UTC
-                    </div>
-                    <div className="text-text-secondary mb-1">
-                      &nbsp;&nbsp;Process: 1247 ExecStartPre=/usr/sbin/nginx -t
-                      (code=exited, status=0/SUCCESS)
-                    </div>
-                    <div className="text-text-muted mt-2">
-                      <span className="text-accent-green">
-                        admin@rpi-gateway
-                      </span>
-                      :<span className="text-accent-blue">~</span>${" "}
-                      <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
-                    </div>
-                  </div>
-
-                  {/* Playback controls */}
+    <Section>
+      <div className="grid lg:grid-cols-2 gap-12 items-center">
+        {/* Playback Mockup (left on this one for visual variety) */}
+        <Reveal delay={0.1}>
+          <ShimmerCard>
+            <Card className="overflow-hidden">
+              <div className="p-6">
+                {/* Header bar */}
+                <div className="flex items-center justify-between mb-5">
                   <div className="flex items-center gap-3">
-                    <button type="button" aria-label="Rewind" className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
+                    <div className="w-8 h-8 rounded-lg bg-accent-cyan/15 border border-accent-cyan/20 flex items-center justify-center">
                       <svg
-                        className="w-4 h-4 text-text-secondary"
+                        className="w-4 h-4 text-accent-cyan"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
-                        strokeWidth={2}
-                        aria-hidden="true"
+                        strokeWidth={1.5}
                       >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M21 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 0 1 0-1.953l7.108-4.062A1.125 1.125 0 0 1 21 8.688v8.123ZM11.25 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 0 1 0-1.953l7.108-4.062a1.125 1.125 0 0 1 1.683.977v8.123Z"
-                        />
+                        <circle cx="12" cy="12" r="10" />
+                        <polygon points="10 8 16 12 10 16 10 8" />
                       </svg>
-                    </button>
-                    <button type="button" aria-label="Pause" className="w-10 h-10 rounded-lg bg-accent-cyan/15 border border-accent-cyan/25 flex items-center justify-center hover:bg-accent-cyan/25 transition-colors">
-                      <svg
-                        className="w-5 h-5 text-accent-cyan"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                        aria-hidden="true"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M15.75 5.25v13.5m-7.5-13.5v13.5"
-                        />
-                      </svg>
-                    </button>
-                    <button type="button" aria-label="Fast forward" className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors">
-                      <svg
-                        className="w-4 h-4 text-text-secondary"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                        aria-hidden="true"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M3 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 0 1 0 1.953l-7.108 4.062A1.125 1.125 0 0 1 3 16.81V8.688ZM12.75 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 0 1 0 1.953l-7.108 4.062a1.125 1.125 0 0 1-1.683-.977V8.688Z"
-                        />
-                      </svg>
-                    </button>
-
-                    {/* Timeline */}
-                    <div className="flex-1 mx-2">
-                      <div className="h-1.5 bg-surface rounded-full overflow-hidden border border-border">
-                        <div className="h-full w-[62%] bg-gradient-to-r from-accent-cyan to-primary rounded-full relative">
-                          <div className="absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full shadow-[0_0_8px_rgba(78,154,163,0.6)]" />
-                        </div>
-                      </div>
                     </div>
-
-                    <span className="text-2xs text-text-muted font-mono whitespace-nowrap">
-                      04:32 / 07:15
-                    </span>
+                    <div>
+                      <p className="text-xs font-semibold">Session #a7f3c2</p>
+                      <p className="text-2xs text-text-muted font-mono">
+                        admin@rpi-gateway &middot; production
+                      </p>
+                    </div>
                   </div>
+                  <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                    Recorded
+                  </span>
+                </div>
 
-                  {/* Session metadata */}
-                  <div className="mt-4 pt-4 border-t border-border grid grid-cols-3 gap-4">
-                    <div>
-                      <p className="text-2xs text-text-muted mb-0.5">
-                        Duration
-                      </p>
-                      <p className="text-xs font-mono font-medium">7m 15s</p>
-                    </div>
-                    <div>
-                      <p className="text-2xs text-text-muted mb-0.5">
-                        Commands
-                      </p>
-                      <p className="text-xs font-mono font-medium">23</p>
-                    </div>
-                    <div>
-                      <p className="text-2xs text-text-muted mb-0.5">Size</p>
-                      <p className="text-xs font-mono font-medium">1.2 MB</p>
-                    </div>
+                {/* Fake terminal playback area */}
+                <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs mb-4">
+                  <div className="text-text-muted mb-1">
+                    <span className="text-accent-green">admin@rpi-gateway</span>
+                    :<span className="text-accent-blue">~</span>$ systemctl
+                    status nginx
+                  </div>
+                  <div className="text-text-secondary mb-1">
+                    ● nginx.service - A high performance web server
+                  </div>
+                  <div className="text-text-secondary mb-1">
+                    &nbsp;&nbsp;&nbsp;Active:{" "}
+                    <span className="text-accent-green">active (running)</span>{" "}
+                    since Mon 2026-02-14 09:31:04 UTC
+                  </div>
+                  <div className="text-text-secondary mb-1">
+                    &nbsp;&nbsp;Process: 1247 ExecStartPre=/usr/sbin/nginx -t
+                    (code=exited, status=0/SUCCESS)
+                  </div>
+                  <div className="text-text-muted mt-2">
+                    <span className="text-accent-green">admin@rpi-gateway</span>
+                    :<span className="text-accent-blue">~</span>${" "}
+                    <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
                   </div>
                 </div>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
 
-          {/* Text */}
-          <div>
-            <Reveal>
-              <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                Compliance & Audit
-              </p>
-              <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                Record and replay every session
-              </h2>
-              <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                Automatically capture SSH sessions in real-time. Replay them
-                later for security review, incident investigation, training, or
-                compliance auditing. Every keystroke and output is preserved.
-              </p>
-            </Reveal>
-
-            <div className="space-y-3">
-              {[
-                {
-                  label: "Real-time capture",
-                  desc: "Sessions are recorded as they happen with zero performance impact",
-                },
-                {
-                  label: "Full-fidelity playback",
-                  desc: "Replay sessions exactly as they occurred, including timing and output",
-                },
-                {
-                  label: "Searchable history",
-                  desc: "Find sessions by user, device, date, or namespace",
-                },
-                {
-                  label: "Compliance ready",
-                  desc: "Meet SOC 2, HIPAA, and PCI DSS audit requirements",
-                },
-              ].map((item, i) => (
-                <Reveal key={i} delay={i * 0.04}>
-                  <div className="flex items-start gap-3">
+                {/* Playback controls */}
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    aria-label="Rewind"
+                    className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors"
+                  >
                     <svg
-                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      className="w-4 h-4 text-text-secondary"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
                       strokeWidth={2}
+                      aria-hidden="true"
                     >
                       <path
                         strokeLinecap="round"
                         strokeLinejoin="round"
-                        d="m4.5 12.75 6 6 9-13.5"
+                        d="M21 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 0 1 0-1.953l7.108-4.062A1.125 1.125 0 0 1 21 8.688v8.123ZM11.25 16.811c0 .864-.933 1.405-1.683.977l-7.108-4.062a1.125 1.125 0 0 1 0-1.953l7.108-4.062a1.125 1.125 0 0 1 1.683.977v8.123Z"
                       />
                     </svg>
-                    <div>
-                      <p className="text-sm font-medium text-text-primary">
-                        {item.label}
-                      </p>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {item.desc}
-                      </p>
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Pause"
+                    className="w-10 h-10 rounded-lg bg-accent-cyan/15 border border-accent-cyan/25 flex items-center justify-center hover:bg-accent-cyan/25 transition-colors"
+                  >
+                    <svg
+                      className="w-5 h-5 text-accent-cyan"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M15.75 5.25v13.5m-7.5-13.5v13.5"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Fast forward"
+                    className="w-8 h-8 rounded-lg bg-surface border border-border flex items-center justify-center hover:border-border-light transition-colors"
+                  >
+                    <svg
+                      className="w-4 h-4 text-text-secondary"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M3 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 0 1 0 1.953l-7.108 4.062A1.125 1.125 0 0 1 3 16.81V8.688ZM12.75 8.688c0-.864.933-1.405 1.683-.977l7.108 4.062a1.125 1.125 0 0 1 0 1.953l-7.108 4.062a1.125 1.125 0 0 1-1.683-.977V8.688Z"
+                      />
+                    </svg>
+                  </button>
+
+                  {/* Timeline */}
+                  <div className="flex-1 mx-2">
+                    <div className="h-1.5 bg-surface rounded-full overflow-hidden border border-border">
+                      <div className="h-full w-[62%] bg-gradient-to-r from-accent-cyan to-primary rounded-full relative">
+                        <div className="absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-white rounded-full shadow-[0_0_8px_rgba(78,154,163,0.6)]" />
+                      </div>
                     </div>
                   </div>
-                </Reveal>
-              ))}
-            </div>
+
+                  <span className="text-2xs text-text-muted font-mono whitespace-nowrap">
+                    04:32 / 07:15
+                  </span>
+                </div>
+
+                {/* Session metadata */}
+                <div className="mt-4 pt-4 border-t border-border grid grid-cols-3 gap-4">
+                  <div>
+                    <p className="text-2xs text-text-muted mb-0.5">Duration</p>
+                    <p className="text-xs font-mono font-medium">7m 15s</p>
+                  </div>
+                  <div>
+                    <p className="text-2xs text-text-muted mb-0.5">Commands</p>
+                    <p className="text-xs font-mono font-medium">23</p>
+                  </div>
+                  <div>
+                    <p className="text-2xs text-text-muted mb-0.5">Size</p>
+                    <p className="text-xs font-mono font-medium">1.2 MB</p>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
+
+        {/* Text */}
+        <div>
+          <SectionHeader
+            align="left"
+            size="sub"
+            className="mb-8"
+            eyebrow="Compliance & Audit"
+            title="Record and replay every session"
+            subtitle="Automatically capture SSH sessions in real-time. Replay them later for security review, incident investigation, training, or compliance auditing. Every keystroke and output is preserved."
+          />
+
+          <div className="space-y-3">
+            {[
+              {
+                label: "Real-time capture",
+                desc: "Sessions are recorded as they happen with zero performance impact",
+              },
+              {
+                label: "Full-fidelity playback",
+                desc: "Replay sessions exactly as they occurred, including timing and output",
+              },
+              {
+                label: "Searchable history",
+                desc: "Find sessions by user, device, date, or namespace",
+              },
+              {
+                label: "Compliance ready",
+                desc: "Meet SOC 2, HIPAA, and PCI DSS audit requirements",
+              },
+            ].map((item, i) => (
+              <Reveal key={i} delay={i * 0.04}>
+                <div className="flex items-start gap-3">
+                  <svg
+                    className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="m4.5 12.75 6 6 9-13.5"
+                    />
+                  </svg>
+                  <div>
+                    <p className="text-sm font-medium text-text-primary">
+                      {item.label}
+                    </p>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {item.desc}
+                    </p>
+                  </div>
+                </div>
+              </Reveal>
+            ))}
           </div>
         </div>
       </div>
-    </section>
+    </Section>
   );
 }
 
@@ -502,143 +491,131 @@ function SessionRecording() {
 /* ═══════════════════════════════════════════════════════════════ */
 function WebTerminal() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          {/* Text */}
-          <div>
-            <Reveal>
-              <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                Zero Install
-              </p>
-              <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                Terminal in your browser
-              </h2>
-              <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                Access any device directly from the ShellHub web UI. No SSH
-                client needed. Perfect for quick troubleshooting from a tablet,
-                a shared workstation, or when your usual tools are not
-                available.
-              </p>
-            </Reveal>
+    <Section>
+      <div className="grid lg:grid-cols-2 gap-12 items-center">
+        {/* Text */}
+        <div>
+          <SectionHeader
+            align="left"
+            size="sub"
+            className="mb-8"
+            eyebrow="Zero Install"
+            title="Terminal in your browser"
+            subtitle="Access any device directly from the ShellHub web UI. No SSH client needed. Perfect for quick troubleshooting from a tablet, a shared workstation, or when your usual tools are not available."
+          />
 
-            <div className="space-y-3">
-              {[
-                {
-                  label: "Full terminal emulation",
-                  desc: "Powered by xterm.js with WebGL rendering for native-like performance",
-                },
-                {
-                  label: "Works from any browser",
-                  desc: "Chrome, Firefox, Safari, Edge — desktop and mobile",
-                },
-                {
-                  label: "Secure WebSocket connection",
-                  desc: "End-to-end encrypted channel between browser and device",
-                },
-                {
-                  label: "Copy and paste support",
-                  desc: "Seamless clipboard integration for efficient workflows",
-                },
-              ].map((item, i) => (
-                <Reveal key={i} delay={i * 0.04}>
-                  <div className="flex items-start gap-3">
-                    <svg
-                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="m4.5 12.75 6 6 9-13.5"
-                      />
-                    </svg>
-                    <div>
-                      <p className="text-sm font-medium text-text-primary">
-                        {item.label}
-                      </p>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {item.desc}
-                      </p>
-                    </div>
+          <div className="space-y-3">
+            {[
+              {
+                label: "Full terminal emulation",
+                desc: "Powered by xterm.js with WebGL rendering for native-like performance",
+              },
+              {
+                label: "Works from any browser",
+                desc: "Chrome, Firefox, Safari, Edge — desktop and mobile",
+              },
+              {
+                label: "Secure WebSocket connection",
+                desc: "End-to-end encrypted channel between browser and device",
+              },
+              {
+                label: "Copy and paste support",
+                desc: "Seamless clipboard integration for efficient workflows",
+              },
+            ].map((item, i) => (
+              <Reveal key={i} delay={i * 0.04}>
+                <div className="flex items-start gap-3">
+                  <svg
+                    className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="m4.5 12.75 6 6 9-13.5"
+                    />
+                  </svg>
+                  <div>
+                    <p className="text-sm font-medium text-text-primary">
+                      {item.label}
+                    </p>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {item.desc}
+                    </p>
                   </div>
-                </Reveal>
-              ))}
-            </div>
+                </div>
+              </Reveal>
+            ))}
           </div>
-
-          {/* Browser Mockup */}
-          <Reveal delay={0.1}>
-            <ShimmerCard>
-              <Card className="overflow-hidden">
-                <BrowserChrome url="shellhub.io/devices/rpi-gateway/terminal">
-                  {/* Fake tabs row */}
-                  <div className="flex items-center gap-1 mb-4">
-                    <div className="px-3 py-1.5 bg-surface border border-border rounded-t-lg text-2xs font-mono text-text-primary flex items-center gap-2">
-                      <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                      rpi-gateway
-                    </div>
-                    <div className="px-3 py-1.5 bg-card border border-border/50 rounded-t-lg text-2xs font-mono text-text-muted flex items-center gap-2">
-                      <div className="w-1.5 h-1.5 rounded-full bg-text-muted" />
-                      sensor-node-04
-                    </div>
-                  </div>
-
-                  {/* Terminal area inside browser */}
-                  <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs">
-                    <div className="text-text-muted mb-1.5">
-                      <span className="text-accent-green">
-                        admin@rpi-gateway
-                      </span>
-                      :<span className="text-accent-blue">~</span>$ docker ps
-                      --format &quot;table {"{{.Names}}"}\t{"{{.Status}}"}&quot;
-                    </div>
-                    <div className="text-text-secondary mb-0.5">
-                      NAMES&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;STATUS
-                    </div>
-                    <div className="text-text-secondary mb-0.5">
-                      nginx-proxy&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                      days
-                    </div>
-                    <div className="text-text-secondary mb-0.5">
-                      app-backend&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                      days
-                    </div>
-                    <div className="text-text-secondary mb-0.5">
-                      redis-cache&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                      days
-                    </div>
-                    <div className="text-text-secondary mb-1.5">
-                      postgres-db&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                      days
-                    </div>
-                    <div className="text-text-muted">
-                      <span className="text-accent-green">
-                        admin@rpi-gateway
-                      </span>
-                      :<span className="text-accent-blue">~</span>${" "}
-                      <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
-                    </div>
-                  </div>
-
-                  {/* Status bar */}
-                  <div className="mt-3 flex items-center justify-between text-2xs text-text-muted">
-                    <div className="flex items-center gap-2">
-                      <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                      <span>Connected &middot; WebSocket</span>
-                    </div>
-                    <span className="font-mono">80x24</span>
-                  </div>
-                </BrowserChrome>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
         </div>
+
+        {/* Browser Mockup */}
+        <Reveal delay={0.1}>
+          <ShimmerCard>
+            <Card className="overflow-hidden">
+              <BrowserChrome url="shellhub.io/devices/rpi-gateway/terminal">
+                {/* Fake tabs row */}
+                <div className="flex items-center gap-1 mb-4">
+                  <div className="px-3 py-1.5 bg-surface border border-border rounded-t-lg text-2xs font-mono text-text-primary flex items-center gap-2">
+                    <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                    rpi-gateway
+                  </div>
+                  <div className="px-3 py-1.5 bg-card border border-border/50 rounded-t-lg text-2xs font-mono text-text-muted flex items-center gap-2">
+                    <div className="w-1.5 h-1.5 rounded-full bg-text-muted" />
+                    sensor-node-04
+                  </div>
+                </div>
+
+                {/* Terminal area inside browser */}
+                <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs">
+                  <div className="text-text-muted mb-1.5">
+                    <span className="text-accent-green">admin@rpi-gateway</span>
+                    :<span className="text-accent-blue">~</span>$ docker ps
+                    --format &quot;table {"{{.Names}}"}\t{"{{.Status}}"}&quot;
+                  </div>
+                  <div className="text-text-secondary mb-0.5">
+                    NAMES&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;STATUS
+                  </div>
+                  <div className="text-text-secondary mb-0.5">
+                    nginx-proxy&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
+                    days
+                  </div>
+                  <div className="text-text-secondary mb-0.5">
+                    app-backend&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
+                    days
+                  </div>
+                  <div className="text-text-secondary mb-0.5">
+                    redis-cache&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
+                    days
+                  </div>
+                  <div className="text-text-secondary mb-1.5">
+                    postgres-db&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
+                    days
+                  </div>
+                  <div className="text-text-muted">
+                    <span className="text-accent-green">admin@rpi-gateway</span>
+                    :<span className="text-accent-blue">~</span>${" "}
+                    <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
+                  </div>
+                </div>
+
+                {/* Status bar */}
+                <div className="mt-3 flex items-center justify-between text-2xs text-text-muted">
+                  <div className="flex items-center gap-2">
+                    <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                    <span>Connected &middot; WebSocket</span>
+                  </div>
+                  <span className="font-mono">80x24</span>
+                </div>
+              </BrowserChrome>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }
 
@@ -764,46 +741,37 @@ const securityFeatures = [
 
 function SecurityGrid() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Security & Access Control
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-            Defense in depth, built into every layer
-          </h2>
-          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            Multiple layers of authentication, authorization, and auditing to
-            secure your fleet from the network edge to the terminal.
-          </p>
-        </Reveal>
+    <Section>
+      <SectionHeader
+        eyebrow="Security & Access Control"
+        title="Defense in depth, built into every layer"
+        subtitle="Multiple layers of authentication, authorization, and auditing to secure your fleet from the network edge to the terminal."
+      />
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {securityFeatures.map((f, i) => (
-            <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-          ))}
-        </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {securityFeatures.map((f, i) => (
+          <Reveal key={i} delay={i * 0.04}>
+            <ShimmerCard>
+              <Card hover className="p-6 h-full">
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                  style={{
+                    background: `${f.color}15`,
+                    borderColor: `${f.color}25`,
+                  }}
+                >
+                  {f.icon}
+                </div>
+                <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                <p className="text-xs text-text-secondary leading-relaxed">
+                  {f.desc}
+                </p>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+        ))}
       </div>
-    </section>
+    </Section>
   );
 }
 
@@ -812,102 +780,624 @@ function SecurityGrid() {
 /* ═══════════════════════════════════════════════════════════════ */
 function FileTransfer() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          {/* Terminal Mockup */}
-          <Reveal delay={0.1}>
-            <ShimmerCard>
-              <Card className="overflow-hidden">
-                <TerminalChrome title="Terminal — scp / sftp" accent={C.cyan}>
-                  <div className="mb-4">
-                    <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
-                      SCP &mdash; Copy files to device
-                    </p>
-                    <Line
-                      prompt="$"
-                      cmd="scp firmware-v2.4.bin admin@rpi-gateway.production.shellhub:/opt/firmware/"
-                    />
-                    <div className="mt-1 flex items-center gap-3">
-                      <div className="flex-1 h-1.5 bg-surface rounded-full overflow-hidden border border-border">
-                        <div className="h-full w-full bg-gradient-to-r from-accent-cyan to-primary rounded-full" />
-                      </div>
-                      <span className="text-accent-green text-2xs">100%</span>
+    <Section>
+      <div className="grid lg:grid-cols-2 gap-12 items-center">
+        {/* Terminal Mockup */}
+        <Reveal delay={0.1}>
+          <ShimmerCard>
+            <Card className="overflow-hidden">
+              <TerminalChrome title="Terminal — scp / sftp" accent={C.cyan}>
+                <div className="mb-4">
+                  <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
+                    SCP &mdash; Copy files to device
+                  </p>
+                  <Line
+                    prompt="$"
+                    cmd="scp firmware-v2.4.bin admin@rpi-gateway.production.shellhub:/opt/firmware/"
+                  />
+                  <div className="mt-1 flex items-center gap-3">
+                    <div className="flex-1 h-1.5 bg-surface rounded-full overflow-hidden border border-border">
+                      <div className="h-full w-full bg-gradient-to-r from-accent-cyan to-primary rounded-full" />
                     </div>
-                    <p className="text-text-muted text-2xs mt-1">
-                      firmware-v2.4.bin &nbsp; 24.3 MB &nbsp; 12.1MB/s &nbsp;
-                      00:02
+                    <span className="text-accent-green text-2xs">100%</span>
+                  </div>
+                  <p className="text-text-muted text-2xs mt-1">
+                    firmware-v2.4.bin &nbsp; 24.3 MB &nbsp; 12.1MB/s &nbsp;
+                    00:02
+                  </p>
+                </div>
+
+                <div className="pt-4 border-t border-border">
+                  <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
+                    SFTP &mdash; Interactive session
+                  </p>
+                  <Line prompt="sftp>" cmd="ls /var/log/" />
+                  <div className="text-text-secondary ml-0">
+                    <p>
+                      syslog &nbsp;&nbsp; auth.log &nbsp;&nbsp; kern.log
+                      &nbsp;&nbsp; nginx/
                     </p>
                   </div>
+                  <Line
+                    prompt="sftp>"
+                    cmd="get /var/log/syslog ./diagnostics/"
+                  />
+                  <p className="text-text-muted text-2xs mt-1">
+                    Fetching /var/log/syslog to ./diagnostics/syslog
+                  </p>
+                  <p className="text-accent-green text-2xs">
+                    /var/log/syslog &nbsp; 100% &nbsp; 847KB &nbsp; 4.2MB/s
+                    &nbsp; 00:00
+                  </p>
+                </div>
+              </TerminalChrome>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
 
-                  <div className="pt-4 border-t border-border">
-                    <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
-                      SFTP &mdash; Interactive session
-                    </p>
-                    <Line prompt="sftp>" cmd="ls /var/log/" />
-                    <div className="text-text-secondary ml-0">
-                      <p>
-                        syslog &nbsp;&nbsp; auth.log &nbsp;&nbsp; kern.log
-                        &nbsp;&nbsp; nginx/
-                      </p>
-                    </div>
-                    <Line
-                      prompt="sftp>"
-                      cmd="get /var/log/syslog ./diagnostics/"
+        {/* Text */}
+        <div>
+          <SectionHeader
+            align="left"
+            size="sub"
+            className="mb-8"
+            eyebrow="File Transfer"
+            title="SCP and SFTP, built right in"
+            subtitle="Transfer files to and from remote devices using the same SCP and SFTP commands you already know. Push firmware updates, pull log files, manage configurations — all through the ShellHub gateway with no extra setup."
+          />
+
+          <div className="space-y-3">
+            {[
+              {
+                label: "Standard protocols",
+                desc: "Works with any SCP/SFTP client, including WinSCP and FileZilla",
+              },
+              {
+                label: "Bidirectional transfers",
+                desc: "Push files to devices or pull files from them using familiar commands",
+              },
+              {
+                label: "Large file support",
+                desc: "Transfer firmware images, database dumps, and large log archives",
+              },
+              {
+                label: "Secure by default",
+                desc: "Files are encrypted in transit through the ShellHub tunnel",
+              },
+            ].map((item, i) => (
+              <Reveal key={i} delay={i * 0.04}>
+                <div className="flex items-start gap-3">
+                  <svg
+                    className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="m4.5 12.75 6 6 9-13.5"
                     />
-                    <p className="text-text-muted text-2xs mt-1">
-                      Fetching /var/log/syslog to ./diagnostics/syslog
+                  </svg>
+                  <div>
+                    <p className="text-sm font-medium text-text-primary">
+                      {item.label}
                     </p>
-                    <p className="text-accent-green text-2xs">
-                      /var/log/syslog &nbsp; 100% &nbsp; 847KB &nbsp; 4.2MB/s
-                      &nbsp; 00:00
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {item.desc}
                     </p>
                   </div>
-                </TerminalChrome>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Section>
+  );
+}
 
-          {/* Text */}
-          <div>
-            <Reveal>
-              <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                File Transfer
-              </p>
-              <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                SCP and SFTP, built right in
-              </h2>
-              <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                Transfer files to and from remote devices using the same SCP and
-                SFTP commands you already know. Push firmware updates, pull log
-                files, manage configurations — all through the ShellHub gateway
-                with no extra setup.
-              </p>
-            </Reveal>
+/* ═══════════════════════════════════════════════════════════════ */
+/*  DOCKER CONTAINER ACCESS                                       */
+/* ═══════════════════════════════════════════════════════════════ */
+function DockerAccess() {
+  return (
+    <Section>
+      <Reveal>
+        <ShimmerCard className="h-full">
+          <div className="relative bg-card border border-primary/30 rounded-2xl overflow-hidden shadow-[0_0_60px_rgba(102,122,204,0.08)]">
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.03] pointer-events-none" />
+            <div className="relative grid lg:grid-cols-2 gap-0">
+              {/* Diagram side */}
+              <div className="p-8 lg:p-10 border-b lg:border-b-0 lg:border-r border-border/50">
+                <div className="mb-6">
+                  <p className="text-2xs font-mono font-semibold uppercase tracking-label text-primary mb-3">
+                    Docker Integration
+                  </p>
+                  <h2 className="text-[clamp(1.5rem,3vw,2rem)] font-bold tracking-[-0.03em] leading-tight mb-3">
+                    SSH into containers directly
+                  </h2>
+                  <p className="text-sm text-text-secondary leading-relaxed">
+                    Access Docker containers on remote hosts with the same SSH
+                    workflow you use for VMs. No need for docker exec or SSH
+                    into the host first.
+                  </p>
+                </div>
 
-            <div className="space-y-3">
-              {[
-                {
-                  label: "Standard protocols",
-                  desc: "Works with any SCP/SFTP client, including WinSCP and FileZilla",
-                },
-                {
-                  label: "Bidirectional transfers",
-                  desc: "Push files to devices or pull files from them using familiar commands",
-                },
-                {
-                  label: "Large file support",
-                  desc: "Transfer firmware images, database dumps, and large log archives",
-                },
-                {
-                  label: "Secure by default",
-                  desc: "Files are encrypted in transit through the ShellHub tunnel",
-                },
-              ].map((item, i) => (
-                <Reveal key={i} delay={i * 0.04}>
-                  <div className="flex items-start gap-3">
+                {/* Architecture diagram */}
+                <div className="mt-6">
+                  <svg viewBox="0 0 400 220" className="w-full" fill="none">
+                    {/* Your workstation */}
+                    <rect
+                      x="10"
+                      y="10"
+                      width="120"
+                      height="50"
+                      rx="8"
+                      fill={`${C.surface}`}
+                      stroke={C.border}
+                      strokeWidth="1"
+                    />
+                    <text
+                      x="70"
+                      y="31"
+                      textAnchor="middle"
+                      fill={C.textSec}
+                      fontSize="9"
+                      fontFamily="monospace"
+                    >
+                      Your Workstation
+                    </text>
+                    <text
+                      x="70"
+                      y="46"
+                      textAnchor="middle"
+                      fill={C.primary}
+                      fontSize="10"
+                      fontWeight="600"
+                      fontFamily="monospace"
+                    >
+                      ssh client
+                    </text>
+
+                    {/* Arrow */}
+                    <line
+                      x1="130"
+                      y1="35"
+                      x2="165"
+                      y2="35"
+                      stroke={C.primary}
+                      strokeWidth="1.5"
+                      strokeDasharray="4 3"
+                    />
+                    <polygon points="165,31 173,35 165,39" fill={C.primary} />
+
+                    {/* ShellHub Gateway */}
+                    <rect
+                      x="175"
+                      y="10"
+                      width="110"
+                      height="50"
+                      rx="8"
+                      fill={`${C.primaryDim}`}
+                      stroke={C.primary}
+                      strokeWidth="1"
+                    />
+                    <text
+                      x="230"
+                      y="31"
+                      textAnchor="middle"
+                      fill={C.textSec}
+                      fontSize="9"
+                      fontFamily="monospace"
+                    >
+                      ShellHub
+                    </text>
+                    <text
+                      x="230"
+                      y="46"
+                      textAnchor="middle"
+                      fill={C.primary}
+                      fontSize="10"
+                      fontWeight="600"
+                      fontFamily="monospace"
+                    >
+                      Gateway
+                    </text>
+
+                    {/* Arrow down */}
+                    <line
+                      x1="230"
+                      y1="60"
+                      x2="230"
+                      y2="85"
+                      stroke={C.primary}
+                      strokeWidth="1.5"
+                      strokeDasharray="4 3"
+                    />
+                    <polygon points="226,85 230,93 234,85" fill={C.primary} />
+
+                    {/* Remote Host */}
+                    <rect
+                      x="50"
+                      y="95"
+                      width="340"
+                      height="115"
+                      rx="10"
+                      fill={`${C.surface}`}
+                      stroke={C.border}
+                      strokeWidth="1"
+                    />
+                    <text
+                      x="70"
+                      y="115"
+                      fill={C.textMuted}
+                      fontSize="9"
+                      fontFamily="monospace"
+                    >
+                      Remote Host
+                    </text>
+
+                    {/* ShellHub Agent */}
+                    <rect
+                      x="160"
+                      y="100"
+                      width="140"
+                      height="28"
+                      rx="6"
+                      fill={`${C.primaryDim}`}
+                      stroke={`${C.primary}40`}
+                      strokeWidth="1"
+                    />
+                    <text
+                      x="230"
+                      y="118"
+                      textAnchor="middle"
+                      fill={C.primary}
+                      fontSize="9"
+                      fontWeight="600"
+                      fontFamily="monospace"
+                    >
+                      ShellHub Agent
+                    </text>
+
+                    {/* Container 1 */}
+                    <rect
+                      x="70"
+                      y="140"
+                      width="100"
+                      height="55"
+                      rx="6"
+                      fill={`${C.cyanDim}`}
+                      stroke={`${C.cyan}50`}
+                      strokeWidth="1"
+                    />
+                    <text
+                      x="120"
+                      y="158"
+                      textAnchor="middle"
+                      fill={C.cyan}
+                      fontSize="9"
+                      fontWeight="600"
+                      fontFamily="monospace"
+                    >
+                      nginx-proxy
+                    </text>
+                    <text
+                      x="120"
+                      y="176"
+                      textAnchor="middle"
+                      fill={C.textMuted}
+                      fontSize="8"
+                      fontFamily="monospace"
+                    >
+                      container
+                    </text>
+                    <text
+                      x="120"
+                      y="188"
+                      textAnchor="middle"
+                      fill={C.green}
+                      fontSize="8"
+                      fontFamily="monospace"
+                    >
+                      running
+                    </text>
+
+                    {/* Container 2 */}
+                    <rect
+                      x="185"
+                      y="140"
+                      width="100"
+                      height="55"
+                      rx="6"
+                      fill={`${C.cyanDim}`}
+                      stroke={`${C.cyan}50`}
+                      strokeWidth="1"
+                    />
+                    <text
+                      x="235"
+                      y="158"
+                      textAnchor="middle"
+                      fill={C.cyan}
+                      fontSize="9"
+                      fontWeight="600"
+                      fontFamily="monospace"
+                    >
+                      app-backend
+                    </text>
+                    <text
+                      x="235"
+                      y="176"
+                      textAnchor="middle"
+                      fill={C.textMuted}
+                      fontSize="8"
+                      fontFamily="monospace"
+                    >
+                      container
+                    </text>
+                    <text
+                      x="235"
+                      y="188"
+                      textAnchor="middle"
+                      fill={C.green}
+                      fontSize="8"
+                      fontFamily="monospace"
+                    >
+                      running
+                    </text>
+
+                    {/* Container 3 */}
+                    <rect
+                      x="300"
+                      y="140"
+                      width="75"
+                      height="55"
+                      rx="6"
+                      fill={`${C.cyanDim}`}
+                      stroke={`${C.cyan}50`}
+                      strokeWidth="1"
+                    />
+                    <text
+                      x="337"
+                      y="158"
+                      textAnchor="middle"
+                      fill={C.cyan}
+                      fontSize="9"
+                      fontWeight="600"
+                      fontFamily="monospace"
+                    >
+                      redis
+                    </text>
+                    <text
+                      x="337"
+                      y="176"
+                      textAnchor="middle"
+                      fill={C.textMuted}
+                      fontSize="8"
+                      fontFamily="monospace"
+                    >
+                      container
+                    </text>
+                    <text
+                      x="337"
+                      y="188"
+                      textAnchor="middle"
+                      fill={C.green}
+                      fontSize="8"
+                      fontFamily="monospace"
+                    >
+                      running
+                    </text>
+
+                    {/* Connection lines from agent to containers */}
+                    <line
+                      x1="195"
+                      y1="128"
+                      x2="120"
+                      y2="140"
+                      stroke={`${C.cyan}60`}
+                      strokeWidth="1"
+                      strokeDasharray="3 2"
+                    />
+                    <line
+                      x1="230"
+                      y1="128"
+                      x2="235"
+                      y2="140"
+                      stroke={`${C.cyan}60`}
+                      strokeWidth="1"
+                      strokeDasharray="3 2"
+                    />
+                    <line
+                      x1="265"
+                      y1="128"
+                      x2="337"
+                      y2="140"
+                      stroke={`${C.cyan}60`}
+                      strokeWidth="1"
+                      strokeDasharray="3 2"
+                    />
+                  </svg>
+                </div>
+              </div>
+
+              {/* Terminal side */}
+              <div className="p-8 lg:p-10 flex flex-col justify-center">
+                <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs mb-6">
+                  <p className="text-text-muted mb-2">
+                    # Connect to a container on a remote host
+                  </p>
+                  <Line
+                    prompt="$"
+                    cmd="ssh admin@nginx-proxy.production.shellhub"
+                  />
+                  <div className="my-2 px-2 py-1.5 bg-surface/50 rounded border border-border/50">
+                    <span className="text-accent-green text-2xs">
+                      Connected to container
+                    </span>{" "}
+                    <span className="text-accent-cyan text-2xs font-semibold">
+                      nginx-proxy
+                    </span>
+                  </div>
+                  <div className="text-text-muted mt-2 mb-1">
+                    <span className="text-accent-green">root@nginx-proxy</span>:
+                    <span className="text-accent-blue">/</span># nginx -t
+                  </div>
+                  <div className="text-text-secondary text-2xs">
+                    nginx: configuration file /etc/nginx/nginx.conf test is
+                    successful
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  {[
+                    "Same SSH workflow — no docker exec needed",
+                    "Access containers behind NAT and firewalls",
+                    "Full SCP/SFTP support for containers",
+                    "Works with Docker, Podman, and containerd",
+                  ].map((item, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center gap-2.5 text-sm text-text-secondary"
+                    >
+                      <svg
+                        className="w-4 h-4 text-accent-green shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m4.5 12.75 6 6 9-13.5"
+                        />
+                      </svg>
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </ShimmerCard>
+      </Reveal>
+    </Section>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════ */
+/*  DEVICE ORGANIZATION                                           */
+/* ═══════════════════════════════════════════════════════════════ */
+function DeviceOrganization() {
+  return (
+    <Section>
+      <SectionHeader
+        eyebrow="Device Organization"
+        title="Tags and namespaces for fleet control"
+        subtitle="Organize thousands of devices with tags for flexible grouping and namespaces for complete isolation between teams and environments."
+      />
+
+      <div className="grid md:grid-cols-2 gap-6">
+        {/* Tags card */}
+        <Reveal delay={0}>
+          <ShimmerCard className="h-full">
+            <Card hover className="p-8 h-full">
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                  <svg
+                    className="w-5 h-5 text-primary"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z"
+                    />
+                    <line x1="7" y1="7" x2="7.01" y2="7" />
+                  </svg>
+                </div>
+                <div>
+                  <h3 className="text-sm font-bold">Device Tags</h3>
+                  <p className="text-2xs text-text-muted">
+                    Flexible grouping & filtering
+                  </p>
+                </div>
+              </div>
+
+              {/* Tag mockup */}
+              <div className="space-y-2.5 mb-6">
+                {[
+                  {
+                    name: "rpi-gateway-01",
+                    tags: [
+                      { label: "production", color: C.green },
+                      { label: "gateway", color: C.primary },
+                      { label: "eu-west", color: C.blue },
+                    ],
+                  },
+                  {
+                    name: "sensor-node-04",
+                    tags: [
+                      { label: "staging", color: C.yellow },
+                      { label: "sensor", color: C.cyan },
+                    ],
+                  },
+                  {
+                    name: "edge-server-12",
+                    tags: [
+                      { label: "production", color: C.green },
+                      { label: "compute", color: C.primary },
+                      { label: "us-east", color: C.blue },
+                    ],
+                  },
+                ].map((device) => (
+                  <div
+                    key={device.name}
+                    className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border"
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                      <span className="text-xs font-mono font-medium">
+                        {device.name}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      {device.tags.map((tag) => (
+                        <span
+                          key={tag.label}
+                          className="px-2 py-0.5 text-2xs font-mono rounded-full border"
+                          style={{
+                            background: `${tag.color}12`,
+                            color: tag.color,
+                            borderColor: `${tag.color}25`,
+                          }}
+                        >
+                          {tag.label}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <ul className="space-y-2">
+                {[
+                  "Filter and group devices by custom tags",
+                  "Apply firewall rules based on tags",
+                  "Bulk operations on tagged groups",
+                ].map((item) => (
+                  <li
+                    key={item}
+                    className="flex items-center gap-2.5 text-xs text-text-secondary"
+                  >
                     <svg
-                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      className="w-3.5 h-3.5 text-accent-green shrink-0"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -919,448 +1409,24 @@ function FileTransfer() {
                         d="m4.5 12.75 6 6 9-13.5"
                       />
                     </svg>
-                    <div>
-                      <p className="text-sm font-medium text-text-primary">
-                        {item.label}
-                      </p>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {item.desc}
-                      </p>
-                    </div>
-                  </div>
-                </Reveal>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ═══════════════════════════════════════════════════════════════ */
-/*  DOCKER CONTAINER ACCESS                                       */
-/* ═══════════════════════════════════════════════════════════════ */
-function DockerAccess() {
-  return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal>
-          <ShimmerCard className="h-full">
-            <div className="relative bg-card border border-primary/30 rounded-2xl overflow-hidden shadow-[0_0_60px_rgba(102,122,204,0.08)]">
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.03] pointer-events-none" />
-              <div className="relative grid lg:grid-cols-2 gap-0">
-                {/* Diagram side */}
-                <div className="p-8 lg:p-10 border-b lg:border-b-0 lg:border-r border-border/50">
-                  <div className="mb-6">
-                    <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                      Docker Integration
-                    </p>
-                    <h2 className="text-[clamp(1.5rem,3vw,2rem)] font-bold tracking-[-0.03em] leading-tight mb-3">
-                      SSH into containers directly
-                    </h2>
-                    <p className="text-sm text-text-secondary leading-relaxed">
-                      Access Docker containers on remote hosts with the same SSH
-                      workflow you use for VMs. No need for docker exec or SSH
-                      into the host first.
-                    </p>
-                  </div>
-
-                  {/* Architecture diagram */}
-                  <div className="mt-6">
-                    <svg viewBox="0 0 400 220" className="w-full" fill="none">
-                      {/* Your workstation */}
-                      <rect
-                        x="10"
-                        y="10"
-                        width="120"
-                        height="50"
-                        rx="8"
-                        fill={`${C.surface}`}
-                        stroke={C.border}
-                        strokeWidth="1"
-                      />
-                      <text
-                        x="70"
-                        y="31"
-                        textAnchor="middle"
-                        fill={C.textSec}
-                        fontSize="9"
-                        fontFamily="monospace"
-                      >
-                        Your Workstation
-                      </text>
-                      <text
-                        x="70"
-                        y="46"
-                        textAnchor="middle"
-                        fill={C.primary}
-                        fontSize="10"
-                        fontWeight="600"
-                        fontFamily="monospace"
-                      >
-                        ssh client
-                      </text>
-
-                      {/* Arrow */}
-                      <line
-                        x1="130"
-                        y1="35"
-                        x2="165"
-                        y2="35"
-                        stroke={C.primary}
-                        strokeWidth="1.5"
-                        strokeDasharray="4 3"
-                      />
-                      <polygon points="165,31 173,35 165,39" fill={C.primary} />
-
-                      {/* ShellHub Gateway */}
-                      <rect
-                        x="175"
-                        y="10"
-                        width="110"
-                        height="50"
-                        rx="8"
-                        fill={`${C.primaryDim}`}
-                        stroke={C.primary}
-                        strokeWidth="1"
-                      />
-                      <text
-                        x="230"
-                        y="31"
-                        textAnchor="middle"
-                        fill={C.textSec}
-                        fontSize="9"
-                        fontFamily="monospace"
-                      >
-                        ShellHub
-                      </text>
-                      <text
-                        x="230"
-                        y="46"
-                        textAnchor="middle"
-                        fill={C.primary}
-                        fontSize="10"
-                        fontWeight="600"
-                        fontFamily="monospace"
-                      >
-                        Gateway
-                      </text>
-
-                      {/* Arrow down */}
-                      <line
-                        x1="230"
-                        y1="60"
-                        x2="230"
-                        y2="85"
-                        stroke={C.primary}
-                        strokeWidth="1.5"
-                        strokeDasharray="4 3"
-                      />
-                      <polygon points="226,85 230,93 234,85" fill={C.primary} />
-
-                      {/* Remote Host */}
-                      <rect
-                        x="50"
-                        y="95"
-                        width="340"
-                        height="115"
-                        rx="10"
-                        fill={`${C.surface}`}
-                        stroke={C.border}
-                        strokeWidth="1"
-                      />
-                      <text
-                        x="70"
-                        y="115"
-                        fill={C.textMuted}
-                        fontSize="9"
-                        fontFamily="monospace"
-                      >
-                        Remote Host
-                      </text>
-
-                      {/* ShellHub Agent */}
-                      <rect
-                        x="160"
-                        y="100"
-                        width="140"
-                        height="28"
-                        rx="6"
-                        fill={`${C.primaryDim}`}
-                        stroke={`${C.primary}40`}
-                        strokeWidth="1"
-                      />
-                      <text
-                        x="230"
-                        y="118"
-                        textAnchor="middle"
-                        fill={C.primary}
-                        fontSize="9"
-                        fontWeight="600"
-                        fontFamily="monospace"
-                      >
-                        ShellHub Agent
-                      </text>
-
-                      {/* Container 1 */}
-                      <rect
-                        x="70"
-                        y="140"
-                        width="100"
-                        height="55"
-                        rx="6"
-                        fill={`${C.cyanDim}`}
-                        stroke={`${C.cyan}50`}
-                        strokeWidth="1"
-                      />
-                      <text
-                        x="120"
-                        y="158"
-                        textAnchor="middle"
-                        fill={C.cyan}
-                        fontSize="9"
-                        fontWeight="600"
-                        fontFamily="monospace"
-                      >
-                        nginx-proxy
-                      </text>
-                      <text
-                        x="120"
-                        y="176"
-                        textAnchor="middle"
-                        fill={C.textMuted}
-                        fontSize="8"
-                        fontFamily="monospace"
-                      >
-                        container
-                      </text>
-                      <text
-                        x="120"
-                        y="188"
-                        textAnchor="middle"
-                        fill={C.green}
-                        fontSize="8"
-                        fontFamily="monospace"
-                      >
-                        running
-                      </text>
-
-                      {/* Container 2 */}
-                      <rect
-                        x="185"
-                        y="140"
-                        width="100"
-                        height="55"
-                        rx="6"
-                        fill={`${C.cyanDim}`}
-                        stroke={`${C.cyan}50`}
-                        strokeWidth="1"
-                      />
-                      <text
-                        x="235"
-                        y="158"
-                        textAnchor="middle"
-                        fill={C.cyan}
-                        fontSize="9"
-                        fontWeight="600"
-                        fontFamily="monospace"
-                      >
-                        app-backend
-                      </text>
-                      <text
-                        x="235"
-                        y="176"
-                        textAnchor="middle"
-                        fill={C.textMuted}
-                        fontSize="8"
-                        fontFamily="monospace"
-                      >
-                        container
-                      </text>
-                      <text
-                        x="235"
-                        y="188"
-                        textAnchor="middle"
-                        fill={C.green}
-                        fontSize="8"
-                        fontFamily="monospace"
-                      >
-                        running
-                      </text>
-
-                      {/* Container 3 */}
-                      <rect
-                        x="300"
-                        y="140"
-                        width="75"
-                        height="55"
-                        rx="6"
-                        fill={`${C.cyanDim}`}
-                        stroke={`${C.cyan}50`}
-                        strokeWidth="1"
-                      />
-                      <text
-                        x="337"
-                        y="158"
-                        textAnchor="middle"
-                        fill={C.cyan}
-                        fontSize="9"
-                        fontWeight="600"
-                        fontFamily="monospace"
-                      >
-                        redis
-                      </text>
-                      <text
-                        x="337"
-                        y="176"
-                        textAnchor="middle"
-                        fill={C.textMuted}
-                        fontSize="8"
-                        fontFamily="monospace"
-                      >
-                        container
-                      </text>
-                      <text
-                        x="337"
-                        y="188"
-                        textAnchor="middle"
-                        fill={C.green}
-                        fontSize="8"
-                        fontFamily="monospace"
-                      >
-                        running
-                      </text>
-
-                      {/* Connection lines from agent to containers */}
-                      <line
-                        x1="195"
-                        y1="128"
-                        x2="120"
-                        y2="140"
-                        stroke={`${C.cyan}60`}
-                        strokeWidth="1"
-                        strokeDasharray="3 2"
-                      />
-                      <line
-                        x1="230"
-                        y1="128"
-                        x2="235"
-                        y2="140"
-                        stroke={`${C.cyan}60`}
-                        strokeWidth="1"
-                        strokeDasharray="3 2"
-                      />
-                      <line
-                        x1="265"
-                        y1="128"
-                        x2="337"
-                        y2="140"
-                        stroke={`${C.cyan}60`}
-                        strokeWidth="1"
-                        strokeDasharray="3 2"
-                      />
-                    </svg>
-                  </div>
-                </div>
-
-                {/* Terminal side */}
-                <div className="p-8 lg:p-10 flex flex-col justify-center">
-                  <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs mb-6">
-                    <p className="text-text-muted mb-2">
-                      # Connect to a container on a remote host
-                    </p>
-                    <Line
-                      prompt="$"
-                      cmd="ssh admin@nginx-proxy.production.shellhub"
-                    />
-                    <div className="my-2 px-2 py-1.5 bg-surface/50 rounded border border-border/50">
-                      <span className="text-accent-green text-2xs">
-                        Connected to container
-                      </span>{" "}
-                      <span className="text-accent-cyan text-2xs font-semibold">
-                        nginx-proxy
-                      </span>
-                    </div>
-                    <div className="text-text-muted mt-2 mb-1">
-                      <span className="text-accent-green">
-                        root@nginx-proxy
-                      </span>
-                      :<span className="text-accent-blue">/</span># nginx -t
-                    </div>
-                    <div className="text-text-secondary text-2xs">
-                      nginx: configuration file /etc/nginx/nginx.conf test is
-                      successful
-                    </div>
-                  </div>
-
-                  <div className="space-y-3">
-                    {[
-                      "Same SSH workflow — no docker exec needed",
-                      "Access containers behind NAT and firewalls",
-                      "Full SCP/SFTP support for containers",
-                      "Works with Docker, Podman, and containerd",
-                    ].map((item, i) => (
-                      <div
-                        key={i}
-                        className="flex items-center gap-2.5 text-sm text-text-secondary"
-                      >
-                        <svg
-                          className="w-4 h-4 text-accent-green shrink-0"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m4.5 12.75 6 6 9-13.5"
-                          />
-                        </svg>
-                        {item}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </div>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </Card>
           </ShimmerCard>
         </Reveal>
-      </div>
-    </section>
-  );
-}
 
-/* ═══════════════════════════════════════════════════════════════ */
-/*  DEVICE ORGANIZATION                                           */
-/* ═══════════════════════════════════════════════════════════════ */
-function DeviceOrganization() {
-  return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Device Organization
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-            Tags and namespaces for fleet control
-          </h2>
-          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            Organize thousands of devices with tags for flexible grouping and
-            namespaces for complete isolation between teams and environments.
-          </p>
-        </Reveal>
-
-        <div className="grid md:grid-cols-2 gap-6">
-          {/* Tags card */}
-          <Reveal delay={0}>
-            <ShimmerCard className="h-full">
-              <Card hover className="p-8 h-full">
+        {/* Namespaces card */}
+        <Reveal delay={0.1}>
+          <ShimmerCard className="h-full">
+            <div className="relative bg-card border border-accent-cyan/30 rounded-xl p-8 h-full hover:border-accent-cyan/50 transition-all duration-300 shadow-[0_0_40px_rgba(78,154,163,0.08)] overflow-hidden">
+              <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.04] via-transparent to-transparent pointer-events-none" />
+              <div className="relative">
                 <div className="flex items-center gap-3 mb-6">
-                  <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                  <div className="w-10 h-10 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center">
                     <svg
-                      className="w-5 h-5 text-primary"
+                      className="w-5 h-5 text-accent-cyan"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -1369,80 +1435,80 @@ function DeviceOrganization() {
                       <path
                         strokeLinecap="round"
                         strokeLinejoin="round"
-                        d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z"
+                        d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"
                       />
-                      <line x1="7" y1="7" x2="7.01" y2="7" />
                     </svg>
                   </div>
                   <div>
-                    <h3 className="text-sm font-bold">Device Tags</h3>
-                    <p className="text-2xs text-text-muted">
-                      Flexible grouping & filtering
+                    <h3 className="text-sm font-bold">Namespaces</h3>
+                    <p className="text-2xs text-accent-cyan">
+                      Full multi-tenancy
                     </p>
                   </div>
                 </div>
 
-                {/* Tag mockup */}
+                {/* Namespace mockup */}
                 <div className="space-y-2.5 mb-6">
                   {[
                     {
-                      name: "rpi-gateway-01",
-                      tags: [
-                        { label: "production", color: C.green },
-                        { label: "gateway", color: C.primary },
-                        { label: "eu-west", color: C.blue },
-                      ],
+                      name: "production",
+                      devices: 142,
+                      members: 8,
+                      color: C.green,
                     },
                     {
-                      name: "sensor-node-04",
-                      tags: [
-                        { label: "staging", color: C.yellow },
-                        { label: "sensor", color: C.cyan },
-                      ],
+                      name: "staging",
+                      devices: 36,
+                      members: 12,
+                      color: C.yellow,
                     },
                     {
-                      name: "edge-server-12",
-                      tags: [
-                        { label: "production", color: C.green },
-                        { label: "compute", color: C.primary },
-                        { label: "us-east", color: C.blue },
-                      ],
+                      name: "development",
+                      devices: 18,
+                      members: 5,
+                      color: C.blue,
                     },
-                  ].map((device) => (
+                  ].map((ns) => (
                     <div
-                      key={device.name}
+                      key={ns.name}
                       className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border"
                     >
                       <div className="flex items-center gap-2.5">
-                        <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                        <span className="text-xs font-mono font-medium">
-                          {device.name}
-                        </span>
+                        <div
+                          className="w-2 h-6 rounded-sm"
+                          style={{ background: ns.color }}
+                        />
+                        <div>
+                          <p className="text-xs font-mono font-medium">
+                            {ns.name}
+                          </p>
+                          <p className="text-2xs text-text-muted">
+                            {ns.devices} devices &middot; {ns.members} members
+                          </p>
+                        </div>
                       </div>
-                      <div className="flex items-center gap-1.5">
-                        {device.tags.map((tag) => (
-                          <span
-                            key={tag.label}
-                            className="px-2 py-0.5 text-2xs font-mono rounded-full border"
-                            style={{
-                              background: `${tag.color}12`,
-                              color: tag.color,
-                              borderColor: `${tag.color}25`,
-                            }}
-                          >
-                            {tag.label}
-                          </span>
-                        ))}
-                      </div>
+                      <svg
+                        className="w-4 h-4 text-text-muted"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m8.25 4.5 7.5 7.5-7.5 7.5"
+                        />
+                      </svg>
                     </div>
                   ))}
                 </div>
 
                 <ul className="space-y-2">
                   {[
-                    "Filter and group devices by custom tags",
-                    "Apply firewall rules based on tags",
-                    "Bulk operations on tagged groups",
+                    "Complete isolation between environments",
+                    "Separate members, devices, and policies",
+                    "Independent firewall rules per namespace",
                   ].map((item) => (
                     <li
                       key={item}
@@ -1465,131 +1531,12 @@ function DeviceOrganization() {
                     </li>
                   ))}
                 </ul>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-
-          {/* Namespaces card */}
-          <Reveal delay={0.1}>
-            <ShimmerCard className="h-full">
-              <div className="relative bg-card border border-accent-cyan/30 rounded-xl p-8 h-full hover:border-accent-cyan/50 transition-all duration-300 shadow-[0_0_40px_rgba(78,154,163,0.08)] overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.04] via-transparent to-transparent pointer-events-none" />
-                <div className="relative">
-                  <div className="flex items-center gap-3 mb-6">
-                    <div className="w-10 h-10 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center">
-                      <svg
-                        className="w-5 h-5 text-accent-cyan"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={1.5}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"
-                        />
-                      </svg>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-bold">Namespaces</h3>
-                      <p className="text-2xs text-accent-cyan">
-                        Full multi-tenancy
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Namespace mockup */}
-                  <div className="space-y-2.5 mb-6">
-                    {[
-                      {
-                        name: "production",
-                        devices: 142,
-                        members: 8,
-                        color: C.green,
-                      },
-                      {
-                        name: "staging",
-                        devices: 36,
-                        members: 12,
-                        color: C.yellow,
-                      },
-                      {
-                        name: "development",
-                        devices: 18,
-                        members: 5,
-                        color: C.blue,
-                      },
-                    ].map((ns) => (
-                      <div
-                        key={ns.name}
-                        className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border"
-                      >
-                        <div className="flex items-center gap-2.5">
-                          <div
-                            className="w-2 h-6 rounded-sm"
-                            style={{ background: ns.color }}
-                          />
-                          <div>
-                            <p className="text-xs font-mono font-medium">
-                              {ns.name}
-                            </p>
-                            <p className="text-2xs text-text-muted">
-                              {ns.devices} devices &middot; {ns.members} members
-                            </p>
-                          </div>
-                        </div>
-                        <svg
-                          className="w-4 h-4 text-text-muted"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m8.25 4.5 7.5 7.5-7.5 7.5"
-                          />
-                        </svg>
-                      </div>
-                    ))}
-                  </div>
-
-                  <ul className="space-y-2">
-                    {[
-                      "Complete isolation between environments",
-                      "Separate members, devices, and policies",
-                      "Independent firewall rules per namespace",
-                    ].map((item) => (
-                      <li
-                        key={item}
-                        className="flex items-center gap-2.5 text-xs text-text-secondary"
-                      >
-                        <svg
-                          className="w-3.5 h-3.5 text-accent-green shrink-0"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m4.5 12.75 6 6 9-13.5"
-                          />
-                        </svg>
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
               </div>
-            </ShimmerCard>
-          </Reveal>
-        </div>
+            </div>
+          </ShimmerCard>
+        </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }
 
@@ -1598,45 +1545,39 @@ function DeviceOrganization() {
 /* ═══════════════════════════════════════════════════════════════ */
 function FeaturesCTA() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
+    <Section>
+      <Reveal>
+        <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+          <ConnectionGrid />
+          <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
 
-            <div className="relative z-10">
-              <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                Ready to get started?
-              </p>
-              <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                Deploy ShellHub in minutes
-              </h2>
-              <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                Open-source and free to start. Run a single command and manage
-                your first device in under five minutes.
-              </p>
+          <div className="relative z-10">
+            <SectionHeader
+              variant="cta"
+              eyebrow="Ready to get started?"
+              title="Deploy ShellHub in minutes"
+              subtitle="Open-source and free to start. Run a single command and manage your first device in under five minutes."
+            />
 
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as={Link}
-                  to="/getting-started"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Get Started Free
-                </Button>
-                <Button as={Link} to="/pricing" variant="outline" size="xl">
-                  View Pricing
-                </Button>
-              </div>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+              <Button
+                as={Link}
+                to="/getting-started"
+                variant="primary"
+                size="xl"
+                glow
+                iconRight={<ArrowRight />}
+              >
+                Get Started Free
+              </Button>
+              <Button as={Link} to="/pricing" variant="outline" size="xl">
+                View Pricing
+              </Button>
             </div>
           </div>
-        </Reveal>
-      </div>
-    </section>
+        </div>
+      </Reveal>
+    </Section>
   );
 }
 

--- a/ui/apps/website/src/pages/getting-started/StepPath.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepPath.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   IconBadge,
 } from "@shellhub/design-system/primitives";
+import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 interface StepPathProps {
@@ -45,25 +46,9 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
                   "Managed updates",
                   "No maintenance",
                 ].map((item) => (
-                  <li
-                    key={item}
-                    className="flex items-center gap-2.5 text-sm text-text-secondary"
-                  >
-                    <svg
-                      className="w-4 h-4 text-accent-green shrink-0"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="m4.5 12.75 6 6 9-13.5"
-                      />
-                    </svg>
+                  <FeatureListItem key={item} color="green">
                     {item}
-                  </li>
+                  </FeatureListItem>
                 ))}
               </ul>
 
@@ -113,25 +98,9 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
               <ul className="space-y-2.5 mb-8 flex-1">
                 {["Open source", "Your data stays yours", "Docker Compose"].map(
                   (item) => (
-                    <li
-                      key={item}
-                      className="flex items-center gap-2.5 text-sm text-text-secondary"
-                    >
-                      <svg
-                        className="w-4 h-4 text-text-muted shrink-0"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
+                    <FeatureListItem key={item} color="muted">
                       {item}
-                    </li>
+                    </FeatureListItem>
                   ),
                 )}
               </ul>

--- a/ui/apps/website/src/pages/getting-started/StepSetup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSetup.tsx
@@ -75,7 +75,7 @@ export function StepSetup({ onBack }: StepSetupProps) {
             href={`${docsUrl}/getting-started`}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-[#7B8EDB] hover:gap-2.5 transition-all group"
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:gap-2.5 transition-all group"
           >
             Full documentation
             <svg

--- a/ui/apps/website/src/pages/getting-started/StepSignup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSignup.tsx
@@ -233,7 +233,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
             <div>
               <label
                 htmlFor="signup-name"
-                className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5"
+                className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-1.5"
               >
                 Name
               </label>
@@ -264,7 +264,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
             <div>
               <label
                 htmlFor="signup-email"
-                className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5"
+                className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-1.5"
               >
                 Email
               </label>
@@ -298,7 +298,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
             <div>
               <label
                 htmlFor="signup-password"
-                className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5"
+                className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-1.5"
               >
                 Password
               </label>
@@ -373,7 +373,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
             <div>
               <label
                 htmlFor="signup-confirm-password"
-                className="block text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-muted mb-1.5"
+                className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-1.5"
               >
                 Confirm password
               </label>

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -210,1117 +211,1031 @@ export default function HowItWorks() {
       </section>
 
       {/* ── Architecture Diagram ─────────────────────────────────── */}
-      <section id="architecture" className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Architecture
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              The full picture, from user to device
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Every connection flows through the ShellHub gateway where it is
-              authenticated, encrypted, and logged before reaching the target
-              device.
-            </p>
-          </Reveal>
+      <Section id="architecture">
+        <SectionHeader
+          eyebrow="Architecture"
+          title="The full picture, from user to device"
+          subtitle="Every connection flows through the ShellHub gateway where it is authenticated, encrypted, and logged before reaching the target device."
+        />
 
-          <Reveal>
-            <ShimmerCard>
-              <Card className="p-6 lg:p-10 overflow-x-auto">
-                <svg
-                  viewBox="0 0 960 340"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="w-full h-auto min-w-[720px]"
+        <Reveal>
+          <ShimmerCard>
+            <Card className="p-6 lg:p-10 overflow-x-auto">
+              <svg
+                viewBox="0 0 960 340"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-full h-auto min-w-[720px]"
+              >
+                <defs>
+                  <marker
+                    id="hw-a-pri"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={C.primary} />
+                  </marker>
+                  <marker
+                    id="hw-a-grn"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={C.green} />
+                  </marker>
+                  <marker
+                    id="hw-a-dim"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={`${C.primary}60`} />
+                  </marker>
+                </defs>
+
+                {/* ── User ── */}
+                <text
+                  x="70"
+                  y="24"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                  letterSpacing=".1em"
                 >
-                  <defs>
-                    <marker
-                      id="hw-a-pri"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
+                  YOU
+                </text>
+                <rect
+                  x="20"
+                  y="36"
+                  width="100"
+                  height="90"
+                  rx="12"
+                  fill={C.card}
+                  stroke={C.border}
+                  strokeWidth="1.2"
+                />
+                <circle
+                  cx="70"
+                  cy="62"
+                  r="14"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  fill="none"
+                />
+                <circle cx="70" cy="58" r="4.5" fill={C.primary} />
+                <path
+                  d="M70 63 L70 67 M63 65 L77 65"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+                <text
+                  x="70"
+                  y="100"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Any location
+                </text>
+                <text
+                  x="70"
+                  y="114"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="8"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                >
+                  laptop / browser
+                </text>
+
+                {/* ── Arrow: User to Gateway ── */}
+                <line
+                  x1="125"
+                  y1="80"
+                  x2="260"
+                  y2="80"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  strokeDasharray="6 4"
+                  markerEnd="url(#hw-a-pri)"
+                />
+                <rect
+                  x="155"
+                  y="58"
+                  width="68"
+                  height="16"
+                  rx="4"
+                  fill={C.bg}
+                />
+                <text
+                  x="189"
+                  y="70"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="8"
+                  fill={C.primary}
+                  textAnchor="middle"
+                >
+                  SSH / HTTPS
+                </text>
+
+                {/* ── ShellHub Cloud ── */}
+                <rect
+                  x="265"
+                  y="20"
+                  width="330"
+                  height="290"
+                  rx="16"
+                  fill={`${C.primary}08`}
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                />
+                <text
+                  x="430"
+                  y="14"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="12"
+                  fill={C.primary}
+                  textAnchor="middle"
+                  fontWeight="600"
+                  letterSpacing=".1em"
+                >
+                  SHELLHUB CLOUD
+                </text>
+
+                {/* Logo badge */}
+                <rect
+                  x="395"
+                  y="38"
+                  width="70"
+                  height="36"
+                  rx="10"
+                  fill={C.primaryDim}
+                  stroke={C.primary}
+                  strokeWidth="1"
+                />
+                <text
+                  x="430"
+                  y="62"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="16"
+                  fill={C.primary}
+                  textAnchor="middle"
+                  fontWeight="700"
+                >
+                  SH
+                </text>
+
+                {/* Internal modules */}
+                {[
+                  {
+                    x: 285,
+                    y: 100,
+                    label: "Authentication",
+                    color: C.primary,
+                    icon: "lock",
+                  },
+                  {
+                    x: 285,
+                    y: 140,
+                    label: "TLS Encryption",
+                    color: C.primary,
+                    icon: "shield",
+                  },
+                  {
+                    x: 285,
+                    y: 180,
+                    label: "Session Recording",
+                    color: C.cyan,
+                    icon: "rec",
+                  },
+                  {
+                    x: 285,
+                    y: 220,
+                    label: "Connection Router",
+                    color: C.green,
+                    icon: "route",
+                  },
+                  {
+                    x: 445,
+                    y: 100,
+                    label: "Firewall Rules",
+                    color: C.yellow,
+                    icon: "fire",
+                  },
+                  {
+                    x: 445,
+                    y: 140,
+                    label: "Audit Logging",
+                    color: C.green,
+                    icon: "log",
+                  },
+                  {
+                    x: 445,
+                    y: 180,
+                    label: "Team RBAC",
+                    color: C.primary,
+                    icon: "team",
+                  },
+                  {
+                    x: 445,
+                    y: 220,
+                    label: "Device Registry",
+                    color: C.blue,
+                    icon: "device",
+                  },
+                ].map((m, i) => (
+                  <g key={i}>
+                    <rect
+                      x={m.x}
+                      y={m.y}
+                      width="130"
+                      height="30"
+                      rx="6"
+                      fill={C.card}
+                      stroke={C.border}
+                    />
+                    <circle
+                      cx={m.x + 16}
+                      cy={m.y + 15}
+                      r="5"
+                      fill={`${m.color}30`}
+                      stroke={m.color}
+                      strokeWidth=".8"
+                    />
+                    <text
+                      x={m.x + 32}
+                      y={m.y + 19}
+                      fontFamily="IBM Plex Sans"
+                      fontSize="9"
+                      fill={C.textSec}
                     >
-                      <path d="M0,0 L8,3 L0,6" fill={C.primary} />
-                    </marker>
-                    <marker
-                      id="hw-a-grn"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
+                      {m.label}
+                    </text>
+                  </g>
+                ))}
+
+                {/* Gateway label */}
+                <text
+                  x="430"
+                  y="278"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="8"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                >
+                  CLOUD OR SELF-HOSTED
+                </text>
+
+                {/* ── NAT Wall ── */}
+                <rect
+                  x="630"
+                  y="30"
+                  width="8"
+                  height="270"
+                  rx="4"
+                  fill={C.border}
+                />
+                <rect
+                  x="630"
+                  y="30"
+                  width="8"
+                  height="270"
+                  rx="4"
+                  fill={`${C.red}12`}
+                />
+                <text
+                  x="634"
+                  y="22"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                >
+                  NAT
+                </text>
+
+                {/* ── Arrow: Gateway to NAT ── */}
+                <line
+                  x1="600"
+                  y1="115"
+                  x2="626"
+                  y2="115"
+                  stroke={C.green}
+                  strokeWidth="1.5"
+                  markerEnd="url(#hw-a-grn)"
+                />
+
+                {/* ── Arrows: NAT to Devices ── */}
+                <line
+                  x1="642"
+                  y1="85"
+                  x2="678"
+                  y2="65"
+                  stroke={`${C.primary}60`}
+                  strokeWidth="1.2"
+                  strokeDasharray="4 3"
+                  markerEnd="url(#hw-a-dim)"
+                />
+                <line
+                  x1="642"
+                  y1="125"
+                  x2="678"
+                  y2="140"
+                  stroke={`${C.primary}60`}
+                  strokeWidth="1.2"
+                  strokeDasharray="4 3"
+                  markerEnd="url(#hw-a-dim)"
+                />
+                <line
+                  x1="642"
+                  y1="175"
+                  x2="678"
+                  y2="215"
+                  stroke={`${C.primary}60`}
+                  strokeWidth="1.2"
+                  strokeDasharray="4 3"
+                  markerEnd="url(#hw-a-dim)"
+                />
+                <line
+                  x1="642"
+                  y1="220"
+                  x2="678"
+                  y2="280"
+                  stroke={`${C.primary}60`}
+                  strokeWidth="1.2"
+                  strokeDasharray="4 3"
+                  markerEnd="url(#hw-a-dim)"
+                />
+
+                <text
+                  x="658"
+                  y="170"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={`${C.primary}50`}
+                  textAnchor="middle"
+                  transform="rotate(-90,658,170)"
+                >
+                  NAT Traversal
+                </text>
+
+                {/* ── YOUR DEVICES label ── */}
+                <text
+                  x="790"
+                  y="22"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                  letterSpacing=".1em"
+                >
+                  YOUR DEVICES
+                </text>
+
+                {/* ── Devices ── */}
+                {[
+                  {
+                    y: 36,
+                    icon: "Pi",
+                    iconBg: C.green,
+                    label: "Raspberry Pi",
+                    sub: "armv7 / aarch64",
+                    begin: "0s",
+                  },
+                  {
+                    y: 112,
+                    icon: "srv",
+                    iconBg: C.primary,
+                    label: "Linux Server",
+                    sub: "Ubuntu / Debian / RHEL",
+                    begin: ".5s",
+                  },
+                  {
+                    y: 188,
+                    icon: "dk",
+                    iconBg: C.blue,
+                    label: "Docker Host",
+                    sub: "container agent",
+                    begin: "1s",
+                  },
+                  {
+                    y: 264,
+                    icon: "iot",
+                    iconBg: C.yellow,
+                    label: "IoT Gateway",
+                    sub: "OpenWrt / Yocto",
+                    begin: "1.5s",
+                  },
+                ].map((d, i) => (
+                  <g key={i}>
+                    <rect
+                      x="682"
+                      y={d.y}
+                      width="160"
+                      height="60"
+                      rx="10"
+                      fill={C.card}
+                      stroke={C.border}
+                    />
+                    {/* icon box */}
+                    <rect
+                      x="696"
+                      y={d.y + 12}
+                      width="28"
+                      height="20"
+                      rx="4"
+                      fill={`${d.iconBg}15`}
+                      stroke={d.iconBg}
+                      strokeWidth=".8"
+                    />
+                    <text
+                      x="710"
+                      y={d.y + 26}
+                      fontSize="9"
+                      fill={d.iconBg}
+                      textAnchor="middle"
+                      fontFamily="IBM Plex Mono"
+                      fontWeight="600"
                     >
-                      <path d="M0,0 L8,3 L0,6" fill={C.green} />
-                    </marker>
-                    <marker
-                      id="hw-a-dim"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
+                      {d.icon === "Pi"
+                        ? "Pi"
+                        : d.icon === "srv"
+                          ? ">_"
+                          : d.icon === "dk"
+                            ? "dk"
+                            : "IoT"}
+                    </text>
+                    {/* labels */}
+                    <text
+                      x="736"
+                      y={d.y + 24}
+                      fontFamily="IBM Plex Sans"
+                      fontSize="10"
+                      fill={C.text}
                     >
-                      <path d="M0,0 L8,3 L0,6" fill={`${C.primary}60`} />
-                    </marker>
-                  </defs>
-
-                  {/* ── User ── */}
-                  <text
-                    x="70"
-                    y="24"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                    letterSpacing=".1em"
-                  >
-                    YOU
-                  </text>
-                  <rect
-                    x="20"
-                    y="36"
-                    width="100"
-                    height="90"
-                    rx="12"
-                    fill={C.card}
-                    stroke={C.border}
-                    strokeWidth="1.2"
-                  />
-                  <circle
-                    cx="70"
-                    cy="62"
-                    r="14"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    fill="none"
-                  />
-                  <circle cx="70" cy="58" r="4.5" fill={C.primary} />
-                  <path
-                    d="M70 63 L70 67 M63 65 L77 65"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                  <text
-                    x="70"
-                    y="100"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Any location
-                  </text>
-                  <text
-                    x="70"
-                    y="114"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="8"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                  >
-                    laptop / browser
-                  </text>
-
-                  {/* ── Arrow: User to Gateway ── */}
-                  <line
-                    x1="125"
-                    y1="80"
-                    x2="260"
-                    y2="80"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    strokeDasharray="6 4"
-                    markerEnd="url(#hw-a-pri)"
-                  />
-                  <rect
-                    x="155"
-                    y="58"
-                    width="68"
-                    height="16"
-                    rx="4"
-                    fill={C.bg}
-                  />
-                  <text
-                    x="189"
-                    y="70"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="8"
-                    fill={C.primary}
-                    textAnchor="middle"
-                  >
-                    SSH / HTTPS
-                  </text>
-
-                  {/* ── ShellHub Cloud ── */}
-                  <rect
-                    x="265"
-                    y="20"
-                    width="330"
-                    height="290"
-                    rx="16"
-                    fill={`${C.primary}08`}
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                  />
-                  <text
-                    x="430"
-                    y="14"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="12"
-                    fill={C.primary}
-                    textAnchor="middle"
-                    fontWeight="600"
-                    letterSpacing=".1em"
-                  >
-                    SHELLHUB CLOUD
-                  </text>
-
-                  {/* Logo badge */}
-                  <rect
-                    x="395"
-                    y="38"
-                    width="70"
-                    height="36"
-                    rx="10"
-                    fill={C.primaryDim}
-                    stroke={C.primary}
-                    strokeWidth="1"
-                  />
-                  <text
-                    x="430"
-                    y="62"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="16"
-                    fill={C.primary}
-                    textAnchor="middle"
-                    fontWeight="700"
-                  >
-                    SH
-                  </text>
-
-                  {/* Internal modules */}
-                  {[
-                    {
-                      x: 285,
-                      y: 100,
-                      label: "Authentication",
-                      color: C.primary,
-                      icon: "lock",
-                    },
-                    {
-                      x: 285,
-                      y: 140,
-                      label: "TLS Encryption",
-                      color: C.primary,
-                      icon: "shield",
-                    },
-                    {
-                      x: 285,
-                      y: 180,
-                      label: "Session Recording",
-                      color: C.cyan,
-                      icon: "rec",
-                    },
-                    {
-                      x: 285,
-                      y: 220,
-                      label: "Connection Router",
-                      color: C.green,
-                      icon: "route",
-                    },
-                    {
-                      x: 445,
-                      y: 100,
-                      label: "Firewall Rules",
-                      color: C.yellow,
-                      icon: "fire",
-                    },
-                    {
-                      x: 445,
-                      y: 140,
-                      label: "Audit Logging",
-                      color: C.green,
-                      icon: "log",
-                    },
-                    {
-                      x: 445,
-                      y: 180,
-                      label: "Team RBAC",
-                      color: C.primary,
-                      icon: "team",
-                    },
-                    {
-                      x: 445,
-                      y: 220,
-                      label: "Device Registry",
-                      color: C.blue,
-                      icon: "device",
-                    },
-                  ].map((m, i) => (
-                    <g key={i}>
-                      <rect
-                        x={m.x}
-                        y={m.y}
-                        width="130"
-                        height="30"
-                        rx="6"
-                        fill={C.card}
-                        stroke={C.border}
+                      {d.label}
+                    </text>
+                    <text
+                      x="736"
+                      y={d.y + 38}
+                      fontFamily="IBM Plex Mono"
+                      fontSize="7"
+                      fill={C.textMuted}
+                    >
+                      {d.sub}
+                    </text>
+                    <text
+                      x="736"
+                      y={d.y + 50}
+                      fontFamily="IBM Plex Mono"
+                      fontSize="7"
+                      fill={C.textMuted}
+                    >
+                      agent running
+                    </text>
+                    {/* animated status dot */}
+                    <circle cx="834" cy={d.y + 10} r="3.5" fill={C.green}>
+                      <animate
+                        attributeName="opacity"
+                        values="1;.3;1"
+                        dur="2s"
+                        repeatCount="indefinite"
+                        begin={d.begin}
                       />
-                      <circle
-                        cx={m.x + 16}
-                        cy={m.y + 15}
-                        r="5"
-                        fill={`${m.color}30`}
-                        stroke={m.color}
-                        strokeWidth=".8"
-                      />
-                      <text
-                        x={m.x + 32}
-                        y={m.y + 19}
-                        fontFamily="IBM Plex Sans"
-                        fontSize="9"
-                        fill={C.textSec}
-                      >
-                        {m.label}
-                      </text>
-                    </g>
-                  ))}
-
-                  {/* Gateway label */}
-                  <text
-                    x="430"
-                    y="278"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="8"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                  >
-                    CLOUD OR SELF-HOSTED
-                  </text>
-
-                  {/* ── NAT Wall ── */}
-                  <rect
-                    x="630"
-                    y="30"
-                    width="8"
-                    height="270"
-                    rx="4"
-                    fill={C.border}
-                  />
-                  <rect
-                    x="630"
-                    y="30"
-                    width="8"
-                    height="270"
-                    rx="4"
-                    fill={`${C.red}12`}
-                  />
-                  <text
-                    x="634"
-                    y="22"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                  >
-                    NAT
-                  </text>
-
-                  {/* ── Arrow: Gateway to NAT ── */}
-                  <line
-                    x1="600"
-                    y1="115"
-                    x2="626"
-                    y2="115"
-                    stroke={C.green}
-                    strokeWidth="1.5"
-                    markerEnd="url(#hw-a-grn)"
-                  />
-
-                  {/* ── Arrows: NAT to Devices ── */}
-                  <line
-                    x1="642"
-                    y1="85"
-                    x2="678"
-                    y2="65"
-                    stroke={`${C.primary}60`}
-                    strokeWidth="1.2"
-                    strokeDasharray="4 3"
-                    markerEnd="url(#hw-a-dim)"
-                  />
-                  <line
-                    x1="642"
-                    y1="125"
-                    x2="678"
-                    y2="140"
-                    stroke={`${C.primary}60`}
-                    strokeWidth="1.2"
-                    strokeDasharray="4 3"
-                    markerEnd="url(#hw-a-dim)"
-                  />
-                  <line
-                    x1="642"
-                    y1="175"
-                    x2="678"
-                    y2="215"
-                    stroke={`${C.primary}60`}
-                    strokeWidth="1.2"
-                    strokeDasharray="4 3"
-                    markerEnd="url(#hw-a-dim)"
-                  />
-                  <line
-                    x1="642"
-                    y1="220"
-                    x2="678"
-                    y2="280"
-                    stroke={`${C.primary}60`}
-                    strokeWidth="1.2"
-                    strokeDasharray="4 3"
-                    markerEnd="url(#hw-a-dim)"
-                  />
-
-                  <text
-                    x="658"
-                    y="170"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={`${C.primary}50`}
-                    textAnchor="middle"
-                    transform="rotate(-90,658,170)"
-                  >
-                    NAT Traversal
-                  </text>
-
-                  {/* ── YOUR DEVICES label ── */}
-                  <text
-                    x="790"
-                    y="22"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                    letterSpacing=".1em"
-                  >
-                    YOUR DEVICES
-                  </text>
-
-                  {/* ── Devices ── */}
-                  {[
-                    {
-                      y: 36,
-                      icon: "Pi",
-                      iconBg: C.green,
-                      label: "Raspberry Pi",
-                      sub: "armv7 / aarch64",
-                      begin: "0s",
-                    },
-                    {
-                      y: 112,
-                      icon: "srv",
-                      iconBg: C.primary,
-                      label: "Linux Server",
-                      sub: "Ubuntu / Debian / RHEL",
-                      begin: ".5s",
-                    },
-                    {
-                      y: 188,
-                      icon: "dk",
-                      iconBg: C.blue,
-                      label: "Docker Host",
-                      sub: "container agent",
-                      begin: "1s",
-                    },
-                    {
-                      y: 264,
-                      icon: "iot",
-                      iconBg: C.yellow,
-                      label: "IoT Gateway",
-                      sub: "OpenWrt / Yocto",
-                      begin: "1.5s",
-                    },
-                  ].map((d, i) => (
-                    <g key={i}>
-                      <rect
-                        x="682"
-                        y={d.y}
-                        width="160"
-                        height="60"
-                        rx="10"
-                        fill={C.card}
-                        stroke={C.border}
-                      />
-                      {/* icon box */}
-                      <rect
-                        x="696"
-                        y={d.y + 12}
-                        width="28"
-                        height="20"
-                        rx="4"
-                        fill={`${d.iconBg}15`}
-                        stroke={d.iconBg}
-                        strokeWidth=".8"
-                      />
-                      <text
-                        x="710"
-                        y={d.y + 26}
-                        fontSize="9"
-                        fill={d.iconBg}
-                        textAnchor="middle"
-                        fontFamily="IBM Plex Mono"
-                        fontWeight="600"
-                      >
-                        {d.icon === "Pi"
-                          ? "Pi"
-                          : d.icon === "srv"
-                            ? ">_"
-                            : d.icon === "dk"
-                              ? "dk"
-                              : "IoT"}
-                      </text>
-                      {/* labels */}
-                      <text
-                        x="736"
-                        y={d.y + 24}
-                        fontFamily="IBM Plex Sans"
-                        fontSize="10"
-                        fill={C.text}
-                      >
-                        {d.label}
-                      </text>
-                      <text
-                        x="736"
-                        y={d.y + 38}
-                        fontFamily="IBM Plex Mono"
-                        fontSize="7"
-                        fill={C.textMuted}
-                      >
-                        {d.sub}
-                      </text>
-                      <text
-                        x="736"
-                        y={d.y + 50}
-                        fontFamily="IBM Plex Mono"
-                        fontSize="7"
-                        fill={C.textMuted}
-                      >
-                        agent running
-                      </text>
-                      {/* animated status dot */}
-                      <circle cx="834" cy={d.y + 10} r="3.5" fill={C.green}>
-                        <animate
-                          attributeName="opacity"
-                          values="1;.3;1"
-                          dur="2s"
-                          repeatCount="indefinite"
-                          begin={d.begin}
-                        />
-                      </circle>
-                    </g>
-                  ))}
-                </svg>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-        </div>
-      </section>
+                    </circle>
+                  </g>
+                ))}
+              </svg>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
+      </Section>
 
       {/* ── 3-Step Process (Vertical Timeline) ───────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-16">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Getting Started
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Three steps to secure remote access
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              From first install to first connection in under five minutes.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Getting Started"
+          title="Three steps to secure remote access"
+          subtitle="From first install to first connection in under five minutes."
+          className="mb-16"
+        />
 
-          <div className="relative max-w-4xl mx-auto">
-            {/* Timeline line */}
-            <div className="absolute left-8 lg:left-1/2 top-0 bottom-0 w-px bg-border hidden md:block" />
+        <div className="relative max-w-4xl mx-auto">
+          {/* Timeline line */}
+          <div className="absolute left-8 lg:left-1/2 top-0 bottom-0 w-px bg-border hidden md:block" />
 
-            {/* Step 1: Install Agent */}
-            <Reveal>
-              <div className="relative grid md:grid-cols-2 gap-8 mb-16">
-                {/* Timeline dot */}
-                <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-primary border-2 border-background z-10 hidden md:block" />
+          {/* Step 1: Install Agent */}
+          <Reveal>
+            <div className="relative grid md:grid-cols-2 gap-8 mb-16">
+              {/* Timeline dot */}
+              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-primary border-2 border-background z-10 hidden md:block" />
 
-                <div className="md:pr-12 md:text-right">
-                  <div className="flex items-center gap-3 mb-4 md:justify-end">
-                    <span className="w-10 h-10 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center text-sm font-bold font-mono text-primary">
-                      01
-                    </span>
-                    <span className="text-2xs font-mono font-semibold uppercase tracking-[0.1em] text-primary">
-                      Install
-                    </span>
-                  </div>
-                  <h3 className="text-lg font-bold tracking-[-0.02em] mb-3">
-                    Install the ShellHub Agent
-                  </h3>
-                  <p className="text-sm text-text-secondary leading-relaxed mb-4">
-                    Deploy a lightweight agent on each device you want to
-                    manage. One command works on any Linux system, Raspberry Pi,
-                    container, or VM.
-                  </p>
-                  <ul className="space-y-2 md:ml-auto md:mr-0">
-                    {[
-                      "Single-line install script",
-                      "Under 10 MB footprint",
-                      "Runs as a system service",
-                      "Auto-starts on boot",
-                    ].map((d) => (
-                      <li
-                        key={d}
-                        className="flex items-center gap-2 text-xs text-text-secondary md:justify-end"
-                      >
-                        <svg
-                          className="w-3.5 h-3.5 text-primary shrink-0 md:order-last"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m4.5 12.75 6 6 9-13.5"
-                          />
-                        </svg>
-                        {d}
-                      </li>
-                    ))}
-                  </ul>
+              <div className="md:pr-12 md:text-right">
+                <div className="flex items-center gap-3 mb-4 md:justify-end">
+                  <span className="w-10 h-10 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center text-sm font-bold font-mono text-primary">
+                    01
+                  </span>
+                  <span className="text-2xs font-mono font-semibold uppercase tracking-[0.1em] text-primary">
+                    Install
+                  </span>
                 </div>
+                <h3 className="text-lg font-bold tracking-[-0.02em] mb-3">
+                  Install the ShellHub Agent
+                </h3>
+                <p className="text-sm text-text-secondary leading-relaxed mb-4">
+                  Deploy a lightweight agent on each device you want to manage.
+                  One command works on any Linux system, Raspberry Pi,
+                  container, or VM.
+                </p>
+                <ul className="space-y-2 md:ml-auto md:mr-0">
+                  {[
+                    "Single-line install script",
+                    "Under 10 MB footprint",
+                    "Runs as a system service",
+                    "Auto-starts on boot",
+                  ].map((d) => (
+                    <li
+                      key={d}
+                      className="flex items-center gap-2 text-xs text-text-secondary md:justify-end"
+                    >
+                      <svg
+                        className="w-3.5 h-3.5 text-primary shrink-0 md:order-last"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m4.5 12.75 6 6 9-13.5"
+                        />
+                      </svg>
+                      {d}
+                    </li>
+                  ))}
+                </ul>
+              </div>
 
-                <div className="md:pl-12">
-                  <ShimmerCard>
-                    <Card className="overflow-hidden">
-                      <div className="p-5">
-                        <div className="flex items-center gap-2 mb-4">
-                          <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                          <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                          <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                          <span className="ml-2 text-2xs text-text-muted font-mono">
-                            Terminal
+              <div className="md:pl-12">
+                <ShimmerCard>
+                  <Card className="overflow-hidden">
+                    <div className="p-5">
+                      <div className="flex items-center gap-2 mb-4">
+                        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                        <span className="ml-2 text-2xs text-text-muted font-mono">
+                          Terminal
+                        </span>
+                      </div>
+                      <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
+                        <p>
+                          <span className="text-accent-green">$</span>{" "}
+                          <span className="text-text-secondary">
+                            curl -sSf https://cloud.shellhub.io/install.sh | sh
                           </span>
-                        </div>
-                        <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
-                          <p>
-                            <span className="text-accent-green">$</span>{" "}
-                            <span className="text-text-secondary">
-                              curl -sSf https://cloud.shellhub.io/install.sh |
-                              sh
-                            </span>
-                          </p>
-                          <p className="text-text-muted">
-                            # Downloading ShellHub agent v0.17.2...
-                          </p>
-                          <p className="text-text-muted">
-                            # Installing to /usr/local/bin/shellhub-agent
-                          </p>
-                          <p className="text-text-muted">
-                            # Registering systemd service...
-                          </p>
-                          <p className="text-accent-green">
-                            # Agent installed and running.
-                          </p>
-                          <p className="text-accent-green">
-                            # Device ID: a1b2c3d4-e5f6-7890
-                          </p>
-                        </div>
-                      </div>
-                    </Card>
-                  </ShimmerCard>
-                </div>
-              </div>
-            </Reveal>
-
-            {/* Step 2: Agent Connects */}
-            <Reveal>
-              <div className="relative grid md:grid-cols-2 gap-8 mb-16">
-                <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-cyan border-2 border-background z-10 hidden md:block" />
-
-                <div className="md:order-last md:text-left md:pl-12">
-                  <div className="flex items-center gap-3 mb-4">
-                    <span className="w-10 h-10 rounded-xl bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center text-sm font-bold font-mono text-accent-cyan">
-                      02
-                    </span>
-                    <span className="text-2xs font-mono font-semibold uppercase tracking-[0.1em] text-accent-cyan">
-                      Connect
-                    </span>
-                  </div>
-                  <h3 className="text-lg font-bold tracking-[-0.02em] mb-3">
-                    Agent Connects to ShellHub
-                  </h3>
-                  <p className="text-sm text-text-secondary leading-relaxed mb-4">
-                    The agent initiates an outbound connection to the ShellHub
-                    gateway. No inbound ports, no public IPs, no firewall
-                    changes required on the device side.
-                  </p>
-                  <ul className="space-y-2">
-                    {[
-                      "Outbound-only connection (port 443)",
-                      "Works behind NAT, firewalls, CGNAT",
-                      "Automatic TLS encryption",
-                      "Persistent WebSocket tunnel",
-                    ].map((d) => (
-                      <li
-                        key={d}
-                        className="flex items-center gap-2 text-xs text-text-secondary"
-                      >
-                        <svg
-                          className="w-3.5 h-3.5 text-accent-cyan shrink-0"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m4.5 12.75 6 6 9-13.5"
-                          />
-                        </svg>
-                        {d}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div className="md:pr-12">
-                  <ShimmerCard>
-                    <Card className="overflow-hidden">
-                      <div className="p-5">
-                        <svg
-                          viewBox="0 0 400 200"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="w-full h-auto"
-                        >
-                          <defs>
-                            <marker
-                              id="hw-s2-a"
-                              markerWidth="7"
-                              markerHeight="5"
-                              refX="7"
-                              refY="2.5"
-                              orient="auto"
-                            >
-                              <path d="M0,0 L7,2.5 L0,5" fill={C.cyan} />
-                            </marker>
-                          </defs>
-
-                          {/* Device */}
-                          <rect
-                            x="20"
-                            y="60"
-                            width="90"
-                            height="80"
-                            rx="10"
-                            fill={C.card}
-                            stroke={C.border}
-                          />
-                          <rect
-                            x="35"
-                            y="74"
-                            width="24"
-                            height="16"
-                            rx="3"
-                            fill={`${C.green}15`}
-                            stroke={C.green}
-                            strokeWidth=".8"
-                          />
-                          <text
-                            x="47"
-                            y="86"
-                            fontSize="8"
-                            fill={C.green}
-                            textAnchor="middle"
-                            fontFamily="IBM Plex Mono"
-                            fontWeight="600"
-                          >
-                            Pi
-                          </text>
-                          <text
-                            x="65"
-                            y="110"
-                            fontFamily="IBM Plex Sans"
-                            fontSize="9"
-                            fill={C.textSec}
-                            textAnchor="middle"
-                          >
-                            Device
-                          </text>
-                          <text
-                            x="65"
-                            y="124"
-                            fontFamily="IBM Plex Mono"
-                            fontSize="7"
-                            fill={C.textMuted}
-                            textAnchor="middle"
-                          >
-                            agent
-                          </text>
-                          <circle cx="100" cy="68" r="3" fill={C.green}>
-                            <animate
-                              attributeName="opacity"
-                              values="1;.3;1"
-                              dur="2s"
-                              repeatCount="indefinite"
-                            />
-                          </circle>
-
-                          {/* NAT Wall */}
-                          <rect
-                            x="145"
-                            y="40"
-                            width="6"
-                            height="120"
-                            rx="3"
-                            fill={C.border}
-                          />
-                          <rect
-                            x="145"
-                            y="40"
-                            width="6"
-                            height="120"
-                            rx="3"
-                            fill={`${C.red}15`}
-                          />
-                          <text
-                            x="148"
-                            y="34"
-                            fontFamily="IBM Plex Mono"
-                            fontSize="8"
-                            fill={C.textMuted}
-                            textAnchor="middle"
-                          >
-                            NAT
-                          </text>
-
-                          {/* Outbound arrow: Device through NAT to Cloud */}
-                          <line
-                            x1="115"
-                            y1="100"
-                            x2="142"
-                            y2="100"
-                            stroke={C.cyan}
-                            strokeWidth="1.5"
-                            markerEnd="url(#hw-s2-a)"
-                          />
-                          <line
-                            x1="154"
-                            y1="100"
-                            x2="225"
-                            y2="100"
-                            stroke={C.cyan}
-                            strokeWidth="1.5"
-                            strokeDasharray="6 4"
-                            markerEnd="url(#hw-s2-a)"
-                          />
-                          <text
-                            x="190"
-                            y="92"
-                            fontFamily="IBM Plex Mono"
-                            fontSize="7"
-                            fill={C.cyan}
-                            textAnchor="middle"
-                          >
-                            outbound :443
-                          </text>
-
-                          {/* Cloud */}
-                          <rect
-                            x="230"
-                            y="50"
-                            width="150"
-                            height="100"
-                            rx="14"
-                            fill={`${C.primary}08`}
-                            stroke={C.primary}
-                            strokeWidth="1.2"
-                          />
-                          <rect
-                            x="278"
-                            y="68"
-                            width="54"
-                            height="28"
-                            rx="8"
-                            fill={C.primaryDim}
-                            stroke={C.primary}
-                            strokeWidth=".8"
-                          />
-                          <text
-                            x="305"
-                            y="87"
-                            fontFamily="IBM Plex Mono"
-                            fontSize="12"
-                            fill={C.primary}
-                            textAnchor="middle"
-                            fontWeight="700"
-                          >
-                            SH
-                          </text>
-                          <text
-                            x="305"
-                            y="118"
-                            fontFamily="IBM Plex Sans"
-                            fontSize="9"
-                            fill={C.textSec}
-                            textAnchor="middle"
-                          >
-                            ShellHub Gateway
-                          </text>
-                          <text
-                            x="305"
-                            y="132"
-                            fontFamily="IBM Plex Mono"
-                            fontSize="7"
-                            fill={C.textMuted}
-                            textAnchor="middle"
-                          >
-                            Auth + Encryption
-                          </text>
-
-                          {/* Labels */}
-                          <text
-                            x="65"
-                            y="170"
-                            fontFamily="IBM Plex Mono"
-                            fontSize="7"
-                            fill={C.textMuted}
-                            textAnchor="middle"
-                          >
-                            PRIVATE NETWORK
-                          </text>
-                          <text
-                            x="305"
-                            y="170"
-                            fontFamily="IBM Plex Mono"
-                            fontSize="7"
-                            fill={C.textMuted}
-                            textAnchor="middle"
-                          >
-                            PUBLIC CLOUD
-                          </text>
-                        </svg>
-                      </div>
-                    </Card>
-                  </ShimmerCard>
-                </div>
-              </div>
-            </Reveal>
-
-            {/* Step 3: SSH from Anywhere */}
-            <Reveal>
-              <div className="relative grid md:grid-cols-2 gap-8">
-                <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-green border-2 border-background z-10 hidden md:block" />
-
-                <div className="md:pr-12 md:text-right">
-                  <div className="flex items-center gap-3 mb-4 md:justify-end">
-                    <span className="w-10 h-10 rounded-xl bg-accent-green/10 border border-accent-green/20 flex items-center justify-center text-sm font-bold font-mono text-accent-green">
-                      03
-                    </span>
-                    <span className="text-2xs font-mono font-semibold uppercase tracking-[0.1em] text-accent-green">
-                      Access
-                    </span>
-                  </div>
-                  <h3 className="text-lg font-bold tracking-[-0.02em] mb-3">
-                    SSH from Anywhere
-                  </h3>
-                  <p className="text-sm text-text-secondary leading-relaxed mb-4">
-                    Use your standard SSH client to connect through ShellHub.
-                    The gateway authenticates the user, applies firewall rules,
-                    and routes the connection to the right device.
-                  </p>
-                  <ul className="space-y-2 md:ml-auto md:mr-0">
-                    {[
-                      "Standard SSH client, no plugins",
-                      "MFA and public key auth",
-                      "Firewall rules per device/user",
-                      "Session recording and audit trail",
-                    ].map((d) => (
-                      <li
-                        key={d}
-                        className="flex items-center gap-2 text-xs text-text-secondary md:justify-end"
-                      >
-                        <svg
-                          className="w-3.5 h-3.5 text-accent-green shrink-0 md:order-last"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m4.5 12.75 6 6 9-13.5"
-                          />
-                        </svg>
-                        {d}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div className="md:pl-12">
-                  <ShimmerCard>
-                    <Card className="overflow-hidden">
-                      <div className="p-5">
-                        <div className="flex items-center gap-2 mb-4">
-                          <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                          <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                          <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                          <span className="ml-2 text-2xs text-text-muted font-mono">
-                            Terminal
-                          </span>
-                        </div>
-                        <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
-                          <p>
-                            <span className="text-accent-green">$</span>{" "}
-                            <span className="text-text-secondary">
-                              ssh pi@a1b2c3d4-e5f6-7890.mycompany.shellhub.io
-                            </span>
-                          </p>
-                          <p className="text-text-muted">
-                            # Connecting through ShellHub gateway...
-                          </p>
-                          <p className="text-text-muted">
-                            # Authenticating with public key...
-                          </p>
-                          <p className="text-text-muted">
-                            # Session recording enabled.
-                          </p>
-                          <p>&nbsp;</p>
-                          <p>
-                            <span className="text-accent-green">
-                              pi@raspberrypi
-                            </span>
-                            :<span className="text-accent-blue">~</span>
-                            <span className="text-text-secondary">
-                              $ uname -a
-                            </span>
-                          </p>
-                          <p className="text-text-secondary">
-                            Linux raspberrypi 6.1.0-rpi7 armv7l GNU/Linux
-                          </p>
-                          <p>
-                            <span className="text-accent-green">
-                              pi@raspberrypi
-                            </span>
-                            :<span className="text-accent-blue">~</span>
-                            <span className="text-text-muted animate-pulse">
-                              _
-                            </span>
-                          </p>
-                        </div>
-                      </div>
-                    </Card>
-                  </ShimmerCard>
-                </div>
-              </div>
-            </Reveal>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Why Not VPN? (Comparison) ────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Comparison
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Why ShellHub over a VPN?
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              VPNs were designed to link networks, not manage individual
-              devices. ShellHub gives you direct, secure access without the
-              overhead.
-            </p>
-          </Reveal>
-
-          <div className="grid md:grid-cols-2 gap-6">
-            {/* ShellHub Side (highlighted) */}
-            <Reveal delay={0}>
-              <ShimmerCard className="h-full">
-                <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
-                  <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-                  <div className="relative">
-                    <div className="flex items-center gap-3 mb-6">
-                      <IconBadge color="primary">
-                        <svg
-                          className="w-5 h-5 text-primary"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
-                          />
-                        </svg>
-                      </IconBadge>
-                      <div>
-                        <h3 className="text-sm font-bold">ShellHub</h3>
-                        <p className="text-2xs text-primary">
-                          Purpose-built for device access
+                        </p>
+                        <p className="text-text-muted">
+                          # Downloading ShellHub agent v0.17.2...
+                        </p>
+                        <p className="text-text-muted">
+                          # Installing to /usr/local/bin/shellhub-agent
+                        </p>
+                        <p className="text-text-muted">
+                          # Registering systemd service...
+                        </p>
+                        <p className="text-accent-green">
+                          # Agent installed and running.
+                        </p>
+                        <p className="text-accent-green">
+                          # Device ID: a1b2c3d4-e5f6-7890
                         </p>
                       </div>
-                      <Badge shape="pill" color="green" className="ml-auto">
-                        Recommended
-                      </Badge>
                     </div>
+                  </Card>
+                </ShimmerCard>
+              </div>
+            </div>
+          </Reveal>
 
-                    <ul className="space-y-3">
-                      {shellhubAdvantages.map((item) => (
-                        <li
-                          key={item.label}
-                          className="flex items-center gap-2.5 text-sm text-text-secondary"
-                        >
-                          <svg
-                            className="w-4 h-4 text-accent-green shrink-0"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="m4.5 12.75 6 6 9-13.5"
-                            />
-                          </svg>
-                          {item.label}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
+          {/* Step 2: Agent Connects */}
+          <Reveal>
+            <div className="relative grid md:grid-cols-2 gap-8 mb-16">
+              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-cyan border-2 border-background z-10 hidden md:block" />
+
+              <div className="md:order-last md:text-left md:pl-12">
+                <div className="flex items-center gap-3 mb-4">
+                  <span className="w-10 h-10 rounded-xl bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center text-sm font-bold font-mono text-accent-cyan">
+                    02
+                  </span>
+                  <span className="text-2xs font-mono font-semibold uppercase tracking-[0.1em] text-accent-cyan">
+                    Connect
+                  </span>
                 </div>
-              </ShimmerCard>
-            </Reveal>
-
-            {/* VPN Side */}
-            <Reveal delay={0.1}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-8 flex flex-col h-full">
-                  <div className="flex items-center gap-3 mb-6">
-                    <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
+                <h3 className="text-lg font-bold tracking-[-0.02em] mb-3">
+                  Agent Connects to ShellHub
+                </h3>
+                <p className="text-sm text-text-secondary leading-relaxed mb-4">
+                  The agent initiates an outbound connection to the ShellHub
+                  gateway. No inbound ports, no public IPs, no firewall changes
+                  required on the device side.
+                </p>
+                <ul className="space-y-2">
+                  {[
+                    "Outbound-only connection (port 443)",
+                    "Works behind NAT, firewalls, CGNAT",
+                    "Automatic TLS encryption",
+                    "Persistent WebSocket tunnel",
+                  ].map((d) => (
+                    <li
+                      key={d}
+                      className="flex items-center gap-2 text-xs text-text-secondary"
+                    >
                       <svg
-                        className="w-5 h-5 text-text-secondary"
+                        className="w-3.5 h-3.5 text-accent-cyan shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m4.5 12.75 6 6 9-13.5"
+                        />
+                      </svg>
+                      {d}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="md:pr-12">
+                <ShimmerCard>
+                  <Card className="overflow-hidden">
+                    <div className="p-5">
+                      <svg
+                        viewBox="0 0 400 200"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="w-full h-auto"
+                      >
+                        <defs>
+                          <marker
+                            id="hw-s2-a"
+                            markerWidth="7"
+                            markerHeight="5"
+                            refX="7"
+                            refY="2.5"
+                            orient="auto"
+                          >
+                            <path d="M0,0 L7,2.5 L0,5" fill={C.cyan} />
+                          </marker>
+                        </defs>
+
+                        {/* Device */}
+                        <rect
+                          x="20"
+                          y="60"
+                          width="90"
+                          height="80"
+                          rx="10"
+                          fill={C.card}
+                          stroke={C.border}
+                        />
+                        <rect
+                          x="35"
+                          y="74"
+                          width="24"
+                          height="16"
+                          rx="3"
+                          fill={`${C.green}15`}
+                          stroke={C.green}
+                          strokeWidth=".8"
+                        />
+                        <text
+                          x="47"
+                          y="86"
+                          fontSize="8"
+                          fill={C.green}
+                          textAnchor="middle"
+                          fontFamily="IBM Plex Mono"
+                          fontWeight="600"
+                        >
+                          Pi
+                        </text>
+                        <text
+                          x="65"
+                          y="110"
+                          fontFamily="IBM Plex Sans"
+                          fontSize="9"
+                          fill={C.textSec}
+                          textAnchor="middle"
+                        >
+                          Device
+                        </text>
+                        <text
+                          x="65"
+                          y="124"
+                          fontFamily="IBM Plex Mono"
+                          fontSize="7"
+                          fill={C.textMuted}
+                          textAnchor="middle"
+                        >
+                          agent
+                        </text>
+                        <circle cx="100" cy="68" r="3" fill={C.green}>
+                          <animate
+                            attributeName="opacity"
+                            values="1;.3;1"
+                            dur="2s"
+                            repeatCount="indefinite"
+                          />
+                        </circle>
+
+                        {/* NAT Wall */}
+                        <rect
+                          x="145"
+                          y="40"
+                          width="6"
+                          height="120"
+                          rx="3"
+                          fill={C.border}
+                        />
+                        <rect
+                          x="145"
+                          y="40"
+                          width="6"
+                          height="120"
+                          rx="3"
+                          fill={`${C.red}15`}
+                        />
+                        <text
+                          x="148"
+                          y="34"
+                          fontFamily="IBM Plex Mono"
+                          fontSize="8"
+                          fill={C.textMuted}
+                          textAnchor="middle"
+                        >
+                          NAT
+                        </text>
+
+                        {/* Outbound arrow: Device through NAT to Cloud */}
+                        <line
+                          x1="115"
+                          y1="100"
+                          x2="142"
+                          y2="100"
+                          stroke={C.cyan}
+                          strokeWidth="1.5"
+                          markerEnd="url(#hw-s2-a)"
+                        />
+                        <line
+                          x1="154"
+                          y1="100"
+                          x2="225"
+                          y2="100"
+                          stroke={C.cyan}
+                          strokeWidth="1.5"
+                          strokeDasharray="6 4"
+                          markerEnd="url(#hw-s2-a)"
+                        />
+                        <text
+                          x="190"
+                          y="92"
+                          fontFamily="IBM Plex Mono"
+                          fontSize="7"
+                          fill={C.cyan}
+                          textAnchor="middle"
+                        >
+                          outbound :443
+                        </text>
+
+                        {/* Cloud */}
+                        <rect
+                          x="230"
+                          y="50"
+                          width="150"
+                          height="100"
+                          rx="14"
+                          fill={`${C.primary}08`}
+                          stroke={C.primary}
+                          strokeWidth="1.2"
+                        />
+                        <rect
+                          x="278"
+                          y="68"
+                          width="54"
+                          height="28"
+                          rx="8"
+                          fill={C.primaryDim}
+                          stroke={C.primary}
+                          strokeWidth=".8"
+                        />
+                        <text
+                          x="305"
+                          y="87"
+                          fontFamily="IBM Plex Mono"
+                          fontSize="12"
+                          fill={C.primary}
+                          textAnchor="middle"
+                          fontWeight="700"
+                        >
+                          SH
+                        </text>
+                        <text
+                          x="305"
+                          y="118"
+                          fontFamily="IBM Plex Sans"
+                          fontSize="9"
+                          fill={C.textSec}
+                          textAnchor="middle"
+                        >
+                          ShellHub Gateway
+                        </text>
+                        <text
+                          x="305"
+                          y="132"
+                          fontFamily="IBM Plex Mono"
+                          fontSize="7"
+                          fill={C.textMuted}
+                          textAnchor="middle"
+                        >
+                          Auth + Encryption
+                        </text>
+
+                        {/* Labels */}
+                        <text
+                          x="65"
+                          y="170"
+                          fontFamily="IBM Plex Mono"
+                          fontSize="7"
+                          fill={C.textMuted}
+                          textAnchor="middle"
+                        >
+                          PRIVATE NETWORK
+                        </text>
+                        <text
+                          x="305"
+                          y="170"
+                          fontFamily="IBM Plex Mono"
+                          fontSize="7"
+                          fill={C.textMuted}
+                          textAnchor="middle"
+                        >
+                          PUBLIC CLOUD
+                        </text>
+                      </svg>
+                    </div>
+                  </Card>
+                </ShimmerCard>
+              </div>
+            </div>
+          </Reveal>
+
+          {/* Step 3: SSH from Anywhere */}
+          <Reveal>
+            <div className="relative grid md:grid-cols-2 gap-8">
+              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-green border-2 border-background z-10 hidden md:block" />
+
+              <div className="md:pr-12 md:text-right">
+                <div className="flex items-center gap-3 mb-4 md:justify-end">
+                  <span className="w-10 h-10 rounded-xl bg-accent-green/10 border border-accent-green/20 flex items-center justify-center text-sm font-bold font-mono text-accent-green">
+                    03
+                  </span>
+                  <span className="text-2xs font-mono font-semibold uppercase tracking-[0.1em] text-accent-green">
+                    Access
+                  </span>
+                </div>
+                <h3 className="text-lg font-bold tracking-[-0.02em] mb-3">
+                  SSH from Anywhere
+                </h3>
+                <p className="text-sm text-text-secondary leading-relaxed mb-4">
+                  Use your standard SSH client to connect through ShellHub. The
+                  gateway authenticates the user, applies firewall rules, and
+                  routes the connection to the right device.
+                </p>
+                <ul className="space-y-2 md:ml-auto md:mr-0">
+                  {[
+                    "Standard SSH client, no plugins",
+                    "MFA and public key auth",
+                    "Firewall rules per device/user",
+                    "Session recording and audit trail",
+                  ].map((d) => (
+                    <li
+                      key={d}
+                      className="flex items-center gap-2 text-xs text-text-secondary md:justify-end"
+                    >
+                      <svg
+                        className="w-3.5 h-3.5 text-accent-green shrink-0 md:order-last"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m4.5 12.75 6 6 9-13.5"
+                        />
+                      </svg>
+                      {d}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="md:pl-12">
+                <ShimmerCard>
+                  <Card className="overflow-hidden">
+                    <div className="p-5">
+                      <div className="flex items-center gap-2 mb-4">
+                        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                        <span className="ml-2 text-2xs text-text-muted font-mono">
+                          Terminal
+                        </span>
+                      </div>
+                      <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
+                        <p>
+                          <span className="text-accent-green">$</span>{" "}
+                          <span className="text-text-secondary">
+                            ssh pi@a1b2c3d4-e5f6-7890.mycompany.shellhub.io
+                          </span>
+                        </p>
+                        <p className="text-text-muted">
+                          # Connecting through ShellHub gateway...
+                        </p>
+                        <p className="text-text-muted">
+                          # Authenticating with public key...
+                        </p>
+                        <p className="text-text-muted">
+                          # Session recording enabled.
+                        </p>
+                        <p>&nbsp;</p>
+                        <p>
+                          <span className="text-accent-green">
+                            pi@raspberrypi
+                          </span>
+                          :<span className="text-accent-blue">~</span>
+                          <span className="text-text-secondary">
+                            $ uname -a
+                          </span>
+                        </p>
+                        <p className="text-text-secondary">
+                          Linux raspberrypi 6.1.0-rpi7 armv7l GNU/Linux
+                        </p>
+                        <p>
+                          <span className="text-accent-green">
+                            pi@raspberrypi
+                          </span>
+                          :<span className="text-accent-blue">~</span>
+                          <span className="text-text-muted animate-pulse">
+                            _
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                  </Card>
+                </ShimmerCard>
+              </div>
+            </div>
+          </Reveal>
+        </div>
+      </Section>
+
+      {/* ── Why Not VPN? (Comparison) ────────────────────────────── */}
+      <Section>
+        <SectionHeader
+          eyebrow="Comparison"
+          title="Why ShellHub over a VPN?"
+          subtitle="VPNs were designed to link networks, not manage individual devices. ShellHub gives you direct, secure access without the overhead."
+        />
+
+        <div className="grid md:grid-cols-2 gap-6">
+          {/* ShellHub Side (highlighted) */}
+          <Reveal delay={0}>
+            <ShimmerCard className="h-full">
+              <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+                <div className="relative">
+                  <div className="flex items-center gap-3 mb-6">
+                    <IconBadge color="primary">
+                      <svg
+                        className="w-5 h-5 text-primary"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
@@ -1329,26 +1244,29 @@ export default function HowItWorks() {
                         <path
                           strokeLinecap="round"
                           strokeLinejoin="round"
-                          d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.25-8.25-3.286zM12 15.75h.007v.008H12v-.008z"
+                          d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"
                         />
                       </svg>
-                    </div>
+                    </IconBadge>
                     <div>
-                      <h3 className="text-sm font-bold">Traditional VPN</h3>
-                      <p className="text-2xs text-text-muted">
-                        Network-level tunneling
+                      <h3 className="text-sm font-bold">ShellHub</h3>
+                      <p className="text-2xs text-primary">
+                        Purpose-built for device access
                       </p>
                     </div>
+                    <Badge shape="pill" color="green" className="ml-auto">
+                      Recommended
+                    </Badge>
                   </div>
 
                   <ul className="space-y-3">
-                    {vpnLimitations.map((item) => (
+                    {shellhubAdvantages.map((item) => (
                       <li
                         key={item.label}
                         className="flex items-center gap-2.5 text-sm text-text-secondary"
                       >
                         <svg
-                          className="w-4 h-4 text-accent-red/70 shrink-0"
+                          className="w-4 h-4 text-accent-green shrink-0"
                           fill="none"
                           viewBox="0 0 24 24"
                           stroke="currentColor"
@@ -1357,102 +1275,142 @@ export default function HowItWorks() {
                           <path
                             strokeLinecap="round"
                             strokeLinejoin="round"
-                            d="M6 18 18 6M6 6l12 12"
+                            d="m4.5 12.75 6 6 9-13.5"
                           />
                         </svg>
                         {item.label}
                       </li>
                     ))}
                   </ul>
+                </div>
+              </div>
+            </ShimmerCard>
+          </Reveal>
+
+          {/* VPN Side */}
+          <Reveal delay={0.1}>
+            <ShimmerCard className="h-full">
+              <Card hover className="p-8 flex flex-col h-full">
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
+                    <svg
+                      className="w-5 h-5 text-text-secondary"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M12 9v3.75m0-10.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.75c0 5.592 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.57-.598-3.75h-.152c-3.196 0-6.1-1.25-8.25-3.286zM12 15.75h.007v.008H12v-.008z"
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-bold">Traditional VPN</h3>
+                    <p className="text-2xs text-text-muted">
+                      Network-level tunneling
+                    </p>
+                  </div>
+                </div>
+
+                <ul className="space-y-3">
+                  {vpnLimitations.map((item) => (
+                    <li
+                      key={item.label}
+                      className="flex items-center gap-2.5 text-sm text-text-secondary"
+                    >
+                      <svg
+                        className="w-4 h-4 text-accent-red/70 shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M6 18 18 6M6 6l12 12"
+                        />
+                      </svg>
+                      {item.label}
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+        </div>
+      </Section>
+
+      {/* ── Technical Details ─────────────────────────────────────── */}
+      <Section>
+        <SectionHeader
+          eyebrow="Under the Hood"
+          title="Built on solid foundations"
+          subtitle="Every component of the stack is designed for security, reliability, and minimal overhead."
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {techDetails.map((f, i) => (
+            <Reveal key={i} delay={i * 0.04}>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${f.color}15`,
+                      borderColor: `${f.color}25`,
+                    }}
+                  >
+                    {f.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {f.desc}
+                  </p>
                 </Card>
               </ShimmerCard>
             </Reveal>
-          </div>
+          ))}
         </div>
-      </section>
-
-      {/* ── Technical Details ─────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Under the Hood
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Built on solid foundations
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Every component of the stack is designed for security,
-              reliability, and minimal overhead.
-            </p>
-          </Reveal>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {techDetails.map((f, i) => (
-              <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard>
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                      style={{
-                        background: `${f.color}15`,
-                        borderColor: `${f.color}25`,
-                      }}
-                    >
-                      {f.icon}
-                    </div>
-                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {f.desc}
-                    </p>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </section>
+      </Section>
 
       {/* ── CTA ──────────────────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal>
-            <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-              <ConnectionGrid />
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
+      <Section>
+        <Reveal>
+          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+            <ConnectionGrid />
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
 
-              <div className="relative z-10">
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Ready to try it?
-                </p>
-                <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  See it in action
-                </h2>
-                <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                  Deploy ShellHub in under five minutes and connect to your
-                  first device. No credit card required.
-                </p>
+            <div className="relative z-10">
+              <SectionHeader
+                variant="cta"
+                eyebrow="Ready to try it?"
+                title="See it in action"
+                subtitle="Deploy ShellHub in under five minutes and connect to your first device. No credit card required."
+              />
 
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                  <Button
-                    as={Link}
-                    to="/getting-started"
-                    variant="primary"
-                    size="xl"
-                    glow
-                    iconRight={<ArrowRight />}
-                  >
-                    Get Started Free
-                  </Button>
-                  <Button as={Link} to="/pricing" variant="outline" size="xl">
-                    View Pricing
-                  </Button>
-                </div>
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+                <Button
+                  as={Link}
+                  to="/getting-started"
+                  variant="primary"
+                  size="xl"
+                  glow
+                  iconRight={<ArrowRight />}
+                >
+                  Get Started Free
+                </Button>
+                <Button as={Link} to="/pricing" variant="outline" size="xl">
+                  View Pricing
+                </Button>
               </div>
             </div>
-          </Reveal>
-        </div>
-      </section>
+          </div>
+        </Reveal>
+      </Section>
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
+import { Section, SectionHeader } from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -132,1127 +133,1075 @@ export default function Integrations() {
       </section>
 
       {/* ─────────── Automation & IaC ─────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            {/* Left copy */}
-            <div>
-              <Reveal>
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Automation &amp; Infrastructure as Code
-                </p>
-                <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Ansible &amp; Terraform, zero VPN
-                </h2>
-                <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                  Use ShellHub as the SSH transport for your Ansible playbooks
-                  and Terraform provisioners. Manage devices behind NAT,
-                  firewalls, or cellular networks without VPN tunnels or bastion
-                  hosts.
-                </p>
-              </Reveal>
+      <Section>
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          {/* Left copy */}
+          <div>
+            <SectionHeader
+              align="left"
+              size="sub"
+              className="mb-8"
+              eyebrow="Automation & Infrastructure as Code"
+              title="Ansible & Terraform, zero VPN"
+              subtitle="Use ShellHub as the SSH transport for your Ansible playbooks and Terraform provisioners. Manage devices behind NAT, firewalls, or cellular networks without VPN tunnels or bastion hosts."
+            />
 
-              <div className="space-y-3">
-                {[
-                  {
-                    label: "Drop-in SSH replacement",
-                    desc: "Set ProxyCommand once and every tool uses ShellHub transparently",
-                  },
-                  {
-                    label: "NAT traversal built in",
-                    desc: "Reach devices behind CGNAT, firewalls, and private networks",
-                  },
-                  {
-                    label: "Ansible connection plugin",
-                    desc: "Native Ansible connection plugin for seamless integration",
-                  },
-                  {
-                    label: "Terraform provisioner",
-                    desc: "Run remote-exec provisioners through ShellHub SSH",
-                  },
-                ].map((cap, i) => (
-                  <Reveal key={i} delay={i * 0.04}>
-                    <div className="flex items-start gap-3">
-                      <svg
-                        className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
-                      <div>
-                        <p className="text-sm font-medium text-text-primary">
-                          {cap.label}
-                        </p>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {cap.desc}
-                        </p>
-                      </div>
+            <div className="space-y-3">
+              {[
+                {
+                  label: "Drop-in SSH replacement",
+                  desc: "Set ProxyCommand once and every tool uses ShellHub transparently",
+                },
+                {
+                  label: "NAT traversal built in",
+                  desc: "Reach devices behind CGNAT, firewalls, and private networks",
+                },
+                {
+                  label: "Ansible connection plugin",
+                  desc: "Native Ansible connection plugin for seamless integration",
+                },
+                {
+                  label: "Terraform provisioner",
+                  desc: "Run remote-exec provisioners through ShellHub SSH",
+                },
+              ].map((cap, i) => (
+                <Reveal key={i} delay={i * 0.04}>
+                  <div className="flex items-start gap-3">
+                    <svg
+                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m4.5 12.75 6 6 9-13.5"
+                      />
+                    </svg>
+                    <div>
+                      <p className="text-sm font-medium text-text-primary">
+                        {cap.label}
+                      </p>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {cap.desc}
+                      </p>
                     </div>
-                  </Reveal>
-                ))}
-              </div>
+                  </div>
+                </Reveal>
+              ))}
             </div>
-
-            {/* Right terminal mockup */}
-            <Reveal delay={0.1}>
-              <TerminalChrome title="ansible-playbook">
-                <Comment># Deploy firmware update via ShellHub SSH</Comment>
-                <Ln>
-                  <Val>$</Val> ansible-playbook -i inventory.yml deploy.yml
-                </Ln>
-                <div className="mt-3" />
-                <Ln color={C.textSec}>
-                  PLAY [Update edge devices] ****************************
-                </Ln>
-                <div className="mt-2" />
-                <Ln color={C.textSec}>
-                  TASK [Gathering Facts] ********************************
-                </Ln>
-                <Ln>
-                  <Str>ok</Str>: [gateway-east-01.d0a1c2.<Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <Ln>
-                  <Str>ok</Str>: [sensor-rack-07.d0a1c2.<Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <Ln>
-                  <Str>ok</Str>: [plc-floor-03.d0a1c2.<Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <div className="mt-2" />
-                <Ln color={C.textSec}>
-                  TASK [Copy firmware binary] ****************************
-                </Ln>
-                <Ln>
-                  <Val>changed</Val>: [gateway-east-01.d0a1c2.
-                  <Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <Ln>
-                  <Val>changed</Val>: [sensor-rack-07.d0a1c2.
-                  <Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <Ln>
-                  <Val>changed</Val>: [plc-floor-03.d0a1c2.
-                  <Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <div className="mt-2" />
-                <Ln color={C.textSec}>
-                  TASK [Apply update &amp; restart] **************************
-                </Ln>
-                <Ln>
-                  <Val>changed</Val>: [gateway-east-01.d0a1c2.
-                  <Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <Ln>
-                  <Val>changed</Val>: [sensor-rack-07.d0a1c2.
-                  <Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <Ln>
-                  <Val>changed</Val>: [plc-floor-03.d0a1c2.
-                  <Cyn>shellhub.io</Cyn>]
-                </Ln>
-                <div className="mt-3" />
-                <Ln color={C.textSec}>
-                  PLAY RECAP ********************************************
-                </Ln>
-                <Ln>
-                  gateway-east-01 : <Str>ok=3</Str> <Val>changed=2</Val>{" "}
-                  unreachable=0 failed=<Str>0</Str>
-                </Ln>
-                <Ln>
-                  sensor-rack-07 &nbsp;: <Str>ok=3</Str> <Val>changed=2</Val>{" "}
-                  unreachable=0 failed=<Str>0</Str>
-                </Ln>
-                <Ln>
-                  plc-floor-03 &nbsp;&nbsp;&nbsp;: <Str>ok=3</Str>{" "}
-                  <Val>changed=2</Val> unreachable=0 failed=<Str>0</Str>
-                </Ln>
-              </TerminalChrome>
-            </Reveal>
           </div>
+
+          {/* Right terminal mockup */}
+          <Reveal delay={0.1}>
+            <TerminalChrome title="ansible-playbook">
+              <Comment># Deploy firmware update via ShellHub SSH</Comment>
+              <Ln>
+                <Val>$</Val> ansible-playbook -i inventory.yml deploy.yml
+              </Ln>
+              <div className="mt-3" />
+              <Ln color={C.textSec}>
+                PLAY [Update edge devices] ****************************
+              </Ln>
+              <div className="mt-2" />
+              <Ln color={C.textSec}>
+                TASK [Gathering Facts] ********************************
+              </Ln>
+              <Ln>
+                <Str>ok</Str>: [gateway-east-01.d0a1c2.<Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <Ln>
+                <Str>ok</Str>: [sensor-rack-07.d0a1c2.<Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <Ln>
+                <Str>ok</Str>: [plc-floor-03.d0a1c2.<Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <div className="mt-2" />
+              <Ln color={C.textSec}>
+                TASK [Copy firmware binary] ****************************
+              </Ln>
+              <Ln>
+                <Val>changed</Val>: [gateway-east-01.d0a1c2.
+                <Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <Ln>
+                <Val>changed</Val>: [sensor-rack-07.d0a1c2.
+                <Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <Ln>
+                <Val>changed</Val>: [plc-floor-03.d0a1c2.
+                <Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <div className="mt-2" />
+              <Ln color={C.textSec}>
+                TASK [Apply update &amp; restart] **************************
+              </Ln>
+              <Ln>
+                <Val>changed</Val>: [gateway-east-01.d0a1c2.
+                <Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <Ln>
+                <Val>changed</Val>: [sensor-rack-07.d0a1c2.
+                <Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <Ln>
+                <Val>changed</Val>: [plc-floor-03.d0a1c2.
+                <Cyn>shellhub.io</Cyn>]
+              </Ln>
+              <div className="mt-3" />
+              <Ln color={C.textSec}>
+                PLAY RECAP ********************************************
+              </Ln>
+              <Ln>
+                gateway-east-01 : <Str>ok=3</Str> <Val>changed=2</Val>{" "}
+                unreachable=0 failed=<Str>0</Str>
+              </Ln>
+              <Ln>
+                sensor-rack-07 &nbsp;: <Str>ok=3</Str> <Val>changed=2</Val>{" "}
+                unreachable=0 failed=<Str>0</Str>
+              </Ln>
+              <Ln>
+                plc-floor-03 &nbsp;&nbsp;&nbsp;: <Str>ok=3</Str>{" "}
+                <Val>changed=2</Val> unreachable=0 failed=<Str>0</Str>
+              </Ln>
+            </TerminalChrome>
+          </Reveal>
         </div>
-      </section>
+      </Section>
 
       {/* ─────────── CI/CD Pipelines ─────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              CI/CD Pipelines
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Deploy from any CI system
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
+      <Section>
+        <SectionHeader
+          eyebrow="CI/CD Pipelines"
+          title="Deploy from any CI system"
+          subtitle={
+            <>
               GitHub Actions, GitLab CI, Jenkins, CircleCI &mdash; if it can run
               SSH, it can deploy through ShellHub. No custom plugins required.
-            </p>
-          </Reveal>
+            </>
+          }
+        />
 
-          <Reveal delay={0.1}>
-            <ShimmerCard className="max-w-3xl mx-auto">
-              <div className="relative bg-card border border-accent-green/25 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(130,165,104,0.08)]">
-                <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.04] via-transparent to-transparent pointer-events-none" />
+        <Reveal delay={0.1}>
+          <ShimmerCard className="max-w-3xl mx-auto">
+            <div className="relative bg-card border border-accent-green/25 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(130,165,104,0.08)]">
+              <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.04] via-transparent to-transparent pointer-events-none" />
+              <div className="relative">
+                {/* Tab bar */}
+                <div className="flex items-center gap-2 px-5 py-3 border-b border-border bg-surface/60">
+                  <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                  <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                  <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                  <span className="ml-2 text-2xs text-text-muted font-mono">
+                    .github/workflows/deploy.yml
+                  </span>
+                  <div className="ml-auto flex items-center gap-1.5">
+                    <Badge shape="pill" color="green">
+                      Passing
+                    </Badge>
+                  </div>
+                </div>
+
+                {/* YAML content */}
+                <div className="p-5 font-mono text-2xs leading-[1.7] overflow-x-auto">
+                  <Ln>
+                    <Kw>name</Kw>: <Str>Deploy to Edge Devices</Str>
+                  </Ln>
+                  <Ln>
+                    <Kw>on</Kw>:
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Kw>push</Kw>:
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Kw>branches</Kw>: [<Str>main</Str>]
+                  </Ln>
+                  <div className="mt-2" />
+                  <Ln>
+                    <Kw>jobs</Kw>:
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Kw>deploy</Kw>:
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Kw>runs-on</Kw>: <Str>ubuntu-latest</Str>
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Kw>steps</Kw>:
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    - <Kw>name</Kw>: <Str>Configure ShellHub SSH</Str>
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Kw>run</Kw>: |
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Dim>mkdir -p ~/.ssh</Dim>
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Dim>
+                      echo{" "}
+                      <Str>"$&#123;&#123; secrets.SSH_KEY &#125;&#125;"</Str>{" "}
+                      &gt; ~/.ssh/id_rsa
+                    </Dim>
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Dim>chmod 600 ~/.ssh/id_rsa</Dim>
+                  </Ln>
+                  <div className="mt-2" />
+                  <Ln>
+                    {" "}
+                    - <Kw>name</Kw>: <Str>Deploy application</Str>
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Kw>run</Kw>: |
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Dim>
+                      ssh <Cyn>admin@device.namespace.shellhub.io</Cyn> \
+                    </Dim>
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Dim>
+                      {" "}
+                      <Str>
+                        "cd /opt/app &amp;&amp; git pull &amp;&amp; systemctl
+                        restart app"
+                      </Str>
+                    </Dim>
+                  </Ln>
+                  <div className="mt-2" />
+                  <Ln>
+                    {" "}
+                    - <Kw>name</Kw>: <Str>Verify deployment</Str>
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Kw>run</Kw>: |
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Dim>
+                      ssh <Cyn>admin@device.namespace.shellhub.io</Cyn> \
+                    </Dim>
+                  </Ln>
+                  <Ln>
+                    {" "}
+                    <Dim>
+                      {" "}
+                      <Str>"curl -sf http://localhost:8080/health"</Str>
+                    </Dim>
+                  </Ln>
+                </div>
+              </div>
+            </div>
+          </ShimmerCard>
+        </Reveal>
+      </Section>
+
+      {/* ─────────── Development Tools ─────────── */}
+      <Section>
+        <SectionHeader
+          eyebrow="Development Tools"
+          title="Develop directly on remote devices"
+          subtitle="Connect your favorite editor or build system to devices through ShellHub. Full IDE support with zero configuration changes."
+        />
+
+        <div className="grid md:grid-cols-2 gap-6">
+          {/* VS Code Remote SSH */}
+          <Reveal delay={0}>
+            <ShimmerCard className="h-full">
+              <div className="relative bg-card border border-accent-blue/25 rounded-xl overflow-hidden h-full hover:border-accent-blue/40 transition-all duration-300 shadow-[0_0_40px_rgba(86,162,225,0.06)]">
+                <div className="absolute inset-0 bg-gradient-to-br from-accent-blue/[0.04] via-transparent to-transparent pointer-events-none" />
                 <div className="relative">
-                  {/* Tab bar */}
-                  <div className="flex items-center gap-2 px-5 py-3 border-b border-border bg-surface/60">
+                  {/* VS Code title bar */}
+                  <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-[#1E1E2E]">
                     <div className="w-3 h-3 rounded-full bg-accent-red/60" />
                     <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
                     <div className="w-3 h-3 rounded-full bg-accent-green/60" />
                     <span className="ml-2 text-2xs text-text-muted font-mono">
-                      .github/workflows/deploy.yml
+                      VS Code &mdash; Remote SSH
                     </span>
-                    <div className="ml-auto flex items-center gap-1.5">
-                      <Badge shape="pill" color="green">
-                        Passing
-                      </Badge>
+                    <div className="ml-auto">
+                      <span className="px-2 py-0.5 text-2xs font-mono bg-accent-blue/10 text-accent-blue border border-accent-blue/20 rounded-full">
+                        SSH: gateway-east-01
+                      </span>
                     </div>
                   </div>
 
-                  {/* YAML content */}
-                  <div className="p-5 font-mono text-2xs leading-[1.7] overflow-x-auto">
-                    <Ln>
-                      <Kw>name</Kw>: <Str>Deploy to Edge Devices</Str>
-                    </Ln>
-                    <Ln>
-                      <Kw>on</Kw>:
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Kw>push</Kw>:
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Kw>branches</Kw>: [<Str>main</Str>]
-                    </Ln>
-                    <div className="mt-2" />
-                    <Ln>
-                      <Kw>jobs</Kw>:
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Kw>deploy</Kw>:
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Kw>runs-on</Kw>: <Str>ubuntu-latest</Str>
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Kw>steps</Kw>:
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      - <Kw>name</Kw>: <Str>Configure ShellHub SSH</Str>
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Kw>run</Kw>: |
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Dim>mkdir -p ~/.ssh</Dim>
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Dim>
-                        echo{" "}
-                        <Str>"$&#123;&#123; secrets.SSH_KEY &#125;&#125;"</Str>{" "}
-                        &gt; ~/.ssh/id_rsa
-                      </Dim>
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Dim>chmod 600 ~/.ssh/id_rsa</Dim>
-                    </Ln>
-                    <div className="mt-2" />
-                    <Ln>
-                      {" "}
-                      - <Kw>name</Kw>: <Str>Deploy application</Str>
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Kw>run</Kw>: |
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Dim>
-                        ssh <Cyn>admin@device.namespace.shellhub.io</Cyn> \
-                      </Dim>
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Dim>
-                        {" "}
-                        <Str>
-                          "cd /opt/app &amp;&amp; git pull &amp;&amp; systemctl
-                          restart app"
-                        </Str>
-                      </Dim>
-                    </Ln>
-                    <div className="mt-2" />
-                    <Ln>
-                      {" "}
-                      - <Kw>name</Kw>: <Str>Verify deployment</Str>
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Kw>run</Kw>: |
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Dim>
-                        ssh <Cyn>admin@device.namespace.shellhub.io</Cyn> \
-                      </Dim>
-                    </Ln>
-                    <Ln>
-                      {" "}
-                      <Dim>
-                        {" "}
-                        <Str>"curl -sf http://localhost:8080/health"</Str>
-                      </Dim>
-                    </Ln>
+                  <div className="flex min-h-[240px]">
+                    {/* Sidebar */}
+                    <div className="w-44 shrink-0 border-r border-border bg-surface/40 p-3">
+                      <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-2">
+                        Explorer
+                      </p>
+                      <div className="space-y-1">
+                        {(
+                          [
+                            {
+                              name: "src/",
+                              indent: 0,
+                              isDir: true,
+                              active: false,
+                            },
+                            {
+                              name: "main.py",
+                              indent: 1,
+                              isDir: false,
+                              active: true,
+                            },
+                            {
+                              name: "config.yml",
+                              indent: 1,
+                              isDir: false,
+                              active: false,
+                            },
+                            {
+                              name: "utils/",
+                              indent: 1,
+                              isDir: true,
+                              active: false,
+                            },
+                            {
+                              name: "tests/",
+                              indent: 0,
+                              isDir: true,
+                              active: false,
+                            },
+                            {
+                              name: "Dockerfile",
+                              indent: 0,
+                              isDir: false,
+                              active: false,
+                            },
+                            {
+                              name: "requirements.txt",
+                              indent: 0,
+                              isDir: false,
+                              active: false,
+                            },
+                          ] as const
+                        ).map((f, i) => (
+                          <div
+                            key={i}
+                            className={`flex items-center gap-1.5 px-1.5 py-0.5 rounded text-2xs font-mono ${f.active ? "bg-accent-blue/10 text-accent-blue" : "text-text-secondary hover:bg-white/[0.03]"}`}
+                            style={{ paddingLeft: `${f.indent * 12 + 6}px` }}
+                          >
+                            {f.isDir ? (
+                              <svg
+                                className="w-3 h-3 shrink-0"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={1.5}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"
+                                />
+                              </svg>
+                            ) : (
+                              <svg
+                                className="w-3 h-3 shrink-0"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={1.5}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                                />
+                              </svg>
+                            )}
+                            {f.name}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* Editor area */}
+                    <div className="flex-1 p-4 font-mono text-2xs leading-[1.8]">
+                      <div className="flex items-center gap-3 mb-3 border-b border-border pb-2">
+                        <span className="px-2 py-0.5 text-2xs bg-accent-blue/10 text-accent-blue border-b-2 border-accent-blue rounded-t">
+                          main.py
+                        </span>
+                        <span className="px-2 py-0.5 text-2xs text-text-muted">
+                          config.yml
+                        </span>
+                      </div>
+                      <div className="flex gap-3">
+                        <div className="text-text-muted select-none text-right w-5 shrink-0">
+                          {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
+                            <div key={n}>{n}</div>
+                          ))}
+                        </div>
+                        <div>
+                          <Ln>
+                            <Kw>import</Kw> <Str>flask</Str>
+                          </Ln>
+                          <Ln>
+                            <Kw>from</Kw> config <Kw>import</Kw> settings
+                          </Ln>
+                          <Ln color={C.textMuted}>&nbsp;</Ln>
+                          <Ln>app = flask.Flask(__name__)</Ln>
+                          <Ln color={C.textMuted}>&nbsp;</Ln>
+                          <Ln>
+                            <Kw>@app</Kw>.route(<Str>"/health"</Str>)
+                          </Ln>
+                          <Ln>
+                            <Kw>def</Kw> <Val>health</Val>():
+                          </Ln>
+                          <Ln>
+                            {" "}
+                            <Kw>return</Kw> {"{"}
+                            <Str>"status"</Str>: <Str>"ok"</Str>
+                            {"}"}
+                          </Ln>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Status bar */}
+                  <div className="flex items-center justify-between px-4 py-1.5 bg-accent-blue/10 border-t border-border text-2xs font-mono">
+                    <div className="flex items-center gap-3">
+                      <span className="text-accent-blue flex items-center gap-1">
+                        <svg
+                          className="w-3 h-3"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
+                          />
+                        </svg>
+                        SSH: gateway-east-01
+                      </span>
+                      <span className="text-text-muted">Python 3.11</span>
+                    </div>
+                    <span className="text-text-muted">Ln 7, Col 12</span>
+                  </div>
+                </div>
+              </div>
+            </ShimmerCard>
+          </Reveal>
+
+          {/* Embedded Linux */}
+          <Reveal delay={0.1}>
+            <ShimmerCard className="h-full">
+              <div className="relative bg-card border border-accent-yellow/25 rounded-xl overflow-hidden h-full hover:border-accent-yellow/40 transition-all duration-300 shadow-[0_0_40px_rgba(191,140,93,0.06)]">
+                <div className="absolute inset-0 bg-gradient-to-br from-accent-yellow/[0.04] via-transparent to-transparent pointer-events-none" />
+                <div className="relative">
+                  {/* Header */}
+                  <div className="px-6 pt-6 pb-4">
+                    <div className="flex items-center gap-3 mb-3">
+                      <IconBadge color="yellow">
+                        <svg
+                          className="w-5 h-5 text-accent-yellow"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={1.5}
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Z"
+                          />
+                        </svg>
+                      </IconBadge>
+                      <div>
+                        <h3 className="text-sm font-bold">Embedded Linux</h3>
+                        <p className="text-2xs text-text-muted">
+                          Yocto &amp; Buildroot
+                        </p>
+                      </div>
+                    </div>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      Include the ShellHub agent in your embedded Linux image.
+                      Ship devices pre-configured for remote access from the
+                      factory floor.
+                    </p>
+                  </div>
+
+                  {/* Build config mockup */}
+                  <div className="mx-4 mb-4">
+                    <div className="bg-surface/60 border border-border rounded-lg overflow-hidden">
+                      <div className="flex items-center gap-2 px-4 py-2 border-b border-border">
+                        <span className="text-2xs text-text-muted font-mono">
+                          local.conf
+                        </span>
+                        <span className="ml-auto px-1.5 py-0.5 text-2xs font-mono bg-accent-yellow/10 text-accent-yellow rounded">
+                          Yocto
+                        </span>
+                      </div>
+                      <div className="p-4 font-mono text-2xs leading-[1.7]">
+                        <Comment># Enable ShellHub agent in the image</Comment>
+                        <Ln>
+                          <Kw>IMAGE_INSTALL</Kw>:append ={" "}
+                          <Str>" shellhub-agent"</Str>
+                        </Ln>
+                        <Ln color={C.textMuted}>&nbsp;</Ln>
+                        <Comment># Configure server address</Comment>
+                        <Ln>
+                          <Kw>SHELLHUB_SERVER</Kw> ={" "}
+                          <Str>"https://cloud.shellhub.io"</Str>
+                        </Ln>
+                        <Ln>
+                          <Kw>SHELLHUB_TENANT_ID</Kw> ={" "}
+                          <Str>"your-tenant-id"</Str>
+                        </Ln>
+                        <Ln color={C.textMuted}>&nbsp;</Ln>
+                        <Comment># Auto-register on first boot</Comment>
+                        <Ln>
+                          <Kw>SHELLHUB_AUTO_REGISTER</Kw> = <Str>"true"</Str>
+                        </Ln>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Buildroot config */}
+                  <div className="mx-4 mb-5">
+                    <div className="bg-surface/60 border border-border rounded-lg overflow-hidden">
+                      <div className="flex items-center gap-2 px-4 py-2 border-b border-border">
+                        <span className="text-2xs text-text-muted font-mono">
+                          .config
+                        </span>
+                        <span className="ml-auto px-1.5 py-0.5 text-2xs font-mono bg-accent-yellow/10 text-accent-yellow rounded">
+                          Buildroot
+                        </span>
+                      </div>
+                      <div className="p-4 font-mono text-2xs leading-[1.7]">
+                        <Ln>
+                          <Kw>BR2_PACKAGE_SHELLHUB_AGENT</Kw>=<Str>y</Str>
+                        </Ln>
+                        <Ln>
+                          <Kw>BR2_PACKAGE_SHELLHUB_AGENT_SERVER</Kw>=
+                          <Str>"https://cloud.shellhub.io"</Str>
+                        </Ln>
+                        <Ln>
+                          <Kw>BR2_PACKAGE_SHELLHUB_AGENT_TENANT_ID</Kw>=
+                          <Str>"your-tenant-id"</Str>
+                        </Ln>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
             </ShimmerCard>
           </Reveal>
         </div>
-      </section>
-
-      {/* ─────────── Development Tools ─────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Development Tools
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Develop directly on remote devices
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Connect your favorite editor or build system to devices through
-              ShellHub. Full IDE support with zero configuration changes.
-            </p>
-          </Reveal>
-
-          <div className="grid md:grid-cols-2 gap-6">
-            {/* VS Code Remote SSH */}
-            <Reveal delay={0}>
-              <ShimmerCard className="h-full">
-                <div className="relative bg-card border border-accent-blue/25 rounded-xl overflow-hidden h-full hover:border-accent-blue/40 transition-all duration-300 shadow-[0_0_40px_rgba(86,162,225,0.06)]">
-                  <div className="absolute inset-0 bg-gradient-to-br from-accent-blue/[0.04] via-transparent to-transparent pointer-events-none" />
-                  <div className="relative">
-                    {/* VS Code title bar */}
-                    <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-[#1E1E2E]">
-                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                      <span className="ml-2 text-2xs text-text-muted font-mono">
-                        VS Code &mdash; Remote SSH
-                      </span>
-                      <div className="ml-auto">
-                        <span className="px-2 py-0.5 text-2xs font-mono bg-accent-blue/10 text-accent-blue border border-accent-blue/20 rounded-full">
-                          SSH: gateway-east-01
-                        </span>
-                      </div>
-                    </div>
-
-                    <div className="flex min-h-[240px]">
-                      {/* Sidebar */}
-                      <div className="w-44 shrink-0 border-r border-border bg-surface/40 p-3">
-                        <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-2">
-                          Explorer
-                        </p>
-                        <div className="space-y-1">
-                          {(
-                            [
-                              {
-                                name: "src/",
-                                indent: 0,
-                                isDir: true,
-                                active: false,
-                              },
-                              {
-                                name: "main.py",
-                                indent: 1,
-                                isDir: false,
-                                active: true,
-                              },
-                              {
-                                name: "config.yml",
-                                indent: 1,
-                                isDir: false,
-                                active: false,
-                              },
-                              {
-                                name: "utils/",
-                                indent: 1,
-                                isDir: true,
-                                active: false,
-                              },
-                              {
-                                name: "tests/",
-                                indent: 0,
-                                isDir: true,
-                                active: false,
-                              },
-                              {
-                                name: "Dockerfile",
-                                indent: 0,
-                                isDir: false,
-                                active: false,
-                              },
-                              {
-                                name: "requirements.txt",
-                                indent: 0,
-                                isDir: false,
-                                active: false,
-                              },
-                            ] as const
-                          ).map((f, i) => (
-                            <div
-                              key={i}
-                              className={`flex items-center gap-1.5 px-1.5 py-0.5 rounded text-2xs font-mono ${f.active ? "bg-accent-blue/10 text-accent-blue" : "text-text-secondary hover:bg-white/[0.03]"}`}
-                              style={{ paddingLeft: `${f.indent * 12 + 6}px` }}
-                            >
-                              {f.isDir ? (
-                                <svg
-                                  className="w-3 h-3 shrink-0"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  strokeWidth={1.5}
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"
-                                  />
-                                </svg>
-                              ) : (
-                                <svg
-                                  className="w-3 h-3 shrink-0"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                  strokeWidth={1.5}
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
-                                  />
-                                </svg>
-                              )}
-                              {f.name}
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-
-                      {/* Editor area */}
-                      <div className="flex-1 p-4 font-mono text-2xs leading-[1.8]">
-                        <div className="flex items-center gap-3 mb-3 border-b border-border pb-2">
-                          <span className="px-2 py-0.5 text-2xs bg-accent-blue/10 text-accent-blue border-b-2 border-accent-blue rounded-t">
-                            main.py
-                          </span>
-                          <span className="px-2 py-0.5 text-2xs text-text-muted">
-                            config.yml
-                          </span>
-                        </div>
-                        <div className="flex gap-3">
-                          <div className="text-text-muted select-none text-right w-5 shrink-0">
-                            {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
-                              <div key={n}>{n}</div>
-                            ))}
-                          </div>
-                          <div>
-                            <Ln>
-                              <Kw>import</Kw> <Str>flask</Str>
-                            </Ln>
-                            <Ln>
-                              <Kw>from</Kw> config <Kw>import</Kw> settings
-                            </Ln>
-                            <Ln color={C.textMuted}>&nbsp;</Ln>
-                            <Ln>app = flask.Flask(__name__)</Ln>
-                            <Ln color={C.textMuted}>&nbsp;</Ln>
-                            <Ln>
-                              <Kw>@app</Kw>.route(<Str>"/health"</Str>)
-                            </Ln>
-                            <Ln>
-                              <Kw>def</Kw> <Val>health</Val>():
-                            </Ln>
-                            <Ln>
-                              {" "}
-                              <Kw>return</Kw> {"{"}
-                              <Str>"status"</Str>: <Str>"ok"</Str>
-                              {"}"}
-                            </Ln>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Status bar */}
-                    <div className="flex items-center justify-between px-4 py-1.5 bg-accent-blue/10 border-t border-border text-2xs font-mono">
-                      <div className="flex items-center gap-3">
-                        <span className="text-accent-blue flex items-center gap-1">
-                          <svg
-                            className="w-3 h-3"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
-                            />
-                          </svg>
-                          SSH: gateway-east-01
-                        </span>
-                        <span className="text-text-muted">Python 3.11</span>
-                      </div>
-                      <span className="text-text-muted">Ln 7, Col 12</span>
-                    </div>
-                  </div>
-                </div>
-              </ShimmerCard>
-            </Reveal>
-
-            {/* Embedded Linux */}
-            <Reveal delay={0.1}>
-              <ShimmerCard className="h-full">
-                <div className="relative bg-card border border-accent-yellow/25 rounded-xl overflow-hidden h-full hover:border-accent-yellow/40 transition-all duration-300 shadow-[0_0_40px_rgba(191,140,93,0.06)]">
-                  <div className="absolute inset-0 bg-gradient-to-br from-accent-yellow/[0.04] via-transparent to-transparent pointer-events-none" />
-                  <div className="relative">
-                    {/* Header */}
-                    <div className="px-6 pt-6 pb-4">
-                      <div className="flex items-center gap-3 mb-3">
-                        <IconBadge color="yellow">
-                          <svg
-                            className="w-5 h-5 text-accent-yellow"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={1.5}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 0 0 2.25-2.25V6.75a2.25 2.25 0 0 0-2.25-2.25H6.75A2.25 2.25 0 0 0 4.5 6.75v10.5a2.25 2.25 0 0 0 2.25 2.25Z"
-                            />
-                          </svg>
-                        </IconBadge>
-                        <div>
-                          <h3 className="text-sm font-bold">Embedded Linux</h3>
-                          <p className="text-2xs text-text-muted">
-                            Yocto &amp; Buildroot
-                          </p>
-                        </div>
-                      </div>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        Include the ShellHub agent in your embedded Linux image.
-                        Ship devices pre-configured for remote access from the
-                        factory floor.
-                      </p>
-                    </div>
-
-                    {/* Build config mockup */}
-                    <div className="mx-4 mb-4">
-                      <div className="bg-surface/60 border border-border rounded-lg overflow-hidden">
-                        <div className="flex items-center gap-2 px-4 py-2 border-b border-border">
-                          <span className="text-2xs text-text-muted font-mono">
-                            local.conf
-                          </span>
-                          <span className="ml-auto px-1.5 py-0.5 text-2xs font-mono bg-accent-yellow/10 text-accent-yellow rounded">
-                            Yocto
-                          </span>
-                        </div>
-                        <div className="p-4 font-mono text-2xs leading-[1.7]">
-                          <Comment>
-                            # Enable ShellHub agent in the image
-                          </Comment>
-                          <Ln>
-                            <Kw>IMAGE_INSTALL</Kw>:append ={" "}
-                            <Str>" shellhub-agent"</Str>
-                          </Ln>
-                          <Ln color={C.textMuted}>&nbsp;</Ln>
-                          <Comment># Configure server address</Comment>
-                          <Ln>
-                            <Kw>SHELLHUB_SERVER</Kw> ={" "}
-                            <Str>"https://cloud.shellhub.io"</Str>
-                          </Ln>
-                          <Ln>
-                            <Kw>SHELLHUB_TENANT_ID</Kw> ={" "}
-                            <Str>"your-tenant-id"</Str>
-                          </Ln>
-                          <Ln color={C.textMuted}>&nbsp;</Ln>
-                          <Comment># Auto-register on first boot</Comment>
-                          <Ln>
-                            <Kw>SHELLHUB_AUTO_REGISTER</Kw> = <Str>"true"</Str>
-                          </Ln>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Buildroot config */}
-                    <div className="mx-4 mb-5">
-                      <div className="bg-surface/60 border border-border rounded-lg overflow-hidden">
-                        <div className="flex items-center gap-2 px-4 py-2 border-b border-border">
-                          <span className="text-2xs text-text-muted font-mono">
-                            .config
-                          </span>
-                          <span className="ml-auto px-1.5 py-0.5 text-2xs font-mono bg-accent-yellow/10 text-accent-yellow rounded">
-                            Buildroot
-                          </span>
-                        </div>
-                        <div className="p-4 font-mono text-2xs leading-[1.7]">
-                          <Ln>
-                            <Kw>BR2_PACKAGE_SHELLHUB_AGENT</Kw>=<Str>y</Str>
-                          </Ln>
-                          <Ln>
-                            <Kw>BR2_PACKAGE_SHELLHUB_AGENT_SERVER</Kw>=
-                            <Str>"https://cloud.shellhub.io"</Str>
-                          </Ln>
-                          <Ln>
-                            <Kw>BR2_PACKAGE_SHELLHUB_AGENT_TENANT_ID</Kw>=
-                            <Str>"your-tenant-id"</Str>
-                          </Ln>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </ShimmerCard>
-            </Reveal>
-          </div>
-        </div>
-      </section>
+      </Section>
 
       {/* ─────────── Docker & Containers ─────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            {/* Left: diagram */}
-            <Reveal>
-              <ShimmerCard>
-                <Card className="p-8 overflow-hidden">
-                  <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-6">
-                    Connection Flow
-                  </p>
+      <Section>
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          {/* Left: diagram */}
+          <Reveal>
+            <ShimmerCard>
+              <Card className="p-8 overflow-hidden">
+                <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-6">
+                  Connection Flow
+                </p>
 
-                  {/* Diagram */}
-                  <div className="flex flex-col items-center gap-0">
-                    {/* Developer */}
-                    <div className="flex items-center gap-3 px-5 py-3 bg-surface border border-border rounded-lg w-full max-w-xs">
-                      <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center">
-                        <svg
-                          className="w-4 h-4 text-primary"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
-                          />
-                        </svg>
-                      </div>
-                      <div>
-                        <p className="text-xs font-medium">Developer</p>
-                        <p className="text-2xs text-text-muted font-mono">
-                          ssh user@container
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Arrow */}
-                    <div className="flex flex-col items-center py-2">
-                      <div className="w-px h-6 bg-primary/40" />
+                {/* Diagram */}
+                <div className="flex flex-col items-center gap-0">
+                  {/* Developer */}
+                  <div className="flex items-center gap-3 px-5 py-3 bg-surface border border-border rounded-lg w-full max-w-xs">
+                    <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center">
                       <svg
-                        className="w-3 h-3 text-primary/60"
-                        viewBox="0 0 12 12"
+                        className="w-4 h-4 text-primary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
                       >
                         <path
-                          d="M6 0v10M2 6l4 5 4-5"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
                         />
                       </svg>
                     </div>
-
-                    {/* ShellHub Cloud */}
-                    <div className="flex items-center gap-3 px-5 py-3 bg-primary/[0.06] border border-primary/25 rounded-lg w-full max-w-xs">
-                      <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center">
-                        <svg
-                          className="w-4 h-4 text-primary"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15Z"
-                          />
-                        </svg>
-                      </div>
-                      <div>
-                        <p className="text-xs font-medium text-primary">
-                          ShellHub
-                        </p>
-                        <p className="text-2xs text-text-muted font-mono">
-                          SSH tunnel &amp; auth
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Arrow */}
-                    <div className="flex flex-col items-center py-2">
-                      <div className="w-px h-6 bg-accent-cyan/40" />
-                      <svg
-                        className="w-3 h-3 text-accent-cyan/60"
-                        viewBox="0 0 12 12"
-                      >
-                        <path
-                          d="M6 0v10M2 6l4 5 4-5"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        />
-                      </svg>
-                    </div>
-
-                    {/* Docker Host */}
-                    <div className="w-full max-w-xs border border-border rounded-lg overflow-hidden">
-                      <div className="px-4 py-2 bg-surface/60 border-b border-border flex items-center gap-2">
-                        <svg
-                          className="w-4 h-4 text-accent-cyan"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z"
-                          />
-                        </svg>
-                        <span className="text-2xs font-mono text-text-muted">
-                          Docker Host
-                        </span>
-                      </div>
-                      <div className="p-3 bg-card space-y-2">
-                        {[
-                          { name: "web-app", port: "8080", color: C.green },
-                          { name: "api-server", port: "3000", color: C.cyan },
-                          { name: "worker", port: "--", color: C.yellow },
-                        ].map((c) => (
-                          <div
-                            key={c.name}
-                            className="flex items-center gap-2 px-3 py-1.5 bg-surface rounded border border-border"
-                          >
-                            <div
-                              className="w-2 h-2 rounded-full"
-                              style={{ background: c.color }}
-                            />
-                            <span className="text-2xs font-mono text-text-secondary flex-1">
-                              {c.name}
-                            </span>
-                            <span className="text-2xs font-mono text-text-muted">
-                              :{c.port}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-
-            {/* Right: copy */}
-            <div>
-              <Reveal>
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Docker &amp; Containers
-                </p>
-                <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  SSH into containers, not just hosts
-                </h2>
-                <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                  SSH directly into Docker containers without exposing ports or
-                  running docker exec. ShellHub routes connections to individual
-                  containers through the agent on the host.
-                </p>
-              </Reveal>
-
-              <Reveal delay={0.05}>
-                <TerminalChrome title="terminal">
-                  <Comment># Connect to a specific container</Comment>
-                  <Ln>
-                    <Val>$</Val> ssh{" "}
-                    <Cyn>root@web-app.host01.ns.shellhub.io</Cyn>
-                  </Ln>
-                  <Ln color={C.textSec}>
-                    Connected to web-app (container: a1b2c3d4)
-                  </Ln>
-                  <Ln color={C.textMuted}>&nbsp;</Ln>
-                  <Ln>
-                    <Val>root@web-app:~#</Val>{" "}
-                    <Dim>curl localhost:8080/health</Dim>
-                  </Ln>
-                  <Ln>
-                    <Str>{'{"status":"healthy","uptime":"14d 6h"}'}</Str>
-                  </Ln>
-                </TerminalChrome>
-              </Reveal>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ─────────── API-First ─────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              API-First
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Automate everything with the REST API
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Every feature in ShellHub is accessible through a well-documented
-              REST API. Build custom dashboards, automate workflows, or
-              integrate with your internal tools.
-            </p>
-          </Reveal>
-
-          <Reveal delay={0.1}>
-            <ShimmerCard className="max-w-4xl mx-auto">
-              <Card className="overflow-hidden">
-                {/* API tabs */}
-                <div className="flex items-center gap-1 px-5 py-3 border-b border-border bg-surface/60">
-                  <Badge shape="pill" color="green">
-                    GET
-                  </Badge>
-                  <span className="text-2xs font-mono text-text-secondary ml-2">
-                    /api/devices
-                  </span>
-                  <div className="ml-auto flex items-center gap-2">
-                    <span className="px-2 py-0.5 text-2xs font-mono text-accent-green bg-accent-green/10 rounded">
-                      200 OK
-                    </span>
-                  </div>
-                </div>
-
-                <div className="grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
-                  {/* Request */}
-                  <div className="p-5">
-                    <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-3">
-                      Request
-                    </p>
-                    <div className="bg-surface/60 border border-border rounded-lg p-4 font-mono text-2xs leading-[1.7]">
-                      <Ln>
-                        <Val>$</Val> curl -s \
-                      </Ln>
-                      <Ln>
-                        {" "}
-                        -H <Str>"Authorization: Bearer $TOKEN"</Str> \
-                      </Ln>
-                      <Ln>
-                        {" "}
-                        -H <Str>"Content-Type: application/json"</Str> \
-                      </Ln>
-                      <Ln>
-                        {" "}
-                        <Cyn>https://cloud.shellhub.io/api/devices</Cyn>
-                      </Ln>
-                    </div>
-                    <div className="mt-4 space-y-2">
-                      <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-2">
-                        Headers
+                    <div>
+                      <p className="text-xs font-medium">Developer</p>
+                      <p className="text-2xs text-text-muted font-mono">
+                        ssh user@container
                       </p>
+                    </div>
+                  </div>
+
+                  {/* Arrow */}
+                  <div className="flex flex-col items-center py-2">
+                    <div className="w-px h-6 bg-primary/40" />
+                    <svg
+                      className="w-3 h-3 text-primary/60"
+                      viewBox="0 0 12 12"
+                    >
+                      <path
+                        d="M6 0v10M2 6l4 5 4-5"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      />
+                    </svg>
+                  </div>
+
+                  {/* ShellHub Cloud */}
+                  <div className="flex items-center gap-3 px-5 py-3 bg-primary/[0.06] border border-primary/25 rounded-lg w-full max-w-xs">
+                    <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center">
+                      <svg
+                        className="w-4 h-4 text-primary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15Z"
+                        />
+                      </svg>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium text-primary">
+                        ShellHub
+                      </p>
+                      <p className="text-2xs text-text-muted font-mono">
+                        SSH tunnel &amp; auth
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Arrow */}
+                  <div className="flex flex-col items-center py-2">
+                    <div className="w-px h-6 bg-accent-cyan/40" />
+                    <svg
+                      className="w-3 h-3 text-accent-cyan/60"
+                      viewBox="0 0 12 12"
+                    >
+                      <path
+                        d="M6 0v10M2 6l4 5 4-5"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      />
+                    </svg>
+                  </div>
+
+                  {/* Docker Host */}
+                  <div className="w-full max-w-xs border border-border rounded-lg overflow-hidden">
+                    <div className="px-4 py-2 bg-surface/60 border-b border-border flex items-center gap-2">
+                      <svg
+                        className="w-4 h-4 text-accent-cyan"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z"
+                        />
+                      </svg>
+                      <span className="text-2xs font-mono text-text-muted">
+                        Docker Host
+                      </span>
+                    </div>
+                    <div className="p-3 bg-card space-y-2">
                       {[
-                        { key: "Authorization", val: "Bearer eyJhb..." },
-                        { key: "Content-Type", val: "application/json" },
-                        { key: "X-Tenant-ID", val: "d0a1c2e4..." },
-                      ].map((h) => (
+                        { name: "web-app", port: "8080", color: C.green },
+                        { name: "api-server", port: "3000", color: C.cyan },
+                        { name: "worker", port: "--", color: C.yellow },
+                      ].map((c) => (
                         <div
-                          key={h.key}
-                          className="flex items-center gap-2 text-2xs font-mono"
+                          key={c.name}
+                          className="flex items-center gap-2 px-3 py-1.5 bg-surface rounded border border-border"
                         >
-                          <span className="text-primary">{h.key}:</span>
-                          <span className="text-text-muted truncate">
-                            {h.val}
+                          <div
+                            className="w-2 h-2 rounded-full"
+                            style={{ background: c.color }}
+                          />
+                          <span className="text-2xs font-mono text-text-secondary flex-1">
+                            {c.name}
+                          </span>
+                          <span className="text-2xs font-mono text-text-muted">
+                            :{c.port}
                           </span>
                         </div>
                       ))}
                     </div>
                   </div>
-
-                  {/* Response */}
-                  <div className="p-5">
-                    <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-3">
-                      Response
-                    </p>
-                    <div className="bg-surface/60 border border-border rounded-lg p-4 font-mono text-2xs leading-[1.7]">
-                      <Ln>[</Ln>
-                      <Ln>
-                        {"  "}
-                        {"{"}
-                      </Ln>
-                      <Ln>
-                        {"    "}
-                        <Kw>"uid"</Kw>: <Str>"a1b2c3d4e5f6"</Str>,
-                      </Ln>
-                      <Ln>
-                        {"    "}
-                        <Kw>"name"</Kw>: <Str>"gateway-east-01"</Str>,
-                      </Ln>
-                      <Ln>
-                        {"    "}
-                        <Kw>"identity"</Kw>: {"{"}
-                      </Ln>
-                      <Ln>
-                        {"      "}
-                        <Kw>"mac"</Kw>: <Str>"00:1a:2b:3c:4d:5e"</Str>
-                      </Ln>
-                      <Ln>
-                        {"    "}
-                        {"}"},
-                      </Ln>
-                      <Ln>
-                        {"    "}
-                        <Kw>"info"</Kw>: {"{"}
-                      </Ln>
-                      <Ln>
-                        {"      "}
-                        <Kw>"version"</Kw>: <Str>"0.15.1"</Str>,
-                      </Ln>
-                      <Ln>
-                        {"      "}
-                        <Kw>"arch"</Kw>: <Str>"amd64"</Str>
-                      </Ln>
-                      <Ln>
-                        {"    "}
-                        {"}"},
-                      </Ln>
-                      <Ln>
-                        {"    "}
-                        <Kw>"status"</Kw>: <Str>"online"</Str>,
-                      </Ln>
-                      <Ln>
-                        {"    "}
-                        <Kw>"last_seen"</Kw>: <Str>"2026-02-14T..."</Str>
-                      </Ln>
-                      <Ln>
-                        {"  "}
-                        {"}"}
-                      </Ln>
-                      <Ln>]</Ln>
-                    </div>
-                  </div>
-                </div>
-
-                {/* More endpoints */}
-                <div className="px-5 py-3 border-t border-border bg-surface/40 flex flex-wrap gap-2">
-                  {[
-                    { method: "POST", path: "/api/sessions", color: C.yellow },
-                    { method: "GET", path: "/api/stats", color: C.green },
-                    {
-                      method: "PUT",
-                      path: "/api/devices/{uid}",
-                      color: C.blue,
-                    },
-                    {
-                      method: "DELETE",
-                      path: "/api/sessions/{uid}",
-                      color: C.red,
-                    },
-                    { method: "GET", path: "/api/namespaces", color: C.green },
-                  ].map((ep) => (
-                    <span
-                      key={ep.path}
-                      className="inline-flex items-center gap-1.5 px-2 py-1 bg-white/[0.03] border border-border rounded text-2xs font-mono text-text-muted hover:border-border-light transition-colors"
-                    >
-                      <span
-                        style={{ color: ep.color }}
-                        className="font-semibold"
-                      >
-                        {ep.method}
-                      </span>
-                      {ep.path}
-                    </span>
-                  ))}
                 </div>
               </Card>
             </ShimmerCard>
           </Reveal>
-        </div>
-      </section>
 
-      {/* ─────────── Standard SSH callout ─────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Standard SSH. Zero plugins.
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              ShellHub works with any tool that supports SSH. No proprietary
-              clients, no custom APIs, no vendor lock-in.
-            </p>
-          </Reveal>
+          {/* Right: copy */}
+          <div>
+            <SectionHeader
+              align="left"
+              size="sub"
+              className="mb-8"
+              eyebrow="Docker & Containers"
+              title="SSH into containers, not just hosts"
+              subtitle="SSH directly into Docker containers without exposing ports or running docker exec. ShellHub routes connections to individual containers through the agent on the host."
+            />
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {[
-              {
-                color: C.primary,
-                title: "SSH as transport",
-                desc: "Any tool that uses SSH for remote execution works with ShellHub out of the box. Ansible, rsync, scp, Git over SSH.",
-                icon: (
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke={C.primary}
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
-                    />
-                  </svg>
-                ),
-              },
-              {
-                color: C.cyan,
-                title: "No agent changes",
-                desc: "The ShellHub agent runs independently on your devices. Install once and use it with every tool in your stack.",
-                icon: (
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke={C.cyan}
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
-                    />
-                  </svg>
-                ),
-              },
-              {
-                color: C.green,
-                title: "API-first design",
-                desc: "Programmatic access to devices, sessions, and configurations. Build custom integrations with the REST API.",
-                icon: (
-                  <svg
-                    className="w-5 h-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke={C.green}
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
-                    />
-                  </svg>
-                ),
-              },
-            ].map((b, i) => (
-              <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard className="h-full">
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                      style={{
-                        background: `${b.color}15`,
-                        borderColor: `${b.color}25`,
-                      }}
-                    >
-                      {b.icon}
-                    </div>
-                    <h4 className="text-sm font-semibold mb-2">{b.title}</h4>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {b.desc}
-                    </p>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
+            <Reveal delay={0.05}>
+              <TerminalChrome title="terminal">
+                <Comment># Connect to a specific container</Comment>
+                <Ln>
+                  <Val>$</Val> ssh <Cyn>root@web-app.host01.ns.shellhub.io</Cyn>
+                </Ln>
+                <Ln color={C.textSec}>
+                  Connected to web-app (container: a1b2c3d4)
+                </Ln>
+                <Ln color={C.textMuted}>&nbsp;</Ln>
+                <Ln>
+                  <Val>root@web-app:~#</Val>{" "}
+                  <Dim>curl localhost:8080/health</Dim>
+                </Ln>
+                <Ln>
+                  <Str>{'{"status":"healthy","uptime":"14d 6h"}'}</Str>
+                </Ln>
+              </TerminalChrome>
+            </Reveal>
           </div>
         </div>
-      </section>
+      </Section>
 
-      {/* ─────────── CTA ─────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal>
-            <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-              <ConnectionGrid />
-              <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
+      {/* ─────────── API-First ─────────── */}
+      <Section>
+        <SectionHeader
+          eyebrow="API-First"
+          title="Automate everything with the REST API"
+          subtitle="Every feature in ShellHub is accessible through a well-documented REST API. Build custom dashboards, automate workflows, or integrate with your internal tools."
+        />
 
-              <div className="relative z-10">
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Ready to integrate?
-                </p>
-                <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Start integrating today
-                </h2>
-                <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                  Get ShellHub running and connect it to your existing workflow
-                  in minutes. Standard SSH means zero learning curve.
-                </p>
-
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                  <Button
-                    as={Link}
-                    to="/getting-started"
-                    variant="primary"
-                    size="xl"
-                    glow
-                    iconRight={<ArrowRight />}
-                  >
-                    Get Started Free
-                  </Button>
-                  <Button
-                    as="a"
-                    href={docsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="outline"
-                    size="xl"
-                  >
-                    Read the Docs
-                  </Button>
+        <Reveal delay={0.1}>
+          <ShimmerCard className="max-w-4xl mx-auto">
+            <Card className="overflow-hidden">
+              {/* API tabs */}
+              <div className="flex items-center gap-1 px-5 py-3 border-b border-border bg-surface/60">
+                <Badge shape="pill" color="green">
+                  GET
+                </Badge>
+                <span className="text-2xs font-mono text-text-secondary ml-2">
+                  /api/devices
+                </span>
+                <div className="ml-auto flex items-center gap-2">
+                  <span className="px-2 py-0.5 text-2xs font-mono text-accent-green bg-accent-green/10 rounded">
+                    200 OK
+                  </span>
                 </div>
               </div>
-            </div>
-          </Reveal>
+
+              <div className="grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
+                {/* Request */}
+                <div className="p-5">
+                  <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-3">
+                    Request
+                  </p>
+                  <div className="bg-surface/60 border border-border rounded-lg p-4 font-mono text-2xs leading-[1.7]">
+                    <Ln>
+                      <Val>$</Val> curl -s \
+                    </Ln>
+                    <Ln>
+                      {" "}
+                      -H <Str>"Authorization: Bearer $TOKEN"</Str> \
+                    </Ln>
+                    <Ln>
+                      {" "}
+                      -H <Str>"Content-Type: application/json"</Str> \
+                    </Ln>
+                    <Ln>
+                      {" "}
+                      <Cyn>https://cloud.shellhub.io/api/devices</Cyn>
+                    </Ln>
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-2">
+                      Headers
+                    </p>
+                    {[
+                      { key: "Authorization", val: "Bearer eyJhb..." },
+                      { key: "Content-Type", val: "application/json" },
+                      { key: "X-Tenant-ID", val: "d0a1c2e4..." },
+                    ].map((h) => (
+                      <div
+                        key={h.key}
+                        className="flex items-center gap-2 text-2xs font-mono"
+                      >
+                        <span className="text-primary">{h.key}:</span>
+                        <span className="text-text-muted truncate">
+                          {h.val}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Response */}
+                <div className="p-5">
+                  <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-3">
+                    Response
+                  </p>
+                  <div className="bg-surface/60 border border-border rounded-lg p-4 font-mono text-2xs leading-[1.7]">
+                    <Ln>[</Ln>
+                    <Ln>
+                      {"  "}
+                      {"{"}
+                    </Ln>
+                    <Ln>
+                      {"    "}
+                      <Kw>"uid"</Kw>: <Str>"a1b2c3d4e5f6"</Str>,
+                    </Ln>
+                    <Ln>
+                      {"    "}
+                      <Kw>"name"</Kw>: <Str>"gateway-east-01"</Str>,
+                    </Ln>
+                    <Ln>
+                      {"    "}
+                      <Kw>"identity"</Kw>: {"{"}
+                    </Ln>
+                    <Ln>
+                      {"      "}
+                      <Kw>"mac"</Kw>: <Str>"00:1a:2b:3c:4d:5e"</Str>
+                    </Ln>
+                    <Ln>
+                      {"    "}
+                      {"}"},
+                    </Ln>
+                    <Ln>
+                      {"    "}
+                      <Kw>"info"</Kw>: {"{"}
+                    </Ln>
+                    <Ln>
+                      {"      "}
+                      <Kw>"version"</Kw>: <Str>"0.15.1"</Str>,
+                    </Ln>
+                    <Ln>
+                      {"      "}
+                      <Kw>"arch"</Kw>: <Str>"amd64"</Str>
+                    </Ln>
+                    <Ln>
+                      {"    "}
+                      {"}"},
+                    </Ln>
+                    <Ln>
+                      {"    "}
+                      <Kw>"status"</Kw>: <Str>"online"</Str>,
+                    </Ln>
+                    <Ln>
+                      {"    "}
+                      <Kw>"last_seen"</Kw>: <Str>"2026-02-14T..."</Str>
+                    </Ln>
+                    <Ln>
+                      {"  "}
+                      {"}"}
+                    </Ln>
+                    <Ln>]</Ln>
+                  </div>
+                </div>
+              </div>
+
+              {/* More endpoints */}
+              <div className="px-5 py-3 border-t border-border bg-surface/40 flex flex-wrap gap-2">
+                {[
+                  { method: "POST", path: "/api/sessions", color: C.yellow },
+                  { method: "GET", path: "/api/stats", color: C.green },
+                  {
+                    method: "PUT",
+                    path: "/api/devices/{uid}",
+                    color: C.blue,
+                  },
+                  {
+                    method: "DELETE",
+                    path: "/api/sessions/{uid}",
+                    color: C.red,
+                  },
+                  { method: "GET", path: "/api/namespaces", color: C.green },
+                ].map((ep) => (
+                  <span
+                    key={ep.path}
+                    className="inline-flex items-center gap-1.5 px-2 py-1 bg-white/[0.03] border border-border rounded text-2xs font-mono text-text-muted hover:border-border-light transition-colors"
+                  >
+                    <span style={{ color: ep.color }} className="font-semibold">
+                      {ep.method}
+                    </span>
+                    {ep.path}
+                  </span>
+                ))}
+              </div>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
+      </Section>
+
+      {/* ─────────── Standard SSH callout ─────────── */}
+      <Section>
+        <Reveal className="text-center mb-14">
+          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
+            Standard SSH. Zero plugins.
+          </h2>
+          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
+            ShellHub works with any tool that supports SSH. No proprietary
+            clients, no custom APIs, no vendor lock-in.
+          </p>
+        </Reveal>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {[
+            {
+              color: C.primary,
+              title: "SSH as transport",
+              desc: "Any tool that uses SSH for remote execution works with ShellHub out of the box. Ansible, rsync, scp, Git over SSH.",
+              icon: (
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke={C.primary}
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
+                  />
+                </svg>
+              ),
+            },
+            {
+              color: C.cyan,
+              title: "No agent changes",
+              desc: "The ShellHub agent runs independently on your devices. Install once and use it with every tool in your stack.",
+              icon: (
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke={C.cyan}
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
+                  />
+                </svg>
+              ),
+            },
+            {
+              color: C.green,
+              title: "API-first design",
+              desc: "Programmatic access to devices, sessions, and configurations. Build custom integrations with the REST API.",
+              icon: (
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke={C.green}
+                  strokeWidth={1.5}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
+                  />
+                </svg>
+              ),
+            },
+          ].map((b, i) => (
+            <Reveal key={i} delay={i * 0.06}>
+              <ShimmerCard className="h-full">
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${b.color}15`,
+                      borderColor: `${b.color}25`,
+                    }}
+                  >
+                    {b.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2">{b.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {b.desc}
+                  </p>
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
         </div>
-      </section>
+      </Section>
+
+      {/* ─────────── CTA ─────────── */}
+      <Section>
+        <Reveal>
+          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+            <ConnectionGrid />
+            <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
+
+            <div className="relative z-10">
+              <SectionHeader
+                variant="cta"
+                eyebrow="Ready to integrate?"
+                title="Start integrating today"
+                subtitle="Get ShellHub running and connect it to your existing workflow in minutes. Standard SSH means zero learning curve."
+              />
+
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+                <Button
+                  as={Link}
+                  to="/getting-started"
+                  variant="primary"
+                  size="xl"
+                  glow
+                  iconRight={<ArrowRight />}
+                >
+                  Get Started Free
+                </Button>
+                <Button
+                  as="a"
+                  href={docsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="outline"
+                  size="xl"
+                >
+                  Read the Docs
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </Section>
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/landing/Architecture.tsx
+++ b/ui/apps/website/src/pages/landing/Architecture.tsx
@@ -1,102 +1,535 @@
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal } from "./components";
 import { C } from "./constants";
 
 export function Architecture() {
   return (
-    <section className="py-24 bg-surface border-t border-b border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-4">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">Architecture</p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">Okay, but how does it actually work?</h2>
-          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">Install a lightweight agent on your devices. The agent connects outbound to ShellHub&apos;s gateway. SSH in from anywhere.</p>
-        </Reveal>
+    <Section background="surface" className="border-b border-border">
+      <SectionHeader
+        className="mb-4"
+        eyebrow="Architecture"
+        title="Okay, but how does it actually work?"
+        subtitle="Install a lightweight agent on your devices. The agent connects outbound to ShellHub's gateway. SSH in from anywhere."
+      />
 
-        <Reveal className="mt-12 bg-card border border-border rounded-xl p-6 lg:p-8 overflow-x-auto">
-          <svg viewBox="0 0 900 320" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto min-w-[700px]">
-            <defs>
-              <marker id="aa" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill={C.primary} /></marker>
-              <marker id="aad" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill={`${C.primary}60`} /></marker>
-            </defs>
-            <text x="100" y="30" fontFamily="IBM Plex Sans" fontSize="12" fill={C.textMuted} textAnchor="middle" letterSpacing=".1em">THE INTERNET</text>
-            <circle cx="100" cy="100" r="35" fill="none" stroke={C.border} strokeWidth="1.5" />
-            <ellipse cx="100" cy="100" rx="35" ry="15" fill="none" stroke={C.border} strokeWidth="1" />
-            <ellipse cx="100" cy="100" rx="15" ry="35" fill="none" stroke={C.border} strokeWidth="1" />
-            <line x1="65" y1="100" x2="135" y2="100" stroke={C.border} strokeWidth="1" />
-            <circle cx="100" cy="100" r="35" fill="none" stroke={`${C.primary}30`} strokeWidth="1.5" />
-            <rect x="60" y="170" width="80" height="65" rx="10" fill={C.card} stroke={C.border} />
-            <circle cx="100" cy="190" r="10" stroke={C.primary} strokeWidth="1.2" fill="none" />
-            <circle cx="100" cy="187" r="3.5" fill={C.primary} />
-            <path d="M100 192 L100 195 M94 194 L106 194" stroke={C.primary} strokeWidth="1.2" strokeLinecap="round" />
-            <text x="100" y="225" fontFamily="IBM Plex Sans" fontSize="10" fill={C.textSec} textAnchor="middle">You</text>
-            <line x1="145" y1="200" x2="285" y2="160" stroke={C.primary} strokeWidth="1.5" markerEnd="url(#aa)" />
-            <rect x="180" y="165" width="80" height="18" rx="4" fill={C.bg} stroke="none" />
-            <text x="220" y="178" fontFamily="IBM Plex Mono" fontSize="8" fill={C.primary} textAnchor="middle">Encrypted Tunnel</text>
-            <rect x="290" y="40" width="300" height="240" rx="16" fill={`${C.primary}08`} stroke={C.primary} strokeWidth="1.5" />
-            <text x="440" y="30" fontFamily="IBM Plex Sans" fontSize="12" fill={C.primary} textAnchor="middle" fontWeight="600" letterSpacing=".1em">SHELLHUB CLOUD</text>
-            <rect x="400" y="80" width="80" height="44" rx="10" fill={C.primaryDim} stroke={C.primary} strokeWidth="1" />
-            <text x="440" y="107" fontFamily="IBM Plex Mono" fontSize="14" fill={C.primary} textAnchor="middle" fontWeight="700">SH</text>
-            {[
-              { x: 310, y: 145, emoji: "\uD83D\uDD10", color: C.primary, label: "Authentication" },
-              { x: 310, y: 182, emoji: "\uD83D\uDD12", color: C.primary, label: "Encryption" },
-              { x: 310, y: 219, emoji: "\u23FA", color: C.cyan, label: "Session Rec." },
-              { x: 460, y: 145, emoji: "\uD83D\uDEE1", color: C.yellow, label: "Firewall Rules" },
-              { x: 460, y: 182, emoji: "\uD83D\uDCCB", color: C.green, label: "Audit Logging" },
-              { x: 460, y: 219, emoji: "\uD83D\uDC65", color: C.primary, label: "Team RBAC" },
-            ].map((b, i) => (
-              <g key={i}>
-                <rect x={b.x} y={b.y} width="110" height="28" rx="6" fill={C.card} stroke={C.border} />
-                <text x={b.x + 12} y={b.y + 17} fontSize="10" fill={b.color}>{b.emoji}</text>
-                <text x={b.x + 30} y={b.y + 18} fontFamily="IBM Plex Sans" fontSize="9" fill={C.textSec}>{b.label}</text>
-              </g>
-            ))}
-            <text x="750" y="30" fontFamily="IBM Plex Sans" fontSize="12" fill={C.textMuted} textAnchor="middle" letterSpacing=".1em">YOUR DEVICES</text>
-            <rect x="630" y="50" width="6" height="225" rx="3" fill={C.border} />
-            <text x="633" y="44" fontFamily="IBM Plex Mono" fontSize="8" fill={C.textMuted} textAnchor="middle">NAT</text>
-            <line x1="595" y1="105" x2="628" y2="105" stroke={C.primary} strokeWidth="1.5" markerEnd="url(#aa)" />
-            <line x1="638" y1="105" x2="660" y2="75" stroke={`${C.primary}60`} strokeWidth="1.2" strokeDasharray="4 3" markerEnd="url(#aad)" />
-            <line x1="638" y1="140" x2="660" y2="150" stroke={`${C.primary}60`} strokeWidth="1.2" strokeDasharray="4 3" markerEnd="url(#aad)" />
-            <line x1="638" y1="175" x2="660" y2="225" stroke={`${C.primary}60`} strokeWidth="1.2" strokeDasharray="4 3" markerEnd="url(#aad)" />
-            <text x="618" y="130" fontFamily="IBM Plex Mono" fontSize="7" fill={`${C.primary}60`} textAnchor="middle" transform="rotate(-90,618,130)">NAT Traversal</text>
-            {[
-              { y: 48, icon: "Pi", iconBg: C.green, label: "Raspberry Pi", begin: "0s" },
-              { y: 110, icon: null, iconBg: C.primary, label: "Linux Server", begin: ".5s" },
-              { y: 172, icon: "\uD83D\uDC33", iconBg: C.blue, label: "Docker Host", begin: "1s" },
-              { y: 234, icon: null, iconBg: C.yellow, label: "IoT Gateway", begin: "1.5s", isIoT: true },
-            ].map((d, i) => (
-              <g key={i}>
-                <rect x="664" y={d.y} width="140" height="52" rx="8" fill={C.card} stroke={C.border} />
-                {d.isIoT ? (
-                  <><circle cx="692" cy={d.y + 20} r="10" fill="none" stroke={`${d.iconBg}50`} strokeWidth=".8" /><circle cx="692" cy={d.y + 20} r="4" fill={`${d.iconBg}30`} /></>
-                ) : d.icon === "\uD83D\uDC33" ? (
-                  <><rect x="678" y={d.y + 10} width="28" height="20" rx="4" fill={`${d.iconBg}15`} stroke={d.iconBg} strokeWidth=".8" /><text x="692" y={d.y + 24} fontSize="8" fill={d.iconBg} textAnchor="middle" fontWeight="600">{d.icon}</text></>
-                ) : d.icon === "Pi" ? (
-                  <><rect x="678" y={d.y + 10} width="28" height="20" rx="4" fill={`${d.iconBg}15`} stroke={d.iconBg} strokeWidth=".8" /><text x="692" y={d.y + 24} fontSize="9" fill={d.iconBg} textAnchor="middle" fontWeight="600">Pi</text></>
-                ) : (
-                  <><rect x="678" y={d.y + 10} width="28" height="20" rx="3" fill={`${d.iconBg}15`} stroke={d.iconBg} strokeWidth=".8" /><rect x="683" y={d.y + 15} width="18" height="10" rx="2" fill={`${d.iconBg}30`} /></>
-                )}
-                <text x="740" y={d.y + 24} fontFamily="IBM Plex Sans" fontSize="10" fill={C.text} textAnchor="start">{d.label}</text>
-                <text x="740" y={d.y + 38} fontFamily="IBM Plex Mono" fontSize="7" fill={C.textMuted} textAnchor="start">agent running</text>
-                <circle cx="794" cy={d.y + 8} r="3" fill={C.green}><animate attributeName="opacity" values="1;.3;1" dur="2s" repeatCount="indefinite" begin={d.begin} /></circle>
-              </g>
-            ))}
-            <rect x="558" y="88" width="32" height="14" rx="3" fill={C.bg} stroke={`${C.primary}30`} />
-            <text x="574" y="98" fontFamily="IBM Plex Mono" fontSize="7" fill={C.primary} textAnchor="middle">SSH</text>
-          </svg>
-        </Reveal>
-
-        <Reveal className="flex gap-4 mt-8 justify-center flex-wrap">
+      <Reveal className="mt-12 bg-card border border-border rounded-xl p-6 lg:p-8 overflow-x-auto">
+        <svg
+          viewBox="0 0 900 320"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="w-full h-auto min-w-[700px]"
+        >
+          <defs>
+            <marker
+              id="aa"
+              markerWidth="8"
+              markerHeight="6"
+              refX="8"
+              refY="3"
+              orient="auto"
+            >
+              <path d="M0,0 L8,3 L0,6" fill={C.primary} />
+            </marker>
+            <marker
+              id="aad"
+              markerWidth="8"
+              markerHeight="6"
+              refX="8"
+              refY="3"
+              orient="auto"
+            >
+              <path d="M0,0 L8,3 L0,6" fill={`${C.primary}60`} />
+            </marker>
+          </defs>
+          <text
+            x="100"
+            y="30"
+            fontFamily="IBM Plex Sans"
+            fontSize="12"
+            fill={C.textMuted}
+            textAnchor="middle"
+            letterSpacing=".1em"
+          >
+            THE INTERNET
+          </text>
+          <circle
+            cx="100"
+            cy="100"
+            r="35"
+            fill="none"
+            stroke={C.border}
+            strokeWidth="1.5"
+          />
+          <ellipse
+            cx="100"
+            cy="100"
+            rx="35"
+            ry="15"
+            fill="none"
+            stroke={C.border}
+            strokeWidth="1"
+          />
+          <ellipse
+            cx="100"
+            cy="100"
+            rx="15"
+            ry="35"
+            fill="none"
+            stroke={C.border}
+            strokeWidth="1"
+          />
+          <line
+            x1="65"
+            y1="100"
+            x2="135"
+            y2="100"
+            stroke={C.border}
+            strokeWidth="1"
+          />
+          <circle
+            cx="100"
+            cy="100"
+            r="35"
+            fill="none"
+            stroke={`${C.primary}30`}
+            strokeWidth="1.5"
+          />
+          <rect
+            x="60"
+            y="170"
+            width="80"
+            height="65"
+            rx="10"
+            fill={C.card}
+            stroke={C.border}
+          />
+          <circle
+            cx="100"
+            cy="190"
+            r="10"
+            stroke={C.primary}
+            strokeWidth="1.2"
+            fill="none"
+          />
+          <circle cx="100" cy="187" r="3.5" fill={C.primary} />
+          <path
+            d="M100 192 L100 195 M94 194 L106 194"
+            stroke={C.primary}
+            strokeWidth="1.2"
+            strokeLinecap="round"
+          />
+          <text
+            x="100"
+            y="225"
+            fontFamily="IBM Plex Sans"
+            fontSize="10"
+            fill={C.textSec}
+            textAnchor="middle"
+          >
+            You
+          </text>
+          <line
+            x1="145"
+            y1="200"
+            x2="285"
+            y2="160"
+            stroke={C.primary}
+            strokeWidth="1.5"
+            markerEnd="url(#aa)"
+          />
+          <rect
+            x="180"
+            y="165"
+            width="80"
+            height="18"
+            rx="4"
+            fill={C.bg}
+            stroke="none"
+          />
+          <text
+            x="220"
+            y="178"
+            fontFamily="IBM Plex Mono"
+            fontSize="8"
+            fill={C.primary}
+            textAnchor="middle"
+          >
+            Encrypted Tunnel
+          </text>
+          <rect
+            x="290"
+            y="40"
+            width="300"
+            height="240"
+            rx="16"
+            fill={`${C.primary}08`}
+            stroke={C.primary}
+            strokeWidth="1.5"
+          />
+          <text
+            x="440"
+            y="30"
+            fontFamily="IBM Plex Sans"
+            fontSize="12"
+            fill={C.primary}
+            textAnchor="middle"
+            fontWeight="600"
+            letterSpacing=".1em"
+          >
+            SHELLHUB CLOUD
+          </text>
+          <rect
+            x="400"
+            y="80"
+            width="80"
+            height="44"
+            rx="10"
+            fill={C.primaryDim}
+            stroke={C.primary}
+            strokeWidth="1"
+          />
+          <text
+            x="440"
+            y="107"
+            fontFamily="IBM Plex Mono"
+            fontSize="14"
+            fill={C.primary}
+            textAnchor="middle"
+            fontWeight="700"
+          >
+            SH
+          </text>
           {[
-            { n: "1", t: "Install the ShellHub agent on your device" },
-            { n: "2", t: "Agent connects outbound to ShellHub Cloud" },
-            { n: "3", t: "Access your devices securely from anywhere" },
-          ].map((s) => (
-            <div key={s.n} className="flex items-center gap-3 px-4 py-2.5 bg-card border border-border rounded-lg">
-              <span className="w-6 h-6 rounded-full bg-primary/10 border border-primary/20 text-primary flex items-center justify-center text-2xs font-bold font-mono">{s.n}</span>
-              <span className="text-sm text-text-secondary">{s.t}</span>
-            </div>
+            {
+              x: 310,
+              y: 145,
+              emoji: "\uD83D\uDD10",
+              color: C.primary,
+              label: "Authentication",
+            },
+            {
+              x: 310,
+              y: 182,
+              emoji: "\uD83D\uDD12",
+              color: C.primary,
+              label: "Encryption",
+            },
+            {
+              x: 310,
+              y: 219,
+              emoji: "\u23FA",
+              color: C.cyan,
+              label: "Session Rec.",
+            },
+            {
+              x: 460,
+              y: 145,
+              emoji: "\uD83D\uDEE1",
+              color: C.yellow,
+              label: "Firewall Rules",
+            },
+            {
+              x: 460,
+              y: 182,
+              emoji: "\uD83D\uDCCB",
+              color: C.green,
+              label: "Audit Logging",
+            },
+            {
+              x: 460,
+              y: 219,
+              emoji: "\uD83D\uDC65",
+              color: C.primary,
+              label: "Team RBAC",
+            },
+          ].map((b, i) => (
+            <g key={i}>
+              <rect
+                x={b.x}
+                y={b.y}
+                width="110"
+                height="28"
+                rx="6"
+                fill={C.card}
+                stroke={C.border}
+              />
+              <text x={b.x + 12} y={b.y + 17} fontSize="10" fill={b.color}>
+                {b.emoji}
+              </text>
+              <text
+                x={b.x + 30}
+                y={b.y + 18}
+                fontFamily="IBM Plex Sans"
+                fontSize="9"
+                fill={C.textSec}
+              >
+                {b.label}
+              </text>
+            </g>
           ))}
-        </Reveal>
-      </div>
-    </section>
+          <text
+            x="750"
+            y="30"
+            fontFamily="IBM Plex Sans"
+            fontSize="12"
+            fill={C.textMuted}
+            textAnchor="middle"
+            letterSpacing=".1em"
+          >
+            YOUR DEVICES
+          </text>
+          <rect x="630" y="50" width="6" height="225" rx="3" fill={C.border} />
+          <text
+            x="633"
+            y="44"
+            fontFamily="IBM Plex Mono"
+            fontSize="8"
+            fill={C.textMuted}
+            textAnchor="middle"
+          >
+            NAT
+          </text>
+          <line
+            x1="595"
+            y1="105"
+            x2="628"
+            y2="105"
+            stroke={C.primary}
+            strokeWidth="1.5"
+            markerEnd="url(#aa)"
+          />
+          <line
+            x1="638"
+            y1="105"
+            x2="660"
+            y2="75"
+            stroke={`${C.primary}60`}
+            strokeWidth="1.2"
+            strokeDasharray="4 3"
+            markerEnd="url(#aad)"
+          />
+          <line
+            x1="638"
+            y1="140"
+            x2="660"
+            y2="150"
+            stroke={`${C.primary}60`}
+            strokeWidth="1.2"
+            strokeDasharray="4 3"
+            markerEnd="url(#aad)"
+          />
+          <line
+            x1="638"
+            y1="175"
+            x2="660"
+            y2="225"
+            stroke={`${C.primary}60`}
+            strokeWidth="1.2"
+            strokeDasharray="4 3"
+            markerEnd="url(#aad)"
+          />
+          <text
+            x="618"
+            y="130"
+            fontFamily="IBM Plex Mono"
+            fontSize="7"
+            fill={`${C.primary}60`}
+            textAnchor="middle"
+            transform="rotate(-90,618,130)"
+          >
+            NAT Traversal
+          </text>
+          {[
+            {
+              y: 48,
+              icon: "Pi",
+              iconBg: C.green,
+              label: "Raspberry Pi",
+              begin: "0s",
+            },
+            {
+              y: 110,
+              icon: null,
+              iconBg: C.primary,
+              label: "Linux Server",
+              begin: ".5s",
+            },
+            {
+              y: 172,
+              icon: "\uD83D\uDC33",
+              iconBg: C.blue,
+              label: "Docker Host",
+              begin: "1s",
+            },
+            {
+              y: 234,
+              icon: null,
+              iconBg: C.yellow,
+              label: "IoT Gateway",
+              begin: "1.5s",
+              isIoT: true,
+            },
+          ].map((d, i) => (
+            <g key={i}>
+              <rect
+                x="664"
+                y={d.y}
+                width="140"
+                height="52"
+                rx="8"
+                fill={C.card}
+                stroke={C.border}
+              />
+              {d.isIoT ? (
+                <>
+                  <circle
+                    cx="692"
+                    cy={d.y + 20}
+                    r="10"
+                    fill="none"
+                    stroke={`${d.iconBg}50`}
+                    strokeWidth=".8"
+                  />
+                  <circle cx="692" cy={d.y + 20} r="4" fill={`${d.iconBg}30`} />
+                </>
+              ) : d.icon === "\uD83D\uDC33" ? (
+                <>
+                  <rect
+                    x="678"
+                    y={d.y + 10}
+                    width="28"
+                    height="20"
+                    rx="4"
+                    fill={`${d.iconBg}15`}
+                    stroke={d.iconBg}
+                    strokeWidth=".8"
+                  />
+                  <text
+                    x="692"
+                    y={d.y + 24}
+                    fontSize="8"
+                    fill={d.iconBg}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    {d.icon}
+                  </text>
+                </>
+              ) : d.icon === "Pi" ? (
+                <>
+                  <rect
+                    x="678"
+                    y={d.y + 10}
+                    width="28"
+                    height="20"
+                    rx="4"
+                    fill={`${d.iconBg}15`}
+                    stroke={d.iconBg}
+                    strokeWidth=".8"
+                  />
+                  <text
+                    x="692"
+                    y={d.y + 24}
+                    fontSize="9"
+                    fill={d.iconBg}
+                    textAnchor="middle"
+                    fontWeight="600"
+                  >
+                    Pi
+                  </text>
+                </>
+              ) : (
+                <>
+                  <rect
+                    x="678"
+                    y={d.y + 10}
+                    width="28"
+                    height="20"
+                    rx="3"
+                    fill={`${d.iconBg}15`}
+                    stroke={d.iconBg}
+                    strokeWidth=".8"
+                  />
+                  <rect
+                    x="683"
+                    y={d.y + 15}
+                    width="18"
+                    height="10"
+                    rx="2"
+                    fill={`${d.iconBg}30`}
+                  />
+                </>
+              )}
+              <text
+                x="740"
+                y={d.y + 24}
+                fontFamily="IBM Plex Sans"
+                fontSize="10"
+                fill={C.text}
+                textAnchor="start"
+              >
+                {d.label}
+              </text>
+              <text
+                x="740"
+                y={d.y + 38}
+                fontFamily="IBM Plex Mono"
+                fontSize="7"
+                fill={C.textMuted}
+                textAnchor="start"
+              >
+                agent running
+              </text>
+              <circle cx="794" cy={d.y + 8} r="3" fill={C.green}>
+                <animate
+                  attributeName="opacity"
+                  values="1;.3;1"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  begin={d.begin}
+                />
+              </circle>
+            </g>
+          ))}
+          <rect
+            x="558"
+            y="88"
+            width="32"
+            height="14"
+            rx="3"
+            fill={C.bg}
+            stroke={`${C.primary}30`}
+          />
+          <text
+            x="574"
+            y="98"
+            fontFamily="IBM Plex Mono"
+            fontSize="7"
+            fill={C.primary}
+            textAnchor="middle"
+          >
+            SSH
+          </text>
+        </svg>
+      </Reveal>
+
+      <Reveal className="flex gap-4 mt-8 justify-center flex-wrap">
+        {[
+          { n: "1", t: "Install the ShellHub agent on your device" },
+          { n: "2", t: "Agent connects outbound to ShellHub Cloud" },
+          { n: "3", t: "Access your devices securely from anywhere" },
+        ].map((s) => (
+          <div
+            key={s.n}
+            className="flex items-center gap-3 px-4 py-2.5 bg-card border border-border rounded-lg"
+          >
+            <span className="w-6 h-6 rounded-full bg-primary/10 border border-primary/20 text-primary flex items-center justify-center text-2xs font-bold font-mono">
+              {s.n}
+            </span>
+            <span className="text-sm text-text-secondary">{s.t}</span>
+          </div>
+        ))}
+      </Reveal>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/landing/CTA.tsx
+++ b/ui/apps/website/src/pages/landing/CTA.tsx
@@ -1,11 +1,16 @@
 import { Button } from "@shellhub/design-system/primitives";
+import { Section } from "@/components/marketing";
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ConnectionGrid } from "./components";
 import { signupUrl } from "@/links";
 
 export function CTA() {
   return (
-    <section className="py-24 text-center relative overflow-hidden grid-bg">
+    <Section
+      container={false}
+      bordered={false}
+      className="text-center grid-bg relative overflow-hidden"
+    >
       <ConnectionGrid />
       <div className="absolute inset-0 bg-gradient-radial from-primary/8 via-transparent to-transparent pointer-events-none" />
       <div className="absolute top-1/2 left-1/3 -translate-y-1/2 w-80 h-80 bg-primary/6 rounded-full blur-3xl pointer-events-none" />
@@ -36,6 +41,6 @@ export function CTA() {
           </Button>
         </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/landing/FeatureGrid.tsx
+++ b/ui/apps/website/src/pages/landing/FeatureGrid.tsx
@@ -1,174 +1,169 @@
 import { Card } from "@shellhub/design-system/primitives";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard } from "./components";
 import { C } from "./constants";
 
 export function FeatureGrid() {
   return (
-    <section className="py-24">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Features
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight">
-            Everything you need to manage remote devices.
-          </h2>
-        </Reveal>
+    <Section bordered={false}>
+      <SectionHeader
+        eyebrow="Features"
+        title="Everything you need to manage remote devices."
+      />
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {[
-            {
-              icon: (
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke={C.primary}
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[
+          {
+            icon: (
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={C.primary}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <polyline points="4 17 10 11 4 5" />
+                <line x1="12" y1="19" x2="20" y2="19" />
+              </svg>
+            ),
+            color: C.primary,
+            title: "Native SSH Support",
+            desc: "Use your standard SSH client. No proprietary tools or plugins required.",
+            delay: 0,
+          },
+          {
+            icon: (
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={C.cyan}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                <polyline points="14 2 14 8 20 8" />
+                <line x1="16" y1="13" x2="8" y2="13" />
+                <line x1="16" y1="17" x2="8" y2="17" />
+              </svg>
+            ),
+            color: C.cyan,
+            title: "SCP/SFTP File Transfer",
+            desc: "Transfer files to and from remote devices with SCP and SFTP.",
+            delay: 0.06,
+          },
+          {
+            icon: (
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={C.yellow}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <rect x="3" y="11" width="18" height="11" rx="2" />
+                <path d="M7 11V7a5 5 0 0110 0v4" />
+                <circle cx="12" cy="16" r="1" />
+              </svg>
+            ),
+            color: C.yellow,
+            title: "Multi-Factor Auth",
+            desc: "Require TOTP-based MFA for SSH connections. Works with any authenticator app.",
+            delay: 0.12,
+          },
+          {
+            icon: (
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={C.green}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
+              </svg>
+            ),
+            color: C.green,
+            title: "Audit Logging",
+            desc: "Full audit trail of every connection, command, and session. Export logs for compliance.",
+            delay: 0,
+          },
+          {
+            icon: (
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={C.primary}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <path d="M23 21v-2a4 4 0 00-3-3.87" />
+                <path d="M16 3.13a4 4 0 010 7.75" />
+              </svg>
+            ),
+            color: C.primary,
+            title: "Team Management & RBAC",
+            desc: "Invite team members, assign roles, and control who can access which devices.",
+            delay: 0.06,
+          },
+          {
+            icon: (
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={C.blue}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <rect x="2" y="6" width="20" height="12" rx="2" />
+                <path d="M12 12h.01" />
+                <path d="M17 12h.01" />
+                <path d="M7 12h.01" />
+              </svg>
+            ),
+            color: C.blue,
+            title: "Docker Container Access",
+            desc: "SSH directly into Docker containers running on remote hosts. No docker exec needed.",
+            delay: 0.12,
+          },
+        ].map((f, i) => (
+          <Reveal key={i} delay={f.delay}>
+            <ShimmerCard>
+              <Card hover className="p-6 h-full">
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                  style={{
+                    background: `${f.color}15`,
+                    borderColor: `${f.color}25`,
+                  }}
                 >
-                  <polyline points="4 17 10 11 4 5" />
-                  <line x1="12" y1="19" x2="20" y2="19" />
-                </svg>
-              ),
-              color: C.primary,
-              title: "Native SSH Support",
-              desc: "Use your standard SSH client. No proprietary tools or plugins required.",
-              delay: 0,
-            },
-            {
-              icon: (
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke={C.cyan}
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                >
-                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                  <line x1="16" y1="13" x2="8" y2="13" />
-                  <line x1="16" y1="17" x2="8" y2="17" />
-                </svg>
-              ),
-              color: C.cyan,
-              title: "SCP/SFTP File Transfer",
-              desc: "Transfer files to and from remote devices with SCP and SFTP.",
-              delay: 0.06,
-            },
-            {
-              icon: (
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke={C.yellow}
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                >
-                  <rect x="3" y="11" width="18" height="11" rx="2" />
-                  <path d="M7 11V7a5 5 0 0110 0v4" />
-                  <circle cx="12" cy="16" r="1" />
-                </svg>
-              ),
-              color: C.yellow,
-              title: "Multi-Factor Auth",
-              desc: "Require TOTP-based MFA for SSH connections. Works with any authenticator app.",
-              delay: 0.12,
-            },
-            {
-              icon: (
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke={C.green}
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                >
-                  <path d="M12 20h9" />
-                  <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
-                </svg>
-              ),
-              color: C.green,
-              title: "Audit Logging",
-              desc: "Full audit trail of every connection, command, and session. Export logs for compliance.",
-              delay: 0,
-            },
-            {
-              icon: (
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke={C.primary}
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                >
-                  <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
-                  <circle cx="9" cy="7" r="4" />
-                  <path d="M23 21v-2a4 4 0 00-3-3.87" />
-                  <path d="M16 3.13a4 4 0 010 7.75" />
-                </svg>
-              ),
-              color: C.primary,
-              title: "Team Management & RBAC",
-              desc: "Invite team members, assign roles, and control who can access which devices.",
-              delay: 0.06,
-            },
-            {
-              icon: (
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke={C.blue}
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                >
-                  <rect x="2" y="6" width="20" height="12" rx="2" />
-                  <path d="M12 12h.01" />
-                  <path d="M17 12h.01" />
-                  <path d="M7 12h.01" />
-                </svg>
-              ),
-              color: C.blue,
-              title: "Docker Container Access",
-              desc: "SSH directly into Docker containers running on remote hosts. No docker exec needed.",
-              delay: 0.12,
-            },
-          ].map((f, i) => (
-            <Reveal key={i} delay={f.delay}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2 group-hover:text-primary transition-colors">
-                    {f.title}
-                  </h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-          ))}
-        </div>
+                  {f.icon}
+                </div>
+                <h4 className="text-sm font-semibold mb-2 group-hover:text-primary transition-colors">
+                  {f.title}
+                </h4>
+                <p className="text-xs text-text-secondary leading-relaxed">
+                  {f.desc}
+                </p>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+        ))}
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/landing/Hero.tsx
+++ b/ui/apps/website/src/pages/landing/Hero.tsx
@@ -28,7 +28,7 @@ export function Hero() {
             <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
             <span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
           </span>
-          <span className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB]">
+          <span className="text-2xs font-mono font-semibold uppercase tracking-label text-primary">
             Open Source SSH Gateway
           </span>
         </div>

--- a/ui/apps/website/src/pages/landing/HowItWorks.tsx
+++ b/ui/apps/website/src/pages/landing/HowItWorks.tsx
@@ -1,1338 +1,1310 @@
 import { Card } from "@shellhub/design-system/primitives";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard } from "./components";
 import { C } from "./constants";
 
 export function HowItWorks() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            How It Works
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-            From anywhere to any device.
-          </h2>
-          <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-            Instead of juggling VPNs, public IPs, and firewall rules, connect to
-            all your devices through one secure gateway.
-          </p>
+    <Section>
+      <SectionHeader
+        eyebrow="How It Works"
+        title="From anywhere to any device."
+        subtitle="Instead of juggling VPNs, public IPs, and firewall rules, connect to all your devices through one secure gateway."
+      />
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Card 1: Remote SSH Access */}
+        <Reveal>
+          <ShimmerCard>
+            <Card className="p-6 lg:p-8 hover:border-primary/30 transition-all duration-300">
+              <div className="flex items-center gap-3 mb-5">
+                <span className="text-2xs font-mono font-semibold text-primary border border-primary/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
+                  Remote Access
+                </span>
+                <span className="text-2xs font-mono font-bold text-text-secondary">
+                  01
+                </span>
+              </div>
+              <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
+                SSH into any device, from anywhere
+              </h3>
+              <svg
+                viewBox="0 0 520 200"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-full h-auto"
+              >
+                <defs>
+                  <marker
+                    id="arrow-pri"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={C.primary} />
+                  </marker>
+                </defs>
+                <rect
+                  x="10"
+                  y="65"
+                  width="80"
+                  height="70"
+                  rx="10"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <circle
+                  cx="50"
+                  cy="85"
+                  r="12"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  fill="none"
+                />
+                <path
+                  d="M50 80 L50 83 M46 82 L54 82"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+                <circle cx="50" cy="78" r="3" fill={C.primary} />
+                <text
+                  x="50"
+                  y="125"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  User
+                </text>
+                <line
+                  x1="95"
+                  y1="100"
+                  x2="148"
+                  y2="100"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  strokeDasharray="4 3"
+                  markerEnd="url(#arrow-pri)"
+                />
+                <text
+                  x="122"
+                  y="92"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.primaryGlow}
+                  textAnchor="middle"
+                  letterSpacing=".05em"
+                >
+                  SSH
+                </text>
+                <rect
+                  x="152"
+                  y="65"
+                  width="90"
+                  height="70"
+                  rx="10"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <rect
+                  x="165"
+                  y="78"
+                  width="64"
+                  height="40"
+                  rx="4"
+                  fill={C.surface}
+                  stroke={C.border}
+                />
+                <text
+                  x="197"
+                  y="95"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="8"
+                  fill={C.primary}
+                  textAnchor="middle"
+                >
+                  $ ssh
+                </text>
+                <text
+                  x="197"
+                  y="107"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                >
+                  user@device
+                </text>
+                <text
+                  x="197"
+                  y="125"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Terminal
+                </text>
+                <line
+                  x1="247"
+                  y1="100"
+                  x2="290"
+                  y2="100"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  markerEnd="url(#arrow-pri)"
+                />
+                <rect
+                  x="294"
+                  y="50"
+                  width="100"
+                  height="100"
+                  rx="12"
+                  fill={C.primaryDim}
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                />
+                <rect
+                  x="322"
+                  y="72"
+                  width="44"
+                  height="28"
+                  rx="6"
+                  fill={`${C.primary}30`}
+                />
+                <text
+                  x="344"
+                  y="89"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.primary}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  SH
+                </text>
+                <text
+                  x="344"
+                  y="115"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.primary}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  ShellHub
+                </text>
+                <text
+                  x="344"
+                  y="130"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="9"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Cloud
+                </text>
+                <line
+                  x1="399"
+                  y1="100"
+                  x2="428"
+                  y2="100"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  markerEnd="url(#arrow-pri)"
+                />
+                <rect
+                  x="432"
+                  y="60"
+                  width="8"
+                  height="80"
+                  rx="2"
+                  fill={C.border}
+                />
+                <rect
+                  x="432"
+                  y="60"
+                  width="8"
+                  height="80"
+                  rx="2"
+                  fill={`${C.primary}15`}
+                />
+                <text
+                  x="436"
+                  y="55"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                  letterSpacing=".05em"
+                >
+                  NAT
+                </text>
+                <line
+                  x1="444"
+                  y1="100"
+                  x2="460"
+                  y2="100"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  markerEnd="url(#arrow-pri)"
+                />
+                <rect
+                  x="464"
+                  y="65"
+                  width="50"
+                  height="70"
+                  rx="10"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <rect
+                  x="474"
+                  y="78"
+                  width="30"
+                  height="22"
+                  rx="3"
+                  fill={C.surface}
+                  stroke={C.primaryGlow}
+                />
+                <rect
+                  x="480"
+                  y="104"
+                  width="18"
+                  height="4"
+                  rx="2"
+                  fill={C.border}
+                />
+                <circle cx="489" cy="111" r="1.5" fill={C.primary} />
+                <text
+                  x="489"
+                  y="125"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Device
+                </text>
+              </svg>
+            </Card>
+          </ShimmerCard>
         </Reveal>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          {/* Card 1: Remote SSH Access */}
-          <Reveal>
-            <ShimmerCard>
-              <Card className="p-6 lg:p-8 hover:border-primary/30 transition-all duration-300">
-                <div className="flex items-center gap-3 mb-5">
-                  <span className="text-2xs font-mono font-semibold text-[#7B8EDB] border border-primary/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
-                    Remote Access
-                  </span>
-                  <span className="text-2xs font-mono font-bold text-text-secondary">
-                    01
-                  </span>
-                </div>
-                <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
-                  SSH into any device, from anywhere
-                </h3>
-                <svg
-                  viewBox="0 0 520 200"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="w-full h-auto"
+        {/* Card 2: Session Recording */}
+        <Reveal delay={0.08}>
+          <ShimmerCard>
+            <Card className="p-6 lg:p-8 hover:border-accent-cyan/30 transition-all duration-300">
+              <div className="flex items-center gap-3 mb-5">
+                <span className="text-2xs font-mono font-semibold text-accent-cyan border border-accent-cyan/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
+                  Audit
+                </span>
+                <span className="text-2xs font-mono font-bold text-text-secondary">
+                  02
+                </span>
+              </div>
+              <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
+                Record and replay every session
+              </h3>
+              <svg
+                viewBox="0 0 520 200"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-full h-auto"
+              >
+                <defs>
+                  <marker
+                    id="arrow-cyan"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={C.cyan} />
+                  </marker>
+                </defs>
+                <rect
+                  x="10"
+                  y="65"
+                  width="100"
+                  height="70"
+                  rx="10"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <rect
+                  x="22"
+                  y="78"
+                  width="76"
+                  height="36"
+                  rx="4"
+                  fill={C.surface}
+                  stroke={C.border}
+                />
+                <text
+                  x="60"
+                  y="94"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={C.cyan}
+                  textAnchor="middle"
                 >
-                  <defs>
-                    <marker
-                      id="arrow-pri"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
-                    >
-                      <path d="M0,0 L8,3 L0,6" fill={C.primary} />
-                    </marker>
-                  </defs>
-                  <rect
-                    x="10"
-                    y="65"
-                    width="80"
-                    height="70"
-                    rx="10"
-                    fill={C.card}
-                    stroke={C.border}
+                  session_01
+                </text>
+                <text
+                  x="60"
+                  y="106"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="6"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                >
+                  recording...
+                </text>
+                <circle cx="90" cy="82" r="4" fill={C.cyan} opacity=".6">
+                  <animate
+                    attributeName="opacity"
+                    values=".3;1;.3"
+                    dur="1.5s"
+                    repeatCount="indefinite"
                   />
-                  <circle
-                    cx="50"
-                    cy="85"
-                    r="12"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    fill="none"
-                  />
-                  <path
-                    d="M50 80 L50 83 M46 82 L54 82"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                  <circle cx="50" cy="78" r="3" fill={C.primary} />
-                  <text
-                    x="50"
-                    y="125"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    User
-                  </text>
-                  <line
-                    x1="95"
-                    y1="100"
-                    x2="148"
-                    y2="100"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    strokeDasharray="4 3"
-                    markerEnd="url(#arrow-pri)"
-                  />
-                  <text
-                    x="122"
-                    y="92"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.primaryGlow}
-                    textAnchor="middle"
-                    letterSpacing=".05em"
-                  >
-                    SSH
-                  </text>
-                  <rect
-                    x="152"
-                    y="65"
-                    width="90"
-                    height="70"
-                    rx="10"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <rect
-                    x="165"
-                    y="78"
-                    width="64"
-                    height="40"
-                    rx="4"
-                    fill={C.surface}
-                    stroke={C.border}
-                  />
-                  <text
-                    x="197"
-                    y="95"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="8"
-                    fill={C.primary}
-                    textAnchor="middle"
-                  >
-                    $ ssh
-                  </text>
-                  <text
-                    x="197"
-                    y="107"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                  >
-                    user@device
-                  </text>
-                  <text
-                    x="197"
-                    y="125"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Terminal
-                  </text>
-                  <line
-                    x1="247"
-                    y1="100"
-                    x2="290"
-                    y2="100"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    markerEnd="url(#arrow-pri)"
-                  />
-                  <rect
-                    x="294"
-                    y="50"
-                    width="100"
-                    height="100"
-                    rx="12"
-                    fill={C.primaryDim}
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                  />
-                  <rect
-                    x="322"
-                    y="72"
-                    width="44"
-                    height="28"
-                    rx="6"
-                    fill={`${C.primary}30`}
-                  />
-                  <text
-                    x="344"
-                    y="89"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.primary}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    SH
-                  </text>
-                  <text
-                    x="344"
-                    y="115"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.primary}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    ShellHub
-                  </text>
-                  <text
-                    x="344"
-                    y="130"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="9"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Cloud
-                  </text>
-                  <line
-                    x1="399"
-                    y1="100"
-                    x2="428"
-                    y2="100"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    markerEnd="url(#arrow-pri)"
-                  />
-                  <rect
-                    x="432"
-                    y="60"
-                    width="8"
-                    height="80"
-                    rx="2"
-                    fill={C.border}
-                  />
-                  <rect
-                    x="432"
-                    y="60"
-                    width="8"
-                    height="80"
-                    rx="2"
-                    fill={`${C.primary}15`}
-                  />
-                  <text
-                    x="436"
-                    y="55"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                    letterSpacing=".05em"
-                  >
-                    NAT
-                  </text>
-                  <line
-                    x1="444"
-                    y1="100"
-                    x2="460"
-                    y2="100"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    markerEnd="url(#arrow-pri)"
-                  />
-                  <rect
-                    x="464"
-                    y="65"
-                    width="50"
-                    height="70"
-                    rx="10"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <rect
-                    x="474"
-                    y="78"
-                    width="30"
-                    height="22"
-                    rx="3"
-                    fill={C.surface}
-                    stroke={C.primaryGlow}
-                  />
-                  <rect
-                    x="480"
-                    y="104"
-                    width="18"
-                    height="4"
-                    rx="2"
-                    fill={C.border}
-                  />
-                  <circle cx="489" cy="111" r="1.5" fill={C.primary} />
-                  <text
-                    x="489"
-                    y="125"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Device
-                  </text>
-                </svg>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+                </circle>
+                <text
+                  x="60"
+                  y="125"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  SSH Session
+                </text>
+                <line
+                  x1="115"
+                  y1="100"
+                  x2="165"
+                  y2="100"
+                  stroke={C.cyan}
+                  strokeWidth="1.5"
+                  markerEnd="url(#arrow-cyan)"
+                />
+                <rect
+                  x="170"
+                  y="55"
+                  width="100"
+                  height="90"
+                  rx="12"
+                  fill={C.cyanDim}
+                  stroke={C.cyan}
+                  strokeWidth="1.5"
+                />
+                <rect
+                  x="196"
+                  y="72"
+                  width="48"
+                  height="28"
+                  rx="6"
+                  fill={`${C.cyan}30`}
+                />
+                <text
+                  x="220"
+                  y="89"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.cyan}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  SH
+                </text>
+                <text
+                  x="220"
+                  y="115"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.cyan}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  ShellHub
+                </text>
+                <text
+                  x="220"
+                  y="130"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="9"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Gateway
+                </text>
+                <line
+                  x1="275"
+                  y1="85"
+                  x2="340"
+                  y2="70"
+                  stroke={C.cyan}
+                  strokeWidth="1.5"
+                  markerEnd="url(#arrow-cyan)"
+                />
+                <line
+                  x1="275"
+                  y1="115"
+                  x2="340"
+                  y2="135"
+                  stroke={C.cyan}
+                  strokeWidth="1.5"
+                  strokeDasharray="4 3"
+                  markerEnd="url(#arrow-cyan)"
+                />
+                <rect
+                  x="345"
+                  y="38"
+                  width="100"
+                  height="64"
+                  rx="10"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <ellipse
+                  cx="395"
+                  cy="55"
+                  rx="20"
+                  ry="8"
+                  fill="none"
+                  stroke={C.cyan}
+                  strokeWidth="1.2"
+                />
+                <path
+                  d="M375 55 L375 72 Q375 80 395 80 Q415 80 415 72 L415 55"
+                  fill="none"
+                  stroke={C.cyan}
+                  strokeWidth="1.2"
+                />
+                <text
+                  x="395"
+                  y="93"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Storage
+                </text>
+                <line
+                  x1="450"
+                  y1="70"
+                  x2="470"
+                  y2="70"
+                  stroke={C.cyan}
+                  strokeWidth="1.2"
+                  strokeDasharray="3 2"
+                  markerEnd="url(#arrow-cyan)"
+                />
+                <rect
+                  x="474"
+                  y="50"
+                  width="40"
+                  height="40"
+                  rx="8"
+                  fill={`${C.cyan}20`}
+                  stroke={C.cyan}
+                  strokeWidth="1"
+                />
+                <polygon points="488,63 488,77 500,70" fill={C.cyan} />
+                <text
+                  x="494"
+                  y="103"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="9"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Replay
+                </text>
+                <rect
+                  x="345"
+                  y="115"
+                  width="100"
+                  height="50"
+                  rx="10"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <rect
+                  x="358"
+                  y="126"
+                  width="74"
+                  height="26"
+                  rx="4"
+                  fill={C.surface}
+                />
+                <text
+                  x="395"
+                  y="137"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={C.cyan}
+                  textAnchor="middle"
+                >
+                  $ ls -la
+                </text>
+                <text
+                  x="395"
+                  y="147"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="6"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                >
+                  drwxr-xr-x
+                </text>
+                <text
+                  x="395"
+                  y="175"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Live View
+                </text>
+              </svg>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
 
-          {/* Card 2: Session Recording */}
-          <Reveal delay={0.08}>
-            <ShimmerCard>
-              <Card className="p-6 lg:p-8 hover:border-accent-cyan/30 transition-all duration-300">
-                <div className="flex items-center gap-3 mb-5">
-                  <span className="text-2xs font-mono font-semibold text-accent-cyan border border-accent-cyan/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
-                    Audit
-                  </span>
-                  <span className="text-2xs font-mono font-bold text-text-secondary">
-                    02
-                  </span>
-                </div>
-                <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
-                  Record and replay every session
-                </h3>
-                <svg
-                  viewBox="0 0 520 200"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="w-full h-auto"
+        {/* Card 3: Firewall Rules */}
+        <Reveal delay={0.16}>
+          <ShimmerCard>
+            <Card className="p-6 lg:p-8 hover:border-accent-yellow/30 transition-all duration-300">
+              <div className="flex items-center gap-3 mb-5">
+                <span className="text-2xs font-mono font-semibold text-accent-yellow border border-accent-yellow/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
+                  Security
+                </span>
+                <span className="text-2xs font-mono font-bold text-text-secondary">
+                  03
+                </span>
+              </div>
+              <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
+                Control access with firewall rules
+              </h3>
+              <svg
+                viewBox="0 0 520 200"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-full h-auto"
+              >
+                <defs>
+                  <marker
+                    id="arrow-yel"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={C.yellow} />
+                  </marker>
+                  <marker
+                    id="arrow-grn"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={C.green} />
+                  </marker>
+                  <marker
+                    id="arrow-red"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={C.red} />
+                  </marker>
+                </defs>
+                <rect
+                  x="10"
+                  y="55"
+                  width="100"
+                  height="90"
+                  rx="10"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <text
+                  x="60"
+                  y="80"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.text}
+                  textAnchor="middle"
+                  fontWeight="600"
                 >
-                  <defs>
-                    <marker
-                      id="arrow-cyan"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
-                    >
-                      <path d="M0,0 L8,3 L0,6" fill={C.cyan} />
-                    </marker>
-                  </defs>
-                  <rect
-                    x="10"
-                    y="65"
-                    width="100"
-                    height="70"
-                    rx="10"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <rect
-                    x="22"
-                    y="78"
-                    width="76"
-                    height="36"
-                    rx="4"
-                    fill={C.surface}
-                    stroke={C.border}
-                  />
-                  <text
-                    x="60"
-                    y="94"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={C.cyan}
-                    textAnchor="middle"
-                  >
-                    session_01
-                  </text>
-                  <text
-                    x="60"
-                    y="106"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="6"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                  >
-                    recording...
-                  </text>
-                  <circle cx="90" cy="82" r="4" fill={C.cyan} opacity=".6">
-                    <animate
-                      attributeName="opacity"
-                      values=".3;1;.3"
-                      dur="1.5s"
-                      repeatCount="indefinite"
-                    />
-                  </circle>
-                  <text
-                    x="60"
-                    y="125"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    SSH Session
-                  </text>
-                  <line
-                    x1="115"
-                    y1="100"
-                    x2="165"
-                    y2="100"
-                    stroke={C.cyan}
-                    strokeWidth="1.5"
-                    markerEnd="url(#arrow-cyan)"
-                  />
-                  <rect
-                    x="170"
-                    y="55"
-                    width="100"
-                    height="90"
-                    rx="12"
-                    fill={C.cyanDim}
-                    stroke={C.cyan}
-                    strokeWidth="1.5"
-                  />
-                  <rect
-                    x="196"
-                    y="72"
-                    width="48"
-                    height="28"
-                    rx="6"
-                    fill={`${C.cyan}30`}
-                  />
-                  <text
-                    x="220"
-                    y="89"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.cyan}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    SH
-                  </text>
-                  <text
-                    x="220"
-                    y="115"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.cyan}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    ShellHub
-                  </text>
-                  <text
-                    x="220"
-                    y="130"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="9"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Gateway
-                  </text>
-                  <line
-                    x1="275"
-                    y1="85"
-                    x2="340"
-                    y2="70"
-                    stroke={C.cyan}
-                    strokeWidth="1.5"
-                    markerEnd="url(#arrow-cyan)"
-                  />
-                  <line
-                    x1="275"
-                    y1="115"
-                    x2="340"
-                    y2="135"
-                    stroke={C.cyan}
-                    strokeWidth="1.5"
-                    strokeDasharray="4 3"
-                    markerEnd="url(#arrow-cyan)"
-                  />
-                  <rect
-                    x="345"
-                    y="38"
-                    width="100"
-                    height="64"
-                    rx="10"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <ellipse
-                    cx="395"
-                    cy="55"
-                    rx="20"
-                    ry="8"
-                    fill="none"
-                    stroke={C.cyan}
-                    strokeWidth="1.2"
-                  />
-                  <path
-                    d="M375 55 L375 72 Q375 80 395 80 Q415 80 415 72 L415 55"
-                    fill="none"
-                    stroke={C.cyan}
-                    strokeWidth="1.2"
-                  />
-                  <text
-                    x="395"
-                    y="93"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Storage
-                  </text>
-                  <line
-                    x1="450"
-                    y1="70"
-                    x2="470"
-                    y2="70"
-                    stroke={C.cyan}
-                    strokeWidth="1.2"
-                    strokeDasharray="3 2"
-                    markerEnd="url(#arrow-cyan)"
-                  />
-                  <rect
-                    x="474"
-                    y="50"
-                    width="40"
-                    height="40"
-                    rx="8"
-                    fill={`${C.cyan}20`}
-                    stroke={C.cyan}
-                    strokeWidth="1"
-                  />
-                  <polygon points="488,63 488,77 500,70" fill={C.cyan} />
-                  <text
-                    x="494"
-                    y="103"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="9"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Replay
-                  </text>
-                  <rect
-                    x="345"
-                    y="115"
-                    width="100"
-                    height="50"
-                    rx="10"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <rect
-                    x="358"
-                    y="126"
-                    width="74"
-                    height="26"
-                    rx="4"
-                    fill={C.surface}
-                  />
-                  <text
-                    x="395"
-                    y="137"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={C.cyan}
-                    textAnchor="middle"
-                  >
-                    $ ls -la
-                  </text>
-                  <text
-                    x="395"
-                    y="147"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="6"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                  >
-                    drwxr-xr-x
-                  </text>
-                  <text
-                    x="395"
-                    y="175"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Live View
-                  </text>
-                </svg>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+                  Connection
+                </text>
+                <text
+                  x="60"
+                  y="95"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.text}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  Requests
+                </text>
+                <rect
+                  x="22"
+                  y="108"
+                  width="76"
+                  height="10"
+                  rx="3"
+                  fill={C.yellowDim}
+                />
+                <circle cx="30" cy="113" r="3" fill={C.green} />
+                <text
+                  x="56"
+                  y="116"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="6"
+                  fill={C.textMuted}
+                >
+                  192.168.1.10
+                </text>
+                <rect
+                  x="22"
+                  y="122"
+                  width="76"
+                  height="10"
+                  rx="3"
+                  fill={C.yellowDim}
+                />
+                <circle cx="30" cy="127" r="3" fill={C.red} />
+                <text
+                  x="56"
+                  y="130"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="6"
+                  fill={C.textMuted}
+                >
+                  10.0.0.55
+                </text>
+                <line
+                  x1="115"
+                  y1="100"
+                  x2="178"
+                  y2="100"
+                  stroke={C.yellow}
+                  strokeWidth="1.5"
+                  markerEnd="url(#arrow-yel)"
+                />
+                <rect
+                  x="182"
+                  y="40"
+                  width="140"
+                  height="120"
+                  rx="12"
+                  fill={C.yellowDim}
+                  stroke={C.yellow}
+                  strokeWidth="1.5"
+                />
+                <text
+                  x="252"
+                  y="62"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.yellow}
+                  textAnchor="middle"
+                  letterSpacing=".05em"
+                >
+                  RULES ENGINE
+                </text>
+                <rect
+                  x="196"
+                  y="72"
+                  width="112"
+                  height="22"
+                  rx="5"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <circle
+                  cx="210"
+                  cy="83"
+                  r="5"
+                  fill={`${C.green}30`}
+                  stroke={C.green}
+                />
+                <text
+                  x="210"
+                  y="86"
+                  fontSize="8"
+                  fill={C.green}
+                  textAnchor="middle"
+                >
+                  &#10003;
+                </text>
+                <text
+                  x="252"
+                  y="86"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Allow 192.168.*
+                </text>
+                <rect
+                  x="196"
+                  y="100"
+                  width="112"
+                  height="22"
+                  rx="5"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <circle
+                  cx="210"
+                  cy="111"
+                  r="5"
+                  fill={C.redDim}
+                  stroke={C.red}
+                />
+                <text
+                  x="210"
+                  y="114"
+                  fontSize="8"
+                  fill={C.red}
+                  textAnchor="middle"
+                >
+                  &#10005;
+                </text>
+                <text
+                  x="252"
+                  y="114"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Deny 10.0.0.*
+                </text>
+                <rect
+                  x="196"
+                  y="128"
+                  width="112"
+                  height="22"
+                  rx="5"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <circle
+                  cx="210"
+                  cy="139"
+                  r="5"
+                  fill={`${C.green}30`}
+                  stroke={C.green}
+                />
+                <text
+                  x="210"
+                  y="142"
+                  fontSize="8"
+                  fill={C.green}
+                  textAnchor="middle"
+                >
+                  &#10003;
+                </text>
+                <text
+                  x="252"
+                  y="142"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Allow port 22
+                </text>
+                <line
+                  x1="327"
+                  y1="80"
+                  x2="380"
+                  y2="60"
+                  stroke={C.green}
+                  strokeWidth="1.5"
+                  markerEnd="url(#arrow-grn)"
+                />
+                <line
+                  x1="327"
+                  y1="120"
+                  x2="380"
+                  y2="150"
+                  stroke={C.red}
+                  strokeWidth="1.5"
+                  strokeDasharray="4 3"
+                  markerEnd="url(#arrow-red)"
+                />
+                <rect
+                  x="384"
+                  y="35"
+                  width="80"
+                  height="55"
+                  rx="10"
+                  fill={C.greenDim}
+                  stroke={C.green}
+                  strokeWidth="1"
+                />
+                <text
+                  x="424"
+                  y="57"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.green}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  Allowed
+                </text>
+                <rect
+                  x="400"
+                  y="67"
+                  width="48"
+                  height="14"
+                  rx="4"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <circle cx="408" cy="74" r="2" fill={C.green} />
+                <text
+                  x="430"
+                  y="77"
+                  fontSize="6"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                >
+                  &rarr; Device
+                </text>
+                <rect
+                  x="384"
+                  y="125"
+                  width="80"
+                  height="55"
+                  rx="10"
+                  fill={C.redDim}
+                  stroke={C.red}
+                  strokeWidth="1"
+                />
+                <text
+                  x="424"
+                  y="148"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.red}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  Denied
+                </text>
+                <line
+                  x1="410"
+                  y1="160"
+                  x2="438"
+                  y2="170"
+                  stroke={C.red}
+                  strokeWidth="1.5"
+                />
+                <line
+                  x1="438"
+                  y1="160"
+                  x2="410"
+                  y2="170"
+                  stroke={C.red}
+                  strokeWidth="1.5"
+                />
+              </svg>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
 
-          {/* Card 3: Firewall Rules */}
-          <Reveal delay={0.16}>
-            <ShimmerCard>
-              <Card className="p-6 lg:p-8 hover:border-accent-yellow/30 transition-all duration-300">
-                <div className="flex items-center gap-3 mb-5">
-                  <span className="text-2xs font-mono font-semibold text-accent-yellow border border-accent-yellow/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
-                    Security
-                  </span>
-                  <span className="text-2xs font-mono font-bold text-text-secondary">
-                    03
-                  </span>
-                </div>
-                <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
-                  Control access with firewall rules
-                </h3>
-                <svg
-                  viewBox="0 0 520 200"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="w-full h-auto"
+        {/* Card 4: Web Terminal */}
+        <Reveal delay={0.24}>
+          <ShimmerCard>
+            <Card className="p-6 lg:p-8 hover:border-accent-green/30 transition-all duration-300">
+              <div className="flex items-center gap-3 mb-5">
+                <span className="text-2xs font-mono font-semibold text-accent-green border border-accent-green/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
+                  Web Terminal
+                </span>
+                <span className="text-2xs font-mono font-bold text-text-secondary">
+                  04
+                </span>
+              </div>
+              <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
+                Access devices from your browser
+              </h3>
+              <svg
+                viewBox="0 0 520 200"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-full h-auto"
+              >
+                <defs>
+                  <marker
+                    id="arrow-green"
+                    markerWidth="8"
+                    markerHeight="6"
+                    refX="8"
+                    refY="3"
+                    orient="auto"
+                  >
+                    <path d="M0,0 L8,3 L0,6" fill={C.green} />
+                  </marker>
+                </defs>
+                <rect
+                  x="10"
+                  y="50"
+                  width="110"
+                  height="100"
+                  rx="10"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <rect
+                  x="10"
+                  y="50"
+                  width="110"
+                  height="24"
+                  rx="10"
+                  fill={C.surface}
+                />
+                <rect x="10" y="64" width="110" height="10" fill={C.surface} />
+                <circle cx="25" cy="62" r="4" fill={C.red} opacity=".7" />
+                <circle cx="37" cy="62" r="4" fill={C.yellow} opacity=".7" />
+                <circle cx="49" cy="62" r="4" fill={C.green} opacity=".7" />
+                <rect x="60" y="58" width="50" height="8" rx="4" fill={C.bg} />
+                <rect x="20" y="82" width="90" height="56" rx="3" fill={C.bg} />
+                <text
+                  x="65"
+                  y="98"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={C.green}
+                  textAnchor="middle"
                 >
-                  <defs>
-                    <marker
-                      id="arrow-yel"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
-                    >
-                      <path d="M0,0 L8,3 L0,6" fill={C.yellow} />
-                    </marker>
-                    <marker
-                      id="arrow-grn"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
-                    >
-                      <path d="M0,0 L8,3 L0,6" fill={C.green} />
-                    </marker>
-                    <marker
-                      id="arrow-red"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
-                    >
-                      <path d="M0,0 L8,3 L0,6" fill={C.red} />
-                    </marker>
-                  </defs>
-                  <rect
-                    x="10"
-                    y="55"
-                    width="100"
-                    height="90"
-                    rx="10"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <text
-                    x="60"
-                    y="80"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.text}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    Connection
-                  </text>
-                  <text
-                    x="60"
-                    y="95"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.text}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    Requests
-                  </text>
-                  <rect
-                    x="22"
-                    y="108"
-                    width="76"
-                    height="10"
-                    rx="3"
-                    fill={C.yellowDim}
-                  />
-                  <circle cx="30" cy="113" r="3" fill={C.green} />
-                  <text
-                    x="56"
-                    y="116"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="6"
-                    fill={C.textMuted}
-                  >
-                    192.168.1.10
-                  </text>
-                  <rect
-                    x="22"
-                    y="122"
-                    width="76"
-                    height="10"
-                    rx="3"
-                    fill={C.yellowDim}
-                  />
-                  <circle cx="30" cy="127" r="3" fill={C.red} />
-                  <text
-                    x="56"
-                    y="130"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="6"
-                    fill={C.textMuted}
-                  >
-                    10.0.0.55
-                  </text>
-                  <line
-                    x1="115"
-                    y1="100"
-                    x2="178"
-                    y2="100"
-                    stroke={C.yellow}
-                    strokeWidth="1.5"
-                    markerEnd="url(#arrow-yel)"
-                  />
-                  <rect
-                    x="182"
-                    y="40"
-                    width="140"
-                    height="120"
-                    rx="12"
-                    fill={C.yellowDim}
-                    stroke={C.yellow}
-                    strokeWidth="1.5"
-                  />
-                  <text
-                    x="252"
-                    y="62"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.yellow}
-                    textAnchor="middle"
-                    letterSpacing=".05em"
-                  >
-                    RULES ENGINE
-                  </text>
-                  <rect
-                    x="196"
-                    y="72"
-                    width="112"
-                    height="22"
-                    rx="5"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <circle
-                    cx="210"
-                    cy="83"
-                    r="5"
-                    fill={`${C.green}30`}
-                    stroke={C.green}
-                  />
-                  <text
-                    x="210"
-                    y="86"
-                    fontSize="8"
-                    fill={C.green}
-                    textAnchor="middle"
-                  >
-                    &#10003;
-                  </text>
-                  <text
-                    x="252"
-                    y="86"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Allow 192.168.*
-                  </text>
-                  <rect
-                    x="196"
-                    y="100"
-                    width="112"
-                    height="22"
-                    rx="5"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <circle
-                    cx="210"
-                    cy="111"
-                    r="5"
-                    fill={C.redDim}
-                    stroke={C.red}
-                  />
-                  <text
-                    x="210"
-                    y="114"
-                    fontSize="8"
-                    fill={C.red}
-                    textAnchor="middle"
-                  >
-                    &#10005;
-                  </text>
-                  <text
-                    x="252"
-                    y="114"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Deny 10.0.0.*
-                  </text>
-                  <rect
-                    x="196"
-                    y="128"
-                    width="112"
-                    height="22"
-                    rx="5"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <circle
-                    cx="210"
-                    cy="139"
-                    r="5"
-                    fill={`${C.green}30`}
-                    stroke={C.green}
-                  />
-                  <text
-                    x="210"
-                    y="142"
-                    fontSize="8"
-                    fill={C.green}
-                    textAnchor="middle"
-                  >
-                    &#10003;
-                  </text>
-                  <text
-                    x="252"
-                    y="142"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Allow port 22
-                  </text>
-                  <line
-                    x1="327"
-                    y1="80"
-                    x2="380"
-                    y2="60"
-                    stroke={C.green}
-                    strokeWidth="1.5"
-                    markerEnd="url(#arrow-grn)"
-                  />
-                  <line
-                    x1="327"
-                    y1="120"
-                    x2="380"
-                    y2="150"
-                    stroke={C.red}
-                    strokeWidth="1.5"
-                    strokeDasharray="4 3"
-                    markerEnd="url(#arrow-red)"
-                  />
-                  <rect
-                    x="384"
-                    y="35"
-                    width="80"
-                    height="55"
-                    rx="10"
-                    fill={C.greenDim}
-                    stroke={C.green}
-                    strokeWidth="1"
-                  />
-                  <text
-                    x="424"
-                    y="57"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.green}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    Allowed
-                  </text>
-                  <rect
-                    x="400"
-                    y="67"
-                    width="48"
-                    height="14"
-                    rx="4"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <circle cx="408" cy="74" r="2" fill={C.green} />
-                  <text
-                    x="430"
-                    y="77"
-                    fontSize="6"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                  >
-                    &rarr; Device
-                  </text>
-                  <rect
-                    x="384"
-                    y="125"
-                    width="80"
-                    height="55"
-                    rx="10"
-                    fill={C.redDim}
-                    stroke={C.red}
-                    strokeWidth="1"
-                  />
-                  <text
-                    x="424"
-                    y="148"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.red}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    Denied
-                  </text>
-                  <line
-                    x1="410"
-                    y1="160"
-                    x2="438"
-                    y2="170"
-                    stroke={C.red}
-                    strokeWidth="1.5"
-                  />
-                  <line
-                    x1="438"
-                    y1="160"
-                    x2="410"
-                    y2="170"
-                    stroke={C.red}
-                    strokeWidth="1.5"
-                  />
-                </svg>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-
-          {/* Card 4: Web Terminal */}
-          <Reveal delay={0.24}>
-            <ShimmerCard>
-              <Card className="p-6 lg:p-8 hover:border-accent-green/30 transition-all duration-300">
-                <div className="flex items-center gap-3 mb-5">
-                  <span className="text-2xs font-mono font-semibold text-accent-green border border-accent-green/20 px-2.5 py-1 rounded-md uppercase tracking-[0.1em]">
-                    Web Terminal
-                  </span>
-                  <span className="text-2xs font-mono font-bold text-text-secondary">
-                    04
-                  </span>
-                </div>
-                <h3 className="text-lg font-bold tracking-[-0.02em] mb-5">
-                  Access devices from your browser
-                </h3>
-                <svg
-                  viewBox="0 0 520 200"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="w-full h-auto"
+                  shellhub.io
+                </text>
+                <text
+                  x="65"
+                  y="112"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="6"
+                  fill={C.textMuted}
+                  textAnchor="middle"
                 >
-                  <defs>
-                    <marker
-                      id="arrow-green"
-                      markerWidth="8"
-                      markerHeight="6"
-                      refX="8"
-                      refY="3"
-                      orient="auto"
-                    >
-                      <path d="M0,0 L8,3 L0,6" fill={C.green} />
-                    </marker>
-                  </defs>
-                  <rect
-                    x="10"
-                    y="50"
-                    width="110"
-                    height="100"
-                    rx="10"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <rect
-                    x="10"
-                    y="50"
-                    width="110"
-                    height="24"
-                    rx="10"
-                    fill={C.surface}
-                  />
-                  <rect
-                    x="10"
-                    y="64"
-                    width="110"
-                    height="10"
-                    fill={C.surface}
-                  />
-                  <circle cx="25" cy="62" r="4" fill={C.red} opacity=".7" />
-                  <circle cx="37" cy="62" r="4" fill={C.yellow} opacity=".7" />
-                  <circle cx="49" cy="62" r="4" fill={C.green} opacity=".7" />
-                  <rect
-                    x="60"
-                    y="58"
-                    width="50"
-                    height="8"
-                    rx="4"
-                    fill={C.bg}
-                  />
-                  <rect
-                    x="20"
-                    y="82"
-                    width="90"
-                    height="56"
-                    rx="3"
-                    fill={C.bg}
-                  />
-                  <text
-                    x="65"
-                    y="98"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={C.green}
-                    textAnchor="middle"
-                  >
-                    shellhub.io
-                  </text>
-                  <text
-                    x="65"
-                    y="112"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="6"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                  >
-                    Web Terminal
-                  </text>
-                  <rect
-                    x="30"
-                    y="118"
-                    width="60"
-                    height="3"
-                    rx="1"
-                    fill={`${C.green}20`}
-                  />
-                  <rect
-                    x="30"
-                    y="124"
-                    width="40"
-                    height="3"
-                    rx="1"
-                    fill={`${C.green}10`}
-                  />
-                  <text
-                    x="65"
-                    y="157"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Browser
-                  </text>
-                  <line
-                    x1="125"
-                    y1="100"
-                    x2="172"
-                    y2="100"
-                    stroke={C.green}
-                    strokeWidth="1.5"
-                    markerEnd="url(#arrow-green)"
-                  />
-                  <text
-                    x="148"
-                    y="92"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={`${C.green}60`}
-                    textAnchor="middle"
-                    letterSpacing=".05em"
-                  >
-                    HTTPS
-                  </text>
-                  <rect
-                    x="176"
-                    y="50"
-                    width="110"
-                    height="100"
-                    rx="12"
-                    fill={C.greenDim}
-                    stroke={C.green}
-                    strokeWidth="1.5"
-                  />
-                  <rect
-                    x="204"
-                    y="68"
-                    width="54"
-                    height="28"
-                    rx="6"
-                    fill={`${C.green}30`}
-                  />
-                  <text
-                    x="231"
-                    y="85"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.green}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    SH
-                  </text>
-                  <text
-                    x="231"
-                    y="115"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="11"
-                    fill={C.green}
-                    textAnchor="middle"
-                    fontWeight="600"
-                  >
-                    ShellHub
-                  </text>
-                  <text
-                    x="231"
-                    y="130"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="9"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Gateway
-                  </text>
-                  <line
-                    x1="291"
-                    y1="75"
-                    x2="340"
-                    y2="45"
-                    stroke={C.green}
-                    strokeWidth="1.2"
-                    markerEnd="url(#arrow-green)"
-                  />
-                  <line
-                    x1="291"
-                    y1="100"
-                    x2="340"
-                    y2="100"
-                    stroke={C.green}
-                    strokeWidth="1.2"
-                    markerEnd="url(#arrow-green)"
-                  />
-                  <line
-                    x1="291"
-                    y1="125"
-                    x2="340"
-                    y2="155"
-                    stroke={C.green}
-                    strokeWidth="1.2"
-                    markerEnd="url(#arrow-green)"
-                  />
-                  <text
-                    x="318"
-                    y="68"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={`${C.green}40`}
-                    textAnchor="middle"
-                  >
-                    SSH
-                  </text>
-                  <text
-                    x="318"
-                    y="94"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={`${C.green}40`}
-                    textAnchor="middle"
-                  >
-                    SSH
-                  </text>
-                  <text
-                    x="318"
-                    y="142"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="7"
-                    fill={`${C.green}40`}
-                    textAnchor="middle"
-                  >
-                    SSH
-                  </text>
-                  <rect
-                    x="344"
-                    y="20"
-                    width="100"
-                    height="50"
-                    rx="8"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <rect
-                    x="356"
-                    y="30"
-                    width="20"
-                    height="14"
-                    rx="3"
-                    fill={`${C.green}20`}
-                    stroke={C.green}
-                    strokeWidth=".8"
-                  />
-                  <text
-                    x="366"
-                    y="40"
-                    fontSize="8"
-                    fill={C.green}
-                    textAnchor="middle"
-                  >
-                    Pi
-                  </text>
-                  <text
-                    x="415"
-                    y="42"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="9"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Raspberry Pi
-                  </text>
-                  <text
-                    x="415"
-                    y="55"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                    letterSpacing=".05em"
-                  >
-                    192.168.1.10
-                  </text>
-                  <rect
-                    x="344"
-                    y="78"
-                    width="100"
-                    height="50"
-                    rx="8"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <rect
-                    x="356"
-                    y="88"
-                    width="20"
-                    height="14"
-                    rx="2"
-                    fill={`${C.green}20`}
-                    stroke={C.green}
-                    strokeWidth=".8"
-                  />
-                  <rect
-                    x="360"
-                    y="92"
-                    width="12"
-                    height="6"
-                    rx="1"
-                    fill={`${C.green}40`}
-                  />
-                  <text
-                    x="415"
-                    y="100"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="9"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    Linux Server
-                  </text>
-                  <text
-                    x="415"
-                    y="113"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                    letterSpacing=".05em"
-                  >
-                    10.0.0.5
-                  </text>
-                  <rect
-                    x="344"
-                    y="136"
-                    width="100"
-                    height="50"
-                    rx="8"
-                    fill={C.card}
-                    stroke={C.border}
-                  />
-                  <circle
-                    cx="366"
-                    cy="155"
-                    r="8"
-                    fill="none"
-                    stroke={C.green}
-                    strokeWidth=".8"
-                  />
-                  <circle cx="366" cy="155" r="3" fill={`${C.green}40`} />
-                  <text
-                    x="415"
-                    y="158"
-                    fontFamily="IBM Plex Sans"
-                    fontSize="9"
-                    fill={C.textSec}
-                    textAnchor="middle"
-                  >
-                    IoT Device
-                  </text>
-                  <text
-                    x="415"
-                    y="171"
-                    fontFamily="IBM Plex Mono"
-                    fontSize="9"
-                    fill={C.textMuted}
-                    textAnchor="middle"
-                    letterSpacing=".05em"
-                  >
-                    172.16.0.8
-                  </text>
-                </svg>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-        </div>
+                  Web Terminal
+                </text>
+                <rect
+                  x="30"
+                  y="118"
+                  width="60"
+                  height="3"
+                  rx="1"
+                  fill={`${C.green}20`}
+                />
+                <rect
+                  x="30"
+                  y="124"
+                  width="40"
+                  height="3"
+                  rx="1"
+                  fill={`${C.green}10`}
+                />
+                <text
+                  x="65"
+                  y="157"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Browser
+                </text>
+                <line
+                  x1="125"
+                  y1="100"
+                  x2="172"
+                  y2="100"
+                  stroke={C.green}
+                  strokeWidth="1.5"
+                  markerEnd="url(#arrow-green)"
+                />
+                <text
+                  x="148"
+                  y="92"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={`${C.green}60`}
+                  textAnchor="middle"
+                  letterSpacing=".05em"
+                >
+                  HTTPS
+                </text>
+                <rect
+                  x="176"
+                  y="50"
+                  width="110"
+                  height="100"
+                  rx="12"
+                  fill={C.greenDim}
+                  stroke={C.green}
+                  strokeWidth="1.5"
+                />
+                <rect
+                  x="204"
+                  y="68"
+                  width="54"
+                  height="28"
+                  rx="6"
+                  fill={`${C.green}30`}
+                />
+                <text
+                  x="231"
+                  y="85"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.green}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  SH
+                </text>
+                <text
+                  x="231"
+                  y="115"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="11"
+                  fill={C.green}
+                  textAnchor="middle"
+                  fontWeight="600"
+                >
+                  ShellHub
+                </text>
+                <text
+                  x="231"
+                  y="130"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="9"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Gateway
+                </text>
+                <line
+                  x1="291"
+                  y1="75"
+                  x2="340"
+                  y2="45"
+                  stroke={C.green}
+                  strokeWidth="1.2"
+                  markerEnd="url(#arrow-green)"
+                />
+                <line
+                  x1="291"
+                  y1="100"
+                  x2="340"
+                  y2="100"
+                  stroke={C.green}
+                  strokeWidth="1.2"
+                  markerEnd="url(#arrow-green)"
+                />
+                <line
+                  x1="291"
+                  y1="125"
+                  x2="340"
+                  y2="155"
+                  stroke={C.green}
+                  strokeWidth="1.2"
+                  markerEnd="url(#arrow-green)"
+                />
+                <text
+                  x="318"
+                  y="68"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={`${C.green}40`}
+                  textAnchor="middle"
+                >
+                  SSH
+                </text>
+                <text
+                  x="318"
+                  y="94"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={`${C.green}40`}
+                  textAnchor="middle"
+                >
+                  SSH
+                </text>
+                <text
+                  x="318"
+                  y="142"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="7"
+                  fill={`${C.green}40`}
+                  textAnchor="middle"
+                >
+                  SSH
+                </text>
+                <rect
+                  x="344"
+                  y="20"
+                  width="100"
+                  height="50"
+                  rx="8"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <rect
+                  x="356"
+                  y="30"
+                  width="20"
+                  height="14"
+                  rx="3"
+                  fill={`${C.green}20`}
+                  stroke={C.green}
+                  strokeWidth=".8"
+                />
+                <text
+                  x="366"
+                  y="40"
+                  fontSize="8"
+                  fill={C.green}
+                  textAnchor="middle"
+                >
+                  Pi
+                </text>
+                <text
+                  x="415"
+                  y="42"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="9"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Raspberry Pi
+                </text>
+                <text
+                  x="415"
+                  y="55"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                  letterSpacing=".05em"
+                >
+                  192.168.1.10
+                </text>
+                <rect
+                  x="344"
+                  y="78"
+                  width="100"
+                  height="50"
+                  rx="8"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <rect
+                  x="356"
+                  y="88"
+                  width="20"
+                  height="14"
+                  rx="2"
+                  fill={`${C.green}20`}
+                  stroke={C.green}
+                  strokeWidth=".8"
+                />
+                <rect
+                  x="360"
+                  y="92"
+                  width="12"
+                  height="6"
+                  rx="1"
+                  fill={`${C.green}40`}
+                />
+                <text
+                  x="415"
+                  y="100"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="9"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  Linux Server
+                </text>
+                <text
+                  x="415"
+                  y="113"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                  letterSpacing=".05em"
+                >
+                  10.0.0.5
+                </text>
+                <rect
+                  x="344"
+                  y="136"
+                  width="100"
+                  height="50"
+                  rx="8"
+                  fill={C.card}
+                  stroke={C.border}
+                />
+                <circle
+                  cx="366"
+                  cy="155"
+                  r="8"
+                  fill="none"
+                  stroke={C.green}
+                  strokeWidth=".8"
+                />
+                <circle cx="366" cy="155" r="3" fill={`${C.green}40`} />
+                <text
+                  x="415"
+                  y="158"
+                  fontFamily="IBM Plex Sans"
+                  fontSize="9"
+                  fill={C.textSec}
+                  textAnchor="middle"
+                >
+                  IoT Device
+                </text>
+                <text
+                  x="415"
+                  y="171"
+                  fontFamily="IBM Plex Mono"
+                  fontSize="9"
+                  fill={C.textMuted}
+                  textAnchor="middle"
+                  letterSpacing=".05em"
+                >
+                  172.16.0.8
+                </text>
+              </svg>
+            </Card>
+          </ShimmerCard>
+        </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/landing/OpenSource.tsx
+++ b/ui/apps/website/src/pages/landing/OpenSource.tsx
@@ -1,69 +1,65 @@
 import { Button } from "@shellhub/design-system/primitives";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal } from "./components";
 import { C } from "./constants";
 import { githubUrl, signupUrl } from "@/links";
 
 export function OpenSource() {
   return (
-    <section className="py-24 bg-surface border-t border-b border-border text-center">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal>
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Open Source
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-3">
-            Built in the open.
-          </h2>
-        </Reveal>
-        <Reveal>
-          <p className="text-sm text-text-secondary max-w-md mx-auto mb-8 leading-relaxed">
-            ShellHub is open source. Self-host it, customize it, or use our
-            managed cloud.
-          </p>
-        </Reveal>
-        <Reveal>
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-border bg-card text-sm text-text-secondary mb-8">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill={C.yellow}>
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-            </svg>
-            <span className="text-xs font-mono">3,200+ stars on GitHub</span>
-          </div>
-        </Reveal>
-        <Reveal>
-          <div className="flex gap-3 justify-center flex-wrap">
-            <Button
-              as="a"
-              href={githubUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="outline"
-              size="lg"
-              icon={
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-                </svg>
-              }
-            >
-              View on GitHub
-            </Button>
-            <Button
-              as="a"
-              href={signupUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="primary"
-              size="lg"
-            >
-              Try Cloud Free
-            </Button>
-          </div>
-        </Reveal>
-      </div>
-    </section>
+    <Section background="surface" className="border-b border-border" centered>
+      <SectionHeader
+        className="mb-3"
+        eyebrow="Open Source"
+        title="Built in the open."
+      />
+      <Reveal>
+        <p className="text-sm text-text-secondary max-w-md mx-auto mb-8 leading-relaxed">
+          ShellHub is open source. Self-host it, customize it, or use our
+          managed cloud.
+        </p>
+      </Reveal>
+      <Reveal>
+        <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-border bg-card text-sm text-text-secondary mb-8">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill={C.yellow}>
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+          </svg>
+          <span className="text-xs font-mono">3,200+ stars on GitHub</span>
+        </div>
+      </Reveal>
+      <Reveal>
+        <div className="flex gap-3 justify-center flex-wrap">
+          <Button
+            as="a"
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="outline"
+            size="lg"
+            icon={
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+            }
+          >
+            View on GitHub
+          </Button>
+          <Button
+            as="a"
+            href={signupUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="primary"
+            size="lg"
+          >
+            Try Cloud Free
+          </Button>
+        </div>
+      </Reveal>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/landing/QuickStart.tsx
+++ b/ui/apps/website/src/pages/landing/QuickStart.tsx
@@ -1,69 +1,64 @@
 import { Card } from "@shellhub/design-system/primitives";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, CopyBtn } from "./components";
 import { docsUrl } from "@/links";
 
 export function QuickStart() {
   return (
-    <section className="py-24">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-10">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Quick Start
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-3">
-            Try ShellHub in seconds.
-          </h2>
-          <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed">
-            Get up and running with a single command.
-          </p>
-        </Reveal>
+    <Section bordered={false}>
+      <SectionHeader
+        className="mb-10"
+        eyebrow="Quick Start"
+        title="Try ShellHub in seconds."
+        subtitle="Get up and running with a single command."
+        subtitleClassName="mt-3 max-w-md"
+      />
 
-        <Reveal>
-          <Card className="max-w-xl mx-auto overflow-hidden">
-            <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border bg-surface">
-              <span className="w-2.5 h-2.5 rounded-full bg-accent-red/70" />
-              <span className="w-2.5 h-2.5 rounded-full bg-accent-yellow/70" />
-              <span className="w-2.5 h-2.5 rounded-full bg-accent-green/70" />
-              <span className="flex-1 text-center text-2xs font-mono text-text-secondary">
-                terminal
+      <Reveal>
+        <Card className="max-w-xl mx-auto overflow-hidden">
+          <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border bg-surface">
+            <span className="w-2.5 h-2.5 rounded-full bg-accent-red/70" />
+            <span className="w-2.5 h-2.5 rounded-full bg-accent-yellow/70" />
+            <span className="w-2.5 h-2.5 rounded-full bg-accent-green/70" />
+            <span className="flex-1 text-center text-2xs font-mono text-text-secondary">
+              terminal
+            </span>
+          </div>
+          <div className="px-5 py-4 flex items-center justify-between gap-4">
+            <code className="font-mono text-sm text-text-secondary leading-relaxed">
+              <span className="text-primary">$ </span>
+              <span className="text-text-primary">
+                docker run -d -p 80:80 shellhubio/shellhub
               </span>
-            </div>
-            <div className="px-5 py-4 flex items-center justify-between gap-4">
-              <code className="font-mono text-sm text-text-secondary leading-relaxed">
-                <span className="text-primary">$ </span>
-                <span className="text-text-primary">
-                  docker run -d -p 80:80 shellhubio/shellhub
-                </span>
-              </code>
-              <CopyBtn text="docker run -d -p 80:80 shellhubio/shellhub" />
-            </div>
-          </Card>
-        </Reveal>
+            </code>
+            <CopyBtn text="docker run -d -p 80:80 shellhubio/shellhub" />
+          </div>
+        </Card>
+      </Reveal>
 
-        <Reveal className="text-center mt-5">
-          <a
-            href={docsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-[#7B8EDB] hover:gap-2.5 transition-all group"
+      <Reveal className="text-center mt-5">
+        <a
+          href={docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:gap-2.5 transition-all group"
+        >
+          Full installation guide
+          <svg
+            className="w-3 h-3 group-hover:translate-x-0.5 transition-transform"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2.5}
           >
-            Full installation guide
-            <svg
-              className="w-3 h-3 group-hover:translate-x-0.5 transition-transform"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-              />
-            </svg>
-          </a>
-        </Reveal>
-      </div>
-    </section>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+            />
+          </svg>
+        </a>
+      </Reveal>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/landing/SupportedPlatforms.tsx
+++ b/ui/apps/website/src/pages/landing/SupportedPlatforms.tsx
@@ -1,30 +1,34 @@
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal } from "./components";
 import { docsUrl } from "@/links";
 
 export function SupportedPlatforms() {
   return (
-    <section className="py-24 border-t border-border relative overflow-hidden">
+    <Section className="relative overflow-hidden" container={false}>
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[700px] bg-primary/[0.03] rounded-full blur-3xl pointer-events-none" />
       <div className="max-w-7xl mx-auto px-8 relative z-10">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Supported Platforms
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-            One agent. <span className="text-primary">Every platform.</span>
-          </h2>
-          <p className="text-sm text-text-secondary max-w-xl mx-auto leading-relaxed">
-            The ShellHub agent runs on{" "}
-            <span className="inline-block px-1.5 py-0.5 bg-border/40 rounded text-2xs font-mono font-medium text-text-primary/90">
-              x86
-            </span>{" "}
-            and{" "}
-            <span className="inline-block px-1.5 py-0.5 bg-border/40 rounded text-2xs font-mono font-medium text-text-primary/90">
-              ARM
-            </span>{" "}
-            — from Docker containers to embedded Linux and FreeBSD.
-          </p>
-        </Reveal>
+        <SectionHeader
+          eyebrow="Supported Platforms"
+          title={
+            <>
+              One agent. <span className="text-primary">Every platform.</span>
+            </>
+          }
+          subtitle={
+            <>
+              The ShellHub agent runs on{" "}
+              <span className="inline-block px-1.5 py-0.5 bg-border/40 rounded text-2xs font-mono font-medium text-text-primary/90">
+                x86
+              </span>{" "}
+              and{" "}
+              <span className="inline-block px-1.5 py-0.5 bg-border/40 rounded text-2xs font-mono font-medium text-text-primary/90">
+                ARM
+              </span>{" "}
+              — from Docker containers to embedded Linux and FreeBSD.
+            </>
+          }
+          subtitleClassName="max-w-xl"
+        />
 
         {/* Bento Grid — 12-col for precise control */}
         <div className="grid grid-cols-2 lg:grid-cols-12 gap-3 auto-rows-auto">
@@ -274,7 +278,7 @@ export function SupportedPlatforms() {
             href={docsUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs font-medium text-[#7B8EDB] hover:gap-2.5 transition-all group"
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:gap-2.5 transition-all group"
           >
             View all supported platforms
             <svg
@@ -293,6 +297,6 @@ export function SupportedPlatforms() {
           </a>
         </Reveal>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/landing/TrustedBy.tsx
+++ b/ui/apps/website/src/pages/landing/TrustedBy.tsx
@@ -1,7 +1,7 @@
 export function TrustedBy() {
   return (
     <section className="py-10 px-6 border-t border-border">
-      <p className="text-center text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-secondary mb-6">Trusted by teams across the globe</p>
+      <p className="text-center text-2xs font-mono font-semibold uppercase tracking-label text-text-secondary mb-6">Trusted by teams across the globe</p>
       <div className="flex items-center justify-center gap-10 md:gap-14 flex-wrap opacity-40">
         {["TechCorp", "CloudBase", "DevOps Inc", "NetSecure", "EdgeStack", "IoTWorks"].map((name) => (
           <span key={name} className="text-lg font-semibold tracking-tight whitespace-nowrap">{name}</span>

--- a/ui/apps/website/src/pages/pricing/ComparisonTable.tsx
+++ b/ui/apps/website/src/pages/pricing/ComparisonTable.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from "react";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal } from "../landing/components";
 
 type FeatureValue = boolean | string;
@@ -21,51 +22,141 @@ const categories: Category[] = [
     features: [
       { name: "SSH access", community: true, cloud: true, enterprise: true },
       { name: "Web terminal", community: true, cloud: true, enterprise: true },
-      { name: "SCP/SFTP file transfer", community: true, cloud: true, enterprise: true },
-      { name: "Docker container access", community: true, cloud: true, enterprise: true },
-      { name: "Device tagging", community: true, cloud: true, enterprise: true },
+      {
+        name: "SCP/SFTP file transfer",
+        community: true,
+        cloud: true,
+        enterprise: true,
+      },
+      {
+        name: "Docker container access",
+        community: true,
+        cloud: true,
+        enterprise: true,
+      },
+      {
+        name: "Device tagging",
+        community: true,
+        cloud: true,
+        enterprise: true,
+      },
     ],
   },
   {
     label: "Security",
     features: [
-      { name: "Multi-factor authentication", community: true, cloud: true, enterprise: true },
-      { name: "Firewall rules", community: true, cloud: true, enterprise: true },
-      { name: "Session recording", community: false, cloud: true, enterprise: true },
+      {
+        name: "Multi-factor authentication",
+        community: true,
+        cloud: true,
+        enterprise: true,
+      },
+      {
+        name: "Firewall rules",
+        community: true,
+        cloud: true,
+        enterprise: true,
+      },
+      {
+        name: "Session recording",
+        community: false,
+        cloud: true,
+        enterprise: true,
+      },
       { name: "Audit logs", community: false, cloud: true, enterprise: true },
-      { name: "MFA enforcement", community: false, cloud: false, enterprise: true },
+      {
+        name: "MFA enforcement",
+        community: false,
+        cloud: false,
+        enterprise: true,
+      },
       { name: "SSO / SAML", community: false, cloud: false, enterprise: true },
-      { name: "LDAP / Active Directory", community: false, cloud: false, enterprise: true },
+      {
+        name: "LDAP / Active Directory",
+        community: false,
+        cloud: false,
+        enterprise: true,
+      },
     ],
   },
   {
     label: "Management",
     features: [
       { name: "Namespaces", community: true, cloud: true, enterprise: true },
-      { name: "Role-based access control", community: true, cloud: true, enterprise: true },
+      {
+        name: "Role-based access control",
+        community: true,
+        cloud: true,
+        enterprise: true,
+      },
       { name: "API keys", community: true, cloud: true, enterprise: true },
       { name: "Admin panel", community: false, cloud: false, enterprise: true },
-      { name: "Billing management", community: false, cloud: false, enterprise: true },
+      {
+        name: "Billing management",
+        community: false,
+        cloud: false,
+        enterprise: true,
+      },
     ],
   },
   {
     label: "Deployment",
     features: [
-      { name: "Self-hosted (Docker)", community: true, cloud: false, enterprise: true },
+      {
+        name: "Self-hosted (Docker)",
+        community: true,
+        cloud: false,
+        enterprise: true,
+      },
       { name: "Cloud hosted", community: false, cloud: true, enterprise: true },
-      { name: "Managed infrastructure", community: false, cloud: true, enterprise: true },
+      {
+        name: "Managed infrastructure",
+        community: false,
+        cloud: true,
+        enterprise: true,
+      },
       { name: "On-premises", community: false, cloud: false, enterprise: true },
-      { name: "Kubernetes / Helm", community: false, cloud: false, enterprise: true },
+      {
+        name: "Kubernetes / Helm",
+        community: false,
+        cloud: false,
+        enterprise: true,
+      },
     ],
   },
   {
     label: "Support",
     features: [
-      { name: "Community (GitHub)", community: true, cloud: true, enterprise: true },
-      { name: "Email support", community: false, cloud: true, enterprise: true },
-      { name: "Priority support & SLA", community: false, cloud: false, enterprise: true },
-      { name: "Dedicated account manager", community: false, cloud: false, enterprise: true },
-      { name: "Onboarding assistance", community: false, cloud: false, enterprise: true },
+      {
+        name: "Community (GitHub)",
+        community: true,
+        cloud: true,
+        enterprise: true,
+      },
+      {
+        name: "Email support",
+        community: false,
+        cloud: true,
+        enterprise: true,
+      },
+      {
+        name: "Priority support & SLA",
+        community: false,
+        cloud: false,
+        enterprise: true,
+      },
+      {
+        name: "Dedicated account manager",
+        community: false,
+        cloud: false,
+        enterprise: true,
+      },
+      {
+        name: "Onboarding assistance",
+        community: false,
+        cloud: false,
+        enterprise: true,
+      },
     ],
   },
 ];
@@ -76,69 +167,100 @@ function CellValue({ value }: { value: FeatureValue }) {
   }
   if (value) {
     return (
-      <svg className="w-4 h-4 text-accent-green mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+      <svg
+        className="w-4 h-4 text-accent-green mx-auto"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="m4.5 12.75 6 6 9-13.5"
+        />
       </svg>
     );
   }
   return (
-    <svg className="w-4 h-4 text-text-muted/40 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+    <svg
+      className="w-4 h-4 text-text-muted/40 mx-auto"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 18 18 6M6 6l12 12"
+      />
     </svg>
   );
 }
 
 export function ComparisonTable() {
   return (
-    <section className="py-24 border-t border-border">
-      <div className="max-w-7xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            Compare Plans
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight">
-            Feature comparison
-          </h2>
-        </Reveal>
+    <Section>
+      <SectionHeader eyebrow="Compare Plans" title="Feature comparison" />
 
-        <Reveal>
-          <div className="overflow-x-auto -mx-8 px-8">
-            <table className="w-full min-w-[640px]">
-              <thead>
-                <tr className="border-b border-border">
-                  <th className="text-left py-4 pr-4 text-sm font-medium text-text-secondary w-[40%]" scope="col"><span className="sr-only">Feature</span></th>
-                  <th className="py-4 px-4 text-center text-sm font-semibold w-[20%]">Community</th>
-                  <th className="py-4 px-4 text-center text-sm font-semibold w-[20%]">
-                    <span className="text-primary">Cloud</span>
-                  </th>
-                  <th className="py-4 px-4 text-center text-sm font-semibold w-[20%]">Enterprise</th>
-                </tr>
-              </thead>
-              <tbody>
-                {categories.map((cat) => (
-                  <Fragment key={cat.label}>
-                    <tr>
-                      <td colSpan={4} className="pt-8 pb-3">
-                        <span className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB]">
-                          {cat.label}
-                        </span>
+      <Reveal>
+        <div className="overflow-x-auto -mx-8 px-8">
+          <table className="w-full min-w-[640px]">
+            <thead>
+              <tr className="border-b border-border">
+                <th
+                  className="text-left py-4 pr-4 text-sm font-medium text-text-secondary w-[40%]"
+                  scope="col"
+                >
+                  <span className="sr-only">Feature</span>
+                </th>
+                <th className="py-4 px-4 text-center text-sm font-semibold w-[20%]">
+                  Community
+                </th>
+                <th className="py-4 px-4 text-center text-sm font-semibold w-[20%]">
+                  <span className="text-primary">Cloud</span>
+                </th>
+                <th className="py-4 px-4 text-center text-sm font-semibold w-[20%]">
+                  Enterprise
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {categories.map((cat) => (
+                <Fragment key={cat.label}>
+                  <tr>
+                    <td colSpan={4} className="pt-8 pb-3">
+                      <span className="text-2xs font-mono font-semibold uppercase tracking-label text-primary">
+                        {cat.label}
+                      </span>
+                    </td>
+                  </tr>
+                  {cat.features.map((f) => (
+                    <tr
+                      key={f.name}
+                      className="border-b border-border/50 hover:bg-white/[0.01] transition-colors"
+                    >
+                      <td className="py-3 pr-4 text-sm text-text-secondary">
+                        {f.name}
+                      </td>
+                      <td className="py-3 px-4 text-center">
+                        <CellValue value={f.community} />
+                      </td>
+                      <td className="py-3 px-4 text-center">
+                        <CellValue value={f.cloud} />
+                      </td>
+                      <td className="py-3 px-4 text-center">
+                        <CellValue value={f.enterprise} />
                       </td>
                     </tr>
-                    {cat.features.map((f) => (
-                      <tr key={f.name} className="border-b border-border/50 hover:bg-white/[0.01] transition-colors">
-                        <td className="py-3 pr-4 text-sm text-text-secondary">{f.name}</td>
-                        <td className="py-3 px-4 text-center"><CellValue value={f.community} /></td>
-                        <td className="py-3 px-4 text-center"><CellValue value={f.cloud} /></td>
-                        <td className="py-3 px-4 text-center"><CellValue value={f.enterprise} /></td>
-                      </tr>
-                    ))}
-                  </Fragment>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </Reveal>
-      </div>
-    </section>
+                  ))}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Reveal>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/pricing/PricingFAQ.tsx
+++ b/ui/apps/website/src/pages/pricing/PricingFAQ.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal } from "../landing/components";
 
 const faqs = [
@@ -41,7 +42,9 @@ function FAQItem({ q, a, index }: { q: string; a: string; index: number }) {
         className="w-full text-left py-5 border-b border-border group"
       >
         <div className="flex items-center justify-between gap-4">
-          <h4 className="text-sm font-semibold group-hover:text-primary transition-colors">{q}</h4>
+          <h4 className="text-sm font-semibold group-hover:text-primary transition-colors">
+            {q}
+          </h4>
           <svg
             className={`w-4 h-4 text-text-muted shrink-0 transition-transform duration-300 ${open ? "rotate-45" : ""}`}
             fill="none"
@@ -50,7 +53,11 @@ function FAQItem({ q, a, index }: { q: string; a: string; index: number }) {
             strokeWidth={2}
             aria-hidden="true"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 4.5v15m7.5-7.5h-15"
+            />
           </svg>
         </div>
         <div
@@ -58,7 +65,9 @@ function FAQItem({ q, a, index }: { q: string; a: string; index: number }) {
             open ? "max-h-40 opacity-100 mt-3" : "max-h-0 opacity-0"
           }`}
         >
-          <p className="text-sm text-text-secondary leading-relaxed pr-8">{a}</p>
+          <p className="text-sm text-text-secondary leading-relaxed pr-8">
+            {a}
+          </p>
         </div>
       </button>
     </Reveal>
@@ -67,23 +76,14 @@ function FAQItem({ q, a, index }: { q: string; a: string; index: number }) {
 
 export function PricingFAQ() {
   return (
-    <section className="py-24">
-      <div className="max-w-3xl mx-auto px-8">
-        <Reveal className="text-center mb-14">
-          <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-            FAQ
-          </p>
-          <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight">
-            Frequently asked questions
-          </h2>
-        </Reveal>
+    <Section bordered={false} containerClassName="max-w-3xl">
+      <SectionHeader eyebrow="FAQ" title="Frequently asked questions" />
 
-        <div>
-          {faqs.map((faq, i) => (
-            <FAQItem key={i} q={faq.q} a={faq.a} index={i} />
-          ))}
-        </div>
+      <div>
+        {faqs.map((faq, i) => (
+          <FAQItem key={i} q={faq.q} a={faq.a} index={i} />
+        ))}
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/pricing/TierCards.tsx
+++ b/ui/apps/website/src/pages/pricing/TierCards.tsx
@@ -1,5 +1,7 @@
 import { Link } from "react-router-dom";
 import { Button } from "@shellhub/design-system/primitives";
+import { Section } from "@/components/marketing";
+import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
 
 const tiers = [
@@ -68,92 +70,77 @@ const tiers = [
 
 export function TierCards() {
   return (
-    <section className="py-12">
-      <div className="max-w-7xl mx-auto px-8">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {tiers.map((tier, i) => (
-            <Reveal key={tier.name} delay={i * 0.08}>
-              <ShimmerCard className="h-full">
-                <div
-                  className={`relative rounded-xl p-8 flex flex-col h-full transition-all duration-300 overflow-hidden ${
-                    tier.highlighted
-                      ? "bg-card border border-primary/30 hover:border-primary/50 shadow-[0_0_40px_rgba(102,122,204,0.15)]"
-                      : "bg-card border border-border hover:border-border-light"
-                  }`}
-                >
-                  {tier.highlighted && (
-                    <>
-                      <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.08] via-primary/[0.02] to-transparent pointer-events-none" />
-                      <div className="absolute top-0 right-0 w-40 h-40 bg-primary/[0.08] rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl pointer-events-none" />
-                    </>
-                  )}
+    <Section bordered={false} padding="md">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {tiers.map((tier, i) => (
+          <Reveal key={tier.name} delay={i * 0.08}>
+            <ShimmerCard className="h-full">
+              <div
+                className={`relative rounded-xl p-8 flex flex-col h-full transition-all duration-300 overflow-hidden ${
+                  tier.highlighted
+                    ? "bg-card border border-primary/30 hover:border-primary/50 shadow-[0_0_40px_rgba(102,122,204,0.15)]"
+                    : "bg-card border border-border hover:border-border-light"
+                }`}
+              >
+                {tier.highlighted && (
+                  <>
+                    <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.08] via-primary/[0.02] to-transparent pointer-events-none" />
+                    <div className="absolute top-0 right-0 w-40 h-40 bg-primary/[0.08] rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl pointer-events-none" />
+                  </>
+                )}
 
-                  <div className="relative">
-                    <div className="flex items-center gap-3 mb-4">
-                      <h3 className="text-lg font-bold">{tier.name}</h3>
-                      <span
-                        className={`px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] border rounded-full ${tier.badgeClass}`}
-                      >
-                        {tier.badge}
-                      </span>
-                    </div>
-
-                    <div className="mb-2">
-                      <span className="text-3xl font-bold">{tier.price}</span>
-                    </div>
-                    <p className="text-2xs text-text-muted mb-4">
-                      {tier.priceSuffix}
-                    </p>
-                    <p className="text-sm text-text-secondary leading-relaxed mb-6">
-                      {tier.desc}
-                    </p>
-
-                    <ul className="space-y-2.5 mb-8 flex-1">
-                      {tier.features.map((feature) => (
-                        <li
-                          key={feature}
-                          className="flex items-center gap-2.5 text-sm text-text-secondary"
-                        >
-                          <svg
-                            className={`w-4 h-4 shrink-0 ${tier.highlighted ? "text-accent-green" : "text-text-muted"}`}
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="m4.5 12.75 6 6 9-13.5"
-                            />
-                          </svg>
-                          {feature}
-                        </li>
-                      ))}
-                    </ul>
-
-                    <Button
-                      as={Link}
-                      to={tier.ctaHref}
-                      variant={tier.highlighted ? "primary" : "surface"}
-                      size="lg"
-                      glow={tier.highlighted}
-                      fullWidth
-                      className={
-                        tier.highlighted
-                          ? undefined
-                          : "hover:scale-[1.02] active:scale-[0.98]"
-                      }
+                <div className="relative">
+                  <div className="flex items-center gap-3 mb-4">
+                    <h3 className="text-lg font-bold">{tier.name}</h3>
+                    <span
+                      className={`px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] border rounded-full ${tier.badgeClass}`}
                     >
-                      {tier.cta}
-                    </Button>
+                      {tier.badge}
+                    </span>
                   </div>
+
+                  <div className="mb-2">
+                    <span className="text-3xl font-bold">{tier.price}</span>
+                  </div>
+                  <p className="text-2xs text-text-muted mb-4">
+                    {tier.priceSuffix}
+                  </p>
+                  <p className="text-sm text-text-secondary leading-relaxed mb-6">
+                    {tier.desc}
+                  </p>
+
+                  <ul className="space-y-2.5 mb-8 flex-1">
+                    {tier.features.map((feature) => (
+                      <FeatureListItem
+                        key={feature}
+                        color={tier.highlighted ? "green" : "muted"}
+                      >
+                        {feature}
+                      </FeatureListItem>
+                    ))}
+                  </ul>
+
+                  <Button
+                    as={Link}
+                    to={tier.ctaHref}
+                    variant={tier.highlighted ? "primary" : "surface"}
+                    size="lg"
+                    glow={tier.highlighted}
+                    fullWidth
+                    className={
+                      tier.highlighted
+                        ? undefined
+                        : "hover:scale-[1.02] active:scale-[0.98]"
+                    }
+                  >
+                    {tier.cta}
+                  </Button>
                 </div>
-              </ShimmerCard>
-            </Reveal>
-          ))}
-        </div>
+              </div>
+            </ShimmerCard>
+          </Reveal>
+        ))}
       </div>
-    </section>
+    </Section>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -7,6 +7,8 @@ import {
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
+import { Section, SectionHeader } from "@/components/marketing";
+import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -554,30 +556,111 @@ export default function ContainerManagement() {
       </section>
 
       {/* ═══════ Before / After ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Before &amp; After
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              From three steps to one
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              See how ShellHub eliminates the multi-step dance of connecting to
-              containers on remote hosts.
-            </p>
+      <Section>
+        <SectionHeader
+          eyebrow="Before & After"
+          title="From three steps to one"
+          subtitle="See how ShellHub eliminates the multi-step dance of connecting to containers on remote hosts."
+        />
+
+        <div className="grid md:grid-cols-2 gap-6">
+          {/* Without ShellHub */}
+          <Reveal delay={0}>
+            <ShimmerCard className="h-full">
+              <Card hover className="p-8 flex flex-col h-full">
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
+                    <svg
+                      className="w-5 h-5 text-text-secondary"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M6 18 18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-bold">Without ShellHub</h3>
+                    <p className="text-2xs text-text-muted">
+                      Manual, multi-step
+                    </p>
+                  </div>
+                </div>
+
+                {/* Fake terminal */}
+                <div className="bg-[#111214] rounded-lg border border-border overflow-hidden flex-1">
+                  <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
+                    <div className="w-2.5 h-2.5 rounded-full bg-accent-red/50" />
+                    <div className="w-2.5 h-2.5 rounded-full bg-accent-yellow/50" />
+                    <div className="w-2.5 h-2.5 rounded-full bg-accent-green/50" />
+                    <span className="ml-2 text-2xs text-text-muted font-mono">
+                      Terminal
+                    </span>
+                  </div>
+                  <div className="p-4 font-mono text-xs leading-relaxed space-y-2">
+                    <p>
+                      <span className="text-text-muted">
+                        # Step 1: SSH into the Docker host
+                      </span>
+                    </p>
+                    <p>
+                      <span className="text-accent-green">$</span>{" "}
+                      <span className="text-text-secondary">
+                        ssh root@192.168.1.42
+                      </span>
+                    </p>
+                    <p className="text-text-muted text-2xs">
+                      Enter password...
+                    </p>
+                    <p>
+                      <span className="text-text-muted">
+                        # Step 2: Find the container
+                      </span>
+                    </p>
+                    <p>
+                      <span className="text-accent-green">$</span>{" "}
+                      <span className="text-text-secondary">
+                        docker ps | grep api
+                      </span>
+                    </p>
+                    <p className="text-text-muted text-2xs">
+                      abc123f8... api-server
+                    </p>
+                    <p>
+                      <span className="text-text-muted">
+                        # Step 3: Exec into it
+                      </span>
+                    </p>
+                    <p>
+                      <span className="text-accent-green">$</span>{" "}
+                      <span className="text-text-secondary">
+                        docker exec -it abc123 /bin/bash
+                      </span>
+                    </p>
+                    <p className="text-text-muted text-2xs mt-2">
+                      No audit. No access control. No recording.
+                    </p>
+                  </div>
+                </div>
+              </Card>
+            </ShimmerCard>
           </Reveal>
 
-          <div className="grid md:grid-cols-2 gap-6">
-            {/* Without ShellHub */}
-            <Reveal delay={0}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-8 flex flex-col h-full">
+          {/* With ShellHub */}
+          <Reveal delay={0.1}>
+            <ShimmerCard className="h-full">
+              <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+                <div className="relative flex-1 flex flex-col">
                   <div className="flex items-center gap-3 mb-6">
-                    <div className="w-10 h-10 rounded-lg bg-white/[0.04] border border-border flex items-center justify-center">
+                    <IconBadge color="primary">
                       <svg
-                        className="w-5 h-5 text-text-secondary"
+                        className="w-5 h-5 text-primary"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
@@ -586,528 +669,378 @@ export default function ContainerManagement() {
                         <path
                           strokeLinecap="round"
                           strokeLinejoin="round"
-                          d="M6 18 18 6M6 6l12 12"
+                          d="m4.5 12.75 6 6 9-13.5"
                         />
                       </svg>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-bold">Without ShellHub</h3>
-                      <p className="text-2xs text-text-muted">
-                        Manual, multi-step
-                      </p>
-                    </div>
+                    </IconBadge>
+                    <Badge shape="pill" color="green">
+                      Recommended
+                    </Badge>
                   </div>
 
+                  <h3 className="text-sm font-bold mb-1">With ShellHub</h3>
+                  <p className="text-2xs text-primary mb-6">
+                    One command, fully recorded
+                  </p>
+
                   {/* Fake terminal */}
-                  <div className="bg-[#111214] rounded-lg border border-border overflow-hidden flex-1">
+                  <div className="bg-[#111214] rounded-lg border border-primary/20 overflow-hidden flex-1">
                     <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
                       <div className="w-2.5 h-2.5 rounded-full bg-accent-red/50" />
                       <div className="w-2.5 h-2.5 rounded-full bg-accent-yellow/50" />
                       <div className="w-2.5 h-2.5 rounded-full bg-accent-green/50" />
-                      <span className="ml-2 text-2xs text-text-muted font-mono">
+                      <span className="ml-2 text-2xs text-primary font-mono">
                         Terminal
                       </span>
                     </div>
                     <div className="p-4 font-mono text-xs leading-relaxed space-y-2">
                       <p>
                         <span className="text-text-muted">
-                          # Step 1: SSH into the Docker host
+                          # One step. That's it.
                         </span>
                       </p>
                       <p>
                         <span className="text-accent-green">$</span>{" "}
-                        <span className="text-text-secondary">
-                          ssh root@192.168.1.42
+                        <span className="text-text-primary">
+                          ssh user@api-server.production
                         </span>
+                      </p>
+                      <p className="text-accent-green text-2xs mt-1">
+                        Connected to api-server
                       </p>
                       <p className="text-text-muted text-2xs">
-                        Enter password...
-                      </p>
-                      <p>
-                        <span className="text-text-muted">
-                          # Step 2: Find the container
-                        </span>
-                      </p>
-                      <p>
-                        <span className="text-accent-green">$</span>{" "}
-                        <span className="text-text-secondary">
-                          docker ps | grep api
-                        </span>
+                        Session recorded: #ses-4a82f1
                       </p>
                       <p className="text-text-muted text-2xs">
-                        abc123f8... api-server
+                        Access policy: production-operators
                       </p>
-                      <p>
-                        <span className="text-text-muted">
-                          # Step 3: Exec into it
-                        </span>
+                      <p className="text-text-muted text-2xs">MFA verified</p>
+                      <p className="mt-3">
+                        <span className="text-accent-cyan">
+                          root@api-server:~#
+                        </span>{" "}
+                        <span className="inline-block w-2 h-3.5 bg-text-primary animate-pulse" />
                       </p>
-                      <p>
-                        <span className="text-accent-green">$</span>{" "}
-                        <span className="text-text-secondary">
-                          docker exec -it abc123 /bin/bash
-                        </span>
-                      </p>
-                      <p className="text-text-muted text-2xs mt-2">
-                        No audit. No access control. No recording.
+                    </div>
+                  </div>
+
+                  {/* Status badges */}
+                  <div className="flex flex-wrap gap-2 mt-4">
+                    {[
+                      { label: "Recorded", color: C.green },
+                      { label: "Access-controlled", color: C.primary },
+                      { label: "MFA", color: C.yellow },
+                      { label: "Audited", color: C.cyan },
+                    ].map((b) => (
+                      <span
+                        key={b.label}
+                        className="px-2 py-0.5 text-2xs font-mono border rounded-full"
+                        style={{
+                          color: b.color,
+                          borderColor: `${b.color}30`,
+                          background: `${b.color}10`,
+                        }}
+                      >
+                        {b.label}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </ShimmerCard>
+          </Reveal>
+        </div>
+      </Section>
+
+      {/* ═══════ Architecture Diagram ═══════ */}
+      <Section>
+        <SectionHeader
+          eyebrow="Architecture"
+          title="How container SSH works"
+          subtitle="The ShellHub agent runs alongside your containers on the Docker host, routing SSH connections to individual containers through the gateway."
+        />
+
+        <Reveal>
+          <ShimmerCard>
+            <Card hover className="p-6 sm:p-8 overflow-hidden">
+              <ArchitectureDiagram />
+            </Card>
+          </ShimmerCard>
+        </Reveal>
+      </Section>
+
+      {/* ═══════ Pain Points ═══════ */}
+      <Section>
+        <SectionHeader
+          eyebrow="The Problem"
+          title="Why docker exec falls short"
+          subtitle="Docker exec was designed for local debugging, not for production access at scale."
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {painPoints.map((p, i) => (
+            <Reveal key={i} delay={i * 0.06}>
+              <ShimmerCard className="h-full">
+                <Card hover className="p-6 h-full">
+                  <div className="flex items-start gap-4">
+                    <div
+                      className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
+                      style={{
+                        background: `${p.color}15`,
+                        borderColor: `${p.color}25`,
+                      }}
+                    >
+                      <svg
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke={p.color}
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                      >
+                        <path d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126z" />
+                        <path d="M12 15.75h.007v.008H12v-.008z" />
+                      </svg>
+                    </div>
+                    <div>
+                      <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {p.desc}
                       </p>
                     </div>
                   </div>
                 </Card>
               </ShimmerCard>
             </Reveal>
-
-            {/* With ShellHub */}
-            <Reveal delay={0.1}>
-              <ShimmerCard className="h-full">
-                <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
-                  <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-                  <div className="relative flex-1 flex flex-col">
-                    <div className="flex items-center gap-3 mb-6">
-                      <IconBadge color="primary">
-                        <svg
-                          className="w-5 h-5 text-primary"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={1.5}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="m4.5 12.75 6 6 9-13.5"
-                          />
-                        </svg>
-                      </IconBadge>
-                      <Badge shape="pill" color="green">
-                        Recommended
-                      </Badge>
-                    </div>
-
-                    <h3 className="text-sm font-bold mb-1">With ShellHub</h3>
-                    <p className="text-2xs text-primary mb-6">
-                      One command, fully recorded
-                    </p>
-
-                    {/* Fake terminal */}
-                    <div className="bg-[#111214] rounded-lg border border-primary/20 overflow-hidden flex-1">
-                      <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
-                        <div className="w-2.5 h-2.5 rounded-full bg-accent-red/50" />
-                        <div className="w-2.5 h-2.5 rounded-full bg-accent-yellow/50" />
-                        <div className="w-2.5 h-2.5 rounded-full bg-accent-green/50" />
-                        <span className="ml-2 text-2xs text-primary font-mono">
-                          Terminal
-                        </span>
-                      </div>
-                      <div className="p-4 font-mono text-xs leading-relaxed space-y-2">
-                        <p>
-                          <span className="text-text-muted">
-                            # One step. That's it.
-                          </span>
-                        </p>
-                        <p>
-                          <span className="text-accent-green">$</span>{" "}
-                          <span className="text-text-primary">
-                            ssh user@api-server.production
-                          </span>
-                        </p>
-                        <p className="text-accent-green text-2xs mt-1">
-                          Connected to api-server
-                        </p>
-                        <p className="text-text-muted text-2xs">
-                          Session recorded: #ses-4a82f1
-                        </p>
-                        <p className="text-text-muted text-2xs">
-                          Access policy: production-operators
-                        </p>
-                        <p className="text-text-muted text-2xs">MFA verified</p>
-                        <p className="mt-3">
-                          <span className="text-accent-cyan">
-                            root@api-server:~#
-                          </span>{" "}
-                          <span className="inline-block w-2 h-3.5 bg-text-primary animate-pulse" />
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Status badges */}
-                    <div className="flex flex-wrap gap-2 mt-4">
-                      {[
-                        { label: "Recorded", color: C.green },
-                        { label: "Access-controlled", color: C.primary },
-                        { label: "MFA", color: C.yellow },
-                        { label: "Audited", color: C.cyan },
-                      ].map((b) => (
-                        <span
-                          key={b.label}
-                          className="px-2 py-0.5 text-2xs font-mono border rounded-full"
-                          style={{
-                            color: b.color,
-                            borderColor: `${b.color}30`,
-                            background: `${b.color}10`,
-                          }}
-                        >
-                          {b.label}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </ShimmerCard>
-            </Reveal>
-          </div>
+          ))}
         </div>
-      </section>
-
-      {/* ═══════ Architecture Diagram ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Architecture
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              How container SSH works
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              The ShellHub agent runs alongside your containers on the Docker
-              host, routing SSH connections to individual containers through the
-              gateway.
-            </p>
-          </Reveal>
-
-          <Reveal>
-            <ShimmerCard>
-              <Card hover className="p-6 sm:p-8 overflow-hidden">
-                <ArchitectureDiagram />
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-        </div>
-      </section>
-
-      {/* ═══════ Pain Points ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              The Problem
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Why docker exec falls short
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Docker exec was designed for local debugging, not for production
-              access at scale.
-            </p>
-          </Reveal>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {painPoints.map((p, i) => (
-              <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard className="h-full">
-                  <Card hover className="p-6 h-full">
-                    <div className="flex items-start gap-4">
-                      <div
-                        className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
-                        style={{
-                          background: `${p.color}15`,
-                          borderColor: `${p.color}25`,
-                        }}
-                      >
-                        <svg
-                          width="18"
-                          height="18"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke={p.color}
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                        >
-                          <path d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126z" />
-                          <path d="M12 15.75h.007v.008H12v-.008z" />
-                        </svg>
-                      </div>
-                      <div>
-                        <h4 className="text-sm font-semibold mb-2">
-                          {p.title}
-                        </h4>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {p.desc}
-                        </p>
-                      </div>
-                    </div>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </section>
+      </Section>
 
       {/* ═══════ Key Features ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Features
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Built for container workflows
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Everything you need to manage SSH access to containers at scale,
-              from access control to session recording.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Features"
+          title="Built for container workflows"
+          subtitle="Everything you need to manage SSH access to containers at scale, from access control to session recording."
+        />
 
-          {/* Big feature card: Per-Container Access Control */}
-          <Reveal className="mb-6">
-            <ShimmerCard>
-              <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)]">
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-                <div className="relative grid lg:grid-cols-2 gap-8 p-8">
-                  {/* Left: description */}
-                  <div className="flex flex-col justify-center">
-                    <IconBadge color="primary" className="mb-4">
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke={C.primary}
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                      >
-                        <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
-                        <circle cx="9" cy="7" r="4" />
-                        <path d="M23 21v-2a4 4 0 00-3-3.87" />
-                        <path d="M16 3.13a4 4 0 010 7.75" />
-                      </svg>
-                    </IconBadge>
-                    <h3 className="text-lg font-bold mb-2">
-                      Per-Container Access Control
-                    </h3>
-                    <p className="text-sm text-text-secondary leading-relaxed mb-6">
-                      Define who can access which containers with role-based
-                      policies. Assign roles at the container level, not just
-                      the host. Restrict shell access, enforce MFA, and audit
-                      every connection attempt.
-                    </p>
-                    <ul className="space-y-2.5">
-                      {[
-                        "Container-level permissions, not host-level",
-                        "Role-based policies per user or group",
-                        "MFA enforcement per container",
-                        "Deny-by-default access model",
-                      ].map((item) => (
-                        <li
-                          key={item}
-                          className="flex items-center gap-2.5 text-sm text-text-secondary"
-                        >
-                          <svg
-                            className="w-4 h-4 text-accent-green shrink-0"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="m4.5 12.75 6 6 9-13.5"
-                            />
-                          </svg>
-                          {item}
-                        </li>
-                      ))}
-                    </ul>
+        {/* Big feature card: Per-Container Access Control */}
+        <Reveal className="mb-6">
+          <ShimmerCard>
+            <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)]">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+              <div className="relative grid lg:grid-cols-2 gap-8 p-8">
+                {/* Left: description */}
+                <div className="flex flex-col justify-center">
+                  <IconBadge color="primary" className="mb-4">
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke={C.primary}
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    >
+                      <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+                      <circle cx="9" cy="7" r="4" />
+                      <path d="M23 21v-2a4 4 0 00-3-3.87" />
+                      <path d="M16 3.13a4 4 0 010 7.75" />
+                    </svg>
+                  </IconBadge>
+                  <h3 className="text-lg font-bold mb-2">
+                    Per-Container Access Control
+                  </h3>
+                  <p className="text-sm text-text-secondary leading-relaxed mb-6">
+                    Define who can access which containers with role-based
+                    policies. Assign roles at the container level, not just the
+                    host. Restrict shell access, enforce MFA, and audit every
+                    connection attempt.
+                  </p>
+                  <ul className="space-y-2.5">
+                    {[
+                      "Container-level permissions, not host-level",
+                      "Role-based policies per user or group",
+                      "MFA enforcement per container",
+                      "Deny-by-default access model",
+                    ].map((item) => (
+                      <FeatureListItem key={item} color="green">
+                        {item}
+                      </FeatureListItem>
+                    ))}
+                  </ul>
+                </div>
+
+                {/* Right: permissions table mockup */}
+                <div className="bg-surface rounded-xl border border-border overflow-hidden">
+                  <div className="flex items-center gap-2 px-5 py-3 border-b border-border">
+                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                    <span className="ml-2 text-2xs text-text-muted font-mono">
+                      Container Permissions
+                    </span>
                   </div>
 
-                  {/* Right: permissions table mockup */}
-                  <div className="bg-surface rounded-xl border border-border overflow-hidden">
-                    <div className="flex items-center gap-2 px-5 py-3 border-b border-border">
-                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                      <span className="ml-2 text-2xs text-text-muted font-mono">
-                        Container Permissions
+                  {/* Table header */}
+                  <div className="grid grid-cols-4 gap-2 px-5 py-2.5 border-b border-border text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                    <span>Container</span>
+                    <span>User</span>
+                    <span>Role</span>
+                    <span>Access</span>
+                  </div>
+
+                  {/* Table rows */}
+                  {permRows.map((row, i) => (
+                    <div
+                      key={i}
+                      className="grid grid-cols-4 gap-2 px-5 py-3 border-b border-border last:border-b-0 hover:bg-white/[0.02] transition-colors"
+                    >
+                      <span className="text-xs font-mono text-text-primary truncate">
+                        {row.container}
                       </span>
-                    </div>
-
-                    {/* Table header */}
-                    <div className="grid grid-cols-4 gap-2 px-5 py-2.5 border-b border-border text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      <span>Container</span>
-                      <span>User</span>
-                      <span>Role</span>
-                      <span>Access</span>
-                    </div>
-
-                    {/* Table rows */}
-                    {permRows.map((row, i) => (
-                      <div
-                        key={i}
-                        className="grid grid-cols-4 gap-2 px-5 py-3 border-b border-border last:border-b-0 hover:bg-white/[0.02] transition-colors"
+                      <span className="text-xs text-text-secondary truncate">
+                        {row.user}
+                      </span>
+                      <span
+                        className="px-2 py-0.5 text-2xs font-mono rounded-full w-fit border"
+                        style={{
+                          color: row.accent,
+                          borderColor: `${row.accent}30`,
+                          background: `${row.accent}10`,
+                        }}
                       >
-                        <span className="text-xs font-mono text-text-primary truncate">
-                          {row.container}
-                        </span>
-                        <span className="text-xs text-text-secondary truncate">
-                          {row.user}
-                        </span>
-                        <span
-                          className="px-2 py-0.5 text-2xs font-mono rounded-full w-fit border"
-                          style={{
-                            color: row.accent,
-                            borderColor: `${row.accent}30`,
-                            background: `${row.accent}10`,
-                          }}
-                        >
-                          {row.role}
-                        </span>
-                        <span className="text-xs text-text-muted">
-                          {row.level}
-                        </span>
-                      </div>
-                    ))}
-
-                    <div className="px-5 py-3 flex items-center justify-between border-t border-border">
-                      <span className="text-2xs text-text-muted">
-                        4 policies in production
+                        {row.role}
                       </span>
-                      <span className="text-2xs text-primary font-medium">
-                        Manage &rarr;
+                      <span className="text-xs text-text-muted">
+                        {row.level}
                       </span>
                     </div>
+                  ))}
+
+                  <div className="px-5 py-3 flex items-center justify-between border-t border-border">
+                    <span className="text-2xs text-text-muted">
+                      4 policies in production
+                    </span>
+                    <span className="text-2xs text-primary font-medium">
+                      Manage &rarr;
+                    </span>
                   </div>
                 </div>
               </div>
-            </ShimmerCard>
-          </Reveal>
+            </div>
+          </ShimmerCard>
+        </Reveal>
 
-          {/* 2x2 smaller feature cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {smallFeatures.map((f, i) => (
-              <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard className="h-full">
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                      style={{
-                        background: `${f.color}15`,
-                        borderColor: `${f.color}25`,
-                      }}
-                    >
-                      {f.icon}
-                    </div>
-                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+        {/* 2x2 smaller feature cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {smallFeatures.map((f, i) => (
+            <Reveal key={i} delay={i * 0.04}>
+              <ShimmerCard className="h-full">
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${f.color}15`,
+                      borderColor: `${f.color}25`,
+                    }}
+                  >
+                    {f.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {f.desc}
+                  </p>
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
+        </div>
+      </Section>
+
+      {/* ═══════ How It Works ═══════ */}
+      <Section>
+        <SectionHeader
+          eyebrow="How It Works"
+          title="Three steps to container SSH"
+          subtitle="Go from zero to SSH-accessible containers in minutes, not hours."
+        />
+
+        <div className="relative grid grid-cols-1 md:grid-cols-3 gap-6">
+          {/* Connecting line (visible on md+) */}
+          <div className="hidden md:block absolute top-[52px] left-[16.66%] right-[16.66%] h-[1px] z-0">
+            <div
+              className="w-full h-full"
+              style={{
+                background: `linear-gradient(to right, ${C.primary}40, ${C.cyan}40, ${C.green}40)`,
+              }}
+            />
+          </div>
+
+          {steps.map((s, i) => (
+            <Reveal key={i} delay={i * 0.08}>
+              <div className="relative text-center">
+                {/* Step number circle */}
+                <div
+                  className="relative z-10 w-[60px] h-[60px] rounded-full mx-auto mb-6 flex items-center justify-center border text-lg font-bold font-mono"
+                  style={{
+                    background: `${s.color}12`,
+                    borderColor: `${s.color}30`,
+                    color: s.color,
+                  }}
+                >
+                  {s.num}
+                </div>
+                <ShimmerCard>
+                  <Card hover className="p-6">
+                    <h4 className="text-sm font-semibold mb-2">{s.title}</h4>
                     <p className="text-xs text-text-secondary leading-relaxed">
-                      {f.desc}
+                      {s.desc}
                     </p>
                   </Card>
                 </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
+              </div>
+            </Reveal>
+          ))}
         </div>
-      </section>
-
-      {/* ═══════ How It Works ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              How It Works
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Three steps to container SSH
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Go from zero to SSH-accessible containers in minutes, not hours.
-            </p>
-          </Reveal>
-
-          <div className="relative grid grid-cols-1 md:grid-cols-3 gap-6">
-            {/* Connecting line (visible on md+) */}
-            <div className="hidden md:block absolute top-[52px] left-[16.66%] right-[16.66%] h-[1px] z-0">
-              <div
-                className="w-full h-full"
-                style={{
-                  background: `linear-gradient(to right, ${C.primary}40, ${C.cyan}40, ${C.green}40)`,
-                }}
-              />
-            </div>
-
-            {steps.map((s, i) => (
-              <Reveal key={i} delay={i * 0.08}>
-                <div className="relative text-center">
-                  {/* Step number circle */}
-                  <div
-                    className="relative z-10 w-[60px] h-[60px] rounded-full mx-auto mb-6 flex items-center justify-center border text-lg font-bold font-mono"
-                    style={{
-                      background: `${s.color}12`,
-                      borderColor: `${s.color}30`,
-                      color: s.color,
-                    }}
-                  >
-                    {s.num}
-                  </div>
-                  <ShimmerCard>
-                    <Card hover className="p-6">
-                      <h4 className="text-sm font-semibold mb-2">{s.title}</h4>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {s.desc}
-                      </p>
-                    </Card>
-                  </ShimmerCard>
-                </div>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </section>
+      </Section>
 
       {/* ═══════ CTA ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal>
-            <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-              <ConnectionGrid />
-              <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
+      <Section>
+        <Reveal>
+          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+            <ConnectionGrid />
+            <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
 
-              <div className="relative z-10">
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-accent-cyan mb-3">
-                  Ready to simplify container access?
-                </p>
-                <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Manage your containers remotely
-                </h2>
-                <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                  Install the ShellHub agent and get instant SSH access to
-                  containers on any remote host. Free to start, no credit card
-                  required.
-                </p>
+            <div className="relative z-10">
+              <SectionHeader
+                variant="cta"
+                eyebrowColor="cyan"
+                eyebrow="Ready to simplify container access?"
+                title="Manage your containers remotely"
+                subtitle="Install the ShellHub agent and get instant SSH access to containers on any remote host. Free to start, no credit card required."
+              />
 
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                  <Button
-                    as={Link}
-                    to="/getting-started"
-                    variant="primary"
-                    size="xl"
-                    glow
-                    iconRight={<ArrowRight />}
-                  >
-                    Get Started Free
-                  </Button>
-                  <Button as={Link} to="/pricing" variant="outline" size="xl">
-                    Compare Plans
-                  </Button>
-                </div>
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+                <Button
+                  as={Link}
+                  to="/getting-started"
+                  variant="primary"
+                  size="xl"
+                  glow
+                  iconRight={<ArrowRight />}
+                >
+                  Get Started Free
+                </Button>
+                <Button as={Link} to="/pricing" variant="outline" size="xl">
+                  Compare Plans
+                </Button>
               </div>
             </div>
-          </Reveal>
-        </div>
-      </section>
+          </div>
+        </Reveal>
+      </Section>
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Badge, Button, Card } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
+import { Section, SectionHeader } from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -366,392 +367,342 @@ export default function DevopsCiCd() {
       </section>
 
       {/* ── Ansible Integration ──────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <div>
-              <Reveal>
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Ansible Integration
-                </p>
-                <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Use ShellHub as your SSH transport for Ansible
-                </h2>
-                <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                  Point your Ansible inventory at ShellHub device identifiers
-                  and run playbooks against devices behind NAT, CGNAT, or
-                  firewalls -- no VPN required. ShellHub acts as a transparent
-                  SSH gateway so existing playbooks work without modification.
-                </p>
-              </Reveal>
+      <Section>
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <SectionHeader
+              align="left"
+              size="sub"
+              className="mb-8"
+              eyebrow="Ansible Integration"
+              title="Use ShellHub as your SSH transport for Ansible"
+              subtitle="Point your Ansible inventory at ShellHub device identifiers and run playbooks against devices behind NAT, CGNAT, or firewalls -- no VPN required. ShellHub acts as a transparent SSH gateway so existing playbooks work without modification."
+            />
 
-              <div className="space-y-3">
-                {[
-                  {
-                    label: "Standard SSH connection",
-                    desc: "No custom connection plugins -- Ansible uses its built-in SSH transport",
-                  },
-                  {
-                    label: "NAT traversal included",
-                    desc: "Reach devices that have no public IP or inbound ports",
-                  },
-                  {
-                    label: "Fleet targeting with tags",
-                    desc: "Build dynamic inventories based on ShellHub device tags",
-                  },
-                  {
-                    label: "Session-level audit trail",
-                    desc: "Every Ansible task is logged with full session recording",
-                  },
-                ].map((item, i) => (
-                  <Reveal key={i} delay={i * 0.04}>
-                    <div className="flex items-start gap-3">
-                      <svg
-                        className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
-                      <div>
-                        <p className="text-sm font-medium text-text-primary">
-                          {item.label}
-                        </p>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {item.desc}
-                        </p>
-                      </div>
+            <div className="space-y-3">
+              {[
+                {
+                  label: "Standard SSH connection",
+                  desc: "No custom connection plugins -- Ansible uses its built-in SSH transport",
+                },
+                {
+                  label: "NAT traversal included",
+                  desc: "Reach devices that have no public IP or inbound ports",
+                },
+                {
+                  label: "Fleet targeting with tags",
+                  desc: "Build dynamic inventories based on ShellHub device tags",
+                },
+                {
+                  label: "Session-level audit trail",
+                  desc: "Every Ansible task is logged with full session recording",
+                },
+              ].map((item, i) => (
+                <Reveal key={i} delay={i * 0.04}>
+                  <div className="flex items-start gap-3">
+                    <svg
+                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m4.5 12.75 6 6 9-13.5"
+                      />
+                    </svg>
+                    <div>
+                      <p className="text-sm font-medium text-text-primary">
+                        {item.label}
+                      </p>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {item.desc}
+                      </p>
                     </div>
-                  </Reveal>
-                ))}
-              </div>
-            </div>
-
-            <Reveal delay={0.1}>
-              <ShimmerCard>
-                <Card className="overflow-hidden">
-                  <TerminalChrome title="ansible-playbook">
-                    <div className="space-y-0">
-                      {ansibleLines.map((line, i) => (
-                        <CodeLine key={i} {...line} />
-                      ))}
-                    </div>
-                  </TerminalChrome>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Terraform Integration ────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <Reveal delay={0.1} className="order-2 lg:order-1">
-              <ShimmerCard>
-                <Card className="overflow-hidden">
-                  <TerminalChrome title="main.tf">
-                    <div className="space-y-0">
-                      {terraformLines.map((line, i) => (
-                        <CodeLine key={i} {...line} />
-                      ))}
-                    </div>
-                  </TerminalChrome>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-
-            <div className="order-1 lg:order-2">
-              <Reveal>
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Terraform Integration
-                </p>
-                <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Infrastructure as code for device provisioning
-                </h2>
-                <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                  Define your device fleet declaratively with Terraform.
-                  Provision namespaces, assign tags, configure firewall rules,
-                  and manage access policies -- all versioned in Git and applied
-                  through your standard IaC workflow.
-                </p>
-              </Reveal>
-
-              <div className="space-y-3">
-                {[
-                  {
-                    label: "Declarative device management",
-                    desc: "Define fleet topology and access policies as HCL resources",
-                  },
-                  {
-                    label: "GitOps-friendly",
-                    desc: "Version your device configuration alongside application code",
-                  },
-                  {
-                    label: "Drift detection",
-                    desc: "Terraform plan shows configuration differences before applying",
-                  },
-                  {
-                    label: "Reproducible environments",
-                    desc: "Spin up identical staging and production fleets from the same config",
-                  },
-                ].map((item, i) => (
-                  <Reveal key={i} delay={i * 0.04}>
-                    <div className="flex items-start gap-3">
-                      <svg
-                        className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
-                      <div>
-                        <p className="text-sm font-medium text-text-primary">
-                          {item.label}
-                        </p>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {item.desc}
-                        </p>
-                      </div>
-                    </div>
-                  </Reveal>
-                ))}
-              </div>
+                  </div>
+                </Reveal>
+              ))}
             </div>
           </div>
-        </div>
-      </section>
-
-      {/* ── CI/CD Pipeline ───────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              CI/CD Pipeline
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Deploy to remote devices from any CI system
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              GitHub Actions, GitLab CI, Jenkins -- any pipeline that can run
-              SSH can deploy through ShellHub.
-            </p>
-          </Reveal>
 
           <Reveal delay={0.1}>
-            <ShimmerCard className="max-w-3xl mx-auto">
-              <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(102,122,204,0.1)]">
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-                <div className="relative">
-                  <TerminalChrome title=".github/workflows/deploy.yml">
-                    {/* Pipeline step indicators */}
-                    <div className="flex items-center gap-6 mb-6 pb-5 border-b border-border">
-                      {pipelineSteps.map((step, i) => (
-                        <div key={i} className="flex items-center gap-2">
-                          <div className="w-5 h-5 rounded-full bg-accent-green/15 border border-accent-green/30 flex items-center justify-center">
-                            <svg
-                              className="w-3 h-3 text-accent-green"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={2.5}
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="m4.5 12.75 6 6 9-13.5"
-                              />
-                            </svg>
-                          </div>
-                          <span className="text-2xs font-mono text-text-secondary">
-                            {step.label}
-                          </span>
-                          {i < pipelineSteps.length - 1 && (
-                            <svg
-                              className="w-3 h-3 text-text-muted ml-2"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={2}
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                              />
-                            </svg>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-
-                    {/* Workflow YAML */}
-                    <div className="space-y-0 mb-6">
-                      {pipelineDeployLines.map((line, i) => (
-                        <CodeLine key={i} {...line} />
-                      ))}
-                    </div>
-
-                    {/* Status bar */}
-                    <div className="pt-4 border-t border-border flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <div className="w-2 h-2 rounded-full bg-accent-green animate-pulse" />
-                        <span className="text-2xs font-mono text-accent-green">
-                          Pipeline succeeded
-                        </span>
-                      </div>
-                      <span className="text-2xs text-text-muted font-mono">
-                        2 devices updated in 34s
-                      </span>
-                    </div>
-                  </TerminalChrome>
-                </div>
-              </div>
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <TerminalChrome title="ansible-playbook">
+                  <div className="space-y-0">
+                    {ansibleLines.map((line, i) => (
+                      <CodeLine key={i} {...line} />
+                    ))}
+                  </div>
+                </TerminalChrome>
+              </Card>
             </ShimmerCard>
           </Reveal>
         </div>
-      </section>
+      </Section>
 
-      {/* ── Pain Points ──────────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              The Problem
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Why automating remote deployments is hard
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Traditional approaches to device automation break down when
-              devices are behind NAT, on unstable networks, or spread across
-              locations.
-            </p>
+      {/* ── Terraform Integration ────────────────────────────────── */}
+      <Section>
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          <Reveal delay={0.1} className="order-2 lg:order-1">
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <TerminalChrome title="main.tf">
+                  <div className="space-y-0">
+                    {terraformLines.map((line, i) => (
+                      <CodeLine key={i} {...line} />
+                    ))}
+                  </div>
+                </TerminalChrome>
+              </Card>
+            </ShimmerCard>
           </Reveal>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {painPoints.map((p, i) => (
-              <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard>
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-2 h-2 rounded-full mb-4"
-                      style={{ background: p.color }}
-                    />
-                    <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {p.desc}
-                    </p>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </section>
+          <div className="order-1 lg:order-2">
+            <SectionHeader
+              align="left"
+              size="sub"
+              className="mb-8"
+              eyebrow="Terraform Integration"
+              title="Infrastructure as code for device provisioning"
+              subtitle="Define your device fleet declaratively with Terraform. Provision namespaces, assign tags, configure firewall rules, and manage access policies -- all versioned in Git and applied through your standard IaC workflow."
+            />
 
-      {/* ── Key Features ─────────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Capabilities
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              ShellHub features for DevOps teams
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Everything your automation toolchain needs to securely deploy to
-              remote and edge devices at scale.
-            </p>
-          </Reveal>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {features.map((f, i) => (
-              <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard>
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                      style={{
-                        background: `${f.color}15`,
-                        borderColor: `${f.color}25`,
-                      }}
+            <div className="space-y-3">
+              {[
+                {
+                  label: "Declarative device management",
+                  desc: "Define fleet topology and access policies as HCL resources",
+                },
+                {
+                  label: "GitOps-friendly",
+                  desc: "Version your device configuration alongside application code",
+                },
+                {
+                  label: "Drift detection",
+                  desc: "Terraform plan shows configuration differences before applying",
+                },
+                {
+                  label: "Reproducible environments",
+                  desc: "Spin up identical staging and production fleets from the same config",
+                },
+              ].map((item, i) => (
+                <Reveal key={i} delay={i * 0.04}>
+                  <div className="flex items-start gap-3">
+                    <svg
+                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
                     >
-                      {f.icon}
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m4.5 12.75 6 6 9-13.5"
+                      />
+                    </svg>
+                    <div>
+                      <p className="text-sm font-medium text-text-primary">
+                        {item.label}
+                      </p>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {item.desc}
+                      </p>
                     </div>
-                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {f.desc}
-                    </p>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
+                  </div>
+                </Reveal>
+              ))}
+            </div>
           </div>
         </div>
-      </section>
+      </Section>
 
-      {/* ── CTA ──────────────────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal>
-            <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-              <ConnectionGrid />
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
+      {/* ── CI/CD Pipeline ───────────────────────────────────────── */}
+      <Section>
+        <SectionHeader
+          eyebrow="CI/CD Pipeline"
+          title="Deploy to remote devices from any CI system"
+          subtitle="GitHub Actions, GitLab CI, Jenkins -- any pipeline that can run SSH can deploy through ShellHub."
+        />
 
-              <div className="relative z-10">
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Ready to automate?
-                </p>
-                <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Automate your device deployments today
-                </h2>
-                <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                  Connect ShellHub to your CI/CD pipeline and start deploying to
-                  remote devices in minutes -- no VPN, no static IPs, no hassle.
-                </p>
+        <Reveal delay={0.1}>
+          <ShimmerCard className="max-w-3xl mx-auto">
+            <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(102,122,204,0.1)]">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+              <div className="relative">
+                <TerminalChrome title=".github/workflows/deploy.yml">
+                  {/* Pipeline step indicators */}
+                  <div className="flex items-center gap-6 mb-6 pb-5 border-b border-border">
+                    {pipelineSteps.map((step, i) => (
+                      <div key={i} className="flex items-center gap-2">
+                        <div className="w-5 h-5 rounded-full bg-accent-green/15 border border-accent-green/30 flex items-center justify-center">
+                          <svg
+                            className="w-3 h-3 text-accent-green"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2.5}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="m4.5 12.75 6 6 9-13.5"
+                            />
+                          </svg>
+                        </div>
+                        <span className="text-2xs font-mono text-text-secondary">
+                          {step.label}
+                        </span>
+                        {i < pipelineSteps.length - 1 && (
+                          <svg
+                            className="w-3 h-3 text-text-muted ml-2"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+                            />
+                          </svg>
+                        )}
+                      </div>
+                    ))}
+                  </div>
 
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                  <Button
-                    as={Link}
-                    to="/getting-started"
-                    variant="primary"
-                    size="xl"
-                    glow
-                    iconRight={<ArrowRight />}
-                  >
-                    Get Started Free
-                  </Button>
-                  <Button
-                    as="a"
-                    href={docsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="outline"
-                    size="xl"
-                  >
-                    Read the Docs
-                  </Button>
-                </div>
+                  {/* Workflow YAML */}
+                  <div className="space-y-0 mb-6">
+                    {pipelineDeployLines.map((line, i) => (
+                      <CodeLine key={i} {...line} />
+                    ))}
+                  </div>
+
+                  {/* Status bar */}
+                  <div className="pt-4 border-t border-border flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <div className="w-2 h-2 rounded-full bg-accent-green animate-pulse" />
+                      <span className="text-2xs font-mono text-accent-green">
+                        Pipeline succeeded
+                      </span>
+                    </div>
+                    <span className="text-2xs text-text-muted font-mono">
+                      2 devices updated in 34s
+                    </span>
+                  </div>
+                </TerminalChrome>
               </div>
             </div>
-          </Reveal>
+          </ShimmerCard>
+        </Reveal>
+      </Section>
+
+      {/* ── Pain Points ──────────────────────────────────────────── */}
+      <Section>
+        <SectionHeader
+          eyebrow="The Problem"
+          title="Why automating remote deployments is hard"
+          subtitle="Traditional approaches to device automation break down when devices are behind NAT, on unstable networks, or spread across locations."
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {painPoints.map((p, i) => (
+            <Reveal key={i} delay={i * 0.06}>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-2 h-2 rounded-full mb-4"
+                    style={{ background: p.color }}
+                  />
+                  <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {p.desc}
+                  </p>
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
         </div>
-      </section>
+      </Section>
+
+      {/* ── Key Features ─────────────────────────────────────────── */}
+      <Section>
+        <SectionHeader
+          eyebrow="Capabilities"
+          title="ShellHub features for DevOps teams"
+          subtitle="Everything your automation toolchain needs to securely deploy to remote and edge devices at scale."
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {features.map((f, i) => (
+            <Reveal key={i} delay={i * 0.04}>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${f.color}15`,
+                      borderColor: `${f.color}25`,
+                    }}
+                  >
+                    {f.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {f.desc}
+                  </p>
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
+        </div>
+      </Section>
+
+      {/* ── CTA ──────────────────────────────────────────────────── */}
+      <Section>
+        <Reveal>
+          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+            <ConnectionGrid />
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
+
+            <div className="relative z-10">
+              <SectionHeader
+                variant="cta"
+                eyebrow="Ready to automate?"
+                title="Automate your device deployments today"
+                subtitle="Connect ShellHub to your CI/CD pipeline and start deploying to remote devices in minutes -- no VPN, no static IPs, no hassle."
+              />
+
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+                <Button
+                  as={Link}
+                  to="/getting-started"
+                  variant="primary"
+                  size="xl"
+                  glow
+                  iconRight={<ArrowRight />}
+                >
+                  Get Started Free
+                </Button>
+                <Button
+                  as="a"
+                  href={docsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="outline"
+                  size="xl"
+                >
+                  Read the Docs
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </Section>
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -8,6 +8,7 @@ import {
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { SiteLayout } from "@/components/SiteLayout";
+import { Section, SectionHeader } from "@/components/marketing";
 import { C } from "../landing/constants";
 
 /* ═══════ Pain-point data ═══════ */
@@ -261,826 +262,769 @@ export default function EdgeComputing() {
       </section>
 
       {/* ───── Edge Network Map ───── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Network Topology
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              One platform, every edge location
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              ShellHub connects to all your distributed edge infrastructure
-              through a single control plane — no matter where your devices are.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Network Topology"
+          title="One platform, every edge location"
+          subtitle="ShellHub connects to all your distributed edge infrastructure through a single control plane — no matter where your devices are."
+        />
 
-          <Reveal delay={0.1}>
-            <ShimmerCard className="bg-card border border-border rounded-2xl overflow-hidden">
-              <div className="relative p-8 md:p-12">
-                {/* Background grid pattern */}
-                <div
-                  className="absolute inset-0 opacity-[0.03]"
-                  style={{
-                    backgroundImage: `radial-gradient(${C.text} 1px, transparent 1px)`,
-                    backgroundSize: "24px 24px",
-                  }}
-                />
+        <Reveal delay={0.1}>
+          <ShimmerCard className="bg-card border border-border rounded-2xl overflow-hidden">
+            <div className="relative p-8 md:p-12">
+              {/* Background grid pattern */}
+              <div
+                className="absolute inset-0 opacity-[0.03]"
+                style={{
+                  backgroundImage: `radial-gradient(${C.text} 1px, transparent 1px)`,
+                  backgroundSize: "24px 24px",
+                }}
+              />
 
-                <svg
-                  viewBox="0 0 100 100"
-                  className="w-full max-w-3xl mx-auto relative"
-                  style={{ minHeight: 320 }}
-                >
-                  {/* Connection lines from center to each location */}
-                  {edgeLocations.map((loc, i) => (
-                    <line
-                      key={`line-${i}`}
-                      x1="50"
-                      y1="48"
-                      x2={loc.x}
-                      y2={loc.y}
+              <svg
+                viewBox="0 0 100 100"
+                className="w-full max-w-3xl mx-auto relative"
+                style={{ minHeight: 320 }}
+              >
+                {/* Connection lines from center to each location */}
+                {edgeLocations.map((loc, i) => (
+                  <line
+                    key={`line-${i}`}
+                    x1="50"
+                    y1="48"
+                    x2={loc.x}
+                    y2={loc.y}
+                    stroke={loc.color}
+                    strokeWidth="0.3"
+                    strokeDasharray="1.5 1"
+                    opacity="0.5"
+                  />
+                ))}
+
+                {/* Central ShellHub Cloud node */}
+                <g>
+                  <circle
+                    cx="50"
+                    cy="48"
+                    r="6"
+                    fill={C.card}
+                    stroke={C.primary}
+                    strokeWidth="0.5"
+                  />
+                  <circle
+                    cx="50"
+                    cy="48"
+                    r="8"
+                    fill="none"
+                    stroke={C.primary}
+                    strokeWidth="0.15"
+                    opacity="0.4"
+                  />
+                  <circle
+                    cx="50"
+                    cy="48"
+                    r="10.5"
+                    fill="none"
+                    stroke={C.primary}
+                    strokeWidth="0.1"
+                    opacity="0.2"
+                  />
+                  {/* Cloud icon */}
+                  <path
+                    d="M46.5 49.5a2.5 2.5 0 0 1 2.5-3 3 3 0 0 1 5.5-1 2 2 0 0 1 .5 4h-7.5z"
+                    fill="none"
+                    stroke={C.primary}
+                    strokeWidth="0.4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <text
+                    x="50"
+                    y="56"
+                    textAnchor="middle"
+                    fill={C.primary}
+                    fontSize="2.2"
+                    fontWeight="600"
+                    fontFamily="monospace"
+                  >
+                    ShellHub Cloud
+                  </text>
+                </g>
+
+                {/* Edge location nodes */}
+                {edgeLocations.map((loc, i) => (
+                  <g key={`node-${i}`}>
+                    {/* Outer glow */}
+                    <circle
+                      cx={loc.x}
+                      cy={loc.y}
+                      r="4"
+                      fill={`${loc.color}08`}
+                      stroke={`${loc.color}30`}
+                      strokeWidth="0.2"
+                    />
+                    {/* Server icon body */}
+                    <rect
+                      x={loc.x - 2}
+                      y={loc.y - 2}
+                      width="4"
+                      height="4"
+                      rx="0.6"
+                      fill={C.surface}
                       stroke={loc.color}
                       strokeWidth="0.3"
-                      strokeDasharray="1.5 1"
+                    />
+                    {/* Server lines */}
+                    <line
+                      x1={loc.x - 1}
+                      y1={loc.y - 0.5}
+                      x2={loc.x + 1}
+                      y2={loc.y - 0.5}
+                      stroke={loc.color}
+                      strokeWidth="0.2"
                       opacity="0.5"
                     />
-                  ))}
-
-                  {/* Central ShellHub Cloud node */}
-                  <g>
+                    <line
+                      x1={loc.x - 1}
+                      y1={loc.y + 0.5}
+                      x2={loc.x + 1}
+                      y2={loc.y + 0.5}
+                      stroke={loc.color}
+                      strokeWidth="0.2"
+                      opacity="0.5"
+                    />
+                    {/* Green status dot */}
                     <circle
-                      cx="50"
-                      cy="48"
-                      r="6"
-                      fill={C.card}
-                      stroke={C.primary}
-                      strokeWidth="0.5"
-                    />
-                    <circle
-                      cx="50"
-                      cy="48"
-                      r="8"
-                      fill="none"
-                      stroke={C.primary}
-                      strokeWidth="0.15"
-                      opacity="0.4"
-                    />
-                    <circle
-                      cx="50"
-                      cy="48"
-                      r="10.5"
-                      fill="none"
-                      stroke={C.primary}
-                      strokeWidth="0.1"
-                      opacity="0.2"
-                    />
-                    {/* Cloud icon */}
-                    <path
-                      d="M46.5 49.5a2.5 2.5 0 0 1 2.5-3 3 3 0 0 1 5.5-1 2 2 0 0 1 .5 4h-7.5z"
-                      fill="none"
-                      stroke={C.primary}
-                      strokeWidth="0.4"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
+                      cx={loc.x + 1.2}
+                      cy={loc.y - 1.2}
+                      r="0.5"
+                      fill={C.green}
+                    >
+                      <animate
+                        attributeName="opacity"
+                        values="1;0.4;1"
+                        dur="2s"
+                        begin={`${i * 0.4}s`}
+                        repeatCount="indefinite"
+                      />
+                    </circle>
+                    {/* Label */}
                     <text
-                      x="50"
-                      y="56"
+                      x={loc.x}
+                      y={loc.y + 5.5}
                       textAnchor="middle"
-                      fill={C.primary}
-                      fontSize="2.2"
+                      fill={C.text}
+                      fontSize="1.8"
                       fontWeight="600"
+                      fontFamily="sans-serif"
+                    >
+                      {loc.label}
+                    </text>
+                    <text
+                      x={loc.x}
+                      y={loc.y + 7.5}
+                      textAnchor="middle"
+                      fill={C.textMuted}
+                      fontSize="1.5"
                       fontFamily="monospace"
                     >
-                      ShellHub Cloud
+                      {loc.city}
                     </text>
                   </g>
+                ))}
+              </svg>
 
-                  {/* Edge location nodes */}
-                  {edgeLocations.map((loc, i) => (
-                    <g key={`node-${i}`}>
-                      {/* Outer glow */}
-                      <circle
-                        cx={loc.x}
-                        cy={loc.y}
-                        r="4"
-                        fill={`${loc.color}08`}
-                        stroke={`${loc.color}30`}
-                        strokeWidth="0.2"
-                      />
-                      {/* Server icon body */}
-                      <rect
-                        x={loc.x - 2}
-                        y={loc.y - 2}
-                        width="4"
-                        height="4"
-                        rx="0.6"
-                        fill={C.surface}
-                        stroke={loc.color}
-                        strokeWidth="0.3"
-                      />
-                      {/* Server lines */}
-                      <line
-                        x1={loc.x - 1}
-                        y1={loc.y - 0.5}
-                        x2={loc.x + 1}
-                        y2={loc.y - 0.5}
-                        stroke={loc.color}
-                        strokeWidth="0.2"
-                        opacity="0.5"
-                      />
-                      <line
-                        x1={loc.x - 1}
-                        y1={loc.y + 0.5}
-                        x2={loc.x + 1}
-                        y2={loc.y + 0.5}
-                        stroke={loc.color}
-                        strokeWidth="0.2"
-                        opacity="0.5"
-                      />
-                      {/* Green status dot */}
-                      <circle
-                        cx={loc.x + 1.2}
-                        cy={loc.y - 1.2}
-                        r="0.5"
-                        fill={C.green}
-                      >
-                        <animate
-                          attributeName="opacity"
-                          values="1;0.4;1"
-                          dur="2s"
-                          begin={`${i * 0.4}s`}
-                          repeatCount="indefinite"
-                        />
-                      </circle>
-                      {/* Label */}
-                      <text
-                        x={loc.x}
-                        y={loc.y + 5.5}
-                        textAnchor="middle"
-                        fill={C.text}
-                        fontSize="1.8"
-                        fontWeight="600"
-                        fontFamily="sans-serif"
-                      >
-                        {loc.label}
-                      </text>
-                      <text
-                        x={loc.x}
-                        y={loc.y + 7.5}
-                        textAnchor="middle"
-                        fill={C.textMuted}
-                        fontSize="1.5"
-                        fontFamily="monospace"
-                      >
-                        {loc.city}
-                      </text>
-                    </g>
-                  ))}
-                </svg>
-
-                {/* Legend */}
-                <div className="flex flex-wrap items-center justify-center gap-4 mt-6">
-                  {edgeLocations.map((loc) => (
-                    <div key={loc.city} className="flex items-center gap-2">
-                      <div
-                        className="w-2 h-2 rounded-full"
-                        style={{ background: loc.color }}
-                      />
-                      <span className="text-2xs font-mono text-text-muted">
-                        {loc.label} - {loc.city}
-                      </span>
-                    </div>
-                  ))}
-                </div>
+              {/* Legend */}
+              <div className="flex flex-wrap items-center justify-center gap-4 mt-6">
+                {edgeLocations.map((loc) => (
+                  <div key={loc.city} className="flex items-center gap-2">
+                    <div
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: loc.color }}
+                    />
+                    <span className="text-2xs font-mono text-text-muted">
+                      {loc.label} - {loc.city}
+                    </span>
+                  </div>
+                ))}
               </div>
-            </ShimmerCard>
-          </Reveal>
-        </div>
-      </section>
+            </div>
+          </ShimmerCard>
+        </Reveal>
+      </Section>
 
       {/* ───── Pain Points ───── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Challenges
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Managing edge infrastructure is hard
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Traditional remote access tools weren't built for the realities of
-              distributed edge computing.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Challenges"
+          title="Managing edge infrastructure is hard"
+          subtitle="Traditional remote access tools weren't built for the realities of distributed edge computing."
+        />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {painPoints.map((p, i) => (
-              <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard>
-                  <Card hover className="p-6 h-full">
-                    <div className="flex items-start gap-4">
-                      <div
-                        className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
-                        style={{
-                          background: `${p.color}15`,
-                          borderColor: `${p.color}25`,
-                        }}
-                      >
-                        {p.icon}
-                      </div>
-                      <div>
-                        <h4 className="text-sm font-semibold mb-2">
-                          {p.title}
-                        </h4>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {p.desc}
-                        </p>
-                      </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {painPoints.map((p, i) => (
+            <Reveal key={i} delay={i * 0.06}>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div className="flex items-start gap-4">
+                    <div
+                      className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
+                      style={{
+                        background: `${p.color}15`,
+                        borderColor: `${p.color}25`,
+                      }}
+                    >
+                      {p.icon}
                     </div>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
+                    <div>
+                      <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {p.desc}
+                      </p>
+                    </div>
+                  </div>
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
         </div>
-      </section>
+      </Section>
 
       {/* ───── Key Features ───── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Features
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Built for the edge
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              ShellHub eliminates the complexity of edge access with NAT
-              traversal, browser-based terminals, and fleet-wide management.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Features"
+          title="Built for the edge"
+          subtitle="ShellHub eliminates the complexity of edge access with NAT traversal, browser-based terminals, and fleet-wide management."
+        />
 
-          {/* Big highlighted card: Instant Remote Access */}
-          <Reveal>
-            <ShimmerCard className="mb-4">
-              <div className="relative bg-card border border-primary/30 rounded-xl p-8 overflow-hidden hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)]">
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-                <div className="relative grid lg:grid-cols-2 gap-8 items-center">
-                  <div>
-                    <div className="flex items-center gap-2 mb-4">
-                      <IconBadge color="primary">
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke={C.primary}
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <polyline points="4 17 10 11 4 5" />
-                          <line x1="12" y1="19" x2="20" y2="19" />
-                        </svg>
-                      </IconBadge>
-                      <Badge shape="pill" color="green">
-                        Core Feature
-                      </Badge>
-                    </div>
-                    <h3 className="text-lg font-bold mb-2">
-                      Instant Remote Access
-                    </h3>
-                    <p className="text-sm text-text-secondary leading-relaxed">
-                      Connect to any edge server in seconds — behind NAT, CGNAT,
-                      or restrictive firewalls. No VPN configuration, no port
-                      forwarding, no static IPs required. The agent handles
-                      everything.
-                    </p>
+        {/* Big highlighted card: Instant Remote Access */}
+        <Reveal>
+          <ShimmerCard className="mb-4">
+            <div className="relative bg-card border border-primary/30 rounded-xl p-8 overflow-hidden hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)]">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+              <div className="relative grid lg:grid-cols-2 gap-8 items-center">
+                <div>
+                  <div className="flex items-center gap-2 mb-4">
+                    <IconBadge color="primary">
+                      <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke={C.primary}
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <polyline points="4 17 10 11 4 5" />
+                        <line x1="12" y1="19" x2="20" y2="19" />
+                      </svg>
+                    </IconBadge>
+                    <Badge shape="pill" color="green">
+                      Core Feature
+                    </Badge>
                   </div>
+                  <h3 className="text-lg font-bold mb-2">
+                    Instant Remote Access
+                  </h3>
+                  <p className="text-sm text-text-secondary leading-relaxed">
+                    Connect to any edge server in seconds — behind NAT, CGNAT,
+                    or restrictive firewalls. No VPN configuration, no port
+                    forwarding, no static IPs required. The agent handles
+                    everything.
+                  </p>
+                </div>
 
-                  {/* Terminal mockup */}
-                  <div className="bg-surface rounded-xl border border-border overflow-hidden">
-                    <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
-                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                      <span className="ml-2 text-2xs text-text-muted font-mono">
-                        Terminal
+                {/* Terminal mockup */}
+                <div className="bg-surface rounded-xl border border-border overflow-hidden">
+                  <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                    <span className="ml-2 text-2xs text-text-muted font-mono">
+                      Terminal
+                    </span>
+                  </div>
+                  <div className="p-4 font-mono text-2xs leading-relaxed space-y-1">
+                    <div>
+                      <span style={{ color: C.green }}>user@ops-laptop</span>
+                      <span style={{ color: C.textMuted }}>:</span>
+                      <span style={{ color: C.blue }}>~</span>
+                      <span style={{ color: C.textMuted }}>$</span>{" "}
+                      <span style={{ color: C.text }}>
+                        ssh admin@edge-nyc-01.production
                       </span>
                     </div>
-                    <div className="p-4 font-mono text-2xs leading-relaxed space-y-1">
-                      <div>
-                        <span style={{ color: C.green }}>user@ops-laptop</span>
-                        <span style={{ color: C.textMuted }}>:</span>
-                        <span style={{ color: C.blue }}>~</span>
-                        <span style={{ color: C.textMuted }}>$</span>{" "}
-                        <span style={{ color: C.text }}>
-                          ssh admin@edge-nyc-01.production
-                        </span>
-                      </div>
-                      <div style={{ color: C.textMuted }}>
-                        Connecting via ShellHub tunnel...
-                      </div>
-                      <div style={{ color: C.green }}>
-                        Connection established (NAT traversal)
-                      </div>
-                      <div>&nbsp;</div>
-                      <div>
-                        <span style={{ color: C.green }}>
-                          admin@edge-nyc-01
-                        </span>
-                        <span style={{ color: C.textMuted }}>:</span>
-                        <span style={{ color: C.blue }}>~</span>
-                        <span style={{ color: C.textMuted }}>$</span>{" "}
-                        <span style={{ color: C.text }}>uname -a</span>
-                      </div>
-                      <div style={{ color: C.textSec }}>
-                        Linux edge-nyc-01 5.15.0 #1 SMP x86_64
-                      </div>
-                      <div>
-                        <span style={{ color: C.green }}>
-                          admin@edge-nyc-01
-                        </span>
-                        <span style={{ color: C.textMuted }}>:</span>
-                        <span style={{ color: C.blue }}>~</span>
-                        <span style={{ color: C.textMuted }}>$</span>{" "}
-                        <span style={{ color: C.text }}>
-                          systemctl status edge-service
-                        </span>
-                      </div>
-                      <div>
-                        <span style={{ color: C.green }}>●</span>{" "}
-                        <span style={{ color: C.textSec }}>
-                          edge-service.service - Edge Compute Service
-                        </span>
-                      </div>
-                      <div style={{ color: C.green }}>
-                        &nbsp;&nbsp;Active: active (running) since Mon
-                        2026-02-14
-                      </div>
-                      <div>
-                        <span style={{ color: C.green }}>
-                          admin@edge-nyc-01
-                        </span>
-                        <span style={{ color: C.textMuted }}>:</span>
-                        <span style={{ color: C.blue }}>~</span>
-                        <span style={{ color: C.textMuted }}>$</span>{" "}
-                        <span
-                          className="animate-pulse"
-                          style={{ color: C.primary }}
-                        >
-                          _
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </ShimmerCard>
-          </Reveal>
-
-          {/* 2-column: Web Terminal + SCP/SFTP */}
-          <div className="grid md:grid-cols-2 gap-4 mb-4">
-            <Reveal delay={0.05}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${C.green}15`,
-                      borderColor: `${C.green}25`,
-                    }}
-                  >
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke={C.green}
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <rect x="2" y="3" width="20" height="14" rx="2" />
-                      <line x1="8" y1="21" x2="16" y2="21" />
-                      <line x1="12" y1="17" x2="12" y2="21" />
-                    </svg>
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">Web Terminal</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed mb-4">
-                    Access edge servers from any browser — no SSH client needed.
-                    Perfect for field engineers using tablets or shared
-                    workstations.
-                  </p>
-
-                  {/* Browser mockup */}
-                  <div className="bg-surface rounded-lg border border-border overflow-hidden">
-                    <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
-                      <div className="w-2 h-2 rounded-full bg-accent-red/50" />
-                      <div className="w-2 h-2 rounded-full bg-accent-yellow/50" />
-                      <div className="w-2 h-2 rounded-full bg-accent-green/50" />
-                      <div className="flex-1 mx-2 px-2 py-0.5 bg-background rounded text-2xs font-mono text-text-muted truncate">
-                        shellhub.io/terminal/edge-chi-03
-                      </div>
-                    </div>
-                    <div className="p-3 font-mono text-2xs space-y-0.5">
-                      <div>
-                        <span style={{ color: C.green }}>
-                          admin@edge-chi-03
-                        </span>
-                        <span style={{ color: C.textMuted }}>:</span>
-                        <span style={{ color: C.blue }}>~</span>
-                        <span style={{ color: C.textMuted }}>$</span>{" "}
-                        <span style={{ color: C.text }}>df -h /data</span>
-                      </div>
-                      <div style={{ color: C.textSec }}>
-                        Filesystem&nbsp;&nbsp;Size&nbsp;&nbsp;Used&nbsp;&nbsp;Avail&nbsp;&nbsp;Use%
-                      </div>
-                      <div style={{ color: C.textSec }}>
-                        /dev/sda1&nbsp;&nbsp;&nbsp;500G&nbsp;&nbsp;312G&nbsp;&nbsp;188G&nbsp;&nbsp;&nbsp;62%
-                      </div>
-                      <div>
-                        <span style={{ color: C.green }}>
-                          admin@edge-chi-03
-                        </span>
-                        <span style={{ color: C.textMuted }}>:</span>
-                        <span style={{ color: C.blue }}>~</span>
-                        <span style={{ color: C.textMuted }}>$</span>{" "}
-                        <span
-                          className="animate-pulse"
-                          style={{ color: C.primary }}
-                        >
-                          _
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-
-            <Reveal delay={0.1}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${C.cyan}15`,
-                      borderColor: `${C.cyan}25`,
-                    }}
-                  >
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke={C.cyan}
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                      <polyline points="14 2 14 8 20 8" />
-                      <path d="M12 18v-6" />
-                      <path d="M9 15l3-3 3 3" />
-                    </svg>
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">
-                    SCP / SFTP File Transfer
-                  </h4>
-                  <p className="text-xs text-text-secondary leading-relaxed mb-4">
-                    Transfer configuration files, firmware updates, and logs to
-                    and from edge servers with progress tracking.
-                  </p>
-
-                  {/* File transfer mockup */}
-                  <div className="bg-surface rounded-lg border border-border p-3 font-mono text-2xs space-y-1.5">
                     <div style={{ color: C.textMuted }}>
-                      $ scp config.yml admin@edge-den-02:/etc/app/
+                      Connecting via ShellHub tunnel...
                     </div>
-                    <div className="flex items-center gap-2">
-                      <span style={{ color: C.text }}>config.yml</span>
-                      <div className="flex-1 h-1.5 bg-background rounded-full overflow-hidden">
-                        <div
-                          className="h-full rounded-full"
-                          style={{ width: "100%", background: C.green }}
-                        />
-                      </div>
-                      <span style={{ color: C.green }}>100%</span>
+                    <div style={{ color: C.green }}>
+                      Connection established (NAT traversal)
+                    </div>
+                    <div>&nbsp;</div>
+                    <div>
+                      <span style={{ color: C.green }}>admin@edge-nyc-01</span>
+                      <span style={{ color: C.textMuted }}>:</span>
+                      <span style={{ color: C.blue }}>~</span>
+                      <span style={{ color: C.textMuted }}>$</span>{" "}
+                      <span style={{ color: C.text }}>uname -a</span>
                     </div>
                     <div style={{ color: C.textSec }}>
-                      2.4 KB&nbsp;&nbsp;&nbsp;0:00
+                      Linux edge-nyc-01 5.15.0 #1 SMP x86_64
                     </div>
-                    <div
-                      className="pt-1 border-t border-border"
-                      style={{ borderColor: `${C.border}80` }}
-                    >
-                      <div style={{ color: C.textMuted }}>
-                        $ scp admin@edge-den-02:/var/log/app.log ./
-                      </div>
-                      <div className="flex items-center gap-2 mt-1">
-                        <span style={{ color: C.text }}>app.log</span>
-                        <div className="flex-1 h-1.5 bg-background rounded-full overflow-hidden">
-                          <div
-                            className="h-full rounded-full"
-                            style={{ width: "68%", background: C.yellow }}
-                          />
-                        </div>
-                        <span style={{ color: C.yellow }}>68%</span>
-                      </div>
-                      <div style={{ color: C.textSec }}>
-                        45 MB&nbsp;&nbsp;&nbsp;12.3 MB/s&nbsp;&nbsp;&nbsp;ETA
-                        0:02
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-          </div>
-
-          {/* 3 smaller cards: Tags, RBAC, Audit */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <Reveal delay={0.05}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${C.yellow}15`,
-                      borderColor: `${C.yellow}25`,
-                    }}
-                  >
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke={C.yellow}
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
-                      <line x1="7" y1="7" x2="7.01" y2="7" />
-                    </svg>
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">Device Tags</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed mb-3">
-                    Organize edge servers by region, site type, or function for
-                    fast filtering and batch operations.
-                  </p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {[
-                      { label: "region:northeast", color: C.primary },
-                      { label: "type:retail", color: C.green },
-                      { label: "env:production", color: C.yellow },
-                      { label: "rack:A3", color: C.cyan },
-                    ].map((tag) => (
-                      <span
-                        key={tag.label}
-                        className="px-2 py-0.5 text-2xs font-mono rounded-full border"
-                        style={{
-                          color: tag.color,
-                          background: `${tag.color}10`,
-                          borderColor: `${tag.color}20`,
-                        }}
-                      >
-                        {tag.label}
+                    <div>
+                      <span style={{ color: C.green }}>admin@edge-nyc-01</span>
+                      <span style={{ color: C.textMuted }}>:</span>
+                      <span style={{ color: C.blue }}>~</span>
+                      <span style={{ color: C.textMuted }}>$</span>{" "}
+                      <span style={{ color: C.text }}>
+                        systemctl status edge-service
                       </span>
-                    ))}
-                  </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-
-            <Reveal delay={0.1}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${C.primary}15`,
-                      borderColor: `${C.primary}25`,
-                    }}
-                  >
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke={C.primary}
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-                      <circle cx="9" cy="7" r="4" />
-                      <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
-                      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-                    </svg>
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">RBAC</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed mb-3">
-                    Give regional teams access to only their edge servers with
-                    role-based controls and namespace isolation.
-                  </p>
-                  <div className="space-y-1.5">
-                    {[
-                      {
-                        role: "NYC Ops Team",
-                        access: "northeast-*",
-                        color: C.primary,
-                      },
-                      {
-                        role: "Field Engineers",
-                        access: "tower-*",
-                        color: C.yellow,
-                      },
-                      {
-                        role: "Warehouse Admins",
-                        access: "warehouse-*",
-                        color: C.green,
-                      },
-                    ].map((r) => (
-                      <div
-                        key={r.role}
-                        className="flex items-center justify-between text-2xs font-mono"
+                    </div>
+                    <div>
+                      <span style={{ color: C.green }}>●</span>{" "}
+                      <span style={{ color: C.textSec }}>
+                        edge-service.service - Edge Compute Service
+                      </span>
+                    </div>
+                    <div style={{ color: C.green }}>
+                      &nbsp;&nbsp;Active: active (running) since Mon 2026-02-14
+                    </div>
+                    <div>
+                      <span style={{ color: C.green }}>admin@edge-nyc-01</span>
+                      <span style={{ color: C.textMuted }}>:</span>
+                      <span style={{ color: C.blue }}>~</span>
+                      <span style={{ color: C.textMuted }}>$</span>{" "}
+                      <span
+                        className="animate-pulse"
+                        style={{ color: C.primary }}
                       >
-                        <span style={{ color: C.textSec }}>{r.role}</span>
-                        <span style={{ color: r.color }}>{r.access}</span>
-                      </div>
-                    ))}
+                        _
+                      </span>
+                    </div>
                   </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-
-            <Reveal delay={0.15}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${C.green}15`,
-                      borderColor: `${C.green}25`,
-                    }}
-                  >
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke={C.green}
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <path d="M12 20h9" />
-                      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-                    </svg>
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">Audit Trail</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed mb-3">
-                    Full session recording and command logging across all edge
-                    locations for compliance and forensics.
-                  </p>
-                  <div className="space-y-1.5">
-                    {[
-                      {
-                        time: "14:32",
-                        user: "jane",
-                        device: "edge-nyc-01",
-                        action: "SSH session",
-                        color: C.green,
-                      },
-                      {
-                        time: "14:28",
-                        user: "mike",
-                        device: "tower-aus-03",
-                        action: "File transfer",
-                        color: C.cyan,
-                      },
-                      {
-                        time: "14:15",
-                        user: "ana",
-                        device: "wh-chi-07",
-                        action: "SSH session",
-                        color: C.green,
-                      },
-                    ].map((log, i) => (
-                      <div
-                        key={i}
-                        className="flex items-center gap-2 text-2xs font-mono"
-                      >
-                        <span style={{ color: C.textMuted }}>{log.time}</span>
-                        <span style={{ color: C.primary }}>{log.user}</span>
-                        <span style={{ color: C.textMuted }}>&rarr;</span>
-                        <span style={{ color: C.textSec }}>{log.device}</span>
-                        <span
-                          className="ml-auto px-1.5 py-0.5 rounded border"
-                          style={{
-                            color: log.color,
-                            background: `${log.color}10`,
-                            borderColor: `${log.color}20`,
-                          }}
-                        >
-                          {log.action}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
-          </div>
-        </div>
-      </section>
-
-      {/* ───── Use Case Scenarios ───── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Real-World Scenarios
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              How teams use ShellHub at the edge
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              From retail to telecom to logistics, ShellHub powers remote access
-              for edge infrastructure across industries.
-            </p>
-          </Reveal>
-
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            {scenarios.map((s, i) => (
-              <Reveal key={i} delay={i * 0.08}>
-                <ShimmerCard className="h-full">
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-2 h-2 rounded-full mb-4"
-                      style={{ background: s.color }}
-                    />
-                    <h4 className="text-sm font-semibold mb-2">{s.title}</h4>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {s.desc}
-                    </p>
-                    {s.mockup}
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ───── CTA ───── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal>
-            <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-              <ConnectionGrid />
-              <div className="absolute inset-0 bg-gradient-to-br from-accent-blue/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
-
-              <div className="relative z-10">
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Ready to connect your edge?
-                </p>
-                <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Your edge servers, instantly accessible
-                </h2>
-                <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                  Install the lightweight agent on your edge servers and start
-                  managing them remotely in minutes — no infrastructure changes
-                  needed.
-                </p>
-
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                  <Button
-                    as={Link}
-                    to="/getting-started"
-                    variant="primary"
-                    size="xl"
-                    glow
-                    iconRight={<ArrowRight />}
-                  >
-                    Get Started Free
-                  </Button>
-                  <Button as={Link} to="/pricing" variant="outline" size="xl">
-                    Compare Plans
-                  </Button>
                 </div>
               </div>
             </div>
+          </ShimmerCard>
+        </Reveal>
+
+        {/* 2-column: Web Terminal + SCP/SFTP */}
+        <div className="grid md:grid-cols-2 gap-4 mb-4">
+          <Reveal delay={0.05}>
+            <ShimmerCard className="h-full">
+              <Card hover className="p-6 h-full">
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                  style={{
+                    background: `${C.green}15`,
+                    borderColor: `${C.green}25`,
+                  }}
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke={C.green}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <rect x="2" y="3" width="20" height="14" rx="2" />
+                    <line x1="8" y1="21" x2="16" y2="21" />
+                    <line x1="12" y1="17" x2="12" y2="21" />
+                  </svg>
+                </div>
+                <h4 className="text-sm font-semibold mb-2">Web Terminal</h4>
+                <p className="text-xs text-text-secondary leading-relaxed mb-4">
+                  Access edge servers from any browser — no SSH client needed.
+                  Perfect for field engineers using tablets or shared
+                  workstations.
+                </p>
+
+                {/* Browser mockup */}
+                <div className="bg-surface rounded-lg border border-border overflow-hidden">
+                  <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+                    <div className="w-2 h-2 rounded-full bg-accent-red/50" />
+                    <div className="w-2 h-2 rounded-full bg-accent-yellow/50" />
+                    <div className="w-2 h-2 rounded-full bg-accent-green/50" />
+                    <div className="flex-1 mx-2 px-2 py-0.5 bg-background rounded text-2xs font-mono text-text-muted truncate">
+                      shellhub.io/terminal/edge-chi-03
+                    </div>
+                  </div>
+                  <div className="p-3 font-mono text-2xs space-y-0.5">
+                    <div>
+                      <span style={{ color: C.green }}>admin@edge-chi-03</span>
+                      <span style={{ color: C.textMuted }}>:</span>
+                      <span style={{ color: C.blue }}>~</span>
+                      <span style={{ color: C.textMuted }}>$</span>{" "}
+                      <span style={{ color: C.text }}>df -h /data</span>
+                    </div>
+                    <div style={{ color: C.textSec }}>
+                      Filesystem&nbsp;&nbsp;Size&nbsp;&nbsp;Used&nbsp;&nbsp;Avail&nbsp;&nbsp;Use%
+                    </div>
+                    <div style={{ color: C.textSec }}>
+                      /dev/sda1&nbsp;&nbsp;&nbsp;500G&nbsp;&nbsp;312G&nbsp;&nbsp;188G&nbsp;&nbsp;&nbsp;62%
+                    </div>
+                    <div>
+                      <span style={{ color: C.green }}>admin@edge-chi-03</span>
+                      <span style={{ color: C.textMuted }}>:</span>
+                      <span style={{ color: C.blue }}>~</span>
+                      <span style={{ color: C.textMuted }}>$</span>{" "}
+                      <span
+                        className="animate-pulse"
+                        style={{ color: C.primary }}
+                      >
+                        _
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+
+          <Reveal delay={0.1}>
+            <ShimmerCard className="h-full">
+              <Card hover className="p-6 h-full">
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                  style={{
+                    background: `${C.cyan}15`,
+                    borderColor: `${C.cyan}25`,
+                  }}
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke={C.cyan}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <path d="M12 18v-6" />
+                    <path d="M9 15l3-3 3 3" />
+                  </svg>
+                </div>
+                <h4 className="text-sm font-semibold mb-2">
+                  SCP / SFTP File Transfer
+                </h4>
+                <p className="text-xs text-text-secondary leading-relaxed mb-4">
+                  Transfer configuration files, firmware updates, and logs to
+                  and from edge servers with progress tracking.
+                </p>
+
+                {/* File transfer mockup */}
+                <div className="bg-surface rounded-lg border border-border p-3 font-mono text-2xs space-y-1.5">
+                  <div style={{ color: C.textMuted }}>
+                    $ scp config.yml admin@edge-den-02:/etc/app/
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span style={{ color: C.text }}>config.yml</span>
+                    <div className="flex-1 h-1.5 bg-background rounded-full overflow-hidden">
+                      <div
+                        className="h-full rounded-full"
+                        style={{ width: "100%", background: C.green }}
+                      />
+                    </div>
+                    <span style={{ color: C.green }}>100%</span>
+                  </div>
+                  <div style={{ color: C.textSec }}>
+                    2.4 KB&nbsp;&nbsp;&nbsp;0:00
+                  </div>
+                  <div
+                    className="pt-1 border-t border-border"
+                    style={{ borderColor: `${C.border}80` }}
+                  >
+                    <div style={{ color: C.textMuted }}>
+                      $ scp admin@edge-den-02:/var/log/app.log ./
+                    </div>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span style={{ color: C.text }}>app.log</span>
+                      <div className="flex-1 h-1.5 bg-background rounded-full overflow-hidden">
+                        <div
+                          className="h-full rounded-full"
+                          style={{ width: "68%", background: C.yellow }}
+                        />
+                      </div>
+                      <span style={{ color: C.yellow }}>68%</span>
+                    </div>
+                    <div style={{ color: C.textSec }}>
+                      45 MB&nbsp;&nbsp;&nbsp;12.3 MB/s&nbsp;&nbsp;&nbsp;ETA 0:02
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            </ShimmerCard>
           </Reveal>
         </div>
-      </section>
+
+        {/* 3 smaller cards: Tags, RBAC, Audit */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <Reveal delay={0.05}>
+            <ShimmerCard className="h-full">
+              <Card hover className="p-6 h-full">
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                  style={{
+                    background: `${C.yellow}15`,
+                    borderColor: `${C.yellow}25`,
+                  }}
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke={C.yellow}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+                    <line x1="7" y1="7" x2="7.01" y2="7" />
+                  </svg>
+                </div>
+                <h4 className="text-sm font-semibold mb-2">Device Tags</h4>
+                <p className="text-xs text-text-secondary leading-relaxed mb-3">
+                  Organize edge servers by region, site type, or function for
+                  fast filtering and batch operations.
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {[
+                    { label: "region:northeast", color: C.primary },
+                    { label: "type:retail", color: C.green },
+                    { label: "env:production", color: C.yellow },
+                    { label: "rack:A3", color: C.cyan },
+                  ].map((tag) => (
+                    <span
+                      key={tag.label}
+                      className="px-2 py-0.5 text-2xs font-mono rounded-full border"
+                      style={{
+                        color: tag.color,
+                        background: `${tag.color}10`,
+                        borderColor: `${tag.color}20`,
+                      }}
+                    >
+                      {tag.label}
+                    </span>
+                  ))}
+                </div>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+
+          <Reveal delay={0.1}>
+            <ShimmerCard className="h-full">
+              <Card hover className="p-6 h-full">
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                  style={{
+                    background: `${C.primary}15`,
+                    borderColor: `${C.primary}25`,
+                  }}
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke={C.primary}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                    <circle cx="9" cy="7" r="4" />
+                    <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+                    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+                  </svg>
+                </div>
+                <h4 className="text-sm font-semibold mb-2">RBAC</h4>
+                <p className="text-xs text-text-secondary leading-relaxed mb-3">
+                  Give regional teams access to only their edge servers with
+                  role-based controls and namespace isolation.
+                </p>
+                <div className="space-y-1.5">
+                  {[
+                    {
+                      role: "NYC Ops Team",
+                      access: "northeast-*",
+                      color: C.primary,
+                    },
+                    {
+                      role: "Field Engineers",
+                      access: "tower-*",
+                      color: C.yellow,
+                    },
+                    {
+                      role: "Warehouse Admins",
+                      access: "warehouse-*",
+                      color: C.green,
+                    },
+                  ].map((r) => (
+                    <div
+                      key={r.role}
+                      className="flex items-center justify-between text-2xs font-mono"
+                    >
+                      <span style={{ color: C.textSec }}>{r.role}</span>
+                      <span style={{ color: r.color }}>{r.access}</span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+
+          <Reveal delay={0.15}>
+            <ShimmerCard className="h-full">
+              <Card hover className="p-6 h-full">
+                <div
+                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                  style={{
+                    background: `${C.green}15`,
+                    borderColor: `${C.green}25`,
+                  }}
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke={C.green}
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M12 20h9" />
+                    <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+                  </svg>
+                </div>
+                <h4 className="text-sm font-semibold mb-2">Audit Trail</h4>
+                <p className="text-xs text-text-secondary leading-relaxed mb-3">
+                  Full session recording and command logging across all edge
+                  locations for compliance and forensics.
+                </p>
+                <div className="space-y-1.5">
+                  {[
+                    {
+                      time: "14:32",
+                      user: "jane",
+                      device: "edge-nyc-01",
+                      action: "SSH session",
+                      color: C.green,
+                    },
+                    {
+                      time: "14:28",
+                      user: "mike",
+                      device: "tower-aus-03",
+                      action: "File transfer",
+                      color: C.cyan,
+                    },
+                    {
+                      time: "14:15",
+                      user: "ana",
+                      device: "wh-chi-07",
+                      action: "SSH session",
+                      color: C.green,
+                    },
+                  ].map((log, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center gap-2 text-2xs font-mono"
+                    >
+                      <span style={{ color: C.textMuted }}>{log.time}</span>
+                      <span style={{ color: C.primary }}>{log.user}</span>
+                      <span style={{ color: C.textMuted }}>&rarr;</span>
+                      <span style={{ color: C.textSec }}>{log.device}</span>
+                      <span
+                        className="ml-auto px-1.5 py-0.5 rounded border"
+                        style={{
+                          color: log.color,
+                          background: `${log.color}10`,
+                          borderColor: `${log.color}20`,
+                        }}
+                      >
+                        {log.action}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+        </div>
+      </Section>
+
+      {/* ───── Use Case Scenarios ───── */}
+      <Section>
+        <SectionHeader
+          eyebrow="Real-World Scenarios"
+          title="How teams use ShellHub at the edge"
+          subtitle="From retail to telecom to logistics, ShellHub powers remote access for edge infrastructure across industries."
+        />
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {scenarios.map((s, i) => (
+            <Reveal key={i} delay={i * 0.08}>
+              <ShimmerCard className="h-full">
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-2 h-2 rounded-full mb-4"
+                    style={{ background: s.color }}
+                  />
+                  <h4 className="text-sm font-semibold mb-2">{s.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {s.desc}
+                  </p>
+                  {s.mockup}
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
+        </div>
+      </Section>
+
+      {/* ───── CTA ───── */}
+      <Section>
+        <Reveal>
+          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+            <ConnectionGrid />
+            <div className="absolute inset-0 bg-gradient-to-br from-accent-blue/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
+
+            <div className="relative z-10">
+              <SectionHeader
+                variant="cta"
+                eyebrow="Ready to connect your edge?"
+                title="Your edge servers, instantly accessible"
+                subtitle="Install the lightweight agent on your edge servers and start managing them remotely in minutes — no infrastructure changes needed."
+              />
+
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+                <Button
+                  as={Link}
+                  to="/getting-started"
+                  variant="primary"
+                  size="xl"
+                  glow
+                  iconRight={<ArrowRight />}
+                >
+                  Get Started Free
+                </Button>
+                <Button as={Link} to="/pricing" variant="outline" size="xl">
+                  Compare Plans
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </Section>
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -7,6 +7,8 @@ import {
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
+import { Section, SectionHeader } from "@/components/marketing";
+import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -193,789 +195,738 @@ export default function IotEmbedded() {
       </section>
 
       {/* ═══════ Fleet Overview Mockup (2-col) ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <div>
-              <Reveal>
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-accent-green mb-3">
-                  Fleet Dashboard
-                </p>
-                <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Manage thousands of devices from one place
-                </h2>
-                <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                  See every device in your fleet at a glance. Filter by status,
-                  location, firmware version, or custom tags. No more SSH-ing
-                  into a jump server to check on a single sensor.
-                </p>
-              </Reveal>
+      <Section>
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <SectionHeader
+              align="left"
+              size="sub"
+              className="mb-8"
+              eyebrowColor="green"
+              eyebrow="Fleet Dashboard"
+              title="Manage thousands of devices from one place"
+              subtitle="See every device in your fleet at a glance. Filter by status, location, firmware version, or custom tags. No more SSH-ing into a jump server to check on a single sensor."
+            />
 
-              <div className="space-y-3">
-                {[
-                  {
-                    label: "Real-time status",
-                    desc: "See which devices are online, offline, or pending across every location",
-                  },
-                  {
-                    label: "Custom tagging",
-                    desc: "Organize by firmware version, deployment site, hardware type, or any custom label",
-                  },
-                  {
-                    label: "Bulk operations",
-                    desc: "Select multiple devices to apply firewall rules, update tags, or revoke access",
-                  },
-                  {
-                    label: "Search & filter",
-                    desc: "Find any device instantly by hostname, IP, tag, or SUID",
-                  },
-                ].map((cap, i) => (
-                  <Reveal key={i} delay={i * 0.04}>
-                    <div className="flex items-start gap-3">
-                      <svg
-                        className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
-                      <div>
-                        <p className="text-sm font-medium text-text-primary">
-                          {cap.label}
-                        </p>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {cap.desc}
-                        </p>
-                      </div>
+            <div className="space-y-3">
+              {[
+                {
+                  label: "Real-time status",
+                  desc: "See which devices are online, offline, or pending across every location",
+                },
+                {
+                  label: "Custom tagging",
+                  desc: "Organize by firmware version, deployment site, hardware type, or any custom label",
+                },
+                {
+                  label: "Bulk operations",
+                  desc: "Select multiple devices to apply firewall rules, update tags, or revoke access",
+                },
+                {
+                  label: "Search & filter",
+                  desc: "Find any device instantly by hostname, IP, tag, or SUID",
+                },
+              ].map((cap, i) => (
+                <Reveal key={i} delay={i * 0.04}>
+                  <div className="flex items-start gap-3">
+                    <svg
+                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m4.5 12.75 6 6 9-13.5"
+                      />
+                    </svg>
+                    <div>
+                      <p className="text-sm font-medium text-text-primary">
+                        {cap.label}
+                      </p>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {cap.desc}
+                      </p>
                     </div>
-                  </Reveal>
-                ))}
-              </div>
+                  </div>
+                </Reveal>
+              ))}
             </div>
+          </div>
 
-            {/* Fake dashboard panel */}
-            <Reveal delay={0.1}>
-              <ShimmerCard>
-                <Card className="overflow-hidden">
-                  <div className="p-6">
-                    {/* Window chrome */}
-                    <div className="flex items-center gap-2 mb-6">
-                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                      <span className="ml-2 text-2xs text-text-muted font-mono">
-                        Device Fleet
-                      </span>
-                    </div>
+          {/* Fake dashboard panel */}
+          <Reveal delay={0.1}>
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <div className="p-6">
+                  {/* Window chrome */}
+                  <div className="flex items-center gap-2 mb-6">
+                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                    <span className="ml-2 text-2xs text-text-muted font-mono">
+                      Device Fleet
+                    </span>
+                  </div>
 
-                    {/* Table header */}
-                    <div className="flex items-center gap-3 px-3 py-2 mb-1">
-                      <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-5">
-                        St
-                      </span>
-                      <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1">
-                        Hostname
-                      </span>
-                      <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-24 hidden sm:block">
-                        IP
-                      </span>
-                      <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1 text-right">
-                        Tags
-                      </span>
-                    </div>
+                  {/* Table header */}
+                  <div className="flex items-center gap-3 px-3 py-2 mb-1">
+                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-5">
+                      St
+                    </span>
+                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1">
+                      Hostname
+                    </span>
+                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-24 hidden sm:block">
+                      IP
+                    </span>
+                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1 text-right">
+                      Tags
+                    </span>
+                  </div>
 
-                    {/* Device rows */}
-                    <div className="space-y-2">
-                      {fleetDevices.map((d, i) => (
+                  {/* Device rows */}
+                  <div className="space-y-2">
+                    {fleetDevices.map((d, i) => (
+                      <div
+                        key={i}
+                        className="flex items-center gap-3 p-3 bg-surface rounded-lg border border-border hover:border-border-light transition-colors duration-200"
+                      >
                         <div
-                          key={i}
-                          className="flex items-center gap-3 p-3 bg-surface rounded-lg border border-border hover:border-border-light transition-colors duration-200"
-                        >
-                          <div
-                            className="w-2 h-2 rounded-full shrink-0"
-                            style={{
-                              background:
-                                d.status === "online" ? C.green : C.textMuted,
-                            }}
-                          />
-                          <div className="flex-1 min-w-0">
-                            <p className="text-xs font-mono font-medium truncate">
-                              {d.name}
-                            </p>
-                          </div>
-                          <span className="text-2xs text-text-muted font-mono w-24 hidden sm:block">
-                            {d.ip}
-                          </span>
-                          <div className="flex items-center gap-1.5 flex-wrap justify-end">
-                            {d.tags.map((t, j) => (
-                              <span
-                                key={j}
-                                className="px-1.5 py-0.5 text-2xs font-mono rounded-full border"
-                                style={{
-                                  background: `${t.color}10`,
-                                  color: t.color,
-                                  borderColor: `${t.color}20`,
-                                }}
-                              >
-                                {t.label}
-                              </span>
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-
-                    {/* Footer */}
-                    <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <div
-                          className="w-2 h-2 rounded-full"
-                          style={{ background: C.green }}
+                          className="w-2 h-2 rounded-full shrink-0"
+                          style={{
+                            background:
+                              d.status === "online" ? C.green : C.textMuted,
+                          }}
                         />
-                        <span className="text-2xs text-text-muted">
-                          24 devices online
+                        <div className="flex-1 min-w-0">
+                          <p className="text-xs font-mono font-medium truncate">
+                            {d.name}
+                          </p>
+                        </div>
+                        <span className="text-2xs text-text-muted font-mono w-24 hidden sm:block">
+                          {d.ip}
                         </span>
+                        <div className="flex items-center gap-1.5 flex-wrap justify-end">
+                          {d.tags.map((t, j) => (
+                            <span
+                              key={j}
+                              className="px-1.5 py-0.5 text-2xs font-mono rounded-full border"
+                              style={{
+                                background: `${t.color}10`,
+                                color: t.color,
+                                borderColor: `${t.color}20`,
+                              }}
+                            >
+                              {t.label}
+                            </span>
+                          ))}
+                        </div>
                       </div>
-                      <span className="text-2xs text-primary font-medium">
-                        View all &rarr;
+                    ))}
+                  </div>
+
+                  {/* Footer */}
+                  <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="w-2 h-2 rounded-full"
+                        style={{ background: C.green }}
+                      />
+                      <span className="text-2xs text-text-muted">
+                        24 devices online
                       </span>
+                    </div>
+                    <span className="text-2xs text-primary font-medium">
+                      View all &rarr;
+                    </span>
+                  </div>
+                </div>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+        </div>
+      </Section>
+
+      {/* ═══════ Pain Points (2x2) ═══════ */}
+      <Section>
+        <SectionHeader
+          eyebrow="The Challenge"
+          title="Why managing IoT devices remotely is hard"
+          subtitle="Traditional SSH workflows break down when devices are distributed, constrained, and unreachable from the public internet."
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {painPoints.map((p, i) => (
+            <Reveal key={i} delay={i * 0.06}>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div className="flex items-start gap-4">
+                    <div
+                      className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
+                      style={{
+                        background: `${p.color}15`,
+                        borderColor: `${p.color}25`,
+                      }}
+                    >
+                      {p.icon}
+                    </div>
+                    <div>
+                      <h4 className="text-sm font-semibold mb-1.5">
+                        {p.title}
+                      </h4>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {p.desc}
+                      </p>
                     </div>
                   </div>
                 </Card>
               </ShimmerCard>
             </Reveal>
-          </div>
+          ))}
         </div>
-      </section>
-
-      {/* ═══════ Pain Points (2x2) ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              The Challenge
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Why managing IoT devices remotely is hard
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Traditional SSH workflows break down when devices are distributed,
-              constrained, and unreachable from the public internet.
-            </p>
-          </Reveal>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {painPoints.map((p, i) => (
-              <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard>
-                  <Card hover className="p-6 h-full">
-                    <div className="flex items-start gap-4">
-                      <div
-                        className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
-                        style={{
-                          background: `${p.color}15`,
-                          borderColor: `${p.color}25`,
-                        }}
-                      >
-                        {p.icon}
-                      </div>
-                      <div>
-                        <h4 className="text-sm font-semibold mb-1.5">
-                          {p.title}
-                        </h4>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {p.desc}
-                        </p>
-                      </div>
-                    </div>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </section>
+      </Section>
 
       {/* ═══════ Key Features — Mixed Layout ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-accent-green mb-3">
-              Built for IoT
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Features designed for embedded fleets
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Every feature in ShellHub was designed with constrained,
-              distributed devices in mind.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Built for IoT"
+          eyebrowColor="green"
+          title="Features designed for embedded fleets"
+          subtitle="Every feature in ShellHub was designed with constrained, distributed devices in mind."
+        />
 
-          {/* Big card: NAT Traversal with SVG diagram */}
-          <Reveal>
-            <ShimmerCard className="mb-4">
-              <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(102,122,204,0.1)] hover:border-primary/50 transition-all duration-300">
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-                <div className="relative grid lg:grid-cols-2 gap-8 p-8">
-                  {/* Left: text */}
-                  <div className="flex flex-col justify-center">
+        {/* Big card: NAT Traversal with SVG diagram */}
+        <Reveal>
+          <ShimmerCard className="mb-4">
+            <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(102,122,204,0.1)] hover:border-primary/50 transition-all duration-300">
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+              <div className="relative grid lg:grid-cols-2 gap-8 p-8">
+                {/* Left: text */}
+                <div className="flex flex-col justify-center">
+                  <div className="flex items-center gap-3 mb-4">
+                    <IconBadge color="primary">
+                      <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke={C.primary}
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                      >
+                        <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+                      </svg>
+                    </IconBadge>
+                    <Badge shape="pill" color="primary">
+                      Core
+                    </Badge>
+                  </div>
+                  <h3 className="text-lg font-bold mb-3">NAT Traversal</h3>
+                  <p className="text-sm text-text-secondary leading-relaxed mb-4">
+                    The ShellHub agent makes an outbound connection from the
+                    device, so it works behind any NAT, CGNAT, or firewall
+                    without opening inbound ports.
+                  </p>
+                  <ul className="space-y-2">
+                    {[
+                      "No public IP required on the device",
+                      "Works behind cellular, satellite, and double-NAT",
+                      "No VPN configuration or port forwarding needed",
+                      "Persistent connection with auto-reconnect",
+                    ].map((item) => (
+                      <FeatureListItem key={item} color="green">
+                        {item}
+                      </FeatureListItem>
+                    ))}
+                  </ul>
+                </div>
+
+                {/* Right: SVG network diagram */}
+                <div className="flex items-center justify-center">
+                  <div className="w-full max-w-md">
+                    <svg
+                      viewBox="0 0 400 220"
+                      fill="none"
+                      className="w-full h-auto"
+                    >
+                      {/* Device box */}
+                      <rect
+                        x="10"
+                        y="60"
+                        width="100"
+                        height="100"
+                        rx="8"
+                        fill={C.card}
+                        stroke={C.border}
+                        strokeWidth="1"
+                      />
+                      <text
+                        x="60"
+                        y="96"
+                        textAnchor="middle"
+                        className="text-[10px]"
+                        fill={C.textSec}
+                        fontFamily="monospace"
+                      >
+                        IoT Device
+                      </text>
+                      <text
+                        x="60"
+                        y="114"
+                        textAnchor="middle"
+                        className="text-[9px]"
+                        fill={C.textMuted}
+                        fontFamily="monospace"
+                      >
+                        10.0.0.42
+                      </text>
+                      {/* Device icon */}
+                      <rect
+                        x="42"
+                        y="124"
+                        width="36"
+                        height="24"
+                        rx="3"
+                        fill="none"
+                        stroke={C.green}
+                        strokeWidth="1"
+                        opacity="0.5"
+                      />
+                      <circle
+                        cx="60"
+                        cy="136"
+                        r="2"
+                        fill={C.green}
+                        opacity="0.7"
+                      />
+
+                      {/* CGNAT wall */}
+                      <rect
+                        x="134"
+                        y="30"
+                        width="36"
+                        height="160"
+                        rx="4"
+                        fill={C.red}
+                        fillOpacity="0.08"
+                        stroke={C.red}
+                        strokeWidth="1"
+                        strokeDasharray="4 3"
+                        opacity="0.6"
+                      />
+                      <text
+                        x="152"
+                        y="22"
+                        textAnchor="middle"
+                        className="text-[9px]"
+                        fill={C.red}
+                        fontFamily="monospace"
+                        opacity="0.8"
+                      >
+                        CGNAT
+                      </text>
+
+                      {/* Outbound arrow: device -> ShellHub (over the wall) */}
+                      <path
+                        d="M110 100 C 130 100, 130 55, 170 55 L 260 55"
+                        stroke={C.green}
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        markerEnd="url(#arrowGreen)"
+                      />
+                      <text
+                        x="210"
+                        y="46"
+                        textAnchor="middle"
+                        className="text-[8px]"
+                        fill={C.green}
+                        fontFamily="monospace"
+                      >
+                        outbound
+                      </text>
+
+                      {/* ShellHub cloud box */}
+                      <rect
+                        x="260"
+                        y="30"
+                        width="130"
+                        height="100"
+                        rx="8"
+                        fill={C.primary}
+                        fillOpacity="0.08"
+                        stroke={C.primary}
+                        strokeWidth="1"
+                      />
+                      <text
+                        x="325"
+                        y="62"
+                        textAnchor="middle"
+                        className="text-[10px]"
+                        fill={C.primary}
+                        fontFamily="monospace"
+                        fontWeight="600"
+                      >
+                        ShellHub
+                      </text>
+                      <text
+                        x="325"
+                        y="78"
+                        textAnchor="middle"
+                        className="text-[9px]"
+                        fill={C.textMuted}
+                        fontFamily="monospace"
+                      >
+                        cloud relay
+                      </text>
+                      {/* Terminal icon inside */}
+                      <rect
+                        x="305"
+                        y="88"
+                        width="40"
+                        height="28"
+                        rx="3"
+                        fill={C.surface}
+                        stroke={C.border}
+                        strokeWidth="1"
+                      />
+                      <text
+                        x="312"
+                        y="106"
+                        className="text-[9px]"
+                        fill={C.green}
+                        fontFamily="monospace"
+                      >
+                        $_
+                      </text>
+
+                      {/* User arrow: user -> ShellHub */}
+                      <path
+                        d="M325 170 L 325 130"
+                        stroke={C.cyan}
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        markerEnd="url(#arrowCyan)"
+                      />
+
+                      {/* User box */}
+                      <rect
+                        x="275"
+                        y="170"
+                        width="100"
+                        height="40"
+                        rx="6"
+                        fill={C.card}
+                        stroke={C.border}
+                        strokeWidth="1"
+                      />
+                      <text
+                        x="325"
+                        y="194"
+                        textAnchor="middle"
+                        className="text-[10px]"
+                        fill={C.textSec}
+                        fontFamily="monospace"
+                      >
+                        You (SSH)
+                      </text>
+
+                      {/* Arrow markers */}
+                      <defs>
+                        <marker
+                          id="arrowGreen"
+                          markerWidth="8"
+                          markerHeight="6"
+                          refX="8"
+                          refY="3"
+                          orient="auto"
+                        >
+                          <polygon points="0 0, 8 3, 0 6" fill={C.green} />
+                        </marker>
+                        <marker
+                          id="arrowCyan"
+                          markerWidth="8"
+                          markerHeight="6"
+                          refX="4"
+                          refY="3"
+                          orient="auto"
+                        >
+                          <polygon points="0 0, 8 3, 0 6" fill={C.cyan} />
+                        </marker>
+                      </defs>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </ShimmerCard>
+        </Reveal>
+
+        {/* 2x2 grid of feature cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+          {[
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.green}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                </svg>
+              ),
+              color: C.green,
+              title: "Firewall Rules",
+              desc: "Define who can access which devices with granular per-device, per-user, or per-tag firewall policies. Block unauthorized connections before they reach the agent.",
+            },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.yellow}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z" />
+                  <line x1="7" y1="7" x2="7.01" y2="7" />
+                </svg>
+              ),
+              color: C.yellow,
+              title: "Device Tags",
+              desc: "Organize fleets by location, firmware version, hardware type, or customer. Apply firewall rules and access policies to entire groups at once.",
+            },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.cyan}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <polygon points="10 8 16 12 10 16 10 8" />
+                </svg>
+              ),
+              color: C.cyan,
+              title: "Session Recording",
+              desc: "Record every SSH session for compliance, debugging, and knowledge sharing. Replay exactly what happened on a remote device during an incident.",
+            },
+            {
+              icon: (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={C.primary}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                >
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
+                </svg>
+              ),
+              color: C.primary,
+              title: "Audit Logging",
+              desc: "Full audit trail of every connection, command, and configuration change. Know who accessed what, when, and from where for regulatory compliance.",
+            },
+          ].map((f, i) => (
+            <Reveal key={i} delay={i * 0.04}>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${f.color}15`,
+                      borderColor: `${f.color}25`,
+                    }}
+                  >
+                    {f.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {f.desc}
+                  </p>
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
+        </div>
+
+        {/* Highlighted card: Lightweight Agent */}
+        <Reveal>
+          <ShimmerCard className="">
+            <div className="relative bg-card border border-accent-green/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(130,165,104,0.08)] hover:border-accent-green/50 transition-all duration-300">
+              <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.05] via-transparent to-transparent pointer-events-none" />
+              <div className="relative p-8">
+                <div className="grid lg:grid-cols-[1fr_auto] gap-8 items-center">
+                  <div>
                     <div className="flex items-center gap-3 mb-4">
-                      <IconBadge color="primary">
+                      <IconBadge color="green">
                         <svg
                           width="20"
                           height="20"
                           viewBox="0 0 24 24"
                           fill="none"
-                          stroke={C.primary}
+                          stroke={C.green}
                           strokeWidth="1.5"
                           strokeLinecap="round"
                         >
-                          <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+                          <polyline points="4 17 10 11 4 5" />
+                          <line x1="12" y1="19" x2="20" y2="19" />
                         </svg>
                       </IconBadge>
-                      <Badge shape="pill" color="primary">
-                        Core
+                      <Badge shape="pill" color="green">
+                        Agent
                       </Badge>
                     </div>
-                    <h3 className="text-lg font-bold mb-3">NAT Traversal</h3>
-                    <p className="text-sm text-text-secondary leading-relaxed mb-4">
-                      The ShellHub agent makes an outbound connection from the
-                      device, so it works behind any NAT, CGNAT, or firewall
-                      without opening inbound ports.
+                    <h3 className="text-lg font-bold mb-3">
+                      Lightweight Agent
+                    </h3>
+                    <p className="text-sm text-text-secondary leading-relaxed">
+                      The ShellHub agent is a single static binary with minimal
+                      resource footprint. It runs on anything from a Raspberry
+                      Pi Zero to an industrial gateway — no runtime dependencies
+                      needed.
                     </p>
-                    <ul className="space-y-2">
-                      {[
-                        "No public IP required on the device",
-                        "Works behind cellular, satellite, and double-NAT",
-                        "No VPN configuration or port forwarding needed",
-                        "Persistent connection with auto-reconnect",
-                      ].map((item) => (
-                        <li
-                          key={item}
-                          className="flex items-center gap-2.5 text-sm text-text-secondary"
-                        >
-                          <svg
-                            className="w-4 h-4 text-accent-green shrink-0"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="m4.5 12.75 6 6 9-13.5"
-                            />
-                          </svg>
-                          {item}
-                        </li>
-                      ))}
-                    </ul>
                   </div>
 
-                  {/* Right: SVG network diagram */}
-                  <div className="flex items-center justify-center">
-                    <div className="w-full max-w-md">
-                      <svg
-                        viewBox="0 0 400 220"
-                        fill="none"
-                        className="w-full h-auto"
+                  {/* Specs panel */}
+                  <div className="flex flex-row lg:flex-col gap-3 flex-wrap">
+                    {[
+                      {
+                        label: "Binary size",
+                        value: "< 10 MB",
+                        color: C.green,
+                      },
+                      {
+                        label: "Architectures",
+                        value: "ARM / x86",
+                        color: C.cyan,
+                      },
+                      {
+                        label: "Reconnect",
+                        value: "Automatic",
+                        color: C.primary,
+                      },
+                      {
+                        label: "Dependencies",
+                        value: "None",
+                        color: C.yellow,
+                      },
+                    ].map((spec, i) => (
+                      <div
+                        key={i}
+                        className="flex items-center gap-3 px-4 py-3 bg-surface rounded-lg border border-border min-w-[160px]"
                       >
-                        {/* Device box */}
-                        <rect
-                          x="10"
-                          y="60"
-                          width="100"
-                          height="100"
-                          rx="8"
-                          fill={C.card}
-                          stroke={C.border}
-                          strokeWidth="1"
-                        />
-                        <text
-                          x="60"
-                          y="96"
-                          textAnchor="middle"
-                          className="text-[10px]"
-                          fill={C.textSec}
-                          fontFamily="monospace"
-                        >
-                          IoT Device
-                        </text>
-                        <text
-                          x="60"
-                          y="114"
-                          textAnchor="middle"
-                          className="text-[9px]"
-                          fill={C.textMuted}
-                          fontFamily="monospace"
-                        >
-                          10.0.0.42
-                        </text>
-                        {/* Device icon */}
-                        <rect
-                          x="42"
-                          y="124"
-                          width="36"
-                          height="24"
-                          rx="3"
-                          fill="none"
-                          stroke={C.green}
-                          strokeWidth="1"
-                          opacity="0.5"
-                        />
-                        <circle
-                          cx="60"
-                          cy="136"
-                          r="2"
-                          fill={C.green}
-                          opacity="0.7"
-                        />
-
-                        {/* CGNAT wall */}
-                        <rect
-                          x="134"
-                          y="30"
-                          width="36"
-                          height="160"
-                          rx="4"
-                          fill={C.red}
-                          fillOpacity="0.08"
-                          stroke={C.red}
-                          strokeWidth="1"
-                          strokeDasharray="4 3"
-                          opacity="0.6"
-                        />
-                        <text
-                          x="152"
-                          y="22"
-                          textAnchor="middle"
-                          className="text-[9px]"
-                          fill={C.red}
-                          fontFamily="monospace"
-                          opacity="0.8"
-                        >
-                          CGNAT
-                        </text>
-
-                        {/* Outbound arrow: device -> ShellHub (over the wall) */}
-                        <path
-                          d="M110 100 C 130 100, 130 55, 170 55 L 260 55"
-                          stroke={C.green}
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          markerEnd="url(#arrowGreen)"
-                        />
-                        <text
-                          x="210"
-                          y="46"
-                          textAnchor="middle"
-                          className="text-[8px]"
-                          fill={C.green}
-                          fontFamily="monospace"
-                        >
-                          outbound
-                        </text>
-
-                        {/* ShellHub cloud box */}
-                        <rect
-                          x="260"
-                          y="30"
-                          width="130"
-                          height="100"
-                          rx="8"
-                          fill={C.primary}
-                          fillOpacity="0.08"
-                          stroke={C.primary}
-                          strokeWidth="1"
-                        />
-                        <text
-                          x="325"
-                          y="62"
-                          textAnchor="middle"
-                          className="text-[10px]"
-                          fill={C.primary}
-                          fontFamily="monospace"
-                          fontWeight="600"
-                        >
-                          ShellHub
-                        </text>
-                        <text
-                          x="325"
-                          y="78"
-                          textAnchor="middle"
-                          className="text-[9px]"
-                          fill={C.textMuted}
-                          fontFamily="monospace"
-                        >
-                          cloud relay
-                        </text>
-                        {/* Terminal icon inside */}
-                        <rect
-                          x="305"
-                          y="88"
-                          width="40"
-                          height="28"
-                          rx="3"
-                          fill={C.surface}
-                          stroke={C.border}
-                          strokeWidth="1"
-                        />
-                        <text
-                          x="312"
-                          y="106"
-                          className="text-[9px]"
-                          fill={C.green}
-                          fontFamily="monospace"
-                        >
-                          $_
-                        </text>
-
-                        {/* User arrow: user -> ShellHub */}
-                        <path
-                          d="M325 170 L 325 130"
-                          stroke={C.cyan}
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          markerEnd="url(#arrowCyan)"
-                        />
-
-                        {/* User box */}
-                        <rect
-                          x="275"
-                          y="170"
-                          width="100"
-                          height="40"
-                          rx="6"
-                          fill={C.card}
-                          stroke={C.border}
-                          strokeWidth="1"
-                        />
-                        <text
-                          x="325"
-                          y="194"
-                          textAnchor="middle"
-                          className="text-[10px]"
-                          fill={C.textSec}
-                          fontFamily="monospace"
-                        >
-                          You (SSH)
-                        </text>
-
-                        {/* Arrow markers */}
-                        <defs>
-                          <marker
-                            id="arrowGreen"
-                            markerWidth="8"
-                            markerHeight="6"
-                            refX="8"
-                            refY="3"
-                            orient="auto"
-                          >
-                            <polygon points="0 0, 8 3, 0 6" fill={C.green} />
-                          </marker>
-                          <marker
-                            id="arrowCyan"
-                            markerWidth="8"
-                            markerHeight="6"
-                            refX="4"
-                            refY="3"
-                            orient="auto"
-                          >
-                            <polygon points="0 0, 8 3, 0 6" fill={C.cyan} />
-                          </marker>
-                        </defs>
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </ShimmerCard>
-          </Reveal>
-
-          {/* 2x2 grid of feature cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-            {[
-              {
-                icon: (
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke={C.green}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  >
-                    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-                  </svg>
-                ),
-                color: C.green,
-                title: "Firewall Rules",
-                desc: "Define who can access which devices with granular per-device, per-user, or per-tag firewall policies. Block unauthorized connections before they reach the agent.",
-              },
-              {
-                icon: (
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke={C.yellow}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  >
-                    <path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z" />
-                    <line x1="7" y1="7" x2="7.01" y2="7" />
-                  </svg>
-                ),
-                color: C.yellow,
-                title: "Device Tags",
-                desc: "Organize fleets by location, firmware version, hardware type, or customer. Apply firewall rules and access policies to entire groups at once.",
-              },
-              {
-                icon: (
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke={C.cyan}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  >
-                    <circle cx="12" cy="12" r="10" />
-                    <polygon points="10 8 16 12 10 16 10 8" />
-                  </svg>
-                ),
-                color: C.cyan,
-                title: "Session Recording",
-                desc: "Record every SSH session for compliance, debugging, and knowledge sharing. Replay exactly what happened on a remote device during an incident.",
-              },
-              {
-                icon: (
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke={C.primary}
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  >
-                    <path d="M12 20h9" />
-                    <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
-                  </svg>
-                ),
-                color: C.primary,
-                title: "Audit Logging",
-                desc: "Full audit trail of every connection, command, and configuration change. Know who accessed what, when, and from where for regulatory compliance.",
-              },
-            ].map((f, i) => (
-              <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard>
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                      style={{
-                        background: `${f.color}15`,
-                        borderColor: `${f.color}25`,
-                      }}
-                    >
-                      {f.icon}
-                    </div>
-                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {f.desc}
-                    </p>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
-
-          {/* Highlighted card: Lightweight Agent */}
-          <Reveal>
-            <ShimmerCard className="">
-              <div className="relative bg-card border border-accent-green/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(130,165,104,0.08)] hover:border-accent-green/50 transition-all duration-300">
-                <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.05] via-transparent to-transparent pointer-events-none" />
-                <div className="relative p-8">
-                  <div className="grid lg:grid-cols-[1fr_auto] gap-8 items-center">
-                    <div>
-                      <div className="flex items-center gap-3 mb-4">
-                        <IconBadge color="green">
-                          <svg
-                            width="20"
-                            height="20"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke={C.green}
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                          >
-                            <polyline points="4 17 10 11 4 5" />
-                            <line x1="12" y1="19" x2="20" y2="19" />
-                          </svg>
-                        </IconBadge>
-                        <Badge shape="pill" color="green">
-                          Agent
-                        </Badge>
-                      </div>
-                      <h3 className="text-lg font-bold mb-3">
-                        Lightweight Agent
-                      </h3>
-                      <p className="text-sm text-text-secondary leading-relaxed">
-                        The ShellHub agent is a single static binary with
-                        minimal resource footprint. It runs on anything from a
-                        Raspberry Pi Zero to an industrial gateway — no runtime
-                        dependencies needed.
-                      </p>
-                    </div>
-
-                    {/* Specs panel */}
-                    <div className="flex flex-row lg:flex-col gap-3 flex-wrap">
-                      {[
-                        {
-                          label: "Binary size",
-                          value: "< 10 MB",
-                          color: C.green,
-                        },
-                        {
-                          label: "Architectures",
-                          value: "ARM / x86",
-                          color: C.cyan,
-                        },
-                        {
-                          label: "Reconnect",
-                          value: "Automatic",
-                          color: C.primary,
-                        },
-                        {
-                          label: "Dependencies",
-                          value: "None",
-                          color: C.yellow,
-                        },
-                      ].map((spec, i) => (
                         <div
-                          key={i}
-                          className="flex items-center gap-3 px-4 py-3 bg-surface rounded-lg border border-border min-w-[160px]"
-                        >
-                          <div
-                            className="w-1.5 h-8 rounded-full"
-                            style={{ background: spec.color }}
-                          />
-                          <div>
-                            <p className="text-2xs text-text-muted font-mono uppercase tracking-wider">
-                              {spec.label}
-                            </p>
-                            <p
-                              className="text-sm font-semibold font-mono"
-                              style={{ color: spec.color }}
-                            >
-                              {spec.value}
-                            </p>
-                          </div>
+                          className="w-1.5 h-8 rounded-full"
+                          style={{ background: spec.color }}
+                        />
+                        <div>
+                          <p className="text-2xs text-text-muted font-mono uppercase tracking-wider">
+                            {spec.label}
+                          </p>
+                          <p
+                            className="text-sm font-semibold font-mono"
+                            style={{ color: spec.color }}
+                          >
+                            {spec.value}
+                          </p>
                         </div>
-                      ))}
-                    </div>
+                      </div>
+                    ))}
                   </div>
                 </div>
               </div>
-            </ShimmerCard>
-          </Reveal>
-        </div>
-      </section>
+            </div>
+          </ShimmerCard>
+        </Reveal>
+      </Section>
 
       {/* ═══════ Supported Platforms ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-12">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Compatibility
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Runs on the platforms you use
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              The ShellHub agent supports any Linux-based system with an ARM or
-              x86 processor. Here are some of the most popular platforms.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Compatibility"
+          title="Runs on the platforms you use"
+          size="sub"
+          subtitle="The ShellHub agent supports any Linux-based system with an ARM or x86 processor. Here are some of the most popular platforms."
+          className="mb-12"
+        />
 
-          <Reveal>
-            <div className="flex flex-wrap justify-center gap-4">
-              {platforms.map((p, i) => (
-                <div
-                  key={i}
-                  className="flex items-center gap-3 px-5 py-3.5 bg-card border border-border rounded-xl hover:border-border-light transition-colors duration-300"
-                >
-                  <div className="w-9 h-9 rounded-lg bg-surface border border-border flex items-center justify-center">
-                    <span className="text-2xs font-mono font-bold text-primary">
-                      {p.abbr}
-                    </span>
-                  </div>
-                  <span className="text-sm font-medium text-text-primary">
-                    {p.name}
+        <Reveal>
+          <div className="flex flex-wrap justify-center gap-4">
+            {platforms.map((p, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-3 px-5 py-3.5 bg-card border border-border rounded-xl hover:border-border-light transition-colors duration-300"
+              >
+                <div className="w-9 h-9 rounded-lg bg-surface border border-border flex items-center justify-center">
+                  <span className="text-2xs font-mono font-bold text-primary">
+                    {p.abbr}
                   </span>
                 </div>
-              ))}
-            </div>
-          </Reveal>
-        </div>
-      </section>
+                <span className="text-sm font-medium text-text-primary">
+                  {p.name}
+                </span>
+              </div>
+            ))}
+          </div>
+        </Reveal>
+      </Section>
 
       {/* ═══════ CTA with ConnectionGrid ═══════ */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal>
-            <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-              <ConnectionGrid />
-              <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
+      <Section>
+        <Reveal>
+          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+            <ConnectionGrid />
+            <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
 
-              <div className="relative z-10">
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-accent-green mb-3">
-                  Ready to get started?
-                </p>
-                <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Start managing your IoT fleet today
-                </h2>
-                <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                  Deploy the ShellHub agent on your devices and get instant
-                  remote access — no network changes, no VPNs, no exposed ports.
-                </p>
+            <div className="relative z-10">
+              <SectionHeader
+                variant="cta"
+                eyebrowColor="green"
+                eyebrow="Ready to get started?"
+                title="Start managing your IoT fleet today"
+                subtitle="Deploy the ShellHub agent on your devices and get instant remote access — no network changes, no VPNs, no exposed ports."
+              />
 
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                  <Button
-                    as={Link}
-                    to="/getting-started"
-                    variant="primary"
-                    size="xl"
-                    glow
-                    iconRight={<ArrowRight />}
-                  >
-                    Get Started Free
-                  </Button>
-                  <Button
-                    as="a"
-                    href="mailto:sales@shellhub.io"
-                    variant="outline"
-                    size="xl"
-                  >
-                    Contact Sales
-                  </Button>
-                </div>
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+                <Button
+                  as={Link}
+                  to="/getting-started"
+                  variant="primary"
+                  size="xl"
+                  glow
+                  iconRight={<ArrowRight />}
+                >
+                  Get Started Free
+                </Button>
+                <Button
+                  as="a"
+                  href="mailto:sales@shellhub.io"
+                  variant="outline"
+                  size="xl"
+                >
+                  Contact Sales
+                </Button>
               </div>
             </div>
-          </Reveal>
-        </div>
-      </section>
+          </div>
+        </Reveal>
+      </Section>
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Badge, Button, Card } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
+import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -269,552 +270,507 @@ export default function RemoteSupport() {
       </section>
 
       {/* ── Session Recording Mockup ─────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <div>
-              <Reveal>
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-accent-cyan mb-3">
-                  Session Recording
-                </p>
-                <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Record every session. Replay any time.
-                </h2>
-                <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                  Every SSH session is automatically captured and stored. Replay
-                  sessions to review what happened during a support interaction,
-                  verify that procedures were followed, or train new engineers
-                  on troubleshooting workflows.
-                </p>
-              </Reveal>
+      <Section>
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <SectionHeader
+              align="left"
+              size="sub"
+              className="mb-8"
+              eyebrowColor="cyan"
+              eyebrow="Session Recording"
+              title="Record every session. Replay any time."
+              subtitle="Every SSH session is automatically captured and stored. Replay sessions to review what happened during a support interaction, verify that procedures were followed, or train new engineers on troubleshooting workflows."
+            />
 
-              <div className="space-y-3">
-                {[
-                  {
-                    label: "Full terminal replay",
-                    desc: "Watch sessions frame by frame, exactly as they happened",
-                  },
-                  {
-                    label: "Searchable archive",
-                    desc: "Find sessions by user, device, date range, or keyword",
-                  },
-                  {
-                    label: "Compliance-ready exports",
-                    desc: "Export session recordings for external audits and compliance reports",
-                  },
-                  {
-                    label: "Incident investigation",
-                    desc: "Pinpoint exactly what command caused an issue, down to the second",
-                  },
-                ].map((item, i) => (
-                  <Reveal key={i} delay={i * 0.04}>
-                    <div className="flex items-start gap-3">
-                      <svg
-                        className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
-                      <div>
-                        <p className="text-sm font-medium text-text-primary">
-                          {item.label}
-                        </p>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {item.desc}
-                        </p>
-                      </div>
-                    </div>
-                  </Reveal>
-                ))}
-              </div>
-            </div>
-
-            {/* Session player mockup */}
-            <Reveal delay={0.1}>
-              <ShimmerCard>
-                <Card className="overflow-hidden">
-                  <div className="p-6">
-                    {/* Window chrome */}
-                    <div className="flex items-center gap-2 mb-4">
-                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                      <span className="ml-2 text-2xs text-text-muted font-mono">
-                        Session Replay
-                      </span>
-                    </div>
-
-                    {/* Terminal area */}
-                    <div className="bg-[#111214] rounded-lg border border-border p-4 font-mono text-2xs leading-relaxed mb-4">
-                      <p className="text-accent-green">
-                        john@prod-server-03:~$
-                        <span className="text-text-primary ml-2">
-                          ls -la /var/log/nginx/
-                        </span>
+            <div className="space-y-3">
+              {[
+                {
+                  label: "Full terminal replay",
+                  desc: "Watch sessions frame by frame, exactly as they happened",
+                },
+                {
+                  label: "Searchable archive",
+                  desc: "Find sessions by user, device, date range, or keyword",
+                },
+                {
+                  label: "Compliance-ready exports",
+                  desc: "Export session recordings for external audits and compliance reports",
+                },
+                {
+                  label: "Incident investigation",
+                  desc: "Pinpoint exactly what command caused an issue, down to the second",
+                },
+              ].map((item, i) => (
+                <Reveal key={i} delay={i * 0.04}>
+                  <div className="flex items-start gap-3">
+                    <svg
+                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m4.5 12.75 6 6 9-13.5"
+                      />
+                    </svg>
+                    <div>
+                      <p className="text-sm font-medium text-text-primary">
+                        {item.label}
                       </p>
-                      <p className="text-text-muted mt-1">total 2184</p>
-                      <p className="text-text-muted">
-                        drwxr-xr-x 2 root root 4096 Feb 14 09:00 .
-                      </p>
-                      <p className="text-text-muted">
-                        -rw-r----- 1 root adm 842560 Feb 14 14:31 access.log
-                      </p>
-                      <p className="text-text-muted">
-                        -rw-r----- 1 root adm 194720 Feb 14 14:28 error.log
-                      </p>
-                      <p className="text-accent-green mt-2">
-                        john@prod-server-03:~$
-                        <span className="text-text-primary ml-2">
-                          systemctl status nginx
-                        </span>
-                      </p>
-                      <p className="text-text-muted mt-1">
-                        <span className="text-accent-green">●</span>{" "}
-                        nginx.service - A high performance web server
-                      </p>
-                      <p className="text-text-muted">
-                        {"   "}Loaded: loaded
-                        (/lib/systemd/system/nginx.service; enabled)
-                      </p>
-                      <p className="text-text-muted">
-                        {"   "}Active:{" "}
-                        <span className="text-accent-green">
-                          active (running)
-                        </span>{" "}
-                        since Fri 2026-02-14 09:00:12 UTC
-                      </p>
-                      <p className="text-accent-green mt-2">
-                        john@prod-server-03:~$
-                        <span className="text-text-primary ml-2 animate-pulse">
-                          _
-                        </span>
-                      </p>
-                    </div>
-
-                    {/* Playback controls */}
-                    <div className="flex items-center gap-3 bg-surface rounded-lg border border-border p-3">
-                      <button type="button" aria-label="Play" className="w-8 h-8 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center shrink-0">
-                        <svg
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill={C.cyan}
-                          stroke="none"
-                          aria-hidden="true"
-                        >
-                          <polygon points="6 4 20 12 6 20 6 4" />
-                        </svg>
-                      </button>
-
-                      {/* Timeline */}
-                      <div className="flex-1 relative">
-                        <div className="h-1.5 bg-border rounded-full overflow-hidden">
-                          <div
-                            className="h-full rounded-full bg-gradient-to-r from-accent-cyan to-primary"
-                            style={{ width: "30%" }}
-                          />
-                        </div>
-                      </div>
-
-                      <span className="text-2xs text-text-muted font-mono shrink-0">
-                        00:03:42 / 00:12:15
-                      </span>
-                    </div>
-
-                    {/* Metadata */}
-                    <div className="mt-4 pt-4 border-t border-border">
-                      <p className="text-2xs text-text-muted font-mono">
-                        User:{" "}
-                        <span className="text-text-secondary">
-                          john@company.com
-                        </span>
-                        <span className="mx-2 text-border">|</span>
-                        Device:{" "}
-                        <span className="text-text-secondary">
-                          prod-server-03
-                        </span>
-                        <span className="mx-2 text-border">|</span>
-                        Duration:{" "}
-                        <span className="text-text-secondary">12m 15s</span>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {item.desc}
                       </p>
                     </div>
                   </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+                </Reveal>
+              ))}
+            </div>
           </div>
+
+          {/* Session player mockup */}
+          <Reveal delay={0.1}>
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <div className="p-6">
+                  {/* Window chrome */}
+                  <div className="flex items-center gap-2 mb-4">
+                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                    <span className="ml-2 text-2xs text-text-muted font-mono">
+                      Session Replay
+                    </span>
+                  </div>
+
+                  {/* Terminal area */}
+                  <div className="bg-[#111214] rounded-lg border border-border p-4 font-mono text-2xs leading-relaxed mb-4">
+                    <p className="text-accent-green">
+                      john@prod-server-03:~$
+                      <span className="text-text-primary ml-2">
+                        ls -la /var/log/nginx/
+                      </span>
+                    </p>
+                    <p className="text-text-muted mt-1">total 2184</p>
+                    <p className="text-text-muted">
+                      drwxr-xr-x 2 root root 4096 Feb 14 09:00 .
+                    </p>
+                    <p className="text-text-muted">
+                      -rw-r----- 1 root adm 842560 Feb 14 14:31 access.log
+                    </p>
+                    <p className="text-text-muted">
+                      -rw-r----- 1 root adm 194720 Feb 14 14:28 error.log
+                    </p>
+                    <p className="text-accent-green mt-2">
+                      john@prod-server-03:~$
+                      <span className="text-text-primary ml-2">
+                        systemctl status nginx
+                      </span>
+                    </p>
+                    <p className="text-text-muted mt-1">
+                      <span className="text-accent-green">●</span> nginx.service
+                      - A high performance web server
+                    </p>
+                    <p className="text-text-muted">
+                      {"   "}Loaded: loaded (/lib/systemd/system/nginx.service;
+                      enabled)
+                    </p>
+                    <p className="text-text-muted">
+                      {"   "}Active:{" "}
+                      <span className="text-accent-green">
+                        active (running)
+                      </span>{" "}
+                      since Fri 2026-02-14 09:00:12 UTC
+                    </p>
+                    <p className="text-accent-green mt-2">
+                      john@prod-server-03:~$
+                      <span className="text-text-primary ml-2 animate-pulse">
+                        _
+                      </span>
+                    </p>
+                  </div>
+
+                  {/* Playback controls */}
+                  <div className="flex items-center gap-3 bg-surface rounded-lg border border-border p-3">
+                    <button
+                      type="button"
+                      aria-label="Play"
+                      className="w-8 h-8 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center shrink-0"
+                    >
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill={C.cyan}
+                        stroke="none"
+                        aria-hidden="true"
+                      >
+                        <polygon points="6 4 20 12 6 20 6 4" />
+                      </svg>
+                    </button>
+
+                    {/* Timeline */}
+                    <div className="flex-1 relative">
+                      <div className="h-1.5 bg-border rounded-full overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-gradient-to-r from-accent-cyan to-primary"
+                          style={{ width: "30%" }}
+                        />
+                      </div>
+                    </div>
+
+                    <span className="text-2xs text-text-muted font-mono shrink-0">
+                      00:03:42 / 00:12:15
+                    </span>
+                  </div>
+
+                  {/* Metadata */}
+                  <div className="mt-4 pt-4 border-t border-border">
+                    <p className="text-2xs text-text-muted font-mono">
+                      User:{" "}
+                      <span className="text-text-secondary">
+                        john@company.com
+                      </span>
+                      <span className="mx-2 text-border">|</span>
+                      Device:{" "}
+                      <span className="text-text-secondary">
+                        prod-server-03
+                      </span>
+                      <span className="mx-2 text-border">|</span>
+                      Duration:{" "}
+                      <span className="text-text-secondary">12m 15s</span>
+                    </p>
+                  </div>
+                </div>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
         </div>
-      </section>
+      </Section>
 
       {/* ── Audit Trail Mockup ───────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            {/* Audit log table mockup */}
-            <Reveal delay={0.1} className="order-2 lg:order-1">
-              <ShimmerCard>
-                <Card className="overflow-hidden">
-                  <div className="p-6">
-                    {/* Window chrome */}
-                    <div className="flex items-center gap-2 mb-5">
-                      <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                      <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                      <span className="ml-2 text-2xs text-text-muted font-mono">
-                        Audit Log
-                      </span>
-                    </div>
+      <Section>
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          {/* Audit log table mockup */}
+          <Reveal delay={0.1} className="order-2 lg:order-1">
+            <ShimmerCard>
+              <Card className="overflow-hidden">
+                <div className="p-6">
+                  {/* Window chrome */}
+                  <div className="flex items-center gap-2 mb-5">
+                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
+                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
+                    <span className="ml-2 text-2xs text-text-muted font-mono">
+                      Audit Log
+                    </span>
+                  </div>
 
-                    {/* Table header */}
-                    <div className="grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2 mb-1">
-                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                        Time
-                      </span>
-                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                        User
-                      </span>
-                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                        Action
-                      </span>
-                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                        Device
-                      </span>
-                      <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                        Duration
-                      </span>
-                    </div>
+                  {/* Table header */}
+                  <div className="grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2 mb-1">
+                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                      Time
+                    </span>
+                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                      User
+                    </span>
+                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                      Action
+                    </span>
+                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                      Device
+                    </span>
+                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                      Duration
+                    </span>
+                  </div>
 
-                    {/* Rows */}
-                    <div className="space-y-1">
-                      {auditRows.map((row, i) => (
-                        <div
-                          key={i}
-                          className={`grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2.5 rounded-lg items-center ${
-                            i % 2 === 0 ? "bg-surface" : "bg-transparent"
-                          }`}
-                        >
-                          <span className="text-2xs font-mono text-text-muted">
-                            {row.time}
-                          </span>
-                          <div className="flex items-center gap-2 min-w-0">
-                            <div
-                              className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-semibold shrink-0"
-                              style={{
-                                background: `${row.color}20`,
-                                color: row.color,
-                              }}
-                            >
-                              {row.initials}
-                            </div>
-                            <span className="text-2xs text-text-secondary truncate">
-                              {row.name}
-                            </span>
+                  {/* Rows */}
+                  <div className="space-y-1">
+                    {auditRows.map((row, i) => (
+                      <div
+                        key={i}
+                        className={`grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2.5 rounded-lg items-center ${
+                          i % 2 === 0 ? "bg-surface" : "bg-transparent"
+                        }`}
+                      >
+                        <span className="text-2xs font-mono text-text-muted">
+                          {row.time}
+                        </span>
+                        <div className="flex items-center gap-2 min-w-0">
+                          <div
+                            className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-semibold shrink-0"
+                            style={{
+                              background: `${row.color}20`,
+                              color: row.color,
+                            }}
+                          >
+                            {row.initials}
                           </div>
-                          <span className="text-2xs text-text-secondary font-mono">
-                            {row.action}
-                          </span>
-                          <span className="text-2xs text-text-secondary font-mono truncate">
-                            {row.device}
-                          </span>
-                          <span className="text-2xs text-text-muted font-mono">
-                            {row.duration}
+                          <span className="text-2xs text-text-secondary truncate">
+                            {row.name}
                           </span>
                         </div>
-                      ))}
-                    </div>
+                        <span className="text-2xs text-text-secondary font-mono">
+                          {row.action}
+                        </span>
+                        <span className="text-2xs text-text-secondary font-mono truncate">
+                          {row.device}
+                        </span>
+                        <span className="text-2xs text-text-muted font-mono">
+                          {row.duration}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
 
-                    {/* Footer */}
-                    <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                      <span className="text-2xs text-text-muted">
-                        Showing 4 of 1,247 entries
-                      </span>
-                      <span className="text-2xs text-primary font-medium">
-                        View all &rarr;
-                      </span>
+                  {/* Footer */}
+                  <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                    <span className="text-2xs text-text-muted">
+                      Showing 4 of 1,247 entries
+                    </span>
+                    <span className="text-2xs text-primary font-medium">
+                      View all &rarr;
+                    </span>
+                  </div>
+                </div>
+              </Card>
+            </ShimmerCard>
+          </Reveal>
+
+          {/* Text */}
+          <div className="order-1 lg:order-2">
+            <SectionHeader
+              align="left"
+              size="sub"
+              className="mb-8"
+              eyebrowColor="green"
+              eyebrow="Audit Trail"
+              title="Full accountability for every connection"
+              subtitle="Every session is logged with the user identity, target device, timestamps, and duration. Build compliance reports, investigate incidents, and prove to auditors exactly who did what, when, and for how long."
+            />
+
+            <div className="space-y-3">
+              {[
+                {
+                  label: "Immutable log entries",
+                  desc: "Audit records cannot be altered or deleted by users",
+                },
+                {
+                  label: "Filter and search",
+                  desc: "Find events by user, device, date, or action type instantly",
+                },
+                {
+                  label: "Compliance reporting",
+                  desc: "Generate reports for SOC 2, ISO 27001, and internal audits",
+                },
+                {
+                  label: "Real-time monitoring",
+                  desc: "View active sessions and who is currently connected to which device",
+                },
+              ].map((item, i) => (
+                <Reveal key={i} delay={i * 0.04}>
+                  <div className="flex items-start gap-3">
+                    <svg
+                      className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m4.5 12.75 6 6 9-13.5"
+                      />
+                    </svg>
+                    <div>
+                      <p className="text-sm font-medium text-text-primary">
+                        {item.label}
+                      </p>
+                      <p className="text-xs text-text-secondary leading-relaxed">
+                        {item.desc}
+                      </p>
                     </div>
                   </div>
+                </Reveal>
+              ))}
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      {/* ── Pain Points ──────────────────────────────────────────── */}
+      <Section>
+        <SectionHeader
+          eyebrow="The Problem"
+          title="Why traditional remote support falls short"
+          subtitle="Legacy workflows leave gaps in security, visibility, and compliance that put your organization at risk."
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {painPoints.map((p, i) => (
+            <Reveal key={i} delay={i * 0.06}>
+              <ShimmerCard className="h-full">
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-2 h-2 rounded-full mb-4"
+                    style={{ background: p.color }}
+                  />
+                  <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {p.desc}
+                  </p>
                 </Card>
               </ShimmerCard>
             </Reveal>
-
-            {/* Text */}
-            <div className="order-1 lg:order-2">
-              <Reveal>
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-accent-green mb-3">
-                  Audit Trail
-                </p>
-                <h2 className="text-[clamp(1.75rem,4vw,2.5rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Full accountability for every connection
-                </h2>
-                <p className="text-sm text-text-secondary leading-relaxed mb-8">
-                  Every session is logged with the user identity, target device,
-                  timestamps, and duration. Build compliance reports,
-                  investigate incidents, and prove to auditors exactly who did
-                  what, when, and for how long.
-                </p>
-              </Reveal>
-
-              <div className="space-y-3">
-                {[
-                  {
-                    label: "Immutable log entries",
-                    desc: "Audit records cannot be altered or deleted by users",
-                  },
-                  {
-                    label: "Filter and search",
-                    desc: "Find events by user, device, date, or action type instantly",
-                  },
-                  {
-                    label: "Compliance reporting",
-                    desc: "Generate reports for SOC 2, ISO 27001, and internal audits",
-                  },
-                  {
-                    label: "Real-time monitoring",
-                    desc: "View active sessions and who is currently connected to which device",
-                  },
-                ].map((item, i) => (
-                  <Reveal key={i} delay={i * 0.04}>
-                    <div className="flex items-start gap-3">
-                      <svg
-                        className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="m4.5 12.75 6 6 9-13.5"
-                        />
-                      </svg>
-                      <div>
-                        <p className="text-sm font-medium text-text-primary">
-                          {item.label}
-                        </p>
-                        <p className="text-xs text-text-secondary leading-relaxed">
-                          {item.desc}
-                        </p>
-                      </div>
-                    </div>
-                  </Reveal>
-                ))}
-              </div>
-            </div>
-          </div>
+          ))}
         </div>
-      </section>
-
-      {/* ── Pain Points ──────────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              The Problem
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Why traditional remote support falls short
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Legacy workflows leave gaps in security, visibility, and
-              compliance that put your organization at risk.
-            </p>
-          </Reveal>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {painPoints.map((p, i) => (
-              <Reveal key={i} delay={i * 0.06}>
-                <ShimmerCard className="h-full">
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-2 h-2 rounded-full mb-4"
-                      style={{ background: p.color }}
-                    />
-                    <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {p.desc}
-                    </p>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </section>
+      </Section>
 
       {/* ── Key Features ─────────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Features
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              Built for audited, accountable support
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              Everything your support team needs to connect securely,
-              troubleshoot efficiently, and maintain a complete compliance
-              record.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Features"
+          title="Built for audited, accountable support"
+          subtitle="Everything your support team needs to connect securely, troubleshoot efficiently, and maintain a complete compliance record."
+        />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {features.map((f, i) => (
-              <Reveal key={i} delay={i * 0.04}>
-                <ShimmerCard>
-                  <Card hover className="p-6 h-full">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                      style={{
-                        background: `${f.color}15`,
-                        borderColor: `${f.color}25`,
-                      }}
-                    >
-                      {f.icon}
-                    </div>
-                    <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {f.desc}
-                    </p>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
-          </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {features.map((f, i) => (
+            <Reveal key={i} delay={i * 0.04}>
+              <ShimmerCard>
+                <Card hover className="p-6 h-full">
+                  <div
+                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+                    style={{
+                      background: `${f.color}15`,
+                      borderColor: `${f.color}25`,
+                    }}
+                  >
+                    {f.icon}
+                  </div>
+                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {f.desc}
+                  </p>
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
         </div>
-      </section>
+      </Section>
 
       {/* ── Support Workflow ──────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal className="text-center mb-14">
-            <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-              Workflow
-            </p>
-            <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-              From ticket to resolution — fully audited
-            </h2>
-            <p className="text-sm text-text-secondary max-w-lg mx-auto leading-relaxed">
-              A streamlined support workflow that captures everything for
-              compliance without slowing your team down.
-            </p>
-          </Reveal>
+      <Section>
+        <SectionHeader
+          eyebrow="Workflow"
+          title="From ticket to resolution — fully audited"
+          subtitle="A streamlined support workflow that captures everything for compliance without slowing your team down."
+        />
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 relative">
-            {/* Connecting arrows (desktop only) */}
-            <div className="hidden md:block absolute top-1/2 left-[calc(33.33%-12px)] w-[calc(33.33%+24px)] -translate-y-1/2 pointer-events-none z-0">
-              <svg
-                className="w-full h-8"
-                viewBox="0 0 400 32"
-                fill="none"
-                preserveAspectRatio="none"
-              >
-                <line
-                  x1="0"
-                  y1="16"
-                  x2="180"
-                  y2="16"
-                  stroke={C.border}
-                  strokeWidth="1"
-                  strokeDasharray="6 4"
-                />
-                <polygon points="180,12 188,16 180,20" fill={C.textMuted} />
-                <line
-                  x1="210"
-                  y1="16"
-                  x2="390"
-                  y2="16"
-                  stroke={C.border}
-                  strokeWidth="1"
-                  strokeDasharray="6 4"
-                />
-                <polygon points="390,12 398,16 390,20" fill={C.textMuted} />
-              </svg>
-            </div>
-
-            {workflowSteps.map((step, i) => (
-              <Reveal key={i} delay={i * 0.08}>
-                <ShimmerCard className="h-full">
-                  <Card hover className="relative p-6 h-full overflow-hidden">
-                    <div
-                      className="absolute top-0 left-0 w-full h-0.5"
-                      style={{
-                        background: `linear-gradient(90deg, ${step.color}00, ${step.color}, ${step.color}00)`,
-                      }}
-                    />
-                    <div className="flex items-center gap-3 mb-4">
-                      <span
-                        className="w-10 h-10 rounded-lg flex items-center justify-center text-xs font-bold font-mono border"
-                        style={{
-                          background: `${step.color}15`,
-                          borderColor: `${step.color}25`,
-                          color: step.color,
-                        }}
-                      >
-                        {step.num}
-                      </span>
-                      <h4 className="text-sm font-semibold">{step.title}</h4>
-                    </div>
-                    <p className="text-xs text-text-secondary leading-relaxed">
-                      {step.desc}
-                    </p>
-                  </Card>
-                </ShimmerCard>
-              </Reveal>
-            ))}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 relative">
+          {/* Connecting arrows (desktop only) */}
+          <div className="hidden md:block absolute top-1/2 left-[calc(33.33%-12px)] w-[calc(33.33%+24px)] -translate-y-1/2 pointer-events-none z-0">
+            <svg
+              className="w-full h-8"
+              viewBox="0 0 400 32"
+              fill="none"
+              preserveAspectRatio="none"
+            >
+              <line
+                x1="0"
+                y1="16"
+                x2="180"
+                y2="16"
+                stroke={C.border}
+                strokeWidth="1"
+                strokeDasharray="6 4"
+              />
+              <polygon points="180,12 188,16 180,20" fill={C.textMuted} />
+              <line
+                x1="210"
+                y1="16"
+                x2="390"
+                y2="16"
+                stroke={C.border}
+                strokeWidth="1"
+                strokeDasharray="6 4"
+              />
+              <polygon points="390,12 398,16 390,20" fill={C.textMuted} />
+            </svg>
           </div>
+
+          {workflowSteps.map((step, i) => (
+            <Reveal key={i} delay={i * 0.08}>
+              <ShimmerCard className="h-full">
+                <Card hover className="relative p-6 h-full overflow-hidden">
+                  <div
+                    className="absolute top-0 left-0 w-full h-0.5"
+                    style={{
+                      background: `linear-gradient(90deg, ${step.color}00, ${step.color}, ${step.color}00)`,
+                    }}
+                  />
+                  <div className="flex items-center gap-3 mb-4">
+                    <span
+                      className="w-10 h-10 rounded-lg flex items-center justify-center text-xs font-bold font-mono border"
+                      style={{
+                        background: `${step.color}15`,
+                        borderColor: `${step.color}25`,
+                        color: step.color,
+                      }}
+                    >
+                      {step.num}
+                    </span>
+                    <h4 className="text-sm font-semibold">{step.title}</h4>
+                  </div>
+                  <p className="text-xs text-text-secondary leading-relaxed">
+                    {step.desc}
+                  </p>
+                </Card>
+              </ShimmerCard>
+            </Reveal>
+          ))}
         </div>
-      </section>
+      </Section>
 
       {/* ── CTA ──────────────────────────────────────────────────── */}
-      <section className="py-24 border-t border-border">
-        <div className="max-w-7xl mx-auto px-8">
-          <Reveal>
-            <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-              <ConnectionGrid />
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
+      <Section>
+        <Reveal>
+          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+            <ConnectionGrid />
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
 
-              <div className="relative z-10">
-                <p className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-[#7B8EDB] mb-3">
-                  Ready to get started?
-                </p>
-                <h2 className="text-[clamp(1.5rem,3vw,2.25rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
-                  Secure support starts here
-                </h2>
-                <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed mb-8">
-                  Enable audited, accountable remote support for your team in
-                  minutes. No VPN required, no SSH keys to manage, no audit
-                  gaps.
-                </p>
+            <div className="relative z-10">
+              <SectionHeader
+                variant="cta"
+                eyebrow="Ready to get started?"
+                title="Secure support starts here"
+                subtitle="Enable audited, accountable remote support for your team in minutes. No VPN required, no SSH keys to manage, no audit gaps."
+              />
 
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                  <Button
-                    as={Link}
-                    to="/getting-started"
-                    variant="primary"
-                    size="xl"
-                    glow
-                    iconRight={<ArrowRight />}
-                  >
-                    Get Started Free
-                  </Button>
-                  <Button as={Link} to="/pricing" variant="outline" size="xl">
-                    View Pricing
-                  </Button>
-                </div>
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+                <Button
+                  as={Link}
+                  to="/getting-started"
+                  variant="primary"
+                  size="xl"
+                  glow
+                  iconRight={<ArrowRight />}
+                >
+                  Get Started Free
+                </Button>
+                <Button as={Link} to="/pricing" variant="outline" size="xl">
+                  View Pricing
+                </Button>
               </div>
             </div>
-          </Reveal>
-        </div>
-      </section>
+          </div>
+        </Reveal>
+      </Section>
     </SiteLayout>
   );
 }

--- a/ui/packages/design-system/package.json
+++ b/ui/packages/design-system/package.json
@@ -8,7 +8,8 @@
     "./css/base.css": "./css/base.css",
     "./components": "./components/index.ts",
     "./constants": "./constants.ts",
-    "./primitives": "./primitives/index.ts"
+    "./primitives": "./primitives/index.ts",
+    "./cn": "./primitives/cn.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/ui/packages/design-system/primitives/index.ts
+++ b/ui/packages/design-system/primitives/index.ts
@@ -1,5 +1,6 @@
 // primitives/index.ts — public surface of the design-system primitives.
-// cn is intentionally NOT exported here; import it directly from "./cn" within the package.
+// cn is intentionally NOT exported from this component barrel. Within the package, import it
+// from "./cn". External consumers should import it via the "@shellhub/design-system/cn" subpath.
 
 export { Button } from "./Button";
 export type { ButtonVariant, ButtonSize } from "./Button";


### PR DESCRIPTION
## What
Extracted three website-local presentational components — `Section`, `SectionHeader`, `FeatureListItem` — and routed all 59 marketing section headers through them, replacing repeated raw markup across the `apps/website` pages.

## Why
The marketing pages hand-rolled the same section scaffolding everywhere: eyebrow typography tokens, `clamp()` fluid heading sizes, and the SVG check-path list icon, duplicated across ~20 page files. Centralizing them removes the drift risk (eyebrow styles had already diverged between pages) and gives one place to evolve the marketing look. Part of `shellhub-io/team#114` Step 4a.

## Changes
- **`@shellhub/design-system/cn` subpath**: added a `./cn` entry to the design-system `exports` map so the website imports `cn` from `@shellhub/design-system/cn` rather than carrying a duplicate. `cn` stays out of the `primitives` component barrel.
- **`Section`**: section shell with `bordered`/`padding`/`background`/`container` props and a polymorphic `as`.
- **`SectionHeader`**: eyebrow + `h2` + subtitle with `size` (`section`/`sub`/`cta`), `align` (`center`/`left`), `eyebrowColor` (`primary`/`cyan`/`green`), and a `variant="cta"` that bundles the CTA-card configuration (`size="cta"`, `reveal={false}`, `mb-0` wrapper, `max-w-md` subtitle). The `align="left"` path drops the centered `max-w-lg mx-auto` from the subtitle.
- **`FeatureListItem`**: check-icon list item with a `color` prop.
- **Adoption**: standalone centered headers, left-aligned grid-column headers (`align="left"`), and CTA cards (`variant="cta"`) across the website now render via `SectionHeader`.
- **Eyebrow color normalization**: eyebrows previously used the off-token literal `text-[#7B8EDB]`; they now use the `text-primary` brand token (`#667ACC`). This is an intentional, site-wide visible hue shift, not an incidental change.
- One heading whose size is `text-[clamp(1.5rem,3vw,2rem)]` (no matching token) was deliberately left as raw markup rather than widening the component API for a single call site.

## Testing
- 67 Vitest unit/component tests pass; the route smoke-test mounts every adopted page. ESLint clean across all touched files.
- Reviewer focus: confirm the eyebrow hue shift (`#7B8EDB` -> `#667ACC`) is acceptable — it is the one deliberate visual change in an otherwise behavior-preserving refactor.