### PR TITLE
feat(api): apply the filter query parameter on GET /api/sessions

### DIFF
--- a/api/openapi/spec_test.go
+++ b/api/openapi/spec_test.go
@@ -1,0 +1,74 @@
+package openapi_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// specDir returns the absolute path to the openapi spec directory, navigating
+// from the test file location up to the repository root and then into openapi/spec.
+func specDir(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+
+	// file is <repo>/api/openapi/spec_test.go
+	// Navigate: api/openapi -> api -> <repo> -> openapi/spec
+	repoRoot := filepath.Join(filepath.Dir(file), "..", "..")
+
+	return filepath.Join(repoRoot, "openapi", "spec")
+}
+
+// TestGetSessionsAdvertisesFilterQueryParameter verifies that the GET /api/sessions
+// OpenAPI path definition advertises a filterQuery parameter, mirroring the
+// pattern already used by GET /api/devices.
+func TestGetSessionsAdvertisesFilterQueryParameter(t *testing.T) {
+	dir := specDir(t)
+	sessionsPath := filepath.Join(dir, "paths", "api@sessions.yaml")
+	filterRef := filepath.Join(dir, "components", "parameters", "query", "filterQuery.yaml")
+
+	// The referenced component file must exist.
+	_, err := os.Stat(filterRef)
+	require.NoError(t, err, "filterQuery.yaml component file should exist at %s", filterRef)
+
+	// Read and parse the sessions path spec.
+	data, err := os.ReadFile(sessionsPath)
+	require.NoError(t, err, "should be able to read %s", sessionsPath)
+
+	var spec map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &spec), "api@sessions.yaml must be valid YAML")
+
+	// Navigate to get.parameters.
+	getOp, ok := spec["get"].(map[string]interface{})
+	require.True(t, ok, "spec must have a 'get' operation")
+
+	params, ok := getOp["parameters"].([]interface{})
+	require.True(t, ok, "get operation must have a 'parameters' list")
+
+	// Look for a $ref entry pointing to filterQuery.yaml.
+	const wantRef = "../components/parameters/query/filterQuery.yaml"
+
+	found := false
+
+	for _, p := range params {
+		entry, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if ref, ok := entry["$ref"].(string); ok && ref == wantRef {
+			found = true
+
+			break
+		}
+	}
+
+	assert.True(t, found, "GET /api/sessions parameters should include $ref: %s", wantRef)
+}

--- a/api/routes/session.go
+++ b/api/routes/session.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 
 	"github.com/shellhub-io/shellhub/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/api/services"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/pkg/websocket"
@@ -38,6 +40,16 @@ func (h *Handler) GetSessionList(c gateway.Context) error {
 
 	// TODO: normalize is not required when request is privileged
 	req.Paginator.Normalize()
+
+	if err := req.Filters.Unmarshal(); err != nil {
+		log.WithError(err).WithField("filter", req.Filters.Raw).Warn("failed to decode session list filter")
+
+		return c.NoContent(http.StatusBadRequest)
+	}
+
+	if err := query.ValidateFilters(&req.Filters, services.SessionFilterFields); err != nil {
+		return c.NoContent(http.StatusBadRequest)
+	}
 
 	sessions, count, err := h.service.ListSessions(c.Ctx(), req)
 	if err != nil {

--- a/api/routes/session_test.go
+++ b/api/routes/session_test.go
@@ -1,12 +1,15 @@
 package routes
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -31,10 +34,12 @@ func TestGetSessionList(t *testing.T) {
 	type Expected struct {
 		expectedSession []models.Session
 		expectedStatus  int
+		expectedCount   int // total count from X-Total-Count header; only checked for 200 responses
 	}
 	cases := []struct {
 		description   string
 		paginator     query.Paginator
+		filter        string
 		headers       map[string]string
 		requiredMocks func()
 		expected      Expected
@@ -55,18 +60,104 @@ func TestGetSessionList(t *testing.T) {
 			},
 		},
 		{
+			// Non-default paginator (Page:2, PerPage:5) distinguishes values
+			// actually bound from the URL from the handler's Normalize() defaults
+			// (Page:1, PerPage:10). If pagination binding regressed the mock
+			// would not match and the test would fail.
 			description: "success when try to searching a session list of a existing session",
-			paginator:   query.Paginator{Page: 1, PerPage: 10},
+			paginator:   query.Paginator{Page: 2, PerPage: 5},
 			headers:     map[string]string{"X-Tenant-ID": "00000000-0000-4000-0000-000000000000"},
 			requiredMocks: func() {
 				mock.
-					On("ListSessions", gomock.Anything, &requests.ListSessions{Paginator: query.Paginator{Page: 1, PerPage: 10}, TenantID: "00000000-0000-4000-0000-000000000000"}).
+					On("ListSessions", gomock.Anything, &requests.ListSessions{Paginator: query.Paginator{Page: 2, PerPage: 5}, TenantID: "00000000-0000-4000-0000-000000000000"}).
 					Return([]models.Session{}, 1, nil).
 					Once()
 			},
 			expected: Expected{
 				expectedSession: []models.Session{},
 				expectedStatus:  http.StatusOK,
+				expectedCount:   1,
+			},
+		},
+		{
+			description: "returns 400 when filter uses a disallowed field",
+			paginator:   query.Paginator{Page: 1, PerPage: 10},
+			filter: func() string {
+				filters := []query.Filter{
+					{
+						Type: query.FilterTypeProperty,
+						Params: &query.FilterProperty{
+							Name:     "username",
+							Operator: "eq",
+							Value:    "johndoe",
+						},
+					},
+				}
+				b, _ := json.Marshal(filters)
+
+				return base64.StdEncoding.EncodeToString(b)
+			}(),
+			headers:       map[string]string{"X-Tenant-ID": "00000000-0000-4000-0000-000000000000"},
+			requiredMocks: func() {},
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusBadRequest,
+			},
+		},
+		{
+			description:   "returns 400 when filter is malformed non-base64",
+			paginator:     query.Paginator{Page: 1, PerPage: 10},
+			filter:        "!!!not-base64!!!",
+			headers:       map[string]string{"X-Tenant-ID": "00000000-0000-4000-0000-000000000000"},
+			requiredMocks: func() {},
+			expected: Expected{
+				expectedSession: nil,
+				expectedStatus:  http.StatusBadRequest,
+			},
+		},
+		{
+			description: "returns 200 for a valid allowed filter",
+			paginator:   query.Paginator{Page: 1, PerPage: 10},
+			filter: func() string {
+				filters := []query.Filter{
+					{
+						Type: query.FilterTypeProperty,
+						Params: &query.FilterProperty{
+							Name:     "device_uid",
+							Operator: "eq",
+							Value:    "abc123",
+						},
+					},
+				}
+				b, _ := json.Marshal(filters)
+
+				return base64.StdEncoding.EncodeToString(b)
+			}(),
+			headers: map[string]string{"X-Tenant-ID": "00000000-0000-4000-0000-000000000000"},
+			requiredMocks: func() {
+				// Assert that the decoded filter is forwarded to the service:
+				// if filter binding or Unmarshal regressed, the MatchedBy
+				// predicate would not match and the test would fail.
+				mock.
+					On("ListSessions", gomock.Anything, gomock.MatchedBy(func(req *requests.ListSessions) bool {
+						if len(req.Filters.Data) != 1 {
+							return false
+						}
+
+						prop, ok := req.Filters.Data[0].Params.(*query.FilterProperty)
+						if !ok {
+							return false
+						}
+
+						return prop.Name == "device_uid" && prop.Operator == "eq" && prop.Value == "abc123"
+					})).
+					Return([]models.Session{}, 1, nil).
+					Once()
+			},
+			expected: Expected{
+				expectedSession: []models.Session{},
+				expectedStatus:  http.StatusOK,
+				expectedCount:   1,
 			},
 		},
 	}
@@ -75,12 +166,17 @@ func TestGetSessionList(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.requiredMocks()
 
-			jsonData, err := json.Marshal(tc.paginator)
-			if err != nil {
-				assert.NoError(t, err)
+			rawURL := "/api/sessions"
+			urlVal := url.Values{}
+			urlVal.Set("page", strconv.Itoa(tc.paginator.Page))
+			urlVal.Set("per_page", strconv.Itoa(tc.paginator.PerPage))
+			if tc.filter != "" {
+				urlVal.Set("filter", tc.filter)
 			}
 
-			req := httptest.NewRequest(http.MethodGet, "/api/sessions", strings.NewReader(string(jsonData)))
+			rawURL += "?" + urlVal.Encode()
+
+			req := httptest.NewRequest(http.MethodGet, rawURL, nil)
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Role", authorizer.RoleOwner.String())
 			for k, v := range tc.headers {
@@ -99,6 +195,10 @@ func TestGetSessionList(t *testing.T) {
 				assert.ErrorIs(t, io.EOF, err)
 			}
 			assert.Equal(t, tc.expected.expectedSession, session)
+
+			if rec.Result().StatusCode == http.StatusOK {
+				assert.Equal(t, strconv.Itoa(tc.expected.expectedCount), rec.Result().Header.Get("X-Total-Count"))
+			}
 		})
 	}
 

--- a/api/services/device.go
+++ b/api/services/device.go
@@ -31,7 +31,11 @@ var DeviceFilterFields = query.NewFieldConstraints(map[string][]string{
 	"tags.name":     {"contains", "eq"},
 	"online":        {"bool", "eq"},
 	"custom_fields": {"contains"},
-})
+},
+	// Virtual bool-backed fields intercepted by ParseFilterProperty before any
+	// SQL column binding — safe to accept bool-convertible values with eq/ne.
+	"online",
+)
 
 // DeviceSortFields is the set of field names accepted in the sort_by query
 // parameter when listing devices.

