### PR TITLE
feat(ui): add skip-to-main-content link to app shells

### DIFF
--- a/ui/apps/console/src/components/layout/AdminLayout.tsx
+++ b/ui/apps/console/src/components/layout/AdminLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet, useLocation } from "react-router-dom";
 import AdminSidebar from "./AdminSidebar";
 import AdminAppBar from "./AdminAppBar";
 import { SidebarMobileDrawer } from "./SidebarShell";
+import SkipToContentLink from "./SkipToContentLink";
 import { useSidebarLayout } from "@/hooks/useSidebarLayout";
 
 export default function AdminLayout() {
@@ -11,6 +12,7 @@ export default function AdminLayout() {
 
   return (
     <div className="flex flex-col h-screen bg-background">
+      <SkipToContentLink />
       <div className="flex flex-1 min-h-0">
         {isDesktop ? (
           <div
@@ -47,6 +49,8 @@ export default function AdminLayout() {
           <div className="relative size-full">
             <div className="grid-bg scanline absolute inset-0 -z-10" />
             <main
+              id="main-content"
+              tabIndex={-1}
               key={pathname}
               className="page-enter absolute inset-0 p-8 pb-4 overflow-y-auto"
             >

--- a/ui/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui/apps/console/src/components/layout/AppLayout.tsx
@@ -10,6 +10,7 @@ import AnnouncementModalTrigger from "../announcements/AnnouncementModalTrigger"
 import DeviceChooserTrigger from "../billing/DeviceChooserTrigger";
 import { SidebarMobileDrawer } from "./SidebarShell";
 import ChatwootProvider from "./ChatwootProvider";
+import SkipToContentLink from "./SkipToContentLink";
 import CommandPalette from "@/components/commandPalette/CommandPalette";
 import { useNamespaces } from "@/hooks/useNamespaces";
 import { useTerminalStore } from "@/stores/terminalStore";
@@ -36,6 +37,7 @@ export default function AppLayout() {
       <div
         className={`flex flex-col h-screen bg-background ${hasVisibleTerminal ? "overflow-hidden" : ""}`}
       >
+        <SkipToContentLink />
         <ConnectivityBanner />
         {isEnterprise && (
           <>
@@ -82,6 +84,8 @@ export default function AppLayout() {
             <div className="relative size-full">
               <div className="grid-bg scanline absolute inset-0 -z-10" />
               <main
+                id="main-content"
+                tabIndex={-1}
                 key={pathname}
                 className="page-enter absolute inset-0 p-8 pb-4 overflow-y-auto"
               >

--- a/ui/apps/console/src/components/layout/SkipToContentLink.tsx
+++ b/ui/apps/console/src/components/layout/SkipToContentLink.tsx
@@ -1,0 +1,21 @@
+/**
+ * Skip-to-main-content link for keyboard users (WCAG 2.4.1 Bypass Blocks).
+ * Rendered as the first child of each authenticated layout shell so it is the
+ * first Tab stop; visually offscreen (translated up) until focused, when it
+ * slides into view at top-left. Activating it moves focus to `#main-content`.
+ *
+ * Trade-off: when the mobile sidebar drawer is open it sets `aria-modal`, so
+ * screen readers treat this link (outside the drawer) as inert until the drawer
+ * closes. That is acceptable — the skip link is not meaningful while the nav
+ * drawer itself is open.
+ */
+export default function SkipToContentLink() {
+  return (
+    <a
+      href="#main-content"
+      className="fixed left-4 top-4 z-[200] -translate-y-20 rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-text-primary transition-transform focus:translate-y-0"
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/ui/apps/console/src/components/layout/__tests__/AdminLayout.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/AdminLayout.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import AdminLayout from "../AdminLayout";
+
+vi.mock("@/hooks/useSidebarLayout", () => ({
+  useSidebarLayout: () => ({
+    expanded: false,
+    pinned: false,
+    isOpen: false,
+    isDesktop: true,
+    drawerOpen: false,
+    handlers: {
+      onMouseEnter: vi.fn(),
+      onMouseLeave: vi.fn(),
+      onFocus: vi.fn(),
+      onBlur: vi.fn(),
+      onToggle: vi.fn(),
+      openDrawer: vi.fn(),
+      closeDrawer: vi.fn(),
+      toggleDrawer: vi.fn(),
+      onDrawerKeyDown: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("../AdminSidebar", () => ({
+  default: () => <nav data-testid="admin-sidebar" />,
+}));
+
+vi.mock("../AdminAppBar", () => ({
+  default: () => <div data-testid="admin-app-bar" />,
+}));
+
+vi.mock("../SidebarShell", () => ({
+  SidebarMobileDrawer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="sidebar-mobile-drawer">{children}</div>
+  ),
+}));
+
+afterEach(cleanup);
+
+function renderLayout() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AdminLayout />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminLayout", () => {
+  describe("skip link", () => {
+    it("renders the skip link pointing at main content", () => {
+      renderLayout();
+      const link = screen.getByRole("link", { name: /skip to main content/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "#main-content");
+    });
+
+    it("exposes the main landmark with id and tabindex", () => {
+      renderLayout();
+      const main = screen.getByRole("main");
+      expect(main).toHaveAttribute("id", "main-content");
+      expect(main).toHaveAttribute("tabindex", "-1");
+    });
+
+    it("renders the skip link before the main content in the DOM", () => {
+      renderLayout();
+      const link = screen.getByRole("link", { name: /skip to main content/i });
+      const main = screen.getByRole("main");
+      expect(
+        link.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+  });
+});

--- a/ui/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
@@ -144,6 +144,44 @@ describe("AppLayout", () => {
     });
   });
 
+  describe("skip link", () => {
+    it("renders the skip link pointing at main content", () => {
+      renderLayout();
+      const link = screen.getByRole("link", { name: /skip to main content/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "#main-content");
+    });
+
+    it("exposes the main landmark with id and tabindex", () => {
+      renderLayout();
+      const main = screen.getByRole("main");
+      expect(main).toHaveAttribute("id", "main-content");
+      expect(main).toHaveAttribute("tabindex", "-1");
+    });
+
+    it("renders the skip link before the main content in the DOM", () => {
+      renderLayout();
+      const link = screen.getByRole("link", { name: /skip to main content/i });
+      const main = screen.getByRole("main");
+      expect(
+        link.compareDocumentPosition(main) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+
+    it("renders the skip link when the sidebar is visible", () => {
+      mockUseNamespaces.mockReturnValue({
+        namespaces: [{ tenant_id: "t1", name: "ns1" }],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderLayout();
+      expect(
+        screen.getByRole("link", { name: /skip to main content/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("enterprise banners", () => {
     it("mounts LicenseBanner and DeviceLimitBanner when enterprise and not cloud", () => {
       mockGetConfig.mockReturnValue({


### PR DESCRIPTION
## What
Adds a keyboard skip-to-content link to both authenticated console shells, so keyboard and screen-reader users can jump straight to the main content instead of tabbing through the entire sidebar on every route change.

## Why
`AppLayout` and `AdminLayout` each render a sidebar with 10+ nav links before `<main>`. With no skip link, keyboard-only users had to traverse the whole sidebar on every navigation — a WCAG 2.4.1 (Bypass Blocks) failure flagged in the ShellHub UI Follow-up Audit.

Fixes: shellhub-io/team#132

## Changes
- **SkipToContentLink**: new presentational component — an `href="#main-content"` anchor rendered as the first child (first Tab stop) of each shell. It uses a fixed-position, transform-offscreen pattern (`-translate-y-20` → `focus:translate-y-0`) rather than `sr-only`/`not-sr-only`, because Tailwind 3's `.not-sr-only` resets `position: static` and silently fights `focus:fixed`. `z-[200]` sits above the highest existing in-app z-index (`z-[90]`).
- **AppLayout / AdminLayout**: render `<SkipToContentLink />` first and add `id="main-content"` + `tabIndex={-1}` to each `<main>` so activating the link moves focus into the content region (not just scrolls). The two shells are route-mutually-exclusive, so sharing the id is safe.
- **Tests**: `AppLayout.test.tsx` gains a skip-link block (link present incl. sidebar-hidden and sidebar-visible states, `<main>` id/tabindex, link-precedes-main DOM order); new `AdminLayout.test.tsx` mirrors the core assertions for the admin shell.

## Testing
`cd ui/apps/console && npm run test` — full suite green (2300 tests). Manual: Tab on any authenticated page; the first stop should reveal "Skip to main content" at top-left, and activating it should move focus into the page body.