### PR TITLE
feat(ui): docs code-block copy button and shared grid background

### DIFF
--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -431,5 +431,67 @@ const nextPage = currentIndex < allPages.length - 1 ? allPages[currentIndex + 1]
         }
       });
     </script>
+
+    <script>
+      // Code block copy button
+      if (navigator.clipboard) {
+        document.querySelectorAll(".prose pre").forEach((pre) => {
+          try {
+            const parent = pre.parentNode;
+            if (!parent) return; // skip detached <pre>
+
+            const wrapper = document.createElement("div");
+            wrapper.className = "code-block";
+            parent.insertBefore(wrapper, pre);
+            wrapper.appendChild(pre);
+
+            const btn = document.createElement("button");
+            btn.className = "code-copy-btn";
+            btn.type = "button";
+            btn.setAttribute("aria-label", "Copy code");
+            btn.innerHTML = `
+              <svg class="icon-copy" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+              <svg class="icon-check" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            `;
+
+            let copyTimeout: ReturnType<typeof setTimeout> | undefined;
+            let failTimeout: ReturnType<typeof setTimeout> | undefined;
+
+            btn.addEventListener("click", () => {
+              const code = pre.querySelector("code");
+              const codeText = code?.textContent;
+              const text = (
+                codeText && codeText.length ? codeText : pre.textContent ?? ""
+              ).replace(/\n+$/, "");
+              navigator.clipboard.writeText(text).then(() => {
+                clearTimeout(copyTimeout);
+                clearTimeout(failTimeout);
+                btn.classList.add("copied");
+                btn.setAttribute("aria-label", "Copied!");
+                copyTimeout = setTimeout(() => {
+                  btn.classList.remove("copied");
+                  btn.setAttribute("aria-label", "Copy code");
+                }, 1500);
+              }).catch(() => {
+                clearTimeout(copyTimeout);
+                clearTimeout(failTimeout);
+                btn.classList.remove("copied");
+                btn.setAttribute("aria-label", "Copy failed");
+                failTimeout = setTimeout(() => btn.setAttribute("aria-label", "Copy code"), 2000);
+              });
+            });
+
+            wrapper.appendChild(btn);
+          } catch (_e) {
+            // DOM error on this block — skip it, continue with remaining blocks
+          }
+        });
+      }
+    </script>
   </body>
 </html>

--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -77,7 +77,7 @@ const nextPage = currentIndex < allPages.length - 1 ? allPages[currentIndex + 1]
 
     <!-- Body: Sidebar + Content + TOC -->
     <div class="relative max-w-7xl mx-auto grid grid-cols-12 gap-8 px-8">
-      <div class="docs-grid-bg"></div>
+      <div class="grid-bg grid-bg-fade absolute inset-0 pointer-events-none"></div>
 
       <!-- Left Sidebar (off-canvas drawer on mobile, static column on md+) -->
       <aside id="docs-sidebar" class="fixed top-14 left-0 h-[calc(100vh-56px)] w-72 z-40 bg-background overflow-y-auto pt-8 pb-12 border-r border-border -translate-x-full md:translate-x-0 md:static md:col-span-3 md:w-auto md:h-[calc(100vh-56px)] md:z-auto md:bg-transparent md:border-r-0 md:sticky md:top-14">

