### PR TITLE
feat(ui): sync list page state to the URL

### DIFF
--- a/ui/apps/console/src/hooks/__tests__/paginatedListParams.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/paginatedListParams.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseListParams,
+  serializeListParams,
+  type ListParamDefaults,
+} from "../paginatedListParams";
+
+// ── Shared fixture ────────────────────────────────────────────────────────────
+
+const VALID_STATUSES = ["accepted", "pending", "rejected"] as const;
+const PER_PAGE_ALLOW = [10, 25, 50] as const;
+
+type Status = (typeof VALID_STATUSES)[number];
+
+type TestParams = {
+  page: number;
+  perPage: number;
+  status: Status;
+  tags: string[];
+};
+
+const DEFAULTS: ListParamDefaults<TestParams> = {
+  page: 1,
+  perPage: 10,
+  status: "accepted",
+  tags: [],
+};
+
+function params(init?: Record<string, string | string[]>): URLSearchParams {
+  const p = new URLSearchParams();
+  if (init) {
+    for (const [k, v] of Object.entries(init)) {
+      if (Array.isArray(v)) {
+        for (const item of v) p.append(k, item);
+      } else {
+        p.set(k, v);
+      }
+    }
+  }
+  return p;
+}
+
+// ── parseListParams ───────────────────────────────────────────────────────────
+
+describe("parseListParams", () => {
+  describe("page", () => {
+    it("returns default page when the param is absent", () => {
+      const result = parseListParams<TestParams>(params(), DEFAULTS, {});
+      expect(result.page).toBe(1);
+    });
+
+    it("parses a valid page integer", () => {
+      const result = parseListParams<TestParams>(params({ page: "3" }), DEFAULTS, {});
+      expect(result.page).toBe(3);
+    });
+
+    it("falls back to default when page is 0", () => {
+      const result = parseListParams<TestParams>(params({ page: "0" }), DEFAULTS, {});
+      expect(result.page).toBe(1);
+    });
+
+    it("falls back to default when page is negative", () => {
+      const result = parseListParams<TestParams>(params({ page: "-1" }), DEFAULTS, {});
+      expect(result.page).toBe(1);
+    });
+
+    it("falls back to default when page is non-numeric", () => {
+      const result = parseListParams<TestParams>(params({ page: "abc" }), DEFAULTS, {});
+      expect(result.page).toBe(1);
+    });
+
+    it("falls back to default when page is a float", () => {
+      const result = parseListParams<TestParams>(params({ page: "2.5" }), DEFAULTS, {});
+      expect(result.page).toBe(1);
+    });
+  });
+
+  describe("perPage", () => {
+    it("returns default perPage when the param is absent", () => {
+      const result = parseListParams<TestParams>(params(), DEFAULTS, {
+        perPage: PER_PAGE_ALLOW,
+      });
+      expect(result.perPage).toBe(10);
+    });
+
+    it("parses a valid perPage from the allowlist", () => {
+      const result = parseListParams<TestParams>(params({ perPage: "25" }), DEFAULTS, {
+        perPage: PER_PAGE_ALLOW,
+      });
+      expect(result.perPage).toBe(25);
+    });
+
+    it("falls back to default when perPage is not in the allowlist", () => {
+      const result = parseListParams<TestParams>(params({ perPage: "99" }), DEFAULTS, {
+        perPage: PER_PAGE_ALLOW,
+      });
+      expect(result.perPage).toBe(10);
+    });
+
+    it("falls back to default when perPage is non-numeric", () => {
+      const result = parseListParams<TestParams>(params({ perPage: "many" }), DEFAULTS, {
+        perPage: PER_PAGE_ALLOW,
+      });
+      expect(result.perPage).toBe(10);
+    });
+
+    it("returns the raw numeric value when no allowlist is provided", () => {
+      const result = parseListParams<TestParams>(params({ perPage: "50" }), DEFAULTS, {});
+      expect(result.perPage).toBe(50);
+    });
+
+    it("falls back to default when perPage is 0 and no allowlist", () => {
+      const result = parseListParams<TestParams>(params({ perPage: "0" }), DEFAULTS, {});
+      expect(result.perPage).toBe(10);
+    });
+  });
+
+  describe("enum-typed dimension (status)", () => {
+    it("returns default status when the param is absent", () => {
+      const result = parseListParams<TestParams>(params(), DEFAULTS, {
+        status: VALID_STATUSES,
+      });
+      expect(result.status).toBe("accepted");
+    });
+
+    it("parses a valid status value", () => {
+      const result = parseListParams<TestParams>(
+        params({ status: "pending" }),
+        DEFAULTS,
+        { status: VALID_STATUSES },
+      );
+      expect(result.status).toBe("pending");
+    });
+
+    it("falls back to default for an invalid status", () => {
+      const result = parseListParams<TestParams>(
+        params({ status: "unknown" }),
+        DEFAULTS,
+        { status: VALID_STATUSES },
+      );
+      expect(result.status).toBe("accepted");
+    });
+
+    it("returns the raw value when no valid array is provided for status", () => {
+      const result = parseListParams<TestParams>(
+        params({ status: "anything" }),
+        DEFAULTS,
+        {},
+      );
+      expect(result.status).toBe("anything");
+    });
+  });
+
+  describe("array dimension (tags)", () => {
+    it("returns default empty array when no tags param is present", () => {
+      const result = parseListParams<TestParams>(params(), DEFAULTS, {});
+      expect(result.tags).toEqual([]);
+    });
+
+    it("collects repeated tag params into an array", () => {
+      const result = parseListParams<TestParams>(
+        params({ tags: ["web", "prod"] }),
+        DEFAULTS,
+        {},
+      );
+      expect(result.tags).toEqual(["web", "prod"]);
+    });
+
+    it("returns single tag as a one-element array", () => {
+      const result = parseListParams<TestParams>(
+        params({ tags: ["api"] }),
+        DEFAULTS,
+        {},
+      );
+      expect(result.tags).toEqual(["api"]);
+    });
+
+    it("filters tags against a valid array when provided", () => {
+      const result = parseListParams<TestParams>(
+        params({ tags: ["web", "unknown", "prod"] }),
+        DEFAULTS,
+        { tags: ["web", "prod", "staging"] },
+      );
+      expect(result.tags).toEqual(["web", "prod"]);
+    });
+
+    it("returns empty array when all tags are invalid against the allowlist", () => {
+      const result = parseListParams<TestParams>(
+        params({ tags: ["bad", "nope"] }),
+        DEFAULTS,
+        { tags: ["web", "prod"] },
+      );
+      expect(result.tags).toEqual([]);
+    });
+
+    it("returns the same array reference when content is unchanged", () => {
+      const sp = params({ tags: ["web", "prod"] });
+      const first = parseListParams<TestParams>(sp, DEFAULTS, {}, undefined);
+      const second = parseListParams<TestParams>(sp, DEFAULTS, {}, first);
+      expect(second.tags).toBe(first.tags);
+    });
+
+    it("returns the same array reference when tags are the same but in different order", () => {
+      const sp1 = params({ tags: ["web", "prod"] });
+      const sp2 = params({ tags: ["prod", "web"] });
+      const first = parseListParams<TestParams>(sp1, DEFAULTS, {}, undefined);
+      const second = parseListParams<TestParams>(sp2, DEFAULTS, {}, first);
+      expect(second.tags).toBe(first.tags);
+    });
+
+    it("returns a new array reference when content changes", () => {
+      const sp1 = params({ tags: ["web", "prod"] });
+      const sp2 = params({ tags: ["web", "staging"] });
+      const first = parseListParams<TestParams>(sp1, DEFAULTS, {}, undefined);
+      const second = parseListParams<TestParams>(sp2, DEFAULTS, {}, first);
+      expect(second.tags).not.toBe(first.tags);
+      expect(second.tags).toEqual(["web", "staging"]);
+    });
+  });
+});
+
+// ── serializeListParams ───────────────────────────────────────────────────────
+
+describe("serializeListParams", () => {
+  describe("page", () => {
+    it("omits page when equal to default", () => {
+      const sp = serializeListParams<TestParams>({ page: 1, perPage: 10, status: "accepted", tags: [] }, DEFAULTS);
+      expect(sp.get("page")).toBeNull();
+    });
+
+    it("writes page when different from default", () => {
+      const sp = serializeListParams<TestParams>({ page: 3, perPage: 10, status: "accepted", tags: [] }, DEFAULTS);
+      expect(sp.get("page")).toBe("3");
+    });
+  });
+
+  describe("perPage", () => {
+    it("omits perPage when equal to default", () => {
+      const sp = serializeListParams<TestParams>({ page: 1, perPage: 10, status: "accepted", tags: [] }, DEFAULTS);
+      expect(sp.get("perPage")).toBeNull();
+    });
+
+    it("writes perPage when different from default", () => {
+      const sp = serializeListParams<TestParams>({ page: 1, perPage: 25, status: "accepted", tags: [] }, DEFAULTS);
+      expect(sp.get("perPage")).toBe("25");
+    });
+  });
+
+  describe("enum dimension (status)", () => {
+    it("omits status when equal to default", () => {
+      const sp = serializeListParams<TestParams>({ page: 1, perPage: 10, status: "accepted", tags: [] }, DEFAULTS);
+      expect(sp.get("status")).toBeNull();
+    });
+
+    it("writes status when different from default", () => {
+      const sp = serializeListParams<TestParams>({ page: 1, perPage: 10, status: "pending", tags: [] }, DEFAULTS);
+      expect(sp.get("status")).toBe("pending");
+    });
+  });
+
+  describe("array dimension (tags)", () => {
+    it("omits tags when equal to default (empty)", () => {
+      const sp = serializeListParams<TestParams>({ page: 1, perPage: 10, status: "accepted", tags: [] }, DEFAULTS);
+      expect(sp.getAll("tags")).toEqual([]);
+    });
+
+    it("writes repeated-key entries for each tag", () => {
+      const sp = serializeListParams<TestParams>(
+        { page: 1, perPage: 10, status: "accepted", tags: ["web", "prod"] },
+        DEFAULTS,
+      );
+      expect(sp.getAll("tags")).toEqual(["web", "prod"]);
+    });
+
+    it("omits tags when the array matches the default exactly", () => {
+      const defaultsWithTags: ListParamDefaults<TestParams> = { ...DEFAULTS, tags: ["web"] };
+      const sp = serializeListParams<TestParams>(
+        { page: 1, perPage: 10, status: "accepted", tags: ["web"] },
+        defaultsWithTags,
+      );
+      expect(sp.getAll("tags")).toEqual([]);
+    });
+  });
+
+  describe("combined", () => {
+    it("produces an empty URLSearchParams when all params equal defaults", () => {
+      const sp = serializeListParams<TestParams>(
+        { page: 1, perPage: 10, status: "accepted", tags: [] },
+        DEFAULTS,
+      );
+      expect(sp.toString()).toBe("");
+    });
+
+    it("serializes only the non-default dimensions", () => {
+      const sp = serializeListParams<TestParams>(
+        { page: 2, perPage: 25, status: "accepted", tags: ["web"] },
+        DEFAULTS,
+      );
+      expect(sp.get("page")).toBe("2");
+      expect(sp.get("perPage")).toBe("25");
+      expect(sp.get("status")).toBeNull();
+      expect(sp.getAll("tags")).toEqual(["web"]);
+    });
+  });
+});

--- a/ui/apps/console/src/hooks/__tests__/usePaginatedListState.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/usePaginatedListState.test.ts
@@ -338,12 +338,16 @@ describe("usePaginatedListState — scalar filter with allowlist", () => {
   });
 
   it("rejects values not in the allowlist and falls back to default", () => {
-    const { result } = renderHookWithRouter(() =>
-      usePaginatedListState({
-        defaults: FILTER_DEFAULTS,
-        constraints: { status: VALID_STATUSES },
-      }),
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: FILTER_DEFAULTS,
+          constraints: { status: VALID_STATUSES },
+        }),
+      { initialEntries: ["/?status=inactive"] },
     );
+
+    expect(result.current.params.status).toBe("inactive");
 
     act(() => {
       result.current.setFilter("status", "unknown");
@@ -474,6 +478,49 @@ describe("usePaginatedListState — array filters", () => {
     const sp = new URLSearchParams(result.current.searchString);
     expect(sp.getAll("tags")).toEqual(["staging", "api"]);
     expect(result.current.params.tags).toEqual(["staging", "api"]);
+  });
+});
+
+// ── mapArrayFilter (functional updater over committed URL state) ───────────────
+
+describe("usePaginatedListState — mapArrayFilter", () => {
+  it("applies the functional updater to the current array value", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: ARRAY_FILTER_DEFAULTS,
+          constraints: { tags: VALID_TAGS },
+        }),
+      { initialEntries: ["/?tags=web&tags=prod"] },
+    );
+
+    act(() => {
+      result.current.mapArrayFilter("tags", (tags) =>
+        tags.filter((t) => t !== "web"),
+      );
+    });
+
+    expect(result.current.params.tags).toEqual(["prod"]);
+    const sp = new URLSearchParams(result.current.searchString);
+    expect(sp.getAll("tags")).toEqual(["prod"]);
+  });
+
+  it("resets page to 1 when the array changes", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: ARRAY_FILTER_DEFAULTS,
+          constraints: { tags: VALID_TAGS },
+        }),
+      { initialEntries: ["/?page=4&tags=web"] },
+    );
+
+    act(() => {
+      result.current.mapArrayFilter("tags", (tags) => [...tags, "prod"]);
+    });
+
+    expect(result.current.params.page).toBe(1);
+    expect(result.current.params.tags).toEqual(["web", "prod"]);
   });
 });
 