--- a/api/services/session.go
+++ b/api/services/session.go
@@ -13,6 +13,26 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// SessionFilterFields maps each filter field the session list endpoint accepts
+// to the set of operators valid for it.
+//
+// "closed" and "active" are boolean-typed; only the "bool" operator is
+// permitted. Allowing "eq" on a boolean column lets a string value
+// (e.g. "true") bypass validation but fail at the Postgres level with
+// "operator does not exist: boolean = text", producing a 500 instead of 400.
+var SessionFilterFields = query.NewFieldConstraints(map[string][]string{
+	"device_uid": {"eq", "ne"},
+	"closed":     {"bool"},
+	"active":     {"bool"},
+},
+	// Virtual bool-backed fields intercepted by ParseFilterProperty before any
+	// SQL column binding — safe to accept bool-convertible values with eq/ne.
+	// "active" is declared virtual here so that IsVirtualBoolField accurately
+	// reflects the store-layer intercept, even though "active" currently only
+	// allows "bool" (not eq/ne) and the distinction is not yet load-bearing.
+	"active",
+)
+
 type SessionService interface {
 	ListSessions(ctx context.Context, req *requests.ListSessions) ([]models.Session, int, error)
 	GetSession(ctx context.Context, uid models.UID) (*models.Session, error)
@@ -29,6 +49,7 @@ func (s *service) ListSessions(ctx context.Context, req *requests.ListSessions) 
 		opts = append(opts, s.store.Options().InNamespace(req.TenantID))
 	}
 
+	opts = append(opts, s.store.Options().Match(&req.Filters))
 	opts = append(opts, s.store.Options().Sort(&query.Sorter{By: "started_at", Order: query.OrderDesc, Tiebreak: "id"}))
 	opts = append(opts, s.store.Options().Paginate(&req.Paginator))
 

--- a/api/services/session_test.go
+++ b/api/services/session_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"net"
+	"reflect"
 	"testing"
 
 	goerrors "errors"
@@ -32,6 +33,49 @@ func TestListSessions(t *testing.T) {
 		err      error
 	}
 
+	// matchFilters returns a MatchedBy matcher that asserts the *query.Filters
+	// passed to Match carries exactly the specified filter data. This catches
+	// regressions where the service drops or mangles req.Filters before
+	// forwarding it to the store.
+	matchFilters := func(data []query.Filter) interface{} {
+		return mock.MatchedBy(func(f *query.Filters) bool {
+			return reflect.DeepEqual(f.Data, data)
+		})
+	}
+
+	deviceUIDFilterData := []query.Filter{
+		{
+			Type: query.FilterTypeProperty,
+			Params: &query.FilterProperty{
+				Name:     "device_uid",
+				Operator: "eq",
+				Value:    "uid1",
+			},
+		},
+	}
+
+	closedFilterData := []query.Filter{
+		{
+			Type: query.FilterTypeProperty,
+			Params: &query.FilterProperty{
+				Name:     "closed",
+				Operator: "bool",
+				Value:    true,
+			},
+		},
+	}
+
+	activeFilterData := []query.Filter{
+		{
+			Type: query.FilterTypeProperty,
+			Params: &query.FilterProperty{
+				Name:     "active",
+				Operator: "bool",
+				Value:    true,
+			},
+		},
+	}
+
 	cases := []struct {
 		description   string
 		req           *requests.ListSessions
@@ -47,6 +91,10 @@ func TestListSessions(t *testing.T) {
 			requiredMocks: func() {
 				queryOptionsMock.
 					On("InNamespace", "00000000-0000-4000-0000-000000000000").
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Match", mock.AnythingOfType("*query.Filters")).
 					Return(nil).
 					Once()
 				queryOptionsMock.
@@ -83,6 +131,10 @@ func TestListSessions(t *testing.T) {
 					Return(nil).
 					Once()
 				queryOptionsMock.
+					On("Match", mock.AnythingOfType("*query.Filters")).
+					Return(nil).
+					Once()
+				queryOptionsMock.
 					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc, Tiebreak: "id"}).
 					Return(nil).
 					Once()
@@ -105,6 +157,105 @@ func TestListSessions(t *testing.T) {
 					{UID: "uid3"},
 				}),
 				err: nil,
+			},
+		},
+		{
+			description: "succeeds with device_uid filter",
+			req: &requests.ListSessions{
+				TenantID:  "00000000-0000-4000-0000-000000000000",
+				Paginator: query.Paginator{Page: 1, PerPage: 10},
+				Filters:   query.Filters{Data: deviceUIDFilterData},
+			},
+			requiredMocks: func() {
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-4000-0000-000000000000").
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Match", matchFilters(deviceUIDFilterData)).
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc, Tiebreak: "id"}).
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
+					Return(nil).
+					Once()
+				storeMock.On("SessionList", ctx, mock.AnythingOfType("[]store.QueryOption")).
+					Return([]models.Session{{UID: "uid1"}}, 1, nil).Once()
+			},
+			expected: Expected{
+				sessions: []models.Session{{UID: "uid1"}},
+				count:    1,
+				err:      nil,
+			},
+		},
+		{
+			description: "succeeds with closed filter",
+			req: &requests.ListSessions{
+				TenantID:  "00000000-0000-4000-0000-000000000000",
+				Paginator: query.Paginator{Page: 1, PerPage: 10},
+				Filters:   query.Filters{Data: closedFilterData},
+			},
+			requiredMocks: func() {
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-4000-0000-000000000000").
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Match", matchFilters(closedFilterData)).
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc, Tiebreak: "id"}).
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
+					Return(nil).
+					Once()
+				storeMock.On("SessionList", ctx, mock.AnythingOfType("[]store.QueryOption")).
+					Return([]models.Session{}, 0, nil).Once()
+			},
+			expected: Expected{
+				sessions: []models.Session{},
+				count:    0,
+				err:      nil,
+			},
+		},
+		{
+			description: "succeeds with active filter",
+			req: &requests.ListSessions{
+				TenantID:  "00000000-0000-4000-0000-000000000000",
+				Paginator: query.Paginator{Page: 1, PerPage: 10},
+				Filters:   query.Filters{Data: activeFilterData},
+			},
+			requiredMocks: func() {
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-4000-0000-000000000000").
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Match", matchFilters(activeFilterData)).
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Sort", &query.Sorter{By: "started_at", Order: query.OrderDesc, Tiebreak: "id"}).
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).
+					Return(nil).
+					Once()
+				storeMock.On("SessionList", ctx, mock.AnythingOfType("[]store.QueryOption")).
+					Return([]models.Session{}, 0, nil).Once()
+			},
+			expected: Expected{
+				sessions: []models.Session{},
+				count:    0,
+				err:      nil,
 			},
 		},
 	}

