### PR TITLE
fix(ui): surface namespace-creation errors on duplicate name

### DIFF
--- a/ui/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespace.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/hooks/useNamespaceMutations";
 import { getNamespaces } from "@/client";
 import { getConfig } from "@/env";
+import { isSdkError } from "@/api/errors";
 import {
   CommandLineIcon,
   SparklesIcon,
@@ -23,6 +24,7 @@ import { Button, Spinner } from "@shellhub/design-system/primitives";
 function CloudForm() {
   const [name, setName] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const createNs = useCreateNamespace();
 
   const handleSubmit = async (e: FormEvent) => {
@@ -33,14 +35,29 @@ function CloudForm() {
       return;
     }
     setValidationError(null);
+    setSubmitError(null);
     try {
       await createNs.mutateAsync(name);
-    } catch {
-      // error is set in mutation
+    } catch (caught) {
+      if (isSdkError(caught)) {
+        if (caught.status === 409) {
+          setSubmitError("A namespace with this name already exists.");
+        } else if (caught.status === 403) {
+          setSubmitError(
+            "You have reached the namespace limit or do not have permission.",
+          );
+        } else if (caught.status === 400) {
+          setSubmitError("The namespace name is invalid.");
+        } else {
+          setSubmitError("An unexpected error occurred. Please try again.");
+        }
+      } else {
+        setSubmitError("An unexpected error occurred. Please try again.");
+      }
     }
   };
 
-  const displayError = validationError ?? createNs.error?.message ?? null;
+  const displayError = validationError ?? submitError ?? null;
 
   return (
     <form onSubmit={(e) => void handleSubmit(e)} className="w-full">
@@ -52,6 +69,7 @@ function CloudForm() {
             onChange={(v) => {
               setName(v);
               setValidationError(null);
+              setSubmitError(null);
               createNs.reset();
             }}
             error={displayError}

--- a/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useId, type FormEvent } from "react";
+import { isSdkError } from "@/api/errors";
 import {
   XMarkIcon,
   BookOpenIcon,
@@ -115,14 +116,14 @@ export default function CreateNamespaceDialog({
 
   const [name, setName] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const createNs = useCreateNamespace();
 
-  const displayError =
-    validationError ??
-    (createNs.error instanceof Error ? createNs.error.message : null);
+  const displayError = validationError ?? submitError ?? null;
 
   const resetError = () => {
     setValidationError(null);
+    setSubmitError(null);
     createNs.reset();
   };
 
@@ -134,11 +135,24 @@ export default function CreateNamespaceDialog({
       return;
     }
     setValidationError(null);
+    setSubmitError(null);
     try {
       await createNs.mutateAsync(name);
       onClose();
-    } catch {
-      // error is surfaced via displayError
+    } catch (caught) {
+      if (isSdkError(caught)) {
+        if (caught.status === 409) {
+          setSubmitError("A namespace with this name already exists.");
+        } else if (caught.status === 403) {
+          setSubmitError("You have reached the namespace limit or do not have permission.");
+        } else if (caught.status === 400) {
+          setSubmitError("The namespace name is invalid.");
+        } else {
+          setSubmitError("An unexpected error occurred. Please try again.");
+        }
+      } else {
+        setSubmitError("An unexpected error occurred. Please try again.");
+      }
     }
   };
 

--- a/ui/apps/console/src/components/common/__tests__/CreateNamespace.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/CreateNamespace.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Stub the community-polling useEffect so it does not leak timers
+vi.mock("@/client", () => ({
+  getNamespaces: vi.fn().mockResolvedValue({ data: [] }),
+}));
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
+
+vi.mock("@/hooks/useNamespaceMutations", () => ({
+  useCreateNamespace: vi.fn(),
+  useSwitchNamespace: vi.fn(),
+}));
+
+import { getConfig, defaultConfig } from "@/env";
+import {
+  useCreateNamespace,
+  useSwitchNamespace,
+} from "@/hooks/useNamespaceMutations";
+import CreateNamespace from "../CreateNamespace";
+
+const mockGetConfig = vi.mocked(getConfig);
+const mockUseCreateNamespace = vi.mocked(useCreateNamespace);
+const mockUseSwitchNamespace = vi.mocked(useSwitchNamespace);
+
+function makeCreateNs(overrides?: Partial<ReturnType<typeof useCreateNamespace>>) {
+  return {
+    mutateAsync: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useCreateNamespace>;
+}
+
+beforeEach(() => {
+  // Default: cloud mode → renders CloudForm
+  mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+  mockUseCreateNamespace.mockReturnValue(makeCreateNs());
+  mockUseSwitchNamespace.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useSwitchNamespace>);
+});
+
+afterEach(cleanup);
+
+function renderComponent() {
+  return render(<CreateNamespace />);
+}
+
+describe("CreateNamespace — CloudForm", () => {
+  it("calls mutateAsync with the typed name on valid submit (no-op regression guard)", async () => {
+    const mutateAsync = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    mockUseCreateNamespace.mockReturnValue(makeCreateNs({ mutateAsync }));
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith("my-ns"));
+  });
+
+  it("shows 'A namespace with this name already exists.' on 409", async () => {
+    const sdkError = { status: 409 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    mockUseCreateNamespace.mockReturnValue(makeCreateNs({ mutateAsync }));
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("A namespace with this name already exists."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the limit/permission message on 403", async () => {
+    const sdkError = { status: 403 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    mockUseCreateNamespace.mockReturnValue(makeCreateNs({ mutateAsync }));
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "You have reached the namespace limit or do not have permission.",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the invalid-name message on 400", async () => {
+    const sdkError = { status: 400 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    mockUseCreateNamespace.mockReturnValue(makeCreateNs({ mutateAsync }));
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("The namespace name is invalid."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the generic fallback message on 500", async () => {
+    const sdkError = { status: 500 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    mockUseCreateNamespace.mockReturnValue(makeCreateNs({ mutateAsync }));
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("An unexpected error occurred. Please try again."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("clears the error text from the DOM when the user types after a failed submission", async () => {
+    const sdkError = { status: 409 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    mockUseCreateNamespace.mockReturnValue(makeCreateNs({ mutateAsync }));
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("A namespace with this name already exists."),
+      ).toBeInTheDocument(),
+    );
+
+    // Now type more — error must disappear
+    await user.type(screen.getByPlaceholderText("my-namespace"), "x");
+
+    expect(
+      screen.queryByText("A namespace with this name already exists."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/CreateNamespaceDialog.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/CreateNamespaceDialog.test.tsx
@@ -305,14 +305,37 @@ describe("CreateNamespaceDialog (cloud/enterprise)", () => {
     expect(screen.getByPlaceholderText("my-namespace")).toHaveValue("myns");
   });
 
-  it("shows the mutation error message when creation fails", async () => {
-    const mutateAsync = vi
-      .fn<() => Promise<void>>()
-      .mockRejectedValue(new Error("name already taken"));
+  it("shows 'A namespace with this name already exists.' on 409 and does NOT call onClose", async () => {
+    const sdkError = { status: 409 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
     mockUseCreateNamespace.mockReturnValue({
       mutateAsync,
       isPending: false,
-      error: new Error("name already taken"),
+      error: null,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useCreateNamespace>);
+
+    const user = userEvent.setup();
+    const { onClose } = renderDialog(true);
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("A namespace with this name already exists."),
+      ).toBeInTheDocument(),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shows the limit/permission message on 403", async () => {
+    const sdkError = { status: 403 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    mockUseCreateNamespace.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+      error: null,
       reset: vi.fn(),
     } as unknown as ReturnType<typeof useCreateNamespace>);
 
@@ -323,29 +346,86 @@ describe("CreateNamespaceDialog (cloud/enterprise)", () => {
     await user.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() =>
-      expect(screen.getByText("name already taken")).toBeInTheDocument(),
+      expect(
+        screen.getByText("You have reached the namespace limit or do not have permission."),
+      ).toBeInTheDocument(),
     );
   });
 
-  it("clears the mutation error when the user types in the input", async () => {
-    const mutateAsync = vi
-      .fn<() => Promise<void>>()
-      .mockRejectedValue(new Error("name already taken"));
-    const reset = vi.fn();
+  it("shows the invalid-name message on 400", async () => {
+    const sdkError = { status: 400 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
     mockUseCreateNamespace.mockReturnValue({
       mutateAsync,
       isPending: false,
-      error: new Error("name already taken"),
-      reset,
+      error: null,
+      reset: vi.fn(),
     } as unknown as ReturnType<typeof useCreateNamespace>);
 
     const user = userEvent.setup();
     renderDialog(true);
 
-    // Type to trigger onChange
-    await user.type(screen.getByPlaceholderText("my-namespace"), "a");
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
 
-    expect(reset).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        screen.getByText("The namespace name is invalid."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows the generic fallback message on 500", async () => {
+    const sdkError = { status: 500 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    mockUseCreateNamespace.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+      error: null,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useCreateNamespace>);
+
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("An unexpected error occurred. Please try again."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("clears the error text from the DOM when the user types after a failed submission", async () => {
+    const sdkError = { status: 409 };
+    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    mockUseCreateNamespace.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+      error: null,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useCreateNamespace>);
+
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    await user.type(screen.getByPlaceholderText("my-namespace"), "my-ns");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("A namespace with this name already exists."),
+      ).toBeInTheDocument(),
+    );
+
+    // Now type more — error must disappear
+    await user.type(screen.getByPlaceholderText("my-namespace"), "x");
+
+    expect(
+      screen.queryByText("A namespace with this name already exists."),
+    ).not.toBeInTheDocument();
   });
 
   it("calls onClose after successful creation", async () => {


### PR DESCRIPTION
## What

Namespace creation now shows a clear, field-level error when it fails. Previously, creating a namespace with a name that already exists returned HTTP 409 but the form did nothing — a silent failure.

## Why

Both create entry points rendered only the mutation's `.message`, which is `null` for an enriched SDK error (the 409 error object carries `.status`, not a `.message`). So `displayError` resolved to `null` and the user got no feedback.

Closes shellhub-io/team#164

## Changes

- **CreateNamespace.tsx / CreateNamespaceDialog.tsx**: filled the previously-empty `catch` blocks to inspect the error via `isSdkError(err)` and map the status to a message — 409 → "A namespace with this name already exists." (matching `EditNamespaceDrawer`), 403 → limit/permission, 400 → invalid name, everything else → a generic fallback. Wired the message into the existing `displayError` → `NamespaceNameField` `error` prop (no markup change), and clear it on the input-change / retry paths.
- **Display sourcing**: `displayError` now reads a dedicated `submitError` state instead of `createNs.error?.message` (which never resolved for SDK errors).

The set of handled statuses (400/401/403/409/500) mirrors what the OpenAPI spec and generated SDK document for `POST /api/namespaces`. Frontend-only — the backend already returns the correct codes.

## Testing

`cd ui/apps/console && npm run test -- src/components/common/__tests__/CreateNamespace.test.tsx src/components/common/__tests__/CreateNamespaceDialog.test.tsx`

Added a new test for `CreateNamespace` and rewrote the two `CreateNamespaceDialog` tests that depended on the old plain-`Error` model; both suites cover each status code plus clearing the error on edit. 37 tests pass; `tsc --noEmit` and `eslint` are clean.