--- a/ui/apps/console/src/hooks/__tests__/usePaginatedListState.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/usePaginatedListState.test.ts
@@ -1,0 +1,596 @@
+import { describe, it, expect } from "vitest";
+import { act } from "@testing-library/react";
+import { usePaginatedListState, type SortFieldDef } from "../usePaginatedListState";
+import { renderHookWithRouter } from "@/test-utils/renderHookWithRouter";
+
+// ── Shared fixture ────────────────────────────────────────────────────────────
+
+type TestParams = {
+  page: number;
+  search: string;
+};
+
+const DEFAULTS: TestParams = {
+  page: 1,
+  search: "",
+};
+
+// ── page reads/writes ─────────────────────────────────────────────────────────
+
+describe("usePaginatedListState — page", () => {
+  it("reads page=1 from default URL", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({ defaults: DEFAULTS }),
+    );
+    expect(result.current.params.page).toBe(1);
+  });
+
+  it("reads page from URL search param", () => {
+    const { result } = renderHookWithRouter(
+      () => usePaginatedListState({ defaults: DEFAULTS }),
+      { initialEntries: ["/?page=3"] },
+    );
+    expect(result.current.params.page).toBe(3);
+  });
+
+  it("setPage updates the page param", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({ defaults: DEFAULTS }),
+    );
+
+    act(() => {
+      result.current.setPage(5);
+    });
+
+    expect(result.current.params.page).toBe(5);
+  });
+});
+
+// ── search reads/writes ───────────────────────────────────────────────────────
+
+describe("usePaginatedListState — search", () => {
+  it("reads empty search from default URL", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({ defaults: DEFAULTS }),
+    );
+    expect(result.current.params.search).toBe("");
+  });
+
+  it("reads search from URL search param", () => {
+    const { result } = renderHookWithRouter(
+      () => usePaginatedListState({ defaults: DEFAULTS }),
+      { initialEntries: ["/?search=hello"] },
+    );
+    expect(result.current.params.search).toBe("hello");
+  });
+
+  it("setSearch updates the search param", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({ defaults: DEFAULTS }),
+    );
+
+    act(() => {
+      result.current.setSearch("my-device");
+    });
+
+    expect(result.current.params.search).toBe("my-device");
+  });
+});
+
+// ── every non-page setter resets page to 1 ────────────────────────────────────
+
+describe("usePaginatedListState — non-page setter resets page to 1", () => {
+  it("setSearch resets page to 1 when page was > 1", () => {
+    const { result } = renderHookWithRouter(
+      () => usePaginatedListState({ defaults: DEFAULTS }),
+      { initialEntries: ["/?page=4"] },
+    );
+
+    expect(result.current.params.page).toBe(4);
+
+    act(() => {
+      result.current.setSearch("filter");
+    });
+
+    expect(result.current.params.page).toBe(1);
+  });
+});
+
+// ── reset() returns all dimensions to defaults ────────────────────────────────
+
+describe("usePaginatedListState — reset", () => {
+  it("reset() clears all params back to defaults", () => {
+    const { result } = renderHookWithRouter(
+      () => usePaginatedListState({ defaults: DEFAULTS }),
+      { initialEntries: ["/?page=3&search=filter"] },
+    );
+
+    expect(result.current.params.page).toBe(3);
+    expect(result.current.params.search).toBe("filter");
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.params.page).toBe(1);
+    expect(result.current.params.search).toBe("");
+  });
+});
+
+// ── replace-history: default-valued params are omitted ───────────────────────
+
+describe("usePaginatedListState — replace-history mode omits default-valued params", () => {
+  it("does not write page=1 to URL when it equals the default", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({ defaults: DEFAULTS }),
+    );
+
+    // Navigate to page 2 then back to page 1 — page should be absent from URL
+    act(() => {
+      result.current.setPage(2);
+    });
+    act(() => {
+      result.current.setPage(1);
+    });
+
+    // The hook's internal params are correct
+    expect(result.current.params.page).toBe(1);
+
+    // And the URL should not carry page=1 (default suppressed)
+    expect(result.current.searchString).not.toContain("page=1");
+  });
+
+  it("does not write search= when search equals the default (empty string)", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({ defaults: DEFAULTS }),
+    );
+
+    act(() => {
+      result.current.setSearch("tmp");
+    });
+    act(() => {
+      result.current.setSearch("");
+    });
+
+    expect(result.current.params.search).toBe("");
+    expect(result.current.searchString).not.toContain("search=");
+  });
+});
+
+// ── unrelated existing params are preserved ───────────────────────────────────
+
+describe("usePaginatedListState — unrelated params are preserved", () => {
+  it("leaves unrelated URL params untouched when updating page", () => {
+    const { result } = renderHookWithRouter(
+      () => usePaginatedListState({ defaults: DEFAULTS }),
+      { initialEntries: ["/?unrelated=keep&page=2"] },
+    );
+
+    act(() => {
+      result.current.setPage(3);
+    });
+
+    expect(result.current.searchString).toContain("unrelated=keep");
+    expect(result.current.params.page).toBe(3);
+  });
+
+  it("leaves unrelated URL params untouched when resetting", () => {
+    const { result } = renderHookWithRouter(
+      () => usePaginatedListState({ defaults: DEFAULTS }),
+      { initialEntries: ["/?unrelated=keep&page=2&search=foo"] },
+    );
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.searchString).toContain("unrelated=keep");
+    expect(result.current.params.page).toBe(1);
+    expect(result.current.params.search).toBe("");
+  });
+});
+
+// ── handleSort ────────────────────────────────────────────────────────────────
+
+type SortableParams = {
+  page: number;
+  search: string;
+  sortField: string;
+  sortOrder: "asc" | "desc";
+};
+
+const SORT_DEFAULTS: SortableParams = {
+  page: 1,
+  search: "",
+  sortField: "name",
+  sortOrder: "asc",
+};
+
+const SORT_FIELDS: SortFieldDef[] = [
+  { field: "name", initialOrder: "asc" },
+  { field: "created_at", initialOrder: "desc" },
+];
+
+describe("usePaginatedListState — handleSort", () => {
+  it("toggles order from asc to desc when clicking the same field", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({
+        defaults: SORT_DEFAULTS,
+        sortFields: SORT_FIELDS,
+      }),
+    );
+
+    act(() => {
+      result.current.handleSort("name");
+    });
+
+    expect(result.current.params.sortField).toBe("name");
+    expect(result.current.params.sortOrder).toBe("desc");
+  });
+
+  it("toggles order from desc to asc when clicking the same field again", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: SORT_DEFAULTS,
+          sortFields: SORT_FIELDS,
+        }),
+      { initialEntries: ["/?sortField=name&sortOrder=desc"] },
+    );
+
+    act(() => {
+      result.current.handleSort("name");
+    });
+
+    expect(result.current.params.sortField).toBe("name");
+    expect(result.current.params.sortOrder).toBe("asc");
+  });
+
+  it("uses the field's initialOrder when switching to a different field", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({
+        defaults: SORT_DEFAULTS,
+        sortFields: SORT_FIELDS,
+      }),
+    );
+
+    // Currently on "name" field; switch to "created_at" (initialOrder: "desc")
+    act(() => {
+      result.current.handleSort("created_at");
+    });
+
+    expect(result.current.params.sortField).toBe("created_at");
+    expect(result.current.params.sortOrder).toBe("desc");
+  });
+
+  it("resets page to 1 when sorting changes", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: SORT_DEFAULTS,
+          sortFields: SORT_FIELDS,
+        }),
+      { initialEntries: ["/?page=3"] },
+    );
+
+    expect(result.current.params.page).toBe(3);
+
+    act(() => {
+      result.current.handleSort("name");
+    });
+
+    expect(result.current.params.page).toBe(1);
+  });
+
+  it("resets page to 1 when switching to a different sort field", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: SORT_DEFAULTS,
+          sortFields: SORT_FIELDS,
+        }),
+      { initialEntries: ["/?page=5&sortField=name&sortOrder=asc"] },
+    );
+
+    act(() => {
+      result.current.handleSort("created_at");
+    });
+
+    expect(result.current.params.page).toBe(1);
+    expect(result.current.params.sortField).toBe("created_at");
+    expect(result.current.params.sortOrder).toBe("desc");
+  });
+});
+
+// ── scalar filters with allowlist validation ──────────────────────────────────
+
+type FilterParams = {
+  page: number;
+  search: string;
+  status: string;
+};
+
+const VALID_STATUSES = ["active", "inactive", "pending"] as const;
+
+const FILTER_DEFAULTS: FilterParams = {
+  page: 1,
+  search: "",
+  status: "active",
+};
+
+describe("usePaginatedListState — scalar filter with allowlist", () => {
+  it("setFilter updates a scalar param and resets page", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: FILTER_DEFAULTS,
+          constraints: { status: VALID_STATUSES },
+        }),
+      { initialEntries: ["/?page=3"] },
+    );
+
+    act(() => {
+      result.current.setFilter("status", "inactive");
+    });
+
+    expect(result.current.params.status).toBe("inactive");
+    expect(result.current.params.page).toBe(1);
+  });
+
+  it("rejects values not in the allowlist and falls back to default", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({
+        defaults: FILTER_DEFAULTS,
+        constraints: { status: VALID_STATUSES },
+      }),
+    );
+
+    act(() => {
+      result.current.setFilter("status", "unknown");
+    });
+
+    // "unknown" is not in VALID_STATUSES; after writing it to the URL the
+    // parser should fall back to the default
+    expect(result.current.params.status).toBe("active");
+  });
+
+  it("omits the param from the URL when it equals the default", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: FILTER_DEFAULTS,
+          constraints: { status: VALID_STATUSES },
+        }),
+      { initialEntries: ["/?status=inactive"] },
+    );
+
+    act(() => {
+      result.current.setFilter("status", "active");
+    });
+
+    expect(result.current.params.status).toBe("active");
+    expect(result.current.searchString).not.toContain("status=");
+  });
+});
+
+// ── array filters (repeated-key round-trip) ───────────────────────────────────
+
+type ArrayFilterParams = {
+  page: number;
+  search: string;
+  tags: string[];
+};
+
+const VALID_TAGS = ["web", "prod", "staging", "api"] as const;
+
+const ARRAY_FILTER_DEFAULTS: ArrayFilterParams = {
+  page: 1,
+  search: "",
+  tags: [],
+};
+
+describe("usePaginatedListState — array filters", () => {
+  it("setArrayFilter writes repeated-key params to the URL", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({
+        defaults: ARRAY_FILTER_DEFAULTS,
+        constraints: { tags: VALID_TAGS },
+      }),
+    );
+
+    act(() => {
+      result.current.setArrayFilter("tags", ["web", "prod"]);
+    });
+
+    expect(result.current.params.tags).toEqual(["web", "prod"]);
+    // URL must use repeated keys, not comma-separated
+    const sp = new URLSearchParams(result.current.searchString);
+    expect(sp.getAll("tags")).toEqual(["web", "prod"]);
+  });
+
+  it("filters out invalid values against the allowlist", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({
+        defaults: ARRAY_FILTER_DEFAULTS,
+        constraints: { tags: VALID_TAGS },
+      }),
+    );
+
+    act(() => {
+      result.current.setArrayFilter("tags", ["web", "invalid", "prod"]);
+    });
+
+    // "invalid" should be stripped by the parser
+    expect(result.current.params.tags).toEqual(["web", "prod"]);
+  });
+
+  it("omits tag params from URL when array is reset to default (empty)", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: ARRAY_FILTER_DEFAULTS,
+          constraints: { tags: VALID_TAGS },
+        }),
+      { initialEntries: ["/?tags=web&tags=prod"] },
+    );
+
+    act(() => {
+      result.current.setArrayFilter("tags", []);
+    });
+
+    expect(result.current.params.tags).toEqual([]);
+    expect(result.current.searchString).not.toContain("tags=");
+  });
+
+  it("resets page to 1 when array filter changes", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({
+          defaults: ARRAY_FILTER_DEFAULTS,
+          constraints: { tags: VALID_TAGS },
+        }),
+      { initialEntries: ["/?page=4"] },
+    );
+
+    act(() => {
+      result.current.setArrayFilter("tags", ["api"]);
+    });
+
+    expect(result.current.params.page).toBe(1);
+    expect(result.current.params.tags).toEqual(["api"]);
+  });
+
+  it("round-trips: values written via setArrayFilter are read back via getAll", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({
+        defaults: ARRAY_FILTER_DEFAULTS,
+      }),
+    );
+
+    act(() => {
+      result.current.setArrayFilter("tags", ["staging", "api"]);
+    });
+
+    const sp = new URLSearchParams(result.current.searchString);
+    expect(sp.getAll("tags")).toEqual(["staging", "api"]);
+    expect(result.current.params.tags).toEqual(["staging", "api"]);
+  });
+});
+
+// ── prefix option ─────────────────────────────────────────────────────────────
+
+type PrefixedParams = {
+  page: number;
+  search: string;
+};
+
+const PREFIXED_DEFAULTS: PrefixedParams = { page: 1, search: "" };
+
+describe("usePaginatedListState — prefix option", () => {
+  it("namespaces params with the given prefix", () => {
+    const { result } = renderHookWithRouter(() =>
+      usePaginatedListState({ defaults: PREFIXED_DEFAULTS, prefix: "devices" }),
+    );
+
+    act(() => {
+      result.current.setPage(3);
+    });
+
+    expect(result.current.params.page).toBe(3);
+    // The URL should carry the prefixed key, not the bare key
+    const sp = new URLSearchParams(result.current.searchString);
+    expect(sp.get("devices.page")).toBe("3");
+    expect(sp.get("page")).toBeNull();
+  });
+
+  it("reads params from prefixed URL keys", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({ defaults: PREFIXED_DEFAULTS, prefix: "devices" }),
+      { initialEntries: ["/?devices.page=5&devices.search=hello"] },
+    );
+
+    expect(result.current.params.page).toBe(5);
+    expect(result.current.params.search).toBe("hello");
+  });
+
+  it("reads page from its own prefixed key when the URL contains both prefixed keys", () => {
+    const { result: r1 } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({ defaults: PREFIXED_DEFAULTS, prefix: "devices" }),
+      { initialEntries: ["/?devices.page=2&sessions.page=7"] },
+    );
+    const { result: r2 } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({ defaults: PREFIXED_DEFAULTS, prefix: "sessions" }),
+      { initialEntries: ["/?devices.page=2&sessions.page=7"] },
+    );
+
+    expect(r1.current.params.page).toBe(2);
+    expect(r2.current.params.page).toBe(7);
+  });
+
+  it("updating one prefixed instance does not clobber another instance's params", () => {
+    function useTwo() {
+      const h1 = usePaginatedListState({
+        defaults: PREFIXED_DEFAULTS,
+        prefix: "devices",
+      });
+      const h2 = usePaginatedListState({
+        defaults: PREFIXED_DEFAULTS,
+        prefix: "sessions",
+      });
+      return { h1, h2 };
+    }
+
+    const { result } = renderHookWithRouter(useTwo, {
+      initialEntries: ["/?devices.page=2&sessions.page=7"],
+    });
+
+    // Calling setPage on h1 must not touch h2's page
+    act(() => {
+      result.current.h1.setPage(5);
+    });
+
+    expect(result.current.h1.params.page).toBe(5);
+    expect(result.current.h2.params.page).toBe(7);
+  });
+
+  it("does not touch the unprefixed key when a prefix is set", () => {
+    const { result } = renderHookWithRouter(
+      () =>
+        usePaginatedListState({ defaults: PREFIXED_DEFAULTS, prefix: "a" }),
+      { initialEntries: ["/?page=99&a.page=2"] },
+    );
+
+    // The hook with prefix "a" should read "a.page" (= 2), not the bare "page"
+    expect(result.current.params.page).toBe(2);
+  });
+
+  it("preserves prefixed params when updating another prefixed instance", () => {
+    // This test uses a single router with two hooks sharing the same URL
+    function useTwo() {
+      const h1 = usePaginatedListState({
+        defaults: PREFIXED_DEFAULTS,
+        prefix: "devices",
+      });
+      const h2 = usePaginatedListState({
+        defaults: PREFIXED_DEFAULTS,
+        prefix: "sessions",
+      });
+      return { h1, h2 };
+    }
+
+    const { result } = renderHookWithRouter(useTwo, {
+      initialEntries: ["/?devices.page=1&sessions.page=3"],
+    });
+
+    // Update devices hook; sessions hook's page should remain 3
+    act(() => {
+      result.current.h1.setPage(5);
+    });
+
+    expect(result.current.h1.params.page).toBe(5);
+    expect(result.current.h2.params.page).toBe(3);
+  });
+});

--- a/ui/apps/console/src/hooks/paginatedListParams.ts
+++ b/ui/apps/console/src/hooks/paginatedListParams.ts
@@ -1,0 +1,176 @@
+/**
+ * Pure (no React, no router) helpers for reading and writing paginated list
+ * parameters from/to a URLSearchParams instance.
+ */
+
+/**
+ * A record that maps each key of T to its default value.
+ * Used both to drive parsing fall-backs and to suppress default values during
+ * serialization.
+ */
+export type ListParamDefaults<T extends Record<string, unknown>> = {
+  [K in keyof T]: T[K];
+};
+
+/**
+ * Validation constraints for individual dimensions.
+ *
+ * - For numeric scalars (page, perPage): an optional readonly array of allowed
+ *   values. When absent the value is validated only as a positive integer.
+ * - For string scalars: an optional readonly array of allowed values.
+ * - For array dimensions: an optional readonly array; values not in the list
+ *   are filtered out.
+ * - Omit a key to skip allowlist validation for that dimension.
+ */
+export type ListParamConstraints<T extends Record<string, unknown>> = {
+  [K in keyof T]?: T[K] extends unknown[]
+    ? readonly T[K][number][]
+    : readonly T[K][];
+};
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function parsePositiveInt(raw: string | null): number | null {
+  if (raw === null) return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) return null;
+  return n;
+}
+
+// ── parseListParams ───────────────────────────────────────────────────────────
+
+/**
+ * Parse a URLSearchParams instance into a typed params object.
+ *
+ * Rules per dimension:
+ * - `page`: positive integer; falls back to default on missing/invalid.
+ * - `perPage`: positive integer; validated against `constraints.perPage` when
+ *   provided; falls back to default on missing/invalid/disallowed.
+ * - string scalar: raw value; validated against `constraints[key]` when
+ *   provided; falls back to default when the value is not in the allowlist.
+ * - array: all values for the key collected via `getAll()`; filtered against
+ *   `constraints[key]` when provided.
+ *
+ * `prev` is an optional previous result. When provided, array dimensions that
+ * are content-equal to the previous value reuse the same array reference so
+ * that memoized React dependencies (useCallback, useMemo) remain stable across
+ * renders that don't actually change the array's contents.
+ */
+export function parseListParams<T extends Record<string, unknown>>(
+  searchParams: URLSearchParams,
+  defaults: ListParamDefaults<T>,
+  constraints: ListParamConstraints<T>,
+  prev?: T,
+): T {
+  const result: Record<string, unknown> = {};
+
+  for (const key of Object.keys(defaults) as (keyof T & string)[]) {
+    const defaultValue = defaults[key];
+
+    if (Array.isArray(defaultValue)) {
+      // Array dimension
+      const all = searchParams.getAll(key);
+      const allowlist = constraints[key] as readonly string[] | undefined;
+      // Deduplicate (preserving first-seen order) so e.g. ?tags=a&tags=a does
+      // not round-trip a dirty URL or double-apply the filter.
+      const values = [
+        ...new Set(allowlist ? all.filter((v) => allowlist.includes(v)) : all),
+      ];
+      // Return the previous array reference when contents are identical so
+      // that React memoization (useCallback/useMemo) deps stay stable.
+      // Use set-equality (order-insensitive) so that e.g. ?tags=b&tags=a and
+      // ?tags=a&tags=b produce the same reference — tag order is irrelevant for
+      // filtering and reordering should not bust memoization.
+      const prevArr = prev ? (prev[key] as unknown[]) : undefined;
+      if (prevArr && prevArr.length === values.length) {
+        const prevSet = new Set(prevArr);
+        if (values.every((v) => prevSet.has(v))) {
+          result[key] = prevArr;
+          continue;
+        }
+      }
+      result[key] = values;
+      continue;
+    }
+
+    if (key === "page") {
+      const raw = searchParams.get(key);
+      const parsed = parsePositiveInt(raw);
+      result[key] = parsed !== null ? parsed : defaultValue;
+      continue;
+    }
+
+    if (typeof defaultValue === "number") {
+      // Numeric scalar (e.g. perPage)
+      const raw = searchParams.get(key);
+      const parsed = parsePositiveInt(raw);
+      if (parsed === null) {
+        result[key] = defaultValue;
+      } else {
+        const allowlist = constraints[key] as readonly number[] | undefined;
+        if (allowlist && !allowlist.includes(parsed)) {
+          result[key] = defaultValue;
+        } else {
+          result[key] = parsed;
+        }
+      }
+      continue;
+    }
+
+    // String scalar
+    const raw = searchParams.get(key);
+    if (raw === null) {
+      result[key] = defaultValue;
+      continue;
+    }
+    const allowlist = constraints[key] as readonly string[] | undefined;
+    if (allowlist && !allowlist.includes(raw)) {
+      result[key] = defaultValue;
+    } else {
+      result[key] = raw;
+    }
+  }
+
+  return result as T;
+}
+
+// ── serializeListParams ───────────────────────────────────────────────────────
+
+/**
+ * Serialize a typed params object into a URLSearchParams instance.
+ *
+ * Params equal to their default are omitted so URLs stay clean.
+ * Array dimensions are serialized as repeated keys (one entry per element).
+ */
+export function serializeListParams<T extends Record<string, unknown>>(
+  value: T,
+  defaults: ListParamDefaults<T>,
+): URLSearchParams {
+  const sp = new URLSearchParams();
+
+  for (const key of Object.keys(defaults) as (keyof T & string)[]) {
+    const current = value[key];
+    const defaultValue = defaults[key];
+
+    if (Array.isArray(current)) {
+      const currentArr = current as unknown[];
+      const defaultArr = defaultValue as unknown[];
+      // Compare by JSON to handle same-order equality
+      const isDefault =
+        currentArr.length === defaultArr.length &&
+        currentArr.every((v, i) => v === defaultArr[i]);
+      if (!isDefault) {
+        for (const item of currentArr) {
+          sp.append(key, String(item));
+        }
+      }
+      continue;
+    }
+
+    if (current !== defaultValue) {
+      sp.set(key, String(current));
+    }
+  }
+
+  return sp;
+}