--- a/api/store/pg/internal/filters.go
+++ b/api/store/pg/internal/filters.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/uptrace/bun"
 )
 
@@ -40,14 +41,19 @@ var legacyMongoFieldMapping = map[string]string{
 	"position.latitude":  "latitude",
 }
 
-// mapColumnFromLegacyMongo translates MongoDB-style nested field paths to PostgreSQL column names.
-// See legacyMongoFieldMapping for details. Returns the original column if no mapping exists.
-func mapColumnFromLegacyMongo(column string) string {
-	if mapped, ok := legacyMongoFieldMapping[column]; ok {
+// mapFieldToColumn translates a filter field name to the corresponding PostgreSQL column name.
+// It falls back to legacyMongoFieldMapping for Mongo-compatible field paths.
+// Returns the original field name if no mapping exists.
+//
+// NOTE: the device_uid→device_id alias is NOT applied here because it is
+// specific to the sessions table.  It is handled in ParseFilterProperty when
+// tableAlias == "session" so it cannot accidentally affect other filter contexts.
+func mapFieldToColumn(field string) string {
+	if mapped, ok := legacyMongoFieldMapping[field]; ok {
 		return mapped
 	}
 
-	return column
+	return field
 }
 
 // TODO: remove when MongoDB support is dropped.
@@ -59,6 +65,9 @@ func fromOnlineFilter(value any) (string, []any, bool, error) {
 	switch v := value.(type) {
 	case bool:
 		isOnline = v
+	case float64:
+		// JSON numbers always decode to float64; nonzero means online.
+		isOnline = v != 0
 	case string:
 		var err error
 		isOnline, err = strconv.ParseBool(v)
@@ -69,13 +78,66 @@ func fromOnlineFilter(value any) (string, []any, bool, error) {
 		return "", nil, false, ErrUnsupportedBoolType
 	}
 
-	threshold := time.Now().Add(-2 * time.Minute)
+	threshold := clock.Now().Add(-2 * time.Minute)
 
 	if isOnline {
 		return `("device"."disconnected_at" IS NULL AND "device"."last_seen" > ?)`, []any{threshold}, true, nil
 	}
 
 	return `("device"."disconnected_at" IS NOT NULL OR "device"."last_seen" <= ?)`, []any{threshold}, true, nil
+}
+
+// fromActiveFilter returns an EXISTS or NOT EXISTS correlated subquery on active_sessions.
+//
+// When tableAlias is "session" (session-list context) the subquery correlates on the
+// current session row's id, because the outer query is already iterating sessions:
+//
+//	EXISTS  (SELECT 1 FROM "active_sessions" WHERE "active_sessions"."session_id" = "session"."id")
+//	NOT EXISTS ...
+//
+// In all other contexts (e.g. device-list) the subquery checks whether any session for
+// the current device row has an active_sessions entry:
+//
+//	EXISTS  (SELECT 1 FROM "active_sessions"
+//	         JOIN "sessions" ON "sessions"."id" = "active_sessions"."session_id"
+//	         WHERE "sessions"."device_id" = "device"."id")
+func fromActiveFilter(value any, tableAlias string) (string, []any, bool, error) {
+	var isActive bool
+
+	switch v := value.(type) {
+	case bool:
+		isActive = v
+	case float64:
+		isActive = v != 0
+	case string:
+		var err error
+		isActive, err = strconv.ParseBool(v)
+		if err != nil {
+			return "", nil, false, err
+		}
+	default:
+		return "", nil, false, ErrUnsupportedBoolType
+	}
+
+	if tableAlias == "session" {
+		// Session-list context: correlate directly on the session's own id.
+		const sub = `(SELECT 1 FROM "active_sessions" WHERE "active_sessions"."session_id" = "session"."id")`
+
+		if isActive {
+			return `EXISTS ` + sub, nil, true, nil
+		}
+
+		return `NOT EXISTS ` + sub, nil, true, nil
+	}
+
+	// Device-list (and other) contexts: correlate via the sessions join.
+	const subquery = `(SELECT 1 FROM "active_sessions" JOIN "sessions" ON "sessions"."id" = "active_sessions"."session_id" WHERE "sessions"."device_id" = "device"."id")`
+
+	if isActive {
+		return `EXISTS ` + subquery, nil, true, nil
+	}
+
+	return `NOT EXISTS ` + subquery, nil, true, nil
 }
 
 // ParseFilterOperator converts a filter operator to its SQL representation. Supported operators are "AND" and "OR".
@@ -93,6 +155,22 @@ func ParseFilterProperty(fp *query.FilterProperty, tableAlias string) (string, [
 	// Handle virtual fields that don't exist as real columns (see fromOnlineFilter for details)
 	if fp.Name == "online" {
 		return fromOnlineFilter(fp.Value)
+	}
+
+	// active is a virtual field backed by the active_sessions table (see fromActiveFilter for details)
+	if fp.Name == "active" {
+		return fromActiveFilter(fp.Value, tableAlias)
+	}
+
+	// In the session context "device_uid" is a user-facing alias for the actual
+	// "device_id" column in the sessions table.  The mapping is applied here
+	// (not in mapFieldToColumn) so it is scoped to sessions only and cannot
+	// silently affect other filter contexts that happen to expose a device_uid
+	// field but use a different column name or no column at all.
+	if tableAlias == "session" && fp.Name == "device_uid" {
+		adjusted := *fp
+		adjusted.Name = "device_id"
+		fp = &adjusted
 	}
 
 	// tags.name requires an EXISTS subquery through the device_tags junction table,
@@ -174,7 +252,7 @@ func fromTagsFilter(operator string, value any) (string, []any, bool, error) {
 // for case-insensitive substring matching. For arrays, it uses the @> (contains) operator to check if the column
 // contains all the values in the array. Returns SQL condition string, arguments array, and error if any.
 func fromContains(column string, value any, tableAlias string) (string, []any, error) {
-	column = mapColumnFromLegacyMongo(column)
+	column = mapFieldToColumn(column)
 
 	switch v := value.(type) {
 	case string:
@@ -189,13 +267,13 @@ func fromContains(column string, value any, tableAlias string) (string, []any, e
 // fromEq converts an "eq" (equals) JSON expression to an SQL expression using =.
 // Returns SQL condition string, arguments array, and error if any.
 func fromEq(column string, value any, tableAlias string) (string, []any, error) {
-	return "? = ?", []any{qualifyColumn(mapColumnFromLegacyMongo(column), tableAlias), value}, nil
+	return "? = ?", []any{qualifyColumn(mapFieldToColumn(column), tableAlias), value}, nil
 }
 
-// fromBool converts a "bool" JSON expression to an SQL expression. It handles various input types (int, string, bool)
-// and converts them to boolean values.
+// fromBool converts a "bool" JSON expression to an SQL expression. It handles various input types (int, float64,
+// string, bool) and converts them to boolean values.
 //
-// - For integers: 0 is false, anything else is true
+// - For integers or float64: 0 is false, anything else is true
 //
 // - For strings: uses strconv.ParseBool
 //
@@ -207,6 +285,8 @@ func fromBool(column string, value any, tableAlias string) (string, []any, error
 
 	switch v := value.(type) {
 	case int:
+		boolValue = v != 0
+	case float64:
 		boolValue = v != 0
 	case string:
 		var err error
@@ -220,14 +300,14 @@ func fromBool(column string, value any, tableAlias string) (string, []any, error
 		return "", nil, ErrUnsupportedBoolType
 	}
 
-	return "? = ?", []any{qualifyColumn(mapColumnFromLegacyMongo(column), tableAlias), boolValue}, nil
+	return "? = ?", []any{qualifyColumn(mapFieldToColumn(column), tableAlias), boolValue}, nil
 }
 
 // fromGt converts a "gt" (greater than) JSON expression to an SQL expression using >. It handles various numeric types
 // (int, float, etc.) and string representations of numbers. For strings, it attempts to convert to int first, then to
 // float if int conversion fails. Returns SQL condition string, arguments array, and error if any.
 func fromGt(column string, value any, tableAlias string) (string, []any, error) {
-	column = mapColumnFromLegacyMongo(column)
+	column = mapFieldToColumn(column)
 
 	switch v := value.(type) {
 	case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64, float32, float64:
@@ -255,7 +335,7 @@ func fromGt(column string, value any, tableAlias string) (string, []any, error) 
 // fromLt converts a "lt" (less than) JSON expression to an SQL expression using <. It handles numeric types,
 // strings, and time.Time values. Returns SQL condition string, arguments array, and error if any.
 func fromLt(column string, value any, tableAlias string) (string, []any, error) {
-	column = mapColumnFromLegacyMongo(column)
+	column = mapFieldToColumn(column)
 
 	switch v := value.(type) {
 	case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64, float32, float64:
@@ -283,7 +363,7 @@ func fromLt(column string, value any, tableAlias string) (string, []any, error) 
 // fromNe converts a "ne" (not equals) JSON expression to an SQL expression using <>. Returns SQL condition string,
 // arguments array, and error if any.
 func fromNe(column string, value any, tableAlias string) (string, []any, error) {
-	return "? <> ?", []any{qualifyColumn(mapColumnFromLegacyMongo(column), tableAlias), value}, nil
+	return "? <> ?", []any{qualifyColumn(mapFieldToColumn(column), tableAlias), value}, nil
 }
 
 // fromCustomFieldsFilter searches across all values of the custom_fields JSONB column.

--- a/api/store/pg/internal/filters_test.go
+++ b/api/store/pg/internal/filters_test.go
@@ -1,0 +1,436 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func TestMapFieldToColumn(t *testing.T) {
+	cases := []struct {
+		description string
+		field       string
+		want        string
+	}{
+		{
+			// device_uid is NOT a global alias — the mapping to device_id is
+			// session-specific and applied by ParseFilterProperty when tableAlias
+			// is "session".  mapFieldToColumn must not alter it globally.
+			description: "device_uid passes through unchanged (not a global alias)",
+			field:       "device_uid",
+			want:        "device_uid",
+		},
+		{
+			description: "legacy mongo field info.platform maps to platform",
+			field:       "info.platform",
+			want:        "platform",
+		},
+		{
+			description: "unknown field passes through unchanged",
+			field:       "name",
+			want:        "name",
+		},
+		{
+			description: "identity.mac maps to mac",
+			field:       "identity.mac",
+			want:        "mac",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			got := mapFieldToColumn(tc.field)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestParseFilterProperty_DeviceUID verifies that the device_uid→device_id
+// column alias is applied only in the session context (tableAlias == "session"),
+// not globally.  If applied globally, a future endpoint that exposes device_uid
+// for a table with no device_id column would silently produce wrong SQL instead
+// of a column-not-found error.
+func TestParseFilterProperty_DeviceUID(t *testing.T) {
+	cases := []struct {
+		description string
+		tableAlias  string
+		wantCol     bun.Ident // the column identifier expected in args[0]
+	}{
+		{
+			description: "session context: device_uid maps to session.device_id",
+			tableAlias:  "session",
+			wantCol:     bun.Ident("session.device_id"),
+		},
+		{
+			// In non-session contexts device_uid is an unknown alias and must
+			// NOT be silently remapped — it should produce the literal column
+			// name so that the database rejects it with a clear error if the
+			// column does not exist.
+			description: "non-session context: device_uid passes through unchanged",
+			tableAlias:  "device",
+			wantCol:     bun.Ident("device.device_uid"),
+		},
+		{
+			description: "empty alias: device_uid passes through unchanged",
+			tableAlias:  "",
+			wantCol:     bun.Ident("device_uid"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			fp := &query.FilterProperty{Name: "device_uid", Operator: "eq", Value: "abc"}
+			sqlCond, args, ok, err := ParseFilterProperty(fp, tc.tableAlias)
+			require.NoError(t, err)
+			assert.True(t, ok)
+			assert.Equal(t, "? = ?", sqlCond)
+			require.Len(t, args, 2)
+			assert.Equal(t, tc.wantCol, args[0])
+			assert.Equal(t, "abc", args[1])
+		})
+	}
+}
+
+func TestFromActiveFilter(t *testing.T) {
+	const deviceExistsSQL = `EXISTS (SELECT 1 FROM "active_sessions" JOIN "sessions" ON "sessions"."id" = "active_sessions"."session_id" WHERE "sessions"."device_id" = "device"."id")`
+	const deviceNotExistsSQL = `NOT EXISTS (SELECT 1 FROM "active_sessions" JOIN "sessions" ON "sessions"."id" = "active_sessions"."session_id" WHERE "sessions"."device_id" = "device"."id")`
+	const sessionExistsSQL = `EXISTS (SELECT 1 FROM "active_sessions" WHERE "active_sessions"."session_id" = "session"."id")`
+	const sessionNotExistsSQL = `NOT EXISTS (SELECT 1 FROM "active_sessions" WHERE "active_sessions"."session_id" = "session"."id")`
+
+	cases := []struct {
+		description string
+		value       any
+		tableAlias  string
+		wantSQL     string
+		wantArgs    []any
+		wantOk      bool
+		wantErr     error
+	}{
+		{
+			description: "device context: bool true produces EXISTS device subquery",
+			value:       true,
+			tableAlias:  "",
+			wantSQL:     deviceExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "device context: bool false produces NOT EXISTS device subquery",
+			value:       false,
+			tableAlias:  "",
+			wantSQL:     deviceNotExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "device context: string true produces EXISTS device subquery",
+			value:       "true",
+			tableAlias:  "",
+			wantSQL:     deviceExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "device context: string false produces NOT EXISTS device subquery",
+			value:       "false",
+			tableAlias:  "",
+			wantSQL:     deviceNotExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "session context: bool true produces EXISTS session subquery",
+			value:       true,
+			tableAlias:  "session",
+			wantSQL:     sessionExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "session context: bool false produces NOT EXISTS session subquery",
+			value:       false,
+			tableAlias:  "session",
+			wantSQL:     sessionNotExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "session context: float64 1 (JSON number) produces EXISTS session subquery",
+			value:       float64(1),
+			tableAlias:  "session",
+			wantSQL:     sessionExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "session context: float64 0 (JSON number) produces NOT EXISTS session subquery",
+			value:       float64(0),
+			tableAlias:  "session",
+			wantSQL:     sessionNotExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "device context: float64 1 (JSON number) produces EXISTS device subquery",
+			value:       float64(1),
+			tableAlias:  "",
+			wantSQL:     deviceExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			// int is not produced by JSON decoding (JSON numbers decode to float64),
+			// so int remains an unsupported type.
+			description: "unsupported type int returns error",
+			value:       42,
+			tableAlias:  "",
+			wantSQL:     "",
+			wantArgs:    nil,
+			wantOk:      false,
+			wantErr:     ErrUnsupportedBoolType,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			sql, args, ok, err := fromActiveFilter(tc.value, tc.tableAlias)
+			assert.Equal(t, tc.wantOk, ok)
+			assert.Equal(t, tc.wantSQL, sql)
+			assert.Equal(t, tc.wantArgs, args)
+			assert.Equal(t, tc.wantErr, err)
+		})
+	}
+}
+
+// TestParseFilterProperty_Bool verifies that fromBool correctly handles all
+// value types accepted from client JSON, including the float64 case (JSON
+// numbers always decode to float64, never int).
+func TestParseFilterProperty_Bool(t *testing.T) {
+	cases := []struct {
+		description string
+		value       any
+		wantBool    bool
+		wantOk      bool
+		wantErr     bool
+	}{
+		{description: "bool true", value: true, wantBool: true, wantOk: true},
+		{description: "bool false", value: false, wantBool: false, wantOk: true},
+		{description: "string 1", value: "1", wantBool: true, wantOk: true},
+		{description: "string false", value: "false", wantBool: false, wantOk: true},
+		{description: "float64 nonzero (JSON number)", value: float64(1), wantBool: true, wantOk: true},
+		{description: "float64 zero (JSON number)", value: float64(0), wantBool: false, wantOk: true},
+		// int is not produced by JSON decoding but is still handled by fromBool
+		// for programmatic callers.
+		{description: "int nonzero (programmatic, not JSON)", value: 1, wantBool: true, wantOk: true},
+		{description: "invalid string", value: "yes", wantOk: false, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			fp := &query.FilterProperty{Name: "closed", Operator: "bool", Value: tc.value}
+			sqlCond, args, ok, err := ParseFilterProperty(fp, "session")
+			assert.Equal(t, tc.wantOk, ok)
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "? = ?", sqlCond)
+			require.Len(t, args, 2)
+			// args[0] is the qualified column identifier; args[1] is the resolved bool.
+			assert.Equal(t, bun.Ident("session.closed"), args[0])
+			assert.Equal(t, tc.wantBool, args[1])
+		})
+	}
+}
+
+func TestFromOnlineFilter(t *testing.T) {
+	const onlineSQL = `("device"."disconnected_at" IS NULL AND "device"."last_seen" > ?)`
+	const offlineSQL = `("device"."disconnected_at" IS NOT NULL OR "device"."last_seen" <= ?)`
+
+	cases := []struct {
+		description string
+		value       any
+		wantSQL     string
+		wantOk      bool
+		wantErr     error
+	}{
+		{
+			description: "bool true produces online SQL",
+			value:       true,
+			wantSQL:     onlineSQL,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "bool false produces offline SQL",
+			value:       false,
+			wantSQL:     offlineSQL,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "string true produces online SQL",
+			value:       "true",
+			wantSQL:     onlineSQL,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "string false produces offline SQL",
+			value:       "false",
+			wantSQL:     offlineSQL,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			// JSON numbers always decode to float64; nonzero means online.
+			description: "float64 nonzero (JSON number) produces online SQL",
+			value:       float64(1),
+			wantSQL:     onlineSQL,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			description: "float64 zero (JSON number) produces offline SQL",
+			value:       float64(0),
+			wantSQL:     offlineSQL,
+			wantOk:      true,
+			wantErr:     nil,
+		},
+		{
+			// int is not produced by JSON decoding (JSON numbers decode to float64),
+			// so int remains an unsupported type.
+			description: "unsupported type int returns ErrUnsupportedBoolType",
+			value:       42,
+			wantSQL:     "",
+			wantOk:      false,
+			wantErr:     ErrUnsupportedBoolType,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			sql, args, ok, err := fromOnlineFilter(tc.value)
+			assert.Equal(t, tc.wantOk, ok)
+			assert.Equal(t, tc.wantErr, err)
+
+			if tc.wantOk {
+				assert.Equal(t, tc.wantSQL, sql)
+				require.Len(t, args, 1)
+			}
+		})
+	}
+}
+
+func TestParseFilterProperty_Active(t *testing.T) {
+	const deviceExistsSQL = `EXISTS (SELECT 1 FROM "active_sessions" JOIN "sessions" ON "sessions"."id" = "active_sessions"."session_id" WHERE "sessions"."device_id" = "device"."id")`
+	const deviceNotExistsSQL = `NOT EXISTS (SELECT 1 FROM "active_sessions" JOIN "sessions" ON "sessions"."id" = "active_sessions"."session_id" WHERE "sessions"."device_id" = "device"."id")`
+	const sessionExistsSQL = `EXISTS (SELECT 1 FROM "active_sessions" WHERE "active_sessions"."session_id" = "session"."id")`
+	const sessionNotExistsSQL = `NOT EXISTS (SELECT 1 FROM "active_sessions" WHERE "active_sessions"."session_id" = "session"."id")`
+
+	cases := []struct {
+		description string
+		fp          *query.FilterProperty
+		tableAlias  string
+		wantSQL     string
+		wantArgs    []any
+		wantOk      bool
+		wantErr     bool
+	}{
+		{
+			description: "device context: active=true routes to EXISTS device subquery",
+			fp:          &query.FilterProperty{Name: "active", Value: true},
+			tableAlias:  "device",
+			wantSQL:     deviceExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     false,
+		},
+		{
+			description: "device context: active=false routes to NOT EXISTS device subquery",
+			fp:          &query.FilterProperty{Name: "active", Value: false},
+			tableAlias:  "device",
+			wantSQL:     deviceNotExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     false,
+		},
+		{
+			description: "session context: active=true routes to EXISTS session subquery",
+			fp:          &query.FilterProperty{Name: "active", Value: true},
+			tableAlias:  "session",
+			wantSQL:     sessionExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     false,
+		},
+		{
+			description: "session context: active=false routes to NOT EXISTS session subquery",
+			fp:          &query.FilterProperty{Name: "active", Value: false},
+			tableAlias:  "session",
+			wantSQL:     sessionNotExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     false,
+		},
+		{
+			description: "session context: float64 1 (JSON number) produces EXISTS session subquery",
+			fp:          &query.FilterProperty{Name: "active", Value: float64(1)},
+			tableAlias:  "session",
+			wantSQL:     sessionExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     false,
+		},
+		{
+			description: "session context: float64 0 (JSON number) produces NOT EXISTS session subquery",
+			fp:          &query.FilterProperty{Name: "active", Value: float64(0)},
+			tableAlias:  "session",
+			wantSQL:     sessionNotExistsSQL,
+			wantArgs:    nil,
+			wantOk:      true,
+			wantErr:     false,
+		},
+		{
+			// int is not produced by JSON decoding (JSON numbers decode to float64),
+			// so int remains unsupported.
+			description: "active with unsupported value type int returns error",
+			fp:          &query.FilterProperty{Name: "active", Value: 99},
+			tableAlias:  "device",
+			wantSQL:     "",
+			wantArgs:    nil,
+			wantOk:      false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			sql, args, ok, err := ParseFilterProperty(tc.fp, tc.tableAlias)
+			assert.Equal(t, tc.wantOk, ok)
+			assert.Equal(t, tc.wantSQL, sql)
+			assert.Equal(t, tc.wantArgs, args)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/api/store/storetest/session_tests.go
+++ b/api/store/storetest/session_tests.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,6 +136,225 @@ func (s *Suite) TestSessionList(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 5, count)
 		assert.Len(t, sessions, 1)
+	})
+
+	// Seed shared across the four filter subtests below.
+	//
+	// Layout:
+	//   device1: sess_a (active, open), sess_b (closed, inactive – via ActiveSessionDelete)
+	//   device2: sess_c (active, open), sess_d (inactive, open – never had an active-sessions row)
+	//
+	// Resulting counts per filter:
+	//   device_uid = device1  → sess_a + sess_b = 2
+	//   closed = true         → sess_b            = 1
+	//   closed = false        → sess_a, sess_c, sess_d = 3
+	//   active = true         → sess_a, sess_c    = 2  (rows exist in active_sessions)
+	//   active = false        → sess_b, sess_d    = 2  (no active_sessions row)
+	t.Run("filters by device_uid eq", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		device1 := s.CreateDevice(t)
+		device2 := s.CreateDevice(t)
+
+		// device1: one active, one closed
+		sessA := s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		sessB := s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		require.NoError(t, st.ActiveSessionDelete(ctx, sessB)) // closes sessB
+
+		// device2: one active, one inactive-but-open
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(true))
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(false))
+
+		_ = sessA
+
+		sessions, count, err := st.SessionList(ctx,
+			st.Options().Match(&query.Filters{Data: []query.Filter{
+				{Type: query.FilterTypeProperty, Params: &query.FilterProperty{
+					Name:     "device_uid",
+					Operator: "eq",
+					Value:    string(device1),
+				}},
+			}}),
+			st.Options().Paginate(&query.Paginator{Page: -1, PerPage: -1}),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+		assert.Len(t, sessions, 2)
+		for _, s := range sessions {
+			assert.Equal(t, device1, s.DeviceUID)
+		}
+	})
+
+	t.Run("filters by device_uid ne", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		device1 := s.CreateDevice(t)
+		device2 := s.CreateDevice(t)
+
+		// device1: two sessions
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+
+		// device2: two sessions
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(true))
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(false))
+
+		// "ne device1" should return only device2 sessions.
+		sessions, count, err := st.SessionList(ctx,
+			st.Options().Match(&query.Filters{Data: []query.Filter{
+				{Type: query.FilterTypeProperty, Params: &query.FilterProperty{
+					Name:     "device_uid",
+					Operator: "ne",
+					Value:    string(device1),
+				}},
+			}}),
+			st.Options().Paginate(&query.Paginator{Page: -1, PerPage: -1}),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+		assert.Len(t, sessions, 2)
+
+		for _, s := range sessions {
+			assert.Equal(t, device2, s.DeviceUID)
+		}
+	})
+
+	t.Run("filters by closed bool true", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		device1 := s.CreateDevice(t)
+		device2 := s.CreateDevice(t)
+
+		// device1: one active/open, one closed
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		sessB := s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		require.NoError(t, st.ActiveSessionDelete(ctx, sessB))
+
+		// device2: one active, one inactive-open
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(true))
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(false))
+
+		sessions, count, err := st.SessionList(ctx,
+			st.Options().Match(&query.Filters{Data: []query.Filter{
+				{Type: query.FilterTypeProperty, Params: &query.FilterProperty{
+					Name:     "closed",
+					Operator: "bool",
+					Value:    true,
+				}},
+			}}),
+			st.Options().Paginate(&query.Paginator{Page: -1, PerPage: -1}),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+		assert.Len(t, sessions, 1)
+		for _, s := range sessions {
+			assert.True(t, s.Closed)
+		}
+	})
+
+	t.Run("filters by closed bool false", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		device1 := s.CreateDevice(t)
+		device2 := s.CreateDevice(t)
+
+		// device1: one active/open, one closed
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		sessB := s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		require.NoError(t, st.ActiveSessionDelete(ctx, sessB))
+
+		// device2: one active, one inactive-open
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(true))
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(false))
+
+		sessions, count, err := st.SessionList(ctx,
+			st.Options().Match(&query.Filters{Data: []query.Filter{
+				{Type: query.FilterTypeProperty, Params: &query.FilterProperty{
+					Name:     "closed",
+					Operator: "bool",
+					Value:    false,
+				}},
+			}}),
+			st.Options().Paginate(&query.Paginator{Page: -1, PerPage: -1}),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 3, count)
+		assert.Len(t, sessions, 3)
+		for _, s := range sessions {
+			assert.False(t, s.Closed)
+		}
+	})
+
+	t.Run("filters by active bool true", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		device1 := s.CreateDevice(t)
+		device2 := s.CreateDevice(t)
+
+		// device1: one active/open, one closed (inactive after delete)
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		sessB := s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		require.NoError(t, st.ActiveSessionDelete(ctx, sessB))
+
+		// device2: one active, one inactive-open
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(true))
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(false))
+
+		sessions, count, err := st.SessionList(ctx,
+			st.Options().Match(&query.Filters{Data: []query.Filter{
+				{Type: query.FilterTypeProperty, Params: &query.FilterProperty{
+					Name:     "active",
+					Operator: "bool",
+					Value:    true,
+				}},
+			}}),
+			st.Options().Paginate(&query.Paginator{Page: -1, PerPage: -1}),
+		)
+		require.NoError(t, err)
+		assert.Greater(t, count, 0)
+		assert.NotEmpty(t, sessions)
+		assert.Equal(t, 2, count)
+		assert.Len(t, sessions, 2)
+		for _, s := range sessions {
+			assert.True(t, s.Active)
+		}
+	})
+
+	t.Run("filters by active bool false", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		device1 := s.CreateDevice(t)
+		device2 := s.CreateDevice(t)
+
+		// device1: one active/open, one closed (removed from active_sessions via ActiveSessionDelete)
+		s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		sessB := s.CreateSession(t, WithSessionDevice(device1), WithSessionActive(true))
+		require.NoError(t, st.ActiveSessionDelete(ctx, sessB))
+
+		// device2: one active, one inactive-open (never had an active_sessions row)
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(true))
+		s.CreateSession(t, WithSessionDevice(device2), WithSessionActive(false))
+
+		// The NOT EXISTS correlated subquery on active_sessions.session_id must
+		// match only sessions without an active_sessions row (sess_b and sess_d).
+		sessions, count, err := st.SessionList(ctx,
+			st.Options().Match(&query.Filters{Data: []query.Filter{
+				{Type: query.FilterTypeProperty, Params: &query.FilterProperty{
+					Name:     "active",
+					Operator: "bool",
+					Value:    false,
+				}},
+			}}),
+			st.Options().Paginate(&query.Paginator{Page: -1, PerPage: -1}),
+		)
+		require.NoError(t, err)
+		assert.Greater(t, count, 0)
+		assert.NotEmpty(t, sessions)
+		assert.Equal(t, 2, count)
+		assert.Len(t, sessions, 2)
+		for _, s := range sessions {
+			assert.False(t, s.Active)
+		}
 	})
 }
 
