### PR TITLE
ci: finalize review tracking comment when summary is skipped

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -398,6 +398,13 @@ jobs:
 
             ## Step 5: Update final summary
 
+            This step is MANDATORY and must be your FINAL action before ending — even if
+            there are zero new findings, even if every finding was already reported in a
+            previous review thread. NEVER end your turn while the tracking comment still
+            contains unchecked `- [ ]` checkboxes. If you have nothing else to do, your
+            last action MUST still be a mcp__github_comment__update_claude_comment call
+            that replaces the checklist with the final summary below.
+
             After Step 4 is complete, update the tracking comment one final time via
             mcp__github_comment__update_claude_comment to become the closing summary.
 
@@ -426,21 +433,24 @@ jobs:
                 If you've addressed the feedback and want a new review, tag
                 `@shellhub-io/admin` and a team member can trigger it.
 
-            ### If there are NO findings:
+            ### If there are NO new findings:
 
-            Update the tracking comment to:
+            This covers two cases: (a) no issues were found at all, and (b) a re-review
+            where every finding deduplicated against issues already reported in previous
+            review threads — i.e. nothing NEW to post. In either case you MUST still update
+            the tracking comment to:
 
                 <!-- claude-code-review -->
                 ## Code Review Complete
 
                 Reviewed N files across code quality, security, testing, language patterns,
-                and architecture — no issues found. The code looks good as-is.
+                and architecture — no new issues found. The code looks good as-is.
 
                 {For non-admin authors only:}
                 If you push additional changes and want a new review, tag
                 `@shellhub-io/admin` and a team member can trigger it.
 
-            Do NOT mention inline comments or `/review` follow-up when there are no findings
+            Do NOT mention inline comments or `/review` follow-up when there are no new findings
             (unless the author is non-admin, in which case include the tag guidance).
 
             In both cases, always update the tracking comment. Never skip Step 5.
@@ -449,3 +459,41 @@ jobs:
             --max-turns 50
             --model claude-opus-4-6
             --allowedTools "Task" "mcp__github_inline_comment__create_inline_comment" "mcp__github_comment__update_claude_comment" "Bash(gh api:*)" "Bash(gh pr diff:*)"
+
+      - name: Finalize tracking comment
+        if: always() && steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          MARKER="<!-- claude-code-review -->"
+          # The tracking comment for THIS run links to this run id in its body.
+          COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | select(.body | contains(\"actions/runs/$RUN_ID\")) | .id" | head -1)
+
+          if [[ -z "$COMMENT_ID" ]]; then
+            echo "No tracking comment for run $RUN_ID; nothing to finalize."
+            exit 0
+          fi
+
+          BODY=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq '.body')
+
+          # A finalized summary has no unchecked checkboxes. If none remain, leave it.
+          if ! grep -qF -- '- [ ]' <<<"$BODY"; then
+            echo "Tracking comment already finalized; nothing to do."
+            exit 0
+          fi
+
+          echo "Tracking comment stuck mid-progress; rewriting to a terminal state."
+          FINAL_BODY=$(printf '%s\n' \
+            "$MARKER" \
+            "## Code Review Complete" \
+            "" \
+            "The automated review ran but did not post an updated summary — this usually means no new issues were found since the previous review. If you've pushed changes and want a fresh pass, comment \`/review\`." \
+            "" \
+            "_[View job]($RUN_URL)_")
+
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -f body="$FINAL_BODY"


### PR DESCRIPTION
## What

The **Claude Code Review** workflow (`anthropics/claude-code-action@v1`, `track_progress: true`) posts a per-run tracking comment and updates it through a 5-step flow, finalizing it into a "Code Review Complete" summary in Step 5.

On `/review` re-runs where every finding **deduplicates against an already-posted review** (i.e. nothing *new* to report), the model ends its turn without the final `update_claude_comment` call. The action still exits `success` (green check), but the tracking comment is left frozen at the Step 1 progress state:

```
### Code Review
- [x] Gathered PR context
- [ ] Reviewing with 5 specialized agents
- [ ] Posting feedback
```

So the job reports done but never reports a *result*. Observed on #6555: the `pull_request_target` auto-review finalized correctly (2 findings), but two subsequent `/review` runs (`28189971340`, `28191849009`) ran 31–33 turns and ~$3 each, then exited `success` with the comment stuck. The existing "Never skip Step 5" instruction did not prevent it, so a prompt-only fix is unreliable.

## Changes

1. **Deterministic finalizer (the real fix)** — a new `Finalize tracking comment` post-step with `if: always() && steps.gate.outputs.proceed == 'true'` (runs on success, failure, and cancellation). It locates *this run's* tracking comment (marker `<!-- claude-code-review -->` + the `actions/runs/<run_id>` link in the body — each run gets its own comment since `use_sticky_comment: false`), and if it still contains unchecked `- [ ]` boxes, rewrites it to a terminal "Code Review Complete" state via `gh api PATCH`. No-ops if already finalized or not found.

2. **Prompt hardening (Step 5)** — make finalizing the comment mandatory even with zero new findings, forbid ending the turn while unchecked `- [ ]` boxes remain, and explicitly cover the re-review/dedup "no *new* findings" case.

Scoped to the two changes above; `concurrency: cancel-in-progress` and a job-level timeout are intentionally left out.

## Verification

- YAML parses cleanly.
- The terminal comment body is built with `printf` so it renders as Markdown (heading + paragraph), not an indented code block.
- Finalizer matches the current run's comment (run-id link is present in the body by the time the post-step runs).