### PR TITLE
feat(ui): wrap route Outlets with ErrorBoundary

### DIFF
--- a/ui/apps/console/src/components/common/AdminRoute.tsx
+++ b/ui/apps/console/src/components/common/AdminRoute.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Outlet, Navigate } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
 import { Spinner } from "@shellhub/design-system/primitives";
+import ErrorBoundary from "./ErrorBoundary";
 
 export default function AdminRoute() {
   const fetchUser = useAuthStore((s) => s.fetchUser);
@@ -24,5 +25,9 @@ export default function AdminRoute() {
     return <Navigate to="/admin/unauthorized" replace />;
   }
 
-  return <Outlet />;
+  return (
+    <ErrorBoundary>
+      <Outlet />
+    </ErrorBoundary>
+  );
 }

--- a/ui/apps/console/src/components/common/ProtectedRoute.tsx
+++ b/ui/apps/console/src/components/common/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Outlet, Navigate } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
+import ErrorBoundary from "./ErrorBoundary";
 
 export default function ProtectedRoute() {
   const token = useAuthStore((s) => s.token);
@@ -8,5 +9,9 @@ export default function ProtectedRoute() {
     return <Navigate to="/login" replace />;
   }
 
-  return <Outlet />;
+  return (
+    <ErrorBoundary>
+      <Outlet />
+    </ErrorBoundary>
+  );
 }


### PR DESCRIPTION
## What
Wrap the rendered `<Outlet />` in `ProtectedRoute` and `AdminRoute` with the
existing `ErrorBoundary`, so an unhandled render error inside a route subtree
is caught at the route level instead of relying solely on the root boundary.

## Why
Part of the ErrorBoundary placement strategy (tracked by shellhub-io/team#154).
The root boundary in `main.tsx` already existed, but the route guards rendered
`<Outlet />` bare — a crash in protected or admin content had no closer
boundary. Fixes: shellhub-io/team#139.

## Changes
- **ui/ProtectedRoute**: wrap `<Outlet />` in `<ErrorBoundary>`.
- **ui/AdminRoute**: wrap `<Outlet />` in `<ErrorBoundary>`.

No change to `ErrorBoundary` itself or to the root boundary in `main.tsx`,
which was already in place.

## Notes
`ErrorBoundary` is a class boundary with no reset logic, so a crashed route
shows the full-screen fallback until reload; it does not self-recover on
navigation. This matches the component's existing behavior elsewhere.