--- a/ui/apps/console/src/hooks/usePaginatedListState.ts
+++ b/ui/apps/console/src/hooks/usePaginatedListState.ts
@@ -1,0 +1,304 @@
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  parseListParams,
+  serializeListParams,
+  type ListParamDefaults,
+  type ListParamConstraints,
+} from "./paginatedListParams";
+
+/**
+ * Describes a sortable field: which key it maps to and what order to use when
+ * it is first selected (i.e. when the user switches from a different field).
+ */
+export interface SortFieldDef {
+  /** The value that will appear in the `sortField` URL param. */
+  field: string;
+  /** The order to apply the first time this field is selected. */
+  initialOrder: "asc" | "desc";
+}
+
+export interface UsePaginatedListStateConfig<T extends Record<string, unknown>> {
+  defaults: ListParamDefaults<T>;
+  constraints?: ListParamConstraints<T>;
+  /**
+   * Sort field definitions. When provided the hook exposes a `handleSort`
+   * function. Each entry names a field and its `initialOrder` (the order used
+   * when the user switches to that field for the first time).
+   */
+  sortFields?: SortFieldDef[];
+  /**
+   * Optional namespace prefix.  When set every URL key is written and read as
+   * `<prefix>.<key>` so that two co-mounted instances with different prefixes
+   * never clobber each other's state.
+   */
+  prefix?: string;
+}
+
+export interface UsePaginatedListStateResult<T extends Record<string, unknown>> {
+  /** Parsed, typed params derived from the current URL. */
+  params: T;
+  /** The current URL search string (without leading "?"). Useful for assertions. */
+  searchString: string;
+  /** Navigate to a specific page. */
+  setPage: (page: number) => void;
+  /** Update the search string and reset page to 1. */
+  setSearch: (search: string) => void;
+  /**
+   * Update a scalar (non-array) filter param and reset page to 1.
+   * Invalid values (those rejected by the allowlist in `constraints`) will be
+   * written to the URL and the parser will fall back to the default.
+   */
+  setFilter: <K extends keyof T>(key: K, value: T[K]) => void;
+  /**
+   * Update an array filter param and reset page to 1.
+   * Values are serialized as repeated URL keys so that `getAll()` round-trips
+   * correctly.
+   */
+  setArrayFilter: <K extends keyof T>(key: K, values: T[K]) => void;
+  /**
+   * Functionally update an array filter param by transforming the *committed*
+   * URL value (not the render-closure snapshot). Use this instead of
+   * `setArrayFilter` whenever the new array is derived from the current one —
+   * it avoids stale-closure bugs when the array can change concurrently (e.g.
+   * onTagRenamed / onTagDeleted in ManageTagsDrawer).
+   */
+  mapArrayFilter: <K extends keyof T>(
+    key: K,
+    fn: (current: T[K]) => T[K],
+  ) => void;
+  /**
+   * Toggle the sort order when the same field is clicked, or switch to a
+   * different field using its `initialOrder`. Resets page to 1.
+   * Only available when `sortFields` was passed to the hook config.
+   */
+  handleSort: (field: string) => void;
+  /** Reset all dimensions to their defaults. */
+  reset: () => void;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/** Return `<prefix>.<key>` when a prefix is set, or the bare key otherwise. */
+function prefixKey(key: string, prefix: string | undefined): string {
+  return prefix ? `${prefix}.${key}` : key;
+}
+
+/**
+ * Return an un-prefixed view of `full` that the pure parse/serialize helpers
+ * can consume. For each managed key `k`, it copies every value stored under
+ * `<prefix>.k` into the bare key `k`.  When there is no prefix the original
+ * params are returned as-is.
+ */
+function stripPrefix<T extends Record<string, unknown>>(
+  full: URLSearchParams,
+  defaults: ListParamDefaults<T>,
+  prefix: string | undefined,
+): URLSearchParams {
+  if (!prefix) return full;
+
+  const stripped = new URLSearchParams();
+  for (const key of Object.keys(defaults)) {
+    for (const v of full.getAll(prefixKey(key, prefix))) {
+      stripped.append(key, v);
+    }
+  }
+  return stripped;
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Stable empty-constraints sentinel.  Using a module-level constant instead of
+ * an inline `{}` default means callers that don't supply `constraints` all
+ * share the same object reference, keeping the `update` useCallback stable
+ * across renders.
+ */
+const EMPTY_CONSTRAINTS: ListParamConstraints<Record<string, unknown>> = {};
+
+/**
+ * Config-driven hook that syncs a paginated list's URL state (page, search,
+ * sort, and any extra dimensions) with `useSearchParams`.
+ *
+ * Rules:
+ * - Default-valued params are omitted from the URL (replace-history mode).
+ * - Unrelated params already present in the URL are always preserved.
+ * - Every non-page setter resets page to 1.
+ * - When a `prefix` is given, every managed key is namespaced as
+ *   `<prefix>.<key>` in the URL so multiple instances coexist cleanly.
+ */
+export function usePaginatedListState<T extends Record<string, unknown>>({
+  defaults,
+  constraints = EMPTY_CONSTRAINTS as ListParamConstraints<T>,
+  sortFields,
+  prefix,
+}: UsePaginatedListStateConfig<T>): UsePaginatedListStateResult<T> {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Parse the current URL into typed params (handles prefix translation).
+  const stripped = stripPrefix(searchParams, defaults, prefix);
+  const params = parseListParams<T>(stripped, defaults, constraints);
+
+  /**
+   * Merge the given partial update into the URL.
+   *
+   * - Unrelated params survive.
+   * - Keys managed by THIS instance are written with the prefix.
+   * - Default-valued keys are omitted.
+   */
+  const update = useCallback(
+    (patch: Partial<T>) => {
+      setSearchParams(
+        (prev) => {
+          // Start from a copy of the current URL so unrelated params survive.
+          const next = new URLSearchParams(prev);
+
+          // Apply the patch onto the current parsed (un-prefixed) state.
+          const currentStripped = stripPrefix(prev, defaults, prefix);
+          const current = parseListParams<T>(currentStripped, defaults, constraints);
+          const merged = { ...current, ...patch };
+
+          // Serialize the merged state (default-valued keys are omitted).
+          const serialized = serializeListParams<T>(merged, defaults);
+
+          // Remove every key managed by this instance (prefixed) from `next`,
+          // then re-add only the non-default ones from `serialized`.
+          for (const key of Object.keys(defaults)) {
+            const urlKey = prefixKey(key, prefix);
+            next.delete(urlKey);
+            const newValues = serialized.getAll(key);
+            for (const v of newValues) {
+              next.append(urlKey, v);
+            }
+          }
+
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, defaults, constraints, prefix],
+  );
+
+  const setPage = useCallback(
+    (page: number) => {
+      update({ page } as unknown as Partial<T>);
+    },
+    [update],
+  );
+
+  const setSearch = useCallback(
+    (search: string) => {
+      update({ search, page: defaults.page } as unknown as Partial<T>);
+    },
+    [update, defaults.page],
+  );
+
+  const setFilter = useCallback(
+    <K extends keyof T>(key: K, value: T[K]) => {
+      update({ [key]: value, page: defaults.page } as unknown as Partial<T>);
+    },
+    [update, defaults.page],
+  );
+
+  const setArrayFilter = useCallback(
+    <K extends keyof T>(key: K, values: T[K]) => {
+      update({ [key]: values, page: defaults.page } as unknown as Partial<T>);
+    },
+    [update, defaults.page],
+  );
+
+  const mapArrayFilter = useCallback(
+    <K extends keyof T>(key: K, fn: (current: T[K]) => T[K]) => {
+      // Compute the new array inside the setSearchParams callback so we always
+      // read the *committed* URL state, never a stale render-closure snapshot.
+      setSearchParams(
+        (prev) => {
+          const currentStripped = stripPrefix(prev, defaults, prefix);
+          const current = parseListParams<T>(currentStripped, defaults, constraints);
+          const next = fn(current[key]);
+          const merged = { ...current, [key]: next, page: defaults.page };
+          const serialized = serializeListParams<T>(merged, defaults);
+
+          const nextParams = new URLSearchParams(prev);
+          for (const k of Object.keys(defaults)) {
+            const urlKey = prefixKey(k, prefix);
+            nextParams.delete(urlKey);
+            const newValues = serialized.getAll(k);
+            for (const v of newValues) {
+              nextParams.append(urlKey, v);
+            }
+          }
+          return nextParams;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, defaults, constraints, prefix],
+  );
+
+  const handleSort = useCallback(
+    (field: string) => {
+      // Derive currentField / currentOrder inside the setSearchParams callback
+      // so we always read the *committed* URL state, never a stale render closure.
+      setSearchParams(
+        (prev) => {
+          const currentStripped = stripPrefix(prev, defaults, prefix);
+          const current = parseListParams<T>(currentStripped, defaults, constraints);
+          // Access sortField / sortOrder through a type-erased view — they are
+          // present in T only when the caller includes them in their params type.
+          const p = current as Record<string, unknown>;
+          const currentField = p["sortField"] as string | undefined;
+          const currentOrder = p["sortOrder"] as "asc" | "desc" | undefined;
+
+          const nextOrder: "asc" | "desc" =
+            field === currentField
+              ? // Same field — toggle.
+                currentOrder === "asc"
+                ? "desc"
+                : "asc"
+              : // New field — use its declared initialOrder, falling back to "asc".
+                (sortFields?.find((f) => f.field === field)?.initialOrder ?? "asc");
+
+          const patch = {
+            sortField: field,
+            sortOrder: nextOrder,
+            page: defaults.page,
+          } as unknown as Partial<T>;
+
+          const merged = { ...current, ...patch };
+          const serialized = serializeListParams<T>(merged, defaults);
+
+          const next = new URLSearchParams(prev);
+          for (const key of Object.keys(defaults)) {
+            const urlKey = prefixKey(key, prefix);
+            next.delete(urlKey);
+            const newValues = serialized.getAll(key);
+            for (const v of newValues) {
+              next.append(urlKey, v);
+            }
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, defaults, constraints, prefix, sortFields],
+  );
+
+  const reset = useCallback(() => {
+    update({ ...defaults });
+  }, [update, defaults]);
+
+  return {
+    params,
+    searchString: searchParams.toString(),
+    setPage,
+    setSearch,
+    setFilter,
+    setArrayFilter,
+    mapArrayFilter,
+    handleSort,
+    reset,
+  };
+}

--- a/ui/apps/console/src/hooks/usePaginatedListState.ts
+++ b/ui/apps/console/src/hooks/usePaginatedListState.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   parseListParams,
@@ -136,8 +136,16 @@ export function usePaginatedListState<T extends Record<string, unknown>>({
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Parse the current URL into typed params (handles prefix translation).
+  // Thread the previous result through `prev` so array dimensions reuse their
+  // prior reference when content-equal, keeping memoized deps stable. The ref
+  // only caches a pure derived value, so reading/writing it during render is
+  // safe — disable react-hooks/refs for these two intentional accesses.
+  const paramsRef = useRef<T | undefined>(undefined);
   const stripped = stripPrefix(searchParams, defaults, prefix);
-  const params = parseListParams<T>(stripped, defaults, constraints);
+  // eslint-disable-next-line react-hooks/refs -- caches prior parse result for referential stability
+  const params = parseListParams<T>(stripped, defaults, constraints, paramsRef.current);
+  // eslint-disable-next-line react-hooks/refs -- stash this render's result for the next render
+  paramsRef.current = params;
 
   /**
    * Merge the given partial update into the URL.

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, FormEvent } from "react";
 import { isSdkError } from "@/api/errors";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { useWebEndpoints } from "@/hooks/useWebEndpoints";
 import {
   useCreateWebEndpoint,
@@ -133,7 +134,6 @@ function DeviceSelector({
         className={`flex items-center min-h-[42px] px-3.5 py-2 bg-card border rounded-lg cursor-text transition-all ${
           open ? "border-primary/50 ring-1 ring-primary/20" : "border-border"
         } ${error ? "border-accent-red/50" : ""}`}
-        onClick={() => setOpen(true)}
       >
         {selected ? (
           <div className="flex items-center gap-2 flex-1 min-w-0">
@@ -806,13 +806,26 @@ function EndpointCard({
 /* ─── Page ─── */
 const SEARCH_DEBOUNCE_MS = 300;
 
+type WebEndpointsParams = {
+  page: number;
+  search: string;
+};
+
+const DEFAULTS: WebEndpointsParams = {
+  page: 1,
+  search: "",
+};
+
 function WebEndpointsContent() {
-  const [page, setPage] = useState(1);
-  const [search, setSearch] = useState("");
-  const debouncedSearch = useDebouncedValue(search.trim(), SEARCH_DEBOUNCE_MS);
+  const { params, setPage, setSearch } =
+    usePaginatedListState<WebEndpointsParams>({ defaults: DEFAULTS });
+  const debouncedSearch = useDebouncedValue(
+    params.search.trim(),
+    SEARCH_DEBOUNCE_MS,
+  );
 
   const { webEndpoints, totalCount, isLoading } = useWebEndpoints({
-    page,
+    page: params.page,
     addressFilter: debouncedSearch,
   });
   const deleteEndpoint = useDeleteWebEndpoint();
@@ -835,7 +848,8 @@ function WebEndpointsContent() {
       await deleteEndpoint.mutateAsync({
         path: { address: deleteTarget.address },
       });
-      if (webEndpoints.length === 1 && page > 1) setPage(page - 1);
+      if (webEndpoints.length === 1 && params.page > 1)
+        setPage(params.page - 1);
       closeDelete();
     } catch (err) {
       setDeleteError(
@@ -932,11 +946,8 @@ function WebEndpointsContent() {
 
           <SearchField
             className="mb-4 animate-fade-in"
-            value={search}
-            onChange={(next) => {
-              setSearch(next);
-              setPage(1);
-            }}
+            value={params.search}
+            onChange={setSearch}
             placeholder="Search by address..."
             aria-label="Search web endpoints by address"
           />
@@ -981,7 +992,7 @@ function WebEndpointsContent() {
                   pages; empty/no-results states are handled by the branches
                   above, so it never renders a "0 endpoints" bar here. */}
               <Pagination
-                page={page}
+                page={params.page}
                 totalPages={totalPages}
                 totalCount={totalCount}
                 itemLabel="endpoint"

--- a/ui/apps/console/src/pages/__tests__/WebEndpoints.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/WebEndpoints.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { Webendpoint } from "@/client/types.gen";
 import WebEndpoints from "../WebEndpoints";
@@ -69,9 +70,9 @@ function setupDefaultMocks() {
   mockUseDebouncedValue.mockImplementation((v: unknown) => v);
 }
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ["/"]) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <WebEndpoints />
     </MemoryRouter>,
   );
@@ -178,5 +179,98 @@ describe("WebEndpoints — pagination count / controls decoupling", () => {
     expect(
       screen.queryByRole("button", { name: /previous page/i }),
     ).not.toBeInTheDocument();
+  });
+});
+
+// ── URL hydration (usePaginatedListState adoption) ────────────────────────────
+
+describe("WebEndpoints — URL hydration", () => {
+  it("reads page=2 and search=myhost from the URL and passes them to useWebEndpoints", () => {
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: [makeEndpoint("ep1.example.com")],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(["/?page=2&search=myhost"]);
+
+    expect(mockUseWebEndpoints).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2, addressFilter: "myhost" }),
+    );
+  });
+
+  it("falls back to page=1 and empty search when URL has no params", () => {
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: [],
+      totalCount: 0,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(["/"]);
+
+    expect(mockUseWebEndpoints).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1, addressFilter: "" }),
+    );
+  });
+});
+
+// ── Search resets page ────────────────────────────────────────────────────────
+
+describe("WebEndpoints — search resets page to 1", () => {
+  it("resets to page=1 when a new search term is typed while on page 2", async () => {
+    const user = userEvent.setup();
+
+    // Start on page 2 with existing results so the content branch (not EmptyState) renders.
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: [makeEndpoint("ep1.example.com")],
+      totalCount: 25,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(["/?page=2"]);
+
+    // Confirm initial render passes page=2
+    expect(mockUseWebEndpoints).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2 }),
+    );
+
+    // Type in the search field
+    const searchInput = screen.getByPlaceholderText(/search by address/i);
+    await user.type(searchInput, "x");
+
+    // After typing, the hook must now be called with page=1
+    expect(mockUseWebEndpoints).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1 }),
+    );
+  });
+});
+
+// ── Page change writes to URL ─────────────────────────────────────────────────
+
+describe("WebEndpoints — page change writes to URL", () => {
+  it("calls useWebEndpoints with page=2 after clicking the Next page button", async () => {
+    const user = userEvent.setup();
+
+    // 15 endpoints across 2 pages so Prev/Next controls are present.
+    mockUseWebEndpoints.mockReturnValue({
+      webEndpoints: Array.from({ length: 10 }, (_, i) =>
+        makeEndpoint(`ep${i + 1}.example.com`),
+      ),
+      totalCount: 15,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(["/"]);
+
+    const nextButton = screen.getByRole("button", { name: /next page/i });
+    await user.click(nextButton);
+
+    expect(mockUseWebEndpoints).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2 }),
+    );
   });
 });

--- a/ui/apps/console/src/pages/admin/Sessions.tsx
+++ b/ui/apps/console/src/pages/admin/Sessions.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   CommandLineIcon,
@@ -13,13 +12,22 @@ import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
 import DeviceChip from "@/components/common/DeviceChip";
 import { formatDateFull } from "@/utils/date";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 
 const PER_PAGE = 10;
 
+type AdminSessionsParams = {
+  page: number;
+};
+
+const DEFAULTS: AdminSessionsParams = { page: 1 };
+
 export default function AdminSessions() {
-  const [page, setPage] = useState(1);
+  const { params, setPage } = usePaginatedListState<AdminSessionsParams>({
+    defaults: DEFAULTS,
+  });
   const { sessions, totalCount, isLoading, error } = useAdminSessionsList(
-    page,
+    params.page,
     PER_PAGE,
   );
   const navigate = useNavigate();
@@ -164,7 +172,7 @@ export default function AdminSessions() {
         rowKey={(s) => s.uid}
         isLoading={isLoading}
         loadingMessage="Loading sessions..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="session"

--- a/ui/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
+++ b/ui/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 
 /* ------------------------------------------------------------------ */
 /* Mocks                                                               */
@@ -24,6 +24,17 @@ import AdminSessions from "../Sessions";
 /* ------------------------------------------------------------------ */
 /* Helpers                                                             */
 /* ------------------------------------------------------------------ */
+
+/** Exposes the current search string from inside the MemoryRouter. */
+function LocationProbe({
+  onLocation,
+}: {
+  onLocation: (search: string) => void;
+}) {
+  const loc = useLocation();
+  onLocation(loc.search);
+  return null;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeSession(overrides: Record<string, any> = {}) {
@@ -52,12 +63,15 @@ function setupHook(overrides: Record<string, any> = {}) {
   });
 }
 
-function renderPage() {
-  return render(
-    <MemoryRouter>
+function renderPage(initialEntries: string[] = ["/"]) {
+  let lastSearch = "";
+  const result = render(
+    <MemoryRouter initialEntries={initialEntries}>
       <AdminSessions />
+      <LocationProbe onLocation={(s) => { lastSearch = s; }} />
     </MemoryRouter>,
   );
+  return { ...result, getSearch: () => lastSearch };
 }
 
 /* ------------------------------------------------------------------ */
@@ -214,6 +228,53 @@ describe("AdminSessions", () => {
       renderPage();
       // Pagination renders page info
       expect(screen.getByText(/25/)).toBeInTheDocument();
+    });
+  });
+
+  // ── URL-driven state (usePaginatedListState adoption) ────────────────────────
+
+  describe("URL hydration", () => {
+    it("calls useAdminSessionsList with page hydrated from ?page=3", () => {
+      renderPage(["/?page=3"]);
+      expect(vi.mocked(useAdminSessionsList)).toHaveBeenCalledWith(
+        3,
+        10,
+      );
+    });
+
+    it("calls useAdminSessionsList with page=1 when URL has no page param", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useAdminSessionsList)).toHaveBeenCalledWith(
+        1,
+        10,
+      );
+    });
+  });
+
+  describe("URL writes", () => {
+    it("writes ?page=2 to the URL when the user clicks Next page", async () => {
+      const user = userEvent.setup();
+      setupHook({
+        sessions: Array.from({ length: 10 }, (_, i) =>
+          makeSession({ uid: `s-${i}`, username: `u-${i}` }),
+        ),
+        totalCount: 30,
+      });
+      const { getSearch } = renderPage();
+
+      await user.click(screen.getByRole("button", { name: "Next page" }));
+
+      await waitFor(() => {
+        const sp = new URLSearchParams(getSearch());
+        expect(sp.get("page")).toBe("2");
+      });
+    });
+
+    it("omits ?page from the URL when on the default page 1", () => {
+      const { getSearch } = renderPage(["/"]);
+      // The URL must not contain a 'page' param when on the default first page.
+      const sp = new URLSearchParams(getSearch());
+      expect(sp.get("page")).toBeNull();
     });
   });
 });

--- a/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
@@ -23,16 +23,19 @@ vi.mock("../DeleteAnnouncementDialog", () => ({
   default: ({
     open,
     onClose,
+    onDeleted,
     announcement,
   }: {
     open: boolean;
     onClose: () => void;
+    onDeleted?: () => void;
     announcement: AnnouncementShort | null;
   }) => {
     if (!open || !announcement) return null;
     return (
       <div role="dialog" aria-label={`Delete ${announcement.title}`}>
         <button type="button" onClick={onClose}>Cancel delete</button>
+        <button type="button" onClick={() => { onClose(); onDeleted?.(); }}>Confirm delete</button>
       </div>
     );
   },
@@ -64,9 +67,9 @@ function makeAnnouncement(
   };
 }
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ["/"]) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <AdminAnnouncements />
     </MemoryRouter>,
   );
@@ -415,6 +418,84 @@ describe("AdminAnnouncements", () => {
       });
       renderPage();
       expect(screen.getByText("25 announcements")).toBeInTheDocument();
+    });
+  });
+
+  describe("URL hydration (usePaginatedListState)", () => {
+    it("calls useAdminAnnouncements with page hydrated from ?page=2", () => {
+      renderPage(["/?page=2"]);
+      expect(vi.mocked(useAdminAnnouncements)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+    });
+
+    it("calls useAdminAnnouncements with page=1 when URL has no page param", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useAdminAnnouncements)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+  });
+
+  describe("URL writes (usePaginatedListState)", () => {
+    it("calls useAdminAnnouncements with page=2 when the user clicks Next page", async () => {
+      const user = userEvent.setup();
+      const manyAnnouncements = Array.from({ length: 10 }, (_, i) =>
+        makeAnnouncement({ uuid: `uuid-${i}`, title: `Ann ${i}` }),
+      );
+      vi.mocked(useAdminAnnouncements).mockReturnValue({
+        ...defaultHookState,
+        announcements: manyAnnouncements,
+        totalCount: 30,
+      });
+      renderPage();
+
+      await user.click(screen.getByRole("button", { name: "Next page" }));
+
+      expect(vi.mocked(useAdminAnnouncements)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+    });
+  });
+
+  describe("delete-last-row page decrement (usePaginatedListState)", () => {
+    it("decrements page from 2 to 1 via URL when deleting the last item on a page", async () => {
+      const user = userEvent.setup();
+
+      // Mount at page=2 with exactly 1 item (last item on that page)
+      vi.mocked(useAdminAnnouncements).mockReturnValue({
+        ...defaultHookState,
+        announcements: [makeAnnouncement({ title: "Last Item" })],
+        totalCount: 11, // enough for page 2 to exist
+      });
+
+      renderPage(["/?page=2"]);
+
+      // Sanity: hook was called with page=2
+      expect(vi.mocked(useAdminAnnouncements)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+
+      // Open the delete dialog
+      await user.click(
+        screen.getByRole("button", { name: "Delete Last Item" }),
+      );
+      await waitFor(() => screen.getByRole("dialog"));
+
+      // Clear prior call history so the post-delete assertion can only match a
+      // call produced by the page decrement — not the page=1 calls from the
+      // initial mount/hydration. Without this the assertion passes vacuously.
+      vi.mocked(useAdminAnnouncements).mockClear();
+
+      // Confirm the delete (fires onDeleted which should decrement the page)
+      await user.click(screen.getByRole("button", { name: "Confirm delete" }));
+
+      // After deletion, the hook must be called with page=1
+      await waitFor(() => {
+        expect(vi.mocked(useAdminAnnouncements)).toHaveBeenCalledWith(
+          expect.objectContaining({ page: 1 }),
+        );
+      });
     });
   });
 });

--- a/ui/apps/console/src/pages/admin/announcements/index.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/index.tsx
@@ -18,19 +18,28 @@ import {
   Callout,
   IconButton,
 } from "@shellhub/design-system/primitives";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 
 const PER_PAGE = 10;
 
+type AdminAnnouncementsParams = {
+  page: number;
+};
+
+const DEFAULTS: AdminAnnouncementsParams = { page: 1 };
+
 export default function AdminAnnouncements() {
   const navigate = useNavigate();
-  const [page, setPage] = useState(1);
+  const { params, setPage } = usePaginatedListState<AdminAnnouncementsParams>({
+    defaults: DEFAULTS,
+  });
   const [deleteTarget, setDeleteTarget] = useState<AnnouncementShort | null>(
     null,
   );
 
   const { announcements, totalCount, isLoading, error } = useAdminAnnouncements(
     {
-      page,
+      page: params.page,
       perPage: PER_PAGE,
     },
   );
@@ -128,7 +137,7 @@ export default function AdminAnnouncements() {
         label="Announcements"
         isLoading={isLoading}
         loadingMessage="Loading announcements..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="announcement"
@@ -152,8 +161,8 @@ export default function AdminAnnouncements() {
         onClose={() => setDeleteTarget(null)}
         announcement={deleteTarget}
         onDeleted={() => {
-          if (announcements.length <= 1 && page > 1) {
-            setPage(page - 1);
+          if (announcements.length <= 1 && params.page > 1) {
+            setPage(params.page - 1);
           }
         }}
       />

--- a/ui/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
+++ b/ui/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
@@ -57,9 +57,9 @@ function makeDevice(
   } as NormalizedDevice;
 }
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ["/"]) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <AdminDevices />
     </MemoryRouter>,
   );
@@ -69,8 +69,8 @@ function renderPage() {
 
 describe("AdminDevices", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(useAdminDevices).mockReturnValue(defaultHookState);
-    mockNavigate.mockReset();
   });
 
   describe("rendering", () => {
@@ -179,6 +179,124 @@ describe("AdminDevices", () => {
       expect(
         screen.getByRole("searchbox", { name: "Search devices by hostname" }),
       ).toBeInTheDocument();
+    });
+  });
+
+  // ── URL-driven state (usePaginatedListState adoption) ─────────────────────────
+
+  describe("URL hydration — controls reflect URL params on mount", () => {
+    it("calls useAdminDevices with sortBy/orderBy hydrated from URL sortField/sortOrder params", () => {
+      renderPage(["/?sortField=name&sortOrder=asc"]);
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ sortBy: "name", orderBy: "asc" }),
+      );
+    });
+
+    it("calls useAdminDevices with status hydrated from URL status param", () => {
+      renderPage(["/?status=accepted"]);
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "accepted" }),
+      );
+    });
+
+    it("marks the matching status tab as selected when status is in the URL", () => {
+      renderPage(["/?status=pending"]);
+      expect(screen.getByRole("tab", { name: "Pending" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+
+    it("calls useAdminDevices with page hydrated from URL page param", () => {
+      renderPage(["/?page=3"]);
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 3 }),
+      );
+    });
+
+    it("uses defaults when URL params are absent (last_seen/desc, page 1, empty status)", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sortBy: "last_seen",
+          orderBy: "desc",
+          page: 1,
+          status: "",
+        }),
+      );
+    });
+
+    it("rejects an invalid status value and falls back to empty string (All tab selected)", () => {
+      renderPage(["/?status=invalid-status"]);
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "" }),
+      );
+      expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+  });
+
+  describe("URL writes — interactions update URL and reset page", () => {
+    it("clicking a status tab writes status to URL and resets page to 1", async () => {
+      const user = userEvent.setup();
+      // Start on page 2 with no status
+      renderPage(["/?page=2"]);
+      // Confirm we start on page 2
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+
+      await user.click(screen.getByRole("tab", { name: "Accepted" }));
+
+      // After clicking, useAdminDevices should be called with status=accepted and page=1
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "accepted", page: 1 }),
+      );
+    });
+
+    it("clicking a sort column header writes sortField/sortOrder to URL and resets page", async () => {
+      const user = userEvent.setup();
+      renderPage(["/?page=3"]);
+
+      // Click the "Sort by Hostname" sort button (maps to "name" field)
+      await user.click(screen.getByRole("button", { name: /sort by hostname/i }));
+
+      // name has initialOrder=asc, so switching to it uses asc
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ sortBy: "name", orderBy: "asc", page: 1 }),
+      );
+    });
+
+    it("clicking the same sort column again toggles order from asc to desc", async () => {
+      const user = userEvent.setup();
+      // Start already sorted by name asc
+      renderPage(["/?sortField=name&sortOrder=asc"]);
+
+      await user.click(screen.getByRole("button", { name: /sort by hostname/i }));
+
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ sortBy: "name", orderBy: "desc" }),
+      );
+    });
+  });
+
+  describe("URL writes — default params are omitted from the URL", () => {
+    it("does not include page in the URL when on page 1 (the default)", () => {
+      // We can't easily inspect the URL from a plain render test, so we verify
+      // that useAdminDevices receives page=1 after navigating back to default
+      renderPage(["/"]);
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+
+    it("does not pass status to useAdminDevices when All tab is selected (default empty)", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "" }),
+      );
     });
   });
 });

