### PR TITLE
ci(review): finalize stuck tracking comment by identity, not run-id

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -219,6 +219,24 @@ jobs:
             echo "is_admin=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Snapshot existing tracking comments
+        id: snapshot
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          MARKER="<!-- claude-code-review -->"
+          # Record the IDs of tracking comments that already exist, so the
+          # Finalize step can identify the one this run creates by identity.
+          # We cannot match on the run-id link in the body: Claude strips it when
+          # it rewrites the comment, and the action only re-adds it at the very
+          # end — racing the Finalize read.
+          IDS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | paste -sd, -)
+          echo "ids=$IDS" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code Review
         if: steps.gate.outputs.proceed == 'true'
         timeout-minutes: 30
@@ -466,16 +484,22 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          RUN_ID: ${{ github.run_id }}
+          PRIOR_IDS: ${{ steps.snapshot.outputs.ids }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           MARKER="<!-- claude-code-review -->"
-          # The tracking comment for THIS run links to this run id in its body.
+          # The tracking comment for THIS run is the marker comment that did not
+          # exist in the pre-run snapshot. Keying on identity avoids racing the
+          # action's end-of-run job-link update.
+          PRIOR=",${PRIOR_IDS},"
           COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq ".[] | select(.body | contains(\"$MARKER\")) | select(.body | contains(\"actions/runs/$RUN_ID\")) | .id" | head -1)
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" \
+            | while read -r id; do
+                [[ "$PRIOR" == *",$id,"* ]] || echo "$id"
+              done | head -1)
 
           if [[ -z "$COMMENT_ID" ]]; then
-            echo "No tracking comment for run $RUN_ID; nothing to finalize."
+            echo "No tracking comment created by this run; nothing to finalize."
             exit 0
           fi
 


### PR DESCRIPTION
## Problem

On PR #6562, the first (automatic) Claude review job finished in 2m29s and left its tracking comment stuck at the Step-1 checklist (`- [ ]` unchecked) — no feedback was posted. A later `/review` run worked fine.

Two failures stacked:

1. **The lead review agent ended its turn before Step 5** (the mandatory final-summary update), leaving the tracking comment as an incomplete checklist. The run still returned `success`. This is model-side non-determinism — not a permissions or config issue (the run that worked actually had *more* permission denials).
2. **The deterministic safety net couldn't rescue it.** The `Finalize tracking comment` step locates the run's comment by matching `actions/runs/<run-id>` in the body. But Claude strips that link when it rewrites the comment, and the action only re-adds it as a header at the very end of the run. The Finalize read raced that update, found no match (`No tracking comment for run …; nothing to finalize`), and bailed — so the half-finished checklist was published as the final state.

## Fix

Target the tracking comment by **identity** instead of a body substring:

- New **`Snapshot existing tracking comments`** step records the marker-comment IDs that exist *before* the review runs.
- **`Finalize tracking comment`** now selects the marker comment that is **new this run** (present now, absent from the snapshot), and rewrites it if it still has unchecked boxes.

The new comment's ID is stable from the moment the action posts it, so there's nothing to race. Empty snapshot degrades safely; pre-existing comments are still excluded so Finalize never touches another run's comment.

This makes the safety net reliable; the agent will still occasionally bail before Step 5, but a stuck checklist will now be rewritten to the terminal "review ran but posted no summary — comment `/review`" message instead of being left as the result.

## Validation

`actionlint` passes clean (validates YAML, Actions expressions, and shellchecks the embedded bash).

Note: forward-looking only — does not retroactively fix #6562's existing run-1 comment.