### PR TITLE
docs: revamp Terraform, Ansible, and CI/CD integration pages

### DIFF
--- a/ui/apps/docs/src/pages/integration/ansible.mdx
+++ b/ui/apps/docs/src/pages/integration/ansible.mdx
@@ -60,17 +60,17 @@ Ansible connects through the ShellHub gateway transparently. No changes to your 
 
 ## Dynamic inventory
 
-For larger fleets, don't maintain a static file. The [`shellhub.cloud`](https://github.com/shellhub-io/ansible-collection) collection ships an inventory plugin that pulls accepted devices straight from your namespace and turns ShellHub tags into Ansible groups:
+For larger fleets, don't maintain a static file. The [`shellhub.core`](https://github.com/shellhub-io/ansible-collection) collection ships an inventory plugin that pulls accepted devices straight from your namespace and turns ShellHub tags into Ansible groups:
 
 ```bash
-$ ansible-galaxy collection install shellhub.cloud
+$ ansible-galaxy collection install shellhub.core
 ```
 
 Create an inventory source file whose name ends in `shellhub.yml`:
 
 ```yaml
 # inventory.shellhub.yml
-plugin: shellhub.cloud.devices
+plugin: shellhub.core.devices
 api_url: https://cloud.shellhub.io   # your server, for self-hosted
 ssh_user: root
 ssh_key: ~/.ssh/id_ed25519
@@ -93,4 +93,4 @@ Your ShellHub tags become Ansible groups automatically (`tag_production`, `tag_r
 
 - [Public Keys](/guides/public-keys) — Set up key-based authentication
 - [Tags](/guides/tags) — Organize devices into groups for targeted automation
