### PR TITLE
feat(ui): add WindowChrome primitive and migrate terminal mockups

### DIFF
--- a/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -6,9 +6,9 @@ import {
 } from "@heroicons/react/24/outline";
 import {
   Button,
-  Card,
   IconBadge,
   IconButton,
+  WindowChrome,
 } from "@shellhub/design-system/primitives";
 import BaseDialog from "./BaseDialog";
 import CopyButton from "./CopyButton";
@@ -49,7 +49,6 @@ function CloudForm({
           resetError();
         }}
         error={displayError}
-
       />
     </form>
   );
@@ -64,25 +63,16 @@ function CeInstructions({ descriptionId }: { descriptionId: string }) {
       </p>
 
       {/* Command block */}
-      <Card className="overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-surface/50">
-          <div className="flex items-center gap-1.5">
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-red/60" />
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-yellow/60" />
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-green/60" />
-          </div>
-          <span className="text-2xs font-mono text-text-muted/50">
-            terminal
-          </span>
-          <CopyButton text={CLI_COMMAND} showLabel />
-        </div>
-        <div className="p-4 overflow-x-auto">
-          <pre className="text-xs font-mono text-accent-cyan leading-relaxed whitespace-pre m-0">
-            <span className="text-text-muted select-none">$ </span>
-            {CLI_COMMAND}
-          </pre>
-        </div>
-      </Card>
+      <WindowChrome
+        variant="terminal"
+        size="sm"
+        titleBarSlot={<CopyButton text={CLI_COMMAND} showLabel />}
+      >
+        <pre className="text-accent-cyan whitespace-pre-wrap break-all m-0">
+          <span className="text-text-muted select-none">$ </span>
+          {CLI_COMMAND}
+        </pre>
+      </WindowChrome>
 
       {/* Name rules */}
       <div>

--- a/ui/apps/console/src/components/wizard/WizardStep2Install.tsx
+++ b/ui/apps/console/src/components/wizard/WizardStep2Install.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
+import { WindowChrome } from "@shellhub/design-system/primitives";
 import { useAuthStore } from "@/stores/authStore";
 import { useDevicePolling } from "@/hooks/useDevicePolling";
 import { buildInstallCommand } from "@/utils/installCommand";
@@ -49,15 +50,16 @@ export default function WizardStep2Install({
       </div>
 
       {/* Command block */}
-      <div className="relative group">
-        <pre className="bg-background border border-border rounded-xl p-4 pr-12 font-mono text-xs text-text-secondary leading-relaxed overflow-x-auto whitespace-pre m-0">
-          <span className="text-primary/50 select-none">$ </span>
+      <WindowChrome
+        variant="terminal"
+        size="sm"
+        titleBarSlot={<CopyButton text={installCmd} showLabel />}
+      >
+        <pre className="text-accent-cyan whitespace-pre-wrap break-all">
+          <span className="text-text-muted select-none">$ </span>
           {installCmd}
         </pre>
-        <div className="absolute top-2.5 right-2.5">
-          <CopyButton text={installCmd} size="md" className="bg-background border border-border/60 shadow-sm" />
-        </div>
-      </div>
+      </WindowChrome>
 
       {/* Requirements */}
       <div>
@@ -79,28 +81,26 @@ export default function WizardStep2Install({
         role="status"
         className="flex items-center gap-3 bg-background border border-border rounded-xl px-4 py-3"
       >
-        {isPolling
-          ? (
-            <>
-              <span className="relative flex h-2.5 w-2.5 shrink-0">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-yellow opacity-60" />
-                <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-accent-yellow" />
-              </span>
-              <span className="text-2xs font-mono text-text-muted">
-                Listening for device connection&hellip;
-              </span>
-            </>
-          )
-          : (
-            <>
-              <span className="relative flex h-2.5 w-2.5 shrink-0">
-                <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-text-muted/30" />
-              </span>
-              <span className="text-2xs font-mono text-text-muted">
-                Waiting to start&hellip;
-              </span>
-            </>
-          )}
+        {isPolling ? (
+          <>
+            <span className="relative flex h-2.5 w-2.5 shrink-0">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-yellow opacity-60" />
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-accent-yellow" />
+            </span>
+            <span className="text-2xs font-mono text-text-muted">
+              Listening for device connection&hellip;
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="relative flex h-2.5 w-2.5 shrink-0">
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-text-muted/30" />
+            </span>
+            <span className="text-2xs font-mono text-text-muted">
+              Waiting to start&hellip;
+            </span>
+          </>
+        )}
       </div>
     </div>
   );

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -26,7 +26,7 @@ import NumericInput from "@/components/common/fields/NumericInput";
 import RadioCard from "@/components/common/fields/RadioCard";
 import RadioGroupField from "@/components/common/fields/RadioGroupField";
 import { LABEL_BASE } from "@/utils/styles";
-import { Button, Card } from "@shellhub/design-system/primitives";
+import { Button, Card, WindowChrome } from "@shellhub/design-system/primitives";
 
 /* ─── Types ─── */
 type Method =
@@ -298,27 +298,16 @@ export default function AddDevice() {
             </div>
           </Card>
         ) : (
-          <Card className="overflow-hidden">
-            {/* Terminal chrome */}
-            <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-surface/50">
-              <div className="flex items-center gap-1.5">
-                <span className="w-2.5 h-2.5 rounded-full bg-accent-red/60" />
-                <span className="w-2.5 h-2.5 rounded-full bg-accent-yellow/60" />
-                <span className="w-2.5 h-2.5 rounded-full bg-accent-green/60" />
-              </div>
-              <span className="text-2xs font-mono text-text-muted/50">
-                terminal
-              </span>
-              <CopyButton text={command} showLabel />
-            </div>
-            {/* Command */}
-            <div className="p-4 overflow-x-auto">
-              <pre className="text-xs font-mono text-accent-cyan leading-relaxed whitespace-pre-wrap break-all">
-                <span className="text-text-muted select-none">$ </span>
-                {command}
-              </pre>
-            </div>
-          </Card>
+          <WindowChrome
+            variant="terminal"
+            size="sm"
+            titleBarSlot={<CopyButton text={command} showLabel />}
+          >
+            <pre className="text-accent-cyan whitespace-pre-wrap break-all">
+              <span className="text-text-muted select-none">$ </span>
+              {command}
+            </pre>
+          </WindowChrome>
         )}
       </div>
 

--- a/ui/apps/website/src/components/marketing/CommandBlock.tsx
+++ b/ui/apps/website/src/components/marketing/CommandBlock.tsx
@@ -1,0 +1,28 @@
+import { WindowChrome } from "@shellhub/design-system/primitives";
+import { CopyBtn } from "@shellhub/design-system/components";
+
+export interface CommandBlockProps {
+  /** The shell command to display and copy. */
+  command: string;
+  className?: string;
+}
+
+/**
+ * A terminal-chrome window showing a single copyable shell command, with the
+ * copy button docked in the title bar. Used across marketing pages (Quick
+ * Start, getting-started) to present the one-line install command.
+ */
+export function CommandBlock({ command, className }: CommandBlockProps) {
+  return (
+    <WindowChrome
+      variant="terminal"
+      className={className}
+      titleBarSlot={<CopyBtn text={command} />}
+    >
+      <code className="text-sm text-accent-cyan">
+        <span className="text-text-muted">$ </span>
+        {command}
+      </code>
+    </WindowChrome>
+  );
+}

--- a/ui/apps/website/src/components/marketing/__tests__/CommandBlock.test.tsx
+++ b/ui/apps/website/src/components/marketing/__tests__/CommandBlock.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { CommandBlock } from "@/components/marketing/CommandBlock";
+
+const COMMAND = "docker run -d -p 80:80 shellhubio/shellhub";
+
+const writeText = vi.fn();
+
+beforeEach(() => {
+  writeText.mockReset();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(cleanup);
+
+describe("CommandBlock", () => {
+  it("displays the command", () => {
+    render(<CommandBlock command={COMMAND} />);
+    expect(screen.getByText(COMMAND)).toBeInTheDocument();
+  });
+
+  it("renders a copy button", () => {
+    render(<CommandBlock command={COMMAND} />);
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+
+  it("copies the command to the clipboard when the copy button is clicked", () => {
+    render(<CommandBlock command={COMMAND} />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    expect(writeText).toHaveBeenCalledWith(COMMAND);
+  });
+
+  it("forwards className to the root element", () => {
+    const { container } = render(
+      <CommandBlock command={COMMAND} className="my-custom-class" />,
+    );
+    expect(container.firstElementChild?.className).toContain("my-custom-class");
+  });
+});

--- a/ui/apps/website/src/components/marketing/index.ts
+++ b/ui/apps/website/src/components/marketing/index.ts
@@ -4,3 +4,5 @@ export { SectionHeader } from "./SectionHeader";
 export type { SectionHeaderProps } from "./SectionHeader";
 export { FeatureListItem } from "./FeatureListItem";
 export type { FeatureListItemProps } from "./FeatureListItem";
+export { CommandBlock } from "./CommandBlock";
+export type { CommandBlockProps } from "./CommandBlock";

--- a/ui/apps/website/src/pages/enterprise/AdminPanel.tsx
+++ b/ui/apps/website/src/pages/enterprise/AdminPanel.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@shellhub/design-system/primitives";
+import { WindowChrome } from "@shellhub/design-system/primitives";
 import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard } from "../landing/components";
 
@@ -76,80 +76,73 @@ export function AdminPanel() {
 
         <Reveal delay={0.1}>
           <ShimmerCard>
-            <Card className="overflow-hidden">
-              <div className="p-6">
-                <div className="flex items-center gap-2 mb-6">
-                  <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                  <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                  <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                  <span className="ml-2 text-2xs text-text-muted font-mono">
-                    Admin Panel
+            <WindowChrome
+              variant="browser"
+              path="/admin"
+              bodyClassName="font-sans"
+            >
+              <div className="space-y-3">
+                <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center text-2xs font-semibold text-primary">
+                      JD
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium">Jane Doe</p>
+                      <p className="text-2xs text-text-muted">
+                        jane@company.com
+                      </p>
+                    </div>
+                  </div>
+                  <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
+                    Admin
                   </span>
                 </div>
 
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center text-2xs font-semibold text-primary">
-                        JD
-                      </div>
-                      <div>
-                        <p className="text-xs font-medium">Jane Doe</p>
-                        <p className="text-2xs text-text-muted">
-                          jane@company.com
-                        </p>
-                      </div>
+                <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-accent-blue/15 flex items-center justify-center text-2xs font-semibold text-accent-blue">
+                      MS
                     </div>
-                    <span className="px-2 py-0.5 text-2xs font-mono bg-accent-green/10 text-accent-green border border-accent-green/20 rounded-full">
-                      Admin
-                    </span>
-                  </div>
-
-                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-accent-blue/15 flex items-center justify-center text-2xs font-semibold text-accent-blue">
-                        MS
-                      </div>
-                      <div>
-                        <p className="text-xs font-medium">Mike Smith</p>
-                        <p className="text-2xs text-text-muted">
-                          mike@company.com
-                        </p>
-                      </div>
+                    <div>
+                      <p className="text-xs font-medium">Mike Smith</p>
+                      <p className="text-2xs text-text-muted">
+                        mike@company.com
+                      </p>
                     </div>
-                    <span className="px-2 py-0.5 text-2xs font-mono bg-primary/10 text-primary border border-primary/20 rounded-full">
-                      Operator
-                    </span>
                   </div>
-
-                  <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-accent-cyan/15 flex items-center justify-center text-2xs font-semibold text-accent-cyan">
-                        AL
-                      </div>
-                      <div>
-                        <p className="text-xs font-medium">Ana Lima</p>
-                        <p className="text-2xs text-text-muted">
-                          ana@company.com
-                        </p>
-                      </div>
-                    </div>
-                    <span className="px-2 py-0.5 text-2xs font-mono bg-white/[0.04] text-text-muted border border-border rounded-full">
-                      Viewer
-                    </span>
-                  </div>
+                  <span className="px-2 py-0.5 text-2xs font-mono bg-primary/10 text-primary border border-primary/20 rounded-full">
+                    Operator
+                  </span>
                 </div>
 
-                <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                  <span className="text-2xs text-text-muted">
-                    3 users in production namespace
-                  </span>
-                  <span className="text-2xs text-primary font-medium">
-                    Manage &rarr;
+                <div className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-accent-cyan/15 flex items-center justify-center text-2xs font-semibold text-accent-cyan">
+                      AL
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium">Ana Lima</p>
+                      <p className="text-2xs text-text-muted">
+                        ana@company.com
+                      </p>
+                    </div>
+                  </div>
+                  <span className="px-2 py-0.5 text-2xs font-mono bg-white/[0.04] text-text-muted border border-border rounded-full">
+                    Observer
                   </span>
                 </div>
               </div>
-            </Card>
+
+              <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                <span className="text-2xs text-text-muted">
+                  3 users in production namespace
+                </span>
+                <span className="text-2xs text-primary font-medium">
+                  Manage &rarr;
+                </span>
+              </div>
+            </WindowChrome>
           </ShimmerCard>
         </Reveal>
       </div>

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -1,73 +1,15 @@
 import { Link } from "react-router-dom";
-import { Badge, Button, Card } from "@shellhub/design-system/primitives";
+import {
+  Badge,
+  Button,
+  Card,
+  WindowChrome,
+} from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
-
-/* ─── Terminal Window Chrome ───────────────────────────────────── */
-function TerminalChrome({
-  title,
-  children,
-  accent = C.primary,
-}: {
-  title: string;
-  children: React.ReactNode;
-  accent?: string;
-}) {
-  return (
-    <Card className="overflow-hidden">
-      <div className="px-4 py-3 border-b border-border flex items-center gap-2">
-        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-        <span className="ml-2 text-2xs text-text-muted font-mono">{title}</span>
-        <div
-          className="ml-auto w-2 h-2 rounded-full animate-pulse"
-          style={{ background: accent }}
-        />
-      </div>
-      <div className="p-5 font-mono text-xs leading-relaxed">{children}</div>
-    </Card>
-  );
-}
-
-/* ─── Browser Window Chrome ────────────────────────────────────── */
-function BrowserChrome({
-  url,
-  children,
-}: {
-  url: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <Card className="overflow-hidden">
-      <div className="px-4 py-3 border-b border-border flex items-center gap-2">
-        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-        <div className="ml-3 flex-1 max-w-xs bg-surface border border-border rounded-md px-3 py-1 flex items-center gap-2">
-          <svg
-            className="w-3 h-3 text-text-muted shrink-0"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"
-            />
-          </svg>
-          <span className="text-2xs text-text-muted truncate">{url}</span>
-        </div>
-      </div>
-      <div className="p-5">{children}</div>
-    </Card>
-  );
-}
 
 /* ─── Typed line helper ────────────────────────────────────────── */
 function Line({
@@ -222,38 +164,31 @@ function NativeSSH() {
         {/* Terminal Mockup */}
         <Reveal delay={0.1}>
           <ShimmerCard>
-            <Card className="overflow-hidden">
-              <TerminalChrome title="Terminal — ssh" accent={C.green}>
-                <Line
-                  prompt="$"
-                  cmd="ssh admin@rpi-gateway.production.shellhub"
-                />
-                <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
-                  <span className="text-accent-green">Connected to</span>{" "}
-                  <span className="text-primary">rpi-gateway</span>
-                  <span className="text-text-muted"> (production)</span>
-                </div>
-                <Line
-                  prompt="$"
-                  cmd="ssh deploy@sensor-node-04.staging.shellhub"
-                />
-                <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
-                  <span className="text-accent-green">Connected to</span>{" "}
-                  <span className="text-primary">sensor-node-04</span>
-                  <span className="text-text-muted"> (staging)</span>
-                </div>
-                <Line
-                  prompt="$"
-                  cmd="ssh root@edge-server.iot-fleet.shellhub"
-                />
-                <div className="mt-2 flex items-center gap-2">
-                  <div className="w-1.5 h-1.5 rounded-full bg-accent-green animate-pulse" />
-                  <span className="text-text-muted text-2xs">
-                    Connecting via ShellHub gateway...
-                  </span>
-                </div>
-              </TerminalChrome>
-            </Card>
+            <WindowChrome
+              variant="terminal"
+              title="Terminal — ssh"
+              accent="green"
+            >
+              <Line cmd="ssh admin@rpi-gateway.production.shellhub" />
+              <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
+                <span className="text-accent-green">Connected to</span>{" "}
+                <span className="text-primary">rpi-gateway</span>
+                <span className="text-text-muted"> (production)</span>
+              </div>
+              <Line cmd="ssh deploy@sensor-node-04.staging.shellhub" />
+              <div className="my-3 px-3 py-2 bg-surface rounded border border-border">
+                <span className="text-accent-green">Connected to</span>{" "}
+                <span className="text-primary">sensor-node-04</span>
+                <span className="text-text-muted"> (staging)</span>
+              </div>
+              <Line cmd="ssh root@edge-server.iot-fleet.shellhub" />
+              <div className="mt-2 flex items-center gap-2">
+                <div className="w-1.5 h-1.5 rounded-full bg-accent-green animate-pulse" />
+                <span className="text-text-muted text-2xs">
+                  Connecting via ShellHub gateway...
+                </span>
+              </div>
+            </WindowChrome>
           </ShimmerCard>
         </Reveal>
       </div>
@@ -555,63 +490,60 @@ function WebTerminal() {
         {/* Browser Mockup */}
         <Reveal delay={0.1}>
           <ShimmerCard>
-            <Card className="overflow-hidden">
-              <BrowserChrome url="shellhub.io/devices/rpi-gateway/terminal">
-                {/* Fake tabs row */}
-                <div className="flex items-center gap-1 mb-4">
-                  <div className="px-3 py-1.5 bg-surface border border-border rounded-t-lg text-2xs font-mono text-text-primary flex items-center gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                    rpi-gateway
-                  </div>
-                  <div className="px-3 py-1.5 bg-card border border-border/50 rounded-t-lg text-2xs font-mono text-text-muted flex items-center gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full bg-text-muted" />
-                    sensor-node-04
-                  </div>
+            <WindowChrome
+              variant="browser"
+              path="/devices/rpi-gateway/terminal"
+            >
+              {/* Fake tabs row */}
+              <div className="flex items-center gap-1 mb-4">
+                <div className="px-3 py-1.5 bg-surface border border-border rounded-t-lg text-2xs font-mono text-text-primary flex items-center gap-2">
+                  <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                  rpi-gateway
                 </div>
+                <div className="px-3 py-1.5 bg-card border border-border/50 rounded-t-lg text-2xs font-mono text-text-muted flex items-center gap-2">
+                  <div className="w-1.5 h-1.5 rounded-full bg-text-muted" />
+                  sensor-node-04
+                </div>
+              </div>
 
-                {/* Terminal area inside browser */}
-                <div className="bg-[#15161A] rounded-lg border border-border p-4 font-mono text-xs">
-                  <div className="text-text-muted mb-1.5">
-                    <span className="text-accent-green">admin@rpi-gateway</span>
-                    :<span className="text-accent-blue">~</span>$ docker ps
-                    --format &quot;table {"{{.Names}}"}\t{"{{.Status}}"}&quot;
-                  </div>
-                  <div className="text-text-secondary mb-0.5">
-                    NAMES&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;STATUS
-                  </div>
-                  <div className="text-text-secondary mb-0.5">
-                    nginx-proxy&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                    days
-                  </div>
-                  <div className="text-text-secondary mb-0.5">
-                    app-backend&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                    days
-                  </div>
-                  <div className="text-text-secondary mb-0.5">
-                    redis-cache&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                    days
-                  </div>
-                  <div className="text-text-secondary mb-1.5">
-                    postgres-db&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3
-                    days
-                  </div>
-                  <div className="text-text-muted">
-                    <span className="text-accent-green">admin@rpi-gateway</span>
-                    :<span className="text-accent-blue">~</span>${" "}
-                    <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
-                  </div>
+              {/* Terminal area inside browser */}
+              <div className="bg-[#15161A] rounded-lg border border-border p-4">
+                <div className="text-text-muted mb-1.5">
+                  <span className="text-accent-green">admin@rpi-gateway</span>:
+                  <span className="text-accent-blue">~</span>$ docker ps
+                  --format &quot;table {"{{.Names}}"}\t{"{{.Status}}"}&quot;
                 </div>
+                <div className="text-text-secondary mb-0.5">
+                  NAMES&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;STATUS
+                </div>
+                <div className="text-text-secondary mb-0.5">
+                  nginx-proxy&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3 days
+                </div>
+                <div className="text-text-secondary mb-0.5">
+                  app-backend&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3 days
+                </div>
+                <div className="text-text-secondary mb-0.5">
+                  redis-cache&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3 days
+                </div>
+                <div className="text-text-secondary mb-1.5">
+                  postgres-db&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Up 3 days
+                </div>
+                <div className="text-text-muted">
+                  <span className="text-accent-green">admin@rpi-gateway</span>:
+                  <span className="text-accent-blue">~</span>${" "}
+                  <span className="inline-block w-2 h-3.5 bg-text-primary/60 animate-pulse" />
+                </div>
+              </div>
 
-                {/* Status bar */}
-                <div className="mt-3 flex items-center justify-between text-2xs text-text-muted">
-                  <div className="flex items-center gap-2">
-                    <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                    <span>Connected &middot; WebSocket</span>
-                  </div>
-                  <span className="font-mono">80x24</span>
+              {/* Status bar */}
+              <div className="mt-3 flex items-center justify-between text-2xs text-text-muted">
+                <div className="flex items-center gap-2">
+                  <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                  <span>Connected &middot; WebSocket</span>
                 </div>
-              </BrowserChrome>
-            </Card>
+                <span className="font-mono">80x24</span>
+              </div>
+            </WindowChrome>
           </ShimmerCard>
         </Reveal>
       </div>
@@ -785,53 +717,51 @@ function FileTransfer() {
         {/* Terminal Mockup */}
         <Reveal delay={0.1}>
           <ShimmerCard>
-            <Card className="overflow-hidden">
-              <TerminalChrome title="Terminal — scp / sftp" accent={C.cyan}>
-                <div className="mb-4">
-                  <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
-                    SCP &mdash; Copy files to device
-                  </p>
-                  <Line
-                    prompt="$"
-                    cmd="scp firmware-v2.4.bin admin@rpi-gateway.production.shellhub:/opt/firmware/"
-                  />
-                  <div className="mt-1 flex items-center gap-3">
-                    <div className="flex-1 h-1.5 bg-surface rounded-full overflow-hidden border border-border">
-                      <div className="h-full w-full bg-gradient-to-r from-accent-cyan to-primary rounded-full" />
-                    </div>
-                    <span className="text-accent-green text-2xs">100%</span>
+            <WindowChrome
+              variant="terminal"
+              title="Terminal — scp / sftp"
+              accent="cyan"
+            >
+              <div className="mb-4">
+                <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
+                  SCP &mdash; Copy files to device
+                </p>
+                <Line
+                  prompt="$"
+                  cmd="scp firmware-v2.4.bin admin@rpi-gateway.production.shellhub:/opt/firmware/"
+                />
+                <div className="mt-1 flex items-center gap-3">
+                  <div className="flex-1 h-1.5 bg-surface rounded-full overflow-hidden border border-border">
+                    <div className="h-full w-full bg-gradient-to-r from-accent-cyan to-primary rounded-full" />
                   </div>
-                  <p className="text-text-muted text-2xs mt-1">
-                    firmware-v2.4.bin &nbsp; 24.3 MB &nbsp; 12.1MB/s &nbsp;
-                    00:02
-                  </p>
+                  <span className="text-accent-green text-2xs">100%</span>
                 </div>
+                <p className="text-text-muted text-2xs mt-1">
+                  firmware-v2.4.bin &nbsp; 24.3 MB &nbsp; 12.1MB/s &nbsp; 00:02
+                </p>
+              </div>
 
-                <div className="pt-4 border-t border-border">
-                  <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
-                    SFTP &mdash; Interactive session
-                  </p>
-                  <Line prompt="sftp>" cmd="ls /var/log/" />
-                  <div className="text-text-secondary ml-0">
-                    <p>
-                      syslog &nbsp;&nbsp; auth.log &nbsp;&nbsp; kern.log
-                      &nbsp;&nbsp; nginx/
-                    </p>
-                  </div>
-                  <Line
-                    prompt="sftp>"
-                    cmd="get /var/log/syslog ./diagnostics/"
-                  />
-                  <p className="text-text-muted text-2xs mt-1">
-                    Fetching /var/log/syslog to ./diagnostics/syslog
-                  </p>
-                  <p className="text-accent-green text-2xs">
-                    /var/log/syslog &nbsp; 100% &nbsp; 847KB &nbsp; 4.2MB/s
-                    &nbsp; 00:00
+              <div className="pt-4 border-t border-border">
+                <p className="text-text-muted text-2xs uppercase tracking-wider mb-2">
+                  SFTP &mdash; Interactive session
+                </p>
+                <Line prompt="sftp>" cmd="ls /var/log/" />
+                <div className="text-text-secondary ml-0">
+                  <p>
+                    syslog &nbsp;&nbsp; auth.log &nbsp;&nbsp; kern.log
+                    &nbsp;&nbsp; nginx/
                   </p>
                 </div>
-              </TerminalChrome>
-            </Card>
+                <Line prompt="sftp>" cmd="get /var/log/syslog ./diagnostics/" />
+                <p className="text-text-muted text-2xs mt-1">
+                  Fetching /var/log/syslog to ./diagnostics/syslog
+                </p>
+                <p className="text-accent-green text-2xs">
+                  /var/log/syslog &nbsp; 100% &nbsp; 847KB &nbsp; 4.2MB/s &nbsp;
+                  00:00
+                </p>
+              </div>
+            </WindowChrome>
           </ShimmerCard>
         </Reveal>
 

--- a/ui/apps/website/src/pages/getting-started/StepSetup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSetup.tsx
@@ -1,6 +1,7 @@
-import { Button, Card } from "@shellhub/design-system/primitives";
+import { Button } from "@shellhub/design-system/primitives";
+import { CommandBlock } from "@/components/marketing";
 import { docsUrl } from "@/links";
-import { Reveal, CopyBtn } from "../landing/components";
+import { Reveal } from "../landing/components";
 
 const DOCKER_CMD = "docker run -d -p 80:80 shellhubio/shellhub";
 
@@ -12,23 +13,7 @@ export function StepSetup({ onBack }: StepSetupProps) {
   return (
     <div className="max-w-xl mx-auto w-full">
       <Reveal>
-        <Card className="overflow-hidden mb-6">
-          <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border bg-surface">
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-red/70" />
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-yellow/70" />
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-green/70" />
-            <span className="flex-1 text-center text-2xs font-mono text-text-secondary">
-              terminal
-            </span>
-          </div>
-          <div className="px-5 py-4 flex items-center justify-between gap-4">
-            <code className="font-mono text-sm text-text-secondary leading-relaxed">
-              <span className="text-primary">$ </span>
-              <span className="text-text-primary">{DOCKER_CMD}</span>
-            </code>
-            <CopyBtn text={DOCKER_CMD} />
-          </div>
-        </Card>
+        <CommandBlock command={DOCKER_CMD} className="mb-6" />
       </Reveal>
 
       <Reveal delay={0.1}>

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Card,
   IconBadge,
+  WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
@@ -789,41 +790,31 @@ export default function HowItWorks() {
 
               <div className="md:pl-12">
                 <ShimmerCard>
-                  <Card className="overflow-hidden">
-                    <div className="p-5">
-                      <div className="flex items-center gap-2 mb-4">
-                        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                        <span className="ml-2 text-2xs text-text-muted font-mono">
-                          Terminal
+                  <WindowChrome variant="terminal">
+                    <div className="space-y-2 overflow-x-auto">
+                      <p>
+                        <span className="text-accent-green">$</span>{" "}
+                        <span className="text-text-secondary">
+                          curl -sSf https://cloud.shellhub.io/install.sh | sh
                         </span>
-                      </div>
-                      <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
-                        <p>
-                          <span className="text-accent-green">$</span>{" "}
-                          <span className="text-text-secondary">
-                            curl -sSf https://cloud.shellhub.io/install.sh | sh
-                          </span>
-                        </p>
-                        <p className="text-text-muted">
-                          # Downloading ShellHub agent v0.17.2...
-                        </p>
-                        <p className="text-text-muted">
-                          # Installing to /usr/local/bin/shellhub-agent
-                        </p>
-                        <p className="text-text-muted">
-                          # Registering systemd service...
-                        </p>
-                        <p className="text-accent-green">
-                          # Agent installed and running.
-                        </p>
-                        <p className="text-accent-green">
-                          # Device ID: a1b2c3d4-e5f6-7890
-                        </p>
-                      </div>
+                      </p>
+                      <p className="text-text-muted">
+                        # Downloading ShellHub agent v0.17.2...
+                      </p>
+                      <p className="text-text-muted">
+                        # Installing to /usr/local/bin/shellhub-agent
+                      </p>
+                      <p className="text-text-muted">
+                        # Registering systemd service...
+                      </p>
+                      <p className="text-accent-green">
+                        # Agent installed and running.
+                      </p>
+                      <p className="text-accent-green">
+                        # Device ID: a1b2c3d4-e5f6-7890
+                      </p>
                     </div>
-                  </Card>
+                  </WindowChrome>
                 </ShimmerCard>
               </div>
             </div>
@@ -1159,57 +1150,43 @@ export default function HowItWorks() {
 
               <div className="md:pl-12">
                 <ShimmerCard>
-                  <Card className="overflow-hidden">
-                    <div className="p-5">
-                      <div className="flex items-center gap-2 mb-4">
-                        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                        <span className="ml-2 text-2xs text-text-muted font-mono">
-                          Terminal
+                  <WindowChrome variant="terminal">
+                    <div className="space-y-2 overflow-x-auto">
+                      <p>
+                        <span className="text-accent-green">$</span>{" "}
+                        <span className="text-text-secondary">
+                          ssh pi@a1b2c3d4-e5f6-7890.mycompany.shellhub.io
                         </span>
-                      </div>
-                      <div className="bg-surface rounded-lg p-4 font-mono text-xs leading-relaxed space-y-2 overflow-x-auto">
-                        <p>
-                          <span className="text-accent-green">$</span>{" "}
-                          <span className="text-text-secondary">
-                            ssh pi@a1b2c3d4-e5f6-7890.mycompany.shellhub.io
-                          </span>
-                        </p>
-                        <p className="text-text-muted">
-                          # Connecting through ShellHub gateway...
-                        </p>
-                        <p className="text-text-muted">
-                          # Authenticating with public key...
-                        </p>
-                        <p className="text-text-muted">
-                          # Session recording enabled.
-                        </p>
-                        <p>&nbsp;</p>
-                        <p>
-                          <span className="text-accent-green">
-                            pi@raspberrypi
-                          </span>
-                          :<span className="text-accent-blue">~</span>
-                          <span className="text-text-secondary">
-                            $ uname -a
-                          </span>
-                        </p>
-                        <p className="text-text-secondary">
-                          Linux raspberrypi 6.1.0-rpi7 armv7l GNU/Linux
-                        </p>
-                        <p>
-                          <span className="text-accent-green">
-                            pi@raspberrypi
-                          </span>
-                          :<span className="text-accent-blue">~</span>
-                          <span className="text-text-muted animate-pulse">
-                            _
-                          </span>
-                        </p>
-                      </div>
+                      </p>
+                      <p className="text-text-muted">
+                        # Connecting through ShellHub gateway...
+                      </p>
+                      <p className="text-text-muted">
+                        # Authenticating with public key...
+                      </p>
+                      <p className="text-text-muted">
+                        # Session recording enabled.
+                      </p>
+                      <p>&nbsp;</p>
+                      <p>
+                        <span className="text-accent-green">
+                          pi@raspberrypi
+                        </span>
+                        :<span className="text-accent-blue">~</span>
+                        <span className="text-text-secondary">$ uname -a</span>
+                      </p>
+                      <p className="text-text-secondary">
+                        Linux raspberrypi 6.1.0-rpi7 armv7l GNU/Linux
+                      </p>
+                      <p>
+                        <span className="text-accent-green">
+                          pi@raspberrypi
+                        </span>
+                        :<span className="text-accent-blue">~</span>
+                        <span className="text-text-muted animate-pulse">_</span>
+                      </p>
                     </div>
-                  </Card>
+                  </WindowChrome>
                 </ShimmerCard>
               </div>
             </div>

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Card,
   IconBadge,
+  WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
@@ -11,35 +12,6 @@ import { Section, SectionHeader } from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
-
-/* ------------------------------------------------------------------ */
-/*  Terminal chrome (macOS-style dots + optional title)                */
-/* ------------------------------------------------------------------ */
-function TerminalChrome({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <ShimmerCard>
-      <Card className="overflow-hidden">
-        <div className="flex items-center gap-2 px-5 py-3 border-b border-border bg-surface/60">
-          <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-          <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-          <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-          <span className="ml-2 text-2xs text-text-muted font-mono">
-            {title}
-          </span>
-        </div>
-        <div className="p-5 font-mono text-2xs leading-[1.7] overflow-x-auto">
-          {children}
-        </div>
-      </Card>
-    </ShimmerCard>
-  );
-}
 
 /* ------------------------------------------------------------------ */
 /*  Syntax-highlighted line helpers                                    */
@@ -196,77 +168,84 @@ export default function Integrations() {
 
           {/* Right terminal mockup */}
           <Reveal delay={0.1}>
-            <TerminalChrome title="ansible-playbook">
-              <Comment># Deploy firmware update via ShellHub SSH</Comment>
-              <Ln>
-                <Val>$</Val> ansible-playbook -i inventory.yml deploy.yml
-              </Ln>
-              <div className="mt-3" />
-              <Ln color={C.textSec}>
-                PLAY [Update edge devices] ****************************
-              </Ln>
-              <div className="mt-2" />
-              <Ln color={C.textSec}>
-                TASK [Gathering Facts] ********************************
-              </Ln>
-              <Ln>
-                <Str>ok</Str>: [gateway-east-01.d0a1c2.<Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <Ln>
-                <Str>ok</Str>: [sensor-rack-07.d0a1c2.<Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <Ln>
-                <Str>ok</Str>: [plc-floor-03.d0a1c2.<Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <div className="mt-2" />
-              <Ln color={C.textSec}>
-                TASK [Copy firmware binary] ****************************
-              </Ln>
-              <Ln>
-                <Val>changed</Val>: [gateway-east-01.d0a1c2.
-                <Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <Ln>
-                <Val>changed</Val>: [sensor-rack-07.d0a1c2.
-                <Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <Ln>
-                <Val>changed</Val>: [plc-floor-03.d0a1c2.
-                <Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <div className="mt-2" />
-              <Ln color={C.textSec}>
-                TASK [Apply update &amp; restart] **************************
-              </Ln>
-              <Ln>
-                <Val>changed</Val>: [gateway-east-01.d0a1c2.
-                <Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <Ln>
-                <Val>changed</Val>: [sensor-rack-07.d0a1c2.
-                <Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <Ln>
-                <Val>changed</Val>: [plc-floor-03.d0a1c2.
-                <Cyn>shellhub.io</Cyn>]
-              </Ln>
-              <div className="mt-3" />
-              <Ln color={C.textSec}>
-                PLAY RECAP ********************************************
-              </Ln>
-              <Ln>
-                gateway-east-01 : <Str>ok=3</Str> <Val>changed=2</Val>{" "}
-                unreachable=0 failed=<Str>0</Str>
-              </Ln>
-              <Ln>
-                sensor-rack-07 &nbsp;: <Str>ok=3</Str> <Val>changed=2</Val>{" "}
-                unreachable=0 failed=<Str>0</Str>
-              </Ln>
-              <Ln>
-                plc-floor-03 &nbsp;&nbsp;&nbsp;: <Str>ok=3</Str>{" "}
-                <Val>changed=2</Val> unreachable=0 failed=<Str>0</Str>
-              </Ln>
-            </TerminalChrome>
+            <ShimmerCard>
+              <WindowChrome
+                variant="terminal"
+                title="ansible-playbook"
+                bodyClassName="overflow-x-auto"
+              >
+                <Comment># Deploy firmware update via ShellHub SSH</Comment>
+                <Ln>
+                  <Val>$</Val> ansible-playbook -i inventory.yml deploy.yml
+                </Ln>
+                <div className="mt-3" />
+                <Ln color={C.textSec}>
+                  PLAY [Update edge devices] ****************************
+                </Ln>
+                <div className="mt-2" />
+                <Ln color={C.textSec}>
+                  TASK [Gathering Facts] ********************************
+                </Ln>
+                <Ln>
+                  <Str>ok</Str>: [gateway-east-01.d0a1c2.
+                  <Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <Ln>
+                  <Str>ok</Str>: [sensor-rack-07.d0a1c2.<Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <Ln>
+                  <Str>ok</Str>: [plc-floor-03.d0a1c2.<Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <div className="mt-2" />
+                <Ln color={C.textSec}>
+                  TASK [Copy firmware binary] ****************************
+                </Ln>
+                <Ln>
+                  <Val>changed</Val>: [gateway-east-01.d0a1c2.
+                  <Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <Ln>
+                  <Val>changed</Val>: [sensor-rack-07.d0a1c2.
+                  <Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <Ln>
+                  <Val>changed</Val>: [plc-floor-03.d0a1c2.
+                  <Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <div className="mt-2" />
+                <Ln color={C.textSec}>
+                  TASK [Apply update &amp; restart] **************************
+                </Ln>
+                <Ln>
+                  <Val>changed</Val>: [gateway-east-01.d0a1c2.
+                  <Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <Ln>
+                  <Val>changed</Val>: [sensor-rack-07.d0a1c2.
+                  <Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <Ln>
+                  <Val>changed</Val>: [plc-floor-03.d0a1c2.
+                  <Cyn>shellhub.io</Cyn>]
+                </Ln>
+                <div className="mt-3" />
+                <Ln color={C.textSec}>
+                  PLAY RECAP ********************************************
+                </Ln>
+                <Ln>
+                  gateway-east-01 : <Str>ok=3</Str> <Val>changed=2</Val>{" "}
+                  unreachable=0 failed=<Str>0</Str>
+                </Ln>
+                <Ln>
+                  sensor-rack-07 &nbsp;: <Str>ok=3</Str> <Val>changed=2</Val>{" "}
+                  unreachable=0 failed=<Str>0</Str>
+                </Ln>
+                <Ln>
+                  plc-floor-03 &nbsp;&nbsp;&nbsp;: <Str>ok=3</Str>{" "}
+                  <Val>changed=2</Val> unreachable=0 failed=<Str>0</Str>
+                </Ln>
+              </WindowChrome>
+            </ShimmerCard>
           </Reveal>
         </div>
       </Section>
@@ -286,130 +265,118 @@ export default function Integrations() {
 
         <Reveal delay={0.1}>
           <ShimmerCard className="max-w-3xl mx-auto">
-            <div className="relative bg-card border border-accent-green/25 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(130,165,104,0.08)]">
-              <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.04] via-transparent to-transparent pointer-events-none" />
-              <div className="relative">
-                {/* Tab bar */}
-                <div className="flex items-center gap-2 px-5 py-3 border-b border-border bg-surface/60">
-                  <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                  <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                  <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                  <span className="ml-2 text-2xs text-text-muted font-mono">
-                    .github/workflows/deploy.yml
-                  </span>
-                  <div className="ml-auto flex items-center gap-1.5">
-                    <Badge shape="pill" color="green">
-                      Passing
-                    </Badge>
-                  </div>
-                </div>
-
-                {/* YAML content */}
-                <div className="p-5 font-mono text-2xs leading-[1.7] overflow-x-auto">
-                  <Ln>
-                    <Kw>name</Kw>: <Str>Deploy to Edge Devices</Str>
-                  </Ln>
-                  <Ln>
-                    <Kw>on</Kw>:
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Kw>push</Kw>:
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Kw>branches</Kw>: [<Str>main</Str>]
-                  </Ln>
-                  <div className="mt-2" />
-                  <Ln>
-                    <Kw>jobs</Kw>:
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Kw>deploy</Kw>:
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Kw>runs-on</Kw>: <Str>ubuntu-latest</Str>
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Kw>steps</Kw>:
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    - <Kw>name</Kw>: <Str>Configure ShellHub SSH</Str>
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Kw>run</Kw>: |
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Dim>mkdir -p ~/.ssh</Dim>
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Dim>
-                      echo{" "}
-                      <Str>"$&#123;&#123; secrets.SSH_KEY &#125;&#125;"</Str>{" "}
-                      &gt; ~/.ssh/id_rsa
-                    </Dim>
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Dim>chmod 600 ~/.ssh/id_rsa</Dim>
-                  </Ln>
-                  <div className="mt-2" />
-                  <Ln>
-                    {" "}
-                    - <Kw>name</Kw>: <Str>Deploy application</Str>
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Kw>run</Kw>: |
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Dim>
-                      ssh <Cyn>admin@device.namespace.shellhub.io</Cyn> \
-                    </Dim>
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Dim>
-                      {" "}
-                      <Str>
-                        "cd /opt/app &amp;&amp; git pull &amp;&amp; systemctl
-                        restart app"
-                      </Str>
-                    </Dim>
-                  </Ln>
-                  <div className="mt-2" />
-                  <Ln>
-                    {" "}
-                    - <Kw>name</Kw>: <Str>Verify deployment</Str>
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Kw>run</Kw>: |
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Dim>
-                      ssh <Cyn>admin@device.namespace.shellhub.io</Cyn> \
-                    </Dim>
-                  </Ln>
-                  <Ln>
-                    {" "}
-                    <Dim>
-                      {" "}
-                      <Str>"curl -sf http://localhost:8080/health"</Str>
-                    </Dim>
-                  </Ln>
-                </div>
-              </div>
-            </div>
+            <WindowChrome
+              variant="terminal"
+              title=".github/workflows/deploy.yml"
+              titleBarSlot={
+                <Badge shape="pill" color="green">
+                  Passing
+                </Badge>
+              }
+              className="border-accent-green/25 shadow-[0_0_40px_rgba(130,165,104,0.08)]"
+              bodyClassName="overflow-x-auto"
+            >
+              <Ln>
+                <Kw>name</Kw>: <Str>Deploy to Edge Devices</Str>
+              </Ln>
+              <Ln>
+                <Kw>on</Kw>:
+              </Ln>
+              <Ln>
+                {" "}
+                <Kw>push</Kw>:
+              </Ln>
+              <Ln>
+                {" "}
+                <Kw>branches</Kw>: [<Str>main</Str>]
+              </Ln>
+              <div className="mt-2" />
+              <Ln>
+                <Kw>jobs</Kw>:
+              </Ln>
+              <Ln>
+                {" "}
+                <Kw>deploy</Kw>:
+              </Ln>
+              <Ln>
+                {" "}
+                <Kw>runs-on</Kw>: <Str>ubuntu-latest</Str>
+              </Ln>
+              <Ln>
+                {" "}
+                <Kw>steps</Kw>:
+              </Ln>
+              <Ln>
+                {" "}
+                - <Kw>name</Kw>: <Str>Configure ShellHub SSH</Str>
+              </Ln>
+              <Ln>
+                {" "}
+                <Kw>run</Kw>: |
+              </Ln>
+              <Ln>
+                {" "}
+                <Dim>mkdir -p ~/.ssh</Dim>
+              </Ln>
+              <Ln>
+                {" "}
+                <Dim>
+                  echo <Str>"$&#123;&#123; secrets.SSH_KEY &#125;&#125;"</Str>{" "}
+                  &gt; ~/.ssh/id_rsa
+                </Dim>
+              </Ln>
+              <Ln>
+                {" "}
+                <Dim>chmod 600 ~/.ssh/id_rsa</Dim>
+              </Ln>
+              <div className="mt-2" />
+              <Ln>
+                {" "}
+                - <Kw>name</Kw>: <Str>Deploy application</Str>
+              </Ln>
+              <Ln>
+                {" "}
+                <Kw>run</Kw>: |
+              </Ln>
+              <Ln>
+                {" "}
+                <Dim>
+                  ssh <Cyn>admin@device.namespace.shellhub.io</Cyn> \
+                </Dim>
+              </Ln>
+              <Ln>
+                {" "}
+                <Dim>
+                  {" "}
+                  <Str>
+                    "cd /opt/app &amp;&amp; git pull &amp;&amp; systemctl
+                    restart app"
+                  </Str>
+                </Dim>
+              </Ln>
+              <div className="mt-2" />
+              <Ln>
+                {" "}
+                - <Kw>name</Kw>: <Str>Verify deployment</Str>
+              </Ln>
+              <Ln>
+                {" "}
+                <Kw>run</Kw>: |
+              </Ln>
+              <Ln>
+                {" "}
+                <Dim>
+                  ssh <Cyn>admin@device.namespace.shellhub.io</Cyn> \
+                </Dim>
+              </Ln>
+              <Ln>
+                {" "}
+                <Dim>
+                  {" "}
+                  <Str>"curl -sf http://localhost:8080/health"</Str>
+                </Dim>
+              </Ln>
+            </WindowChrome>
           </ShimmerCard>
         </Reveal>
       </Section>
@@ -873,23 +840,29 @@ export default function Integrations() {
             />
 
             <Reveal delay={0.05}>
-              <TerminalChrome title="terminal">
-                <Comment># Connect to a specific container</Comment>
-                <Ln>
-                  <Val>$</Val> ssh <Cyn>root@web-app.host01.ns.shellhub.io</Cyn>
-                </Ln>
-                <Ln color={C.textSec}>
-                  Connected to web-app (container: a1b2c3d4)
-                </Ln>
-                <Ln color={C.textMuted}>&nbsp;</Ln>
-                <Ln>
-                  <Val>root@web-app:~#</Val>{" "}
-                  <Dim>curl localhost:8080/health</Dim>
-                </Ln>
-                <Ln>
-                  <Str>{'{"status":"healthy","uptime":"14d 6h"}'}</Str>
-                </Ln>
-              </TerminalChrome>
+              <ShimmerCard>
+                <WindowChrome
+                  variant="terminal"
+                  bodyClassName="overflow-x-auto"
+                >
+                  <Comment># Connect to a specific container</Comment>
+                  <Ln>
+                    <Val>$</Val> ssh{" "}
+                    <Cyn>root@web-app.host01.ns.shellhub.io</Cyn>
+                  </Ln>
+                  <Ln color={C.textSec}>
+                    Connected to web-app (container: a1b2c3d4)
+                  </Ln>
+                  <Ln color={C.textMuted}>&nbsp;</Ln>
+                  <Ln>
+                    <Val>root@web-app:~#</Val>{" "}
+                    <Dim>curl localhost:8080/health</Dim>
+                  </Ln>
+                  <Ln>
+                    <Str>{'{"status":"healthy","uptime":"14d 6h"}'}</Str>
+                  </Ln>
+                </WindowChrome>
+              </ShimmerCard>
             </Reveal>
           </div>
         </div>

--- a/ui/apps/website/src/pages/landing/QuickStart.tsx
+++ b/ui/apps/website/src/pages/landing/QuickStart.tsx
@@ -1,7 +1,8 @@
-import { Card } from "@shellhub/design-system/primitives";
-import { Section, SectionHeader } from "@/components/marketing";
-import { Reveal, CopyBtn } from "./components";
+import { CommandBlock, Section, SectionHeader } from "@/components/marketing";
+import { Reveal } from "./components";
 import { docsUrl } from "@/links";
+
+const DOCKER_CMD = "docker run -d -p 80:80 shellhubio/shellhub";
 
 export function QuickStart() {
   return (
@@ -15,25 +16,7 @@ export function QuickStart() {
       />
 
       <Reveal>
-        <Card className="max-w-xl mx-auto overflow-hidden">
-          <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border bg-surface">
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-red/70" />
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-yellow/70" />
-            <span className="w-2.5 h-2.5 rounded-full bg-accent-green/70" />
-            <span className="flex-1 text-center text-2xs font-mono text-text-secondary">
-              terminal
-            </span>
-          </div>
-          <div className="px-5 py-4 flex items-center justify-between gap-4">
-            <code className="font-mono text-sm text-text-secondary leading-relaxed">
-              <span className="text-primary">$ </span>
-              <span className="text-text-primary">
-                docker run -d -p 80:80 shellhubio/shellhub
-              </span>
-            </code>
-            <CopyBtn text="docker run -d -p 80:80 shellhubio/shellhub" />
-          </div>
-        </Card>
+        <CommandBlock command={DOCKER_CMD} className="max-w-xl mx-auto" />
       </Reveal>
 
       <Reveal className="text-center mt-5">

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Card,
   IconBadge,
+  WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
@@ -138,7 +139,7 @@ const permRows = [
   {
     container: "redis-cache",
     user: "ana@co.com",
-    role: "Viewer",
+    role: "Observer",
     level: "Read only",
     accent: C.cyan,
   },
@@ -147,7 +148,7 @@ const permRows = [
     user: "dev-team",
     role: "Operator",
     level: "Shell only",
-    accent: C.yellow,
+    accent: C.primary,
   },
 ];
 
@@ -593,16 +594,8 @@ export default function ContainerManagement() {
                 </div>
 
                 {/* Fake terminal */}
-                <div className="bg-[#111214] rounded-lg border border-border overflow-hidden flex-1">
-                  <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
-                    <div className="w-2.5 h-2.5 rounded-full bg-accent-red/50" />
-                    <div className="w-2.5 h-2.5 rounded-full bg-accent-yellow/50" />
-                    <div className="w-2.5 h-2.5 rounded-full bg-accent-green/50" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Terminal
-                    </span>
-                  </div>
-                  <div className="p-4 font-mono text-xs leading-relaxed space-y-2">
+                <WindowChrome variant="terminal" size="sm" className="flex-1">
+                  <div className="space-y-2">
                     <p>
                       <span className="text-text-muted">
                         # Step 1: SSH into the Docker host
@@ -646,7 +639,7 @@ export default function ContainerManagement() {
                       No audit. No access control. No recording.
                     </p>
                   </div>
-                </div>
+                </WindowChrome>
               </Card>
             </ShimmerCard>
           </Reveal>
@@ -684,16 +677,12 @@ export default function ContainerManagement() {
                   </p>
 
                   {/* Fake terminal */}
-                  <div className="bg-[#111214] rounded-lg border border-primary/20 overflow-hidden flex-1">
-                    <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-border">
-                      <div className="w-2.5 h-2.5 rounded-full bg-accent-red/50" />
-                      <div className="w-2.5 h-2.5 rounded-full bg-accent-yellow/50" />
-                      <div className="w-2.5 h-2.5 rounded-full bg-accent-green/50" />
-                      <span className="ml-2 text-2xs text-primary font-mono">
-                        Terminal
-                      </span>
-                    </div>
-                    <div className="p-4 font-mono text-xs leading-relaxed space-y-2">
+                  <WindowChrome
+                    variant="terminal"
+                    size="sm"
+                    className="border-primary/20 flex-1"
+                  >
+                    <div className="space-y-2">
                       <p>
                         <span className="text-text-muted">
                           # One step. That's it.
@@ -722,7 +711,7 @@ export default function ContainerManagement() {
                         <span className="inline-block w-2 h-3.5 bg-text-primary animate-pulse" />
                       </p>
                     </div>
-                  </div>
+                  </WindowChrome>
 
                   {/* Status badges */}
                   <div className="flex flex-wrap gap-2 mt-4">
@@ -873,16 +862,11 @@ export default function ContainerManagement() {
                 </div>
 
                 {/* Right: permissions table mockup */}
-                <div className="bg-surface rounded-xl border border-border overflow-hidden">
-                  <div className="flex items-center gap-2 px-5 py-3 border-b border-border">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Container Permissions
-                    </span>
-                  </div>
-
+                <WindowChrome
+                  variant="browser"
+                  path="/containers"
+                  bodyClassName="font-sans"
+                >
                   {/* Table header */}
                   <div className="grid grid-cols-4 gap-2 px-5 py-2.5 border-b border-border text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
                     <span>Container</span>
@@ -927,7 +911,7 @@ export default function ContainerManagement() {
                       Manage &rarr;
                     </span>
                   </div>
-                </div>
+                </WindowChrome>
               </div>
             </div>
           </ShimmerCard>

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -1,5 +1,10 @@
 import { Link } from "react-router-dom";
-import { Badge, Button, Card } from "@shellhub/design-system/primitives";
+import {
+  Badge,
+  Button,
+  Card,
+  WindowChrome,
+} from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
@@ -260,26 +265,6 @@ const pipelineDeployLines: { text: string; color?: string; dim?: boolean }[] = [
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
 
-function TerminalChrome({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="p-6">
-      <div className="flex items-center gap-2 mb-5">
-        <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-        <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-        <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-        <span className="ml-2 text-2xs text-text-muted font-mono">{title}</span>
-      </div>
-      {children}
-    </div>
-  );
-}
-
 function CodeLine({
   text,
   color,
@@ -429,15 +414,13 @@ export default function DevopsCiCd() {
 
           <Reveal delay={0.1}>
             <ShimmerCard>
-              <Card className="overflow-hidden">
-                <TerminalChrome title="ansible-playbook">
-                  <div className="space-y-0">
-                    {ansibleLines.map((line, i) => (
-                      <CodeLine key={i} {...line} />
-                    ))}
-                  </div>
-                </TerminalChrome>
-              </Card>
+              <WindowChrome variant="terminal" title="ansible-playbook">
+                <div className="space-y-0 overflow-x-auto">
+                  {ansibleLines.map((line, i) => (
+                    <CodeLine key={i} {...line} />
+                  ))}
+                </div>
+              </WindowChrome>
             </ShimmerCard>
           </Reveal>
         </div>
@@ -448,15 +431,13 @@ export default function DevopsCiCd() {
         <div className="grid lg:grid-cols-2 gap-12 items-center">
           <Reveal delay={0.1} className="order-2 lg:order-1">
             <ShimmerCard>
-              <Card className="overflow-hidden">
-                <TerminalChrome title="main.tf">
-                  <div className="space-y-0">
-                    {terraformLines.map((line, i) => (
-                      <CodeLine key={i} {...line} />
-                    ))}
-                  </div>
-                </TerminalChrome>
-              </Card>
+              <WindowChrome variant="terminal" title="main.tf">
+                <div className="space-y-0 overflow-x-auto">
+                  {terraformLines.map((line, i) => (
+                    <CodeLine key={i} {...line} />
+                  ))}
+                </div>
+              </WindowChrome>
             </ShimmerCard>
           </Reveal>
 
@@ -530,73 +511,72 @@ export default function DevopsCiCd() {
 
         <Reveal delay={0.1}>
           <ShimmerCard className="max-w-3xl mx-auto">
-            <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(102,122,204,0.1)]">
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
-              <div className="relative">
-                <TerminalChrome title=".github/workflows/deploy.yml">
-                  {/* Pipeline step indicators */}
-                  <div className="flex items-center gap-6 mb-6 pb-5 border-b border-border">
-                    {pipelineSteps.map((step, i) => (
-                      <div key={i} className="flex items-center gap-2">
-                        <div className="w-5 h-5 rounded-full bg-accent-green/15 border border-accent-green/30 flex items-center justify-center">
-                          <svg
-                            className="w-3 h-3 text-accent-green"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2.5}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="m4.5 12.75 6 6 9-13.5"
-                            />
-                          </svg>
-                        </div>
-                        <span className="text-2xs font-mono text-text-secondary">
-                          {step.label}
-                        </span>
-                        {i < pipelineSteps.length - 1 && (
-                          <svg
-                            className="w-3 h-3 text-text-muted ml-2"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                            strokeWidth={2}
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
-                            />
-                          </svg>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-
-                  {/* Workflow YAML */}
-                  <div className="space-y-0 mb-6">
-                    {pipelineDeployLines.map((line, i) => (
-                      <CodeLine key={i} {...line} />
-                    ))}
-                  </div>
-
-                  {/* Status bar */}
-                  <div className="pt-4 border-t border-border flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <div className="w-2 h-2 rounded-full bg-accent-green animate-pulse" />
-                      <span className="text-2xs font-mono text-accent-green">
-                        Pipeline succeeded
-                      </span>
+            <WindowChrome
+              variant="terminal"
+              title=".github/workflows/deploy.yml"
+              className="border-primary/30 shadow-[0_0_40px_rgba(102,122,204,0.1)]"
+            >
+              {/* Pipeline step indicators */}
+              <div className="flex items-center gap-6 mb-6 pb-5 border-b border-border">
+                {pipelineSteps.map((step, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <div className="w-5 h-5 rounded-full bg-accent-green/15 border border-accent-green/30 flex items-center justify-center">
+                      <svg
+                        className="w-3 h-3 text-accent-green"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="m4.5 12.75 6 6 9-13.5"
+                        />
+                      </svg>
                     </div>
-                    <span className="text-2xs text-text-muted font-mono">
-                      2 devices updated in 34s
+                    <span className="text-2xs font-mono text-text-secondary">
+                      {step.label}
                     </span>
+                    {i < pipelineSteps.length - 1 && (
+                      <svg
+                        className="w-3 h-3 text-text-muted ml-2"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+                        />
+                      </svg>
+                    )}
                   </div>
-                </TerminalChrome>
+                ))}
               </div>
-            </div>
+
+              {/* Workflow YAML */}
+              <div className="space-y-0 mb-6 overflow-x-auto">
+                {pipelineDeployLines.map((line, i) => (
+                  <CodeLine key={i} {...line} />
+                ))}
+              </div>
+
+              {/* Status bar */}
+              <div className="pt-4 border-t border-border flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-2 rounded-full bg-accent-green animate-pulse" />
+                  <span className="text-2xs font-mono text-accent-green">
+                    Pipeline succeeded
+                  </span>
+                </div>
+                <span className="text-2xs text-text-muted font-mono">
+                  2 devices updated in 34s
+                </span>
+              </div>
+            </WindowChrome>
           </ShimmerCard>
         </Reveal>
       </Section>

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Card,
   IconBadge,
+  WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
@@ -537,74 +538,64 @@ export default function EdgeComputing() {
                 </div>
 
                 {/* Terminal mockup */}
-                <div className="bg-surface rounded-xl border border-border overflow-hidden">
-                  <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Terminal
+                <WindowChrome variant="terminal" bodyClassName="space-y-1">
+                  <div>
+                    <span style={{ color: C.green }}>user@ops-laptop</span>
+                    <span style={{ color: C.textMuted }}>:</span>
+                    <span style={{ color: C.blue }}>~</span>
+                    <span style={{ color: C.textMuted }}>$</span>{" "}
+                    <span style={{ color: C.text }}>
+                      ssh admin@edge-nyc-01.production
                     </span>
                   </div>
-                  <div className="p-4 font-mono text-2xs leading-relaxed space-y-1">
-                    <div>
-                      <span style={{ color: C.green }}>user@ops-laptop</span>
-                      <span style={{ color: C.textMuted }}>:</span>
-                      <span style={{ color: C.blue }}>~</span>
-                      <span style={{ color: C.textMuted }}>$</span>{" "}
-                      <span style={{ color: C.text }}>
-                        ssh admin@edge-nyc-01.production
-                      </span>
-                    </div>
-                    <div style={{ color: C.textMuted }}>
-                      Connecting via ShellHub tunnel...
-                    </div>
-                    <div style={{ color: C.green }}>
-                      Connection established (NAT traversal)
-                    </div>
-                    <div>&nbsp;</div>
-                    <div>
-                      <span style={{ color: C.green }}>admin@edge-nyc-01</span>
-                      <span style={{ color: C.textMuted }}>:</span>
-                      <span style={{ color: C.blue }}>~</span>
-                      <span style={{ color: C.textMuted }}>$</span>{" "}
-                      <span style={{ color: C.text }}>uname -a</span>
-                    </div>
-                    <div style={{ color: C.textSec }}>
-                      Linux edge-nyc-01 5.15.0 #1 SMP x86_64
-                    </div>
-                    <div>
-                      <span style={{ color: C.green }}>admin@edge-nyc-01</span>
-                      <span style={{ color: C.textMuted }}>:</span>
-                      <span style={{ color: C.blue }}>~</span>
-                      <span style={{ color: C.textMuted }}>$</span>{" "}
-                      <span style={{ color: C.text }}>
-                        systemctl status edge-service
-                      </span>
-                    </div>
-                    <div>
-                      <span style={{ color: C.green }}>●</span>{" "}
-                      <span style={{ color: C.textSec }}>
-                        edge-service.service - Edge Compute Service
-                      </span>
-                    </div>
-                    <div style={{ color: C.green }}>
-                      &nbsp;&nbsp;Active: active (running) since Mon 2026-02-14
-                    </div>
-                    <div>
-                      <span style={{ color: C.green }}>admin@edge-nyc-01</span>
-                      <span style={{ color: C.textMuted }}>:</span>
-                      <span style={{ color: C.blue }}>~</span>
-                      <span style={{ color: C.textMuted }}>$</span>{" "}
-                      <span
-                        className="animate-pulse"
-                        style={{ color: C.primary }}
-                      >
-                        _
-                      </span>
-                    </div>
+                  <div style={{ color: C.textMuted }}>
+                    Connecting via ShellHub tunnel...
                   </div>
-                </div>
+                  <div style={{ color: C.green }}>
+                    Connection established (NAT traversal)
+                  </div>
+                  <div>&nbsp;</div>
+                  <div>
+                    <span style={{ color: C.green }}>admin@edge-nyc-01</span>
+                    <span style={{ color: C.textMuted }}>:</span>
+                    <span style={{ color: C.blue }}>~</span>
+                    <span style={{ color: C.textMuted }}>$</span>{" "}
+                    <span style={{ color: C.text }}>uname -a</span>
+                  </div>
+                  <div style={{ color: C.textSec }}>
+                    Linux edge-nyc-01 5.15.0 #1 SMP x86_64
+                  </div>
+                  <div>
+                    <span style={{ color: C.green }}>admin@edge-nyc-01</span>
+                    <span style={{ color: C.textMuted }}>:</span>
+                    <span style={{ color: C.blue }}>~</span>
+                    <span style={{ color: C.textMuted }}>$</span>{" "}
+                    <span style={{ color: C.text }}>
+                      systemctl status edge-service
+                    </span>
+                  </div>
+                  <div>
+                    <span style={{ color: C.green }}>●</span>{" "}
+                    <span style={{ color: C.textSec }}>
+                      edge-service.service - Edge Compute Service
+                    </span>
+                  </div>
+                  <div style={{ color: C.green }}>
+                    &nbsp;&nbsp;Active: active (running) since Mon 2026-02-14
+                  </div>
+                  <div>
+                    <span style={{ color: C.green }}>admin@edge-nyc-01</span>
+                    <span style={{ color: C.textMuted }}>:</span>
+                    <span style={{ color: C.blue }}>~</span>
+                    <span style={{ color: C.textMuted }}>$</span>{" "}
+                    <span
+                      className="animate-pulse"
+                      style={{ color: C.primary }}
+                    >
+                      _
+                    </span>
+                  </div>
+                </WindowChrome>
               </div>
             </div>
           </ShimmerCard>
@@ -645,43 +636,38 @@ export default function EdgeComputing() {
                 </p>
 
                 {/* Browser mockup */}
-                <div className="bg-surface rounded-lg border border-border overflow-hidden">
-                  <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
-                    <div className="w-2 h-2 rounded-full bg-accent-red/50" />
-                    <div className="w-2 h-2 rounded-full bg-accent-yellow/50" />
-                    <div className="w-2 h-2 rounded-full bg-accent-green/50" />
-                    <div className="flex-1 mx-2 px-2 py-0.5 bg-background rounded text-2xs font-mono text-text-muted truncate">
-                      shellhub.io/terminal/edge-chi-03
-                    </div>
+                <WindowChrome
+                  variant="browser"
+                  size="sm"
+                  path="/terminal/edge-chi-03"
+                  bodyClassName="space-y-0.5"
+                >
+                  <div>
+                    <span style={{ color: C.green }}>admin@edge-chi-03</span>
+                    <span style={{ color: C.textMuted }}>:</span>
+                    <span style={{ color: C.blue }}>~</span>
+                    <span style={{ color: C.textMuted }}>$</span>{" "}
+                    <span style={{ color: C.text }}>df -h /data</span>
                   </div>
-                  <div className="p-3 font-mono text-2xs space-y-0.5">
-                    <div>
-                      <span style={{ color: C.green }}>admin@edge-chi-03</span>
-                      <span style={{ color: C.textMuted }}>:</span>
-                      <span style={{ color: C.blue }}>~</span>
-                      <span style={{ color: C.textMuted }}>$</span>{" "}
-                      <span style={{ color: C.text }}>df -h /data</span>
-                    </div>
-                    <div style={{ color: C.textSec }}>
-                      Filesystem&nbsp;&nbsp;Size&nbsp;&nbsp;Used&nbsp;&nbsp;Avail&nbsp;&nbsp;Use%
-                    </div>
-                    <div style={{ color: C.textSec }}>
-                      /dev/sda1&nbsp;&nbsp;&nbsp;500G&nbsp;&nbsp;312G&nbsp;&nbsp;188G&nbsp;&nbsp;&nbsp;62%
-                    </div>
-                    <div>
-                      <span style={{ color: C.green }}>admin@edge-chi-03</span>
-                      <span style={{ color: C.textMuted }}>:</span>
-                      <span style={{ color: C.blue }}>~</span>
-                      <span style={{ color: C.textMuted }}>$</span>{" "}
-                      <span
-                        className="animate-pulse"
-                        style={{ color: C.primary }}
-                      >
-                        _
-                      </span>
-                    </div>
+                  <div style={{ color: C.textSec }}>
+                    Filesystem&nbsp;&nbsp;Size&nbsp;&nbsp;Used&nbsp;&nbsp;Avail&nbsp;&nbsp;Use%
                   </div>
-                </div>
+                  <div style={{ color: C.textSec }}>
+                    /dev/sda1&nbsp;&nbsp;&nbsp;500G&nbsp;&nbsp;312G&nbsp;&nbsp;188G&nbsp;&nbsp;&nbsp;62%
+                  </div>
+                  <div>
+                    <span style={{ color: C.green }}>admin@edge-chi-03</span>
+                    <span style={{ color: C.textMuted }}>:</span>
+                    <span style={{ color: C.blue }}>~</span>
+                    <span style={{ color: C.textMuted }}>$</span>{" "}
+                    <span
+                      className="animate-pulse"
+                      style={{ color: C.primary }}
+                    >
+                      _
+                    </span>
+                  </div>
+                </WindowChrome>
               </Card>
             </ShimmerCard>
           </Reveal>

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Card,
   IconBadge,
+  WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
@@ -259,92 +260,80 @@ export default function IotEmbedded() {
           {/* Fake dashboard panel */}
           <Reveal delay={0.1}>
             <ShimmerCard>
-              <Card className="overflow-hidden">
-                <div className="p-6">
-                  {/* Window chrome */}
-                  <div className="flex items-center gap-2 mb-6">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Device Fleet
-                    </span>
-                  </div>
-
-                  {/* Table header */}
-                  <div className="flex items-center gap-3 px-3 py-2 mb-1">
-                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-5">
-                      St
-                    </span>
-                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1">
-                      Hostname
-                    </span>
-                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-24 hidden sm:block">
-                      IP
-                    </span>
-                    <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1 text-right">
-                      Tags
-                    </span>
-                  </div>
-
-                  {/* Device rows */}
-                  <div className="space-y-2">
-                    {fleetDevices.map((d, i) => (
-                      <div
-                        key={i}
-                        className="flex items-center gap-3 p-3 bg-surface rounded-lg border border-border hover:border-border-light transition-colors duration-200"
-                      >
-                        <div
-                          className="w-2 h-2 rounded-full shrink-0"
-                          style={{
-                            background:
-                              d.status === "online" ? C.green : C.textMuted,
-                          }}
-                        />
-                        <div className="flex-1 min-w-0">
-                          <p className="text-xs font-mono font-medium truncate">
-                            {d.name}
-                          </p>
-                        </div>
-                        <span className="text-2xs text-text-muted font-mono w-24 hidden sm:block">
-                          {d.ip}
-                        </span>
-                        <div className="flex items-center gap-1.5 flex-wrap justify-end">
-                          {d.tags.map((t, j) => (
-                            <span
-                              key={j}
-                              className="px-1.5 py-0.5 text-2xs font-mono rounded-full border"
-                              style={{
-                                background: `${t.color}10`,
-                                color: t.color,
-                                borderColor: `${t.color}20`,
-                              }}
-                            >
-                              {t.label}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-
-                  {/* Footer */}
-                  <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <div
-                        className="w-2 h-2 rounded-full"
-                        style={{ background: C.green }}
-                      />
-                      <span className="text-2xs text-text-muted">
-                        24 devices online
-                      </span>
-                    </div>
-                    <span className="text-2xs text-primary font-medium">
-                      View all &rarr;
-                    </span>
-                  </div>
+              <WindowChrome variant="browser" path="/devices">
+                {/* Table header */}
+                <div className="flex items-center gap-3 px-3 py-2 mb-1">
+                  <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-5">
+                    St
+                  </span>
+                  <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1">
+                    Hostname
+                  </span>
+                  <span className="text-2xs text-text-muted font-mono uppercase tracking-wider w-24 hidden sm:block">
+                    IP
+                  </span>
+                  <span className="text-2xs text-text-muted font-mono uppercase tracking-wider flex-1 text-right">
+                    Tags
+                  </span>
                 </div>
-              </Card>
+
+                {/* Device rows */}
+                <div className="space-y-2">
+                  {fleetDevices.map((d, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center gap-3 p-3 bg-surface rounded-lg border border-border hover:border-border-light transition-colors duration-200"
+                    >
+                      <div
+                        className="w-2 h-2 rounded-full shrink-0"
+                        style={{
+                          background:
+                            d.status === "online" ? C.green : C.textMuted,
+                        }}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs font-mono font-medium truncate">
+                          {d.name}
+                        </p>
+                      </div>
+                      <span className="text-2xs text-text-muted font-mono w-24 hidden sm:block">
+                        {d.ip}
+                      </span>
+                      <div className="flex flex-1 items-center gap-1.5 flex-wrap justify-end">
+                        {d.tags.map((t, j) => (
+                          <span
+                            key={j}
+                            className="px-1.5 py-0.5 text-2xs font-mono rounded-full border"
+                            style={{
+                              background: `${t.color}10`,
+                              color: t.color,
+                              borderColor: `${t.color}20`,
+                            }}
+                          >
+                            {t.label}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Footer */}
+                <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div
+                      className="w-2 h-2 rounded-full"
+                      style={{ background: C.green }}
+                    />
+                    <span className="text-2xs text-text-muted">
+                      24 devices online
+                    </span>
+                  </div>
+                  <span className="text-2xs text-primary font-medium">
+                    View all &rarr;
+                  </span>
+                </div>
+              </WindowChrome>
             </ShimmerCard>
           </Reveal>
         </div>

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -1,5 +1,10 @@
 import { Link } from "react-router-dom";
-import { Badge, Button, Card } from "@shellhub/design-system/primitives";
+import {
+  Badge,
+  Button,
+  Card,
+  WindowChrome,
+} from "@shellhub/design-system/primitives";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
@@ -334,118 +339,102 @@ export default function RemoteSupport() {
           {/* Session player mockup */}
           <Reveal delay={0.1}>
             <ShimmerCard>
-              <Card className="overflow-hidden">
-                <div className="p-6">
-                  {/* Window chrome */}
-                  <div className="flex items-center gap-2 mb-4">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Session Replay
+              <WindowChrome variant="terminal" title="Session Replay">
+                {/* Terminal area */}
+                <div className="bg-[#111214] rounded-lg border border-border p-4 font-mono text-2xs leading-relaxed mb-4">
+                  <p className="text-accent-green">
+                    john@prod-server-03:~$
+                    <span className="text-text-primary ml-2">
+                      ls -la /var/log/nginx/
                     </span>
-                  </div>
-
-                  {/* Terminal area */}
-                  <div className="bg-[#111214] rounded-lg border border-border p-4 font-mono text-2xs leading-relaxed mb-4">
-                    <p className="text-accent-green">
-                      john@prod-server-03:~$
-                      <span className="text-text-primary ml-2">
-                        ls -la /var/log/nginx/
-                      </span>
-                    </p>
-                    <p className="text-text-muted mt-1">total 2184</p>
-                    <p className="text-text-muted">
-                      drwxr-xr-x 2 root root 4096 Feb 14 09:00 .
-                    </p>
-                    <p className="text-text-muted">
-                      -rw-r----- 1 root adm 842560 Feb 14 14:31 access.log
-                    </p>
-                    <p className="text-text-muted">
-                      -rw-r----- 1 root adm 194720 Feb 14 14:28 error.log
-                    </p>
-                    <p className="text-accent-green mt-2">
-                      john@prod-server-03:~$
-                      <span className="text-text-primary ml-2">
-                        systemctl status nginx
-                      </span>
-                    </p>
-                    <p className="text-text-muted mt-1">
-                      <span className="text-accent-green">●</span> nginx.service
-                      - A high performance web server
-                    </p>
-                    <p className="text-text-muted">
-                      {"   "}Loaded: loaded (/lib/systemd/system/nginx.service;
-                      enabled)
-                    </p>
-                    <p className="text-text-muted">
-                      {"   "}Active:{" "}
-                      <span className="text-accent-green">
-                        active (running)
-                      </span>{" "}
-                      since Fri 2026-02-14 09:00:12 UTC
-                    </p>
-                    <p className="text-accent-green mt-2">
-                      john@prod-server-03:~$
-                      <span className="text-text-primary ml-2 animate-pulse">
-                        _
-                      </span>
-                    </p>
-                  </div>
-
-                  {/* Playback controls */}
-                  <div className="flex items-center gap-3 bg-surface rounded-lg border border-border p-3">
-                    <button
-                      type="button"
-                      aria-label="Play"
-                      className="w-8 h-8 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center shrink-0"
-                    >
-                      <svg
-                        width="14"
-                        height="14"
-                        viewBox="0 0 24 24"
-                        fill={C.cyan}
-                        stroke="none"
-                        aria-hidden="true"
-                      >
-                        <polygon points="6 4 20 12 6 20 6 4" />
-                      </svg>
-                    </button>
-
-                    {/* Timeline */}
-                    <div className="flex-1 relative">
-                      <div className="h-1.5 bg-border rounded-full overflow-hidden">
-                        <div
-                          className="h-full rounded-full bg-gradient-to-r from-accent-cyan to-primary"
-                          style={{ width: "30%" }}
-                        />
-                      </div>
-                    </div>
-
-                    <span className="text-2xs text-text-muted font-mono shrink-0">
-                      00:03:42 / 00:12:15
+                  </p>
+                  <p className="text-text-muted mt-1">total 2184</p>
+                  <p className="text-text-muted">
+                    drwxr-xr-x 2 root root 4096 Feb 14 09:00 .
+                  </p>
+                  <p className="text-text-muted">
+                    -rw-r----- 1 root adm 842560 Feb 14 14:31 access.log
+                  </p>
+                  <p className="text-text-muted">
+                    -rw-r----- 1 root adm 194720 Feb 14 14:28 error.log
+                  </p>
+                  <p className="text-accent-green mt-2">
+                    john@prod-server-03:~$
+                    <span className="text-text-primary ml-2">
+                      systemctl status nginx
                     </span>
-                  </div>
-
-                  {/* Metadata */}
-                  <div className="mt-4 pt-4 border-t border-border">
-                    <p className="text-2xs text-text-muted font-mono">
-                      User:{" "}
-                      <span className="text-text-secondary">
-                        john@company.com
-                      </span>
-                      <span className="mx-2 text-border">|</span>
-                      Device:{" "}
-                      <span className="text-text-secondary">
-                        prod-server-03
-                      </span>
-                      <span className="mx-2 text-border">|</span>
-                      Duration:{" "}
-                      <span className="text-text-secondary">12m 15s</span>
-                    </p>
-                  </div>
+                  </p>
+                  <p className="text-text-muted mt-1">
+                    <span className="text-accent-green">●</span> nginx.service -
+                    A high performance web server
+                  </p>
+                  <p className="text-text-muted">
+                    {"   "}Loaded: loaded (/lib/systemd/system/nginx.service;
+                    enabled)
+                  </p>
+                  <p className="text-text-muted">
+                    {"   "}Active:{" "}
+                    <span className="text-accent-green">active (running)</span>{" "}
+                    since Fri 2026-02-14 09:00:12 UTC
+                  </p>
+                  <p className="text-accent-green mt-2">
+                    john@prod-server-03:~$
+                    <span className="text-text-primary ml-2 animate-pulse">
+                      _
+                    </span>
+                  </p>
                 </div>
-              </Card>
+
+                {/* Playback controls */}
+                <div className="flex items-center gap-3 bg-surface rounded-lg border border-border p-3">
+                  <button
+                    type="button"
+                    aria-label="Play"
+                    className="w-8 h-8 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center shrink-0"
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill={C.cyan}
+                      stroke="none"
+                      aria-hidden="true"
+                    >
+                      <polygon points="6 4 20 12 6 20 6 4" />
+                    </svg>
+                  </button>
+
+                  {/* Timeline */}
+                  <div className="flex-1 relative">
+                    <div className="h-1.5 bg-border rounded-full overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-gradient-to-r from-accent-cyan to-primary"
+                        style={{ width: "30%" }}
+                      />
+                    </div>
+                  </div>
+
+                  <span className="text-2xs text-text-muted font-mono shrink-0">
+                    00:03:42 / 00:12:15
+                  </span>
+                </div>
+
+                {/* Metadata */}
+                <div className="mt-4 pt-4 border-t border-border">
+                  <p className="text-2xs text-text-muted font-mono">
+                    User:{" "}
+                    <span className="text-text-secondary">
+                      john@company.com
+                    </span>
+                    <span className="mx-2 text-border">|</span>
+                    Device:{" "}
+                    <span className="text-text-secondary">prod-server-03</span>
+                    <span className="mx-2 text-border">|</span>
+                    Duration:{" "}
+                    <span className="text-text-secondary">12m 15s</span>
+                  </p>
+                </div>
+              </WindowChrome>
             </ShimmerCard>
           </Reveal>
         </div>
@@ -457,87 +446,75 @@ export default function RemoteSupport() {
           {/* Audit log table mockup */}
           <Reveal delay={0.1} className="order-2 lg:order-1">
             <ShimmerCard>
-              <Card className="overflow-hidden">
-                <div className="p-6">
-                  {/* Window chrome */}
-                  <div className="flex items-center gap-2 mb-5">
-                    <div className="w-3 h-3 rounded-full bg-accent-red/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-yellow/60" />
-                    <div className="w-3 h-3 rounded-full bg-accent-green/60" />
-                    <span className="ml-2 text-2xs text-text-muted font-mono">
-                      Audit Log
-                    </span>
-                  </div>
+              <WindowChrome variant="terminal" title="Audit Log">
+                {/* Table header */}
+                <div className="grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2 mb-1">
+                  <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                    Time
+                  </span>
+                  <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                    User
+                  </span>
+                  <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                    Action
+                  </span>
+                  <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                    Device
+                  </span>
+                  <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
+                    Duration
+                  </span>
+                </div>
 
-                  {/* Table header */}
-                  <div className="grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2 mb-1">
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      Time
-                    </span>
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      User
-                    </span>
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      Action
-                    </span>
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      Device
-                    </span>
-                    <span className="text-2xs font-mono font-semibold text-text-muted uppercase tracking-wider">
-                      Duration
-                    </span>
-                  </div>
-
-                  {/* Rows */}
-                  <div className="space-y-1">
-                    {auditRows.map((row, i) => (
-                      <div
-                        key={i}
-                        className={`grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2.5 rounded-lg items-center ${
-                          i % 2 === 0 ? "bg-surface" : "bg-transparent"
-                        }`}
-                      >
-                        <span className="text-2xs font-mono text-text-muted">
-                          {row.time}
-                        </span>
-                        <div className="flex items-center gap-2 min-w-0">
-                          <div
-                            className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-semibold shrink-0"
-                            style={{
-                              background: `${row.color}20`,
-                              color: row.color,
-                            }}
-                          >
-                            {row.initials}
-                          </div>
-                          <span className="text-2xs text-text-secondary truncate">
-                            {row.name}
-                          </span>
+                {/* Rows */}
+                <div className="space-y-1">
+                  {auditRows.map((row, i) => (
+                    <div
+                      key={i}
+                      className={`grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2.5 rounded-lg items-center ${
+                        i % 2 === 0 ? "bg-surface" : "bg-transparent"
+                      }`}
+                    >
+                      <span className="text-2xs font-mono text-text-muted">
+                        {row.time}
+                      </span>
+                      <div className="flex items-center gap-2 min-w-0">
+                        <div
+                          className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-semibold shrink-0"
+                          style={{
+                            background: `${row.color}20`,
+                            color: row.color,
+                          }}
+                        >
+                          {row.initials}
                         </div>
-                        <span className="text-2xs text-text-secondary font-mono">
-                          {row.action}
-                        </span>
-                        <span className="text-2xs text-text-secondary font-mono truncate">
-                          {row.device}
-                        </span>
-                        <span className="text-2xs text-text-muted font-mono">
-                          {row.duration}
+                        <span className="text-2xs text-text-secondary truncate">
+                          {row.name}
                         </span>
                       </div>
-                    ))}
-                  </div>
-
-                  {/* Footer */}
-                  <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
-                    <span className="text-2xs text-text-muted">
-                      Showing 4 of 1,247 entries
-                    </span>
-                    <span className="text-2xs text-primary font-medium">
-                      View all &rarr;
-                    </span>
-                  </div>
+                      <span className="text-2xs text-text-secondary font-mono">
+                        {row.action}
+                      </span>
+                      <span className="text-2xs text-text-secondary font-mono truncate">
+                        {row.device}
+                      </span>
+                      <span className="text-2xs text-text-muted font-mono">
+                        {row.duration}
+                      </span>
+                    </div>
+                  ))}
                 </div>
-              </Card>
+
+                {/* Footer */}
+                <div className="mt-4 pt-4 border-t border-border flex items-center justify-between">
+                  <span className="text-2xs text-text-muted">
+                    Showing 4 of 1,247 entries
+                  </span>
+                  <span className="text-2xs text-primary font-medium">
+                    View all &rarr;
+                  </span>
+                </div>
+              </WindowChrome>
             </ShimmerCard>
           </Reveal>
 

--- a/ui/packages/design-system/__tests__/WindowChrome.test.tsx
+++ b/ui/packages/design-system/__tests__/WindowChrome.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WindowChrome } from "../primitives/WindowChrome";
+
+// ---------------------------------------------------------------------------
+// Terminal variant
+// ---------------------------------------------------------------------------
+describe("WindowChrome — terminal variant", () => {
+  it("shows title text", () => {
+    render(<WindowChrome variant="terminal" title="My Terminal" />);
+    expect(screen.getByText("My Terminal")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Browser variant
+// ---------------------------------------------------------------------------
+describe("WindowChrome — browser variant", () => {
+  it("shows the namespace url path", () => {
+    render(<WindowChrome variant="browser" path="/devices/rpi-gateway" />);
+    expect(
+      screen.getByText("shellhub.io/devices/rpi-gateway"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an svg lock icon", () => {
+    const { container } = render(
+      <WindowChrome variant="browser" path="/devices/rpi-gateway" />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Title bar slot
+// ---------------------------------------------------------------------------
+describe("WindowChrome — titleBarSlot", () => {
+  it("renders titleBarSlot content", () => {
+    render(
+      <WindowChrome variant="terminal" titleBarSlot={<button>Copy</button>} />,
+    );
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Children render inside body
+// ---------------------------------------------------------------------------
+describe("WindowChrome — children", () => {
+  it("renders children inside the body", () => {
+    render(
+      <WindowChrome variant="terminal">
+        <span data-testid="body-child">content</span>
+      </WindowChrome>,
+    );
+    expect(screen.getByTestId("body-child")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caller-provided classes are forwarded
+// ---------------------------------------------------------------------------
+describe("WindowChrome — class forwarding", () => {
+  it("applies bodyClassName to the body div", () => {
+    const { container } = render(
+      <WindowChrome variant="terminal" bodyClassName="custom-body">
+        body
+      </WindowChrome>,
+    );
+    expect(container.querySelector(".custom-body")).not.toBeNull();
+  });
+
+  it("applies className to the root element", () => {
+    const { container } = render(
+      <WindowChrome variant="terminal" className="my-root-class" />,
+    );
+    expect(container.firstElementChild!.className).toContain("my-root-class");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Export re-check from primitives/index
+// ---------------------------------------------------------------------------
+describe("WindowChrome — exported from primitives/index", () => {
+  it("is exported as a callable component from the primitives barrel", async () => {
+    const mod = await import("../primitives/index");
+    expect(mod.WindowChrome).toBeDefined();
+    expect(typeof mod.WindowChrome).toBe("function");
+  });
+});

--- a/ui/packages/design-system/primitives/WindowChrome.tsx
+++ b/ui/packages/design-system/primitives/WindowChrome.tsx
@@ -1,0 +1,146 @@
+import type { ReactNode } from "react";
+import { cn } from "./cn";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type WindowChromeVariant = "terminal" | "browser";
+export type WindowChromeSize = "sm" | "md";
+export type WindowChromeAccent =
+  | "green"
+  | "cyan"
+  | "primary"
+  | "red"
+  | "yellow";
+
+export interface WindowChromeProps {
+  variant: WindowChromeVariant;
+  size?: WindowChromeSize;
+  title?: string;
+  path?: string;
+  /** Optional 4th animated pulse dot, by accent token */
+  accent?: WindowChromeAccent;
+  /** Slot rendered on the right side of the title bar */
+  titleBarSlot?: ReactNode;
+  className?: string;
+  bodyClassName?: string;
+  children?: ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const DOT_SIZE: Record<WindowChromeSize, string> = {
+  sm: "w-2.5 h-2.5",
+  md: "w-3 h-3",
+};
+
+const ACCENT_BG: Record<WindowChromeAccent, string> = {
+  green: "bg-accent-green",
+  cyan: "bg-accent-cyan",
+  primary: "bg-primary",
+  red: "bg-accent-red",
+  yellow: "bg-accent-yellow",
+};
+
+// Lock icon (heroicons outline lock-closed, inline SVG)
+function LockIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-3 h-3 shrink-0"
+      aria-hidden="true"
+    >
+      <rect x="5" y="11" width="14" height="10" rx="2" />
+      <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function WindowChrome({
+  variant,
+  size = "md",
+  title,
+  path,
+  accent,
+  titleBarSlot,
+  className,
+  bodyClassName,
+  children,
+}: WindowChromeProps) {
+  const dotSize = DOT_SIZE[size];
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-surface overflow-hidden",
+        className,
+      )}
+    >
+      {/* Title bar */}
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+        {/* Traffic-light dots */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span className={cn("rounded-full", dotSize, "bg-accent-red/60")} />
+          <span
+            className={cn("rounded-full", dotSize, "bg-accent-yellow/60")}
+          />
+          <span className={cn("rounded-full", dotSize, "bg-accent-green/60")} />
+          {accent && (
+            <span
+              className={cn(
+                "rounded-full animate-pulse",
+                dotSize,
+                ACCENT_BG[accent],
+              )}
+            />
+          )}
+        </div>
+
+        {/* Center content */}
+        <div className="flex flex-1 items-center min-w-0">
+          {variant === "terminal" && title && (
+            <span className="text-2xs text-text-muted font-mono truncate">
+              {title}
+            </span>
+          )}
+          {variant === "browser" && (
+            <div className="flex items-center gap-1 text-xs text-text-secondary min-w-0 max-w-xs w-full bg-background rounded px-2 py-0.5">
+              <LockIcon />
+              {path && (
+                <span className="truncate font-mono">shellhub.io{path}</span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Actions slot */}
+        {titleBarSlot && (
+          <div className="flex items-center gap-1 shrink-0">{titleBarSlot}</div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div
+        className={cn(
+          "relative p-5 font-mono text-xs leading-relaxed",
+          bodyClassName,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/ui/packages/design-system/primitives/index.ts
+++ b/ui/packages/design-system/primitives/index.ts
@@ -19,3 +19,10 @@ export type {
   StatusDotSize,
   StatusDotProps,
 } from "./StatusDot";
+export { WindowChrome } from "./WindowChrome";
+export type {
+  WindowChromeVariant,
+  WindowChromeSize,
+  WindowChromeAccent,
+  WindowChromeProps,
+} from "./WindowChrome";


### PR DESCRIPTION
## What

Introduce a shared `WindowChrome` design-system primitive (macOS-style terminal/browser window chrome) and migrate the hand-rolled terminal, command, and browser mockups across the marketing website and console onto it.

## Why

The same traffic-light + title-bar markup was reimplemented across roughly twenty website use-case pages and console dialogs, and every copy had drifted in padding, typography, and tokens. A single primitive removes the duplication and stops the drift.

## Changes

- **design-system**: new `WindowChrome` primitive — `variant` (`terminal`/`browser`), `size`, `title`, `path`, `accent`, `titleBarSlot`, `className`, `bodyClassName`. The body default carries the shared `font-mono text-xs leading-relaxed` so call sites no longer repeat it; exported from the primitives barrel.
- **migration**: replaced bespoke chrome in features, integrations, how-it-works, DevopsCiCd, EdgeComputing, IotEmbedded, RemoteSupport, ContainerManagement, AdminPanel, QuickStart, StepSetup, AddDevice, CreateNamespaceDialog, and WizardStep2Install. Per-site typography and padding were folded into the primitive default.
- **CommandBlock**: extracted the install-command block shared by QuickStart and StepSetup into `@/components/marketing`.
- **overflow**: copyable commands now wrap (`whitespace-pre-wrap break-all`); code/config blocks scroll (`overflow-x-auto`) instead of clipping against the chrome's `overflow-hidden`.
- **browser variant**: opted the AdminPanel and ContainerManagement web-UI mockups back to `font-sans` so names, emails, and prose are not monospaced by the body default.
- **tests**: behavioral coverage for `WindowChrome` and `CommandBlock`; removed brittle class-coupled and page-structure assertions in favor of role/text/wiring checks.

## Testing

This is presentational, so verification is mostly visual. Worth eyeballing the two featured CI/CD frames (DevopsCiCd blue, integrations green) where bespoke wrapper divs were collapsed onto the primitive's `className`, and the browser-variant mockups (AdminPanel user list, ContainerManagement permissions table) where the font handling changed. Website, console, and design-system vitest suites pass locally.