### PR TITLE
fix(ui): hide decorative StatCard icon from assistive tech

### DIFF
--- a/ui/apps/console/src/components/common/StatCard.tsx
+++ b/ui/apps/console/src/components/common/StatCard.tsx
@@ -27,7 +27,10 @@ export default function StatCard(props: StatCardProps) {
 
   return (
     <Card className="rounded-lg p-6 flex flex-col items-center text-center group hover:border-primary/30 transition-all duration-300">
-      <div className="w-14 h-14 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center text-primary mb-5">
+      <div
+        aria-hidden="true"
+        className="w-14 h-14 rounded-xl bg-primary/10 border border-primary/20 flex items-center justify-center text-primary mb-5"
+      >
         {icon}
       </div>
 

--- a/ui/apps/console/src/components/common/__tests__/StatCard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/StatCard.test.tsx
@@ -55,4 +55,13 @@ describe("StatCard", () => {
       screen.getByRole("button", { name: /view pending/i }),
     ).toBeInTheDocument();
   });
+
+  it("hides the decorative icon wrapper from assistive technology", () => {
+    renderLink();
+    // closest() is robust to any intermediate wrapper the icon slot might add.
+    expect(screen.getByText("icon").closest("[aria-hidden]")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
 });


### PR DESCRIPTION
## What

Mark the StatCard decorative icon wrapper `aria-hidden` so screen readers no longer announce it before the card's title and value.

## Why

`StatCard.tsx`'s icon wrapper `<div>` is purely decorative but was exposed in the accessibility tree. Note: the Heroicons SVGs themselves already render `aria-hidden`, but the wrapper element was not — so the wrapper subtree was still reachable by assistive tech. Marking the wrapper `aria-hidden="true"` silences it cleanly.

Closes shellhub-io/team#134

## Changes

- **StatCard.tsx** — add `aria-hidden="true"` to the icon wrapper `<div>`. Applies anywhere StatCard renders, including the user dashboard and `admin/Dashboard.tsx`.
- **StatCard.test.tsx** — assert the icon wrapper is hidden from assistive tech, using `closest("[aria-hidden]")` so the selector is robust to any future intermediate wrapper.

## Testing

`vitest` StatCard suite: 5/5 pass. `eslint` and `tsc --noEmit` clean. No visual or behavioral change beyond the accessibility-tree fix.