-- [shellhub.cloud collection](https://github.com/shellhub-io/ansible-collection) — The dynamic inventory plugin
+- [shellhub.core collection](https://github.com/shellhub-io/ansible-collection) — The dynamic inventory plugin

--- a/ui/apps/docs/src/pages/integration/ansible.mdx
+++ b/ui/apps/docs/src/pages/integration/ansible.mdx
@@ -42,6 +42,8 @@ Or pass it on the command line:
 $ ansible-playbook -i inventory.ini --private-key ~/.ssh/id_ed25519 playbook.yml
 ```
 
+> **Note:** On the first connection Ansible verifies the gateway's SSH host key. For unattended runs, either add it up front with `ssh-keyscan cloud.shellhub.io >> ~/.ssh/known_hosts`, or set `host_key_checking = False` in `ansible.cfg`. Otherwise the run fails with `Host key verification failed`.
+
 ## Running playbooks
 
 Run playbooks as you normally would:
@@ -58,19 +60,37 @@ Ansible connects through the ShellHub gateway transparently. No changes to your 
 
 ## Dynamic inventory
 
-For larger fleets, use the ShellHub API to generate inventory dynamically instead of maintaining a static file. The API returns device lists with tags and online status that you can map to Ansible groups:
+For larger fleets, don't maintain a static file. The [`shellhub.cloud`](https://github.com/shellhub-io/ansible-collection) collection ships an inventory plugin that pulls accepted devices straight from your namespace and turns ShellHub tags into Ansible groups:
 
 ```bash
-$ curl -H "Authorization: Bearer YOUR_API_KEY" \
-    https://cloud.shellhub.io/api/devices?status=accepted
+$ ansible-galaxy collection install shellhub.cloud
 ```
 
-If you organize devices with tags in ShellHub (e.g., `production`, `staging`, `region-us`), you can map tags to Ansible groups. This keeps your inventory in sync with the ShellHub dashboard without manual updates.
+Create an inventory source file whose name ends in `shellhub.yml`:
 
-See [API Reference](/developers/api-reference) for the full device list endpoint.
+```yaml
+# inventory.shellhub.yml
+plugin: shellhub.cloud.devices
+api_url: https://cloud.shellhub.io   # your server, for self-hosted
+ssh_user: root
+ssh_key: ~/.ssh/id_ed25519
+keyed_groups:
+  - key: shellhub_tags               # each ShellHub tag becomes a group: tag_<name>
+    prefix: tag
+```
+
+Provide a namespace API key and run:
+
+```bash
+$ export SHELLHUB_API_KEY=...
+$ ansible-inventory -i inventory.shellhub.yml --graph
+$ ansible -i inventory.shellhub.yml tag_production -m ping
+```
+
+Your ShellHub tags become Ansible groups automatically (`tag_production`, `tag_region_us`, …), so the inventory tracks the dashboard with no manual updates. The plugin paginates the device list and resolves the namespace from the API key.
 
 ## Next steps
 
 - [Public Keys](/guides/public-keys) — Set up key-based authentication
-- [Tags](/guides/tags) — Organize devices for targeted automation
-- [API Reference](/developers/api-reference) — Build dynamic inventory from the API
+- [Tags](/guides/tags) — Organize devices into groups for targeted automation
+- [shellhub.cloud collection](https://github.com/shellhub-io/ansible-collection) — The dynamic inventory plugin

--- a/ui/apps/docs/src/pages/integration/ci-cd.mdx
+++ b/ui/apps/docs/src/pages/integration/ci-cd.mdx
@@ -1,22 +1,16 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: CI/CD Pipelines
-description: Deploy to ShellHub devices from GitHub Actions, GitLab CI, and other CI/CD systems
+description: Deploy to ShellHub devices and debug CI runners from GitHub Actions and other CI/CD pipelines
 ---
 
 # CI/CD Pipelines
 
-Deploy code, run commands, or provision devices from your CI/CD pipeline. ShellHub provides standard SSH access, so any pipeline that supports SSH can reach your devices.
+From your pipeline you can reach your devices over SSH two ways: deploy code and run commands on them, or drop into the CI runner itself to debug a failing build. Both go through the ShellHub gateway, addressed by SSHID (`user@namespace.device@gateway`), so the target needs no public IP and no inbound ports — the gateway routes the session through the agent's reverse tunnel.
 
-## How it works
+## Deploy to a device (GitHub Actions)
 
-1. Store an SSH private key as a CI/CD secret
-2. Upload the corresponding public key to ShellHub (scoped to the target devices)
-3. Use `ssh` or `scp` in your pipeline to connect through the ShellHub gateway
-
-The gateway acts as an SSH proxy — your pipeline connects to the gateway, which routes the session to the target device through the agent's reverse tunnel.
-
-## GitHub Actions
+Use [`appleboy/ssh-action`](https://github.com/appleboy/ssh-action) to run commands on a device. You need an online device and an SSH key registered in ShellHub — store its private key as a secret (recommended over a password). Address the device by its SSHID: `host` is the gateway, `username` is `<user>@<namespace>.<device>`.
 
 ```yaml
 name: Deploy to device
@@ -28,47 +22,33 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -p 22 cloud.shellhub.io >> ~/.ssh/known_hosts
-
-      - name: Deploy
-        run: |
-          ssh root@my-namespace.web-server@cloud.shellhub.io \
-              "cd /app && git pull && systemctl restart myapp"
+      - uses: appleboy/ssh-action@v1
+        with:
+          host: cloud.shellhub.io
+          port: 22
+          username: deploy@my-namespace.web-server
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd /app && git pull && systemctl restart myapp
 ```
 
-### Copying files
+The agent has no public IP and no inbound ports — ShellHub routes the session through the reverse tunnel. Copying files works the same way with [`appleboy/scp-action`](https://github.com/appleboy/scp-action).
+
+## Debug a CI runner (GitHub Actions)
+
+To SSH into a live runner and debug a failing build, use the [`shellhub-io/ci-action`](https://github.com/shellhub-io/ci-action). It needs a namespace API key with device accept/remove permission, stored as a secret. The action registers the runner as an ephemeral device, authorizes your keys, prints an `ssh` command and a web-terminal URL, and removes the device when the job ends:
 
 ```yaml
-      - name: Upload build artifacts
-        run: |
-          scp ./dist/app.tar.gz \
-              root@my-namespace.web-server@cloud.shellhub.io:/tmp/
+      - name: Open a ShellHub debug session on this runner
+        uses: shellhub-io/ci-action@v1
+        with:
+          server: https://cloud.shellhub.io
+          tenant-id: ${{ secrets.SHELLHUB_TENANT_ID }}
+          api-key: ${{ secrets.SHELLHUB_API_KEY }}
+          authorize-actor: auto   # authorize the GitHub keys of whoever triggered the run
 ```
 
-## GitLab CI
-
-```yaml
-deploy:
-  stage: deploy
-  image: alpine:latest
-  before_script:
-    - apk add --no-cache openssh-client
-    - mkdir -p ~/.ssh
-    - echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
-    - chmod 600 ~/.ssh/id_ed25519
-    - ssh-keyscan -p 22 cloud.shellhub.io >> ~/.ssh/known_hosts
-  script:
-    - ssh root@my-namespace.web-server@cloud.shellhub.io "cd /app && git pull && systemctl restart myapp"
-  only:
-    - main
-```
+No public session URL is ever printed — the runner shows up in your namespace and you reach it by SSHID from your own machine, governed by namespace RBAC and recorded. The job blocks until you connect and disconnect; run `sudo touch /continue` to release it early. See [`ci-action-demo`](https://github.com/shellhub-io/ci-action-demo) for a complete, runnable workflow.
 
 ## Other CI/CD systems
 
@@ -85,11 +65,3 @@ This works with Jenkins, CircleCI, Drone, Bitbucket Pipelines, Azure DevOps, and
 - **Use dedicated keys** — Create an SSH key pair specifically for CI/CD. Don't reuse personal keys.
 - **Scope keys narrowly** — In ShellHub, scope the public key to only the devices and usernames your pipeline needs.
 - **Use device tags** — Tag devices by environment (`production`, `staging`) and scope keys to tags rather than individual devices.
-- **Rotate keys regularly** — Replace CI/CD keys on a schedule. ShellHub makes this easy since you manage keys centrally.
-- **Verify host keys** — Use `ssh-keyscan` to add the gateway's host key and enable `StrictHostKeyChecking` in production pipelines.
-
-## Next steps
-
-- [Public Keys](/guides/public-keys) — Set up and scope SSH keys
-- [Tags](/guides/tags) — Organize devices by environment
-- [Connecting](/guides/connecting) — SSH connection details and SSHID format

--- a/ui/apps/docs/src/pages/integration/terraform.mdx
+++ b/ui/apps/docs/src/pages/integration/terraform.mdx
@@ -6,34 +6,28 @@ description: Provision infrastructure with the ShellHub agent pre-installed usin
 
 # Terraform
 
-Provision cloud instances, VMs, or bare-metal servers with the ShellHub agent pre-installed using Terraform. Every new machine connects to ShellHub automatically — no manual setup after deployment.
+Provision cloud instances, VMs, or bare-metal servers with the ShellHub agent pre-installed using Terraform. Every new machine connects out to ShellHub on boot and shows up in your dashboard — no public IP, no inbound firewall rule, no manual setup after deployment.
+
+ShellHub doesn't ship a Terraform provider, and you don't need one. You drop the agent install into your instance's cloud-init `user_data` using whatever cloud provider you already have.
 
 ## How it works
 
-Use Terraform's `user_data` (cloud-init) or provisioners to run the ShellHub agent install command during instance creation. The agent starts immediately, and the device appears in your ShellHub dashboard as soon as it boots.
-
-## Cloud-init (recommended)
-
-The simplest approach. Pass the agent install command as `user_data` in your resource definition. This works with AWS, GCP, Azure, DigitalOcean, Hetzner, and any provider that supports cloud-init.
-
-### AWS EC2
+The agent install goes in your instance's `user_data` (cloud-init). On boot it opens a reverse tunnel to the ShellHub gateway, so the machine becomes reachable through ShellHub even when it sits behind NAT with no inbound ports open. The device appears in your dashboard as soon as it boots.
 
 ```hcl
-resource "aws_instance" "device" {
-  ami           = "ami-xxxxxxxxxxxxxxxxx" # Ubuntu 24.04 LTS
-  instance_type = "t3.micro"
+user_data = <<-EOF
+  #!/bin/bash
+  curl -sSf https://cloud.shellhub.io/install.sh | TENANT_ID=${var.shellhub_tenant_id} sh
+EOF
+```
 
-  user_data = <<-EOF
-    #!/bin/bash
-    curl -fsSL https://get.docker.com | sh
-    curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=${var.shellhub_tenant_id}" | sh
-  EOF
+The install script reads its config from environment variables. `TENANT_ID` (your namespace tenant ID, found in the dashboard under namespace settings) is the only required one. The script auto-detects how to run the agent — Docker if present, otherwise a native service — so this one line is all you need. It works on any provider that supports cloud-init; only the resource around it changes.
 
-  tags = {
-    Name = "web-server"
-  }
-}
+For a self-hosted server, also pass `SERVER_ADDRESS` so the agent points at it instead of the default `https://cloud.shellhub.io`. Other settings — preferred hostname, identity, keepalive — are listed in the [install script reference](/agent/install-script#environment-variables).
 
+Keep the tenant ID in a variable so it stays out of plan output and state:
+
+```hcl
 variable "shellhub_tenant_id" {
   description = "ShellHub namespace tenant ID"
   type        = string
@@ -41,102 +35,50 @@ variable "shellhub_tenant_id" {
 }
 ```
 
-### DigitalOcean
+## Verify
 
-```hcl
-resource "digitalocean_droplet" "device" {
-  image  = "ubuntu-24-04-x64"
-  name   = "edge-node"
-  region = "nyc3"
-  size   = "s-1vcpu-1gb"
+Apply it:
 
-  user_data = <<-EOF
-    #!/bin/bash
-    curl -fsSL https://get.docker.com | sh
-    curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=${var.shellhub_tenant_id}" | sh
-  EOF
-}
+```bash
+$ terraform apply
 ```
 
-### Hetzner Cloud
+The machine boots, the agent dials out, and the device shows up in your ShellHub dashboard within seconds. If your namespace doesn't auto-accept devices, accept the new one there. Then connect through the gateway to confirm it's reachable — no public IP involved:
 
-```hcl
-resource "hcloud_server" "device" {
-  name        = "gateway"
-  server_type = "cx22"
-  image       = "ubuntu-24.04"
-
-  user_data = <<-EOF
-    #!/bin/bash
-    curl -fsSL https://get.docker.com | sh
-    curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=${var.shellhub_tenant_id}" | sh
-  EOF
-}
+```bash
+$ ssh <user>@<namespace>.<device-name>@cloud.shellhub.io
 ```
 
-## Using provisioners
+## Using a remote-exec provisioner
 
-For cases where cloud-init isn't available, use Terraform's `remote-exec` provisioner:
+To reach the device from a `remote-exec` provisioner, you express the connection with ShellHub's SSHID. In the `connection` block, set `host` to the ShellHub gateway and `user` to the SSHID `<user>@<namespace>.<device>` — Terraform connects through the gateway, never the instance's IP, so it works even though the machine has no inbound access. Authenticate with an SSH key registered in ShellHub or the device's password:
 
 ```hcl
-resource "aws_instance" "device" {
-  ami           = "ami-xxxxxxxxxxxxxxxxx" # Ubuntu 24.04 LTS
-  instance_type = "t3.micro"
-  key_name      = aws_key_pair.deploy.key_name
+resource "null_resource" "configure" {
+  depends_on = [<your_instance_resource>]
 
   provisioner "remote-exec" {
-    inline = [
-      "curl -fsSL https://get.docker.com | sh",
-      "curl -sSf 'https://cloud.shellhub.io/install.sh?tenant_id=${var.shellhub_tenant_id}' | sh",
-    ]
-
     connection {
       type        = "ssh"
-      user        = "ubuntu"
-      private_key = file("~/.ssh/id_ed25519")
-      host        = self.public_ip
+      host        = "cloud.shellhub.io"
+      port        = 22
+      user        = "root@${var.shellhub_namespace}.${var.device_name}"
+      private_key = file("~/.ssh/id_ed25519") # public key registered in ShellHub
+      # password  = var.device_password       # or the device's own system password
     }
+
+    inline = [
+      "echo configured via ShellHub", # your provisioning commands
+    ]
   }
 }
 ```
 
-> **Note:** Provisioners require network access to the instance during creation. Cloud-init runs without this requirement and is the preferred approach.
-
-## Self-hosted ShellHub
-
-For self-hosted instances, replace the server address in the install command:
-
-```hcl
-user_data = <<-EOF
-  #!/bin/bash
-  curl -fsSL https://get.docker.com | sh
-  curl -sSf "https://${var.shellhub_server}/install.sh?tenant_id=${var.shellhub_tenant_id}" | sh
-EOF
-```
-
-## Setting the hostname
-
-Use `PREFERRED_HOSTNAME` to give each device a predictable name in the dashboard:
-
-```hcl
-user_data = <<-EOF
-  #!/bin/bash
-  curl -fsSL https://get.docker.com | sh
-  export PREFERRED_HOSTNAME="${var.device_name}"
-  curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=${var.shellhub_tenant_id}" | sh
-EOF
-```
+> **Note:** The device must be accepted in your namespace before you can connect. Key auth checks SSH public keys you've [registered in ShellHub](/guides/public-keys); password auth checks the device's own system users. For unattended fleets, turn on device auto-accept for the namespace or accept devices via the [API](/developers/api-reference).
 
 ## Best practices
 
 - **Store tenant ID as a variable** — Mark it `sensitive = true` to keep it out of plan output and state files
-- **Use cloud-init over provisioners** — Cloud-init runs without needing SSH access to the instance during creation
-- **Set preferred hostname** — Use Terraform resource names or IDs as hostnames for traceability between your infra code and ShellHub dashboard
+- **Use cloud-init over provisioners** — The agent connects on its own at boot; you rarely need to reach the machine during creation
+- **Authenticate with SSH keys, not passwords** — Register a public key in ShellHub and reference it with `private_key` in the connection. Keys are passwordless and keep device credentials out of your Terraform config and state
 - **Accept devices via API** — For large fleets, use the [ShellHub API](/developers/api-reference) to accept devices programmatically after provisioning
-
-## Next steps
-
-- [Agent Overview](/agent/overview) — How the agent works
-- [Docker](/agent/docker) — Agent Docker image details
-- [CI/CD Pipelines](/integration/ci-cd) — Automate deployments after provisioning
-- [API Reference](/developers/api-reference) — Auto-accept devices via the API


### PR DESCRIPTION
Reworks four integration docs pages, each verified against a live ShellHub stack.

**Terraform** (`integration/terraform.mdx`)
The install one-liner passed the tenant ID as a URL query (`?tenant_id=`), which the server ignores, so the agent failed with `TENANT_ID is missing`. It now uses the `TENANT_ID` environment variable, which is what `install.sh` reads. The page is reframed around reaching a machine behind NAT through the gateway (an SSHID in a `remote-exec` connection) instead of a per-provider catalog and a public-IP example.

**Ansible** (`integration/ansible.mdx`)
The dynamic-inventory example authenticated with `Authorization: Bearer`, which the API rejects (401); it now uses the `X-API-Key` header. The raw `curl` is replaced by a real inventory plugin shipped as the `shellhub.core` collection (shellhub-io/ansible-collection), which pulls devices from the namespace and maps ShellHub tags to Ansible groups via `keyed_groups`. It also notes the gateway host-key check on first connect.

**CI/CD** (`integration/ci-cd.mdx`)
Rebuilt around two GitHub Actions use cases: deploy to a device with `appleboy/ssh-action` via SSHID (key auth recommended), and debug a CI runner with `shellhub-io/ci-action` (ephemeral device, no public session URL, RBAC-scoped, recorded). The GitLab section and the raw ssh-key plumbing are gone.

Companion repo: `shellhub-io/ansible-collection` (the `shellhub.core` Ansible collection).