### PR TITLE
fix(api): make device cleanup counter decrement deterministic

### DIFF
--- a/api/services/task.go
+++ b/api/services/task.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"maps"
 	"slices"
 	"time"
 
@@ -151,7 +152,10 @@ func (s *service) deviceCleanup() store.TransactionCb {
 			}
 		}
 
-		for tenantID, deletedCount := range deletedPerTenant {
+		// Iterate tenants in a stable order so the decrement sequence is
+		// deterministic (map iteration order is randomized in Go).
+		for _, tenantID := range slices.Sorted(maps.Keys(deletedPerTenant)) {
+			deletedCount := deletedPerTenant[tenantID]
 			if err := s.store.NamespaceIncrementDeviceCount(ctx, tenantID, models.DeviceStatusRemoved, -deletedCount); err != nil {
 				log.WithFields(log.Fields{"tenant_id": tenantID, "deleted_count": deletedCount, "error": err}).
 					Error("Failed to decrement removed device count for namespace")


### PR DESCRIPTION
## Problem

`TestService_DeviceCleanup` is flaky and intermittently breaks `master`. The failure surfaces in cloud's *Validate Enterprise* workflow, which runs the shellhub test suite:

```
--- FAIL: TestService_DeviceCleanup
    mock_store.go: FAIL: NamespaceIncrementDeviceCount(...)
    FAIL: 26 out of 27 expectation(s) were met.
```

## Root cause

`DeviceCleanup` iterates the `deletedPerTenant` map and returns on the first `NamespaceIncrementDeviceCount` error. Go randomizes map iteration order, so in the error case (`tenant-1` returns nil, `tenant-2` returns an error, both mocked `.Once()`):

- iterate `tenant-1` first then `tenant-2` errors → both calls made, 27/27 met
- iterate `tenant-2` first → returns immediately, `tenant-1` never called → 26/27

It passed roughly half the time. Introduced by `0b4e914cb`.

## Fix

Iterate tenants in sorted key order so the decrement sequence is deterministic in both production and tests.

Reproduced the flake (failed within 15 runs) and validated the fix (30/30 passing).