### PR TITLE
feat(ui): add column sorting to backend-ready data-tables

### DIFF
--- a/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
+++ b/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
@@ -73,7 +73,20 @@ export default function DeviceChooserDialog({
   const [page, setPage] = useState(1);
   const [selected, setSelected] = useState<NormalizedDevice[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<"name" | "last_seen">("last_seen");
+  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
   const inFlightRef = useRef(false);
+
+  const handleSort = (field: string) => {
+    const f = field as "name" | "last_seen";
+    if (sortBy === f) {
+      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(f);
+      setOrderBy(f === "name" ? "asc" : "desc");
+    }
+    setPage(1);
+  };
 
   // Force the All tab whenever Suggested is empty so a refetch that returns
   // [] doesn't strand the user on a tab that would submit zero choices.
@@ -91,6 +104,8 @@ export default function DeviceChooserDialog({
     status: "accepted",
     search: debouncedSearch,
     enabled: tab === "all",
+    sortBy,
+    orderBy,
   });
 
   const totalPages = Math.max(1, Math.ceil(totalCount / PER_PAGE));
@@ -239,6 +254,9 @@ export default function DeviceChooserDialog({
               totalPages={totalPages}
               totalCount={totalCount}
               onPageChange={setPage}
+              sortField={sortBy}
+              sortOrder={orderBy}
+              onSort={handleSort}
             />
             <SelectedChips
               selected={selected}
@@ -489,6 +507,9 @@ interface AllTabProps {
   totalPages: number;
   totalCount: number;
   onPageChange: (page: number) => void;
+  sortField: string;
+  sortOrder: "asc" | "desc";
+  onSort: (field: string) => void;
 }
 
 function AllTab({
@@ -500,6 +521,9 @@ function AllTab({
   totalPages,
   totalCount,
   onPageChange,
+  sortField,
+  sortOrder,
+  onSort,
 }: AllTabProps) {
   const isSelected = (d: NormalizedDevice) =>
     selected.some((s) => s.uid === d.uid);
@@ -534,6 +558,7 @@ function AllTab({
     {
       key: "name",
       header: "Hostname",
+      sortable: true,
       render: (d) => (
         <span className="text-sm font-medium text-text-primary">{d.name}</span>
       ),
@@ -546,6 +571,7 @@ function AllTab({
     {
       key: "last_seen",
       header: "Last Seen",
+      sortable: true,
       render: (d) => <LastSeenCell value={d.last_seen} />,
     },
   ];
@@ -564,6 +590,9 @@ function AllTab({
       totalCount={totalCount}
       itemLabel="device"
       onPageChange={onPageChange}
+      sortField={sortField}
+      sortOrder={sortOrder}
+      onSort={onSort}
     />
   );
 }

--- a/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
+++ b/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
@@ -17,6 +17,7 @@ import SearchField from "@/components/common/fields/SearchField";
 import CheckboxField from "@/components/common/fields/CheckboxField";
 import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useTableSort } from "@/hooks/useTableSort";
 import {
   useChoiceDevices,
   useSuggestedDevices,
@@ -73,20 +74,11 @@ export default function DeviceChooserDialog({
   const [page, setPage] = useState(1);
   const [selected, setSelected] = useState<NormalizedDevice[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [sortBy, setSortBy] = useState<"name" | "last_seen">("last_seen");
-  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
+  const { sortBy, orderBy, handleSort } = useTableSort<"name" | "last_seen">({
+    defaultField: "last_seen",
+    onSortChange: () => setPage(1),
+  });
   const inFlightRef = useRef(false);
-
-  const handleSort = (field: string) => {
-    const f = field as "name" | "last_seen";
-    if (sortBy === f) {
-      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
-    } else {
-      setSortBy(f);
-      setOrderBy(f === "name" ? "asc" : "desc");
-    }
-    setPage(1);
-  };
 
   // Force the All tab whenever Suggested is empty so a refetch that returns
   // [] doesn't strand the user on a tab that would submit zero choices.

--- a/ui/apps/console/src/components/billing/__tests__/DeviceChooserDialog.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/DeviceChooserDialog.test.tsx
@@ -554,6 +554,25 @@ describe("DeviceChooserDialog", () => {
         expect.objectContaining({ perPage: 5 }),
       );
     });
+
+    it("requests last_seen/desc sort by default", () => {
+      renderDialog();
+      expect(mockUseDevices).toHaveBeenCalledWith(
+        expect.objectContaining({ sortBy: "last_seen", orderBy: "desc" }),
+      );
+    });
+
+    it("toggles sort to name/asc when the Hostname header is clicked", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await user.click(screen.getByRole("tab", { name: "All" }));
+      await user.click(
+        screen.getByRole("button", { name: "Sort by Hostname" }),
+      );
+      const last =
+        mockUseDevices.mock.calls[mockUseDevices.mock.calls.length - 1][0];
+      expect(last).toMatchObject({ sortBy: "name", orderBy: "asc" });
+    });
   });
 
   // ── Tab keyboard navigation ──────────────────────────────────────────────────

--- a/ui/apps/console/src/hooks/useApiKeys.ts
+++ b/ui/apps/console/src/hooks/useApiKeys.ts
@@ -10,10 +10,17 @@ import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 interface UseApiKeysParams {
   page?: number;
   perPage?: number;
+  sortBy?: string;
+  orderBy?: "asc" | "desc";
 }
 
-export function useApiKeys({ page = 1, perPage = 10 }: UseApiKeysParams = {}) {
-  const options = { query: { page, per_page: perPage } } satisfies { query: ApiKeyListData["query"] };
+export function useApiKeys({
+  page = 1,
+  perPage = 10,
+  sortBy = "created_at",
+  orderBy = "desc",
+}: UseApiKeysParams = {}) {
+  const options = { query: { page, per_page: perPage, sort_by: sortBy, order_by: orderBy } } satisfies { query: ApiKeyListData["query"] };
 
   const result = useQuery<PaginatedResult<ApiKey>>({
     queryKey: apiKeyListQueryKey(options),

--- a/ui/apps/console/src/hooks/useContainers.ts
+++ b/ui/apps/console/src/hooks/useContainers.ts
@@ -47,6 +47,8 @@ interface UseContainersParams {
   status?: DeviceStatus | "";
   search?: string;
   filterTags?: string[];
+  sortBy?: string;
+  orderBy?: "asc" | "desc";
 }
 
 export function useContainers({
@@ -55,11 +57,15 @@ export function useContainers({
   status = "",
   search = "",
   filterTags = [],
+  sortBy = "last_seen",
+  orderBy = "desc",
 }: UseContainersParams = {}) {
   const query: GetContainersData["query"] = { page, per_page: perPage };
   if (status) query.status = status;
   if (search || filterTags.length > 0)
     query.filter = buildFilter(search, filterTags);
+  query.sort_by = sortBy;
+  query.order_by = orderBy;
 
   const options = { query };
 

--- a/ui/apps/console/src/hooks/useDevices.ts
+++ b/ui/apps/console/src/hooks/useDevices.ts
@@ -59,6 +59,8 @@ interface UseDevicesParams {
   search?: string;
   filterTags?: string[];
   enabled?: boolean;
+  sortBy?: string;
+  orderBy?: "asc" | "desc";
 }
 
 export function useDevices({
@@ -68,11 +70,15 @@ export function useDevices({
   search = "",
   filterTags = [],
   enabled = true,
+  sortBy = "last_seen",
+  orderBy = "desc",
 }: UseDevicesParams = {}) {
   const query: GetDevicesData["query"] = { page, per_page: perPage };
   if (status) query.status = status;
   if (search || filterTags.length > 0)
     query.filter = buildFilter(search, filterTags);
+  query.sort_by = sortBy;
+  query.order_by = orderBy;
 
   const options = { query };
 

--- a/ui/apps/console/src/hooks/useTableSort.ts
+++ b/ui/apps/console/src/hooks/useTableSort.ts
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+export type SortOrder = "asc" | "desc";
+
+interface UseTableSortOptions<TField extends string> {
+  /** Field selected on first render. */
+  defaultField: TField;
+  /** Order selected on first render. Defaults to "desc". */
+  defaultOrder?: SortOrder;
+  /** Side effect to run after any sort change (e.g. reset pagination to page 1). */
+  onSortChange?: () => void;
+}
+
+export function useTableSort<TField extends string>({
+  defaultField,
+  defaultOrder = "desc",
+  onSortChange,
+}: UseTableSortOptions<TField>) {
+  const [sortBy, setSortBy] = useState<TField>(defaultField);
+  const [orderBy, setOrderBy] = useState<SortOrder>(defaultOrder);
+
+  const handleSort = (field: string) => {
+    const f = field as TField;
+    if (sortBy === f) {
+      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(f);
+      setOrderBy(f === "name" ? "asc" : "desc");
+    }
+    onSortChange?.();
+  };
+
+  return { sortBy, orderBy, handleSort };
+}

--- a/ui/apps/console/src/pages/admin/devices/index.tsx
+++ b/ui/apps/console/src/pages/admin/devices/index.tsx
@@ -14,6 +14,7 @@ import DataTable, { type Column } from "@/components/common/DataTable";
 import SearchField from "@/components/common/fields/SearchField";
 import DistroIcon from "@/components/common/DistroIcon";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useTableSort } from "@/hooks/useTableSort";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatRelative } from "@/utils/date";
 
@@ -58,8 +59,10 @@ export default function AdminDevices() {
   const [searchInput, setSearchInput] = useState("");
   const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
   const [status, setStatus] = useState<DeviceStatus | "">("");
-  const [sortBy, setSortBy] = useState<SortField>("last_seen");
-  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
+  const { sortBy, orderBy, handleSort } = useTableSort<SortField>({
+    defaultField: "last_seen",
+    onSortChange: () => setPage(1),
+  });
 
   const { devices, totalCount, isLoading, error } = useAdminDevices({
     page,
@@ -74,17 +77,6 @@ export default function AdminDevices() {
 
   const handleStatusChange = (newStatus: DeviceStatus | "") => {
     setStatus(newStatus);
-    setPage(1);
-  };
-
-  const handleSort = (field: string) => {
-    const f = field as SortField;
-    if (sortBy === f) {
-      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
-    } else {
-      setSortBy(f);
-      setOrderBy(f === "name" ? "asc" : "desc");
-    }
     setPage(1);
   };
 

--- a/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
+++ b/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
@@ -2,13 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import type { NormalizedDevice } from "@/hooks/useDevices";
+import type { NormalizedContainer } from "@/hooks/useContainers";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
-vi.mock("@/hooks/useDevices", () => ({
-  useDevices: vi.fn(),
-  buildFilter: vi.fn(),
+vi.mock("@/hooks/useContainers", () => ({
+  useContainers: vi.fn(),
 }));
 
 vi.mock("@/hooks/useNamespaces", () => ({
@@ -50,10 +49,6 @@ vi.mock("@/components/common/PageHeader", () => ({
   ),
 }));
 
-vi.mock("@/components/common/PlatformBadge", () => ({
-  default: ({ platform }: { platform: string }) => <span>{platform}</span>,
-}));
-
 vi.mock("@/utils/date", () => ({
   formatRelative: () => "just now",
   formatDateFull: () => "Jan 15, 2024",
@@ -75,14 +70,28 @@ vi.mock("@/components/ConnectDrawer", () => ({
   default: () => <div />,
 }));
 
-vi.mock("../TagsPopover", () => ({
-  default: ({ device }: { device: NormalizedDevice }) => (
-    <span>{device.tags.length > 0 ? device.tags.join(", ") : "No tags"}</span>
+vi.mock("../ContainerTagsPopover", () => ({
+  default: ({ container }: { container: NormalizedContainer }) => (
+    <span>
+      {container.tags.length > 0 ? container.tags.join(", ") : "No tags"}
+    </span>
   ),
 }));
 
-vi.mock("../DeviceActionDialog", () => ({
+vi.mock("../ContainerActionDialog", () => ({
   default: () => <div />,
+}));
+
+vi.mock("../AddDockerConnectorDrawer", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/components/billing/BillingWarning", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/env", () => ({
+  getConfig: () => ({ cloud: false }),
 }));
 
 vi.mock("@/components/common/RestrictedAction", () => ({
@@ -98,31 +107,30 @@ vi.mock("react-router-dom", async (importOriginal) => {
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import React from "react";
-import { useDevices } from "@/hooks/useDevices";
-import Devices from "../index";
+import { useContainers } from "@/hooks/useContainers";
+import Containers from "../index";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const defaultHookState = {
-  devices: [] as NormalizedDevice[],
+  containers: [] as NormalizedContainer[],
   totalCount: 0,
   isLoading: false,
   error: null,
   refetch: vi.fn(),
 };
 
-function makeDevice(
-  overrides: Partial<NormalizedDevice> = {},
-): NormalizedDevice {
+function makeContainer(
+  overrides: Partial<NormalizedContainer> = {},
+): NormalizedContainer {
   return {
-    uid: "device-uid-1",
-    name: "my-device",
+    uid: "container-uid-1",
+    name: "my-container",
     status: "accepted",
     online: true,
     tags: [],
     last_seen: new Date().toISOString(),
     created_at: new Date().toISOString(),
-    identity: { mac: "aa:bb:cc:dd:ee:ff" },
     info: {
       id: "ubuntu",
       pretty_name: "Ubuntu 22.04 LTS",
@@ -130,25 +138,23 @@ function makeDevice(
       platform: "linux",
       version: "0.14.0",
     },
-    remote_addr: "1.2.3.4",
-    custom_fields: {},
     ...overrides,
-  } as NormalizedDevice;
+  } as NormalizedContainer;
 }
 
 function renderPage() {
   return render(
     <MemoryRouter>
-      <Devices />
+      <Containers />
     </MemoryRouter>,
   );
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-describe("Devices list", () => {
+describe("Containers list", () => {
   beforeEach(() => {
-    vi.mocked(useDevices).mockReturnValue(defaultHookState);
+    vi.mocked(useContainers).mockReturnValue(defaultHookState);
     mockNavigate.mockReset();
   });
 
@@ -156,112 +162,39 @@ describe("Devices list", () => {
     it("renders the page heading", () => {
       renderPage();
       expect(
-        screen.getByRole("heading", { name: "Devices" }),
+        screen.getByRole("heading", { name: "Containers" }),
       ).toBeInTheDocument();
-    });
-
-    it("renders all status filter tabs", () => {
-      renderPage();
-      expect(
-        screen.getByRole("button", { name: "Accepted" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Pending" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "Rejected" }),
-      ).toBeInTheDocument();
-    });
-
-    it("renders the search input", () => {
-      renderPage();
-      expect(
-        screen.getByPlaceholderText("Search by hostname..."),
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe("loading state", () => {
-    it("renders the loading message", () => {
-      vi.mocked(useDevices).mockReturnValue({
-        ...defaultHookState,
-        isLoading: true,
-      });
-      renderPage();
-      expect(screen.getByText("Loading devices...")).toBeInTheDocument();
-    });
-  });
-
-  describe("empty state", () => {
-    it('renders "No devices found" when list is empty', () => {
-      renderPage();
-      expect(screen.getByText("No devices found")).toBeInTheDocument();
-    });
-  });
-
-  describe("device rows", () => {
-    it("renders a row for each device", () => {
-      vi.mocked(useDevices).mockReturnValue({
-        ...defaultHookState,
-        devices: [
-          makeDevice({ uid: "uid-1", name: "alpha" }),
-          makeDevice({ uid: "uid-2", name: "beta" }),
-        ],
-        totalCount: 2,
-      });
-      renderPage();
-      expect(screen.getByText("alpha")).toBeInTheDocument();
-      expect(screen.getByText("beta")).toBeInTheDocument();
-    });
-
-    it("navigates to device detail on row click", async () => {
-      const user = userEvent.setup();
-      vi.mocked(useDevices).mockReturnValue({
-        ...defaultHookState,
-        devices: [makeDevice({ uid: "uid-abc", name: "clickable" })],
-        totalCount: 1,
-      });
-      renderPage();
-      await user.click(screen.getByText("clickable"));
-      expect(mockNavigate).toHaveBeenCalledWith("/devices/uid-abc");
-    });
-  });
-
-  describe("error state", () => {
-    it("renders an error message when hook returns an error", () => {
-      vi.mocked(useDevices).mockReturnValue({
-        ...defaultHookState,
-        error: new Error("Request failed"),
-      });
-      renderPage();
-      expect(screen.getByText("Request failed")).toBeInTheDocument();
     });
   });
 
   describe("sorting", () => {
     it("requests last_seen/desc sort by default", () => {
       renderPage();
-      expect(useDevices).toHaveBeenCalledWith(
+      expect(useContainers).toHaveBeenCalledWith(
         expect.objectContaining({ sortBy: "last_seen", orderBy: "desc" }),
       );
     });
 
     it("toggles sort when the Hostname header is clicked", async () => {
       const user = userEvent.setup();
-      vi.mocked(useDevices).mockReturnValue({
+      vi.mocked(useContainers).mockReturnValue({
         ...defaultHookState,
-        devices: [makeDevice({ uid: "uid-1", name: "alpha" })],
+        containers: [makeContainer({ uid: "uid-1", name: "alpha" })],
         totalCount: 1,
       });
       renderPage();
 
-      await user.click(screen.getByRole("button", { name: "Sort by Hostname" }));
-      let calls = vi.mocked(useDevices).mock.calls;
+      await user.click(
+        screen.getByRole("button", { name: "Sort by Hostname" }),
+      );
+      let calls = vi.mocked(useContainers).mock.calls;
       let last = calls[calls.length - 1][0];
       expect(last).toMatchObject({ sortBy: "name", orderBy: "asc" });
 
-      await user.click(screen.getByRole("button", { name: "Sort by Hostname" }));
-      calls = vi.mocked(useDevices).mock.calls;
+      await user.click(
+        screen.getByRole("button", { name: "Sort by Hostname" }),
+      );
+      calls = vi.mocked(useContainers).mock.calls;
       last = calls[calls.length - 1][0];
       expect(last).toMatchObject({ sortBy: "name", orderBy: "desc" });
     });

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -41,6 +41,8 @@ const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
 const VALID_STATUSES = new Set<string>(["accepted", "pending", "rejected"]);
 
+type SortField = "name" | "last_seen";
+
 export default function Containers() {
   const [searchParams] = useSearchParams();
   const initialStatus = searchParams.get("status") ?? "accepted";
@@ -68,6 +70,8 @@ export default function Containers() {
   const [manageTagsOpen, setManageTagsOpen] = useState(false);
   const [addConnectorOpen, setAddConnectorOpen] = useState(false);
   const [billingWarningOpen, setBillingWarningOpen] = useState(false);
+  const [sortBy, setSortBy] = useState<SortField>("last_seen");
+  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
 
   const { containers, totalCount, isLoading, error, refetch } = useContainers({
     page,
@@ -75,6 +79,8 @@ export default function Containers() {
     status,
     search: debouncedSearch,
     filterTags,
+    sortBy,
+    orderBy,
   });
 
   const tenantId = useAuthStore((s) => s.tenant) ?? "";
@@ -86,6 +92,17 @@ export default function Containers() {
 
   const handleStatusChange = (newStatus: DeviceStatus) => {
     setStatus(newStatus);
+    setPage(1);
+  };
+
+  const handleSort = (field: string) => {
+    const f = field as SortField;
+    if (sortBy === f) {
+      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(f);
+      setOrderBy(f === "name" ? "asc" : "desc");
+    }
     setPage(1);
   };
 
@@ -107,8 +124,9 @@ export default function Containers() {
   const columns = useMemo<Column<NormalizedContainer>[]>(() => {
     const baseColumns: Column<NormalizedContainer>[] = [
       {
-        key: "hostname",
+        key: "name",
         header: "Hostname",
+        sortable: true,
         render: (container) => (
           <span className="text-sm font-medium text-text-primary group-hover:text-primary transition-colors">
             {container.name}
@@ -137,6 +155,7 @@ export default function Containers() {
       {
         key: "last_seen",
         header: "Last Seen",
+        sortable: true,
         render: (container) => (
           <span className="text-xs text-text-secondary">
             {formatRelative(container.last_seen)}
@@ -421,6 +440,9 @@ export default function Containers() {
         onRowClick={(container) =>
           void navigate(`/containers/${container.uid}`)
         }
+        sortField={sortBy}
+        sortOrder={orderBy}
+        onSort={handleSort}
         emptyState={
           <div className="text-center">
             <CubeIcon

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useContainers, type NormalizedContainer } from "@/hooks/useContainers";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useTableSort } from "@/hooks/useTableSort";
 import type { DeviceStatus } from "@/client";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useAuthStore } from "@/stores/authStore";
@@ -70,8 +71,10 @@ export default function Containers() {
   const [manageTagsOpen, setManageTagsOpen] = useState(false);
   const [addConnectorOpen, setAddConnectorOpen] = useState(false);
   const [billingWarningOpen, setBillingWarningOpen] = useState(false);
-  const [sortBy, setSortBy] = useState<SortField>("last_seen");
-  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
+  const { sortBy, orderBy, handleSort } = useTableSort<SortField>({
+    defaultField: "last_seen",
+    onSortChange: () => setPage(1),
+  });
 
   const { containers, totalCount, isLoading, error, refetch } = useContainers({
     page,
@@ -92,17 +95,6 @@ export default function Containers() {
 
   const handleStatusChange = (newStatus: DeviceStatus) => {
     setStatus(newStatus);
-    setPage(1);
-  };
-
-  const handleSort = (field: string) => {
-    const f = field as SortField;
-    if (sortBy === f) {
-      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
-    } else {
-      setSortBy(f);
-      setOrderBy(f === "name" ? "asc" : "desc");
-    }
     setPage(1);
   };
 

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -43,6 +43,8 @@ const SEARCH_DEBOUNCE_MS = 300;
 
 const VALID_STATUSES = new Set<string>(["accepted", "pending", "rejected"]);
 
+type SortField = "name" | "last_seen";
+
 export default function Devices() {
   const [searchParams] = useSearchParams();
   const initialStatus = searchParams.get("status") ?? "accepted";
@@ -69,6 +71,8 @@ export default function Devices() {
   } | null>(null);
   const [manageTagsOpen, setManageTagsOpen] = useState(false);
   const [billingWarningOpen, setBillingWarningOpen] = useState(false);
+  const [sortBy, setSortBy] = useState<SortField>("last_seen");
+  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
 
   const { devices, totalCount, isLoading, error, refetch } = useDevices({
     page,
@@ -76,6 +80,8 @@ export default function Devices() {
     status,
     search: debouncedSearch,
     filterTags,
+    sortBy,
+    orderBy,
   });
 
   const tenantId = useAuthStore((s) => s.tenant) ?? "";
@@ -87,6 +93,17 @@ export default function Devices() {
 
   const handleStatusChange = (newStatus: DeviceStatus) => {
     setStatus(newStatus);
+    setPage(1);
+  };
+
+  const handleSort = (field: string) => {
+    const f = field as SortField;
+    if (sortBy === f) {
+      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(f);
+      setOrderBy(f === "name" ? "asc" : "desc");
+    }
     setPage(1);
   };
 
@@ -108,8 +125,9 @@ export default function Devices() {
   const columns = useMemo<Column<NormalizedDevice>[]>(() => {
     const baseColumns: Column<NormalizedDevice>[] = [
       {
-        key: "hostname",
+        key: "name",
         header: "Hostname",
+        sortable: true,
         render: (device) => (
           <span className="text-sm font-medium text-text-primary group-hover:text-primary transition-colors">
             {device.name}
@@ -140,6 +158,7 @@ export default function Devices() {
       {
         key: "last_seen",
         header: "Last Seen",
+        sortable: true,
         render: (device) => <LastSeenCell value={device.last_seen} />,
       },
     ];
@@ -407,6 +426,9 @@ export default function Devices() {
         itemLabel="device"
         onPageChange={setPage}
         onRowClick={(device) => void navigate(`/devices/${device.uid}`)}
+        sortField={sortBy}
+        sortOrder={orderBy}
+        onSort={handleSort}
         emptyState={
           <div className="text-center">
             <CpuChipIcon

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { useDevices, type NormalizedDevice } from "@/hooks/useDevices";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useTableSort } from "@/hooks/useTableSort";
 import type { DeviceStatus } from "@/client";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useAuthStore } from "@/stores/authStore";
@@ -71,8 +72,10 @@ export default function Devices() {
   } | null>(null);
   const [manageTagsOpen, setManageTagsOpen] = useState(false);
   const [billingWarningOpen, setBillingWarningOpen] = useState(false);
-  const [sortBy, setSortBy] = useState<SortField>("last_seen");
-  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
+  const { sortBy, orderBy, handleSort } = useTableSort<SortField>({
+    defaultField: "last_seen",
+    onSortChange: () => setPage(1),
+  });
 
   const { devices, totalCount, isLoading, error, refetch } = useDevices({
     page,
@@ -93,17 +96,6 @@ export default function Devices() {
 
   const handleStatusChange = (newStatus: DeviceStatus) => {
     setStatus(newStatus);
-    setPage(1);
-  };
-
-  const handleSort = (field: string) => {
-    const f = field as SortField;
-    if (sortBy === f) {
-      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
-    } else {
-      setSortBy(f);
-      setOrderBy(f === "name" ? "asc" : "desc");
-    }
     setPage(1);
   };
 

--- a/ui/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -7,6 +7,7 @@ import {
 import { Button, IconButton } from "@shellhub/design-system/primitives";
 import { useApiKeys } from "@/hooks/useApiKeys";
 import { useDeleteApiKey } from "@/hooks/useApiKeyMutations";
+import { useTableSort } from "@/hooks/useTableSort";
 import { type ApiKey } from "@/client";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import DataTable, { type Column } from "@/components/common/DataTable";
@@ -23,24 +24,16 @@ type SortField = "name" | "created_at" | "expires_in";
 
 function ApiKeysTab() {
   const [page, setPage] = useState(1);
-  const [sortBy, setSortBy] = useState<SortField>("created_at");
-  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
+  const { sortBy, orderBy, handleSort } = useTableSort<SortField>({
+    defaultField: "created_at",
+    onSortChange: () => setPage(1),
+  });
   const { apiKeys, totalCount, isLoading } = useApiKeys({
     page,
     sortBy,
     orderBy,
   });
 
-  const handleSort = (field: string) => {
-    const f = field as SortField;
-    if (sortBy === f) {
-      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
-    } else {
-      setSortBy(f);
-      setOrderBy(f === "name" ? "asc" : "desc");
-    }
-    setPage(1);
-  };
   const deleteKey = useDeleteApiKey();
   const [generateOpen, setGenerateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ApiKey | null>(null);

--- a/ui/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -19,9 +19,28 @@ import EditKeyDrawer from "./EditKeyDrawer";
 
 const PER_PAGE = 10;
 
+type SortField = "name" | "created_at" | "expires_in";
+
 function ApiKeysTab() {
   const [page, setPage] = useState(1);
-  const { apiKeys, totalCount, isLoading } = useApiKeys({ page });
+  const [sortBy, setSortBy] = useState<SortField>("created_at");
+  const [orderBy, setOrderBy] = useState<"asc" | "desc">("desc");
+  const { apiKeys, totalCount, isLoading } = useApiKeys({
+    page,
+    sortBy,
+    orderBy,
+  });
+
+  const handleSort = (field: string) => {
+    const f = field as SortField;
+    if (sortBy === f) {
+      setOrderBy((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(f);
+      setOrderBy(f === "name" ? "asc" : "desc");
+    }
+    setPage(1);
+  };
   const deleteKey = useDeleteApiKey();
   const [generateOpen, setGenerateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ApiKey | null>(null);
@@ -53,6 +72,7 @@ function ApiKeysTab() {
     {
       key: "name",
       header: "Name",
+      sortable: true,
       render: (key) => {
         const expired = isExpired(key.expires_in);
         return (
@@ -71,8 +91,9 @@ function ApiKeysTab() {
       render: (key) => <RoleBadge role={key.role} />,
     },
     {
-      key: "created",
+      key: "created_at",
       header: "Created",
+      sortable: true,
       render: (key) => (
         <span className="text-xs text-text-secondary">
           {formatDateShort(key.created_at)}
@@ -80,8 +101,9 @@ function ApiKeysTab() {
       ),
     },
     {
-      key: "expires",
+      key: "expires_in",
       header: "Expires",
+      sortable: true,
       render: (key) => {
         const expired = isExpired(key.expires_in);
         return (
@@ -150,6 +172,9 @@ function ApiKeysTab() {
         page={page}
         totalPages={totalPages}
         onPageChange={setPage}
+        sortField={sortBy}
+        sortOrder={orderBy}
+        onSort={handleSort}
         // border-l-2 on every row (transparent by default) keeps the row
         // height stable when the red border appears on expired keys.
         // No hover darkening here — rows are not clickable.

--- a/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -127,6 +127,30 @@ describe("ApiKeysTab — pagination count display", () => {
   });
 });
 
+describe("ApiKeysTab — sorting", () => {
+  it("requests created_at/desc sort by default", () => {
+    render(<ApiKeysTab />);
+    expect(useApiKeys).toHaveBeenCalledWith(
+      expect.objectContaining({ sortBy: "created_at", orderBy: "desc" }),
+    );
+  });
+
+  it("toggles sort when the Name header is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ApiKeysTab />);
+
+    await user.click(screen.getByRole("button", { name: "Sort by Name" }));
+    let calls = vi.mocked(useApiKeys).mock.calls;
+    let last = calls[calls.length - 1][0];
+    expect(last).toMatchObject({ sortBy: "name", orderBy: "asc" });
+
+    await user.click(screen.getByRole("button", { name: "Sort by Name" }));
+    calls = vi.mocked(useApiKeys).mock.calls;
+    last = calls[calls.length - 1][0];
+    expect(last).toMatchObject({ sortBy: "name", orderBy: "desc" });
+  });
+});
+
 describe("ApiKeysTab — delete error handling", () => {
   async function openDeleteDialog() {
     const user = userEvent.setup();


### PR DESCRIPTION
## What

Adds user-controllable column sorting to four console data-tables whose API endpoints already accept `sort_by`/`order_by`: **Devices**, **Containers**, **API Keys**, and the billing **Device Chooser** ("All Devices" tab). Frontend-only — no backend change.

## Why

These lists rendered a `DataTable` with no sorting, even though the component and the backing endpoints already supported it. Only the admin Devices list was wired up. This brings the user-facing tables in line.

Fixes: shellhub-io/team#165

## Changes

Each table mirrors the existing `admin/devices` pattern — local `sortBy`/`orderBy` state, a `handleSort` toggle (same field flips asc⇄desc; switching field resets direction; every sort resets to page 1), `sortField`/`sortOrder`/`onSort` passed to `DataTable`, and the data hook forwarding `sort_by`/`order_by` to the SDK query.

- **Devices** (`pages/devices`, `hooks/useDevices`): sortable **Hostname** (`name`), **Last Seen** (`last_seen`); default `last_seen` desc.
- **Containers** (`pages/containers`, `hooks/useContainers`): sortable **Hostname** (`name`), **Last Seen** (`last_seen`); default `last_seen` desc.
- **API Keys** (`pages/team/ApiKeysTab`, `hooks/useApiKeys`): sortable **Name** (`name`), **Created** (`created_at`), **Expires** (`expires_in`); default `created_at` desc. Field names match the backend sorter (`api/routes/api-key.go`, `api/services/api-key.go`).
- **Device Chooser** (`components/billing/DeviceChooserDialog`, "All" tab): sortable **Hostname**, **Last Seen**.

Column `key`s were aligned to the backend sort fields (`hostname`→`name`, `created`→`created_at`, `expires`→`expires_in`) because `DataTable` passes the column key as the sort field.

## Testing

TDD (red→green) per table. New/updated test files for all four assert that sortable headers render as controls and that clicking them drives the hook with the expected `sortBy`/`orderBy` and toggles direction.

`cd ui/apps/console && npm run test -- <the four table test files>` → 72 pass; `tsc --noEmit` and `eslint` clean.

Non-sortable derived columns (tags, online indicator, role) are intentionally left non-sortable. Tables whose endpoints lack sort params (Sessions, Firewall Rules, Public Keys, several admin lists) are out of scope and tracked separately in shellhub-io/team#165.