### PR TITLE
fix(ui): hide decorative ConnectionGrid from assistive tech

### DIFF
--- a/ui/apps/console/src/components/common/WelcomeScreen.tsx
+++ b/ui/apps/console/src/components/common/WelcomeScreen.tsx
@@ -15,7 +15,7 @@ interface WelcomeScreenProps {
 
 function ConnectionGrid() {
   return (
-    <div className="connection-grid">
+    <div className="connection-grid" aria-hidden="true">
       {/* Horizontal lines */}
       <div
         className="connection-line"

--- a/ui/apps/console/src/components/common/__tests__/WelcomeScreen.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/WelcomeScreen.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import WelcomeScreen from "../WelcomeScreen";
+
+function renderWelcomeScreen() {
+  return render(
+    <MemoryRouter>
+      <WelcomeScreen namespaceName="my-namespace" />
+    </MemoryRouter>,
+  );
+}
+
+describe("WelcomeScreen", () => {
+  it("hides the decorative ConnectionGrid from assistive technology", () => {
+    const { container } = renderWelcomeScreen();
+    const grid = container.querySelector(".connection-grid");
+    expect(grid).not.toBeNull();
+    expect(grid).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/ui/packages/design-system/__tests__/ConnectionGrid.test.tsx
+++ b/ui/packages/design-system/__tests__/ConnectionGrid.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { ConnectionGrid } from "../components/ConnectionGrid";
+
+describe("ConnectionGrid", () => {
+  it("root .connection-grid div has aria-hidden=\"true\"", () => {
+    const { container: c } = render(<ConnectionGrid />);
+    const root = c.querySelector(".connection-grid");
+    expect(root).not.toBeNull();
+    expect(root).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("root .connection-grid div has no role attribute", () => {
+    const { container: c } = render(<ConnectionGrid />);
+    const root = c.querySelector(".connection-grid");
+    expect(root).not.toBeNull();
+    expect(root).not.toHaveAttribute("role");
+  });
+});

--- a/ui/packages/design-system/components/ConnectionGrid.tsx
+++ b/ui/packages/design-system/components/ConnectionGrid.tsx
@@ -1,6 +1,6 @@
 export function ConnectionGrid() {
   return (
-    <div className="connection-grid">
+    <div className="connection-grid" aria-hidden="true">
       <div className="connection-line" style={{ top: "15%", left: 0, width: "55%", animationDelay: "0s" }} />
       <div className="connection-line" style={{ top: "35%", left: "25%", width: "75%", animationDelay: "1.5s" }} />
       <div className="connection-line" style={{ top: "55%", left: "10%", width: "50%", animationDelay: "0.8s" }} />


### PR DESCRIPTION
## What
Marks the decorative `ConnectionGrid` animated grid as `aria-hidden="true"` so screen readers skip it.

## Why
`ConnectionGrid` renders only styled, animated `<div>`s — no text, no interactive content. Without `aria-hidden`, assistive tech traverses and announces its empty decorative nodes.

Fixes: shellhub-io/team#133

## Changes
- **design-system**: `aria-hidden="true"` on the root of `ConnectionGrid` (propagates to all 14 website call sites that consume it). New `ConnectionGrid.test.tsx` mirrors the existing `Spinner.test.tsx` decorative-component precedent.
- **console**: same attribute on the separate local `ConnectionGrid` inside `WelcomeScreen.tsx` (fixed in place — not deduped, so the welcome-screen grid layout is unchanged). New `WelcomeScreen.test.tsx`.

The maintainer confirmed on the issue that the component is purely decorative with no interactive elements.