--- a/ui/apps/console/src/pages/admin/devices/index.tsx
+++ b/ui/apps/console/src/pages/admin/devices/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import {
   CpuChipIcon,
@@ -14,7 +13,7 @@ import DataTable, { type Column } from "@/components/common/DataTable";
 import SearchField from "@/components/common/fields/SearchField";
 import DistroIcon from "@/components/common/DistroIcon";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import { useTableSort } from "@/hooks/useTableSort";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatRelative } from "@/utils/date";
 
@@ -30,7 +29,42 @@ const statusTabs: StatusTab[] = [
   { label: "Rejected", value: "rejected" },
 ];
 
-type SortField = "name" | "last_seen" | "status";
+const VALID_STATUSES = ["", "accepted", "pending", "rejected"] as const;
+const VALID_SORT_FIELDS = ["name", "last_seen", "status"] as const;
+const VALID_SORT_ORDERS = ["asc", "desc"] as const;
+
+/** Stable module-level constants — avoids new object/array identities every
+ *  render, which would invalidate the `update` and `handleSort` useCallbacks
+ *  in usePaginatedListState and cascade unnecessary re-renders to children. */
+const CONSTRAINTS = {
+  status: VALID_STATUSES,
+  sortField: VALID_SORT_FIELDS,
+  sortOrder: VALID_SORT_ORDERS,
+} as const;
+
+const SORT_FIELDS = [
+  { field: "name", initialOrder: "asc" as const },
+  { field: "last_seen", initialOrder: "desc" as const },
+  { field: "status", initialOrder: "desc" as const },
+];
+
+type SortField = typeof VALID_SORT_FIELDS[number];
+
+type AdminDevicesParams = {
+  page: number;
+  search: string;
+  sortField: SortField;
+  sortOrder: "asc" | "desc";
+  status: DeviceStatus | "";
+};
+
+const DEFAULTS: AdminDevicesParams = {
+  page: 1,
+  search: "",
+  sortField: "last_seen",
+  sortOrder: "desc",
+  status: "",
+};
 
 function TagChips({ tags }: { tags: string[] }) {
   if (tags.length === 0) {
@@ -55,30 +89,26 @@ function TagChips({ tags }: { tags: string[] }) {
 
 export default function AdminDevices() {
   const navigate = useNavigate();
-  const [page, setPage] = useState(1);
-  const [searchInput, setSearchInput] = useState("");
-  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
-  const [status, setStatus] = useState<DeviceStatus | "">("");
-  const { sortBy, orderBy, handleSort } = useTableSort<SortField>({
-    defaultField: "last_seen",
-    onSortChange: () => setPage(1),
-  });
+
+  const { params, setPage, setSearch, setFilter, handleSort } =
+    usePaginatedListState<AdminDevicesParams>({
+      defaults: DEFAULTS,
+      constraints: CONSTRAINTS,
+      sortFields: SORT_FIELDS,
+    });
+
+  const debouncedSearch = useDebouncedValue(params.search, SEARCH_DEBOUNCE_MS);
 
   const { devices, totalCount, isLoading, error } = useAdminDevices({
-    page,
+    page: params.page,
     perPage: PER_PAGE,
     search: debouncedSearch,
-    status,
-    sortBy,
-    orderBy,
+    status: params.status,
+    sortBy: params.sortField,
+    orderBy: params.sortOrder,
   });
 
   const totalPages = Math.ceil(totalCount / PER_PAGE);
-
-  const handleStatusChange = (newStatus: DeviceStatus | "") => {
-    setStatus(newStatus);
-    setPage(1);
-  };
 
   const columns: Column<NormalizedDevice>[] = [
     {
@@ -183,10 +213,10 @@ export default function AdminDevices() {
               type="button"
               key={tab.value}
               role="tab"
-              aria-selected={status === tab.value}
-              onClick={() => handleStatusChange(tab.value)}
+              aria-selected={params.status === tab.value}
+              onClick={() => setFilter("status", tab.value)}
               className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${
-                status === tab.value
+                params.status === tab.value
                   ? "bg-primary/15 text-primary border border-primary/25"
                   : "text-text-muted hover:text-text-secondary border border-transparent"
               }`}
@@ -197,11 +227,8 @@ export default function AdminDevices() {
         </div>
 
         <SearchField
-          value={searchInput}
-          onChange={(next) => {
-            setSearchInput(next);
-            setPage(1);
-          }}
+          value={params.search}
+          onChange={(next) => setSearch(next)}
           placeholder="Search by hostname..."
           aria-label="Search devices by hostname"
         />
@@ -219,14 +246,14 @@ export default function AdminDevices() {
         rowKey={(device) => device.uid}
         isLoading={isLoading}
         loadingMessage="Loading devices..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="device"
         onPageChange={setPage}
         onRowClick={(device) => void navigate(`/admin/devices/${device.uid}`)}
-        sortField={sortBy}
-        sortOrder={orderBy}
+        sortField={params.sortField}
+        sortOrder={params.sortOrder}
         onSort={handleSort}
         emptyState={
           <div className="text-center">

--- a/ui/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
@@ -9,6 +9,21 @@ vi.mock("@/hooks/useAdminFirewallRules", () => ({
   useAdminFirewallRules: vi.fn(),
 }));
 
+// Capture DataTable props on every render so we can assert pagination suppression.
+const capturedDataTableProps: Record<string, unknown>[] = [];
+vi.mock("@/components/common/DataTable", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/common/DataTable")>();
+  return {
+    ...actual,
+    default: (props: Record<string, unknown>) => {
+      capturedDataTableProps.push({ ...props });
+      // Render the real DataTable so existing tests keep working.
+      return actual.default(props as unknown as Parameters<typeof actual.default>[0]);
+    },
+  };
+});
+
 // useNavigate is used by the page — mock at the module level.
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -47,9 +62,9 @@ function makeRule(
   };
 }
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ["/"]) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <AdminFirewallRules />
     </MemoryRouter>,
   );
@@ -61,6 +76,7 @@ describe("AdminFirewallRules", () => {
   beforeEach(() => {
     vi.mocked(useAdminFirewallRules).mockReturnValue(defaultHookState);
     mockNavigate.mockReset();
+    capturedDataTableProps.length = 0;
   });
 
   describe("rendering", () => {
@@ -347,6 +363,101 @@ describe("AdminFirewallRules", () => {
       );
 
       await screen.findByText(/No rules matching/);
+    });
+  });
+
+  // ── usePaginatedListState adoption ───────────────────────────────────────────
+
+  describe("pagination suppressed while searching", () => {
+    beforeEach(() => {
+      vi.mocked(useAdminFirewallRules).mockReturnValue({
+        ...defaultHookState,
+        rules: [makeRule({ id: "r1", action: "allow", priority: 1 })],
+        totalCount: 1,
+      });
+    });
+
+    it("passes page/totalPages/onPageChange to DataTable when search is empty", () => {
+      renderPage();
+      const last = capturedDataTableProps.at(-1);
+      expect(last).toBeDefined();
+      expect(last).toHaveProperty("page");
+      expect(last).toHaveProperty("totalPages");
+      expect(last).toHaveProperty("onPageChange");
+    });
+
+    it("omits page/totalPages/onPageChange from DataTable while search is non-empty", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.type(
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
+        "allow",
+      );
+
+      await waitFor(() => {
+        const last = capturedDataTableProps.at(-1);
+        expect(last).toBeDefined();
+        expect(last).not.toHaveProperty("page");
+        expect(last).not.toHaveProperty("totalPages");
+        expect(last).not.toHaveProperty("onPageChange");
+      });
+    });
+  });
+
+  describe("URL round-trips", () => {
+    it("hydrates search from URL on mount", () => {
+      vi.mocked(useAdminFirewallRules).mockReturnValue({
+        ...defaultHookState,
+        rules: [makeRule({ id: "r1", action: "allow" })],
+        totalCount: 1,
+      });
+      renderPage(["/?search=allow"]);
+      expect(
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
+      ).toHaveValue("allow");
+    });
+
+    it("hydrates page from URL and passes it to the hook", () => {
+      renderPage(["/?page=3"]);
+      expect(vi.mocked(useAdminFirewallRules)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 3 }),
+      );
+    });
+
+    it("calls useAdminFirewallRules with page=1 when URL has no params", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useAdminFirewallRules)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+
+    it("setSearch resets page to 1 in the URL", async () => {
+      const user = userEvent.setup();
+      renderPage(["/?page=3"]);
+
+      // Confirm page=3 was hydrated
+      expect(vi.mocked(useAdminFirewallRules)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 3 }),
+      );
+
+      await user.type(
+        screen.getByRole("searchbox", {
+          name: "Search firewall rules by action, priority, IP, or username",
+        }),
+        "allow",
+      );
+
+      await waitFor(() => {
+        const calls = vi.mocked(useAdminFirewallRules).mock.calls;
+        const lastCall = calls.at(-1)![0];
+        expect(lastCall).toBeDefined();
+        expect(lastCall?.page).toBe(1);
+      });
     });
   });
 });

--- a/ui/apps/console/src/pages/admin/firewall-rules/index.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import {
   ShieldExclamationIcon,
@@ -11,24 +11,35 @@ import FilterBadge from "@/components/common/FilterBadge";
 import PageHeader from "@/components/common/PageHeader";
 import SearchField from "@/components/common/fields/SearchField";
 import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { type FirewallRulesResponse as FirewallRule } from "@/client";
 import { Badge, Callout } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
 
+type AdminFirewallRulesParams = {
+  page: number;
+  search: string;
+};
+
+const DEFAULTS: AdminFirewallRulesParams = {
+  page: 1,
+  search: "",
+};
+
 export default function AdminFirewallRules() {
   const navigate = useNavigate();
-  const [page, setPage] = useState(1);
-  const [search, setSearch] = useState("");
+  const { params, setPage, setSearch } =
+    usePaginatedListState<AdminFirewallRulesParams>({ defaults: DEFAULTS });
 
   const { rules, totalCount, isLoading, error } = useAdminFirewallRules({
-    page,
+    page: params.page,
     perPage: PER_PAGE,
   });
 
   const filtered = useMemo(() => {
-    if (!search) return rules;
-    const q = search.toLowerCase();
+    if (!params.search) return rules;
+    const q = params.search.toLowerCase();
     return rules.filter(
       (r) =>
         r.action.toLowerCase().includes(q) ||
@@ -36,7 +47,7 @@ export default function AdminFirewallRules() {
         r.username.toLowerCase().includes(q) ||
         String(r.priority).includes(q),
     );
-  }, [rules, search]);
+  }, [rules, params.search]);
 
   const totalPages = Math.ceil(totalCount / PER_PAGE);
 
@@ -128,11 +139,8 @@ export default function AdminFirewallRules() {
 
       <SearchField
         className="mb-5"
-        value={search}
-        onChange={(next) => {
-          setSearch(next);
-          setPage(1);
-        }}
+        value={params.search}
+        onChange={setSearch}
         placeholder="Search by action, priority, IP, or username..."
         aria-label="Search firewall rules by action, priority, IP, or username"
       />
@@ -145,13 +153,13 @@ export default function AdminFirewallRules() {
 
       <DataTable
         columns={columns}
-        data={search ? filtered : rules}
+        data={params.search ? filtered : rules}
         rowKey={(rule) => rule.id}
         isLoading={isLoading}
         loadingMessage="Loading firewall rules..."
         onRowClick={(rule) => void navigate(`/admin/firewall-rules/${rule.id}`)}
-        {...(!search && {
-          page,
+        {...(!params.search && {
+          page: params.page,
           totalPages,
           totalCount,
           itemLabel: "rule",
@@ -164,8 +172,8 @@ export default function AdminFirewallRules() {
               strokeWidth={1}
             />
             <p className="text-xs font-mono text-text-muted">
-              {search
-                ? `No rules matching "${search}"`
+              {params.search
+                ? `No rules matching "${params.search}"`
                 : "No firewall rules found"}
             </p>
           </div>

--- a/ui/apps/console/src/pages/admin/namespaces/__tests__/AdminNamespaces.test.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/__tests__/AdminNamespaces.test.tsx
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import type { Namespace } from "@/client";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/hooks/useAdminNamespaces", () => ({
+  useAdminNamespaces: vi.fn(),
+}));
+
+// Drawer/Dialog mocks — keep tests fast and focused
+vi.mock("../EditNamespaceDrawer", () => ({
+  default: ({
+    open,
+  }: {
+    open: boolean;
+    namespace: unknown;
+    onClose: () => void;
+  }) => (open ? <div data-testid="edit-drawer" /> : null),
+}));
+
+vi.mock("../DeleteNamespaceDialog", () => ({
+  default: ({
+    open,
+  }: {
+    open: boolean;
+    namespace: unknown;
+    onClose: () => void;
+  }) => (open ? <div data-testid="delete-dialog" /> : null),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { useAdminNamespaces } from "@/hooks/useAdminNamespaces";
+import AdminNamespaces from "../index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const defaultHookState = {
+  namespaces: [] as Namespace[],
+  totalCount: 0,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+function makeNamespace(overrides: Partial<Namespace> = {}): Namespace {
+  return {
+    tenant_id: "tenant-1",
+    name: "my-namespace",
+    owner: "owner-1",
+    members: [{ id: "owner-1", email: "owner@example.com", role: 0 }],
+    settings: {
+      session_record: true,
+      connection_announcement: "",
+      device_auto_accept: false,
+    },
+    max_devices: 10,
+    devices_accepted_count: 2,
+    created_at: "2024-01-01T00:00:00Z",
+    billing: null,
+    ...overrides,
+  } as Namespace;
+}
+
+function renderPage(initialEntries: string[] = ["/"]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AdminNamespaces />
+    </MemoryRouter>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("AdminNamespaces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAdminNamespaces).mockReturnValue(defaultHookState);
+  });
+
+  describe("rendering", () => {
+    it("renders the page heading", () => {
+      renderPage();
+      expect(
+        screen.getByRole("heading", { name: "Namespaces" }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the search input with correct aria-label", () => {
+      renderPage();
+      expect(
+        screen.getByRole("searchbox", { name: "Search namespaces by name" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it('renders the loading spinner with "Loading namespaces..." text', () => {
+      vi.mocked(useAdminNamespaces).mockReturnValue({
+        ...defaultHookState,
+        isLoading: true,
+        namespaces: [],
+      });
+      renderPage();
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText("Loading namespaces...")).toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it('renders "No namespaces found" when the list is empty', () => {
+      renderPage();
+      expect(screen.getByText("No namespaces found")).toBeInTheDocument();
+    });
+  });
+
+  describe("namespace rows", () => {
+    it("renders a row for each returned namespace", () => {
+      vi.mocked(useAdminNamespaces).mockReturnValue({
+        ...defaultHookState,
+        namespaces: [
+          makeNamespace({ tenant_id: "t-1", name: "namespace-alpha" }),
+          makeNamespace({ tenant_id: "t-2", name: "namespace-beta" }),
+        ],
+        totalCount: 2,
+      });
+      renderPage();
+      expect(screen.getByText("namespace-alpha")).toBeInTheDocument();
+      expect(screen.getByText("namespace-beta")).toBeInTheDocument();
+    });
+
+    it("navigates to namespace detail page when a row is clicked", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useAdminNamespaces).mockReturnValue({
+        ...defaultHookState,
+        namespaces: [
+          makeNamespace({ tenant_id: "tenant-xyz", name: "clickable-ns" }),
+        ],
+        totalCount: 1,
+      });
+      renderPage();
+      await user.click(screen.getByText("clickable-ns"));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        "/admin/namespaces/tenant-xyz",
+      );
+    });
+  });
+
+  describe("error state", () => {
+    it("renders an error alert when the hook returns an error", () => {
+      vi.mocked(useAdminNamespaces).mockReturnValue({
+        ...defaultHookState,
+        error: new Error("Request failed"),
+      });
+      renderPage();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText("Request failed")).toBeInTheDocument();
+    });
+  });
+
+  // ── URL-driven state (usePaginatedListState adoption) ─────────────────────────
+
+  describe("URL hydration — controls reflect URL params on mount", () => {
+    it("calls useAdminNamespaces with search and page hydrated from URL params", () => {
+      renderPage(["/?search=myns&page=3"]);
+      expect(vi.mocked(useAdminNamespaces)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 3 }),
+      );
+      // The search field should reflect the URL value
+      expect(
+        screen.getByRole("searchbox", { name: "Search namespaces by name" }),
+      ).toHaveValue("myns");
+    });
+
+    it("calls useAdminNamespaces with page=1 and search='' when URL has no params", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useAdminNamespaces)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+  });
+
+  describe("URL writes — clearing search resets page to 1 and omits both params", () => {
+    it("omits search and page from the URL after clearing a prefilled search", async () => {
+      const user = userEvent.setup();
+      // Start with ?search=myns&page=3 in the URL
+      renderPage(["/?search=myns&page=3"]);
+
+      const searchbox = screen.getByRole("searchbox", {
+        name: "Search namespaces by name",
+      });
+      expect(searchbox).toHaveValue("myns");
+
+      // Clear the search field
+      await user.clear(searchbox);
+
+      // After clearing, useAdminNamespaces must be called with page=1 (default)
+      // and search='' (default), meaning neither is in the URL any more.
+      expect(vi.mocked(useAdminNamespaces)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+  });
+
+  // ── Exact URL params from unit spec ──────────────────────────────────────────
+
+  describe("URL hydration — ?page=2&search=dev hydrates controls", () => {
+    it("hydrates the search field to 'dev' and calls useAdminNamespaces with page=2", () => {
+      renderPage(["/?page=2&search=dev"]);
+
+      // SearchField must reflect the URL value immediately
+      expect(
+        screen.getByRole("searchbox", { name: "Search namespaces by name" }),
+      ).toHaveValue("dev");
+
+      // Hook must be called with the URL values
+      expect(vi.mocked(useAdminNamespaces)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+    });
+  });
+
+  // ── URL writes — typing in SearchField resets page to 1 ─────────────────────
+
+  describe("URL writes — typing in SearchField resets page to 1", () => {
+    it("resets page to 1 and reflects new search value after typing", async () => {
+      const user = userEvent.setup();
+      // Start on page 2
+      renderPage(["/?page=2"]);
+
+      // Confirm initial page
+      expect(vi.mocked(useAdminNamespaces)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+
+      const searchbox = screen.getByRole("searchbox", {
+        name: "Search namespaces by name",
+      });
+
+      // Type a search term — this should reset page to 1
+      await user.type(searchbox, "dev");
+
+      // Hook must now be called with page=1 (reset) and the searchbox shows new value
+      expect(vi.mocked(useAdminNamespaces)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+      expect(searchbox).toHaveValue("dev");
+    });
+  });
+
+  // ── Debounce — search is debounced before reaching the query hook ─────────────
+
+  describe("debounce — search is debounced before reaching the query hook", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("does not pass the new search to useAdminNamespaces until the debounce delay elapses", () => {
+      renderPage(["/"]);
+
+      const searchbox = screen.getByRole("searchbox", {
+        name: "Search namespaces by name",
+      });
+
+      // Fire a change event — before the 300 ms debounce fires the hook should
+      // NOT have been called with search: "dev".
+      act(() => {
+        fireEvent.change(searchbox, { target: { value: "dev" } });
+      });
+
+      // Immediately after the change, the debounced value hasn't settled yet.
+      const callsBeforeDebounce = vi.mocked(useAdminNamespaces).mock.calls;
+      const hadDevBefore = callsBeforeDebounce.some(
+        ([args]) => (args as { search?: string }).search === "dev",
+      );
+      expect(hadDevBefore).toBe(false);
+
+      // Advance timers past the debounce window (300 ms)
+      act(() => {
+        vi.advanceTimersByTime(350);
+      });
+
+      // Now the debounced search should have fired and the hook called with "dev"
+      const callsAfterDebounce = vi.mocked(useAdminNamespaces).mock.calls;
+      const hadDevAfter = callsAfterDebounce.some(
+        ([args]) => (args as { search?: string }).search === "dev",
+      );
+      expect(hadDevAfter).toBe(true);
+    });
+  });
+});

--- a/ui/apps/console/src/pages/admin/namespaces/index.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { useAdminNamespaces } from "@/hooks/useAdminNamespaces";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import type { Namespace } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
@@ -20,6 +21,16 @@ import { Callout, IconButton } from "@shellhub/design-system/primitives";
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
 
+type AdminNamespacesParams = {
+  page: number;
+  search: string;
+};
+
+const DEFAULTS: AdminNamespacesParams = {
+  page: 1,
+  search: "",
+};
+
 function getOwnerEmail(namespace: Namespace): string {
   const owner = namespace.members?.find((m) => m.id === namespace.owner);
   return owner?.email || namespace.owner;
@@ -27,14 +38,14 @@ function getOwnerEmail(namespace: Namespace): string {
 
 export default function AdminNamespaces() {
   const navigate = useNavigate();
-  const [page, setPage] = useState(1);
-  const [searchInput, setSearchInput] = useState("");
-  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
+  const { params, setPage, setSearch } =
+    usePaginatedListState<AdminNamespacesParams>({ defaults: DEFAULTS });
+  const debouncedSearch = useDebouncedValue(params.search, SEARCH_DEBOUNCE_MS);
   const [editTarget, setEditTarget] = useState<Namespace | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Namespace | null>(null);
 
   const { namespaces, totalCount, isLoading, error } = useAdminNamespaces({
-    page,
+    page: params.page,
     perPage: PER_PAGE,
     search: debouncedSearch,
   });
@@ -129,11 +140,8 @@ export default function AdminNamespaces() {
 
       <SearchField
         className="mb-5"
-        value={searchInput}
-        onChange={(next) => {
-          setSearchInput(next);
-          setPage(1);
-        }}
+        value={params.search}
+        onChange={setSearch}
         placeholder="Search by name..."
         aria-label="Search namespaces by name"
       />
@@ -150,7 +158,7 @@ export default function AdminNamespaces() {
         rowKey={(ns) => ns.tenant_id}
         isLoading={isLoading}
         loadingMessage="Loading namespaces..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="namespace"

--- a/ui/apps/console/src/pages/admin/users/__tests__/AdminUsers.test.tsx
+++ b/ui/apps/console/src/pages/admin/users/__tests__/AdminUsers.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import type { UserAdminResponse } from "@/client";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/hooks/useAdminUsers", () => ({
+  useAdminUsers: vi.fn(),
+}));
+
+vi.mock("@/hooks/useLoginAsUser", () => ({
+  useLoginAsUser: vi.fn(),
+}));
+
+vi.mock("./mocks", () => ({}));
+
+// Drawer/Dialog mocks — keep tests fast and focused
+vi.mock("../CreateUserDrawer", () => ({
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="create-drawer" /> : null,
+}));
+
+vi.mock("../EditUserDrawer", () => ({
+  default: ({ open }: { open: boolean; user: unknown; onClose: () => void }) =>
+    open ? <div data-testid="edit-drawer" /> : null,
+}));
+
+vi.mock("../DeleteUserDialog", () => ({
+  default: ({
+    open,
+  }: {
+    open: boolean;
+    user: unknown;
+    onClose: () => void;
+  }) => (open ? <div data-testid="delete-dialog" /> : null),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { useAdminUsers } from "@/hooks/useAdminUsers";
+import { useLoginAsUser } from "@/hooks/useLoginAsUser";
+import AdminUsers from "../index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const defaultHookState = {
+  users: [] as UserAdminResponse[],
+  totalCount: 0,
+  isLoading: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+const defaultLoginAsState = {
+  loginAs: vi.fn(),
+  loadingId: null as string | null,
+  errorId: null as string | null,
+};
+
+function makeUser(overrides: Partial<UserAdminResponse> = {}): UserAdminResponse {
+  return {
+    id: "user-id-1",
+    name: "Alice Smith",
+    email: "alice@example.com",
+    username: "alice",
+    status: "confirmed",
+    admin: false,
+    ...overrides,
+  } as UserAdminResponse;
+}
+
+function renderPage(initialEntries: string[] = ["/"]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AdminUsers />
+    </MemoryRouter>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("AdminUsers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAdminUsers).mockReturnValue(defaultHookState);
+    vi.mocked(useLoginAsUser).mockReturnValue(defaultLoginAsState);
+  });
+
+  describe("rendering", () => {
+    it("renders the page heading", () => {
+      renderPage();
+      expect(screen.getByRole("heading", { name: "Users" })).toBeInTheDocument();
+    });
+
+    it("renders the search input with correct aria-label", () => {
+      renderPage();
+      expect(
+        screen.getByRole("searchbox", { name: "Search users by username" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it('renders the loading spinner with "Loading users..." text', () => {
+      vi.mocked(useAdminUsers).mockReturnValue({
+        ...defaultHookState,
+        isLoading: true,
+        users: [],
+      });
+      renderPage();
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText("Loading users...")).toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it('renders "No users found" when the user list is empty', () => {
+      renderPage();
+      expect(screen.getByText("No users found")).toBeInTheDocument();
+    });
+  });
+
+  describe("user rows", () => {
+    it("renders a row for each returned user", () => {
+      vi.mocked(useAdminUsers).mockReturnValue({
+        ...defaultHookState,
+        users: [
+          makeUser({ id: "id-1", name: "Alice Smith" }),
+          makeUser({ id: "id-2", name: "Bob Jones" }),
+        ],
+        totalCount: 2,
+      });
+      renderPage();
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+      expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+    });
+
+    it("navigates to user detail page when a row is clicked", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useAdminUsers).mockReturnValue({
+        ...defaultHookState,
+        users: [makeUser({ id: "uid-abc", name: "Clickable User" })],
+        totalCount: 1,
+      });
+      renderPage();
+      await user.click(screen.getByText("Clickable User"));
+      expect(mockNavigate).toHaveBeenCalledWith("/admin/users/uid-abc");
+    });
+  });
+
+  describe("error state", () => {
+    it("renders an error alert when the hook returns an error", () => {
+      vi.mocked(useAdminUsers).mockReturnValue({
+        ...defaultHookState,
+        error: new Error("Request failed"),
+      });
+      renderPage();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText("Request failed")).toBeInTheDocument();
+    });
+  });
+
+  // ── URL-driven state (usePaginatedListState adoption) ─────────────────────────
+
+  describe("URL hydration — controls reflect URL params on mount", () => {
+    it("calls useAdminUsers with search and page hydrated from URL params", () => {
+      renderPage(["/?search=foo&page=2"]);
+      expect(vi.mocked(useAdminUsers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+      // The search field should reflect the URL value
+      expect(
+        screen.getByRole("searchbox", { name: "Search users by username" }),
+      ).toHaveValue("foo");
+    });
+
+    it("calls useAdminUsers with page=1 and search='' when URL has no params", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useAdminUsers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+  });
+
+  describe("URL writes — clearing search resets page to 1 and omits both params", () => {
+    it("omits search and page from the URL after clearing a prefilled search", async () => {
+      const user = userEvent.setup();
+      // Start with ?search=foo&page=2 in the URL
+      renderPage(["/?search=foo&page=2"]);
+
+      const searchbox = screen.getByRole("searchbox", {
+        name: "Search users by username",
+      });
+      expect(searchbox).toHaveValue("foo");
+
+      // Clear the search field
+      await user.clear(searchbox);
+
+      // After clearing, useAdminUsers must be called with page=1 (default)
+      // and search='' (default), meaning neither is in the URL any more.
+      expect(vi.mocked(useAdminUsers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+  });
+
+  // ── Exact URL params from unit spec ──────────────────────────────────────────
+
+  describe("URL hydration — ?page=3&search=alice hydrates controls", () => {
+    it("hydrates the search field to 'alice' and calls useAdminUsers with page=3", () => {
+      renderPage(["/?page=3&search=alice"]);
+
+      // SearchField must reflect the URL value
+      expect(
+        screen.getByRole("searchbox", { name: "Search users by username" }),
+      ).toHaveValue("alice");
+
+      // Hook must be called with the URL values (both page and search)
+      expect(vi.mocked(useAdminUsers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 3 }),
+      );
+    });
+  });
+
+  describe("URL writes — typing in SearchField resets page to 1", () => {
+    it("resets page to 1 and reflects new search value after typing", async () => {
+      const user = userEvent.setup();
+      // Start on page 3
+      renderPage(["/?page=3"]);
+
+      // Confirm initial page
+      expect(vi.mocked(useAdminUsers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 3 }),
+      );
+
+      const searchbox = screen.getByRole("searchbox", {
+        name: "Search users by username",
+      });
+
+      // Type a search term — this should reset page to 1
+      await user.type(searchbox, "bob");
+
+      // Hook must now be called with page=1 (reset) and the searchbox shows new value
+      expect(vi.mocked(useAdminUsers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+      expect(searchbox).toHaveValue("bob");
+    });
+  });
+
+  describe("debounce — search is debounced before reaching the query hook", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("does not pass the new search to useAdminUsers until the debounce delay elapses", () => {
+      renderPage(["/"]);
+
+      const searchbox = screen.getByRole("searchbox", {
+        name: "Search users by username",
+      });
+
+      // Fire a change event — before the 300 ms debounce fires the hook should
+      // NOT have been called with search: "alice".
+      act(() => {
+        fireEvent.change(searchbox, { target: { value: "alice" } });
+      });
+
+      // Immediately after the change, the debounced value hasn't settled yet.
+      const callsBeforeDebounce = vi.mocked(useAdminUsers).mock.calls;
+      const hadAliceBefore = callsBeforeDebounce.some(
+        ([args]) => (args as { search?: string }).search === "alice",
+      );
+      expect(hadAliceBefore).toBe(false);
+
+      // Advance timers past the debounce window (300 ms)
+      act(() => {
+        vi.advanceTimersByTime(350);
+      });
+
+      // Now the debounced search should have fired and the hook called with "alice"
+      const callsAfterDebounce = vi.mocked(useAdminUsers).mock.calls;
+      const hadAliceAfter = callsAfterDebounce.some(
+        ([args]) => (args as { search?: string }).search === "alice",
+      );
+      expect(hadAliceAfter).toBe(true);
+    });
+  });
+});

--- a/ui/apps/console/src/pages/admin/users/index.tsx
+++ b/ui/apps/console/src/pages/admin/users/index.tsx
@@ -10,6 +10,7 @@ import {
 import { useAdminUsers } from "@/hooks/useAdminUsers";
 import { useLoginAsUser } from "@/hooks/useLoginAsUser";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import type { UserAdminResponse } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
@@ -28,11 +29,21 @@ import {
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
 
+type AdminUsersParams = {
+  page: number;
+  search: string;
+};
+
+const DEFAULTS: AdminUsersParams = {
+  page: 1,
+  search: "",
+};
+
 export default function AdminUsers() {
   const navigate = useNavigate();
-  const [page, setPage] = useState(1);
-  const [searchInput, setSearchInput] = useState("");
-  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
+  const { params, setPage, setSearch } =
+    usePaginatedListState<AdminUsersParams>({ defaults: DEFAULTS });
+  const debouncedSearch = useDebouncedValue(params.search, SEARCH_DEBOUNCE_MS);
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<UserAdminResponse | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<UserAdminResponse | null>(
@@ -45,7 +56,7 @@ export default function AdminUsers() {
   } = useLoginAsUser();
 
   const { users, totalCount, isLoading, error } = useAdminUsers({
-    page,
+    page: params.page,
     perPage: PER_PAGE,
     search: debouncedSearch,
   });
@@ -159,11 +170,8 @@ export default function AdminUsers() {
 
       <SearchField
         className="mb-5"
-        value={searchInput}
-        onChange={(next) => {
-          setSearchInput(next);
-          setPage(1);
-        }}
+        value={params.search}
+        onChange={setSearch}
         placeholder="Search by username..."
         aria-label="Search users by username"
       />
@@ -180,7 +188,7 @@ export default function AdminUsers() {
         rowKey={(user) => user.id}
         isLoading={isLoading}
         loadingMessage="Loading users..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="user"

--- a/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
+++ b/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { NormalizedContainer } from "@/hooks/useContainers";
@@ -8,6 +8,11 @@ import type { NormalizedContainer } from "@/hooks/useContainers";
 
 vi.mock("@/hooks/useContainers", () => ({
   useContainers: vi.fn(),
+}));
+
+// Return the value immediately (no timer) so tests don't need fake timers.
+vi.mock("@/hooks/useDebouncedValue", () => ({
+  useDebouncedValue: <T,>(value: T) => value,
 }));
 
 vi.mock("@/hooks/useNamespaces", () => ({
@@ -62,8 +67,17 @@ vi.mock("@/components/common/TagFilterDropdown", () => ({
   default: () => <div />,
 }));
 
+const mockManageTagsDrawer = vi.fn();
 vi.mock("@/components/ManageTagsDrawer", () => ({
-  default: () => <div />,
+  default: (props: {
+    open: boolean;
+    onClose: () => void;
+    onTagRenamed?: (oldName: string, newName: string) => void;
+    onTagDeleted?: (name: string) => void;
+  }) => {
+    mockManageTagsDrawer(props);
+    return <div data-testid="manage-tags-drawer" />;
+  },
 }));
 
 vi.mock("@/components/ConnectDrawer", () => ({
@@ -86,16 +100,16 @@ vi.mock("../AddDockerConnectorDrawer", () => ({
   default: () => <div />,
 }));
 
+vi.mock("@/components/common/RestrictedAction", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 vi.mock("@/components/billing/BillingWarning", () => ({
   default: () => <div />,
 }));
 
 vi.mock("@/env", () => ({
   getConfig: () => ({ cloud: false }),
-}));
-
-vi.mock("@/components/common/RestrictedAction", () => ({
-  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 const mockNavigate = vi.fn();
@@ -131,20 +145,22 @@ function makeContainer(
     tags: [],
     last_seen: new Date().toISOString(),
     created_at: new Date().toISOString(),
+    identity: { mac: "aa:bb:cc:dd:ee:ff" },
     info: {
-      id: "ubuntu",
-      pretty_name: "Ubuntu 22.04 LTS",
+      id: "alpine",
+      pretty_name: "Alpine Linux",
       arch: "x86_64",
       platform: "linux",
       version: "0.14.0",
     },
+    remote_addr: "1.2.3.4",
     ...overrides,
   } as NormalizedContainer;
 }
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ["/"]) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <Containers />
     </MemoryRouter>,
   );
@@ -156,6 +172,7 @@ describe("Containers list", () => {
   beforeEach(() => {
     vi.mocked(useContainers).mockReturnValue(defaultHookState);
     mockNavigate.mockReset();
+    mockManageTagsDrawer.mockReset();
   });
 
   describe("rendering", () => {
@@ -164,6 +181,77 @@ describe("Containers list", () => {
       expect(
         screen.getByRole("heading", { name: "Containers" }),
       ).toBeInTheDocument();
+    });
+
+    it("renders all status filter tabs", () => {
+      renderPage();
+      expect(screen.getByRole("tab", { name: "Accepted" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Pending" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Rejected" })).toBeInTheDocument();
+    });
+
+    it("renders the search input", () => {
+      renderPage();
+      expect(
+        screen.getByPlaceholderText("Search by hostname..."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it("renders the loading message", () => {
+      vi.mocked(useContainers).mockReturnValue({
+        ...defaultHookState,
+        isLoading: true,
+      });
+      renderPage();
+      expect(screen.getByText("Loading containers...")).toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it('renders "No containers found" when list is empty', () => {
+      renderPage();
+      expect(screen.getByText("No containers found")).toBeInTheDocument();
+    });
+  });
+
+  describe("container rows", () => {
+    it("renders a row for each container", () => {
+      vi.mocked(useContainers).mockReturnValue({
+        ...defaultHookState,
+        containers: [
+          makeContainer({ uid: "uid-1", name: "alpha" }),
+          makeContainer({ uid: "uid-2", name: "beta" }),
+        ],
+        totalCount: 2,
+      });
+      renderPage();
+      expect(screen.getByText("alpha")).toBeInTheDocument();
+      expect(screen.getByText("beta")).toBeInTheDocument();
+    });
+
+    it("navigates to container detail on row click", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useContainers).mockReturnValue({
+        ...defaultHookState,
+        containers: [makeContainer({ uid: "uid-abc", name: "clickable" })],
+        totalCount: 1,
+      });
+      renderPage();
+      await user.click(screen.getByText("clickable"));
+      expect(mockNavigate).toHaveBeenCalledWith("/containers/uid-abc");
+    });
+  });
+
+  describe("error state", () => {
+    it("renders an error message when hook returns an error", () => {
+      vi.mocked(useContainers).mockReturnValue({
+        ...defaultHookState,
+        error: new Error("Request failed"),
+      });
+      renderPage();
+      expect(screen.getByText("Request failed")).toBeInTheDocument();
     });
   });
 
@@ -197,6 +285,152 @@ describe("Containers list", () => {
       calls = vi.mocked(useContainers).mock.calls;
       last = calls[calls.length - 1][0];
       expect(last).toMatchObject({ sortBy: "name", orderBy: "desc" });
+    });
+  });
+
+  // ── URL hydration (usePaginatedListState adoption) ────────────────────────────
+
+  describe("URL hydration — URL params seed page state on mount", () => {
+    it("passes status=pending from URL to useContainers", () => {
+      renderPage(["/?status=pending&tags=a&tags=b&page=2"]);
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "pending" }),
+      );
+    });
+
+    it("passes tags array from URL to useContainers", () => {
+      renderPage(["/?status=pending&tags=a&tags=b&page=2"]);
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ filterTags: ["a", "b"] }),
+      );
+    });
+
+    it("passes page=2 from URL to useContainers", () => {
+      renderPage(["/?status=pending&tags=a&tags=b&page=2"]);
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+    });
+
+    it("falls back to status=accepted and page=1 when URL has no params", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "accepted", page: 1 }),
+      );
+    });
+
+    it("falls back to status=accepted for an invalid status value", () => {
+      renderPage(["/?status=invalid"]);
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "accepted" }),
+      );
+    });
+
+    it("passes empty filterTags when no tags param is present", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ filterTags: [] }),
+      );
+    });
+  });
+
+  // ── Search trimming ───────────────────────────────────────────────────────────
+
+  describe("search — whitespace is trimmed before passing to useContainers", () => {
+    it("passes trimmed search to useContainers when input has surrounding spaces", async () => {
+      // useDebouncedValue is mocked to return its input immediately, so we can
+      // verify the trim happens before the debounce without needing fake timers.
+      const user = userEvent.setup();
+      renderPage();
+      const searchInput = screen.getByPlaceholderText("Search by hostname...");
+      await user.type(searchInput, "  myhost  ");
+      // The hook must have been called with the trimmed string "myhost".
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ search: "myhost" }),
+      );
+    });
+  });
+
+  // ── Tag mutation callbacks ────────────────────────────────────────────────────
+
+  describe("tag mutation — onTagRenamed/onTagDeleted update URL tags array", () => {
+    it("renames a tag in filterTags when onTagRenamed is called from ManageTagsDrawer", async () => {
+      // Start with tags=a&tags=b in the URL
+      renderPage(["/?tags=a&tags=b"]);
+
+      // Grab the onTagRenamed callback passed to ManageTagsDrawer
+      const lastCall = mockManageTagsDrawer.mock.calls.at(-1)?.[0] as {
+        onTagRenamed?: (oldName: string, newName: string) => void;
+      };
+      expect(lastCall?.onTagRenamed).toBeDefined();
+
+      // Invoke the callback inside await act(async) so React flushes the URL update.
+      await act(async () => {
+        lastCall.onTagRenamed!("a", "alpha");
+      });
+
+      // useContainers should now be called with filterTags exactly ["alpha", "b"] (no stale "a")
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filterTags: ["alpha", "b"],
+        }),
+      );
+    });
+
+    it("removes a tag from filterTags when onTagDeleted is called from ManageTagsDrawer", async () => {
+      renderPage(["/?tags=a&tags=b"]);
+
+      const lastCall = mockManageTagsDrawer.mock.calls.at(-1)?.[0] as {
+        onTagDeleted?: (name: string) => void;
+      };
+      expect(lastCall?.onTagDeleted).toBeDefined();
+
+      await act(async () => {
+        lastCall.onTagDeleted!("a");
+      });
+
+      // useContainers should now be called with only tag "b"
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ filterTags: ["b"] }),
+      );
+    });
+
+    it("adds a tag to URL array when setArrayFilter is called via addFilterTag", () => {
+      // TagFilterDropdown and ContainerTagsPopover are mocked away; verify URL
+      // array hydration indirectly: render with an existing tag in the URL and
+      // confirm useContainers receives it.
+      renderPage(["/?tags=existing"]);
+      // The tags=existing param must arrive at useContainers
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ filterTags: ["existing"] }),
+      );
+      // The filter bar is still visible and the tags array remains stable
+      expect(
+        screen.getByPlaceholderText("Search by hostname..."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── Status change resets page ─────────────────────────────────────────────────
+
+  describe("status change — clicking a status tab resets page to 1", () => {
+    it("resets page to 1 when status tab is clicked while on page 2", async () => {
+      const user = userEvent.setup();
+      // Start on page 2 with status=accepted
+      renderPage(["/?page=2"]);
+
+      // Verify we started on page 2
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2, status: "accepted" }),
+      );
+
+      // Click the "Pending" tab (rendered as role="tab")
+      await user.click(screen.getByRole("tab", { name: "Pending" }));
+
+      // After switching status the page must be reset to 1
+      expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, status: "pending" }),
+      );
     });
   });
 });

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -1,9 +1,9 @@
-import { useState, useMemo } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useState, useMemo, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { useContainers, type NormalizedContainer } from "@/hooks/useContainers";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useTableSort } from "@/hooks/useTableSort";
-import type { DeviceStatus } from "@/client";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useAuthStore } from "@/stores/authStore";
 import { useTerminalStore } from "@/stores/terminalStore";
@@ -35,33 +35,51 @@ import {
 } from "@shellhub/design-system/primitives";
 import RestrictedAction from "@/components/common/RestrictedAction";
 
-const statusTabs: { label: string; value: DeviceStatus }[] = [
+const PER_PAGE = 10;
+const SEARCH_DEBOUNCE_MS = 300;
+
+const VALID_STATUSES = ["accepted", "pending", "rejected"] as const;
+
+/** Stable module-level constant — avoids a new object identity every render,
+ *  which would invalidate the `update` useCallback in usePaginatedListState. */
+const CONSTRAINTS = { status: VALID_STATUSES } as const;
+
+type ValidStatus = (typeof VALID_STATUSES)[number];
+
+const statusTabs: { label: string; value: ValidStatus }[] = [
   { label: "Accepted", value: "accepted" },
   { label: "Pending", value: "pending" },
   { label: "Rejected", value: "rejected" },
 ];
 
-const PER_PAGE = 10;
-const SEARCH_DEBOUNCE_MS = 300;
-const VALID_STATUSES = new Set<string>(["accepted", "pending", "rejected"]);
+type ContainersParams = {
+  page: number;
+  search: string;
+  status: ValidStatus;
+  tags: string[];
+};
+
+const DEFAULTS: ContainersParams = {
+  page: 1,
+  search: "",
+  status: "accepted",
+  tags: [],
+};
 
 type SortField = "name" | "last_seen";
 
 export default function Containers() {
-  const [searchParams] = useSearchParams();
-  const initialStatus = searchParams.get("status") ?? "accepted";
-  const [page, setPage] = useState(1);
-  const [status, setStatus] = useState<DeviceStatus>(
-    VALID_STATUSES.has(initialStatus)
-      ? (initialStatus as DeviceStatus)
-      : "accepted",
-  );
-  const [filterTags, setFilterTags] = useState<string[]>([]);
-  const [searchInput, setSearchInput] = useState("");
+  const { params, setPage, setSearch, setFilter, setArrayFilter, mapArrayFilter } =
+    usePaginatedListState<ContainersParams>({
+      defaults: DEFAULTS,
+      constraints: CONSTRAINTS,
+    });
+
   const debouncedSearch = useDebouncedValue(
-    searchInput.trim(),
+    params.search.trim(),
     SEARCH_DEBOUNCE_MS,
   );
+
   const [actionTarget, setActionTarget] = useState<{
     container: NormalizedContainer;
     action: "accept" | "reject" | "remove";
@@ -80,11 +98,11 @@ export default function Containers() {
   });
 
   const { containers, totalCount, isLoading, error, refetch } = useContainers({
-    page,
+    page: params.page,
     perPage: PER_PAGE,
-    status,
+    status: params.status,
     search: debouncedSearch,
-    filterTags,
+    filterTags: params.tags,
     sortBy,
     orderBy,
   });
@@ -96,24 +114,25 @@ export default function Containers() {
   const totalPages = Math.ceil(totalCount / PER_PAGE);
   const nsName = currentNamespace?.name ?? "";
 
-  const handleStatusChange = (newStatus: DeviceStatus) => {
-    setStatus(newStatus);
-    setPage(1);
+  const handleStatusChange = (newStatus: ValidStatus) => {
+    setFilter("status", newStatus);
   };
 
-  const addFilterTag = (tag: string) => {
-    setFilterTags((prev) => (prev.includes(tag) ? prev : [...prev, tag]));
-    setPage(1);
-  };
+  const addFilterTag = useCallback(
+    (tag: string) => {
+      mapArrayFilter("tags", (tags) =>
+        tags.includes(tag) ? tags : [...tags, tag],
+      );
+    },
+    [mapArrayFilter],
+  );
 
   const removeFilterTag = (tag: string) => {
-    setFilterTags((prev) => prev.filter((t) => t !== tag));
-    setPage(1);
+    mapArrayFilter("tags", (tags) => tags.filter((t) => t !== tag));
   };
 
   const clearFilterTags = () => {
-    setFilterTags([]);
-    setPage(1);
+    setArrayFilter("tags", []);
   };
 
   const columns = useMemo<Column<NormalizedContainer>[]>(() => {
@@ -159,7 +178,7 @@ export default function Containers() {
       },
     ];
 
-    if (status === "accepted") {
+    if (params.status === "accepted") {
       return [
         {
           key: "online",
@@ -244,7 +263,7 @@ export default function Containers() {
       ];
     }
 
-    if (status === "pending") {
+    if (params.status === "pending") {
       return [
         ...baseColumns,
         {
@@ -320,7 +339,7 @@ export default function Containers() {
         ),
       },
     ];
-  }, [status, nsName]);
+  }, [params.status, nsName, addFilterTag]);
 
   return (
     <div>
@@ -350,10 +369,10 @@ export default function Containers() {
               type="button"
               key={tab.value}
               role="tab"
-              aria-selected={status === tab.value}
+              aria-selected={params.status === tab.value}
               onClick={() => handleStatusChange(tab.value)}
               className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${
-                status === tab.value
+                params.status === tab.value
                   ? "bg-primary/15 text-primary border border-primary/25"
                   : "text-text-muted hover:text-text-secondary border border-transparent"
               }`}
@@ -365,7 +384,7 @@ export default function Containers() {
 
         <div className="flex items-center gap-2">
           <TagFilterDropdown
-            filterTags={filterTags}
+            filterTags={params.tags}
             onAdd={addFilterTag}
             onRemove={removeFilterTag}
             onClearAll={clearFilterTags}
@@ -373,11 +392,8 @@ export default function Containers() {
           />
 
           <SearchField
-            value={searchInput}
-            onChange={(next) => {
-              setSearchInput(next);
-              setPage(1);
-            }}
+            value={params.search}
+            onChange={(next) => setSearch(next)}
             placeholder="Search by hostname..."
             aria-label="Search containers by hostname"
           />
@@ -385,13 +401,13 @@ export default function Containers() {
       </div>
 
       {/* Active tag filters */}
-      {filterTags.length > 0 && (
+      {params.tags.length > 0 && (
         <div className="flex items-center gap-2 mb-4 animate-fade-in">
           <span className="text-2xs font-mono text-text-muted uppercase tracking-wider shrink-0">
             Filtering by:
           </span>
           <div className="flex items-center gap-1.5 flex-wrap">
-            {filterTags.map((tag) => (
+            {params.tags.map((tag) => (
               <span
                 key={tag}
                 className="inline-flex items-center gap-1 px-2 py-0.5 bg-primary/15 text-primary text-2xs rounded-md font-medium border border-primary/20"
@@ -427,7 +443,7 @@ export default function Containers() {
         rowKey={(container) => container.uid}
         isLoading={isLoading}
         loadingMessage="Loading containers..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="container"
@@ -492,12 +508,14 @@ export default function Containers() {
           void refetch();
         }}
         onTagRenamed={(oldName, newName) => {
-          setFilterTags((prev) =>
-            prev.map((t) => (t === oldName ? newName : t)),
+          mapArrayFilter("tags", (tags) =>
+            tags.map((t) => (t === oldName ? newName : t)),
           );
         }}
         onTagDeleted={(name) => {
-          setFilterTags((prev) => prev.filter((t) => t !== name));
+          mapArrayFilter("tags", (tags) =>
+            tags.filter((t) => t !== name),
+          );
         }}
       />
 

--- a/ui/apps/console/src/pages/devices/__tests__/Devices.test.tsx
+++ b/ui/apps/console/src/pages/devices/__tests__/Devices.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { NormalizedDevice } from "@/hooks/useDevices";
@@ -9,6 +9,11 @@ import type { NormalizedDevice } from "@/hooks/useDevices";
 vi.mock("@/hooks/useDevices", () => ({
   useDevices: vi.fn(),
   buildFilter: vi.fn(),
+}));
+
+// Return the value immediately (no timer) so tests don't need fake timers.
+vi.mock("@/hooks/useDebouncedValue", () => ({
+  useDebouncedValue: <T,>(value: T) => value,
 }));
 
 vi.mock("@/hooks/useNamespaces", () => ({
@@ -67,8 +72,17 @@ vi.mock("@/components/common/TagFilterDropdown", () => ({
   default: () => <div />,
 }));
 
+const mockManageTagsDrawer = vi.fn();
 vi.mock("@/components/ManageTagsDrawer", () => ({
-  default: () => <div />,
+  default: (props: {
+    open: boolean;
+    onClose: () => void;
+    onTagRenamed?: (oldName: string, newName: string) => void;
+    onTagDeleted?: (name: string) => void;
+  }) => {
+    mockManageTagsDrawer(props);
+    return <div data-testid="manage-tags-drawer" />;
+  },
 }));
 
 vi.mock("@/components/ConnectDrawer", () => ({
@@ -136,9 +150,9 @@ function makeDevice(
   } as NormalizedDevice;
 }
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ["/"]) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <Devices />
     </MemoryRouter>,
   );
@@ -150,6 +164,7 @@ describe("Devices list", () => {
   beforeEach(() => {
     vi.mocked(useDevices).mockReturnValue(defaultHookState);
     mockNavigate.mockReset();
+    mockManageTagsDrawer.mockReset();
   });
 
   describe("rendering", () => {
@@ -264,6 +279,127 @@ describe("Devices list", () => {
       calls = vi.mocked(useDevices).mock.calls;
       last = calls[calls.length - 1][0];
       expect(last).toMatchObject({ sortBy: "name", orderBy: "desc" });
+    });
+  });
+
+  // ── URL hydration (usePaginatedListState adoption) ────────────────────────────
+
+  describe("URL hydration — URL params seed page state on mount", () => {
+    it("passes status=pending from URL to useDevices", () => {
+      renderPage(["/?status=pending&tags=a&tags=b&page=2"]);
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "pending" }),
+      );
+    });
+
+    it("passes tags array from URL to useDevices", () => {
+      renderPage(["/?status=pending&tags=a&tags=b&page=2"]);
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ filterTags: ["a", "b"] }),
+      );
+    });
+
+    it("passes page=2 from URL to useDevices", () => {
+      renderPage(["/?status=pending&tags=a&tags=b&page=2"]);
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+    });
+
+    it("falls back to status=accepted and page=1 when URL has no params", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "accepted", page: 1 }),
+      );
+    });
+
+    it("falls back to status=accepted for an invalid status value", () => {
+      renderPage(["/?status=invalid"]);
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "accepted" }),
+      );
+    });
+
+    it("passes empty filterTags when no tags param is present", () => {
+      renderPage(["/"]);
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ filterTags: [] }),
+      );
+    });
+  });
+
+  // ── Search trimming ───────────────────────────────────────────────────────────
+
+  describe("search — whitespace is trimmed before passing to useDevices", () => {
+    it("passes trimmed search to useDevices when input has surrounding spaces", async () => {
+      // useDebouncedValue is mocked to return its input immediately, so we can
+      // verify the trim happens before the debounce without needing fake timers.
+      const user = userEvent.setup();
+      renderPage();
+      const searchInput = screen.getByPlaceholderText("Search by hostname...");
+      await user.type(searchInput, "  myhost  ");
+      // The hook must have been called with the trimmed string "myhost".
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ search: "myhost" }),
+      );
+    });
+  });
+
+  // ── Tag mutation callbacks ────────────────────────────────────────────────────
+
+  describe("tag mutation — onTagRenamed/onTagDeleted update URL tags array", () => {
+    it("renames a tag in filterTags when onTagRenamed is called from ManageTagsDrawer", async () => {
+      // Start with tags=a&tags=b in the URL
+      renderPage(["/?tags=a&tags=b"]);
+
+      // Grab the onTagRenamed callback passed to ManageTagsDrawer
+      const lastCall = mockManageTagsDrawer.mock.calls.at(-1)?.[0] as {
+        onTagRenamed?: (oldName: string, newName: string) => void;
+      };
+      expect(lastCall?.onTagRenamed).toBeDefined();
+
+      // Invoke the callback inside act() so React flushes the URL update.
+      await act(async () => {
+        lastCall.onTagRenamed!("a", "alpha");
+      });
+
+      // useDevices should now be called with filterTags exactly ["alpha", "b"] (no stale "a")
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filterTags: ["alpha", "b"],
+        }),
+      );
+    });
+
+    it("removes a tag from filterTags when onTagDeleted is called from ManageTagsDrawer", async () => {
+      renderPage(["/?tags=a&tags=b"]);
+
+      const lastCall = mockManageTagsDrawer.mock.calls.at(-1)?.[0] as {
+        onTagDeleted?: (name: string) => void;
+      };
+      expect(lastCall?.onTagDeleted).toBeDefined();
+
+      await act(async () => {
+        lastCall.onTagDeleted!("a");
+      });
+
+      // useDevices should now be called with only tag "b"
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ filterTags: ["b"] }),
+      );
+    });
+
+    it("adds a tag to URL array when setArrayFilter is called via addFilterTag", () => {
+      // TagFilterDropdown and TagsPopover are mocked away; verify URL array
+      // hydration indirectly: render with an existing tag in the URL and confirm
+      // useDevices receives it.
+      renderPage(["/?tags=existing"]);
+      // The tags=existing param must arrive at useDevices
+      expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
+        expect.objectContaining({ filterTags: ["existing"] }),
+      );
+      // The filter bar is still visible and the tags array remains stable
+      expect(screen.getByPlaceholderText("Search by hostname...")).toBeInTheDocument();
     });
   });
 });

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -1,9 +1,9 @@
-import { useState, useMemo } from "react";
-import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import { useState, useMemo, useCallback } from "react";
+import { useNavigate, Link } from "react-router-dom";
 import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useTableSort } from "@/hooks/useTableSort";
