### PR TITLE
fix(ui): show pagination item count on single-page lists

### DIFF
--- a/ui/apps/console/src/components/common/Pagination.tsx
+++ b/ui/apps/console/src/components/common/Pagination.tsx
@@ -13,36 +13,57 @@ export default function Pagination({
   itemLabel = "item",
   onPageChange,
 }: Props) {
-  if (totalPages <= 1) return null;
+  // Nothing to render: no navigation needed and no positive count to show.
+  // (Empty lists — totalCount 0 — defer to each page's own empty-state.)
+  if (totalPages <= 1 && !totalCount) return null;
+
+  const countLabel =
+    totalCount !== undefined
+      ? `${totalCount} ${itemLabel}${totalCount !== 1 ? "s" : ""}`
+      : null;
+
+  const leftLabel =
+    countLabel ??
+    (totalPages > 1 ? `Page ${page} of ${totalPages}` : null);
 
   return (
-    <div className="flex items-center justify-between mt-4 px-1">
-      <span className="text-2xs font-mono text-text-muted">
-        {totalCount !== undefined
-          ? `${totalCount} ${itemLabel}${totalCount !== 1 ? "s" : ""}`
-          : `Page ${page} of ${totalPages}`}
-      </span>
-      <div className="flex items-center gap-1">
-        <button
-          type="button"
-          onClick={() => onPageChange(page - 1)}
-          disabled={page <= 1}
-          className="px-2.5 py-1 text-xs font-mono text-text-secondary hover:text-text-primary disabled:opacity-soft disabled:cursor-not-allowed transition-colors"
-        >
-          Prev
-        </button>
-        <span className="text-xs font-mono text-text-muted tabular-nums px-2">
-          {page} / {totalPages}
-        </span>
-        <button
-          type="button"
-          onClick={() => onPageChange(page + 1)}
-          disabled={page >= totalPages}
-          className="px-2.5 py-1 text-xs font-mono text-text-secondary hover:text-text-primary disabled:opacity-soft disabled:cursor-not-allowed transition-colors"
-        >
-          Next
-        </button>
-      </div>
-    </div>
+    <nav
+      aria-label="Pagination"
+      className="flex items-center justify-between mt-4 px-1"
+    >
+      {leftLabel ? (
+        <span className="text-xs font-mono text-text-muted">{leftLabel}</span>
+      ) : (
+        <span />
+      )}
+      {totalPages > 1 && (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onPageChange(page - 1)}
+            disabled={page <= 1}
+            aria-label="Previous page"
+            className="px-2.5 py-1 text-xs font-medium text-text-secondary hover:text-text-primary disabled:opacity-soft disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 rounded"
+          >
+            Prev
+          </button>
+          <span
+            className="text-xs font-mono text-text-muted tabular-nums px-2"
+            aria-current="page"
+          >
+            {page} / {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => onPageChange(page + 1)}
+            disabled={page >= totalPages}
+            aria-label="Next page"
+            className="px-2.5 py-1 text-xs font-medium text-text-secondary hover:text-text-primary disabled:opacity-soft disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 rounded"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </nav>
   );
 }

--- a/ui/apps/console/src/components/common/__tests__/Pagination.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/Pagination.test.tsx
@@ -1,14 +1,153 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import Pagination from "../Pagination";
 
 describe("Pagination", () => {
   it("Prev and Next buttons have explicit type='button'", () => {
-    render(<Pagination page={1} totalPages={3} onPageChange={() => {}} />);
-    // must pass totalPages >= 2 so buttons render
+    render(
+      <Pagination page={1} totalPages={3} totalCount={30} onPageChange={() => {}} />,
+    );
     const buttons = screen.getAllByRole("button");
     buttons.forEach((btn) => {
       expect(btn).toHaveAttribute("type", "button");
+    });
+  });
+
+  it("shows count for single-page non-empty list and no navigation buttons", () => {
+    const { container } = render(
+      <Pagination page={1} totalPages={1} totalCount={5} onPageChange={() => {}} />,
+    );
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText("5 items")).toBeInTheDocument();
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("uses singular label when totalCount is 1", () => {
+    const { container } = render(
+      <Pagination page={1} totalPages={1} totalCount={1} onPageChange={() => {}} />,
+    );
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText("1 item")).toBeInTheDocument();
+  });
+
+  it("renders null for an empty list (totalCount 0, totalPages 0)", () => {
+    // Empty lists defer to each page's own empty-state, so Pagination renders nothing
+    // rather than a lonely "0 items" beside it.
+    const { container } = render(
+      <Pagination page={1} totalPages={0} totalCount={0} onPageChange={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows count but no navigation when totalPages is 0 yet totalCount is provided and non-zero", () => {
+    const { container } = render(
+      <Pagination page={1} totalPages={0} totalCount={7} onPageChange={() => {}} />,
+    );
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText("7 items")).toBeInTheDocument();
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("renders null when totalCount is omitted and totalPages is 1", () => {
+    const { container } = render(
+      <Pagination page={1} totalPages={1} onPageChange={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders Prev/Next navigation when totalPages > 1 and totalCount is omitted", () => {
+    render(
+      <Pagination page={1} totalPages={3} onPageChange={() => {}} />,
+    );
+    expect(screen.queryAllByRole("button")).toHaveLength(2);
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+    // No item-count label when totalCount is not provided; Page X of Y fallback renders instead
+    expect(screen.queryByText(/item/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+  });
+
+  it("Prev is disabled on the first page when totalCount is omitted", () => {
+    render(
+      <Pagination page={1} totalPages={3} onPageChange={() => {}} />,
+    );
+    expect(screen.getByText("Prev")).toBeDisabled();
+    expect(screen.getByText("Next")).not.toBeDisabled();
+  });
+
+  it("Next is disabled on the last page when totalCount is omitted", () => {
+    render(
+      <Pagination page={3} totalPages={3} onPageChange={() => {}} />,
+    );
+    expect(screen.getByText("Next")).toBeDisabled();
+    expect(screen.getByText("Prev")).not.toBeDisabled();
+  });
+
+  it("shows count, two navigation buttons, and page indicator with multiple pages", () => {
+    render(
+      <Pagination page={2} totalPages={3} totalCount={30} onPageChange={() => {}} />,
+    );
+    expect(screen.getByText("30 items")).toBeInTheDocument();
+    expect(screen.queryAllByRole("button")).toHaveLength(2);
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+  });
+
+  it("Prev button calls onPageChange with page - 1", async () => {
+    const onPageChange = vi.fn();
+    render(
+      <Pagination page={2} totalPages={3} totalCount={30} onPageChange={onPageChange} />,
+    );
+    await userEvent.click(screen.getByText("Prev"));
+    expect(onPageChange).toHaveBeenCalledOnce();
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it("Next button calls onPageChange with page + 1", async () => {
+    const onPageChange = vi.fn();
+    render(
+      <Pagination page={2} totalPages={3} totalCount={30} onPageChange={onPageChange} />,
+    );
+    await userEvent.click(screen.getByText("Next"));
+    expect(onPageChange).toHaveBeenCalledOnce();
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it("renders null when totalCount is 0 and totalPages is 1", () => {
+    // A single empty page has nothing to navigate and no positive count to show,
+    // so it defers to the page's own empty-state.
+    const { container } = render(
+      <Pagination page={1} totalPages={1} totalCount={0} onPageChange={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe("accessibility", () => {
+    it("wraps the controls in a labelled navigation landmark", () => {
+      render(
+        <Pagination page={1} totalPages={3} totalCount={30} onPageChange={() => {}} />,
+      );
+      expect(
+        screen.getByRole("navigation", { name: "Pagination" }),
+      ).toBeInTheDocument();
+    });
+
+    it("exposes the Prev/Next buttons via aria-label, not just text", () => {
+      render(
+        <Pagination page={2} totalPages={3} totalCount={30} onPageChange={() => {}} />,
+      );
+      expect(
+        screen.getByRole("button", { name: "Previous page" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Next page" }),
+      ).toBeInTheDocument();
+    });
+
+    it("marks the page indicator with aria-current", () => {
+      render(
+        <Pagination page={2} totalPages={3} totalCount={30} onPageChange={() => {}} />,
+      );
+      expect(screen.getByText("2 / 3")).toHaveAttribute("aria-current", "page");
     });
   });
 });

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -36,6 +36,7 @@ import {
 } from "@heroicons/react/24/outline";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
+import Pagination from "@/components/common/Pagination";
 import { Badge, Button, IconButton } from "@shellhub/design-system/primitives";
 
 /* ─── Constants ─── */
@@ -975,44 +976,17 @@ function WebEndpointsContent() {
                 ))}
               </ul>
 
-              {/* Pagination */}
-              {totalPages > 1 && (
-                <nav
-                  aria-label="Pagination"
-                  className="flex items-center justify-between mt-4 px-1"
-                >
-                  <span className="text-xs font-mono text-text-muted">
-                    {totalCount} endpoint
-                    {totalCount !== 1 ? "s" : ""}
-                  </span>
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      onClick={() => setPage(page - 1)}
-                      disabled={page <= 1}
-                      aria-label="Previous page"
-                      className="px-2.5 py-1 text-xs font-medium text-text-secondary hover:text-text-primary disabled:opacity-soft disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 rounded"
-                    >
-                      Prev
-                    </button>
-                    <span
-                      className="text-xs font-mono text-text-muted px-2"
-                      aria-current="page"
-                    >
-                      {page} /{totalPages}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => setPage(page + 1)}
-                      disabled={page >= totalPages}
-                      aria-label="Next page"
-                      className="px-2.5 py-1 text-xs font-medium text-text-secondary hover:text-text-primary disabled:opacity-soft disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 rounded"
-                    >
-                      Next
-                    </button>
-                  </div>
-                </nav>
-              )}
+              {/* Pagination — the shared component shows the count whenever
+                  there are endpoints and only renders Prev/Next on multiple
+                  pages; empty/no-results states are handled by the branches
+                  above, so it never renders a "0 endpoints" bar here. */}
+              <Pagination
+                page={page}
+                totalPages={totalPages}
+                totalCount={totalCount}
+                itemLabel="endpoint"
+                onPageChange={setPage}
+              />
             </>
           )}
         </>

--- a/ui/apps/console/src/pages/__tests__/WebEndpoints.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/WebEndpoints.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { Webendpoint } from "@/client/types.gen";
+import WebEndpoints from "../WebEndpoints";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+vi.mock("@/hooks/useWebEndpoints");
+vi.mock("@/hooks/useWebEndpointMutations");
+vi.mock("@/hooks/useDevices");
+vi.mock("@/hooks/useResetOnOpen");
+vi.mock("@/hooks/useHasPermission");
+vi.mock("@/hooks/useDebouncedValue");
+
+import { useWebEndpoints } from "@/hooks/useWebEndpoints";
+import { useDeleteWebEndpoint, useCreateWebEndpoint } from "@/hooks/useWebEndpointMutations";
+import { useDevices } from "@/hooks/useDevices";
+import { useHasPermission } from "@/hooks/useHasPermission";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+
+const mockUseWebEndpoints = vi.mocked(useWebEndpoints);
+const mockUseDeleteWebEndpoint = vi.mocked(useDeleteWebEndpoint);
+const mockUseCreateWebEndpoint = vi.mocked(useCreateWebEndpoint);
+const mockUseDevices = vi.mocked(useDevices);
+const mockUseHasPermission = vi.mocked(useHasPermission);
+const mockUseDebouncedValue = vi.mocked(useDebouncedValue);
+
+// Minimal fixture for the fields WebEndpoints renders; cast to the full
+// generated type so the mocked hook return stays type-compatible.
+function makeEndpoint(address: string): Webendpoint {
+  return {
+    address,
+    full_address: address,
+    namespace: "00000000-0000-4000-0000-000000000000",
+    device_uid: "dev-uid",
+    host: "localhost",
+    port: 8080,
+    ttl: 30,
+    expires_in: "0001-01-01T00:00:00Z",
+    created_at: "2024-01-15T10:00:00Z",
+    device: { name: "my-device", uid: "dev-uid" },
+  } as unknown as Webendpoint;
+}
+
+function setupDefaultMocks() {
+  mockUseDeleteWebEndpoint.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useDeleteWebEndpoint>);
+
+  mockUseCreateWebEndpoint.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    reset: vi.fn(),
+  } as unknown as ReturnType<typeof useCreateWebEndpoint>);
+
+  mockUseDevices.mockReturnValue({
+    devices: [],
+    totalCount: 0,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+
+  mockUseHasPermission.mockReturnValue(true);
+  mockUseDebouncedValue.mockImplementation((v: unknown) => v);
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <WebEndpoints />
+    </MemoryRouter>,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  setupDefaultMocks();
+});
+
+describe("WebEndpoints — pagination count / controls decoupling", () => {
+  it("shows the endpoint count when totalCount > 0 and only one page exists", () => {
+    // One endpoint fits on a single page — totalPages = Math.ceil(1/10) = 1
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: [makeEndpoint("ep1.example.com")],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    // The count span MUST appear even though there is only 1 page
+    expect(screen.getByText(/1 endpoint/i)).toBeInTheDocument();
+  });
+
+  it("hides Prev/Next controls when only one page exists", () => {
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: [makeEndpoint("ep1.example.com")],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    // Prev/Next must NOT be present when totalPages === 1.
+    // The buttons expose their accessible name via aria-label ("Previous/Next page").
+    expect(
+      screen.queryByRole("button", { name: /previous page/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /next page/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Prev/Next controls and the count when multiple pages exist", () => {
+    // 15 endpoints across 2 pages (perPage = 10)
+    const endpoints = Array.from({ length: 10 }, (_, i) =>
+      makeEndpoint(`ep${i + 1}.example.com`),
+    );
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: endpoints,
+      totalCount: 15,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    expect(screen.getByText(/15 endpoints/i)).toBeInTheDocument();
+    // The buttons expose their accessible name via aria-label ("Previous/Next page").
+    expect(
+      screen.getByRole("button", { name: /previous page/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next page/i })).toBeInTheDocument();
+  });
+
+  it("does not show the Pagination nav when there are no endpoints (truly empty, no search)", () => {
+    // isTrulyEmpty=true -> EmptyState renders; Pagination component is never mounted.
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: [],
+      totalCount: 0,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+
+    // The EmptyState branch is taken — no pagination rendered at all.
+    expect(screen.queryByText(/0 endpoints/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /previous page/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not flash a '0 endpoints' count while a search request is in-flight", () => {
+    // isSearching=true, isLoading=true -> the Pagination component must be suppressed
+    // so stale zero counts do not appear mid-request.
+    mockUseDebouncedValue.mockReturnValue("some-query");
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: [],
+      totalCount: 0,
+      isLoading: true,
+      error: null,
+    });
+
+    renderPage();
+
+    expect(screen.queryByText(/0 endpoints/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /previous page/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
@@ -378,10 +378,10 @@ describe("AdminAnnouncements", () => {
       });
       renderPage();
       expect(
-        screen.queryByRole("button", { name: /prev/i }),
+        screen.queryByRole("button", { name: "Previous page" }),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: /next/i }),
+        screen.queryByRole("button", { name: "Next page" }),
       ).not.toBeInTheDocument();
     });
 
@@ -396,8 +396,12 @@ describe("AdminAnnouncements", () => {
         totalCount: 25,
       });
       renderPage();
-      expect(screen.getByRole("button", { name: "Prev" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Previous page" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Next page" }),
+      ).toBeInTheDocument();
     });
 
     it("renders the item count label in the pagination area", () => {

--- a/ui/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -149,8 +149,6 @@ function ApiKeysTab() {
         loadingMessage="Loading API keys..."
         page={page}
         totalPages={totalPages}
-        totalCount={totalCount}
-        itemLabel="key"
         onPageChange={setPage}
         // border-l-2 on every row (transparent by default) keeps the row
         // height stable when the red border appears on expired keys.

--- a/ui/apps/console/src/pages/team/InvitationsTab.tsx
+++ b/ui/apps/console/src/pages/team/InvitationsTab.tsx
@@ -330,8 +330,6 @@ function InvitationsTab({ tenantId }: { tenantId: string }) {
         loadingMessage="Loading invitations..."
         page={page}
         totalPages={totalPages}
-        totalCount={totalCount}
-        itemLabel="invitation"
         onPageChange={setPage}
         rowClassName={(inv) =>
           inv.status === "pending" && isInvitationExpired(inv.expires_at)

--- a/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -95,6 +95,38 @@ beforeEach(() => {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
+describe("ApiKeysTab — pagination count display", () => {
+  it("does not pass totalCount to DataTable so count is shown only in the header (single page)", () => {
+    render(<ApiKeysTab />);
+
+    // The header renders "1 key" exactly once — the Pagination below the table
+    // must NOT duplicate it (totalCount is intentionally not forwarded to DataTable).
+    const countMatches = screen.getAllByText(/\b1 key\b/);
+    expect(countMatches).toHaveLength(1);
+  });
+
+  it("renders Prev/Next navigation buttons when there are more than PER_PAGE keys", () => {
+    // 25 total keys, 10 on the current page -> totalPages=3, page=1
+    const keys = Array.from({ length: 10 }, (_, i) =>
+      makeApiKey({ name: `key-${i}`, created_by: `user-${i}` }),
+    );
+    vi.mocked(useApiKeys).mockReturnValue({
+      apiKeys: keys,
+      totalCount: 25,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ApiKeysTab />);
+
+    // Prev/Next buttons must exist even though totalCount is not passed to DataTable
+    expect(screen.getByRole("button", { name: /prev/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+    // Page indicator
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+});
+
 describe("ApiKeysTab — delete error handling", () => {
   async function openDeleteDialog() {
     const user = userEvent.setup();

--- a/ui/apps/console/src/pages/team/__tests__/InvitationsTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/InvitationsTab.test.tsx
@@ -154,14 +154,35 @@ beforeEach(() => {
 
 describe("InvitationsTab", () => {
   describe("rendering", () => {
-    it("shows the invitation count from totalCount", () => {
+    it("shows the invitation count from totalCount exactly once in the header (not duplicated in the DataTable pagination footer)", () => {
       mockInvitations.mockReturnValue({
         invitations: [],
         totalCount: 5,
         isLoading: false,
       });
       renderTab();
-      expect(screen.getByText(/5 invitation/i)).toBeInTheDocument();
+      // The count label must appear exactly once — in the dedicated header paragraph.
+      // totalCount is intentionally not forwarded to DataTable to avoid duplication.
+      expect(screen.getAllByText(/5 invitations/i)).toHaveLength(1);
+    });
+
+    it("renders Prev/Next navigation buttons when there are more than PER_PAGE invitations", () => {
+      // 25 total invitations, 10 on the current page -> totalPages=3, page=1
+      const invitations = Array.from({ length: 10 }, (_, i) =>
+        makeInvitation({ user: { id: `u${i}`, email: `user${i}@example.com` } }),
+      );
+      mockInvitations.mockReturnValue({
+        invitations,
+        totalCount: 25,
+        isLoading: false,
+      });
+      renderTab();
+
+      // Prev/Next buttons must exist even though totalCount is not passed to DataTable
+      expect(screen.getByRole("button", { name: /prev/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+      // Page indicator
+      expect(screen.getByText("1 / 3")).toBeInTheDocument();
     });
 
     it("uses singular 'invitation' when count is 1", () => {


### PR DESCRIPTION
## What

Fix the shared `Pagination` component so it shows the item-count label on single-page lists,
and uplevel it to the accessible markup that was previously unique to the WebEndpoints page —
then reuse it there, removing the duplication.

## Why

`Pagination` returned `null` whenever `totalPages <= 1`, hiding the item-count label together
with the (legitimately unneeded) Prev/Next controls. The count and the controls have independent
visibility rules and should be decoupled.

Separately, the WebEndpoints page had its own ad-hoc pagination that was *more* accessible than
the shared component (navigation landmark, `aria-label`led buttons, `aria-current`, focus rings).
Keeping the better version siloed in one page left every other list page with the weaker markup.

Closes shellhub-io/team#146

## Changes

- **Pagination.tsx**: Guard is now `if (totalPages <= 1 && !totalCount) return null`, and the
  Prev/Next control group is gated by `totalPages > 1`. The count shows for single-page non-empty
  lists; empty lists (`totalCount` 0) still render `null` so each page's own empty-state stays the
  sole feedback (every list hook returns `totalCount ?? 0`, and each list page already renders a
  dedicated empty-state at `totalCount === 0`, so this avoids stacking a lonely "0 items").
  The component also adopts the richer accessible markup: a `<nav aria-label="Pagination">`
  landmark, `aria-label`led Prev/Next buttons, an `aria-current` page indicator, and
  focus-visible rings — inherited by all ~14 list pages that use it.
- **WebEndpoints.tsx**: Replaced its ad-hoc inline pagination with the shared `Pagination`
  component (per review feedback). Behavior is unchanged.
- **ApiKeysTab.tsx / InvitationsTab.tsx**: Stopped forwarding `totalCount` to their `DataTable`,
  since both render their own count header — otherwise the shared Pagination would duplicate it
  (this also removes a pre-existing multi-page duplicate).
- **Tests**: Extended `Pagination.test.tsx` (single-page count, singular label, empty/`null`
  cases, multi-page controls, and the new navigation landmark / button accessible-name /
  `aria-current` assertions). Updated `WebEndpoints`, `ApiKeysTab`, `InvitationsTab`, and
  `AdminAnnouncements` tests to query the Prev/Next buttons by their new accessible names
  (`"Previous page"` / `"Next page"`) instead of their text content.

## Testing

Full console `vitest` suite passes (2292 tests). `tsc --noEmit` and `eslint` are clean
(0 errors) on the touched files.