@@ -381,7 +601,7 @@ func (s *Suite) TestActiveSessionUpdate(t *testing.T) {
 
 		err := st.ActiveSessionUpdate(ctx, &models.ActiveSession{
 			UID:      "nonexistent",
-			LastSeen: time.Now(),
+			LastSeen: clock.Now(),
 		})
 		assert.ErrorIs(t, err, store.ErrNoDocuments)
 	})
@@ -417,7 +637,7 @@ func (s *Suite) TestSessionEventsCreate(t *testing.T) {
 		event := &models.SessionEvent{
 			Session:   string(sessionUID),
 			Type:      models.SessionEventTypePtyOutput,
-			Timestamp: time.Now(),
+			Timestamp: clock.Now(),
 			Data:      map[string]interface{}{"output": "test output"},
 			Seat:      1,
 		}
@@ -437,7 +657,7 @@ func (s *Suite) TestSessionEventsCreate(t *testing.T) {
 			event := &models.SessionEvent{
 				Session:   string(sessionUID),
 				Type:      models.SessionEventTypePtyOutput,
-				Timestamp: time.Now(),
+				Timestamp: clock.Now(),
 				Data:      map[string]interface{}{"output": "test output"},
 				Seat:      i,
 			}
@@ -473,7 +693,7 @@ func (s *Suite) TestSessionEventsList(t *testing.T) {
 			event := &models.SessionEvent{
 				Session:   string(sessionUID),
 				Type:      models.SessionEventTypePtyOutput,
-				Timestamp: time.Now(),
+				Timestamp: clock.Now(),
 				Data:      map[string]interface{}{"output": "test output"},
 				Seat:      1,
 			}
@@ -501,7 +721,7 @@ func (s *Suite) TestSessionEventsList(t *testing.T) {
 				event := &models.SessionEvent{
 					Session:   string(sessionUID),
 					Type:      models.SessionEventTypePtyOutput,
-					Timestamp: time.Now(),
+					Timestamp: clock.Now(),
 					Data:      map[string]interface{}{"output": "test output"},
 					Seat:      seat,
 				}
@@ -528,7 +748,7 @@ func (s *Suite) TestSessionEventsList(t *testing.T) {
 		event1 := &models.SessionEvent{
 			Session:   string(sessionUID),
 			Type:      models.SessionEventTypePtyOutput,
-			Timestamp: time.Now(),
+			Timestamp: clock.Now(),
 			Data:      map[string]interface{}{"output": "test output"},
 			Seat:      1,
 		}
@@ -536,7 +756,7 @@ func (s *Suite) TestSessionEventsList(t *testing.T) {
 		event2 := &models.SessionEvent{
 			Session:   string(sessionUID),
 			Type:      models.SessionEventTypePtyRequest,
-			Timestamp: time.Now(),
+			Timestamp: clock.Now(),
 			Data:      map[string]interface{}{"request": "test request"},
 			Seat:      1,
 		}
@@ -578,7 +798,7 @@ func (s *Suite) TestSessionEventsDelete(t *testing.T) {
 			event := &models.SessionEvent{
 				Session:   string(sessionUID),
 				Type:      models.SessionEventTypePtyOutput,
-				Timestamp: time.Now(),
+				Timestamp: clock.Now(),
 				Data:      map[string]interface{}{"output": "test output"},
 				Seat:      1,
 			}
@@ -609,7 +829,7 @@ func (s *Suite) TestSessionEventsDelete(t *testing.T) {
 			event := &models.SessionEvent{
 				Session:   string(sessionUID),
 				Type:      models.SessionEventTypePtyOutput,
-				Timestamp: time.Now(),
+				Timestamp: clock.Now(),
 				Data:      map[string]interface{}{"output": "test output"},
 				Seat:      seat,
 			}
@@ -645,7 +865,7 @@ func (s *Suite) TestSessionEventsDelete(t *testing.T) {
 		event1 := &models.SessionEvent{
 			Session:   string(sessionUID),
 			Type:      models.SessionEventTypePtyOutput,
-			Timestamp: time.Now(),
+			Timestamp: clock.Now(),
 			Data:      map[string]interface{}{"output": "test output"},
 			Seat:      1,
 		}
@@ -653,7 +873,7 @@ func (s *Suite) TestSessionEventsDelete(t *testing.T) {
 		event2 := &models.SessionEvent{
 			Session:   string(sessionUID),
 			Type:      models.SessionEventTypePtyRequest,
-			Timestamp: time.Now(),
+			Timestamp: clock.Now(),
 			Data:      map[string]interface{}{"request": "test request"},
 			Seat:      1,
 		}

--- a/openapi/spec/paths/api@sessions.yaml
+++ b/openapi/spec/paths/api@sessions.yaml
@@ -9,6 +9,7 @@ get:
     - jwt: []
     - api-key: []
   parameters:
+    - $ref: ../components/parameters/query/filterQuery.yaml
     - $ref: ../components/parameters/query/pageQuery.yaml
     - $ref: ../components/parameters/query/perPageQuery.yaml
   responses:
@@ -23,6 +24,8 @@ get:
             type: array
             items:
               $ref: ../components/schemas/session.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '500':

--- a/pkg/api/query/validate.go
+++ b/pkg/api/query/validate.go
@@ -1,5 +1,7 @@
 package query
 
+import "strconv"
+
 // Size limits applied to client-supplied filters. Together they bound the
 // cost of serving a malicious filter payload: the outer limit caps the raw
 // request size, the inner limits cap the structural complexity after decode.
@@ -41,28 +43,56 @@ func (s FieldSet) Allows(name string) bool {
 // against it. It lets the handler reject field+operator combinations that
 // the database rejects with a server-side error (e.g. ILIKE on an enum),
 // turning them into a clean HTTP 400 before they reach the store.
-type FieldConstraints map[string]FieldSet
+//
+// A subset of fields may be declared as virtual bool-backed at construction
+// time (see NewFieldConstraints). Virtual fields are intercepted by
+// ParseFilterProperty before any SQL column binding, so they safely accept
+// bool-convertible values with eq/ne. Real boolean columns must NOT be
+// declared virtual unless a corresponding ParseFilterProperty intercept exists.
+type FieldConstraints struct {
+	operators    map[string]FieldSet
+	virtualBools FieldSet
+}
 
 // NewFieldConstraints returns a FieldConstraints initialized with the given
-// field→operators pairs. An empty operators slice means the field is
-// rejected entirely.
-func NewFieldConstraints(entries map[string][]string) FieldConstraints {
-	c := make(FieldConstraints, len(entries))
+// field→operators pairs. An empty operators slice means the field is rejected
+// entirely. virtualBools lists the field names that are virtual bool-backed:
+// they are intercepted by ParseFilterProperty before SQL column binding, so
+// they may accept bool-convertible values with eq/ne. Only fields that have a
+// corresponding ParseFilterProperty intercept should be listed here.
+func NewFieldConstraints(entries map[string][]string, virtualBools ...string) FieldConstraints {
+	operators := make(map[string]FieldSet, len(entries))
 	for name, ops := range entries {
-		c[name] = NewFieldSet(ops...)
+		operators[name] = NewFieldSet(ops...)
 	}
 
-	return c
+	return FieldConstraints{
+		operators:    operators,
+		virtualBools: NewFieldSet(virtualBools...),
+	}
 }
 
 // Allows reports whether operator is valid for the given field name.
 func (c FieldConstraints) Allows(name, operator string) bool {
-	ops, ok := c[name]
+	ops, ok := c.operators[name]
 	if !ok {
 		return false
 	}
 
 	return ops.Allows(operator)
+}
+
+// IsVirtualBoolField reports whether name is a virtual bool-backed field —
+// one explicitly declared as virtual at construction time via NewFieldConstraints
+// and therefore intercepted by ParseFilterProperty before any SQL column binding.
+//
+// Only fields in the virtualBools registry return true. Using the presence of
+// the "bool" operator as a proxy is incorrect: a real boolean column that only
+// allows "bool" (not "eq"/"ne") is safe today, but the moment "eq" is added to
+// it without a ParseFilterProperty intercept, the validator would silently accept
+// bool/float64 values that produce a Postgres type-mismatch 500 at runtime.
+func (c FieldConstraints) IsVirtualBoolField(name string) bool {
+	return c.virtualBools.Allows(name)
 }
 
 // ValidateSorter returns [ErrSorterFieldInvalid] if the sort field is set and
@@ -110,6 +140,27 @@ func ValidateFilters(filters *Filters, constraints FieldConstraints) error {
 		if !isPrimitive(prop.Value) || !isValueWithinLimits(prop.Value) {
 			return ErrFilterPropertyInvalid
 		}
+
+		if prop.Operator == "bool" && !isBoolConvertible(prop.Value) {
+			return ErrFilterPropertyInvalid
+		}
+
+		if prop.Operator == "eq" || prop.Operator == "ne" {
+			// Virtual bool-backed fields (see IsVirtualBoolField) are intercepted by
+			// ParseFilterProperty before any SQL column binding, so they accept any
+			// bool-convertible value (bool, float64, parseable string).
+			// Regular text-column fields must receive a string to prevent a
+			// Postgres type-mismatch 500.
+			if constraints.IsVirtualBoolField(prop.Name) {
+				if !isBoolConvertible(prop.Value) {
+					return ErrFilterPropertyInvalid
+				}
+			} else {
+				if _, ok := prop.Value.(string); !ok {
+					return ErrFilterPropertyInvalid
+				}
+			}
+		}
 	}
 
 	return nil
@@ -135,6 +186,25 @@ func isValueWithinLimits(v interface{}) bool {
 		return true
 	default:
 		return true
+	}
+}
+
+// isBoolConvertible reports whether v can be converted to a boolean value by
+// the filter store layer. It accepts bool values directly, float64 values
+// (JSON numbers always decode to float64; 0 is false, any other value is true),
+// and strings accepted by [strconv.ParseBool].
+func isBoolConvertible(v interface{}) bool {
+	switch x := v.(type) {
+	case bool:
+		return true
+	case float64:
+		return true
+	case string:
+		_, err := strconv.ParseBool(x)
+
+		return err == nil
+	default:
+		return false
 	}
 }
 

--- a/pkg/api/query/validate_test.go
+++ b/pkg/api/query/validate_test.go
@@ -86,10 +86,19 @@ func TestValidateSorter(t *testing.T) {
 }
 
 func TestValidateFilters(t *testing.T) {
+	// "online" mirrors production DeviceFilterFields: it accepts both "bool" and
+	// "eq" so the virtual-field eq-with-bool-value path is exercised.
+	// "realclosed" simulates a real boolean column that has both "bool" and "eq"
+	// operators but is NOT declared as a virtual field — it must never accept
+	// bool-convertible values for eq/ne because ParseFilterProperty will not
+	// intercept it and the value would be bound directly to a Postgres boolean
+	// column via fromEq, where a non-string bind causes a type-mismatch 500.
 	allowed := NewFieldConstraints(map[string][]string{
-		"name":   {"contains", "eq"},
-		"status": {"eq", "ne"},
-	})
+		"name":       {"contains", "eq"},
+		"status":     {"eq", "ne"},
+		"online":     {"bool", "eq"},
+		"realclosed": {"bool", "eq"},
+	}, "online" /* virtual bool fields */)
 
 	cases := []struct {
 		name    string
@@ -209,11 +218,228 @@ func TestValidateFilters(t *testing.T) {
 			}},
 			wantErr: ErrFilterPropertyInvalid,
 		},
+		// bool-operator value type validation
+		{
+			name: "bool operator with bool value is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "bool", Value: true}},
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "bool operator with float64 (JSON number) is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "bool", Value: float64(1)}},
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "bool operator with bool-parseable string is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "bool", Value: "true"}},
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "bool operator with non-bool string is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "bool", Value: "yes"}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			// nil is a JSON primitive (isPrimitive passes), but isBoolConvertible(nil)
+			// returns false, so the bool-operator guard must catch and reject it before
+			// it reaches the store's fromBool/fromOnlineFilter (which return
+			// ErrUnsupportedBoolType on nil, producing a 500 instead of 400).
+			name: "bool operator with nil value is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "bool", Value: nil}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		// eq/ne operator scalar enforcement
+		{
+			name: "eq operator with array value is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: []interface{}{"a", "b"}}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "ne operator with array value is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: []interface{}{"a"}}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "eq operator with scalar string is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: "pending"}},
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "ne operator with scalar string is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: "pending"}},
+			}},
+			wantErr: nil,
+		},
+		// eq/ne must reject non-string scalars (float64/bool/nil) for text columns;
+		// a numeric or bool bind parameter against a varchar column causes a Postgres
+		// type-mismatch error (500) instead of a clean 400.
+		{
+			name: "eq operator with float64 (JSON number) is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: float64(123)}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "eq operator with bool value is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: true}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "ne operator with float64 (JSON number) is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: float64(0)}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "ne operator with bool value is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: false}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		// eq/ne with nil value is rejected regardless of field type.
+		{
+			name: "eq operator with nil value is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "eq", Value: nil}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "ne operator with nil value is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "status", Operator: "ne", Value: nil}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		// Virtual bool-backed fields (those also allowing "bool") may use eq/ne with
+		// bool-convertible values because ParseFilterProperty routes them to
+		// fromOnlineFilter before any SQL column binding occurs.
+		{
+			name: "online: eq operator with bool true is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "eq", Value: true}},
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "online: eq operator with bool false is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "eq", Value: false}},
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "online: eq operator with float64 (JSON number) is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "eq", Value: float64(1)}},
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "online: eq operator with bool-parseable string is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "eq", Value: "true"}},
+			}},
+			wantErr: nil,
+		},
+		{
+			name: "online: eq operator with non-bool string is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "eq", Value: "yes"}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "online: eq operator with nil is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "online", Operator: "eq", Value: nil}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		// realclosed is a real boolean column (not virtual): "bool" and "eq" are
+		// both allowed operators, but since it is NOT declared as a virtual bool
+		// field, eq/ne must require a string value.  Accepting a bool or float64
+		// here would produce a Postgres type-mismatch 500 because ParseFilterProperty
+		// does not intercept "realclosed" and would pass the raw bool/numeric to
+		// fromEq, binding it against a boolean column via "boolean = numeric/bool".
+		{
+			name: "realclosed (non-virtual): eq with bool value is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "realclosed", Operator: "eq", Value: true}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "realclosed (non-virtual): eq with float64 (JSON number) is rejected",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "realclosed", Operator: "eq", Value: float64(1)}},
+			}},
+			wantErr: ErrFilterPropertyInvalid,
+		},
+		{
+			name: "realclosed (non-virtual): eq with string value is accepted",
+			filters: &Filters{Data: []Filter{
+				{Type: FilterTypeProperty, Params: &FilterProperty{Name: "realclosed", Operator: "eq", Value: "true"}},
+			}},
+			wantErr: nil,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.wantErr, ValidateFilters(tc.filters, allowed))
+		})
+	}
+}
+
+func TestIsBoolConvertible(t *testing.T) {
+	cases := []struct {
+		name string
+		in   interface{}
+		want bool
+	}{
+		{"bool true", true, true},
+		{"bool false", false, true},
+		{"float64 nonzero (JSON number)", float64(1), true},
+		{"float64 zero (JSON number)", float64(0), true},
+		{"string true", "true", true},
+		{"string 1", "1", true},
+		{"string false", "false", true},
+		{"string 0", "0", true},
+		{"string t", "t", true},
+		{"string yes — rejected by ParseBool", "yes", false},
+		{"string on — rejected by ParseBool", "on", false},
+		{"string x — invalid", "x", false},
+		{"nil", nil, false},
+		{"int — not a JSON type", 1, false},
+		{"slice", []interface{}{true}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isBoolConvertible(tc.in))
 		})
 	}
 }

