### PR TITLE
fix(ui): show Admin Console link for admins in cloud mode

### DIFF
--- a/ui/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -9,7 +9,7 @@ import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
 import { useAuthStore } from "@/stores/authStore";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import { getInitials } from "@/utils/string";
-import { getConfig } from "@/env";
+import { isPremiumFeature } from "@/utils/features";
 import CreateNamespaceDialog from "../common/CreateNamespaceDialog";
 import { useNavigate } from "react-router-dom";
 
@@ -35,17 +35,11 @@ export default function NamespaceSelector({
 
   useClickOutside(containerRef, () => setOpen(false));
 
-  const showAdminLink
-    = !isAdminContext
-      && getConfig().enterprise
-      && !getConfig().cloud
-      && isAdmin;
+  const showAdminLink = !isAdminContext && isPremiumFeature() && isAdmin;
 
   const availableNamespaces = isAdminContext
     ? namespaces
-    : namespaces.filter(
-      (ns) => ns.tenant_id !== currentNamespace?.tenant_id,
-    );
+    : namespaces.filter((ns) => ns.tenant_id !== currentNamespace?.tenant_id);
 
   const handleSwitch = async (id: string) => {
     setOpen(false);
@@ -65,34 +59,34 @@ export default function NamespaceSelector({
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        aria-label={isAdminContext ? "Admin Console" : currentNamespace?.name ?? "Select Namespace"}
+        aria-label={
+          isAdminContext
+            ? "Admin Console"
+            : (currentNamespace?.name ?? "Select Namespace")
+        }
         aria-haspopup="true"
         aria-expanded={open}
         className="flex items-center gap-2.5 h-9 px-3 rounded-md border border-transparent hover:border-border hover:bg-hover-subtle transition-all duration-150"
       >
-        {isAdminContext
-          ? (
-            <>
-              <ShieldCheckIcon className="w-5 h-5 text-accent-red" />
-              <span className="hidden md:inline text-sm font-medium text-text-primary">
-                Admin Console
-              </span>
-            </>
-          )
-          : currentNamespace
-            ? (
-              <>
-                <span className="w-6 h-6 rounded bg-primary/15 border border-primary/20 flex items-center justify-center text-primary text-2xs font-bold font-mono">
-                  {getInitials(currentNamespace.name)}
-                </span>
-                <span className="hidden md:inline text-sm font-medium text-text-primary max-w-[180px] truncate">
-                  {currentNamespace.name}
-                </span>
-              </>
-            )
-            : (
-              <span className="text-sm text-text-muted italic">No namespace</span>
-            )}
+        {isAdminContext ? (
+          <>
+            <ShieldCheckIcon className="w-5 h-5 text-accent-red" />
+            <span className="hidden md:inline text-sm font-medium text-text-primary">
+              Admin Console
+            </span>
+          </>
+        ) : currentNamespace ? (
+          <>
+            <span className="w-6 h-6 rounded bg-primary/15 border border-primary/20 flex items-center justify-center text-primary text-2xs font-bold font-mono">
+              {getInitials(currentNamespace.name)}
+            </span>
+            <span className="hidden md:inline text-sm font-medium text-text-primary max-w-[180px] truncate">
+              {currentNamespace.name}
+            </span>
+          </>
+        ) : (
+          <span className="text-sm text-text-muted italic">No namespace</span>
+        )}
         <ChevronDownIcon
           className={`w-3 h-3 text-text-muted transition-transform duration-200 ${open ? "rotate-180" : ""}`}
           strokeWidth={2.5}
@@ -166,9 +160,7 @@ export default function NamespaceSelector({
                       {ns.name}
                     </p>
                     <p className="text-2xs font-mono text-text-muted truncate">
-                      {ns.devices_accepted_count}
-                      {" "}
-                      device
+                      {ns.devices_accepted_count} device
                       {ns.devices_accepted_count !== 1 ? "s" : ""}
                     </p>
                   </div>
@@ -177,13 +169,17 @@ export default function NamespaceSelector({
             </div>
           )}
 
-          {availableNamespaces.length === 0 && !isAdminContext && !currentNamespace && (
-            <div className="p-6 text-center">
-              <p className="text-xs text-text-muted">No namespaces available</p>
-            </div>
-          )}
+          {availableNamespaces.length === 0 &&
+            !isAdminContext &&
+            !currentNamespace && (
+              <div className="p-6 text-center">
+                <p className="text-xs text-text-muted">
+                  No namespaces available
+                </p>
+              </div>
+            )}
 
-          {/* Admin Console link (non-admin context, enterprise admins) */}
+          {/* Admin Console link (non-admin context, enterprise or cloud admins) */}
           {showAdminLink && (
             <div className="p-2 border-t border-border">
               <button

--- a/ui/apps/console/src/components/layout/__tests__/NamespaceSelector.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/NamespaceSelector.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAuthStore } from "@/stores/authStore";
+import { defaultConfig } from "@/env";
+import NamespaceSelector from "../NamespaceSelector";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockGetConfig = vi.fn();
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: (): unknown => mockGetConfig() };
+});
+
+vi.mock("@/hooks/useNamespaces", () => ({
+  useNamespaces: () => ({
+    namespaces: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useNamespace: () => ({
+    namespace: null,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useInitRole: () => {},
+}));
+
+vi.mock("@/hooks/useNamespaceMutations", () => ({
+  useSwitchNamespace: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/components/common/CreateNamespaceDialog", () => ({
+  default: () => null,
+}));
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderSelector(isAdminContext = false) {
+  return render(<NamespaceSelector isAdminContext={isAdminContext} />, {
+    wrapper: createWrapper(),
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup / teardown                                                    */
+/* ------------------------------------------------------------------ */
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockReturnValue({ ...defaultConfig });
+  useAuthStore.setState({
+    token: "test-token",
+    user: "alice",
+    userId: "user-1",
+    email: "alice@example.com",
+    tenant: "t1",
+    role: "owner",
+    name: "Alice",
+    isAdmin: false,
+    loading: false,
+  });
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("NamespaceSelector", () => {
+  describe("showAdminLink", () => {
+    // Case 1 — enterprise=true and cloud=true: link must appear and navigate to /admin.
+    it("shows Admin Console link when enterprise=true, cloud=true, isAdmin=true, isAdminContext=false", async () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        enterprise: true,
+        cloud: true,
+      });
+      useAuthStore.setState({ tenant: "t1", isAdmin: true });
+      renderSelector(false);
+      await userEvent.click(
+        screen.getByRole("button", { name: /select namespace/i }),
+      );
+      const adminLink = screen.getByRole("button", { name: /admin console/i });
+      expect(adminLink).toBeInTheDocument();
+      await userEvent.click(adminLink);
+      expect(mockNavigate).toHaveBeenCalledWith("/admin");
+    });
+
+    // Case 2 — already passes with current logic (enterprise=true, cloud=false).
+    it("shows Admin Console link when enterprise=true, cloud=false, isAdmin=true, isAdminContext=false", async () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        enterprise: true,
+        cloud: false,
+      });
+      useAuthStore.setState({ tenant: "t1", isAdmin: true });
+      renderSelector(false);
+      await userEvent.click(
+        screen.getByRole("button", { name: /select namespace/i }),
+      );
+      const adminLink = screen.getByRole("button", { name: /admin console/i });
+      expect(adminLink).toBeInTheDocument();
+      await userEvent.click(adminLink);
+      expect(mockNavigate).toHaveBeenCalledWith("/admin");
+    });
+
+    // Case 7 — cloud-only admin: the key case this fix enables.
+    // cloud=true, enterprise=false → admin link must appear and navigate to /admin.
+    it("shows Admin Console link when cloud=true, enterprise=false, isAdmin=true, isAdminContext=false", async () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        enterprise: false,
+        cloud: true,
+      });
+      useAuthStore.setState({ tenant: "t1", isAdmin: true });
+      renderSelector(false);
+      await userEvent.click(
+        screen.getByRole("button", { name: /select namespace/i }),
+      );
+      const adminLink = screen.getByRole("button", { name: /admin console/i });
+      expect(adminLink).toBeInTheDocument();
+      await userEvent.click(adminLink);
+      expect(mockNavigate).toHaveBeenCalledWith("/admin");
+    });
+
+    // Case 3 — community instance (no enterprise, no cloud): link must be absent.
+    it("hides Admin Console link when enterprise=false, cloud=false, isAdmin=true, isAdminContext=false", async () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        enterprise: false,
+        cloud: false,
+      });
+      useAuthStore.setState({ tenant: "t1", isAdmin: true });
+      renderSelector(false);
+      await userEvent.click(
+        screen.getByRole("button", { name: /select namespace/i }),
+      );
+      // Confirm the dropdown opened before asserting the link is absent.
+      expect(screen.getByText("No namespaces available")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /admin console/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    // Case 4 — non-admin user on enterprise: link must be absent.
+    it("hides Admin Console link when enterprise=true, cloud=false, isAdmin=false, isAdminContext=false", async () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        enterprise: true,
+        cloud: false,
+      });
+      useAuthStore.setState({ tenant: "t1", isAdmin: false });
+      renderSelector(false);
+      await userEvent.click(
+        screen.getByRole("button", { name: /select namespace/i }),
+      );
+      // Confirm the dropdown opened before asserting the link is absent.
+      expect(screen.getByText("No namespaces available")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /admin console/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    // Case 5 — already inside admin context: showAdminLink must be false
+    // because !isAdminContext short-circuits before enterprise/cloud.
+    // The trigger is labeled "Admin Console" when isAdminContext=true; the dropdown
+    // shows an "Admin Console" header (a <p>), but NOT the footer link button.
+    it("hides Admin Console link when enterprise=true, cloud=true, isAdmin=true, isAdminContext=true", async () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        enterprise: true,
+        cloud: true,
+      });
+      useAuthStore.setState({ tenant: "t1", isAdmin: true });
+      renderSelector(true);
+      await userEvent.click(
+        screen.getByRole("button", { name: /^admin console$/i }),
+      );
+      // Confirm the dropdown opened — the admin context header subtitle is visible.
+      expect(screen.getByText("Super Admin · Instance")).toBeInTheDocument();
+      // The footer link button (accessible name includes "Super Admin") must not render
+      // in admin context — !isAdminContext suppresses showAdminLink.
+      expect(
+        screen.queryByRole("button", { name: /super admin/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    // Case 6 — cloud=true but non-admin user: isAdmin=false means link must be absent.
+    it("hides Admin Console link when enterprise=false, cloud=true, isAdmin=false, isAdminContext=false", async () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        enterprise: false,
+        cloud: true,
+      });
+      useAuthStore.setState({ tenant: "t1", isAdmin: false });
+      renderSelector(false);
+      await userEvent.click(
+        screen.getByRole("button", { name: /select namespace/i }),
+      );
+      // Confirm the dropdown opened before asserting the link is absent.
+      expect(screen.getByText("No namespaces available")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /admin console/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## What

Make the Admin Console link in the namespace selector visible to admin users in cloud deployments, not just enterprise ones.

## Why

The link was gated on `enterprise && !cloud`, so it never appeared in cloud — even though cloud always implies enterprise (`SHELLHUB_CLOUD=true` requires `SHELLHUB_ENTERPRISE=true`) and the admin backend (`/admin/api/*`) is fully registered there. The `!cloud` term was written as if cloud and enterprise were mutually exclusive; they are not. Enterprise dev (`enterprise=true`, `cloud` unset) showed the link, cloud (both true) hid it — the reported "enterprise works, cloud doesn't" symptom.

## Changes

- **ui/NamespaceSelector**: gate `showAdminLink` on `isPremiumFeature()` (`cloud || enterprise`) instead of `enterprise && !cloud`. Reuses the existing helper and covers the case where a cloud config serves `cloud:true, enterprise:false`, since the two flags are independent in `ClientConfig`. Still hidden in community (both false) and in admin context.
- **ui/NamespaceSelector.test**: new suite covering the `enterprise × cloud × isAdmin × isAdminContext` matrix, including the previously-broken cloud-admin case and the cloud-only-admin case.

Scope is intentionally limited to making the link visible. A follow-up PR will handle the admin/license flow for cloud (clicking through to `/admin` under `LicenseGuard`), which this change newly exposes.

## Testing

`NamespaceSelector.test.tsx` — 7 cases, all green; lint clean.