### PR TITLE
refactor(api): remove dead UserChanges and TagChanges structs

### DIFF
--- a/pkg/models/tags.go
+++ b/pkg/models/tags.go
@@ -31,10 +31,6 @@ type Tag struct {
 	UpdatedAt time.Time `json:"updated_at" bson:"updated_at"`
 }
 
-type TagChanges struct {
-	Name string `bson:"name,omitempty"`
-}
-
 type TagConflicts struct {
 	Name string
 }

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -175,23 +175,6 @@ type UserTokenRecover struct {
 	CreatedAt time.Time `json:"created_at" bson:"created_at"`
 }
 
-// UserChanges specifies the attributes that can be updated for a user. Any zero values in this
-// struct must be ignored. If an attribute is a pointer type, its zero value is represented as `nil`.
-type UserChanges struct {
-	LastLogin          time.Time        `bson:"last_login,omitempty"`
-	Name               string           `bson:"name,omitempty"`
-	Username           string           `bson:"username,omitempty"`
-	Email              string           `bson:"email,omitempty"`
-	RecoveryEmail      string           `bson:"recovery_email,omitempty"`
-	Password           string           `bson:"password,omitempty"`
-	Status             UserStatus       `bson:"status,omitempty"`
-	ExternalID         *string          `bson:"external_id,omitempty"`
-	PreferredNamespace *string          `bson:"preferences.preferred_namespace,omitempty"`
-	MaxNamespaces      *int             `bson:"max_namespaces,omitempty"`
-	EmailMarketing     *bool            `bson:"email_marketing,omitempty"`
-	AuthMethods        []UserAuthMethod `bson:"preferences.auth_methods,omitempty"`
-}
-
 type UserInfo struct {
 	// OwnedNamespaces are the namespaces where the user is the owner.
 	OwnedNamespaces []Namespace


### PR DESCRIPTION
## What

Removes the last two `${Model}Changes` partial-update structs —
`models.UserChanges` and `models.TagChanges` — that were left behind after
the Mongo→Postgres store migration.

## Why

The Postgres migration replaced the per-model `${Model}Changes` structs with
direct `Update(ctx, *models.<Model>)` methods that take the full model. The
user and tag callers were migrated, but the struct definitions were never
deleted. They are now dead code: a whole-repo, word-boundary grep finds no
reference to either type outside its own definition (the `applyUserChanges`
function is an unrelated substring match and is untouched). A broader audit
confirms no other `${Model}Changes` structs remain.

Closes shellhub-io/team#159 (Stage-3 cleanup, tracked under #38).

## Changes

- **pkg/models/user.go**: deleted the `UserChanges` struct and its doc comment.
- **pkg/models/tags.go**: deleted the `TagChanges` struct.

No store, service, or test changes were needed — nothing referenced these
types, so there was no caller to migrate and no mock to regenerate.

## Testing

- `go build ./...` (root + `api` modules) and `go vet ./services/ ./store/...`
  pass — the vet over the test packages confirms no test referenced the structs.
- `golangci-lint` clean on `pkg/models`.

## Companion PR

A trivial cloud doc-comment fix (`fix/remove-userchanges-doc-ref`) drops a now
dangling `[UserChanges]` godoc link. It should merge in the same window so the
cross-reference is never left broken.