### PR TITLE
fix(ui): announce sidebar logo once to screen readers

### DIFF
--- a/ui/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui/apps/console/src/components/layout/SidebarShell.tsx
@@ -157,11 +157,13 @@ export default function SidebarShell({
           <img
             src="/logo.svg"
             alt="ShellHub"
+            aria-hidden={!expanded}
             className={`h-8 transition-opacity duration-200 ${expanded ? "opacity-100" : "opacity-0 absolute"}`}
           />
           <img
             src="/cloud-icon.svg"
             alt="ShellHub"
+            aria-hidden={expanded}
             className={`h-6 w-6 transition-opacity duration-200 ${expanded ? "opacity-0 absolute" : "opacity-100"}`}
           />
         </NavLink>

--- a/ui/apps/console/src/components/layout/__tests__/SidebarShell.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/SidebarShell.test.tsx
@@ -46,4 +46,18 @@ describe("SidebarShell", () => {
     const button = screen.getByRole("button", { name: "Close sidebar" });
     expect(button).toHaveAttribute("title", "Close sidebar");
   });
+
+  it("exposes only the expanded logo to assistive tech when expanded", () => {
+    renderSidebarShell({ expanded: true });
+
+    // Both logos stay in the DOM (CSS opacity crossfade); aria-hidden keeps the
+    // collapsed icon out of the accessibility tree so "ShellHub" is announced once.
+    expect(screen.getAllByRole("img", { name: "ShellHub" })).toHaveLength(1);
+  });
+
+  it("exposes only the collapsed logo to assistive tech when collapsed", () => {
+    renderSidebarShell({ expanded: false });
+
+    expect(screen.getAllByRole("img", { name: "ShellHub" })).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## What
Stops screen readers announcing "ShellHub" twice on every page by marking the visually-hidden sidebar logo `aria-hidden`.

## Why
`SidebarShell` keeps both the expanded wordmark (`logo.svg`) and the collapsed icon (`cloud-icon.svg`) in the DOM, crossfading them with CSS opacity. Both share `alt="ShellHub"`, and screen readers ignore CSS visibility — so both were announced.

Fixes: shellhub-io/team#135

## Changes
- **SidebarShell**: `aria-hidden={!expanded}` on the wordmark and `aria-hidden={expanded}` on the icon, so only the currently-visible logo is in the accessibility tree. Conditional `aria-hidden` was chosen over a single conditional-`src` `<img>` to preserve the existing opacity crossfade animation.
- **Tests**: two assertions confirming exactly one accessible "ShellHub" image in each state (expanded and collapsed).