### PR TITLE
feat(ui): add light theme

### DIFF
--- a/ui/apps/console/src/components/common/PageHeader.tsx
+++ b/ui/apps/console/src/components/common/PageHeader.tsx
@@ -25,7 +25,7 @@ export default function PageHeader({
       className={`relative -mx-8 -mt-8 px-8 py-6 mb-8 border-b border-border ${
         variant === "decorated"
           ? "animate-fade-in overflow-hidden"
-          : "bg-surface"
+          : "bg-surface page-header-band"
       }`}
     >
       {variant === "decorated" && (

--- a/ui/apps/console/src/components/layout/AppBar.tsx
+++ b/ui/apps/console/src/components/layout/AppBar.tsx
@@ -27,9 +27,7 @@ type CrossfadeAction =
   | { type: "fade-out-done" }
   | { type: "settle-idle" };
 
-const activeSessionOf = (
-  sessions: TerminalSession[],
-): TerminalSession | null =>
+const activeSessionOf = (sessions: TerminalSession[]): TerminalSession | null =>
   sessions.find((s) => s.state !== "minimized") ?? null;
 
 // Pure reducer for the left-content crossfade state machine — safe under
@@ -118,7 +116,7 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
 
   return (
     <header
-      className={`relative z-50 h-14 border-b px-3 sm:px-5 flex items-center justify-between shrink-0 transition-colors duration-300 ${
+      className={`theme-dark relative z-50 h-14 border-b px-3 sm:px-5 flex items-center justify-between shrink-0 transition-colors duration-300 ${
         displayed ? "border-transparent" : "bg-surface border-border"
       }`}
       style={displayed ? { backgroundColor: themeBg } : undefined}

--- a/ui/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui/apps/console/src/components/layout/AppLayout.tsx
@@ -91,6 +91,7 @@ export default function AppLayout() {
               >
                 <Outlet />
               </main>
+              <div className="content-seam pointer-events-none absolute inset-0 z-10" />
             </div>
           </div>
         </div>

--- a/ui/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui/apps/console/src/components/layout/SidebarShell.tsx
@@ -143,7 +143,7 @@ export default function SidebarShell({
 
   return (
     <aside
-      className={`bg-surface border-r border-border flex flex-col h-full shrink-0 transition-all duration-200 ease-in-out overflow-hidden ${
+      className={`theme-dark bg-surface border-r border-border flex flex-col h-full shrink-0 transition-all duration-200 ease-in-out overflow-hidden ${
         hidden ? "w-0 opacity-0" : expanded ? "w-[220px]" : "w-[60px]"
       }`}
     >

--- a/ui/apps/console/src/components/layout/UserMenu.tsx
+++ b/ui/apps/console/src/components/layout/UserMenu.tsx
@@ -5,16 +5,22 @@ import {
   UserIcon,
   Cog6ToothIcon,
   ArrowRightStartOnRectangleIcon,
+  MoonIcon,
+  SunIcon,
 } from "@heroicons/react/24/outline";
 import { useAuthStore } from "@/stores/authStore";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import { useNamespaces } from "@/hooks/useNamespaces";
+import { useThemeStore } from "@/stores/themeStore";
 import { getInitials } from "@/utils/string";
 
 export default function UserMenu() {
   const { user, logout } = useAuthStore();
   const navigate = useNavigate();
   const { namespaces } = useNamespaces();
+  const theme = useThemeStore((s) => s.theme);
+  const toggleTheme = useThemeStore((s) => s.toggleTheme);
+  const isDark = theme === "dark";
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -97,6 +103,23 @@ export default function UserMenu() {
                 </span>
               </button>
             )}
+            <button
+              type="button"
+              onClick={toggleTheme}
+              aria-label={
+                isDark ? "Switch to light theme" : "Switch to dark theme"
+              }
+              className="w-full flex items-center gap-2.5 px-3 py-2 rounded-md text-left hover:bg-hover-medium transition-colors group"
+            >
+              {isDark ? (
+                <SunIcon className="w-4 h-4 text-text-muted group-hover:text-text-primary transition-colors" />
+              ) : (
+                <MoonIcon className="w-4 h-4 text-text-muted group-hover:text-text-primary transition-colors" />
+              )}
+              <span className="text-sm text-text-secondary group-hover:text-text-primary transition-colors">
+                {isDark ? "Light theme" : "Dark theme"}
+              </span>
+            </button>
           </div>
 
           {/* Logout */}

--- a/ui/apps/console/src/main.tsx
+++ b/ui/apps/console/src/main.tsx
@@ -8,6 +8,7 @@ import ErrorBoundary from "./components/common/ErrorBoundary";
 import { ClipboardProvider } from "./components/common/ClipboardProvider";
 import { loadConfig } from "./env";
 import { queryClient } from "./api/queryClient";
+import "./stores/themeStore";
 import "./api/fetchInterceptors";
 import "@xterm/xterm/css/xterm.css";
 import "font-logos/assets/font-logos.css";

--- a/ui/apps/console/src/stores/themeStore.ts
+++ b/ui/apps/console/src/stores/themeStore.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+
+export type AppTheme = "dark" | "light";
+
+const STORAGE_KEY = "appTheme";
+
+function resolveInitialTheme(): AppTheme {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved === "light" || saved === "dark") return saved;
+  return "dark";
+}
+
+function applyTheme(theme: AppTheme) {
+  // Tokens default to dark in :root; the `light` class swaps the CSS variables.
+  document.documentElement.classList.toggle("light", theme === "light");
+}
+
+interface ThemeState {
+  theme: AppTheme;
+  setTheme: (theme: AppTheme) => void;
+  toggleTheme: () => void;
+}
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  theme: resolveInitialTheme(),
+
+  setTheme: (theme) => {
+    localStorage.setItem(STORAGE_KEY, theme);
+    applyTheme(theme);
+    set({ theme });
+  },
+
+  toggleTheme: () => {
+    get().setTheme(get().theme === "dark" ? "light" : "dark");
+  },
+}));
+
+// Apply the persisted theme as soon as the module loads, before first paint.
+applyTheme(resolveInitialTheme());

--- a/ui/packages/design-system/__tests__/tokens.test.ts
+++ b/ui/packages/design-system/__tests__/tokens.test.ts
@@ -1,17 +1,12 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import rawPreset from "../tailwind.preset.js";
 import { C } from "../constants";
 
 interface PresetColors {
   primary: { DEFAULT: string; [key: string]: string };
-  background: string;
-  surface: string;
-  card: string;
-  border: string;
-  "border-light": string;
-  "text-primary": string;
-  "text-secondary": string;
-  "text-muted": string;
   accent: {
     green: string;
     red: string;
@@ -28,37 +23,71 @@ const preset = rawPreset as unknown as {
 const colors = preset.theme.extend.colors;
 
 /**
- * Base-color mappings: [C key, preset path description, preset value]
- *
- * C values are hand-maintained literals — the point of this test is to
- * catch future hand-edits to constants.ts that drift from the preset.
- * Do NOT derive C values from the preset here.
+ * Semantic tokens (background, surface, text, ...) no longer hold literal
+ * colors in the preset — they resolve through `rgb(var(--c-*) / <alpha>)` so
+ * the UI can flip between dark and light (see css/base.css). Their canonical
+ * dark values now live in the `:root` block of base.css as space-separated RGB
+ * channels. Parse those and convert to hex so we can still check that the
+ * hand-maintained C constants (used for SVG fills) don't drift from them.
  */
-const baseColorMappings: Array<[keyof typeof C, string, string]> = [
+const baseCss = readFileSync(
+  fileURLToPath(new URL("../css/base.css", import.meta.url)),
+  "utf8",
+);
+
+const rootBlock = baseCss.match(/:root\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+
+function rgbChannelsToHex(channels: string): string {
+  const hex = channels
+    .trim()
+    .split(/\s+/)
+    .map((n) => Number(n).toString(16).padStart(2, "0"))
+    .join("");
+  return `#${hex}`.toUpperCase();
+}
+
+function darkToken(name: string): string {
+  const match = rootBlock.match(new RegExp(`--c-${name}:\\s*([\\d\\s]+);`));
+  if (!match) throw new Error(`--c-${name} not found in base.css :root`);
+  return rgbChannelsToHex(match[1]);
+}
+
+/** Preset-literal base colors: [C key, preset path description, preset value] */
+const presetColorMappings: Array<[keyof typeof C, string, string]> = [
   ["primary", "primary.DEFAULT", colors.primary.DEFAULT],
   ["cyan", "accent.cyan", colors.accent.cyan],
   ["yellow", "accent.yellow", colors.accent.yellow],
   ["green", "accent.green", colors.accent.green],
   ["red", "accent.red", colors.accent.red],
   ["blue", "accent.blue", colors.accent.blue],
-  ["bg", "background", colors.background],
-  ["surface", "surface", colors.surface],
-  ["card", "card", colors.card],
-  ["border", "border", colors.border],
-  ["borderLight", "border-light", colors["border-light"]],
-  ["text", "text-primary", colors["text-primary"]],
-  ["textSec", "text-secondary", colors["text-secondary"]],
-  ["textMuted", "text-muted", colors["text-muted"]],
 ];
 
-describe("design-system token parity: C constants match tailwind.preset.js", () => {
-  describe("base colors", () => {
-    it.each(baseColorMappings)(
+/** CSS-var-driven base colors: [C key, css var name] (dark values from :root) */
+const cssVarColorMappings: Array<[keyof typeof C, string]> = [
+  ["bg", "background"],
+  ["surface", "surface"],
+  ["card", "card"],
+  ["border", "border"],
+  ["borderLight", "border-light"],
+  ["text", "text-primary"],
+  ["textSec", "text-secondary"],
+  ["textMuted", "text-muted"],
+];
+
+describe("design-system token parity: C constants match their source of truth", () => {
+  describe("preset-literal base colors", () => {
+    it.each(presetColorMappings)(
       "C.%s matches preset %s",
       (cKey, _presetPath, presetValue) => {
         expect(C[cKey]).toBe(presetValue);
       },
     );
+  });
+
+  describe("css-var-driven base colors match base.css :root (dark)", () => {
+    it.each(cssVarColorMappings)("C.%s matches --c-%s", (cKey, varName) => {
+      expect(C[cKey].toUpperCase()).toBe(darkToken(varName));
+    });
   });
 
   describe("alpha variants follow the *Dim=base+'20' / primaryGlow=base+'40' convention", () => {

--- a/ui/packages/design-system/css/base.css
+++ b/ui/packages/design-system/css/base.css
@@ -1,10 +1,58 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap');
 
 @layer base {
+  /* Dark theme (default). Channels are space-separated RGB for Tailwind's
+     `rgb(var(--x) / <alpha-value>)` tokens defined in tailwind.preset.js. */
   :root {
     --color-primary-rgb: 102, 122, 204;
     --dialog-backdrop-bg: rgba(0, 0, 0, 0.7);
     --dialog-backdrop-blur: 4px;
+
+    --c-background: 24 25 27;
+    --c-surface: 30 33 39;
+    --c-card: 34 37 43;
+    --c-border: 44 47 54;
+    --c-border-light: 56 61 71;
+    --c-text-primary: 225 228 234;
+    --c-text-secondary: 139 143 153;
+    --c-text-muted: 129 135 156;
+    --c-hover: 255 255 255;
+    --c-scrollbar: 44 47 54;
+    --c-scrollbar-hover: 56 61 71;
+  }
+
+  /* Pin a subtree to the dark token set regardless of the active theme.
+     Used for the app chrome (top bar + sidebar), which stays dark in light mode. */
+  .theme-dark {
+    --c-background: 24 25 27;
+    --c-surface: 30 33 39;
+    --c-card: 34 37 43;
+    --c-border: 44 47 54;
+    --c-border-light: 56 61 71;
+    --c-text-primary: 225 228 234;
+    --c-text-secondary: 139 143 153;
+    --c-text-muted: 129 135 156;
+    --c-hover: 255 255 255;
+    --c-scrollbar: 44 47 54;
+    --c-scrollbar-hover: 56 61 71;
+    color-scheme: dark;
+  }
+
+  /* Light theme — applied by toggling `class="light"` on <html>. */
+  html.light {
+    --dialog-backdrop-bg: rgba(17, 19, 24, 0.45);
+
+    --c-background: 238 240 243;
+    --c-surface: 255 255 255;
+    --c-card: 255 255 255;
+    --c-border: 224 227 233;
+    --c-border-light: 203 209 217;
+    --c-text-primary: 26 28 31;
+    --c-text-secondary: 90 96 107;
+    --c-text-muted: 134 141 153;
+    --c-hover: 17 24 39;
+    --c-scrollbar: 203 209 217;
+    --c-scrollbar-hover: 168 176 188;
   }
 
   body {
@@ -35,7 +83,7 @@
 
   * {
     scrollbar-width: thin;
-    scrollbar-color: #2C2F36 transparent;
+    scrollbar-color: rgb(var(--c-scrollbar)) transparent;
   }
 
   ::-webkit-scrollbar {
@@ -48,16 +96,32 @@
   }
 
   ::-webkit-scrollbar-thumb {
-    background: #2C2F36;
+    background: rgb(var(--c-scrollbar));
     border-radius: 3px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: #383D47;
+    background: rgb(var(--c-scrollbar-hover));
   }
 }
 
 @layer components {
+  /* Soft seam between the dark chrome (top bar + sidebar) and the light content.
+     Only in light mode — in dark mode chrome and content match, so no shadow. */
+  .content-seam {
+    box-shadow: none;
+  }
+
+  html.light .content-seam {
+    box-shadow: inset 8px 8px 14px -10px rgba(15, 18, 24, 0.35);
+  }
+
+  /* Page header keeps its default look (bg-surface + bottom border); in light
+     it just gains a soft drop shadow so it reads as a raised sheet. */
+  html.light .page-header-band {
+    box-shadow: 0 2px 5px rgb(var(--c-border) / 0.9);
+  }
+
   .grid-bg {
     background-image:
       linear-gradient(rgba(var(--color-primary-rgb), 0.03) 1px, transparent 1px),

--- a/ui/packages/design-system/tailwind.preset.js
+++ b/ui/packages/design-system/tailwind.preset.js
@@ -14,14 +14,16 @@ export default {
           600: "#5468b3",
           700: "#4a5c9e",
         },
-        background: "#18191B",
-        surface: "#1E2127",
-        card: "#22252B",
-        border: "#2C2F36",
-        "border-light": "#383D47",
-        "text-primary": "#E1E4EA",
-        "text-secondary": "#8B8F99",
-        "text-muted": "#81879C",
+        // Semantic tokens are driven by CSS variables (see design-system/css/base.css)
+        // so the whole UI can flip between dark (default) and light themes.
+        background: "rgb(var(--c-background) / <alpha-value>)",
+        surface: "rgb(var(--c-surface) / <alpha-value>)",
+        card: "rgb(var(--c-card) / <alpha-value>)",
+        border: "rgb(var(--c-border) / <alpha-value>)",
+        "border-light": "rgb(var(--c-border-light) / <alpha-value>)",
+        "text-primary": "rgb(var(--c-text-primary) / <alpha-value>)",
+        "text-secondary": "rgb(var(--c-text-secondary) / <alpha-value>)",
+        "text-muted": "rgb(var(--c-text-muted) / <alpha-value>)",
         accent: {
           green: "#82a568",
           red: "#D8737B",
@@ -29,9 +31,10 @@ export default {
           blue: "#56a2e1",
           cyan: "#4e9aa3",
         },
-        "hover-subtle": "rgba(255, 255, 255, 0.03)",
-        "hover-medium": "rgba(255, 255, 255, 0.05)",
-        "hover-strong": "rgba(255, 255, 255, 0.08)",
+        // Hover overlays flip from white-on-dark to black-on-light via --c-hover.
+        "hover-subtle": "rgb(var(--c-hover) / 0.03)",
+        "hover-medium": "rgb(var(--c-hover) / 0.05)",
+        "hover-strong": "rgb(var(--c-hover) / 0.08)",
       },
       fontFamily: {
         sans: ['"IBM Plex Sans"', "system-ui", "sans-serif"],


### PR DESCRIPTION
The console UI was dark only. This adds a light theme and a way to switch between the two.

## How it works

The design-system semantic tokens (`background`, `surface`, `card`, `border`, `text-*`, hover overlays) now resolve through CSS variables instead of literal colors. Dark values live in `:root` (the default), light values under `html.light`. Every component that already uses `bg-background` / `text-text-primary` / etc. picks up the right value with no change.

A small Zustand store (`themeStore`) toggles the `light` class on `<html>` and persists the choice to localStorage. It applies the saved theme as the module loads, before first paint, so there is no flash on reload. The switch is a sun/moon entry inside the user account menu.

## Chrome stays dark

The top bar is pinned to the dark token set via a `.theme-dark` utility that re-declares the variables locally, while the sidebar follows the active theme. In light mode the page header gains a soft drop shadow so it reads as a raised sheet against the lighter canvas.

## Known rough edges

These are calibrated for the dark background and look washed on light. Left as follow-ups so the foundation can land first:

- Accent colors (green/orange/blue/cyan/red) need a slightly darker light variant.
- Cards are low-contrast on the light canvas and want a stronger border or shadow.
- ~99 `text-white` / `bg-white` spots can end up white-on-light.
