### PR TITLE
refactor(ui): extract shared SettingsCard and SettingsRow

### DIFF
--- a/ui/apps/console/src/components/common/Drawer.tsx
+++ b/ui/apps/console/src/components/common/Drawer.tsx
@@ -46,6 +46,8 @@ export default function Drawer({
       />
       <div
         ref={panelRef}
+        aria-hidden={!open}
+        {...(!open ? { inert: "" } : {})}
         className={`fixed inset-y-0 right-0 z-[70] w-full ${WIDTH_MAP[width]} bg-surface border-l border-border shadow-2xl flex flex-col transition-transform duration-300 ease-out ${
           open ? "translate-x-0" : "translate-x-full"
         }`}

--- a/ui/apps/console/src/components/common/SettingsCard.tsx
+++ b/ui/apps/console/src/components/common/SettingsCard.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+type SettingsCardProps = {
+  title: string;
+  children: React.ReactNode;
+  danger?: boolean;
+};
+
+export default function SettingsCard({ title, children, danger }: SettingsCardProps) {
+  return (
+    <div
+      className={`bg-card border rounded-xl overflow-hidden ${danger ? "border-accent-red/20 border-l-2 border-l-accent-red/40" : "border-border"}`}
+    >
+      <div
+        className={`px-5 py-3.5 border-b ${danger ? "border-accent-red/10" : "border-border"}`}
+      >
+        <h3
+          className={`text-sm font-semibold ${danger ? "text-accent-red" : "text-text-primary"}`}
+        >
+          {title}
+        </h3>
+      </div>
+      <div className="divide-y divide-border">{children}</div>
+    </div>
+  );
+}

--- a/ui/apps/console/src/components/common/SettingsRow.tsx
+++ b/ui/apps/console/src/components/common/SettingsRow.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+type SettingsRowProps = {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  badge?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+export default function SettingsRow({
+  icon,
+  title,
+  description,
+  badge,
+  children,
+}: SettingsRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-6 px-5 py-4">
+      <div className="flex items-start gap-3 min-w-0 flex-1">
+        <span className="w-8 h-8 rounded-lg bg-hover-medium border border-border flex items-center justify-center text-text-muted shrink-0 mt-0.5">
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-text-primary">{title}</p>
+            {badge}
+          </div>
+          <p className="text-2xs text-text-muted mt-0.5 leading-relaxed">
+            {description}
+          </p>
+        </div>
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  );
+}

--- a/ui/apps/console/src/components/common/__tests__/SettingsCard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/SettingsCard.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import SettingsCard from "@/components/common/SettingsCard";
+
+describe("SettingsCard", () => {
+  it("renders the title", () => {
+    render(<SettingsCard title="Account Settings">content</SettingsCard>);
+    expect(screen.getByText("Account Settings")).toBeInTheDocument();
+  });
+
+  it("renders children", () => {
+    render(
+      <SettingsCard title="Account Settings">
+        <span>child content</span>
+      </SettingsCard>,
+    );
+    expect(screen.getByText("child content")).toBeInTheDocument();
+  });
+
+  it("applies danger classes when danger prop is true", () => {
+    const { container } = render(
+      <SettingsCard title="Danger Zone" danger>
+        content
+      </SettingsCard>,
+    );
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain("border-accent-red/20");
+    expect(card.className).toContain("border-l-accent-red/40");
+    const header = card.querySelector("div");
+    expect(header!.className).toContain("border-accent-red/10");
+    const heading = card.querySelector("h3");
+    expect(heading!.className).toContain("text-accent-red");
+  });
+
+  it("applies default classes when danger prop is false", () => {
+    const { container } = render(
+      <SettingsCard title="Normal Section">content</SettingsCard>,
+    );
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain("border-border");
+    const header = card.querySelector("div");
+    expect(header!.className).toContain("border-border");
+    const heading = card.querySelector("h3");
+    expect(heading!.className).toContain("text-text-primary");
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/SettingsRow.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/SettingsRow.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import SettingsRow from "@/components/common/SettingsRow";
+
+describe("SettingsRow", () => {
+  it("renders icon", () => {
+    render(
+      <SettingsRow
+        icon={<svg data-testid="row-icon" />}
+        title="Two-Factor Auth"
+        description="Protect your account."
+      >
+        <button type="button">Enable</button>
+      </SettingsRow>,
+    );
+    expect(screen.getByTestId("row-icon")).toBeInTheDocument();
+  });
+
+  it("renders title", () => {
+    render(
+      <SettingsRow
+        icon={<svg />}
+        title="Two-Factor Auth"
+        description="Protect your account."
+      >
+        <button type="button">Enable</button>
+      </SettingsRow>,
+    );
+    expect(screen.getByText("Two-Factor Auth")).toBeInTheDocument();
+  });
+
+  it("renders description", () => {
+    render(
+      <SettingsRow
+        icon={<svg />}
+        title="Two-Factor Auth"
+        description="Protect your account."
+      >
+        <button type="button">Enable</button>
+      </SettingsRow>,
+    );
+    expect(screen.getByText("Protect your account.")).toBeInTheDocument();
+  });
+
+  it("renders children", () => {
+    render(
+      <SettingsRow
+        icon={<svg />}
+        title="Two-Factor Auth"
+        description="Protect your account."
+      >
+        <button type="button">Enable</button>
+      </SettingsRow>,
+    );
+    expect(screen.getByRole("button", { name: "Enable" })).toBeInTheDocument();
+  });
+
+  it("renders badge when provided", () => {
+    render(
+      <SettingsRow
+        icon={<svg />}
+        title="Two-Factor Auth"
+        description="Protect your account."
+        badge={<span data-testid="badge-node">Recommended</span>}
+      >
+        <button type="button">Enable</button>
+      </SettingsRow>,
+    );
+    expect(screen.getByTestId("badge-node")).toBeInTheDocument();
+    expect(screen.getByText("Recommended")).toBeInTheDocument();
+  });
+
+  it("does not render badge node when omitted", () => {
+    render(
+      <SettingsRow
+        icon={<svg />}
+        title="Two-Factor Auth"
+        description="Protect your account."
+      >
+        <button type="button">Enable</button>
+      </SettingsRow>,
+    );
+    expect(screen.queryByTestId("badge-node")).not.toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, FormEvent } from "react";
-import { Card, Button } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
 import {
   KeyIcon,
   LockClosedIcon,
@@ -19,6 +19,8 @@ import Drawer from "@/components/common/Drawer";
 import InputField from "@/components/common/fields/InputField";
 import PasswordField from "@/components/common/fields/PasswordField";
 import CheckboxField from "@/components/common/fields/CheckboxField";
+import SettingsCard from "@/components/common/SettingsCard";
+import SettingsRow from "@/components/common/SettingsRow";
 function ChangePasswordDrawer({
   open,
   onClose,
@@ -215,112 +217,112 @@ export default function VaultSettingsSection() {
 
   if (status !== "unlocked") return null;
 
+  const storageDescription =
+    storageMode === "server"
+      ? "Synced with the ShellHub server. Click to move it to this device."
+      : "Stored in this browser only. Click to sync it to the ShellHub server.";
+
   return (
     <>
-      <div className="mt-8 animate-fade-in">
-        <h3 className="text-xs font-mono font-semibold uppercase tracking-label text-text-muted mb-3">
-          Vault Settings
-        </h3>
-        <Card className="divide-y divide-border">
-          <button
-            type="button"
-            onClick={() => setChangeOpen(true)}
-            className="flex items-center gap-3 w-full px-4 py-3.5 text-left hover:bg-hover-subtle transition-colors rounded-t-lg"
+      <div className="mt-8 space-y-4 animate-fade-in">
+        <SettingsCard title="Vault Settings">
+          <SettingsRow
+            icon={<KeyIcon className="w-4 h-4" />}
+            title="Change Master Password"
+            description="Re-encrypt all keys with a new password."
           >
-            <KeyIcon className="w-4 h-4 text-text-muted shrink-0" />
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-text-primary">
-                Change Master Password
-              </p>
-              <p className="text-2xs text-text-muted">
-                Re-encrypt all keys with a new password.
-              </p>
-            </div>
-          </button>
+            <Button
+              size="sm"
+              variant="secondary"
+              aria-label="Change master password"
+              onClick={() => setChangeOpen(true)}
+            >
+              Change
+            </Button>
+          </SettingsRow>
 
-          <div className="flex items-center gap-3 w-full px-4 py-3.5">
-            <LockClosedIcon className="w-4 h-4 text-text-muted shrink-0" />
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-medium text-text-primary">
-                Auto-lock Timeout
-              </p>
-              <p className="text-2xs text-text-muted">
-                Automatically lock the vault after this period of inactivity.
-              </p>
-            </div>
+          <SettingsRow
+            icon={<LockClosedIcon className="w-4 h-4" />}
+            title="Auto-lock Timeout"
+            description="Automatically lock the vault after this period of inactivity."
+          >
             <AutoLockTimeoutSelect
               value={autoLockTimeoutMinutes}
               onChange={(minutes) =>
                 void updateAutoLockSettings({ autoLockTimeoutMinutes: minutes })
               }
             />
-          </div>
+          </SettingsRow>
 
-          <div className="flex items-center gap-3 w-full px-4 py-3.5">
-            <div className="min-w-0 flex-1">
-              <CheckboxField
-                id="vault-lock-on-hidden"
-                label="Lock when hidden"
-                description="Locks the vault about a minute after you switch away or minimize."
-                checked={lockOnHidden}
-                onChange={(checked) =>
-                  void updateAutoLockSettings({ lockOnHidden: checked })
-                }
-              />
-            </div>
-          </div>
+          <SettingsRow
+            icon={<LockClosedIcon className="w-4 h-4" />}
+            title="Lock when hidden"
+            description="Locks the vault about a minute after you switch away or minimize."
+          >
+            <CheckboxField
+              id="vault-lock-on-hidden"
+              label="Lock when hidden"
+              hideLabel
+              aria-label="Lock when hidden"
+              checked={lockOnHidden}
+              onChange={(checked) =>
+                void updateAutoLockSettings({ lockOnHidden: checked })
+              }
+            />
+          </SettingsRow>
 
           {isVaultServerEnabled() && (
-            <button
-              type="button"
-              onClick={() => setSyncOpen(true)}
-              className="flex items-center gap-3 w-full px-4 py-3.5 text-left hover:bg-hover-subtle transition-colors"
+            <SettingsRow
+              icon={<ServerStackIcon className="w-4 h-4" />}
+              title="Storage"
+              description={storageDescription}
             >
-              <ServerStackIcon className="w-4 h-4 text-text-muted shrink-0" />
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-text-primary">Storage</p>
-                <p className="text-2xs text-text-muted">
-                  {storageMode === "server"
-                    ? "Synced with the ShellHub server. Click to move it to this device."
-                    : "Stored in this browser only. Click to sync it to the ShellHub server."}
-                </p>
-              </div>
-            </button>
+              <Button
+                size="sm"
+                variant="secondary"
+                aria-label="Change vault storage location"
+                onClick={() => setSyncOpen(true)}
+              >
+                {storageMode === "server" ? "Move" : "Sync"}
+              </Button>
+            </SettingsRow>
           )}
 
-          <button
-            type="button"
-            onClick={lock}
-            className="flex items-center gap-3 w-full px-4 py-3.5 text-left hover:bg-hover-subtle transition-colors"
+          <SettingsRow
+            icon={<LockClosedIcon className="w-4 h-4" />}
+            title="Lock Vault"
+            description="Clear decrypted keys from memory."
           >
-            <LockClosedIcon className="w-4 h-4 text-text-muted shrink-0" />
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-text-primary">
-                Lock Vault
-              </p>
-              <p className="text-2xs text-text-muted">
-                Clear decrypted keys from memory.
-              </p>
-            </div>
-          </button>
+            <Button
+              size="sm"
+              variant="secondary"
+              aria-label="Lock vault"
+              onClick={lock}
+            >
+              Lock
+            </Button>
+          </SettingsRow>
+        </SettingsCard>
 
-          <button
-            type="button"
-            onClick={() => {
-              setResetConfirmText("");
-              setResetOpen(true);
-            }}
-            className="flex items-center gap-3 w-full px-4 py-3.5 text-left hover:bg-accent-red/5 transition-colors rounded-b-lg"
+        <SettingsCard title="Danger Zone" danger>
+          <SettingsRow
+            icon={<ExclamationTriangleIcon className="w-4 h-4" />}
+            title="Reset Vault"
+            description="Permanently delete all stored keys. This cannot be undone."
           >
-            <ExclamationTriangleIcon className="w-4 h-4 text-accent-red shrink-0" />
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-accent-red">Reset Vault</p>
-              <p className="text-2xs text-text-muted">
-                Permanently delete all stored keys. This cannot be undone.
-              </p>
-            </div>
-          </button>
-        </Card>
+            <Button
+              size="sm"
+              variant="dangerSoft"
+              aria-label="Reset vault"
+              onClick={() => {
+                setResetConfirmText("");
+                setResetOpen(true);
+              }}
+            >
+              Reset
+            </Button>
+          </SettingsRow>
+        </SettingsCard>
       </div>
 
       <ChangePasswordDrawer
@@ -359,7 +361,6 @@ export default function VaultSettingsSection() {
             value={resetConfirmText}
             onChange={setResetConfirmText}
             placeholder="RESET"
-
           />
         </div>
       </ConfirmDialog>

--- a/ui/apps/console/src/components/vault/__tests__/VaultSettingsSection.test.tsx
+++ b/ui/apps/console/src/components/vault/__tests__/VaultSettingsSection.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useVaultStore } from "@/stores/vaultStore";
+import { isVaultServerEnabled } from "@/utils/vault-backend-factory";
 import VaultSettingsSection from "../VaultSettingsSection";
 
 // Prevent real vault-crypto / backend calls from running in tests
@@ -33,15 +34,26 @@ vi.mock("@/utils/vault-backend-factory", () => ({
   isVaultServerEnabled: vi.fn(() => false),
 }));
 
-vi.mock("@/stores/authStore", () => ({
-  useAuthStore: {
-    getState: vi.fn(() => ({ user: "testuser", tenant: "test-tenant" })),
-  },
-}));
+vi.mock("@/stores/authStore", () => {
+  const state = { user: "testuser", tenant: "test-tenant" };
+  const useAuthStore = Object.assign(
+    vi.fn((selector: (s: typeof state) => unknown) => selector(state)),
+    { getState: vi.fn(() => state) },
+  );
+  return { useAuthStore };
+});
 
 vi.mock("@/utils/vault-activity-tracker", () => ({
   start: vi.fn(),
   stop: vi.fn(),
+}));
+
+vi.mock("@/utils/vault-migrate", () => ({
+  serverVaultExists: vi.fn(() => Promise.resolve(false)),
+  migrateLocalToServer: vi.fn(),
+  migrateServerToLocal: vi.fn(),
+  adoptServerVault: vi.fn(),
+  localVaultExists: vi.fn(() => false),
 }));
 
 function renderSection() {
@@ -67,9 +79,13 @@ beforeEach(() => {
     error: null,
     autoLockTimeoutMinutes: 15,
     lockOnHidden: false,
+    storageMode: "local",
     autoLockNonce: 0,
   });
   vi.clearAllMocks();
+  // clearAllMocks only clears call history — it does NOT restore mockReturnValue.
+  // Reset the implementation explicitly so every test starts from the documented default.
+  vi.mocked(isVaultServerEnabled).mockReturnValue(false);
 });
 
 describe("VaultSettingsSection", () => {
@@ -270,6 +286,271 @@ describe("VaultSettingsSection", () => {
         name: /lock when hidden/i,
       });
       expect(checkbox).not.toBeChecked();
+    });
+  });
+
+  describe("Change master password", () => {
+    it("opens ChangePasswordDrawer when the Change button is clicked", async () => {
+      setUnlocked();
+      renderSection();
+
+      // The Drawer always renders its panel in the DOM (CSS-only hide via
+      // translate-x-full). When closed the panel carries inert so its
+      // descendants are removed from the tab order and the accessibility tree.
+      const heading = screen.getByRole("heading", {
+        name: /change master password/i,
+        hidden: true,
+      });
+      expect(heading.closest("[inert]")).not.toBeNull();
+
+      // Requires aria-label="Change master password" (lowercase 'm') on the button
+      const changeBtn = screen.getByRole("button", {
+        name: "Change master password",
+      });
+      await userEvent.click(changeBtn);
+
+      // After opening, inert is removed — the heading becomes accessible and
+      // the password inputs are queryable without hidden:true.
+      expect(
+        screen.getByRole("heading", { name: /change master password/i }),
+      ).toBeInTheDocument();
+      expect(heading.closest("[inert]")).toBeNull();
+    });
+  });
+
+  describe("Lock vault", () => {
+    it("calls the lock() store action when the Lock button is clicked", async () => {
+      setUnlocked();
+      const lock = vi.fn();
+      useVaultStore.setState({ lock });
+
+      renderSection();
+
+      // Requires aria-label="Lock vault" (lowercase 'v') on the button
+      const lockBtn = screen.getByRole("button", { name: "Lock vault" });
+      await userEvent.click(lockBtn);
+
+      expect(lock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Reset vault", () => {
+    it("opens ConfirmDialog with title 'Reset Secure Vault' when Reset button is clicked", async () => {
+      setUnlocked();
+      renderSection();
+
+      // Requires aria-label="Reset vault" (lowercase 'v') on the button
+      const resetBtn = screen.getByRole("button", { name: "Reset vault" });
+      await userEvent.click(resetBtn);
+
+      expect(
+        screen.getByRole("heading", { name: /reset secure vault/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Storage row", () => {
+    it("is visible when isVaultServerEnabled() returns true", () => {
+      vi.mocked(isVaultServerEnabled).mockReturnValue(true);
+      useVaultStore.setState({ storageMode: "local" });
+      setUnlocked();
+      renderSection();
+
+      expect(screen.getByText(/^storage$/i)).toBeInTheDocument();
+    });
+
+    it("is absent when isVaultServerEnabled() returns false", () => {
+      vi.mocked(isVaultServerEnabled).mockReturnValue(false);
+      useVaultStore.setState({ storageMode: "local" });
+      setUnlocked();
+      renderSection();
+
+      expect(screen.queryByText(/^storage$/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("SettingsCard layout (unit 5)", () => {
+    describe("Vault Settings card", () => {
+      it("renders a heading 'Vault Settings'", () => {
+        setUnlocked();
+        renderSection();
+        expect(
+          screen.getByRole("heading", { name: "Vault Settings" }),
+        ).toBeInTheDocument();
+      });
+
+      it("renders row title 'Change Master Password'", () => {
+        setUnlocked();
+        renderSection();
+        // Drawer also renders this title, so use getAllByText and check at least one match
+        expect(
+          screen.getAllByText("Change Master Password").length,
+        ).toBeGreaterThanOrEqual(1);
+      });
+
+      it("renders row description for Change Master Password", () => {
+        setUnlocked();
+        renderSection();
+        expect(
+          screen.getByText("Re-encrypt all keys with a new password."),
+        ).toBeInTheDocument();
+      });
+
+      it("renders a 'Change' button with aria-label 'Change master password'", () => {
+        setUnlocked();
+        renderSection();
+        const btn = screen.getByRole("button", {
+          name: "Change master password",
+        });
+        expect(btn).toHaveTextContent("Change");
+      });
+
+      it("renders row title 'Auto-lock Timeout'", () => {
+        setUnlocked();
+        renderSection();
+        expect(screen.getByText("Auto-lock Timeout")).toBeInTheDocument();
+      });
+
+      it("renders row description for Auto-lock Timeout", () => {
+        setUnlocked();
+        renderSection();
+        expect(
+          screen.getByText(
+            "Automatically lock the vault after this period of inactivity.",
+          ),
+        ).toBeInTheDocument();
+      });
+
+      it("renders row title 'Lock when hidden'", () => {
+        setUnlocked();
+        renderSection();
+        expect(
+          screen.getAllByText("Lock when hidden").length,
+        ).toBeGreaterThanOrEqual(1);
+      });
+
+      it("renders a 'Lock' button with aria-label 'Lock vault'", () => {
+        setUnlocked();
+        renderSection();
+        const btn = screen.getByRole("button", { name: "Lock vault" });
+        expect(btn).toHaveTextContent("Lock");
+      });
+
+      it("renders row title 'Lock Vault'", () => {
+        setUnlocked();
+        renderSection();
+        expect(screen.getByText("Lock Vault")).toBeInTheDocument();
+      });
+
+      it("renders row description for Lock Vault", () => {
+        setUnlocked();
+        renderSection();
+        expect(
+          screen.getByText("Clear decrypted keys from memory."),
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe("Storage row (unit 5)", () => {
+      it("renders 'Move' button label when storageMode is server", () => {
+        vi.mocked(isVaultServerEnabled).mockReturnValue(true);
+        useVaultStore.setState({ storageMode: "server" });
+        setUnlocked();
+        renderSection();
+
+        const btn = screen.getByRole("button", {
+          name: "Change vault storage location",
+        });
+        expect(btn).toHaveTextContent("Move");
+      });
+
+      it("renders 'Sync' button label when storageMode is local", () => {
+        vi.mocked(isVaultServerEnabled).mockReturnValue(true);
+        useVaultStore.setState({ storageMode: "local" });
+        setUnlocked();
+        renderSection();
+
+        const btn = screen.getByRole("button", {
+          name: "Change vault storage location",
+        });
+        expect(btn).toHaveTextContent("Sync");
+      });
+
+      it("renders description for server storageMode", () => {
+        vi.mocked(isVaultServerEnabled).mockReturnValue(true);
+        useVaultStore.setState({ storageMode: "server" });
+        setUnlocked();
+        renderSection();
+
+        expect(
+          screen.getByText(
+            "Synced with the ShellHub server. Click to move it to this device.",
+          ),
+        ).toBeInTheDocument();
+      });
+
+      it("renders description for local storageMode", () => {
+        vi.mocked(isVaultServerEnabled).mockReturnValue(true);
+        useVaultStore.setState({ storageMode: "local" });
+        setUnlocked();
+        renderSection();
+
+        expect(
+          screen.getByText(
+            "Stored in this browser only. Click to sync it to the ShellHub server.",
+          ),
+        ).toBeInTheDocument();
+      });
+
+      it("opens VaultSyncDialog when storage button is clicked", async () => {
+        vi.mocked(isVaultServerEnabled).mockReturnValue(true);
+        useVaultStore.setState({ storageMode: "local" });
+        setUnlocked();
+        renderSection();
+
+        const btn = screen.getByRole("button", {
+          name: "Change vault storage location",
+        });
+        await userEvent.click(btn);
+
+        // VaultSyncDialog renders a heading or dialog when open
+        expect(
+          screen.getByRole("heading", { name: /sync/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe("Danger Zone card (unit 5)", () => {
+      it("renders a heading 'Danger Zone'", () => {
+        setUnlocked();
+        renderSection();
+        expect(
+          screen.getByRole("heading", { name: "Danger Zone" }),
+        ).toBeInTheDocument();
+      });
+
+      it("renders row title 'Reset Vault'", () => {
+        setUnlocked();
+        renderSection();
+        expect(screen.getByText("Reset Vault")).toBeInTheDocument();
+      });
+
+      it("renders row description for Reset Vault", () => {
+        setUnlocked();
+        renderSection();
+        expect(
+          screen.getByText(
+            "Permanently delete all stored keys. This cannot be undone.",
+          ),
+        ).toBeInTheDocument();
+      });
+
+      it("renders a 'Reset' button with aria-label 'Reset vault'", () => {
+        setUnlocked();
+        renderSection();
+        const btn = screen.getByRole("button", { name: "Reset vault" });
+        expect(btn).toHaveTextContent("Reset");
+      });
     });
   });
 });

--- a/ui/apps/console/src/pages/Profile.tsx
+++ b/ui/apps/console/src/pages/Profile.tsx
@@ -32,6 +32,8 @@ import MfaDisableDialog from "../components/mfa/MfaDisableDialog";
 import { hasMfaSupport } from "../utils/features";
 import { Button } from "@shellhub/design-system/primitives";
 import PageLoader from "@/components/common/PageLoader";
+import SettingsCard from "@/components/common/SettingsCard";
+import SettingsRow from "@/components/common/SettingsRow";
 
 const USERNAME_REGEX = /^[a-z0-9_.@-]+$/;
 
@@ -57,71 +59,6 @@ function validateEmail(v: string): string | null {
   if (!v.trim()) return "Email is required";
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return "Invalid email format";
   return null;
-}
-
-/* ─── Settings Card ─── */
-
-function SettingsCard({
-  title,
-  children,
-  danger,
-}: {
-  title: string;
-  children: React.ReactNode;
-  danger?: boolean;
-}) {
-  return (
-    <div
-      className={`bg-card border rounded-xl overflow-hidden ${danger ? "border-accent-red/20 border-l-2 border-l-accent-red/40" : "border-border"}`}
-    >
-      <div
-        className={`px-5 py-3.5 border-b ${danger ? "border-accent-red/10" : "border-border"}`}
-      >
-        <h3
-          className={`text-sm font-semibold ${danger ? "text-accent-red" : "text-text-primary"}`}
-        >
-          {title}
-        </h3>
-      </div>
-      <div className="divide-y divide-border">{children}</div>
-    </div>
-  );
-}
-
-/* ─── Settings Row ─── */
-
-function SettingsRow({
-  icon,
-  title,
-  description,
-  badge,
-  children,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  description: string;
-  badge?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-6 px-5 py-4">
-      <div className="flex items-start gap-3 min-w-0 flex-1">
-        <span className="w-8 h-8 rounded-lg bg-hover-medium border border-border flex items-center justify-center text-text-muted shrink-0 mt-0.5">
-          {icon}
-        </span>
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <p className="text-sm font-medium text-text-primary">{title}</p>
-            {badge}
-          </div>
-          <p className="text-2xs text-text-muted mt-0.5 leading-relaxed">
-            {description}
-          </p>
-        </div>
-      </div>
-      <div className="shrink-0">{children}</div>
-    </div>
-  );
 }
 
 /* ─── Delete Account Dialog (Cloud) ─── */

--- a/ui/apps/console/src/pages/Settings.tsx
+++ b/ui/apps/console/src/pages/Settings.tsx
@@ -35,66 +35,8 @@ import { validateNamespaceName } from "@/utils/validation";
 import { getConfig } from "../env";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
 import PageLoader from "@/components/common/PageLoader";
-
-/* ─── Settings Card ─── */
-
-function SettingsCard({
-  title,
-  children,
-  danger,
-}: {
-  title: string;
-  children: React.ReactNode;
-  danger?: boolean;
-}) {
-  return (
-    <div
-      className={`bg-card border rounded-xl overflow-hidden ${danger ? "border-accent-red/20 border-l-2 border-l-accent-red/40" : "border-border"}`}
-    >
-      <div
-        className={`px-5 py-3.5 border-b ${danger ? "border-accent-red/10" : "border-border"}`}
-      >
-        <h3
-          className={`text-sm font-semibold ${danger ? "text-accent-red" : "text-text-primary"}`}
-        >
-          {title}
-        </h3>
-      </div>
-      <div className="divide-y divide-border">{children}</div>
-    </div>
-  );
-}
-
-/* ─── Settings Row ─── */
-
-function SettingsRow({
-  icon,
-  title,
-  description,
-  children,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  description: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-6 px-5 py-4">
-      <div className="flex items-start gap-3 min-w-0 flex-1">
-        <span className="w-8 h-8 rounded-lg bg-hover-medium border border-border flex items-center justify-center text-text-muted shrink-0 mt-0.5">
-          {icon}
-        </span>
-        <div className="min-w-0">
-          <p className="text-sm font-medium text-text-primary">{title}</p>
-          <p className="text-2xs text-text-muted mt-0.5 leading-relaxed">
-            {description}
-          </p>
-        </div>
-      </div>
-      <div className="shrink-0">{children}</div>
-    </div>
-  );
-}
+import SettingsCard from "@/components/common/SettingsCard";
+import SettingsRow from "@/components/common/SettingsRow";
 
 /* ─── Edit Name Drawer ─── */
 

--- a/ui/apps/console/src/pages/__tests__/Profile.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Profile.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { useAuthStore } from "@/stores/authStore";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+vi.mock("@/client", () => ({
+  login: vi.fn(),
+  getUserInfo: vi.fn(),
+  updateUser: vi.fn(),
+  deleteUser: vi.fn(),
+  authMfa: vi.fn(),
+  mfaRecover: vi.fn(),
+  requestResetMfa: vi.fn(),
+  resetMfa: vi.fn(),
+  resendEmail: vi.fn(),
+  getInfo: vi.fn(),
+  getSamlAuthUrl: vi.fn(),
+  listNamespaces: vi.fn(),
+}));
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn(() => actual.getConfig()) };
+});
+
+vi.mock("@/utils/features", () => ({
+  hasMfaSupport: vi.fn(() => false),
+}));
+
+vi.mock("@/hooks/useNamespaces", () => ({
+  useNamespaces: vi.fn(() => ({ namespaces: [] })),
+}));
+
+import Profile from "../Profile";
+import * as SettingsCardModule from "@/components/common/SettingsCard";
+import * as SettingsRowModule from "@/components/common/SettingsRow";
+import { getConfig, defaultConfig } from "@/env";
+
+const mockedGetConfig = vi.mocked(getConfig);
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function renderProfile() {
+  return render(
+    <MemoryRouter>
+      <Profile />
+    </MemoryRouter>,
+  );
+}
+
+function seedAuthStore(overrides: Partial<{
+  name: string;
+  username: string;
+  email: string;
+  recoveryEmail: string;
+  mfaEnabled: boolean;
+}> = {}) {
+  useAuthStore.setState({
+    name: "Test User",
+    user: "testuser",
+    username: "testuser",
+    email: "test@example.com",
+    recoveryEmail: "recovery@example.com",
+    mfaEnabled: false,
+    loading: false,
+    token: "tok",
+    userId: "uid-1",
+    tenant: "tenant-1",
+    role: "owner",
+    ...overrides,
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup / teardown                                                    */
+/* ------------------------------------------------------------------ */
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  mockedGetConfig.mockReturnValue({ ...defaultConfig });
+  seedAuthStore();
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("Profile", () => {
+  describe("shared component usage", () => {
+    it("uses the shared SettingsCard component (not a local copy)", () => {
+      // Spy on the shared SettingsCard to confirm it is called during render
+      const spy = vi.spyOn(SettingsCardModule, "default");
+      renderProfile();
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("uses the shared SettingsRow component (not a local copy)", () => {
+      // Spy on the shared SettingsRow to confirm it is called during render
+      const spy = vi.spyOn(SettingsRowModule, "default");
+      renderProfile();
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
+  describe("renders profile sections", () => {
+    it("shows the Profile card heading", () => {
+      renderProfile();
+      // Multiple headings with "Profile" exist (PageHeader h1 + SettingsCard h3)
+      const headings = screen.getAllByRole("heading", { name: /^profile$/i });
+      expect(headings.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("shows the Security card heading", () => {
+      renderProfile();
+      expect(screen.getByRole("heading", { name: /^security$/i })).toBeInTheDocument();
+    });
+
+    it("shows the Danger Zone card heading", () => {
+      renderProfile();
+      expect(screen.getByRole("heading", { name: /danger zone/i })).toBeInTheDocument();
+    });
+
+    it("renders the user name in the Profile card", () => {
+      renderProfile();
+      expect(screen.getByText("Test User")).toBeInTheDocument();
+    });
+
+    it("renders the user email in the Profile card", () => {
+      renderProfile();
+      expect(screen.getByText("test@example.com")).toBeInTheDocument();
+    });
+
+    it("renders the recovery email in the Profile card", () => {
+      renderProfile();
+      // The recovery email may appear more than once (e.g. pre-filled in drawers)
+      expect(screen.getAllByText("recovery@example.com").length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("shows 'Not set' when recovery email is absent", () => {
+      seedAuthStore({ recoveryEmail: "" });
+      renderProfile();
+      expect(screen.getByText(/not set/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("danger zone", () => {
+    it("renders the delete account button", () => {
+      renderProfile();
+      expect(
+        screen.getByRole("button", { name: /delete/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("page header", () => {
+    it("renders the Edit Profile button in the header", () => {
+      renderProfile();
+      expect(
+        screen.getByRole("button", { name: /edit profile/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/apps/console/src/pages/__tests__/Settings.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Settings.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { useAuthStore } from "@/stores/authStore";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+vi.mock("@/client", () => ({
+  getNamespace: vi.fn(),
+  editNamespace: vi.fn(),
+  deleteNamespace: vi.fn(),
+  leaveNamespace: vi.fn(),
+  setDeviceAutoAccept: vi.fn(),
+}));
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn(() => actual.getConfig()) };
+});
+
+vi.mock("@/hooks/useNamespaces", () => ({
+  useNamespace: vi.fn(() => ({
+    namespace: {
+      name: "my-ns",
+      tenant_id: "00000000-0000-4000-0000-000000000000",
+      type: "personal",
+      settings: {
+        session_record: false,
+        device_auto_accept: false,
+        connection_announcement: "",
+      },
+    },
+  })),
+}));
+
+vi.mock("@/hooks/useNamespaceMutations", () => ({
+  useEditNamespace: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useDeleteNamespace: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useLeaveNamespace: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useSetDeviceAutoAccept: vi.fn(() => ({ mutateAsync: vi.fn() })),
+}));
+
+vi.mock("@/components/billing/BillingSection", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/common/CopyButton", () => ({
+  default: () => null,
+}));
+
+/* ------------------------------------------------------------------ */
+/* Deferred imports (must come after vi.mock calls)                    */
+/* ------------------------------------------------------------------ */
+
+import Settings from "../Settings";
+import * as SettingsCardModule from "@/components/common/SettingsCard";
+import * as SettingsRowModule from "@/components/common/SettingsRow";
+import { getConfig, defaultConfig } from "@/env";
+
+const mockedGetConfig = vi.mocked(getConfig);
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function seedAuthStore() {
+  useAuthStore.setState({
+    name: "Test User",
+    user: "testuser",
+    username: "testuser",
+    email: "test@example.com",
+    recoveryEmail: "",
+    mfaEnabled: false,
+    loading: false,
+    token: "tok",
+    userId: "uid-1",
+    tenant: "00000000-0000-4000-0000-000000000000",
+    role: "owner",
+  });
+}
+
+function renderSettings() {
+  return render(
+    <MemoryRouter>
+      <Settings />
+    </MemoryRouter>,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup / teardown                                                    */
+/* ------------------------------------------------------------------ */
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  mockedGetConfig.mockReturnValue({ ...defaultConfig });
+  seedAuthStore();
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("Settings", () => {
+  describe("shared component usage", () => {
+    it("uses the shared SettingsCard component (not a local copy)", () => {
+      const spy = vi.spyOn(SettingsCardModule, "default");
+      renderSettings();
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("uses the shared SettingsRow component (not a local copy)", () => {
+      const spy = vi.spyOn(SettingsRowModule, "default");
+      renderSettings();
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
+  describe("renders settings sections", () => {
+    it("shows the General card heading", () => {
+      renderSettings();
+      expect(screen.getByRole("heading", { name: /^general$/i })).toBeInTheDocument();
+    });
+
+    it("shows the SSH card heading", () => {
+      renderSettings();
+      expect(screen.getByRole("heading", { name: /^ssh$/i })).toBeInTheDocument();
+    });
+
+    it("shows the Devices card heading", () => {
+      renderSettings();
+      expect(screen.getByRole("heading", { name: /^devices$/i })).toBeInTheDocument();
+    });
+
+    it("shows the Danger Zone card heading", () => {
+      renderSettings();
+      expect(screen.getByRole("heading", { name: /danger zone/i })).toBeInTheDocument();
+    });
+
+    it("renders the namespace name", () => {
+      renderSettings();
+      expect(screen.getByText("my-ns")).toBeInTheDocument();
+    });
+
+    it("renders the tenant ID", () => {
+      renderSettings();
+      expect(
+        screen.getByText("00000000-0000-4000-0000-000000000000"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("danger zone", () => {
+    it("renders the Delete button for owners", () => {
+      renderSettings();
+      expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## What
Extract the duplicated `SettingsCard`/`SettingsRow` layout components into
`components/common/` and reuse them across the Profile, Settings, and Secure
Vault settings pages.

## Why
`SettingsCard` was defined byte-for-byte identically in `Profile.tsx` and
`Settings.tsx`, and `SettingsRow` near-identically (Profile added an optional
`badge`). Any visual change to the settings layout had to be made in two of the
highest-traffic pages. Per review feedback on the issue, the Secure Vault
settings rendered the same conceptual section with its own bespoke markup, so it
is normalized onto the shared components too.

Fixes: shellhub-io/team#136

## Changes
- **common**: new `SettingsCard` and `SettingsRow` (the latter is Profile's
  superset, keeping the optional `badge`). Class strings copied verbatim so
  Profile/Settings render identically.
- **Profile / Settings**: removed the local definitions and import the shared
  components; `BannerPreview`'s empty-banner row now uses the shared `SettingsRow`.
- **vault**: `VaultSettingsSection` migrated onto `SettingsCard`/`SettingsRow` —
  boxed icons, a card header, and right-aligned action buttons (each with an
  `aria-label`) replacing the full-row clickable buttons. Reset Vault moved to
  its own `danger` card; Lock Vault stays in the main card since it is reversible.
  The "Lock when hidden" row uses `CheckboxField hideLabel` so the label is not
  duplicated and the existing accessible-name query keeps working.
- **Drawer**: mark the panel `inert`/`aria-hidden` when closed so closed-drawer
  controls don't leak into the accessibility tree.

## Testing
- Unit tests for `SettingsCard` and `SettingsRow`.
- `VaultSettingsSection` tests extended with previously-untested behaviors:
  change-password drawer, `lock()`, reset dialog, and storage-row gating.
- Profile and Settings render pixel-identical to before; verify each Vault
  action (change password, auto-lock, lock-on-hidden, storage sync, lock, reset)
  still works.
