### PR TITLE
refactor(ui): drive AppBar crossfade from store events

### DIFF
--- a/ui/apps/console/src/components/layout/AppBar.tsx
+++ b/ui/apps/console/src/components/layout/AppBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { useTerminalStore, type TerminalSession } from "@/stores/terminalStore";
 import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 import { Bars3Icon } from "@heroicons/react/24/outline";
@@ -14,59 +14,107 @@ interface AppBarProps {
   onMenuToggle?: () => void;
 }
 
+type Phase = "idle" | "fading-out" | "swapped";
+
+interface CrossfadeState {
+  displayed: TerminalSession | null;
+  phase: Phase;
+  pending: TerminalSession | null;
+}
+
+type CrossfadeAction =
+  | { type: "active-changed"; session: TerminalSession | null }
+  | { type: "fade-out-done" }
+  | { type: "settle-idle" };
+
+const activeSessionOf = (
+  sessions: TerminalSession[],
+): TerminalSession | null =>
+  sessions.find((s) => s.state !== "minimized") ?? null;
+
+// Pure reducer for the left-content crossfade state machine — safe under
+// StrictMode double-invocation.
+function crossfadeReducer(
+  state: CrossfadeState,
+  action: CrossfadeAction,
+): CrossfadeState {
+  switch (action.type) {
+    case "active-changed": {
+      const next = action.session;
+      if (state.phase !== "idle") {
+        // Safety net: active session vanished mid fade-out — settle straight to idle.
+        if (state.phase === "fading-out" && !next) {
+          return { displayed: null, phase: "idle", pending: null };
+        }
+        // Already animating — stash the latest value to apply when the fade ends.
+        return { ...state, pending: next };
+      }
+      // Mode change (terminal <-> namespace) — start the crossfade.
+      if (!!next !== !!state.displayed) {
+        return { ...state, pending: next, phase: "fading-out" };
+      }
+      // Same mode, different session — instant swap (no flash).
+      if (next) {
+        return { ...state, displayed: next };
+      }
+      return state;
+    }
+    // Fade-out finished — swap in the pending content, then fade back in (see handler).
+    case "fade-out-done":
+      if (state.phase !== "fading-out") return state;
+      return { displayed: state.pending, pending: null, phase: "swapped" };
+    case "settle-idle":
+      return state.phase === "idle" ? state : { ...state, phase: "idle" };
+    default:
+      return state;
+  }
+}
+
 export default function AppBar({ onMenuToggle }: AppBarProps) {
-  const activeSession = useTerminalStore((s) =>
-    s.sessions.find((s) => s.state !== "minimized"),
-  );
   const themeBg = useTerminalThemeStore((s) => s.theme.colors.background);
 
-  const [displayed, setDisplayed] = useState<TerminalSession | null>(
-    activeSession ?? null,
+  const [{ displayed, phase }, dispatch] = useReducer(
+    crossfadeReducer,
+    null,
+    (): CrossfadeState => ({
+      displayed: activeSessionOf(useTerminalStore.getState().sessions),
+      phase: "idle",
+      pending: null,
+    }),
   );
-  const [phase, setPhase] = useState<"idle" | "fading-out" | "swapped">("idle");
-  const [pending, setPending] = useState<TerminalSession | null>(null);
-  const [trackedId, setTrackedId] = useState<string | undefined>(
-    activeSession?.id,
+
+  const prevIdRef = useRef<string | undefined>(
+    activeSessionOf(useTerminalStore.getState().sessions)?.id,
   );
 
   const visible = phase === "idle";
-  const currentId = activeSession?.id;
 
-  // Detect changes during render (React-blessed setState-during-render pattern)
-  if (currentId !== trackedId) {
-    setTrackedId(currentId);
+  // The crossfade is driven by store changes — an external event fired OUTSIDE
+  // React's render/effect cycle — not detected during render. Dispatching from the
+  // subscription callback (never during render, never synchronously in an effect
+  // body) keeps both react-hooks/set-state-in-render and set-state-in-effect happy
+  // while removing all render-phase state updates — the fix for the audit's
+  // concurrent-rendering concern (team#137). dispatch is stable so the effect runs
+  // once ([] deps); the listener fires on every store change but early-returns
+  // unless the active-session id actually changed.
+  useEffect(() => {
+    const unsubscribe = useTerminalStore.subscribe((state) => {
+      const next = activeSessionOf(state.sessions);
+      if (next?.id === prevIdRef.current) return;
+      prevIdRef.current = next?.id;
+      dispatch({ type: "active-changed", session: next });
+    });
+    return unsubscribe;
+  }, []);
 
-    if (phase === "fading-out" || phase === "swapped") {
-      // Already animating — stash the latest value
-      setPending(activeSession ?? null);
-    } else if (!!activeSession !== !!displayed) {
-      // Mode changed (terminal ↔ namespace) — start crossfade
-      setPending(activeSession ?? null);
-      setPhase("fading-out");
-    } else if (activeSession) {
-      // Same mode, different session — instant swap
-      setDisplayed(activeSession);
-    }
-  }
-
-  // Safety net: if fade-out gets stuck (e.g. transitionend never fires
-  // because the page re-mounts during navigation), skip straight to idle.
-  if (phase === "fading-out" && !activeSession && !pending) {
-    setDisplayed(null);
-    setPhase("idle");
-  }
-
+  // Fade-out transition ended — commit the swap, then fade back in over two paint frames.
   const handleTransitionEnd = useCallback(() => {
     if (phase !== "fading-out") return;
-
-    // Fade-out finished — swap content, then fade in after one paint frame
-    setDisplayed(pending);
-    setPending(null);
-    setPhase("swapped");
+    dispatch({ type: "fade-out-done" });
     requestAnimationFrame(() => {
-      requestAnimationFrame(() => setPhase("idle"));
+      requestAnimationFrame(() => dispatch({ type: "settle-idle" }));
     });
-  }, [phase, pending]);
+  }, [phase]);
 
   return (
     <header

--- a/ui/apps/console/src/components/layout/__tests__/AppBar.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/AppBar.test.tsx
@@ -1,0 +1,172 @@
+import { StrictMode } from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import AppBar from "../AppBar";
+import {
+  useTerminalStore,
+  type TerminalSession,
+} from "@/stores/terminalStore";
+
+// Mock the leaf children so only AppBar's own crossfade logic is under test.
+vi.mock("../NamespaceSelector", () => ({
+  default: () => <div data-testid="namespace-selector" />,
+}));
+vi.mock("../UserMenu", () => ({ default: () => <div data-testid="user-menu" /> }));
+vi.mock("../InvitationsMenu", () => ({
+  default: () => <div data-testid="invitations-menu" />,
+}));
+vi.mock("../SupportButton", () => ({
+  default: () => <div data-testid="support-button" />,
+}));
+vi.mock("../../terminal/TerminalControls", () => ({
+  TerminalInfo: ({ session }: { session: TerminalSession }) => (
+    <div data-testid="terminal-info">{session.deviceName}</div>
+  ),
+  TerminalActions: ({ session }: { session: TerminalSession }) => (
+    <div data-testid="terminal-actions">{session.deviceName}</div>
+  ),
+}));
+vi.mock("@/stores/terminalThemeStore", () => ({
+  useTerminalThemeStore: (selector: (s: unknown) => unknown) =>
+    selector({ theme: { colors: { background: "#000000" } } }),
+}));
+
+function makeSession(overrides: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: "t1",
+    deviceUid: "uid-1",
+    deviceName: "device-1",
+    username: "root",
+    password: "",
+    state: "docked",
+    connectionStatus: "connected",
+    ...overrides,
+  };
+}
+
+function renderAppBar() {
+  return render(
+    <MemoryRouter>
+      <AppBar />
+    </MemoryRouter>,
+  );
+}
+
+// The left-content crossfade wrapper is the parent of whichever child is shown.
+function contentWrapper(): HTMLElement {
+  const child =
+    screen.queryByTestId("terminal-info") ??
+    screen.getByTestId("namespace-selector");
+  return child.parentElement as HTMLElement;
+}
+
+beforeEach(() => {
+  useTerminalStore.setState({ sessions: [] });
+  // Run rAF callbacks synchronously so the post-fade "swapped → idle" settle
+  // completes within the triggering act().
+  vi.spyOn(global, "requestAnimationFrame").mockImplementation(
+    (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AppBar", () => {
+  it("shows the namespace selector when there is no active session", () => {
+    renderAppBar();
+
+    expect(screen.getByTestId("namespace-selector")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-info")).not.toBeInTheDocument();
+    expect(contentWrapper().className).toContain("opacity-100");
+  });
+
+  it("crossfades into terminal mode when a session becomes active", () => {
+    renderAppBar();
+
+    act(() => {
+      useTerminalStore.setState({
+        sessions: [makeSession({ id: "t1", deviceName: "device-1" })],
+      });
+    });
+
+    // Mode change triggers a render-phase state update → fade the old content out first.
+    // Content is still the namespace selector, now hidden (phase: fading-out).
+    const wrapper = contentWrapper();
+    expect(screen.getByTestId("namespace-selector")).toBeInTheDocument();
+    expect(wrapper.className).toContain("opacity-0");
+
+    // Fade-out finished → swap to the terminal info and settle back to visible.
+    act(() => {
+      fireEvent.transitionEnd(wrapper);
+    });
+
+    expect(screen.getByTestId("terminal-info")).toHaveTextContent("device-1");
+    expect(contentWrapper().className).toContain("opacity-100");
+  });
+
+  it("swaps same-mode sessions instantly without a fade (no flash)", () => {
+    // Session already active at mount → terminal mode, idle.
+    useTerminalStore.setState({
+      sessions: [makeSession({ id: "t1", deviceName: "device-1" })],
+    });
+    renderAppBar();
+    expect(screen.getByTestId("terminal-info")).toHaveTextContent("device-1");
+
+    act(() => {
+      useTerminalStore.setState({
+        sessions: [makeSession({ id: "t2", deviceName: "device-2" })],
+      });
+    });
+
+    // Instant swap: new session shown immediately, wrapper never leaves opacity-100.
+    expect(screen.getByTestId("terminal-info")).toHaveTextContent("device-2");
+    const wrapper = contentWrapper();
+    expect(wrapper.className).toContain("opacity-100");
+    expect(wrapper.className).not.toContain("opacity-0");
+  });
+
+  it("recovers to namespace mode if the session vanishes mid fade-out (safety net)", () => {
+    renderAppBar();
+
+    act(() => {
+      useTerminalStore.setState({
+        sessions: [makeSession({ id: "t1", deviceName: "device-1" })],
+      });
+    });
+    // Now mid fade-out (pending = t1, nothing committed yet).
+    expect(contentWrapper().className).toContain("opacity-0");
+
+    // Session removed before transitionend ever fires.
+    act(() => {
+      useTerminalStore.setState({ sessions: [] });
+    });
+
+    expect(screen.getByTestId("namespace-selector")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-info")).not.toBeInTheDocument();
+    expect(contentWrapper().className).toContain("opacity-100");
+  });
+
+  it("renders correctly under StrictMode (idempotent render-phase swap)", () => {
+    useTerminalStore.setState({
+      sessions: [makeSession({ id: "t1", deviceName: "device-1" })],
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <StrictMode>
+        <MemoryRouter>
+          <AppBar />
+        </MemoryRouter>
+      </StrictMode>,
+    );
+
+    expect(screen.getByTestId("terminal-info")).toHaveTextContent("device-1");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What
Removes all render-phase `setState` from `AppBar`. The terminal ↔ namespace crossfade is now driven by a `useReducer` state machine fed from a `useTerminalStore` subscription, instead of detecting active-session changes during render. Visible behavior is unchanged.

## Why
Closes shellhub-io/team#137. The audit flagged AppBar for calling `setState` during render and recommended moving it into `useEffect`. That recommendation isn't viable here: a `useState` setter called synchronously in an effect body trips the project's `react-hooks/set-state-in-effect` rule (verified). The render-phase pattern, conversely, isn't caught by any rule but is what the audit wants gone.

The fix sidesteps both: drive the crossfade from a store subscription. The subscription callback fires outside React's render/effect cycle (a store "event"), so dispatching transitions from it satisfies **both** `react-hooks/set-state-in-render` and `react-hooks/set-state-in-effect` while genuinely removing render-phase state updates.

## Changes
- **AppBar.tsx**: replaced the render-phase `if (currentId !== trackedId) { setState… }` detection and the render-phase safety-net block with:
  - a pure `crossfadeReducer` (`idle`/`fading-out`/`swapped`) — pure, so StrictMode double-invocation is safe;
  - a mount `useEffect` registering `useTerminalStore.subscribe(...)` that dispatches `active-changed` only when the active session id actually changes (early-returns otherwise);
  - `handleTransitionEnd` dispatching `fade-out-done` then `settle-idle` across two paint frames.
  - The reactive `useTerminalStore((s) => …)` selector is dropped — the component now re-renders only on real transitions.
- **AppBar.test.tsx**: new suite — mode-change crossfade, instant same-mode swap, stuck-fade safety net, and a StrictMode idempotency case (no `console.error`).

## Testing
Inside the `ui` container: `npx vitest run src/components/layout/__tests__/AppBar.test.tsx` (5 pass), `npx eslint src/components/layout/AppBar.tsx` (0 errors — both set-state rules silent), `npx tsc --noEmit` (clean).

## Note
Behavior is preserved exactly, including a pre-existing trait: `displayed` is a session snapshot, so `session.state` can briefly lag (e.g. after a fullscreen toggle on the same session) — unchanged from the previous implementation.