### PR TITLE
ci: run Claude code review via Workflow tool instead of Task agents

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -253,120 +253,149 @@ jobs:
                 ## Code Review
 
                 - [x] Gathered PR context
-                - [ ] Reviewing with 5 specialized agents
+                - [ ] Reviewing the diff (parallel workflow)
                 - [ ] Posting feedback
 
-            ## Step 2: Spawn 5 reviewer agents IN PARALLEL
+            ## Step 2: Run the parallel review with the Workflow tool
 
-            Launch exactly 5 Task agents in a SINGLE message (so they run in parallel).
-            Model assignments by agent role:
-            - Agent 1 (Code Quality): model: "sonnet"
-            - Agent 2 (Security): model: "opus"
-            - Agent 3 (Testing): model: "opus"
-            - Agent 4 (Go/TypeScript Patterns): model: "sonnet"
-            - Agent 5 (Architecture & Cross-repo): model: "opus"
-            - Validation subagents (Step 3.5): model: "sonnet"
-            Each agent gets:
-            - The PR diff (pass it in the prompt)
-            - The list of changed files
-            - Read access to the full codebase (current directory for shellhub, $GITHUB_WORKSPACE/cloud/ for cloud)
+            Run the review as a single Workflow that fans out the five review dimensions
+            in parallel and then validates each finding. Do NOT use the Task tool and do
+            NOT spawn Task sub-agents directly.
 
-            Agent assignments:
-            1. **Code Quality**: Project conventions (CLAUDE.md), dead code, single responsibility, error handling, commit hygiene
-            2. **Security**: OWASP Top 10 (injection, XSS, CSRF, SSRF), hardcoded secrets, crypto/rand usage, access control, input validation
-            3. **Testing**: Missing tests for new/changed behavior, edge cases, test determinism, untested error paths
-            4. **Go/TypeScript Patterns**: Error wrapping (%w), goroutine leaks, context propagation, minimal interfaces, React patterns (no `any`, no unnecessary re-renders, Zustand)
-            5. **Architecture & Cross-repo**: If PR changes pkg/, check $GITHUB_WORKSPACE/cloud/ for impact. API contract changes, interface compatibility, breaking changes.
+            First gather the inputs the workflow needs:
+            - PR number: ${{ github.event.pull_request.number || github.event.issue.number }}
+            - The unified diff: run
+              `gh pr diff ${{ github.event.pull_request.number || github.event.issue.number }}`
+              and capture the full output.
 
-            Each agent must return findings as a structured list:
-            - file_path: exact path relative to repo root
-            - line_start and line_end: exact line numbers in the NEW file
-            - severity: critical | high | medium | low
-            - description: what's wrong and why
-            - suggestion: corrected code (if applicable), or empty string
+            Then call the Workflow tool with the script below, passing
+            `args = { "prNumber": <PR number>, "diff": "<the full diff text>" }`.
+            The Workflow returns `{ findings: [...] }` already deduplicated and validated.
 
-            Agent assumptions (applies to all agents):
-            - All tools are functional. Do not test tools or make exploratory calls.
-            - Only call a tool if it is required. Every tool call should have a clear purpose.
-            - Do not speculatively read files unless you have a specific reason to suspect an issue there.
+                export const meta = {
+                  name: 'pr-parallel-review',
+                  description: 'Review the PR diff across five dimensions in parallel, then validate each finding',
+                  phases: [{ title: 'Review' }, { title: 'Validate' }],
+                }
 
-            CRITICAL: Only flag HIGH SIGNAL issues.
+                // args may arrive as a JSON string in this runtime — normalize first.
+                const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
 
-            Flag issues where:
-            - Code will fail to compile or parse (syntax errors, type errors, missing imports)
-            - Code will definitely produce wrong results regardless of inputs (clear logic errors)
-            - Clear, unambiguous CLAUDE.md or project convention violations where you can quote the exact rule
-            - Code introduces an exploitable security vulnerability (not theoretical)
-            - Code will cause data loss, corruption, or undefined behavior
+                const FINDINGS_SCHEMA = {
+                  type: 'object', additionalProperties: false, required: ['findings'],
+                  properties: { findings: { type: 'array', items: {
+                    type: 'object', additionalProperties: false,
+                    required: ['file_path', 'line_start', 'line_end', 'severity', 'description', 'suggestion'],
+                    properties: {
+                      file_path: { type: 'string' },
+                      line_start: { type: 'integer' },
+                      line_end: { type: 'integer' },
+                      severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
+                      description: { type: 'string' },
+                      suggestion: { type: 'string', description: 'corrected code, or empty string' },
+                    } } } },
+                }
 
-            Do NOT flag:
-            - Code style or quality concerns
-            - Potential issues that depend on specific inputs or state
-            - Subjective suggestions or improvements
-            - Performance concerns unless there is a clear algorithmic regression
-            - Suggestions to add comments or documentation
+                const VERDICT_SCHEMA = {
+                  type: 'object', additionalProperties: false,
+                  required: ['confirmed', 'confidence', 'reason'],
+                  properties: {
+                    confirmed: { type: 'boolean' },
+                    confidence: { type: 'integer', description: '0-100' },
+                    reason: { type: 'string' },
+                  },
+                }
 
