### PR TITLE
refactor(ui): code-quality cleanups (Login, Sidebar, DeviceDetails)

### DIFF
--- a/ui/apps/console/src/components/layout/Sidebar.tsx
+++ b/ui/apps/console/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useCallback, type ReactNode } from "react";
 import { getConfig } from "@/env";
 import { useTerminalStore } from "@/stores/terminalStore";
 import {
@@ -155,7 +155,7 @@ export default function Sidebar({
     state.sessions.some((session) => session.state === "fullscreen"),
   );
 
-  const sections = useMemo(() => buildSections(), []);
+  const sections = buildSections();
 
   const handleNavClick = useCallback(() => {
     minimizeAll();

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import Breadcrumb from "@/components/common/Breadcrumb";
+import { LABEL_BASE } from "@/utils/styles";
 import {
   TrashIcon,
   InformationCircleIcon,
@@ -32,8 +33,6 @@ import CustomFieldsSection from "./devices/CustomFieldsSection";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 /* ─── Shared styles ─── */
-const LABEL =
-  "text-2xs font-mono font-semibold uppercase tracking-label text-text-muted";
 const VALUE = "text-sm text-text-primary font-medium mt-0.5";
 
 /* ─── Page ─── */
@@ -253,7 +252,7 @@ export default function DeviceDetails() {
       {device.status === "accepted" && (
         <Card className="p-4 mb-6 flex items-center justify-between gap-4">
           <div>
-            <p className={LABEL}>SSHID</p>
+            <p className={LABEL_BASE}>SSHID</p>
             <code className="text-sm font-mono text-accent-cyan mt-0.5 block">
               {sshid}
             </code>
@@ -307,7 +306,7 @@ export default function DeviceDetails() {
               mono
             />
             <div>
-              <dt className={LABEL}>Platform</dt>
+              <dt className={LABEL_BASE}>Platform</dt>
               <dd className="mt-1">
                 {device.info?.platform ? (
                   <PlatformBadge platform={device.info.platform} />
@@ -331,11 +330,11 @@ export default function DeviceDetails() {
           </h3>
           <dl className="space-y-3">
             <div>
-              <dt className={LABEL}>Created</dt>
+              <dt className={LABEL_BASE}>Created</dt>
               <dd className={VALUE}>{formatDateFull(device.created_at)}</dd>
             </div>
             <div>
-              <dt className={LABEL}>Last Seen</dt>
+              <dt className={LABEL_BASE}>Last Seen</dt>
               <dd className="flex items-center gap-2 mt-0.5">
                 <span className="text-sm text-text-primary font-medium">
                   {formatRelative(device.last_seen)}
@@ -346,7 +345,7 @@ export default function DeviceDetails() {
               </dd>
             </div>
             <div>
-              <dt className={LABEL}>Status Updated</dt>
+              <dt className={LABEL_BASE}>Status Updated</dt>
               <dd className={VALUE}>
                 {formatDateFull(device.status_update_at ?? "")}
               </dd>

--- a/ui/apps/console/src/pages/Login.tsx
+++ b/ui/apps/console/src/pages/Login.tsx
@@ -68,8 +68,7 @@ function useLoginCountdown(lockoutEndEpoch: number | null) {
 }
 
 export default function Login() {
-  const isCloud = getConfig().cloud;
-  const isEnterprise = getConfig().enterprise;
+  const { cloud: isCloud, enterprise: isEnterprise } = getConfig();
   const location = useLocation();
   const rawState = location.state as Record<string, unknown> | null;
   const notice =


### PR DESCRIPTION
## What

Three small, non-visual code-quality cleanups in the console UI, each its own commit.

## Changes

- **Login.tsx** — destructure `getConfig()` once instead of calling it twice. Closes shellhub-io/team#142
- **Sidebar.tsx** — drop the misleading `useMemo(() => buildSections(), [])`; `buildSections()` reads a static config singleton and has no reactive inputs, so the empty-dep memo was misleading and would silently go stale if config became reactive. Call it directly. Closes shellhub-io/team#143
- **DeviceDetails.tsx** — replace the local `LABEL` constant (which duplicated the shared label style) with the shared `LABEL_BASE` export to remove drift risk. `LABEL_BASE` is the correct match: the local string equals it minus the leading `block` utility (a no-op on the `<p>`/`<dt>` elements it's used on), whereas the `LABEL` export would add an unwanted `mb-1.5` margin. Closes shellhub-io/team#144

## Testing

`eslint` and `tsc --noEmit` clean on all three files. Existing `Login.test.tsx` passes (21/21). Sidebar and DeviceDetails have no test files; changes are mechanical with no behavioral or visual change.