### PR TITLE
test(ui): silence jsdom error noise in ClipboardProvider test

### DIFF
--- a/ui/apps/console/src/components/common/__tests__/ClipboardProvider.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/ClipboardProvider.test.tsx
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "./helpers/setup-dialog";
 
@@ -52,10 +59,20 @@ function renderWithProvider(text?: string) {
 describe("ClipboardProvider / useCopy", () => {
   describe("throws outside provider", () => {
     it("throws when used outside ClipboardProvider", () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      // React reports the thrown render error through jsdom's event dispatch
+      // path, which bypasses the console.error spy and prints a stack trace.
+      // Swallow that one error event so the CI log stays clean.
+      const suppressError = (event: ErrorEvent) => event.preventDefault();
+      window.addEventListener("error", suppressError);
+
       expect(() => render(<CopyConsumer />)).toThrow(
         "useCopy must be used within <ClipboardProvider>",
       );
+
+      window.removeEventListener("error", suppressError);
       consoleSpy.mockRestore();
     });
   });


### PR DESCRIPTION
## What

Removes the noisy `useCopy must be used within <ClipboardProvider>` stack trace that the `validate (console)` CI job prints (twice) during the run, even though the test suite passes.

## Why

The `throws outside provider` test already mocks `console.error` to silence React, but React also reports the thrown render error through jsdom's event dispatch path (`callTheUserObjectsOperation` / `dispatchEvent`), which bypasses the `console.error` spy. So the stack trace prints regardless.

## How

During that one assertion, a temporary `window` `error` listener calls `event.preventDefault()` to swallow the bubbling error, then is removed afterward. The assertion itself is unchanged.

## Testing

Ran `vitest run` for `ClipboardProvider.test.tsx` — all 11 tests pass and the log is now clean (no stack trace).

Fixes: shellhub-io/shellhub#6571