-            If you are not certain an issue is real, do not flag it.
-            False positives erode trust and waste reviewer time.
+                const HIGH_SIGNAL = [
+                  'CRITICAL: Only flag HIGH SIGNAL issues.',
+                  '',
+                  'Flag issues where:',
+                  '- Code will fail to compile or parse (syntax errors, type errors, missing imports)',
+                  '- Code will definitely produce wrong results regardless of inputs (clear logic errors)',
+                  '- Clear, unambiguous CLAUDE.md or project convention violations where you can quote the exact rule',
+                  '- Code introduces an exploitable security vulnerability (not theoretical)',
+                  '- Code will cause data loss, corruption, or undefined behavior',
+                  '',
+                  'Do NOT flag:',
+                  '- Code style/quality concerns, subjective suggestions, or improvements',
+                  '- Issues that depend on specific inputs or state',
+                  '- Performance concerns unless there is a clear algorithmic regression',
+                  '- Suggestions to add comments or documentation',
+                  '- Pre-existing issues not introduced in this branch diff',
+                  '- Cosmetic formatting or anything a linter/formatter catches (gofmt, eslint, prettier, golangci-lint)',
+                  '- Issues silenced by lint-ignore comments (nolint, eslint-disable, etc.)',
+                  '- Pedantic nitpicks a senior engineer would not flag; error handling for errors already handled upstream',
+                  '',
+                  'If you are not certain an issue is real, do not flag it. False positives erode trust.',
+                ].join('\n')
 
-            Additional rules:
-            - For each suggestion you make, verify it is correct: check that all
-              referenced variables exist, all event fields are available for every
-              trigger type, token permissions are sufficient, and your fix does not
-              introduce new issues.
-            - Read the actual source files (not just the diff) to understand surrounding
-              context before flagging an issue.
-            - Do NOT flag pre-existing issues that were not introduced in this branch.
+                const DIMENSIONS = [
+                  { key: 'quality', brief: 'Code Quality: project conventions (CLAUDE.md), dead code, single responsibility, error handling, commit hygiene' },
+                  { key: 'security', brief: 'Security: OWASP Top 10 (injection, XSS, CSRF, SSRF), hardcoded secrets, crypto/rand usage, access control, input validation' },
+                  { key: 'testing', brief: 'Testing: missing tests for new/changed behavior, edge cases, test determinism, untested error paths' },
+                  { key: 'patterns', brief: 'Go/TypeScript Patterns: error wrapping (%w), goroutine leaks, context propagation, minimal interfaces, React patterns (no any, no unnecessary re-renders, Zustand)' },
+                  { key: 'architecture', brief: 'Architecture & Cross-repo: if the PR changes pkg/, check $GITHUB_WORKSPACE/cloud/ for impact; API contract changes, interface compatibility, breaking changes' },
+                ]
 
-            Agents must NOT post any GitHub comments. They only return findings.
+                phase('Review')
+                const raw = (await parallel(DIMENSIONS.map((d) => () =>
+                  agent(
+                    `You are reviewing PR #${A.prNumber} in shellhub-io/shellhub (Community Edition).\n` +
+                    `Review dimension — ${d.brief}\n\n` +
+                    `Read the actual source files (current dir for shellhub, $GITHUB_WORKSPACE/cloud/ for cloud) ` +
+                    `for surrounding context before flagging anything. Report line numbers in the NEW file.\n\n` +
+                    `${HIGH_SIGNAL}\n\nThe PR diff:\n${A.diff}`,
+                    { label: `review:${d.key}`, phase: 'Review', schema: FINDINGS_SCHEMA },
+                  )
+                ))).filter(Boolean).flatMap((r) => r.findings)
 
-            After all agents complete, update the tracking comment via mcp__github_comment__update_claude_comment:
+                // Deduplicate: same file + same line range + same description.
+                const seen = new Set()
+                const deduped = raw.filter((f) => {
+                  const k = `${f.file_path}:${f.line_start}-${f.line_end}:${f.description}`
+                  if (seen.has(k)) return false
+                  seen.add(k)
+                  return true
+                })
+
+                phase('Validate')
+                const validated = await parallel(deduped.map((f) => () =>
+                  agent(
+                    `Validate this code-review finding against the real source. Read the file at the ` +
+                    `reported location with surrounding context.\n` +
+                    `Confirm it is real (not a misreading, not pre-existing, not assumption-dependent) AND ` +
+                    `introduced in this PR's diff. If a suggestion is given, confirm it compiles and adds no new issue.\n` +
+                    `Set confirmed=false or confidence<80 if unsure.\n\nFinding: ${JSON.stringify(f)}`,
+                    { label: `validate:${f.file_path}:${f.line_start}`, phase: 'Validate', schema: VERDICT_SCHEMA },
+                  ).then((v) => ({ ...f, validation: v }))
+                ))
+
+                const confirmed = validated
+                  .filter(Boolean)
+                  .filter((x) => x.validation.confirmed && x.validation.confidence >= 80)
+                  .map(({ validation, ...f }) => f)
+
+                return { findings: confirmed }
+
+            If the Workflow surfaces more than 10 confirmed findings, re-check that the
+            high-signal filter was applied correctly before posting.
+
+            ## Step 3: Reconcile with existing reviews
+
+            Take the `findings` returned by the Workflow. Compare them against the existing
+            review comments fetched in Step 1 and drop any already reported on the same file
+            and line. If the same logical issue appears at multiple locations, keep the first
+            occurrence and list the rest in its body:
+            "Same issue also at: `path/file.go:42`, `path/other.go:87`".
+
+            Update the tracking comment via mcp__github_comment__update_claude_comment:
 
                 <!-- claude-code-review -->
                 ## Code Review
 
                 - [x] Gathered PR context