--- a/ui/apps/docs/src/styles/global.css
+++ b/ui/apps/docs/src/styles/global.css
@@ -330,6 +330,86 @@ html {
 
 /* Code blocks */
 
+.code-block {
+  position: relative;
+  margin-bottom: 20px;
+}
+
+.prose .code-block pre {
+  margin-bottom: 0;
+}
+
+.code-copy-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: theme('colors.hover-strong');
+  border: 1px solid theme('colors.border');
+  border-radius: 6px;
+  color: theme('colors.text-muted');
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+
+.code-block:hover .code-copy-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Touch devices: always show the button (no :hover available) */
+@media (hover: none) {
+  .code-copy-btn {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.code-copy-btn:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+  outline: 2px solid theme('colors.primary.DEFAULT');
+  outline-offset: 2px;
+}
+
+.code-copy-btn:hover {
+  background: theme('colors.hover-strong');
+  color: theme('colors.text-secondary');
+}
+
+.code-copy-btn.copied {
+  color: theme('colors.accent.green');
+  border-color: theme('colors.accent.green / 30%');
+}
+
+.code-copy-btn svg {
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+}
+
+.code-copy-btn .icon-copy {
+  display: block;
+}
+
+.code-copy-btn .icon-check {
+  display: none;
+}
+
+.code-copy-btn.copied .icon-copy {
+  display: none;
+}
+
+.code-copy-btn.copied .icon-check {
+  display: block;
+}
+
 .prose pre {
   position: relative;
   background: #141517;

--- a/ui/apps/docs/src/styles/global.css
+++ b/ui/apps/docs/src/styles/global.css
@@ -13,34 +13,16 @@ html {
   scroll-margin-top: 5rem;
 }
 
-/* ══════════════════════════════════════
-   Background Patterns (complex gradients)
-   ══════════════════════════════════════ */
-
-/* Content page grid background */
-.docs-grid-bg {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image:
-    linear-gradient(rgba(102, 122, 204, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(102, 122, 204, 0.03) 1px, transparent 1px);
-  background-size: 40px 40px;
-  mask-image: linear-gradient(to bottom, rgba(0,0,0,0.5) 0%, transparent 60%);
-  -webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,0.5) 0%, transparent 60%);
-}
-
-/* Hero section grid background */
-.docs-hero-grid {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image:
-    linear-gradient(rgba(102, 122, 204, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(102, 122, 204, 0.04) 1px, transparent 1px);
-  background-size: 40px 40px;
-  mask-image: radial-gradient(ellipse 80% 100% at 50% 0%, rgba(0,0,0,0.6) 0%, transparent 70%);
-  -webkit-mask-image: radial-gradient(ellipse 80% 100% at 50% 0%, rgba(0,0,0,0.6) 0%, transparent 70%);
+@layer components {
+  /* Fade modifier: top-anchored linear mask for the shared .grid-bg utility */
+  .grid-bg-fade {
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5) 0%, transparent 60%);
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.5) 0%,
+      transparent 60%
+    );
+  }
 }
 
 /* ══════════════════════════════════════


### PR DESCRIPTION
## What
Two self-contained presentation cleanups in the `docs` app: code blocks now have a copy-to-clipboard button, and the content-page grid background reuses the shared `.grid-bg` utility instead of a docs-local duplicate.

## Why
Groundwork before the real documentation content lands — both are reader-facing polish independent of the larger `@shellhub/design-system` extraction (SiteHeader, `Callout`, shared diagrams remain deferred) and touch no `*.mdx` content. They remove a grid-background duplicate and add a missing copy affordance called out in the cross-app shared-components map (team#114).

## Changes
- **grid background**: `DocsLayout.astro` now composes the shared `.grid-bg` (from `@shellhub/design-system/css/base.css`) with a small docs-local `.grid-bg-fade` mask modifier, replacing the near-identical `.docs-grid-bg`. The shared `base.css` is left untouched, so the 8 existing `.grid-bg` consumers across console/website/docs are unaffected. The dead `.docs-hero-grid` class (zero consumers) is removed. Color source shifts from a hardcoded `rgba(102,122,204,…)` literal to the `--color-primary-rgb` variable, which resolves identically.
- **copy button**: a self-contained vanilla script wraps each `.prose pre` in a `.code-block` and appends a sibling button. The wrapper sits outside the `<pre>`'s `overflow-x` scroll area so the button is never clipped on long lines. Copy uses `navigator.clipboard` with `textContent` (entity-safe), strips trailing newlines, and shows a transient confirmation. The button is keyboard-focusable, hidden until hover/focus (always shown on touch via `@media (hover: none)`), bails when the Clipboard API is unavailable, and is wrapped in `try/catch` so a failure can never break the existing TOC or drawer scripts.

## Testing
Run the docs app and open any page with a fenced code block. Verify the copy button appears on hover and on keyboard focus, copies the exact code (no trailing blank line), and stays visible when scrolling a wide code block horizontally. Confirm the content-page grid still fades from the top as before, and spot-check a console and a website page using `.grid-bg` for no visual regression.
