### PR TITLE
fix(ui): bypass admin license gating in cloud deployments

### DIFF
--- a/ui/apps/console/src/App.tsx
+++ b/ui/apps/console/src/App.tsx
@@ -116,7 +116,16 @@ export default function App() {
                   element={<AdminUnauthorized />}
                 />
                 <Route element={<AdminRoute />}>
-                  <Route path="/admin/license" element={<AdminLicense />} />
+                  <Route
+                    path="/admin/license"
+                    element={
+                      getConfig().cloud ? (
+                        <Navigate to="/admin/dashboard" replace />
+                      ) : (
+                        <AdminLicense />
+                      )
+                    }
+                  />
                   <Route element={<LicenseGuard />}>
                     <Route
                       path="/admin"
@@ -197,33 +206,36 @@ export default function App() {
                   <Route path="/devices/add" element={<AddDevice />} />
                   <Route path="/devices/:uid" element={<DeviceDetails />} />
                   <Route path="/containers" element={<Containers />} />
-                  <Route path="/containers/:uid" element={<ContainerDetails />} />
+                  <Route
+                    path="/containers/:uid"
+                    element={<ContainerDetails />}
+                  />
                   <Route path="/sessions" element={<Sessions />} />
                   <Route path="/sessions/:uid" element={<SessionDetails />} />
                   <Route path="/sshkeys/public-keys" element={<PublicKeys />} />
                   <Route path="/secure-vault" element={<SecureVault />} />
                   <Route
                     path="/firewall-rules"
-                    element={(
+                    element={
                       <FeatureGate
                         feature="Firewall Rules"
                         description="Control SSH connections to your devices with allow and deny rules evaluated by priority."
                       >
                         <FirewallRules />
                       </FeatureGate>
-                    )}
+                    }
                   />
                   {getConfig().webEndpoints && (
                     <Route
                       path="/web-endpoints"
-                      element={(
+                      element={
                         <FeatureGate
                           feature="Web Endpoints"
                           description="Tunnel HTTP traffic to services running on your devices through unique URLs."
                         >
                           <WebEndpoints />
                         </FeatureGate>
-                      )}
+                      }
                     />
                   )}
                   <Route path="/team" element={<Team />} />

--- a/ui/apps/console/src/components/common/LicenseGuard.tsx
+++ b/ui/apps/console/src/components/common/LicenseGuard.tsx
@@ -3,17 +3,13 @@ import { useAdminLicense } from "@/hooks/useAdminLicense";
 import PageLoader from "@/components/common/PageLoader";
 
 export default function LicenseGuard() {
-  const { data: license, isLoading, isError } = useAdminLicense();
+  const { isLoading, isError, isExpired } = useAdminLicense();
 
   if (isLoading) {
     return <PageLoader label="Checking license..." showLabel padding="fill" />;
   }
 
-  const installedLicense =
-    license && "grace_period" in license ? license : null;
-
-  // Expired, missing, or error -> redirect to license page
-  if (isError || !installedLicense || installedLicense.expired) {
+  if (isError || isExpired) {
     return <Navigate to="/admin/license" replace />;
   }
 

--- a/ui/apps/console/src/components/common/__tests__/DeviceLimitBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/DeviceLimitBanner.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
-import type { UseQueryResult } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { GetLicenseResponse } from "@/client/types.gen";
+import { defaultConfig } from "@/env";
+import { useAuthStore } from "@/stores/authStore";
 
 // ── Dependency mocks ──────────────────────────────────────────────────────────
 
@@ -13,14 +15,39 @@ vi.mock("@/hooks/useAdminStats", () => ({
   useAdminStats: vi.fn(),
 }));
 
+// These mocks are used by the real useAdminLicense in the cloud integration case.
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
+
+vi.mock("@/client", () => ({
+  getLicense: vi.fn(),
+}));
+
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
+  getLicenseQueryKey: vi.fn(() => ["getLicense"]),
+}));
+
+vi.mock("@/api/errors", () => ({
+  isSdkError: vi.fn(
+    (err: unknown): err is { status: number } =>
+      typeof err === "object" && err !== null && "status" in err,
+  ),
+}));
+
 import { useAdminLicense } from "@/hooks/useAdminLicense";
 import { useAdminStats } from "@/hooks/useAdminStats";
+import { getConfig } from "@/env";
+import { getLicense } from "@/client";
 import DeviceLimitBanner from "../DeviceLimitBanner";
 
 // ── Typed mocks ───────────────────────────────────────────────────────────────
 
 const mockUseAdminLicense = vi.mocked(useAdminLicense);
 const mockUseAdminStats = vi.mocked(useAdminStats);
+const mockGetConfig = vi.mocked(getConfig);
+const mockGetLicense = vi.mocked(getLicense);
 
 type LicenseData = GetLicenseResponse | null;
 
@@ -36,9 +63,11 @@ function makeLicenseQueryResult(
     data: undefined,
     isLoading: false,
     isError: false,
+    isExpired: false,
+    installedLicense: null,
     dataUpdatedAt: Date.now(),
     ...overrides,
-  } as unknown as UseQueryResult<LicenseData, Error>;
+  } as unknown as ReturnType<typeof useAdminLicense>;
 }
 
 function makeStatsResult(
@@ -87,6 +116,8 @@ function makeLicense(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: enterprise non-cloud config
+  mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: false });
   // Default: admin with a license allowing 100 devices
   mockUseAdminLicense.mockReturnValue(
     makeLicenseQueryResult({ data: makeLicense(100) }),
@@ -278,6 +309,45 @@ describe("DeviceLimitBanner", () => {
       render(<DeviceLimitBanner />);
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("cloud deployment", () => {
+    it("is hidden when cloud=true and admin=true (banner suppressed, getLicense never fires)", async () => {
+      // Do NOT mock useAdminLicense for this test: restore the real implementation
+      // to verify the cloud bypass path end-to-end through DeviceLimitBanner.
+      // When cloud=true the query is disabled, data stays undefined, and the banner
+      // must stay hidden regardless of getLicense responses.
+      const { useAdminLicense: real } = await vi.importActual<
+        typeof import("@/hooks/useAdminLicense")
+      >("@/hooks/useAdminLicense");
+      mockUseAdminLicense.mockImplementation(real);
+
+      mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+      useAuthStore.setState({ isAdmin: true } as never);
+      // getLicense must never fire on cloud deployments.
+      mockGetLicense.mockRejectedValue({ status: 400 });
+
+      // useAdminStats is still mocked from beforeEach; stats are irrelevant here
+      // because the license guard (license != null) will suppress the banner first.
+
+      render(
+        <QueryClientProvider
+          client={
+            new QueryClient({
+              defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+            })
+          }
+        >
+          <DeviceLimitBanner />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      });
+      expect(mockGetLicense).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
-import type { UseQueryResult } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { GetLicenseResponse } from "@/client/types.gen";
+import { defaultConfig } from "@/env";
+import { useAuthStore } from "@/stores/authStore";
 
 // ── Dependency mocks ──────────────────────────────────────────────────────────
 
@@ -9,12 +11,37 @@ vi.mock("@/hooks/useAdminLicense", () => ({
   useAdminLicense: vi.fn(),
 }));
 
+// These mocks are used by the real useAdminLicense in the cloud integration case.
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
+
+vi.mock("@/client", () => ({
+  getLicense: vi.fn(),
+}));
+
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
+  getLicenseQueryKey: vi.fn(() => ["getLicense"]),
+}));
+
+vi.mock("@/api/errors", () => ({
+  isSdkError: vi.fn(
+    (err: unknown): err is { status: number } =>
+      typeof err === "object" && err !== null && "status" in err,
+  ),
+}));
+
 import { useAdminLicense } from "@/hooks/useAdminLicense";
+import { getConfig } from "@/env";
+import { getLicense } from "@/client";
 import LicenseBanner from "../LicenseBanner";
 
 // ── Typed mocks ───────────────────────────────────────────────────────────────
 
 const mockUseAdminLicense = vi.mocked(useAdminLicense);
+const mockGetConfig = vi.mocked(getConfig);
+const mockGetLicense = vi.mocked(getLicense);
 
 type LicenseData = GetLicenseResponse | null;
 
@@ -30,9 +57,11 @@ function makeQueryResult(
     data: undefined,
     isLoading: false,
     isError: false,
+    isExpired: false,
+    installedLicense: null,
     dataUpdatedAt: Date.now(),
     ...overrides,
-  } as unknown as UseQueryResult<LicenseData, Error>;
+  } as unknown as ReturnType<typeof useAdminLicense>;
 }
 
 function makeLicense(
@@ -63,6 +92,8 @@ function makeLicense(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: enterprise non-cloud config
+  mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: false });
   // Default: admin with no license installed
   mockUseAdminLicense.mockReturnValue(makeQueryResult({ data: null }));
 });