-                - [x] Code review complete
+                - [x] Reviewed the diff (parallel workflow)
                 - [ ] Posting feedback
-
-            ## Step 3: Aggregate and deduplicate
-
-            After all 5 agents complete, collect their findings. Then:
-            1. Remove duplicate findings (same file + same line range + same issue)
-            2. If the same pattern repeats across multiple locations, keep only the first occurrence and note "Same issue also at: file:line, file:line, ..."
-            3. Compare against the existing review comments fetched in Step 1. Skip any finding already reported in a previous review thread on the same file and line.
-
-            Post exactly ONE comment per unique issue. If the same logical issue
-            appears in multiple locations, post on the first occurrence and list
-            others in the body: "Same issue also at: `path/file.go:42`, `path/other.go:87`"
-
-            ## Step 3.5: Validate each finding
-
-            For each finding that survived deduplication, launch a validation subagent
-            (model: "sonnet"). Pass it the finding details and the PR diff context.
-
-            The validation agent must:
-            1. Read the source file at the reported location with surrounding context
-            2. Confirm the issue is real — not a misreading, not pre-existing, not assumption-dependent
-            3. Confirm the issue was introduced in this branch's diff
-            4. If a suggestion is provided, verify it compiles and doesn't introduce new issues
-            5. Return: confirmed (true/false), confidence (0-100), reason
-
-            Discard any finding where confirmed is false OR confidence is below 80.
-
-            Cap: if more than 10 findings survive deduplication, re-evaluate whether
-            the high-signal filter was applied correctly before spawning validation agents.
-
-            Do NOT flag (remove even if an agent reports them):
-            - Pre-existing issues not introduced in this branch's diff
-            - Purely cosmetic formatting (whitespace, brace placement, import order)
-            - Issues a linter or formatter would catch (gofmt, eslint, prettier, golangci-lint)
-            - Subjective preferences with no concrete impact on correctness
-            - Issues silenced by lint-ignore comments (nolint, eslint-disable, etc.)
-            - General code quality concerns (e.g., lack of test coverage) unless explicitly required in CLAUDE.md
-            - Pedantic nitpicks that a senior engineer would not flag
-            - Suggestions to add error handling for errors already handled upstream
-            - Something that appears to be a bug but is actually correct
 
             ## Step 4: Post inline comments
 
@@ -448,4 +477,4 @@ jobs:
           claude_args: |
             --max-turns 50
             --model claude-opus-4-6
-            --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Workflow" "mcp__github_inline_comment__create_inline_comment" "mcp__github_comment__update_claude_comment" "Bash(gh api:*)" "Bash(gh pr diff:*)"


### PR DESCRIPTION
## Problem

The `Claude Code Review` workflow stopped posting reviews. Its prompt launched **5 parallel `Task` sub-agents** (plus per-finding validation subagents), which depended on the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` flag. That flag was removed in `718d225ec` ("ci: disable experimental Claude agent-teams in review workflows"), so inside the action the `Task` tool is no longer available.

Result on the last real `/review` run: **21 permission denials**, no findings gathered, `"No buffered inline comments"`, yet the action exited `is_error:false` → the GitHub check went green while the tracking comment stayed frozen at *"Reviewing with 5 specialized agents"*. No inline comments, no submitted review.

## Fix

Rewrite **Step 2** to run the parallel, five-dimension review through the **Workflow tool** instead of `Task`:

- The prompt fetches the diff (`gh pr diff`) and calls `Workflow` with an embedded `pr-parallel-review` script that fans out the five review dimensions via `parallel()` `agent()` calls, deduplicates, then runs a parallel validation stage and returns confirmed findings.
- The old Step 3 (aggregate/dedupe) and Step 3.5 (validate-via-subagents) fold into that script; Steps 4–5 (post inline + summary) are unchanged.
- `--allowedTools` widened to grant `Workflow`, `mcp__github_comment__update_claude_comment`, `Bash(gh api:*)`, and `Bash(gh pr diff:*)`.

## ⚠️ Needs a live `/review` to validate

This assumes the `anthropics/claude-code-action@v1` SDK runtime **exposes the `Workflow` tool** and delivers its background result back into the run so the posting step executes — the same class of dependency that the `Task` path relied on. Please confirm with a `/review` on a test PR after merge. If the runtime does not expose `Workflow`, the fallback is a single-pass in-instance review.

The cloud repo has the identical fix in shellhub-io/cloud.