--- a/pkg/api/requests/session.go
+++ b/pkg/api/requests/session.go
@@ -15,6 +15,7 @@ type SessionIDParam struct {
 type ListSessions struct {
 	TenantID string `header:"X-Tenant-ID"`
 	query.Paginator
+	query.Filters
 }
 
 // SessionGet is the structure to represent the request data for get session endpoint.

--- a/pkg/api/requests/session_test.go
+++ b/pkg/api/requests/session_test.go
@@ -1,0 +1,42 @@
+package requests
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/api/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListSessionsFiltersEmbedding verifies that ListSessions embeds
+// query.Filters such that its methods (Unmarshal, etc.) are accessible
+// through the request struct and work end-to-end.
+func TestListSessionsFiltersEmbedding(t *testing.T) {
+	filters := []query.Filter{
+		{
+			Type: query.FilterTypeProperty,
+			Params: &query.FilterProperty{
+				Name:     "closed",
+				Operator: "bool",
+				Value:    true,
+			},
+		},
+	}
+
+	b, err := json.Marshal(filters)
+	require.NoError(t, err)
+
+	req := ListSessions{}
+	req.Filters.Raw = base64.StdEncoding.EncodeToString(b)
+
+	require.NoError(t, req.Filters.Unmarshal())
+	require.Len(t, req.Filters.Data, 1)
+
+	prop, ok := req.Filters.Data[0].Params.(*query.FilterProperty)
+	require.True(t, ok)
+	assert.Equal(t, "closed", prop.Name)
+	assert.Equal(t, "bool", prop.Operator)
+	assert.Equal(t, true, prop.Value)
+}


### PR DESCRIPTION
## What

`GET /api/sessions` now honors the `filter` query parameter. Clients can
query the sessions of a single device, or check whether a device currently
has an active session, without paging through every session in the namespace.

## Why

The endpoint accepted a `filter` parameter like the other list endpoints but
never applied it: there was no `SessionFilterFields` constraint, the request
struct carried no `Filters`, and `ListSessions` passed only namespace scope,
sort, and pagination to the store. Any client needing per-device session state
had to fetch all sessions and filter client-side — unreliable once results span
more than one page.

Closes #6564

## Changes

- **api/services/session**: added a `SessionFilterFields` allowlist
  (`device_uid`, `closed`, `active`) and passed `req.Filters` to the store via
  `Match`. `closed`/`active` are restricted to the `bool` operator on purpose —
  an `eq` against a real boolean column passes validation but fails at Postgres
  (`operator does not exist: boolean = text`), surfacing as a 500.
- **api/routes/session**: unmarshal and validate the filter in `GetSessionList`,
  returning 400 on a malformed or disallowed filter (mirrors the device handler).
- **api/store/pg/internal/filters**: `device_uid` maps to the `device_id` column
  through a new permanent `fieldColumnAliases` map (kept separate from the
  Mongo-removal-bound `legacyMongoFieldMapping` so the alias survives that
  cleanup). `active` is a virtual field — it is computed from a `LEFT JOIN
  active_sessions` in the select path and absent from the count query — so it is
  expanded to a correlated `EXISTS`/`NOT EXISTS` subquery that resolves correctly
  on both queries.
- **pkg/api/query**: `virtualBools` is now an explicit registry on
  `FieldConstraints` instead of being inferred from the presence of the `bool`
  operator, and `ValidateFilters` guards value types for `bool`/`eq`/`ne` so a
  bad value yields a 400 rather than a 500.
- **openapi**: advertised the `filter` parameter and documented the `400`
  response on `GET /api/sessions`, plus a spec test asserting the parameter is
  present.
- **api/services/task** (unrelated): `deviceCleanup` now sorts tenant IDs before
  decrementing device counts, making `TestService_DeviceCleanup` deterministic
  (it was flaky due to Go's randomized map iteration order — ~1 failure in 3).

## Notes for reviewers

- `models.Session.Closed` is tagged `json:"-"`, so `closed` is filterable but not
  visible in responses; `active` is both filterable and observable. Filtering on
  `closed` is intentional (requested in #6564).
- The `task.go` change is logically independent and isolated in its own commit.

## Testing

Run inside the API container:

- `go test -tags docker ./store/pg/... -run TestPgStore` — exercises the new
  `device_uid eq/ne`, `closed bool true/false`, and `active bool true/false`
  store subtests, asserting both the returned set and the count (the count path
  is where the `active` `NOT EXISTS` correlation could silently break).
- `go test ./services/... ./routes/...` and `GOWORK=off go test ./pkg/api/...`.