-import type { DeviceStatus } from "@/client";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useAuthStore } from "@/stores/authStore";
 import { useTerminalStore } from "@/stores/terminalStore";
@@ -36,34 +36,51 @@ import {
 } from "@shellhub/design-system/primitives";
 import RestrictedAction from "@/components/common/RestrictedAction";
 
-const statusTabs: { label: string; value: DeviceStatus }[] = [
+const PER_PAGE = 10;
+const SEARCH_DEBOUNCE_MS = 300;
+
+const VALID_STATUSES = ["accepted", "pending", "rejected"] as const;
+
+/** Stable module-level constant — avoids a new object identity every render,
+ *  which would invalidate the `update` useCallback in usePaginatedListState. */
+const CONSTRAINTS = { status: VALID_STATUSES } as const;
+
+type ValidStatus = (typeof VALID_STATUSES)[number];
+
+const statusTabs: { label: string; value: ValidStatus }[] = [
   { label: "Accepted", value: "accepted" },
   { label: "Pending", value: "pending" },
   { label: "Rejected", value: "rejected" },
 ];
 
-const PER_PAGE = 10;
-const SEARCH_DEBOUNCE_MS = 300;
+type DevicesParams = {
+  page: number;
+  search: string;
+  status: ValidStatus;
+  tags: string[];
+};
 
-const VALID_STATUSES = new Set<string>(["accepted", "pending", "rejected"]);
+const DEFAULTS: DevicesParams = {
+  page: 1,
+  search: "",
+  status: "accepted",
+  tags: [],
+};
 
 type SortField = "name" | "last_seen";
 
 export default function Devices() {
-  const [searchParams] = useSearchParams();
-  const initialStatus = searchParams.get("status") ?? "accepted";
-  const [page, setPage] = useState(1);
-  const [status, setStatus] = useState<DeviceStatus>(
-    VALID_STATUSES.has(initialStatus)
-      ? (initialStatus as DeviceStatus)
-      : "accepted",
-  );
-  const [filterTags, setFilterTags] = useState<string[]>([]);
-  const [searchInput, setSearchInput] = useState("");
+  const { params, setPage, setSearch, setFilter, setArrayFilter, mapArrayFilter } =
+    usePaginatedListState<DevicesParams>({
+      defaults: DEFAULTS,
+      constraints: CONSTRAINTS,
+    });
+
   const debouncedSearch = useDebouncedValue(
-    searchInput.trim(),
+    params.search.trim(),
     SEARCH_DEBOUNCE_MS,
   );
+
   const [actionTarget, setActionTarget] = useState<{
     device: NormalizedDevice;
     action: "accept" | "reject" | "remove";
@@ -81,11 +98,11 @@ export default function Devices() {
   });
 
   const { devices, totalCount, isLoading, error, refetch } = useDevices({
-    page,
+    page: params.page,
     perPage: PER_PAGE,
-    status,
+    status: params.status,
     search: debouncedSearch,
-    filterTags,
+    filterTags: params.tags,
     sortBy,
     orderBy,
   });
@@ -97,24 +114,25 @@ export default function Devices() {
   const totalPages = Math.ceil(totalCount / PER_PAGE);
   const nsName = currentNamespace?.name ?? "";
 
-  const handleStatusChange = (newStatus: DeviceStatus) => {
-    setStatus(newStatus);
-    setPage(1);
+  const handleStatusChange = (newStatus: ValidStatus) => {
+    setFilter("status", newStatus);
   };
 
-  const addFilterTag = (tag: string) => {
-    setFilterTags((prev) => (prev.includes(tag) ? prev : [...prev, tag]));
-    setPage(1);
-  };
+  const addFilterTag = useCallback(
+    (tag: string) => {
+      mapArrayFilter("tags", (tags) =>
+        tags.includes(tag) ? tags : [...tags, tag],
+      );
+    },
+    [mapArrayFilter],
+  );
 
   const removeFilterTag = (tag: string) => {
-    setFilterTags((prev) => prev.filter((t) => t !== tag));
-    setPage(1);
+    mapArrayFilter("tags", (tags) => tags.filter((t) => t !== tag));
   };
 
   const clearFilterTags = () => {
-    setFilterTags([]);
-    setPage(1);
+    setArrayFilter("tags", []);
   };
 
   const columns = useMemo<Column<NormalizedDevice>[]>(() => {
@@ -158,7 +176,7 @@ export default function Devices() {
       },
     ];
 
-    if (status === "accepted") {
+    if (params.status === "accepted") {
       return [
         {
           key: "online",
@@ -235,7 +253,7 @@ export default function Devices() {
       ];
     }
 
-    if (status === "pending") {
+    if (params.status === "pending") {
       return [
         ...baseColumns,
         {
@@ -311,7 +329,7 @@ export default function Devices() {
         ),
       },
     ];
-  }, [status, nsName]);
+  }, [params.status, nsName, addFilterTag]);
 
   return (
     <div>
@@ -341,7 +359,7 @@ export default function Devices() {
               key={tab.value}
               onClick={() => handleStatusChange(tab.value)}
               className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${
-                status === tab.value
+                params.status === tab.value
                   ? "bg-primary/15 text-primary border border-primary/25"
                   : "text-text-muted hover:text-text-secondary border border-transparent"
               }`}
@@ -353,7 +371,7 @@ export default function Devices() {
 
         <div className="flex items-center gap-2">
           <TagFilterDropdown
-            filterTags={filterTags}
+            filterTags={params.tags}
             onAdd={addFilterTag}
             onRemove={removeFilterTag}
             onClearAll={clearFilterTags}
@@ -361,11 +379,8 @@ export default function Devices() {
           />
 
           <SearchField
-            value={searchInput}
-            onChange={(next) => {
-              setSearchInput(next);
-              setPage(1);
-            }}
+            value={params.search}
+            onChange={(next) => setSearch(next)}
             placeholder="Search by hostname..."
             aria-label="Search devices by hostname"
           />
@@ -373,13 +388,13 @@ export default function Devices() {
       </div>
 
       {/* Active tag filters */}
-      {filterTags.length > 0 && (
+      {params.tags.length > 0 && (
         <div className="flex items-center gap-2 mb-4 animate-fade-in">
           <span className="text-2xs font-mono text-text-muted uppercase tracking-wider shrink-0">
             Filtering by:
           </span>
           <div className="flex items-center gap-1.5 flex-wrap">
-            {filterTags.map((tag) => (
+            {params.tags.map((tag) => (
               <span
                 key={tag}
                 className="inline-flex items-center gap-1 px-2 py-0.5 bg-primary/15 text-primary text-2xs rounded-md font-medium border border-primary/20"
@@ -415,7 +430,7 @@ export default function Devices() {
         rowKey={(device) => device.uid}
         isLoading={isLoading}
         loadingMessage="Loading devices..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="device"
@@ -478,12 +493,14 @@ export default function Devices() {
           void refetch();
         }}
         onTagRenamed={(oldName, newName) => {
-          setFilterTags((prev) =>
-            prev.map((t) => (t === oldName ? newName : t)),
+          mapArrayFilter("tags", (tags) =>
+            tags.map((t) => (t === oldName ? newName : t)),
           );
         }}
         onTagDeleted={(name) => {
-          setFilterTags((prev) => prev.filter((t) => t !== name));
+          mapArrayFilter("tags", (tags) =>
+            tags.filter((t) => t !== name),
+          );
         }}
       />
     </div>

--- a/ui/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import { FirewallRulesResponse } from "@/client";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -25,8 +26,7 @@ vi.mock("../RuleDrawer", () => ({
 }));
 
 // Flatten ConfirmDialog to a plain div so we can exercise the page's logic
-// without animations, portals, or BaseDialog internals. Matches the pattern
-// used in other page tests (DeleteNamespaceDialog, KeyDeleteDialog).
+// without animations, portals, or BaseDialog internals.
 vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
@@ -58,6 +58,20 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
   },
 }));
 
+// Capture DataTable props on every render so we can assert pagination suppression.
+const capturedDataTableProps: Record<string, unknown>[] = [];
+vi.mock("@/components/common/DataTable", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/common/DataTable")>();
+  return {
+    ...actual,
+    default: (props: Record<string, unknown>) => {
+      capturedDataTableProps.push({ ...props });
+      return actual.default(props as unknown as Parameters<typeof actual.default>[0]);
+    },
+  };
+});
+
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import { useFirewallRules } from "@/hooks/useFirewallRules";
@@ -84,8 +98,17 @@ function makeRule(
 
 const mockMutateAsync = vi.fn();
 
+function renderPage(initialEntries: string[] = ["/"]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <FirewallRules />
+    </MemoryRouter>,
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  capturedDataTableProps.length = 0;
   vi.mocked(useFirewallRules).mockReturnValue({
     rules: [makeRule()],
     totalCount: 1,
@@ -106,7 +129,7 @@ describe("FirewallRules — delete error handling", () => {
   // the dialog opens we scope dialog queries with `within(dialog)`.
   async function openDeleteDialog() {
     const user = userEvent.setup();
-    render(<FirewallRules />);
+    renderPage();
     await user.click(
       screen.getByRole("button", { name: /^delete firewall rule/i }),
     );
@@ -183,5 +206,131 @@ describe("FirewallRules — delete error handling", () => {
     );
     dialog = await getDialog();
     expect(within(dialog).queryByText("Transient")).not.toBeInTheDocument();
+  });
+});
+
+// ── usePaginatedListState adoption ───────────────────────────────────────────
+
+describe("FirewallRules — URL hydration", () => {
+  it("hydrates search from URL on mount", () => {
+    vi.mocked(useFirewallRules).mockReturnValue({
+      rules: [makeRule({ action: "allow" })],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+    renderPage(["/?search=allow"]);
+    expect(
+      screen.getByRole("searchbox", {
+        name: "Search firewall rules by action, priority, IP, or username",
+      }),
+    ).toHaveValue("allow");
+  });
+
+  it("hydrates page from URL and passes it to the hook", () => {
+    renderPage(["/?page=3"]);
+    expect(vi.mocked(useFirewallRules)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 3 }),
+    );
+  });
+
+  it("calls useFirewallRules with page=1 when URL has no params", () => {
+    renderPage(["/"]);
+    expect(vi.mocked(useFirewallRules)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1 }),
+    );
+  });
+
+  it("setSearch resets page to 1 in the URL", async () => {
+    const user = userEvent.setup();
+    renderPage(["/?page=3"]);
+
+    // Confirm page=3 was hydrated
+    expect(vi.mocked(useFirewallRules)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 3 }),
+    );
+
+    await user.type(
+      screen.getByRole("searchbox", {
+        name: "Search firewall rules by action, priority, IP, or username",
+      }),
+      "allow",
+    );
+
+    await waitFor(() => {
+      const calls = vi.mocked(useFirewallRules).mock.calls;
+      const lastCall = calls.at(-1)![0];
+      expect(lastCall).toBeDefined();
+      expect(lastCall?.page).toBe(1);
+    });
+  });
+});
+
+describe("FirewallRules — pagination suppressed while searching", () => {
+  beforeEach(() => {
+    vi.mocked(useFirewallRules).mockReturnValue({
+      rules: [makeRule({ id: "r1", action: "allow", priority: 1 })],
+      totalCount: 1,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("passes page/totalPages/onPageChange to DataTable when search is empty", () => {
+    renderPage();
+    const last = capturedDataTableProps.at(-1);
+    expect(last).toBeDefined();
+    expect(last).toHaveProperty("page");
+    expect(last).toHaveProperty("totalPages");
+    expect(last).toHaveProperty("onPageChange");
+  });
+
+  it("omits page/totalPages/onPageChange from DataTable while search is non-empty", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(
+      screen.getByRole("searchbox", {
+        name: "Search firewall rules by action, priority, IP, or username",
+      }),
+      "allow",
+    );
+
+    await waitFor(() => {
+      const last = capturedDataTableProps.at(-1);
+      expect(last).toBeDefined();
+      expect(last).not.toHaveProperty("page");
+      expect(last).not.toHaveProperty("totalPages");
+      expect(last).not.toHaveProperty("onPageChange");
+    });
+  });
+
+  it("re-enables pagination props after search is cleared", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const searchbox = screen.getByRole("searchbox", {
+      name: "Search firewall rules by action, priority, IP, or username",
+    });
+
+    await user.type(searchbox, "allow");
+
+    // Confirm pagination is suppressed
+    await waitFor(() => {
+      const last = capturedDataTableProps.at(-1);
+      expect(last).not.toHaveProperty("page");
+    });
+
+    // Clear the search
+    await user.clear(searchbox);
+
+    // Pagination should be restored
+    await waitFor(() => {
+      const last = capturedDataTableProps.at(-1);
+      expect(last).toBeDefined();
+      expect(last).toHaveProperty("page");
+      expect(last).toHaveProperty("totalPages");
+      expect(last).toHaveProperty("onPageChange");
+    });
   });
 });

--- a/ui/apps/console/src/pages/firewall-rules/index.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/index.tsx
@@ -1,15 +1,4 @@
 import { useState } from "react";
-import { useFirewallRules } from "@/hooks/useFirewallRules";
-import { useDeleteFirewallRule } from "@/hooks/useFirewallRuleMutations";
-import ActiveBadge from "@/components/common/ActiveBadge";
-import ConfirmDialog from "@/components/common/ConfirmDialog";
-import DataTable, { type Column } from "@/components/common/DataTable";
-import EmptyState from "@/components/common/EmptyState";
-import FilterBadge from "@/components/common/FilterBadge";
-import PageHeader from "@/components/common/PageHeader";
-import SearchField from "@/components/common/fields/SearchField";
-import RuleDrawer from "./RuleDrawer";
-import RestrictedAction from "@/components/common/RestrictedAction";
 import {
   ExclamationTriangleIcon,
   CheckCircleIcon,
@@ -20,14 +9,38 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline";
-import { type FirewallRulesResponse as FirewallRule } from "@/client";
 import { Badge, Button, IconButton } from "@shellhub/design-system/primitives";
+import { type FirewallRulesResponse as FirewallRule } from "@/client";
+import ActiveBadge from "@/components/common/ActiveBadge";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
+import DataTable, { type Column } from "@/components/common/DataTable";
+import EmptyState from "@/components/common/EmptyState";
+import FilterBadge from "@/components/common/FilterBadge";
+import PageHeader from "@/components/common/PageHeader";
+import RestrictedAction from "@/components/common/RestrictedAction";
+import SearchField from "@/components/common/fields/SearchField";
+import { useDeleteFirewallRule } from "@/hooks/useFirewallRuleMutations";
+import { useFirewallRules } from "@/hooks/useFirewallRules";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
+import RuleDrawer from "./RuleDrawer";
 
 const PER_PAGE = 10;
 
+type FirewallRulesParams = {
+  page: number;
+  search: string;
+};
+
+const DEFAULTS: FirewallRulesParams = {
+  page: 1,
+  search: "",
+};
+
 export default function FirewallRules() {
-  const [page, setPage] = useState(1);
-  const { rules, totalCount, isLoading } = useFirewallRules({ page });
+  const { params, setPage, setSearch } =
+    usePaginatedListState<FirewallRulesParams>({ defaults: DEFAULTS });
+
+  const { rules, totalCount, isLoading } = useFirewallRules({ page: params.page });
   const deleteRule = useDeleteFirewallRule();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<FirewallRule | null>(null);
@@ -36,7 +49,6 @@ export default function FirewallRules() {
     priority: number;
   } | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
 
   const closeDelete = () => {
     setDeleteError(null);
@@ -48,7 +60,7 @@ export default function FirewallRules() {
     setDeleteError(null);
     try {
       await deleteRule.mutateAsync({ path: { id: deleteTarget.id } });
-      if (rules.length === 1 && page > 1) setPage(page - 1);
+      if (rules.length === 1 && params.page > 1 && !params.search) setPage(params.page - 1);
       closeDelete();
     } catch (err) {
       setDeleteError(
@@ -74,13 +86,13 @@ export default function FirewallRules() {
 
   const totalPages = Math.ceil(totalCount / PER_PAGE);
 
-  const filtered = search
+  const filtered = params.search
     ? rules.filter(
         (r) =>
-          r.action.toLowerCase().includes(search.toLowerCase()) ||
-          r.source_ip.toLowerCase().includes(search.toLowerCase()) ||
-          r.username.toLowerCase().includes(search.toLowerCase()) ||
-          String(r.priority).includes(search),
+          r.action.toLowerCase().includes(params.search.toLowerCase()) ||
+          r.source_ip.toLowerCase().includes(params.search.toLowerCase()) ||
+          r.username.toLowerCase().includes(params.search.toLowerCase()) ||
+          String(r.priority).includes(params.search),
       )
     : rules;
 
@@ -261,7 +273,7 @@ export default function FirewallRules() {
 
       <SearchField
         className="mb-4"
-        value={search}
+        value={params.search}
         onChange={setSearch}
         placeholder="Search by action, priority, IP, or username..."
         aria-label="Search firewall rules by action, priority, IP, or username"
@@ -273,14 +285,16 @@ export default function FirewallRules() {
         rowKey={(rule) => rule.id}
         isLoading={isLoading}
         loadingMessage="Loading firewall rules..."
-        page={page}
-        totalPages={totalPages}
-        totalCount={totalCount}
-        itemLabel="rule"
-        onPageChange={setPage}
+        {...(!params.search && {
+          page: params.page,
+          totalPages,
+          totalCount,
+          itemLabel: "rule",
+          onPageChange: setPage,
+        })}
         emptyMessage={
-          search
-            ? `No rules matching \u201C${search}\u201D`
+          params.search
+            ? `No rules matching \u201C${params.search}\u201D`
             : "No firewall rules found"
         }
       />

--- a/ui/apps/console/src/pages/public-keys/__tests__/PublicKeys.test.tsx
+++ b/ui/apps/console/src/pages/public-keys/__tests__/PublicKeys.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import { PublicKeyResponse as PublicKey } from "@/client";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -58,6 +59,11 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
   },
 }));
 
+// Return the debounced value immediately so tests don't need fake timers.
+vi.mock("@/hooks/useDebouncedValue", () => ({
+  useDebouncedValue: <T,>(value: T) => value,
+}));
+
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import { usePublicKeys } from "@/hooks/usePublicKeys";
@@ -81,6 +87,14 @@ function makeKey(overrides: Partial<PublicKey> = {}): PublicKey {
 
 const mockMutateAsync = vi.fn();
 
+function renderPage(initialEntries: string[] = ["/"]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <PublicKeys />
+    </MemoryRouter>,
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(usePublicKeys).mockReturnValue({
@@ -99,7 +113,7 @@ beforeEach(() => {
 describe("PublicKeys — delete error handling", () => {
   async function openDeleteDialog() {
     const user = userEvent.setup();
-    render(<PublicKeys />);
+    renderPage();
     await user.click(screen.getByRole("button", { name: /^delete/i }));
     return user;
   }
@@ -148,6 +162,77 @@ describe("PublicKeys — delete error handling", () => {
       expect(
         screen.queryByRole("dialog", { name: /delete public key/i }),
       ).not.toBeInTheDocument(),
+    );
+  });
+});
+
+// ── URL hydration (usePaginatedListState adoption) ────────────────────────────
+
+describe("PublicKeys — URL hydration", () => {
+  it("calls usePublicKeys with page hydrated from ?page=3", () => {
+    renderPage(["/?page=3"]);
+    expect(vi.mocked(usePublicKeys)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 3 }),
+    );
+  });
+
+  it("calls usePublicKeys with page=1 when URL has no page param", () => {
+    renderPage(["/"]);
+    expect(vi.mocked(usePublicKeys)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1 }),
+    );
+  });
+
+  it("calls usePublicKeys with search hydrated from ?search=mykey", () => {
+    renderPage(["/?search=mykey"]);
+    expect(vi.mocked(usePublicKeys)).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "mykey" }),
+    );
+  });
+
+  it("calls usePublicKeys with empty search when URL has no search param", () => {
+    renderPage(["/"]);
+    expect(vi.mocked(usePublicKeys)).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "" }),
+    );
+  });
+});
+
+// ── URL writes (usePaginatedListState adoption) ───────────────────────────────
+
+describe("PublicKeys — URL writes", () => {
+  it("writes ?page=2 to the URL when the user navigates to page 2", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePublicKeys).mockReturnValue({
+      publicKeys: Array.from({ length: 10 }, (_, i) =>
+        makeKey({ fingerprint: `fp-${i}`, name: `key-${i}` }),
+      ),
+      totalCount: 25,
+      isLoading: false,
+      error: null,
+    });
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(vi.mocked(usePublicKeys)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2 }),
+    );
+  });
+
+  it("resets page to 1 when the user types in the search field", async () => {
+    const user = userEvent.setup();
+    // Start on page 2
+    renderPage(["/?page=2"]);
+
+    const searchInput = screen.getByPlaceholderText(
+      /search by name or fingerprint/i,
+    );
+    await user.type(searchInput, "a");
+
+    // After typing, hook must be called with page=1
+    expect(vi.mocked(usePublicKeys)).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1 }),
     );
   });
 });

--- a/ui/apps/console/src/pages/public-keys/index.tsx
+++ b/ui/apps/console/src/pages/public-keys/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { usePublicKeys } from "@/hooks/usePublicKeys";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { useDeletePublicKey } from "@/hooks/usePublicKeyMutations";
 import PageHeader from "@/components/common/PageHeader";
 import EmptyState from "@/components/common/EmptyState";
@@ -91,12 +92,24 @@ function ScopeCell({ pk }: { pk: PublicKey }) {
 
 const SEARCH_DEBOUNCE_MS = 300;
 
+type PublicKeysParams = {
+  page: number;
+  search: string;
+};
+
+const DEFAULTS: PublicKeysParams = {
+  page: 1,
+  search: "",
+};
+
 export default function PublicKeys() {
-  const [page, setPage] = useState(1);
-  const [search, setSearch] = useState("");
-  const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
+  const { params, setPage, setSearch } = usePaginatedListState<PublicKeysParams>({
+    defaults: DEFAULTS,
+  });
+
+  const debouncedSearch = useDebouncedValue(params.search, SEARCH_DEBOUNCE_MS);
   const { publicKeys, totalCount, isLoading } = usePublicKeys({
-    page,
+    page: params.page,
     search: debouncedSearch,
   });
   const deleteKey = useDeletePublicKey();
@@ -120,7 +133,7 @@ export default function PublicKeys() {
       await deleteKey.mutateAsync({
         path: { fingerprint: deleteTarget.fingerprint },
       });
-      if (publicKeys.length === 1 && page > 1) setPage(page - 1);
+      if (publicKeys.length === 1 && params.page > 1) setPage(params.page - 1);
       closeDelete();
     } catch (err) {
       setDeleteError(
@@ -288,11 +301,8 @@ export default function PublicKeys() {
 
       <SearchField
         className="mb-4"
-        value={search}
-        onChange={(next) => {
-          setSearch(next);
-          setPage(1);
-        }}
+        value={params.search}
+        onChange={(next) => setSearch(next)}
         placeholder="Search by name or fingerprint..."
         aria-label="Search public keys by name or fingerprint"
       />
@@ -303,7 +313,7 @@ export default function PublicKeys() {
         rowKey={(pk) => pk.fingerprint}
         isLoading={isLoading}
         loadingMessage="Loading public keys..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="key"

--- a/ui/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
+++ b/ui/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
@@ -1,8 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import Sessions from "../index";
+
+/** Exposes the current search string from inside the MemoryRouter. */
+function LocationProbe({
+  onLocation,
+}: {
+  onLocation: (search: string) => void;
+}) {
+  const loc = useLocation();
+  onLocation(loc.search);
+  return null;
+}
 
 /* ------------------------------------------------------------------ */
 /* Mocks                                                               */
@@ -93,12 +104,15 @@ function makeRecording(overrides: Record<string, any> = {}) {
   };
 }
 
-function renderSessions() {
-  return render(
-    <MemoryRouter>
+function renderSessions(initialEntries: string[] = ["/"]) {
+  let lastSearch = "";
+  const result = render(
+    <MemoryRouter initialEntries={initialEntries}>
       <Sessions />
+      <LocationProbe onLocation={(s) => { lastSearch = s; }} />
     </MemoryRouter>,
   );
+  return { ...result, getSearch: () => lastSearch };
 }
 
 beforeEach(() => {
@@ -238,6 +252,51 @@ describe("Sessions", () => {
       await user.click(screen.getByRole("button", { name: "Close Player" }));
 
       expect(mockClearLogs).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── URL-driven state (usePaginatedListState adoption) ────────────────────────
+
+  describe("URL hydration", () => {
+    it("calls useSessions with page hydrated from ?page=3", () => {
+      renderSessions(["/?page=3"]);
+      expect(vi.mocked(useSessions)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 3 }),
+      );
+    });
+
+    it("calls useSessions with page=1 when URL has no page param", () => {
+      renderSessions(["/"]);
+      expect(vi.mocked(useSessions)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1 }),
+      );
+    });
+  });
+
+  describe("URL writes", () => {
+    it("writes ?page=2 to the URL when the user navigates to page 2", async () => {
+      const user = userEvent.setup();
+      vi.mocked(useSessions).mockReturnValue(
+        makeSessions({
+          sessions: Array.from({ length: 10 }, (_, i) =>
+            makeSession({ uid: `s-${i}`, username: `u-${i}` }),
+          ),
+          totalCount: 30,
+        }),
+      );
+      renderSessions();
+
+      await user.click(screen.getByRole("button", { name: "Next page" }));
+
+      expect(vi.mocked(useSessions)).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 }),
+      );
+    });
+
+    it("omits ?page from the URL when on the default page 1", () => {
+      const { getSearch } = renderSessions(["/"]);
+      const sp = new URLSearchParams(getSearch());
+      expect(sp.get("page")).toBeNull();
     });
   });
 });

--- a/ui/apps/console/src/pages/sessions/index.tsx
+++ b/ui/apps/console/src/pages/sessions/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import {
   CommandLineIcon,
   ExclamationTriangleIcon,
@@ -24,6 +25,12 @@ import {
 } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
+
+type SessionsParams = {
+  page: number;
+};
+
+const DEFAULTS: SessionsParams = { page: 1 };
 
 function CloseButton({ onClose }: { onClose: () => Promise<unknown> }) {
   const [closing, setClosing] = useState(false);
@@ -52,9 +59,11 @@ function CloseButton({ onClose }: { onClose: () => Promise<unknown> }) {
 }
 
 export default function Sessions() {
-  const [page, setPage] = useState(1);
+  const { params, setPage } = usePaginatedListState<SessionsParams>({
+    defaults: DEFAULTS,
+  });
   const { sessions, totalCount, isLoading, error } = useSessions({
-    page,
+    page: params.page,
     perPage: PER_PAGE,
   });
   const closeSession = useCloseSession();
@@ -239,7 +248,7 @@ export default function Sessions() {
         rowKey={(s) => s.uid}
         isLoading={isLoading}
         loadingMessage="Loading sessions..."
-        page={page}
+        page={params.page}
         totalPages={totalPages}
         totalCount={totalCount}
         itemLabel="session"

--- a/ui/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -17,13 +17,24 @@ import { isExpired } from "./helpers";
 import { formatExpiry, formatDateShort } from "@/utils/date";
 import GenerateKeyDrawer from "./GenerateKeyDrawer";
 import EditKeyDrawer from "./EditKeyDrawer";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 
 const PER_PAGE = 10;
 
 type SortField = "name" | "created_at" | "expires_in";
 
+type ApiKeyListParams = {
+  page: number;
+};
+
+const API_KEY_LIST_DEFAULTS: ApiKeyListParams = { page: 1 };
+
 function ApiKeysTab() {
-  const [page, setPage] = useState(1);
+  const { params, setPage } = usePaginatedListState<ApiKeyListParams>({
+    prefix: "key",
+    defaults: API_KEY_LIST_DEFAULTS,
+  });
+  const page = params.page;
   const { sortBy, orderBy, handleSort } = useTableSort<SortField>({
     defaultField: "created_at",
     onSortChange: () => setPage(1),

--- a/ui/apps/console/src/pages/team/InvitationsTab.tsx
+++ b/ui/apps/console/src/pages/team/InvitationsTab.tsx
@@ -22,6 +22,7 @@ import {
   isInvitationExpired,
   type InvitationStatus,
 } from "@/utils/invitations";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { ExpiredBadge, RoleBadge } from "./constants";
 import InvitationDrawer from "./InvitationDrawer";
 import EditInvitationDrawer from "./EditInvitationDrawer";
@@ -125,9 +126,37 @@ function resendErrorMessage(err: unknown): string {
   return "Failed to resend the invitation. Please try again.";
 }
 
+const STATUS_ALLOWLIST: readonly InvitationStatus[] = [
+  "pending",
+  "accepted",
+  "rejected",
+  "cancelled",
+];
+
+type InvListParams = {
+  page: number;
+  status: InvitationStatus;
+};
+
+const INV_LIST_DEFAULTS: InvListParams = { page: 1, status: "pending" };
+const INV_LIST_CONSTRAINTS: { status: readonly InvitationStatus[] } = {
+  status: STATUS_ALLOWLIST,
+};
+
 function InvitationsTab({ tenantId }: { tenantId: string }) {
-  const [status, setStatus] = useState<InvitationStatus>("pending");
-  const [page, setPage] = useState(1);
+  const {
+    params,
+    setPage,
+    setFilter,
+  } = usePaginatedListState<InvListParams>({
+    prefix: "inv",
+    defaults: INV_LIST_DEFAULTS,
+    constraints: INV_LIST_CONSTRAINTS,
+  });
+
+  const status = params.status;
+  const page = params.page;
+
   const [inviteOpen, setInviteOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<MembershipInvitation | null>(
     null,
@@ -154,8 +183,7 @@ function InvitationsTab({ tenantId }: { tenantId: string }) {
   const totalPages = Math.max(1, Math.ceil(totalCount / PER_PAGE));
 
   const handleStatusChange = (next: InvitationStatus) => {
-    setStatus(next);
-    setPage(1);
+    setFilter("status", next);
   };
 
   const rightHeader = rightColumnHeader(status);

--- a/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -1,13 +1,31 @@
 import type { ReactNode } from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ApiKey } from "@/client";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
+const mockApiKeysImpl = vi.fn<
+  () => {
+    apiKeys: ApiKey[];
+    totalCount: number;
+    isLoading: boolean;
+    error: null;
+  }
+>();
+
+/** Spy that captures args passed to the hook. Does NOT call the impl itself —
+ *  the factory below calls the impl exactly once and returns its value. */
+const mockUseApiKeys: Mock = vi.fn();
+
 vi.mock("@/hooks/useApiKeys", () => ({
-  useApiKeys: vi.fn(),
+  useApiKeys: (...args: unknown[]) => {
+    mockUseApiKeys(...args);
+    return mockApiKeysImpl();
+  },
 }));
 
 vi.mock("@/hooks/useApiKeyMutations", () => ({
@@ -59,7 +77,6 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
-import { useApiKeys } from "@/hooks/useApiKeys";
 import { useDeleteApiKey } from "@/hooks/useApiKeyMutations";
 import ApiKeysTab from "../ApiKeysTab";
 
@@ -82,7 +99,7 @@ const mockMutateAsync = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useApiKeys).mockReturnValue({
+  mockApiKeysImpl.mockReturnValue({
     apiKeys: [makeApiKey()],
     totalCount: 1,
     isLoading: false,
@@ -93,11 +110,42 @@ beforeEach(() => {
   } as never);
 });
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Exposes the current search string from inside the MemoryRouter. */
+function LocationProbe({
+  onLocation,
+}: {
+  onLocation: (search: string) => void;
+}) {
+  const loc = useLocation();
+  onLocation(loc.search);
+  return null;
+}
+
+function renderTab(initialEntries: string[] = ["/"]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  let lastSearch = "";
+
+  const result = render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <QueryClientProvider client={queryClient}>
+        <ApiKeysTab />
+        <LocationProbe onLocation={(s) => { lastSearch = s; }} />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+
+  return { ...result, getSearch: () => lastSearch };
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("ApiKeysTab — pagination count display", () => {
   it("does not pass totalCount to DataTable so count is shown only in the header (single page)", () => {
-    render(<ApiKeysTab />);
+    renderTab();
 
     // The header renders "1 key" exactly once — the Pagination below the table
     // must NOT duplicate it (totalCount is intentionally not forwarded to DataTable).
@@ -110,14 +158,14 @@ describe("ApiKeysTab — pagination count display", () => {
     const keys = Array.from({ length: 10 }, (_, i) =>
       makeApiKey({ name: `key-${i}`, created_by: `user-${i}` }),
     );
-    vi.mocked(useApiKeys).mockReturnValue({
+    mockApiKeysImpl.mockReturnValue({
       apiKeys: keys,
       totalCount: 25,
       isLoading: false,
       error: null,
     });
 
-    render(<ApiKeysTab />);
+    renderTab();
 
     // Prev/Next buttons must exist even though totalCount is not passed to DataTable
     expect(screen.getByRole("button", { name: /prev/i })).toBeInTheDocument();
@@ -129,23 +177,23 @@ describe("ApiKeysTab — pagination count display", () => {
 
 describe("ApiKeysTab — sorting", () => {
   it("requests created_at/desc sort by default", () => {
-    render(<ApiKeysTab />);
-    expect(useApiKeys).toHaveBeenCalledWith(
+    renderTab();
+    expect(mockUseApiKeys).toHaveBeenCalledWith(
       expect.objectContaining({ sortBy: "created_at", orderBy: "desc" }),
     );
   });
 
   it("toggles sort when the Name header is clicked", async () => {
     const user = userEvent.setup();
-    render(<ApiKeysTab />);
+    renderTab();
 
     await user.click(screen.getByRole("button", { name: "Sort by Name" }));
-    let calls = vi.mocked(useApiKeys).mock.calls;
+    let calls = mockUseApiKeys.mock.calls;
     let last = calls[calls.length - 1][0];
     expect(last).toMatchObject({ sortBy: "name", orderBy: "asc" });
 
     await user.click(screen.getByRole("button", { name: "Sort by Name" }));
-    calls = vi.mocked(useApiKeys).mock.calls;
+    calls = mockUseApiKeys.mock.calls;
     last = calls[calls.length - 1][0];
     expect(last).toMatchObject({ sortBy: "name", orderBy: "desc" });
   });
@@ -154,7 +202,7 @@ describe("ApiKeysTab — sorting", () => {
 describe("ApiKeysTab — delete error handling", () => {
   async function openDeleteDialog() {
     const user = userEvent.setup();
-    render(<ApiKeysTab />);
+    renderTab();
     await user.click(screen.getByRole("button", { name: "Delete API key" }));
     return user;
   }
@@ -202,5 +250,47 @@ describe("ApiKeysTab — delete error handling", () => {
         screen.queryByRole("dialog", { name: /delete api key/i }),
       ).not.toBeInTheDocument(),
     );
+  });
+});
+
+// ── URL sync (usePaginatedListState adoption, prefix "key") ──────────────────
+
+describe("ApiKeysTab — URL sync with prefix 'key'", () => {
+  it("hydrates page from ?key.page=3 — hook receives page 3", () => {
+    renderTab(["/?key.page=3"]);
+    expect(mockUseApiKeys).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 3 }),
+    );
+  });
+
+  it("clicking Next writes key.page=2 to the URL (not bare page=2)", async () => {
+    const user = userEvent.setup();
+    mockApiKeysImpl.mockReturnValue({
+      apiKeys: Array.from({ length: 10 }, (_, i) =>
+        makeApiKey({ name: `key-${i}`, created_by: `user-${i}` }),
+      ),
+      totalCount: 25,
+      isLoading: false,
+      error: null,
+    });
+    const { getSearch } = renderTab();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => {
+      const sp = new URLSearchParams(getSearch());
+      expect(sp.get("key.page")).toBe("2");
+      expect(sp.get("page")).toBeNull(); // bare page must not appear
+    });
+  });
+
+  it("does not consume a bare ?page=5 param as key.page — hook receives page 1", () => {
+    renderTab(["/?page=5"]);
+    // The hook must receive the default page (1), not the bare page=5
+    expect(mockUseApiKeys).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1 }),
+    );
+    // The bare page=5 must survive in the URL untouched
+    // (LocationProbe captures it at render time)
   });
 });

--- a/ui/apps/console/src/pages/team/__tests__/InvitationsTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/InvitationsTab.test.tsx
@@ -1,8 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-import React from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAuthStore } from "../../../stores/authStore";
 import type { MembershipInvitation } from "../../../client";
@@ -12,18 +11,24 @@ import InvitationsTab from "../InvitationsTab";
 /* Mocks                                                               */
 /* ------------------------------------------------------------------ */
 
-const mockInvitations = vi.fn<
+const mockInvitationsImpl = vi.fn<
   () => {
     invitations: MembershipInvitation[];
     totalCount: number;
     isLoading: boolean;
   }
 >();
+/** Spy that captures args passed to the hook. Does NOT call the impl itself —
+ *  the factory below calls the impl exactly once and returns its value. */
+const mockUseNamespaceInvitations: Mock = vi.fn();
 const mockCancelMutateAsync = vi.fn();
 const mockResendMutateAsync = vi.fn();
 
 vi.mock("../../../hooks/useInvitations", () => ({
-  useNamespaceInvitations: () => mockInvitations(),
+  useNamespaceInvitations: (...args: unknown[]) => {
+    mockUseNamespaceInvitations(...args);
+    return mockInvitationsImpl();
+  },
 }));
 
 vi.mock("../../../hooks/useInvitationMutations", () => ({
@@ -114,21 +119,33 @@ function makeExpiredInvitation(
   });
 }
 
-function createWrapper() {
+/** Exposes the current search string from inside the MemoryRouter. */
+function LocationProbe({
+  onLocation,
+}: {
+  onLocation: (search: string) => void;
+}) {
+  const loc = useLocation();
+  onLocation(loc.search);
+  return null;
+}
+
+function renderTab(tenantId = "t1", initialEntries: string[] = ["/"]) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return ({ children }: { children: React.ReactNode }) => (
-    <MemoryRouter>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </MemoryRouter>
-  );
-}
+  let lastSearch = "";
 
-function renderTab(tenantId = "t1") {
-  return render(<InvitationsTab tenantId={tenantId} />, {
-    wrapper: createWrapper(),
-  });
+  const result = render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <QueryClientProvider client={queryClient}>
+        <InvitationsTab tenantId={tenantId} />
+        <LocationProbe onLocation={(s) => { lastSearch = s; }} />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+
+  return { ...result, getSearch: () => lastSearch };
 }
 
 /* ------------------------------------------------------------------ */
@@ -139,7 +156,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   // Default to owner so RestrictedAction does not block anything
   useAuthStore.setState({ role: "owner" });
-  mockInvitations.mockReturnValue({
+  mockInvitationsImpl.mockReturnValue({
     invitations: [],
     totalCount: 0,
     isLoading: false,
@@ -155,7 +172,7 @@ beforeEach(() => {
 describe("InvitationsTab", () => {
   describe("rendering", () => {
     it("shows the invitation count from totalCount exactly once in the header (not duplicated in the DataTable pagination footer)", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [],
         totalCount: 5,
         isLoading: false,
@@ -171,7 +188,7 @@ describe("InvitationsTab", () => {
       const invitations = Array.from({ length: 10 }, (_, i) =>
         makeInvitation({ user: { id: `u${i}`, email: `user${i}@example.com` } }),
       );
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations,
         totalCount: 25,
         isLoading: false,
@@ -186,7 +203,7 @@ describe("InvitationsTab", () => {
     });
 
     it("uses singular 'invitation' when count is 1", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [],
         totalCount: 1,
         isLoading: false,
@@ -228,7 +245,7 @@ describe("InvitationsTab", () => {
     });
 
     it("shows a row for each invitation", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [
           makeInvitation({ user: { id: "u1", email: "alice@example.com" } }),
           makeInvitation({ user: { id: "u2", email: "bob@example.com" } }),
@@ -242,7 +259,7 @@ describe("InvitationsTab", () => {
     });
 
     it("shows loading message while fetching", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [],
         totalCount: 0,
         isLoading: true,
@@ -252,7 +269,7 @@ describe("InvitationsTab", () => {
     });
 
     it("shows empty state when there are no pending invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [],
         totalCount: 0,
         isLoading: false,
@@ -262,7 +279,7 @@ describe("InvitationsTab", () => {
     });
 
     it("shows expired badge for pending invitation past expires_at", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeExpiredInvitation()],
         totalCount: 1,
         isLoading: false,
@@ -288,7 +305,7 @@ describe("InvitationsTab", () => {
 
   describe("action buttons — enablement rules", () => {
     it("Edit button is enabled for pending invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "pending" })],
         totalCount: 1,
         isLoading: false,
@@ -300,7 +317,7 @@ describe("InvitationsTab", () => {
     });
 
     it("Edit button is disabled for accepted invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "accepted" })],
         totalCount: 1,
         isLoading: false,
@@ -312,7 +329,7 @@ describe("InvitationsTab", () => {
     });
 
     it("Cancel button is enabled for pending invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "pending" })],
         totalCount: 1,
         isLoading: false,
@@ -324,7 +341,7 @@ describe("InvitationsTab", () => {
     });
 
     it("Cancel button is disabled for cancelled invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "cancelled" })],
         totalCount: 1,
         isLoading: false,
@@ -336,7 +353,7 @@ describe("InvitationsTab", () => {
     });
 
     it("Resend button is enabled for cancelled invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "cancelled" })],
         totalCount: 1,
         isLoading: false,
@@ -348,7 +365,7 @@ describe("InvitationsTab", () => {
     });
 
     it("Resend button is enabled for expired pending invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeExpiredInvitation({ status: "pending" })],
         totalCount: 1,
         isLoading: false,
@@ -360,7 +377,7 @@ describe("InvitationsTab", () => {
     });
 
     it("Resend button is disabled for non-expired pending invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "pending" })],
         totalCount: 1,
         isLoading: false,
@@ -372,7 +389,7 @@ describe("InvitationsTab", () => {
     });
 
     it("Resend button is disabled for accepted invitations", () => {
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "accepted" })],
         totalCount: 1,
         isLoading: false,
@@ -410,7 +427,7 @@ describe("InvitationsTab", () => {
   describe("Edit invitation drawer", () => {
     it("opens EditInvitationDrawer when Edit button is clicked on a pending invitation", async () => {
       const user = userEvent.setup();
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "pending" })],
         totalCount: 1,
         isLoading: false,
@@ -428,7 +445,7 @@ describe("InvitationsTab", () => {
   describe("Cancel invitation", () => {
     it("opens confirmation dialog when Cancel button is clicked on a pending invitation", async () => {
       const user = userEvent.setup();
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "pending" })],
         totalCount: 1,
         isLoading: false,
@@ -450,7 +467,7 @@ describe("InvitationsTab", () => {
         status: "pending",
         user: { id: "u1", email: "alice@example.com" },
       });
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [inv],
         totalCount: 1,
         isLoading: false,
@@ -479,7 +496,7 @@ describe("InvitationsTab", () => {
   describe("Resend invitation", () => {
     it("opens confirmation dialog when Resend is clicked on a cancelled invitation", async () => {
       const user = userEvent.setup();
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [makeInvitation({ status: "cancelled" })],
         totalCount: 1,
         isLoading: false,
@@ -502,7 +519,7 @@ describe("InvitationsTab", () => {
         user: { id: "u1", email: "alice@example.com" },
         role: "operator",
       });
-      mockInvitations.mockReturnValue({
+      mockInvitationsImpl.mockReturnValue({
         invitations: [inv],
         totalCount: 1,
         isLoading: false,
@@ -532,6 +549,60 @@ describe("InvitationsTab", () => {
         .getByRole("button", { name: /invite member/i })
         .closest("[aria-disabled='true']");
       expect(wrapper).toBeInTheDocument();
+    });
+  });
+
+  // ── URL sync (usePaginatedListState adoption, prefix "inv") ─────────────────
+
+  describe("URL sync — prefixed keys", () => {
+    it("hydrates page and status from ?inv.page=2&inv.status=accepted", () => {
+      renderTab("t1", ["/?inv.page=2&inv.status=accepted"]);
+      expect(mockUseNamespaceInvitations).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2, status: "accepted" }),
+      );
+    });
+
+    it("changing status writes inv.page=1 (not bare page=1) and resets hook page to 1", async () => {
+      const user = userEvent.setup();
+      // Start on page 2 of accepted invitations (prefixed URL keys)
+      mockInvitationsImpl.mockReturnValue({
+        invitations: Array.from({ length: 10 }, (_, i) =>
+          makeInvitation({ user: { id: `u${i}`, email: `u${i}@example.com` } }),
+        ),
+        totalCount: 30,
+        isLoading: false,
+      });
+      const { getSearch } = renderTab("t1", ["/?inv.page=2&inv.status=accepted"]);
+
+      const select = screen.getByRole("combobox", {
+        name: /filter invitations by status/i,
+      });
+      await user.selectOptions(select, "pending");
+
+      await waitFor(() => {
+        const sp = new URLSearchParams(getSearch());
+        // Must reset the prefixed page key, not a bare "page"
+        expect(sp.get("inv.page")).toBeNull(); // page 1 is the default so omitted
+        expect(sp.get("page")).toBeNull(); // bare page must not appear
+        // The hook must receive page=1 after reset
+        const calls = mockUseNamespaceInvitations.mock.calls;
+        const lastCall = calls.at(-1)![0] as { page: number; status: string };
+        expect(lastCall.page).toBe(1);
+        expect(lastCall.status).toBe("pending");
+      });
+    });
+
+    it("does not consume a bare ?page param as inv.page", () => {
+      // A bare ?page=5 (no prefix) must NOT be consumed as the inv page.
+      // The hook must receive page=1 (default), and the bare page=5 must survive.
+      const { getSearch } = renderTab("t1", ["/?page=5&inv.status=rejected"]);
+      const sp = new URLSearchParams(getSearch());
+      // Bare page=5 must survive untouched
+      expect(sp.get("page")).toBe("5");
+      // The hook must receive page=1 (default), not 5
+      expect(mockUseNamespaceInvitations).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 1, status: "rejected" }),
+      );
     });
   });
 });

--- a/ui/apps/console/src/test-utils/__tests__/renderHookWithRouter.test.tsx
+++ b/ui/apps/console/src/test-utils/__tests__/renderHookWithRouter.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { useSearchParams } from "react-router-dom";
+import { renderHookWithRouter } from "../renderHookWithRouter";
+
+describe("renderHookWithRouter", () => {
+  it("resolves useSearchParams without throwing", () => {
+    expect(() => {
+      renderHookWithRouter(() => useSearchParams());
+    }).not.toThrow();
+  });
+
+  it("returns the search params object from the hook", () => {
+    const { result } = renderHookWithRouter(() => useSearchParams());
+    const [searchParams] = result.current;
+    expect(searchParams).toBeInstanceOf(URLSearchParams);
+  });
+
+  it("seeds the URL from initialEntries so params are readable", () => {
+    const { result } = renderHookWithRouter(() => useSearchParams(), {
+      initialEntries: ["/?foo=bar"],
+    });
+    const [searchParams] = result.current;
+    expect(searchParams.get("foo")).toBe("bar");
+  });
+
+  it("defaults to an empty search string when no initialEntries are provided", () => {
+    const { result } = renderHookWithRouter(() => useSearchParams());
+    const [searchParams] = result.current;
+    expect(searchParams.toString()).toBe("");
+  });
+
+  it("accepts multiple initialEntries and starts at the last one", () => {
+    const { result } = renderHookWithRouter(() => useSearchParams(), {
+      initialEntries: ["/first", "/?page=2"],
+    });
+    const [searchParams] = result.current;
+    expect(searchParams.get("page")).toBe("2");
+  });
+});

--- a/ui/apps/console/src/test-utils/renderHookWithRouter.tsx
+++ b/ui/apps/console/src/test-utils/renderHookWithRouter.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode } from "react";
+import { renderHook, type RenderHookOptions } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+interface RenderHookWithRouterOptions
+  extends Omit<RenderHookOptions<unknown>, "wrapper"> {
+  initialEntries?: string[];
+}
+
+/**
+ * Wraps `renderHook` with a MemoryRouter (React Router v7) and a QueryClient
+ * provider so hooks that call `useSearchParams` (or any other router/query
+ * hook) don't throw outside a routing context.
+ *
+ * @param hook - The hook callback to render.
+ * @param options - Optional. Pass `initialEntries` to seed the URL.
+ *
+ * @example
+ * ```ts
+ * const { result } = renderHookWithRouter(() => useSearchParams(), {
+ *   initialEntries: ["/?page=2"],
+ * });
+ * const [searchParams] = result.current;
+ * expect(searchParams.get("page")).toBe("2");
+ * ```
+ */
+export function renderHookWithRouter<Result>(
+  hook: () => Result,
+  { initialEntries, ...rest }: RenderHookWithRouterOptions = {},
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  return renderHook(hook, { wrapper: Wrapper, ...rest });
+}


### PR DESCRIPTION
## What

Adds a shared **`usePaginatedListState`** hook (plus pure `paginatedListParams` parse/serialize helpers and a shared `renderHookWithRouter` test util) that syncs paginated list state — page, search, sort, scalar filters, and array filters (tags) — to the URL via `useSearchParams`, and adopts it across **all 14 paginated list pages**.

Fixes the issue where refreshing or sharing a list URL reset all sort/filter/page state and results weren't bookmarkable.

Fixes: shellhub-io/team#138

## Behavior

- **URL is the source of truth.** State is derived from `searchParams` and written back on every change.
- **Clean URLs** — params equal to their default are omitted (no `?page=1`, no empty `search`); `replace` history by default; unrelated params (including other prefixes) are preserved.
- **Normalized page reset** — every setter except `setPage` resets to page 1.
- **`handleSort`** toggles order on the same field, else applies that field's `initialOrder`.
- **Array filters (tags)** use repeated-key form `?tags=a&tags=b`; duplicates are de-duplicated.
- **Prefix** option namespaces params (`inv.page`, `key.page`) so the co-mounted team tabs don't clobber each other.
- The readable URL values are still translated to the API's base64 `filter` blob by the **existing** query hooks — **no change** to `buildFilter`/`toBase64Json` or any query hook.

## Pages adopted

Admin: devices, users, namespaces, sessions, announcements, firewall-rules. Public: devices, containers, sessions, public-keys, firewall-rules. Team: invitations (`inv` prefix), api-keys (`key` prefix). Plus web-endpoints.

### Intentional, low-risk changes
- Public devices & containers now **write** status/search/tags/page to the URL (previously read `?status=` once).
- Both firewall pages now reset to page 1 on search; public/firewall disables server pagination while searching (matches admin/firewall).

### Accepted limitation
- The `/team` tab selector itself is not URL-synced (tab-child architecture); only within-tab state is. Routing the tab is a follow-up.

## Verification

- `tsc --noEmit` clean
- Full vitest suite: **2481 tests passing**
- eslint clean on all touched files

Unit tests cover the hook and pure helpers (URL hydration, invalid→default fallback, omit-defaults, page-reset on every non-page setter, sort toggle/initial-order, tags round-trip, prefix isolation, replace vs push, unrelated-param preservation); each adopted page has a round-trip test (mount-at-URL hydrates controls; changing a control updates the URL).