@@ -309,6 +340,42 @@ describe("LicenseBanner", () => {
       render(<LicenseBanner />);
       expect(screen.queryByRole("link")).not.toBeInTheDocument();
       expect(screen.queryByText(/upload license/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("cloud deployment", () => {
+    it("is hidden when cloud=true and admin=true (banner suppressed, getLicense never fires)", async () => {
+      // Do NOT mock useAdminLicense for this test: restore the real implementation
+      // to verify the cloud bypass path end-to-end through LicenseBanner.
+      // When cloud=true the query is disabled, data stays undefined, and the banner
+      // must stay hidden regardless of getLicense responses.
+      const { useAdminLicense: real } = await vi.importActual<
+        typeof import("@/hooks/useAdminLicense")
+      >("@/hooks/useAdminLicense");
+      mockUseAdminLicense.mockImplementation(real);
+
+      mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+      useAuthStore.setState({ isAdmin: true } as never);
+      // getLicense must never fire on cloud deployments.
+      mockGetLicense.mockRejectedValue({ status: 400 });
+
+      render(
+        <QueryClientProvider
+          client={
+            new QueryClient({
+              defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+            })
+          }
+        >
+          <LicenseBanner />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+        expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      });
+      expect(mockGetLicense).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/apps/console/src/components/common/__tests__/LicenseGuard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/LicenseGuard.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { defaultConfig } from "@/env";
+import { useAuthStore } from "@/stores/authStore";
+import type { GetLicenseResponse } from "@/client/types.gen";
+
+// ── Dependency mocks ──────────────────────────────────────────────────────────
+
+vi.mock("@/hooks/useAdminLicense", () => ({
+  useAdminLicense: vi.fn(),
+}));
+
+// These mocks are used by the real useAdminLicense in the cloud integration case.
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
+
+vi.mock("@/client", () => ({
+  getLicense: vi.fn(),
+}));
+
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
+  getLicenseQueryKey: vi.fn(() => ["getLicense"]),
+}));
+
+vi.mock("@/api/errors", () => ({
+  isSdkError: vi.fn(
+    (err: unknown): err is { status: number } =>
+      typeof err === "object" && err !== null && "status" in err,
+  ),
+}));
+
+import { useAdminLicense } from "@/hooks/useAdminLicense";
+import { getConfig } from "@/env";
+import { getLicense } from "@/client";
+import LicenseGuard from "../LicenseGuard";
+
+// ── Typed mocks ───────────────────────────────────────────────────────────────
+
+const mockUseAdminLicense = vi.mocked(useAdminLicense);
+const mockGetConfig = vi.mocked(getConfig);
+const mockGetLicense = vi.mocked(getLicense);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type LicenseData = GetLicenseResponse | null;
+
+function makeLicense(
+  overrides: Partial<GetLicenseResponse> = {},
+): GetLicenseResponse {
+  return {
+    expired: false,
+    grace_period: false,
+    about_to_expire: false,
+    expires_at: 9999999999,
+    issued_at: 0,
+    starts_at: 0,
+    allowed_regions: [],
+    customer: { id: "c1", name: "Acme", email: "a@b.com", company: "Acme" },
+    features: {
+      devices: -1,
+      session_recording: true,
+      firewall_rules: true,
+      billing: false,
+      login_link: false,
+      reports: false,
+    },
+    ...overrides,
+  } as GetLicenseResponse;
+}
+
+type HookReturn = ReturnType<typeof useAdminLicense>;
+
+function makeHookReturn(
+  overrides: {
+    isLoading?: boolean;
+    isError?: boolean;
+    isExpired?: boolean;
+    data?: LicenseData;
+  } = {},
+): HookReturn {
+  return {
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    isExpired: false,
+    installedLicense: null,
+    ...overrides,
+  } as unknown as HookReturn;
+}
+
+function createQueryWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+function renderGuard(
+  Wrapper?: React.ComponentType<{ children: React.ReactNode }>,
+) {
+  const ui = (
+    <MemoryRouter initialEntries={["/admin/dashboard"]}>
+      <Routes>
+        <Route element={<LicenseGuard />}>
+          <Route
+            path="/admin/dashboard"
+            element={<div>protected content</div>}
+          />
+        </Route>
+        <Route path="/admin/license" element={<div>license page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+  return render(Wrapper ? <Wrapper>{ui}</Wrapper> : ui);
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: false });
+  mockUseAdminLicense.mockReturnValue(makeHookReturn());
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("LicenseGuard", () => {
+  describe("isLoading — shows PageLoader", () => {
+    it("renders a loading indicator while the license check is in progress", () => {
+      mockUseAdminLicense.mockReturnValue(makeHookReturn({ isLoading: true }));
+      renderGuard();
+      expect(screen.getByText("Checking license...")).toBeInTheDocument();
+      expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+    });
+
+    it("does not render the Outlet while loading", () => {
+      mockUseAdminLicense.mockReturnValue(makeHookReturn({ isLoading: true }));
+      renderGuard();
+      expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("isError — redirects to /admin/license", () => {
+    it("navigates to the license page when the query errors", () => {
+      mockUseAdminLicense.mockReturnValue(makeHookReturn({ isError: true }));
+      renderGuard();
+      expect(screen.getByText("license page")).toBeInTheDocument();
+      expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("isExpired — redirects to /admin/license", () => {
+    it("navigates to the license page when the hook reports the license is expired", () => {
+      // data contains a technically valid (unexpired) license, but the hook has
+      // already derived isExpired=true (e.g. grace_period scenario).
+      // The current component re-derives expiry locally from data and renders
+      // the Outlet instead of redirecting — this test documents the desired behavior.
+      mockUseAdminLicense.mockReturnValue(
+        makeHookReturn({
+          isExpired: true,
+          data: makeLicense({ expired: false, grace_period: false }),
+        }),
+      );
+      renderGuard();
+      expect(screen.getByText("license page")).toBeInTheDocument();
+      expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("valid license — renders Outlet", () => {
+    it("renders the child route when all flags are false", () => {
+      mockUseAdminLicense.mockReturnValue(
+        makeHookReturn({ data: makeLicense() }),
+      );
+      renderGuard();
+      expect(screen.getByText("protected content")).toBeInTheDocument();
+      expect(screen.queryByText("license page")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("cloud real-hook path", () => {
+    it("renders the Outlet without calling getLicense when cloud=true and admin=true", async () => {
+      // Do NOT mock useAdminLicense for this test: restore the real implementation
+      // to verify the cloud bypass path end-to-end through LicenseGuard.
+      // When cloud=true the query is disabled, so getLicense must never fire,
+      // isExpired stays false, and the guard must pass through to the Outlet.
+      const { useAdminLicense: real } = await vi.importActual<
+        typeof import("@/hooks/useAdminLicense")
+      >("@/hooks/useAdminLicense");
+      mockUseAdminLicense.mockImplementation(real);
+
+      mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+      useAuthStore.setState({ isAdmin: true } as never);
+      // getLicense must never fire on cloud deployments.
+      mockGetLicense.mockRejectedValue({ status: 400 });
+
+      renderGuard(createQueryWrapper());
+
+      await waitFor(() => {
+        expect(screen.getByText("protected content")).toBeInTheDocument();
+      });
+      expect(mockGetLicense).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/apps/console/src/components/layout/AdminSidebar.tsx
+++ b/ui/apps/console/src/components/layout/AdminSidebar.tsx
@@ -17,7 +17,12 @@ import type { ReactNode } from "react";
 import { getConfig } from "@/env";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
 import { useAuthStore } from "@/stores/authStore";
-import SidebarShell, { NavItemLink, navBase, navDisabled, navIcon } from "./SidebarShell";
+import SidebarShell, {
+  NavItemLink,
+  navBase,
+  navDisabled,
+  navIcon,
+} from "./SidebarShell";
 
 // ---- Types ----
 
@@ -42,12 +47,36 @@ function isNavGroup(entry: NavEntry): entry is NavGroup {
 // ---- Nav definition ----
 
 const coreNavEntries: NavEntry[] = [
-  { to: "/admin/dashboard", label: "Dashboard", icon: <HomeIcon className={navIcon} /> },
-  { to: "/admin/users", label: "Users", icon: <UsersIcon className={navIcon} /> },
-  { to: "/admin/devices", label: "Devices", icon: <CpuChipIcon className={navIcon} /> },
-  { to: "/admin/sessions", label: "Sessions", icon: <CommandLineIcon className={navIcon} /> },
-  { to: "/admin/firewall-rules", label: "Firewall Rules", icon: <ShieldCheckIcon className={navIcon} /> },
-  { to: "/admin/namespaces", label: "Namespaces", icon: <ServerStackIcon className={navIcon} /> },
+  {
+    to: "/admin/dashboard",
+    label: "Dashboard",
+    icon: <HomeIcon className={navIcon} />,
+  },
+  {
+    to: "/admin/users",
+    label: "Users",
+    icon: <UsersIcon className={navIcon} />,
+  },
+  {
+    to: "/admin/devices",
+    label: "Devices",
+    icon: <CpuChipIcon className={navIcon} />,
+  },
+  {
+    to: "/admin/sessions",
+    label: "Sessions",
+    icon: <CommandLineIcon className={navIcon} />,
+  },
+  {
+    to: "/admin/firewall-rules",
+    label: "Firewall Rules",
+    icon: <ShieldCheckIcon className={navIcon} />,
+  },
+  {
+    to: "/admin/namespaces",
+    label: "Namespaces",
+    icon: <ServerStackIcon className={navIcon} />,
+  },
 ];
 
 const announcementsEntry: NavEntry = {
@@ -60,8 +89,16 @@ const settingsGroup: NavGroup = {
   label: "Settings",
   icon: <Cog6ToothIcon className={navIcon} />,
   children: [
-    { to: "/admin/settings/authentication", label: "Authentication", icon: <KeyIcon className={navIcon} /> },
-    { to: "/admin/license", label: "License", icon: <DocumentCheckIcon className={navIcon} /> },
+    {
+      to: "/admin/settings/authentication",
+      label: "Authentication",
+      icon: <KeyIcon className={navIcon} />,
+    },
+    {
+      to: "/admin/license",
+      label: "License",
+      icon: <DocumentCheckIcon className={navIcon} />,
+    },
   ],
 };
 
@@ -70,7 +107,11 @@ const expiredNavEntries: NavEntry[] = [
     label: "Settings",
     icon: <Cog6ToothIcon className={navIcon} />,
     children: [
-      { to: "/admin/license", label: "License", icon: <DocumentCheckIcon className={navIcon} /> },
+      {
+        to: "/admin/license",
+        label: "License",
+        icon: <DocumentCheckIcon className={navIcon} />,
+      },
     ],
   },
 ];
@@ -82,7 +123,16 @@ function buildNavEntries(): NavEntry[] {
     entries.push(announcementsEntry);
   }
 
-  entries.push(settingsGroup);
+  const settings = getConfig().cloud
+    ? {
+        ...settingsGroup,
+        children: settingsGroup.children.filter(
+          (c) => c.to !== "/admin/license",
+        ),
+      }
+    : settingsGroup;
+  entries.push(settings);
+
   return entries;
 }
 
@@ -105,9 +155,8 @@ function NavGroupItem({
   currentPath: string;
   onNavClick?: () => void;
 }) {
-  const isChildActive = !disabled && group.children.some((c) =>
-    currentPath.startsWith(c.to),
-  );
+  const isChildActive =
+    !disabled && group.children.some((c) => currentPath.startsWith(c.to));
   const align = expanded ? "" : "justify-center";
 
   return (
@@ -153,7 +202,8 @@ function NavGroupItem({
                   isActive
                     ? "text-primary bg-primary/5"
                     : "text-text-secondary hover:text-text-primary hover:bg-hover-subtle"
-                }`}
+                }`
+              }
             >
               <span className="truncate">{child.label}</span>
             </NavLink>
@@ -179,13 +229,11 @@ export default function AdminSidebar({
   onClose?: () => void;
   toggleLabel?: string;
 }) {
-  const { data: license, isLoading } = useAdminLicense();
+  const { isLoading, isExpired } = useAdminLicense();
   const isAdmin = useAuthStore((s) => s.isAdmin);
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
   const { pathname } = useLocation();
 
-  const installedLicense = license && "grace_period" in license ? license : null;
-  const isExpired = !isLoading && (!installedLicense || installedLicense.expired);
   const showRestrictedNav = !isAdmin || isLoading || isExpired;
   const isDisabled = !isAdmin;
 

--- a/ui/apps/console/src/components/layout/__tests__/AdminSidebar.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/AdminSidebar.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+
+import { defaultConfig } from "@/env";
+import { useAuthStore } from "@/stores/authStore";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
+
+vi.mock("@/hooks/useAdminLicense", () => ({
+  useAdminLicense: vi.fn(),
+}));
+
+vi.mock("../SidebarShell", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sidebar-shell">{children}</div>
+  ),
+  NavItemLink: ({
+    item,
+    disabled,
+  }: {
+    item: { to: string; label: string; icon: React.ReactNode };
+    expanded: boolean;
+    disabled?: boolean;
+  }) =>
+    disabled ? (
+      <span aria-disabled="true">{item.label}</span>
+    ) : (
+      <a href={item.to}>{item.label}</a>
+    ),
+  navBase: "",
+  navDisabled: "",
+  navIcon: "",
+}));
+
+import { getConfig } from "@/env";
+import { useAdminLicense } from "@/hooks/useAdminLicense";
+import AdminSidebar from "../AdminSidebar";
+
+const mockGetConfig = vi.mocked(getConfig);
+const mockUseAdminLicense = vi.mocked(useAdminLicense);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <AdminSidebar expanded={true} pinned={true} onToggle={vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
+function openSettingsGroup() {
+  fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+afterEach(cleanup);
+
+describe("AdminSidebar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({ isAdmin: true } as never);
+    mockUseAdminLicense.mockReturnValue({
+      isLoading: false,
+      isExpired: false,
+    } as never);
+    mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: false });
+  });
+
+  describe("cloud admin (cloud=true, isAdmin=true)", () => {
+    beforeEach(() => {
+      mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+    });
+
+    it("shows the core nav entries", () => {
+      renderSidebar();
+      expect(screen.getByText("Dashboard")).toBeInTheDocument();
+      expect(screen.getByText("Users")).toBeInTheDocument();
+      expect(screen.getByText("Devices")).toBeInTheDocument();
+      expect(screen.getByText("Sessions")).toBeInTheDocument();
+      expect(screen.getByText("Firewall Rules")).toBeInTheDocument();
+      expect(screen.getByText("Namespaces")).toBeInTheDocument();
+    });
+
+    it("shows Authentication but NOT License in the Settings group", () => {
+      renderSidebar();
+      openSettingsGroup();
+      expect(screen.getByText("Authentication")).toBeInTheDocument();
+      expect(screen.queryByText("License")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("enterprise admin with valid license (cloud=false, isExpired=false)", () => {
+    it("shows the core nav entries", () => {
+      renderSidebar();
+      expect(screen.getByText("Dashboard")).toBeInTheDocument();
+      expect(screen.getByText("Users")).toBeInTheDocument();
+      expect(screen.getByText("Devices")).toBeInTheDocument();
+      expect(screen.getByText("Sessions")).toBeInTheDocument();
+      expect(screen.getByText("Firewall Rules")).toBeInTheDocument();
+      expect(screen.getByText("Namespaces")).toBeInTheDocument();
+    });
+
+    it("shows both Authentication and License in the Settings group", () => {
+      renderSidebar();
+      openSettingsGroup();
+      expect(screen.getByText("Authentication")).toBeInTheDocument();
+      expect(screen.getByText("License")).toBeInTheDocument();
+    });
+  });
+
+  describe("enterprise admin with expired/no license (cloud=false, isExpired=true)", () => {
+    beforeEach(() => {
+      mockUseAdminLicense.mockReturnValue({
+        isLoading: false,
+        isExpired: true,
+      } as never);
+    });
+
+    it("shows the restricted nav with only the License entry", () => {
+      renderSidebar();
+      openSettingsGroup();
+      expect(screen.getByText("License")).toBeInTheDocument();
+      expect(screen.queryByText("Authentication")).not.toBeInTheDocument();
+      expect(screen.queryByText("Dashboard")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/apps/console/src/hooks/__tests__/useAdminLicense.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminLicense.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { defaultConfig } from "@/env";
+import { useAuthStore } from "@/stores/authStore";
+
+// ── Dependency mocks ──────────────────────────────────────────────────────────
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn() };
+});
+
+vi.mock("@/client", () => ({
+  getLicense: vi.fn(),
+}));
+
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
+  getLicenseQueryKey: vi.fn(() => ["getLicense"]),
+}));
+
+vi.mock("@/api/errors", () => ({
+  isSdkError: vi.fn(
+    (err: unknown): err is { status: number } =>
+      typeof err === "object" && err !== null && "status" in err,
+  ),
+}));
+
+import { getConfig } from "@/env";
+import { getLicense } from "@/client";
+import { useAdminLicense } from "../useAdminLicense";
+
+const mockGetConfig = vi.mocked(getConfig);
+const mockGetLicense = vi.mocked(getLicense);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, retryDelay: 0 },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function makeLicense(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "license-1",
+    expired: false,
+    about_to_expire: false,
+    grace_period: false,
+    issued_at: 0,
+    starts_at: 0,
+    expires_at: -1,
+    allowed_regions: [],
+    customer: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: enterprise admin, non-cloud
+  useAuthStore.setState({ isAdmin: true } as never);
+  mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: false });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useAdminLicense", () => {
+  describe("enterprise admin — valid license", () => {
+    it("calls getLicense and returns installedLicense", async () => {
+      const license = makeLicense();
+      mockGetLicense.mockResolvedValue({ data: license } as never);
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(mockGetLicense).toHaveBeenCalledTimes(1);
+      expect(result.current.installedLicense).toEqual(license);
+    });
+
+    it("sets isExpired to false when license is not expired", async () => {
+      mockGetLicense.mockResolvedValue({
+        data: makeLicense({ expired: false }),
+      } as never);
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.isExpired).toBe(false);
+    });
+  });
+
+  describe("enterprise admin — 400 (no license stored)", () => {
+    it("normalizes 400 to installedLicense null", async () => {
+      mockGetLicense.mockRejectedValue({ status: 400 });
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.installedLicense).toBeNull();
+    });
+
+    it("sets isExpired to true when no license is installed", async () => {
+      mockGetLicense.mockRejectedValue({ status: 400 });
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.isExpired).toBe(true);
+    });
+  });
+
+  describe("enterprise admin — expired license", () => {
+    it("sets isExpired to true when license.expired is true", async () => {
+      mockGetLicense.mockResolvedValue({
+        data: makeLicense({ expired: true }),
+      } as never);
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.isExpired).toBe(true);
+    });
+
+    it("keeps isExpired false for a non-expired license still in its grace period", async () => {
+      mockGetLicense.mockResolvedValue({
+        data: makeLicense({ expired: false, grace_period: true }),
+      } as never);
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.isExpired).toBe(false);
+    });
+  });
+
+  describe("cloud admin — bypass", () => {
+    it("does NOT call getLicense on cloud deployments", async () => {
+      mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      // Give React Query a chance to fire (it should not)
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(mockGetLicense).not.toHaveBeenCalled();
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("returns isExpired false on cloud deployments", async () => {
+      mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(result.current.isExpired).toBe(false);
+    });
+  });
+
+  describe("non-admin on enterprise", () => {
+    it("does NOT call getLicense when user is not admin", async () => {
+      useAuthStore.setState({ isAdmin: false } as never);
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(mockGetLicense).not.toHaveBeenCalled();
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("returns isExpired false when user is not admin", async () => {
+      useAuthStore.setState({ isAdmin: false } as never);
+
+      const { result } = renderHook(() => useAdminLicense(), {
+        wrapper: createWrapper(),
+      });
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(result.current.isExpired).toBe(false);
+    });
+  });
+});

--- a/ui/apps/console/src/hooks/useAdminLicense.ts
+++ b/ui/apps/console/src/hooks/useAdminLicense.ts
@@ -1,10 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import {
-  getLicenseQueryKey,
-} from "../client/@tanstack/react-query.gen";
+import { getLicenseQueryKey } from "../client/@tanstack/react-query.gen";
 import { getLicense } from "../client";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
+import { getConfig } from "../env";
 import type { GetLicenseResponse } from "../client/types.gen";
 
 export { getLicenseQueryKey };
@@ -13,8 +12,10 @@ type LicenseData = GetLicenseResponse | null;
 
 export function useAdminLicense() {
   const isAdmin = useAuthStore((s) => s.isAdmin);
+  const isCloud = getConfig().cloud;
+  const enabled = isAdmin && !isCloud;
 
-  return useQuery<LicenseData>({
+  const query = useQuery<LicenseData>({
     queryKey: getLicenseQueryKey(),
     queryFn: async ({ signal }) => {
       try {
@@ -26,10 +27,20 @@ export function useAdminLicense() {
         throw err;
       }
     },
-    enabled: isAdmin,
+    enabled,
     staleTime: 5 * 60 * 1000, // 5 minutes
     retry: (count) => count < 1,
     // Prevent refetch when the OS file picker closes and returns focus to the window.
     refetchOnWindowFocus: false,
   });
+
+  const installedLicense =
+    query.data && "grace_period" in query.data ? query.data : null;
+
+  const isExpired =
+    enabled &&
+    !query.isLoading &&
+    (!installedLicense || installedLicense.expired);
+
+  return { ...query, installedLicense, isExpired };
 }

--- a/ui/apps/console/src/pages/__tests__/AdminLicenseRoute.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AdminLicenseRoute.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import {
+  MemoryRouter,
+  Navigate,
+  Routes,
+  Route,
+  useLocation,
+} from "react-router-dom";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return { ...actual, getConfig: vi.fn(() => actual.getConfig()) };
+});
+
+// Stub AdminLicense — its real implementation pulls in many hooks/components
+// that are irrelevant to the routing behaviour under test.
+vi.mock("../admin/License", () => ({
+  default: () => <div data-testid="admin-license-page">Admin License</div>,
+}));
+
+import { getConfig, defaultConfig } from "@/env";
+import AdminLicense from "../admin/License";
+
+const mockedGetConfig = vi.mocked(getConfig);
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/** Captures the current pathname so we can assert post-redirect location. */
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="pathname">{location.pathname}</div>;
+}
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={["/admin/license"]}>
+      <Routes>
+        <Route
+          path="/admin/license"
+          element={
+            getConfig().cloud ? (
+              <Navigate to="/admin/dashboard" replace />
+            ) : (
+              <AdminLicense />
+            )
+          }
+        />
+        <Route path="/admin/dashboard" element={<LocationDisplay />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup / teardown                                                    */
+/* ------------------------------------------------------------------ */
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("AdminLicenseRoute — /admin/license element", () => {
+  describe("cloud=true", () => {
+    beforeEach(() => {
+      mockedGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+    });
+
+    it("redirects to /admin/dashboard in cloud mode", () => {
+      renderRoute();
+
+      // The Navigate component should redirect the router to /admin/dashboard,
+      // which renders LocationDisplay. Asserting on its text content confirms
+      // that the redirect happened.
+      expect(screen.getByTestId("pathname")).toHaveTextContent(
+        "/admin/dashboard",
+      );
+    });
+  });
+
+  describe("cloud=false (enterprise / self-hosted)", () => {
+    beforeEach(() => {
+      mockedGetConfig.mockReturnValue({ ...defaultConfig, cloud: false });
+    });
+
+    it("renders the AdminLicense page when not in cloud mode", () => {
+      renderRoute();
+
+      expect(screen.getByTestId("admin-license-page")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## What

Stop the admin console from redirecting cloud admins to a `/admin/license` dead-end. In cloud, license gating is bypassed entirely (cloud has no license file — it uses billing), so admins reach the dashboard with the full admin menu.

## Why

Licensing is a self-hosted/enterprise concept: a `.dat` license file. Cloud deployments ship no license, so `GET /admin/api/license` returns 400, which the frontend normalized to `null`. Nothing in the license-checking flow checked `getConfig().cloud`, so `LicenseGuard` redirected every `/admin/*` page to `/admin/license`, and `AdminSidebar` collapsed to a single "License" link. This was unreachable in cloud until the sibling change (#6559) made the Admin Console link visible there — now it's a live dead-end.

This is the follow-up to #6559 (which only made the link visible).

## Changes

- **`useAdminLicense`** — single source of truth. Skip the query in cloud (`enabled: isAdmin && !isCloud`) and derive `isExpired` only when the query is enabled. A disabled query (cloud, or a non-admin on enterprise) no longer reads as "expired" — fixing a latent footgun. Existing `expired` semantics preserved (grace-period licenses stay valid).
- **`LicenseGuard`** — consumes the hook's derived `isExpired`; in cloud the query is disabled so it falls through to the admin pages.
- **`AdminSidebar`** — consumes `isExpired` (full nav in cloud) and drops the "License" entry from the Settings group in cloud, built as a fresh object (no mutation of the module-level const).
- **`App.tsx`** — `/admin/license` redirects to `/admin/dashboard` in cloud at the route layer; `License.tsx` is untouched.
- **Side effect**: cloud admins no longer see the spurious "no license" banner in the user console (`LicenseBanner`/`DeviceLimitBanner` consume the same hook). Both banner tests updated for the widened hook return type and now assert the banner is hidden in cloud.

## Testing

New suites: `useAdminLicense` (cloud/non-admin bypass, expired, grace-period-stays-valid), `LicenseGuard` (cloud real-hook falls through; per-branch redirects), `AdminSidebar` (cloud full nav minus License; enterprise expired → restricted), and the `/admin/license` cloud redirect. `npm run build` (`tsc -b`) passes — the widened return type required updating the banner-test mock casts, which vitest alone would not catch.