### PR TITLE
refactor(ui): centralize device & container action logic

### DIFF
--- a/ui/apps/console/src/hooks/__tests__/useActionDialogState.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useActionDialogState.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  useActionDialogState,
+  type UseActionDialogStateOptions,
+} from "../useActionDialogState";
+import { useDeviceActions } from "../useDeviceActions";
+import { useContainerActions } from "../useContainerActions";
+import { defaultConfig, type ClientConfig } from "@/env";
+
+// Only the wrapper hooks read getConfig().cloud; the core hook never touches env.
+const mockGetConfig = vi.fn<() => ClientConfig>();
+vi.mock("@/env", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/env")>()),
+  getConfig: () => mockGetConfig(),
+}));
+
+const entity = { uid: "device-123", name: "Device 123" };
+
+const setup = (options: Partial<UseActionDialogStateOptions> = {}) =>
+  renderHook(() => useActionDialogState({ enableBillingWarning: false, ...options }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: false });
+});
+
+describe("useActionDialogState", () => {
+  it("requestAction opens the dialog for an entity/action pair", () => {
+    const { result } = setup();
+
+    act(() => result.current.requestAction(entity, "remove"));
+
+    expect(result.current.operation).toEqual({ entity, action: "remove" });
+  });
+
+  it("close clears the operation", () => {
+    const { result } = setup();
+
+    act(() => result.current.requestAction(entity, "remove"));
+    act(() => result.current.close());
+
+    expect(result.current.operation).toBeUndefined();
+  });
+
+  describe("billing warning", () => {
+    it("exposes onBillingWarning and billingEnabled only when enabled", () => {
+      const off = setup({ enableBillingWarning: false }).result.current;
+      expect(off.onBillingWarning).toBeUndefined();
+      expect(off.billingEnabled).toBe(false);
+
+      const on = setup({ enableBillingWarning: true }).result.current;
+      expect(on.onBillingWarning).toBeTypeOf("function");
+      expect(on.billingEnabled).toBe(true);
+    });
+
+    it("opening the warning dismisses the action dialog", () => {
+      const { result } = setup({ enableBillingWarning: true });
+
+      act(() => result.current.requestAction(entity, "accept"));
+      act(() => result.current.onBillingWarning!());
+
+      expect(result.current.billingWarningOpen).toBe(true);
+      expect(result.current.operation).toBeUndefined();
+    });
+
+    it("closeBillingWarning closes the warning", () => {
+      const { result } = setup({ enableBillingWarning: true });
+
+      act(() => result.current.onBillingWarning!());
+      act(() => result.current.closeBillingWarning());
+
+      expect(result.current.billingWarningOpen).toBe(false);
+    });
+  });
+
+  describe("runSuccess", () => {
+    it("invokes onSuccess with the passed action and leaves the dialog open for the caller to close", () => {
+      const onSuccess = vi.fn();
+      const { result } = setup({ onSuccess });
+
+      act(() => result.current.requestAction(entity, "remove"));
+      act(() => result.current.runSuccess("remove"));
+
+      expect(onSuccess).toHaveBeenCalledOnce();
+      expect(onSuccess).toHaveBeenCalledWith("remove");
+      expect(result.current.operation).toEqual({ entity, action: "remove" });
+    });
+
+    it("fires onSuccess with the captured action even after close() (cancel-race)", () => {
+      const onSuccess = vi.fn();
+      const { result } = setup({ onSuccess });
+
+      act(() => result.current.requestAction(entity, "remove"));
+      act(() => result.current.close());
+      act(() => result.current.runSuccess("remove"));
+
+      expect(onSuccess).toHaveBeenCalledOnce();
+      expect(onSuccess).toHaveBeenCalledWith("remove");
+    });
+
+    it("reports the captured action, not whatever operation is currently live", () => {
+      const onSuccess = vi.fn();
+      const { result } = setup({ onSuccess });
+
+      act(() => result.current.requestAction(entity, "accept"));
+      act(() => result.current.requestAction(entity, "remove"));
+      act(() => result.current.runSuccess("accept"));
+
+      expect(onSuccess).toHaveBeenCalledWith("accept");
+    });
+
+    it("calls the latest onSuccess after the callback prop changes", () => {
+      const first = vi.fn();
+      const second = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ onSuccess }: { onSuccess: UseActionDialogStateOptions["onSuccess"] }) =>
+          useActionDialogState({ enableBillingWarning: false, onSuccess }),
+        { initialProps: { onSuccess: first } },
+      );
+
+      act(() => result.current.requestAction(entity, "remove"));
+      rerender({ onSuccess: second });
+      act(() => result.current.runSuccess("remove"));
+
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledWith("remove");
+    });
+  });
+
+  it("returns referentially stable callbacks across re-renders and state changes", () => {
+    const { result, rerender } = setup({ onSuccess: vi.fn() });
+    const callbacks = ["requestAction", "close", "closeBillingWarning", "runSuccess"] as const;
+    const before = callbacks.map((name) => result.current[name]);
+
+    act(() => result.current.requestAction(entity, "remove")); // operation changes
+    rerender();
+
+    callbacks.forEach((name, i) => expect(result.current[name]).toBe(before[i]));
+  });
+});
+
+// Both wrappers are thin adapters over the core hook that only differ in their
+// domain label, so they share one parametrised suite.
+describe.each([
+  { name: "useDeviceActions", useActions: useDeviceActions, target: { uid: "d-1", name: "my-device" } },
+  { name: "useContainerActions", useActions: useContainerActions, target: { uid: "c-1", name: "my-container" } },
+])("$name", ({ useActions, target }) => {
+  it("derives onBillingWarning from getConfig().cloud", () => {
+    mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: true });
+    expect(renderHook(() => useActions()).result.current.onBillingWarning).toBeTypeOf("function");
+
+    mockGetConfig.mockReturnValue({ ...defaultConfig, cloud: false });
+    expect(renderHook(() => useActions()).result.current.onBillingWarning).toBeUndefined();
+  });
+
+  it("stores a requested action as an operation", () => {
+    const { result } = renderHook(() => useActions());
+
+    act(() => result.current.requestAction(target, "accept"));
+
+    expect(result.current.operation).toEqual({ entity: target, action: "accept" });
+  });
+
+  it("forwards onSuccess, even after close() (cancel-race)", () => {
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useActions({ onSuccess }));
+
+    act(() => result.current.requestAction(target, "remove"));
+    act(() => result.current.close());
+    act(() => result.current.runSuccess("remove"));
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onSuccess).toHaveBeenCalledWith("remove");
+  });
+});

--- a/ui/apps/console/src/hooks/useActionDialogState.ts
+++ b/ui/apps/console/src/hooks/useActionDialogState.ts
@@ -1,0 +1,113 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+
+/**
+ * Shared entity shape used by both device and container action flows (and by
+ * the `*ActionDialog` components). Both domains require only `uid` and `name`.
+ */
+export interface EntityBase {
+  uid: string;
+  name: string;
+}
+
+/**
+ * The set of actions supported for both devices and containers.
+ */
+export type EntityAction = "accept" | "reject" | "remove";
+
+export interface Operation {
+  entity: EntityBase;
+  action: EntityAction;
+}
+
+export interface UseActionDialogStateOptions {
+  enableBillingWarning: boolean;
+  onSuccess?: (action: EntityAction) => void;
+}
+
+export interface UseActionDialogStateResult {
+  operation: Operation | undefined;
+  requestAction: (entity: EntityBase, action: EntityAction) => void;
+  close: () => void;
+  billingWarningOpen: boolean;
+  closeBillingWarning: () => void;
+  onBillingWarning: (() => void) | undefined;
+  /**
+   * Invoke `onSuccess` with the action that was confirmed. Callers (portals/dialogs) must pass
+   * the action explicitly — captured at `handleConfirm` time — rather than relying on the live
+   * operation state, so that the correct action is reported even if the dialog was cancelled
+   * (via `close()`) while the mutation was in-flight.
+   */
+  runSuccess: (action: EntityAction) => void;
+  /** True when billing warning is supported for this controller (mirrors enableBillingWarning). */
+  billingEnabled: boolean;
+}
+
+/**
+ * Shared state core for action-triggered dialogs with optional billing warning gate.
+ *
+ * - `requestAction(entity, action)` — open the dialog for a specific entity/action pair.
+ * - `close()` — clear the operation (dismiss the dialog).
+ * - `billingWarningOpen` / `closeBillingWarning` — control the billing warning overlay.
+ * - `onBillingWarning` — defined only when `enableBillingWarning` is truthy; call it to show
+ *   the billing warning before the action proceeds. Callers (e.g. `useDeviceActions`) are
+ *   responsible for passing `enableBillingWarning: !!getConfig().cloud`.
+ * - `runSuccess(action)` — invoke `onSuccess` with the explicitly passed action. The caller
+ *   must capture the action at confirm time and pass it here, so the correct action is reported
+ *   even if the dialog was cancelled (via `close()`) while a mutation was in-flight. Does NOT
+ *   close the dialog; the portal/dialog is responsible for calling `close()` after this.
+ *
+ * All returned functions are stable across re-renders (wrapped in `useCallback`).
+ */
+export function useActionDialogState({
+  enableBillingWarning,
+  onSuccess,
+}: UseActionDialogStateOptions): UseActionDialogStateResult {
+  const [operation, setOperation] = useState<Operation | undefined>(undefined);
+  const [billingWarningOpen, setBillingWarningOpen] = useState(false);
+
+  const requestAction = useCallback((entity: EntityBase, action: EntityAction) => {
+    setOperation({ entity, action });
+  }, []);
+
+  const close = useCallback(() => {
+    setOperation(undefined);
+  }, []);
+
+  const closeBillingWarning = useCallback(() => {
+    setBillingWarningOpen(false);
+  }, []);
+
+  const openBillingWarning = useCallback(() => {
+    setOperation(undefined);
+    setBillingWarningOpen(true);
+  }, []);
+
+  const onBillingWarning = enableBillingWarning ? openBillingWarning : undefined;
+
+  // Keep a ref to onSuccess so runSuccess always invokes the latest callback
+  // without being in the useCallback dep array. This avoids stale-closure bugs
+  // when callers pass inline lambdas and prevents runSuccess identity churn on
+  // every requestAction() call (which would force re-renders in memoised consumers).
+  const onSuccessRef = useRef(onSuccess);
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+  });
+
+  // The caller (portal/dialog) passes the action it confirmed explicitly.
+  // This ensures the correct action is forwarded even when the dialog was
+  // cancelled (close() cleared operation state) while the mutation was in-flight.
+  const runSuccess = useCallback((action: EntityAction) => {
+    onSuccessRef.current?.(action);
+  }, []);
+
+  return {
+    operation,
+    requestAction,
+    close,
+    billingWarningOpen,
+    closeBillingWarning,
+    onBillingWarning,
+    runSuccess,
+    billingEnabled: enableBillingWarning,
+  };
+}

--- a/ui/apps/console/src/hooks/useContainerActions.ts
+++ b/ui/apps/console/src/hooks/useContainerActions.ts
@@ -1,0 +1,23 @@
+import { getConfig } from "@/env";
+import {
+  useActionDialogState,
+  type UseActionDialogStateOptions,
+  type UseActionDialogStateResult,
+} from "./useActionDialogState";
+
+export type UseContainerActionsResult = UseActionDialogStateResult;
+
+/**
+ * Thin wrapper over useActionDialogState for container list/detail actions.
+ *
+ * Billing warning defaults to the cloud flag; callers may override it
+ * (e.g. ContainerDetails disables it to preserve its inline-error flow).
+ */
+export function useContainerActions(
+  options?: Partial<Pick<UseActionDialogStateOptions, "enableBillingWarning" | "onSuccess">>,
+): UseContainerActionsResult {
+  return useActionDialogState({
+    ...options,
+    enableBillingWarning: options?.enableBillingWarning ?? !!getConfig().cloud,
+  });
+}

--- a/ui/apps/console/src/hooks/useDeviceActions.ts
+++ b/ui/apps/console/src/hooks/useDeviceActions.ts
@@ -1,0 +1,23 @@
+import { getConfig } from "@/env";
+import {
+  useActionDialogState,
+  type UseActionDialogStateOptions,
+  type UseActionDialogStateResult,
+} from "./useActionDialogState";
+
+export type UseDeviceActionsResult = UseActionDialogStateResult;
+
+/**
+ * Thin wrapper over useActionDialogState for device list/detail actions.
+ *
+ * Billing warning defaults to the cloud flag; callers may override it
+ * (e.g. ContainerDetails disables it to preserve its inline-error flow).
+ */
+export function useDeviceActions(
+  options?: Partial<Pick<UseActionDialogStateOptions, "enableBillingWarning" | "onSuccess">>,
+): UseDeviceActionsResult {
+  return useActionDialogState({
+    ...options,
+    enableBillingWarning: options?.enableBillingWarning ?? !!getConfig().cloud,
+  });
+}

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -30,7 +30,8 @@ import { normalizeContainer } from "../hooks/useContainers";
 import { useNamespace } from "../hooks/useNamespaces";
 import { useAuthStore } from "../stores/authStore";
 import { useTerminalStore } from "../stores/terminalStore";
-import ContainerActionDialog from "./containers/ContainerActionDialog";
+import { useContainerActions } from "../hooks/useContainerActions";
+import ContainerActionsPortal from "./containers/ContainerActionsPortal";
 import ConnectDrawer from "../components/ConnectDrawer";
 import CopyButton from "../components/common/CopyButton";
 import { formatDateFull, formatRelative } from "../utils/date";
@@ -309,10 +310,15 @@ export default function ContainerDetails() {
   );
   const restoreTerminal = useTerminalStore((s) => s.restore);
   const [connectOpen, setConnectOpen] = useState(false);
-  const [operation, setOperation] = useState<{
-    container: { uid: string; name: string };
-    action: "accept" | "reject" | "remove";
-  } | null>(null);
+
+  const containerActions = useContainerActions({
+    // ContainerDetails never showed the billing warning on master — a 402 on
+    // accept surfaces as the dialog's inline error instead. Keep that behavior.
+    enableBillingWarning: false,
+    onSuccess: (action) => {
+      if (action === "remove") void navigate("/containers");
+    },
+  });
 
   const shouldAutoConnect =
     searchParams.get("connect") === "true" &&
@@ -351,10 +357,6 @@ export default function ContainerDetails() {
   const sshid = nsName ? buildSshid(nsName, container.name) : container.uid;
 
   const tags = normalizeContainer(container).tags;
-
-  const handleActionSuccess = () => {
-    if (operation?.action === "remove") void navigate("/containers");
-  };
 
   return (
     <div className="animate-fade-in">
@@ -447,10 +449,7 @@ export default function ContainerDetails() {
                   aria-label="Remove container"
                   className="border border-border"
                   onClick={() =>
-                    setOperation({
-                      container: { uid: container.uid, name: container.name },
-                      action: "remove",
-                    })
+                    containerActions.requestAction(container, "remove")
                   }
                 >
                   <TrashIcon className="w-4 h-4" />
@@ -463,7 +462,9 @@ export default function ContainerDetails() {
               <RestrictedAction action="device:accept">
                 <Button
                   variant="success"
-                  onClick={() => setOperation({ container, action: "accept" })}
+                  onClick={() =>
+                    containerActions.requestAction(container, "accept")
+                  }
                 >
                   Accept
                 </Button>
@@ -471,7 +472,9 @@ export default function ContainerDetails() {
               <RestrictedAction action="device:reject">
                 <Button
                   variant="warning"
-                  onClick={() => setOperation({ container, action: "reject" })}
+                  onClick={() =>
+                    containerActions.requestAction(container, "reject")
+                  }
                 >
                   Reject
                 </Button>
@@ -483,7 +486,9 @@ export default function ContainerDetails() {
               <RestrictedAction action="device:accept">
                 <Button
                   variant="success"
-                  onClick={() => setOperation({ container, action: "accept" })}
+                  onClick={() =>
+                    containerActions.requestAction(container, "accept")
+                  }
                 >
                   Accept
                 </Button>
@@ -491,7 +496,9 @@ export default function ContainerDetails() {
               <RestrictedAction action="device:remove">
                 <Button
                   variant="destructive"
-                  onClick={() => setOperation({ container, action: "remove" })}
+                  onClick={() =>
+                    containerActions.requestAction(container, "remove")
+                  }
                 >
                   Remove
                 </Button>
@@ -613,18 +620,7 @@ export default function ContainerDetails() {
       />
 
       {/* Action Dialog */}
-      <ContainerActionDialog
-        key={
-          operation
-            ? `${operation.action}/${operation.container.uid}`
-            : "closed"
-        }
-        open={!!operation}
-        container={operation?.container ?? null}
-        action={operation?.action ?? "accept"}
-        onClose={() => setOperation(null)}
-        onSuccess={handleActionSuccess}
-      />
+      <ContainerActionsPortal controller={containerActions} />
     </div>
   );
 }

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -11,20 +11,17 @@ import {
   ChevronDoubleRightIcon,
 } from "@heroicons/react/24/outline";
 import { useDevice } from "../hooks/useDevice";
-import { useRemoveDevice } from "../hooks/useDeviceMutations";
+import { useDeviceActions } from "../hooks/useDeviceActions";
 import { useNamespace } from "../hooks/useNamespaces";
 import { useAuthStore } from "../stores/authStore";
 import { useTerminalStore } from "../stores/terminalStore";
-import DeviceActionDialog from "./devices/DeviceActionDialog";
-import BillingWarning from "../components/billing/BillingWarning";
+import DeviceActionsPortal from "./devices/DeviceActionsPortal";
 import ConnectDrawer from "../components/ConnectDrawer";
-import ConfirmDialog from "../components/common/ConfirmDialog";
 import CopyButton from "../components/common/CopyButton";
 import PlatformBadge from "../components/common/PlatformBadge";
 import { formatDateFull, formatRelative } from "../utils/date";
 import { buildSshid } from "../utils/sshid";
 import RestrictedAction from "../components/common/RestrictedAction";
-import { getConfig } from "../env";
 import PageLoader from "@/components/common/PageLoader";
 import InfoItem from "./devices/InfoItem";
 import TagsSection from "./devices/TagsSection";
@@ -41,7 +38,6 @@ export default function DeviceDetails() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { device, isLoading } = useDevice(uid ?? "");
-  const removeMutation = useRemoveDevice();
   const tenantId = useAuthStore((s) => s.tenant) ?? "";
   const { namespace: currentNamespace } = useNamespace(tenantId);
   const existingSession = useTerminalStore((s) =>
@@ -49,13 +45,11 @@ export default function DeviceDetails() {
   );
   const restoreTerminal = useTerminalStore((s) => s.restore);
   const [connectOpen, setConnectOpen] = useState(false);
-  const [showDelete, setShowDelete] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [operation, setOperation] = useState<{
-    device: { uid: string; name: string };
-    action: "accept" | "reject" | "remove";
-  } | null>(null);
-  const [billingWarningOpen, setBillingWarningOpen] = useState(false);
+  const actionsController = useDeviceActions({
+    onSuccess: (action) => {
+      if (action === "remove") void navigate("/devices");
+    },
+  });
 
   // Auto-open connect drawer if ?connect=true (adjust during render)
   const shouldAutoConnect =
@@ -95,22 +89,6 @@ export default function DeviceDetails() {
         typeof t === "object" && t !== null && "name" in t ? t.name : String(t),
       )
     : [];
-
-  const handleDelete = async () => {
-    setDeleteError(null);
-    try {
-      await removeMutation.mutateAsync({ path: { uid: device.uid } });
-      setShowDelete(false);
-      void navigate("/devices");
-    } catch {
-      setDeleteError("Failed to delete device. Please try again.");
-    }
-  };
-
-  const handleDeviceActionSuccess = () => {
-    if (!operation) return;
-    if (operation.action === "remove") void navigate("/devices");
-  };
 
   return (
     <div className="animate-fade-in">
@@ -198,7 +176,7 @@ export default function DeviceDetails() {
                   title="Delete device"
                   aria-label="Delete device"
                   className="border border-border"
-                  onClick={() => setShowDelete(true)}
+                  onClick={() => actionsController.requestAction(device, "remove")}
                 >
                   <TrashIcon className="w-4 h-4" />
                 </IconButton>
@@ -210,7 +188,7 @@ export default function DeviceDetails() {
               <RestrictedAction action="device:accept">
                 <Button
                   variant="success"
-                  onClick={() => setOperation({ device, action: "accept" })}
+                  onClick={() => actionsController.requestAction(device, "accept")}
                 >
                   Accept
                 </Button>
@@ -218,7 +196,7 @@ export default function DeviceDetails() {
               <RestrictedAction action="device:reject">
                 <Button
                   variant="warning"
-                  onClick={() => setOperation({ device, action: "reject" })}
+                  onClick={() => actionsController.requestAction(device, "reject")}
                 >
                   Reject
                 </Button>
@@ -230,7 +208,7 @@ export default function DeviceDetails() {
               <RestrictedAction action="device:accept">
                 <Button
                   variant="success"
-                  onClick={() => setOperation({ device, action: "accept" })}
+                  onClick={() => actionsController.requestAction(device, "accept")}
                 >
                   Accept
                 </Button>
@@ -238,7 +216,7 @@ export default function DeviceDetails() {
               <RestrictedAction action="device:remove">
                 <Button
                   variant="destructive"
-                  onClick={() => setOperation({ device, action: "remove" })}
+                  onClick={() => actionsController.requestAction(device, "remove")}
                 >
                   Remove
                 </Button>
@@ -367,27 +345,6 @@ export default function DeviceDetails() {
         </Card>
       </div>
 
-      {/* Delete Dialog */}
-      <ConfirmDialog
-        open={showDelete}
-        onClose={() => {
-          setShowDelete(false);
-          setDeleteError(null);
-        }}
-        onConfirm={handleDelete}
-        title="Delete Device"
-        description={
-          <>
-            Are you sure you want to delete{" "}
-            <span className="font-medium text-text-primary">{device.name}</span>
-            ? This action cannot be undone.
-          </>
-        }
-        confirmLabel="Delete"
-        variant="danger"
-        errorMessage={deleteError}
-      />
-
       {/* Connect Drawer */}
       <ConnectDrawer
         open={connectOpen}
@@ -397,29 +354,8 @@ export default function DeviceDetails() {
         sshid={sshid}
       />
 
-      {/* Action Dialog (accept/reject/remove for pending/rejected devices) */}
-      <DeviceActionDialog
-        key={
-          operation ? `${operation.action}/${operation.device.uid}` : "closed"
-        }
-        open={!!operation}
-        device={operation?.device ?? null}
-        action={operation?.action ?? "accept"}
-        onClose={() => setOperation(null)}
-        onSuccess={handleDeviceActionSuccess}
-        onBillingWarning={
-          getConfig().cloud
-            ? () => {
-                setOperation(null);
-                setBillingWarningOpen(true);
-              }
-            : undefined
-        }
-      />
-      <BillingWarning
-        open={billingWarningOpen}
-        onClose={() => setBillingWarningOpen(false)}
-      />
+      {/* Action Portal (accept/reject/remove for pending/rejected devices) */}
+      <DeviceActionsPortal controller={actionsController} />
     </div>
   );
 }

--- a/ui/apps/console/src/pages/containers/ContainerActionDialog.tsx
+++ b/ui/apps/console/src/pages/containers/ContainerActionDialog.tsx
@@ -6,11 +6,7 @@ import {
   useRemoveContainer,
 } from "@/hooks/useContainerMutations";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
-
-interface ActionContainer {
-  uid: string;
-  name: string;
-}
+import type { EntityBase } from "@/hooks/useActionDialogState";
 
 const ACTION_CONFIG = {
   accept: {
@@ -45,7 +41,7 @@ function ContainerActionDialog({
   onBillingWarning,
   open,
 }: {
-  container: ActionContainer | null;
+  container: EntityBase | null;
   action: "accept" | "reject" | "remove";
   onClose: () => void;
   onSuccess?: () => void;

--- a/ui/apps/console/src/pages/containers/ContainerActionsPortal.tsx
+++ b/ui/apps/console/src/pages/containers/ContainerActionsPortal.tsx
@@ -1,0 +1,31 @@
+import type { UseContainerActionsResult } from "@/hooks/useContainerActions";
+import BillingWarning from "@/components/billing/BillingWarning";
+import ContainerActionDialog from "./ContainerActionDialog";
+
+interface ContainerActionsPortalProps {
+  controller: UseContainerActionsResult;
+}
+
+export default function ContainerActionsPortal({ controller }: ContainerActionsPortalProps) {
+  const { operation, close } = controller;
+
+  return (
+    <>
+      <ContainerActionDialog
+        key={operation ? `${operation.action}/${operation.entity.uid}` : "closed"}
+        open={!!operation}
+        container={operation?.entity ?? null}
+        action={operation?.action ?? "accept"}
+        onClose={close}
+        onBillingWarning={controller.onBillingWarning}
+        onSuccess={operation ? () => controller.runSuccess(operation.action) : undefined}
+      />
+      {controller.billingEnabled && (
+        <BillingWarning
+          open={controller.billingWarningOpen}
+          onClose={controller.closeBillingWarning}
+        />
+      )}
+    </>
+  );
+}

--- a/ui/apps/console/src/pages/containers/__tests__/ContainerActionsPortal.test.tsx
+++ b/ui/apps/console/src/pages/containers/__tests__/ContainerActionsPortal.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UseContainerActionsResult } from "@/hooks/useContainerActions";
+import type { EntityBase } from "@/hooks/useActionDialogState";
+
+// Stand-in for the real dialog: it surfaces the wiring the portal owns (open
+// state, entity, action, and the onClose/onSuccess callbacks) through the DOM
+// so tests can drive it the way a user would, instead of inspecting props.
+vi.mock("../ContainerActionDialog", () => ({
+  default: ({ open, container, action, onClose, onSuccess }: {
+    open: boolean;
+    container: EntityBase | null;
+    action: string;
+    onClose: () => void;
+    onSuccess?: () => void;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label={`${action} ${container?.name}`}>
+        <button type="button" onClick={onClose}>cancel</button>
+        {onSuccess && <button type="button" onClick={onSuccess}>confirm</button>}
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/billing/BillingWarning", () => ({
+  default: () => <div data-testid="billing-warning" />,
+}));
+
+import ContainerActionsPortal from "../ContainerActionsPortal";
+
+function renderPortal(overrides: Partial<UseContainerActionsResult> = {}) {
+  const controller: UseContainerActionsResult = {
+    operation: undefined,
+    requestAction: vi.fn(),
+    close: vi.fn(),
+    billingWarningOpen: false,
+    closeBillingWarning: vi.fn(),
+    onBillingWarning: undefined,
+    runSuccess: vi.fn(),
+    billingEnabled: false,
+    ...overrides,
+  };
+  render(<ContainerActionsPortal controller={controller} />);
+  return controller;
+}
+
+describe("ContainerActionsPortal", () => {
+  it("opens the dialog for the active operation", () => {
+    renderPortal({ operation: { entity: { uid: "uid-1", name: "my-container" }, action: "accept" } });
+
+    expect(screen.getByRole("dialog", { name: "accept my-container" })).toBeInTheDocument();
+  });
+
+  it("keeps the dialog closed when there is no operation", () => {
+    renderPortal();
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("runs the operation's action when the dialog confirms", async () => {
+    const controller = renderPortal({
+      operation: { entity: { uid: "uid-2", name: "c2" }, action: "remove" },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "confirm" }));
+
+    expect(controller.runSuccess).toHaveBeenCalledWith("remove");
+  });
+
+  it("closes when the dialog is cancelled", async () => {
+    const controller = renderPortal({
+      operation: { entity: { uid: "uid-3", name: "c3" }, action: "accept" },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "cancel" }));
+
+    expect(controller.close).toHaveBeenCalledOnce();
+  });
+
+  it("renders BillingWarning only when billing is enabled", () => {
+    renderPortal({ billingEnabled: true });
+    expect(screen.getByTestId("billing-warning")).toBeInTheDocument();
+  });
+
+  it("does not render BillingWarning when billing is disabled", () => {
+    renderPortal();
+    expect(screen.queryByTestId("billing-warning")).not.toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
+++ b/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
@@ -92,9 +92,7 @@ vi.mock("../ContainerTagsPopover", () => ({
   ),
 }));
 
-vi.mock("../ContainerActionDialog", () => ({
-  default: () => <div />,
-}));
+vi.mock("../ContainerActionsPortal", () => ({ default: () => null }));
 
 vi.mock("../AddDockerConnectorDrawer", () => ({
   default: () => <div />,
@@ -110,6 +108,20 @@ vi.mock("@/components/billing/BillingWarning", () => ({
 
 vi.mock("@/env", () => ({
   getConfig: () => ({ cloud: false }),
+}));
+
+const mockRequestAction = vi.fn();
+vi.mock("@/hooks/useContainerActions", () => ({
+  useContainerActions: () => ({
+    requestAction: mockRequestAction,
+    operation: null,
+    close: vi.fn(),
+    runSuccess: vi.fn(),
+    onBillingWarning: vi.fn(),
+    billingEnabled: false,
+    billingWarningOpen: false,
+    closeBillingWarning: vi.fn(),
+  }),
 }));
 
 const mockNavigate = vi.fn();
@@ -173,6 +185,7 @@ describe("Containers list", () => {
     vi.mocked(useContainers).mockReturnValue(defaultHookState);
     mockNavigate.mockReset();
     mockManageTagsDrawer.mockReset();
+    mockRequestAction.mockReset();
   });
 
   describe("rendering", () => {
@@ -431,6 +444,64 @@ describe("Containers list", () => {
       expect(vi.mocked(useContainers)).toHaveBeenCalledWith(
         expect.objectContaining({ page: 1, status: "pending" }),
       );
+    });
+  });
+
+  // ── useContainerActions + ContainerActionsPortal ──────────────────────────────
+
+  describe("action delegation — action buttons use useContainerActions", () => {
+    it("calls requestAction(container, 'accept') when Accept is clicked in pending view", async () => {
+      const user = userEvent.setup();
+      const pendingContainer = makeContainer({
+        uid: "uid-pending",
+        name: "pending-box",
+        status: "pending",
+        online: false,
+      });
+      vi.mocked(useContainers).mockReturnValue({
+        ...defaultHookState,
+        containers: [pendingContainer],
+        totalCount: 1,
+      });
+      renderPage(["/?status=pending"]);
+      await user.click(screen.getByRole("button", { name: "Accept" }));
+      expect(mockRequestAction).toHaveBeenCalledWith(pendingContainer, "accept");
+    });
+
+    it("calls requestAction(container, 'reject') when Reject is clicked in pending view", async () => {
+      const user = userEvent.setup();
+      const pendingContainer = makeContainer({
+        uid: "uid-pending-2",
+        name: "pending-box-2",
+        status: "pending",
+        online: false,
+      });
+      vi.mocked(useContainers).mockReturnValue({
+        ...defaultHookState,
+        containers: [pendingContainer],
+        totalCount: 1,
+      });
+      renderPage(["/?status=pending"]);
+      await user.click(screen.getByRole("button", { name: "Reject" }));
+      expect(mockRequestAction).toHaveBeenCalledWith(pendingContainer, "reject");
+    });
+
+    it("calls requestAction(container, 'remove') when Remove is clicked in rejected view", async () => {
+      const user = userEvent.setup();
+      const rejectedContainer = makeContainer({
+        uid: "uid-rejected",
+        name: "rejected-box",
+        status: "rejected",
+        online: false,
+      });
+      vi.mocked(useContainers).mockReturnValue({
+        ...defaultHookState,
+        containers: [rejectedContainer],
+        totalCount: 1,
+      });
+      renderPage(["/?status=rejected"]);
+      await user.click(screen.getByRole("button", { name: "Remove" }));
+      expect(mockRequestAction).toHaveBeenCalledWith(rejectedContainer, "remove");
     });
   });
 });

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -17,9 +17,8 @@ import TagFilterDropdown from "@/components/common/TagFilterDropdown";
 import { formatRelative } from "@/utils/date";
 import { buildSshid } from "@/utils/sshid";
 import ContainerTagsPopover from "./ContainerTagsPopover";
-import ContainerActionDialog from "./ContainerActionDialog";
-import BillingWarning from "@/components/billing/BillingWarning";
-import { getConfig } from "@/env";
+import ContainerActionsPortal from "./ContainerActionsPortal";
+import { useContainerActions } from "@/hooks/useContainerActions";
 import AddDockerConnectorDrawer from "./AddDockerConnectorDrawer";
 import {
   PlusIcon,
@@ -80,10 +79,8 @@ export default function Containers() {
     SEARCH_DEBOUNCE_MS,
   );
 
-  const [actionTarget, setActionTarget] = useState<{
-    container: NormalizedContainer;
-    action: "accept" | "reject" | "remove";
-  } | null>(null);
+  const containerActions = useContainerActions();
+  const { requestAction: requestContainerAction } = containerActions;
   const [connectTarget, setConnectTarget] = useState<{
     uid: string;
     name: string;
@@ -91,7 +88,6 @@ export default function Containers() {
   } | null>(null);
   const [manageTagsOpen, setManageTagsOpen] = useState(false);
   const [addConnectorOpen, setAddConnectorOpen] = useState(false);
-  const [billingWarningOpen, setBillingWarningOpen] = useState(false);
   const { sortBy, orderBy, handleSort } = useTableSort<SortField>({
     defaultField: "last_seen",
     onSortChange: () => setPage(1),
@@ -278,7 +274,7 @@ export default function Containers() {
                   size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setActionTarget({ container, action: "accept" });
+                    requestContainerAction(container, "accept");
                   }}
                 >
                   Accept
@@ -290,7 +286,7 @@ export default function Containers() {
                   size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setActionTarget({ container, action: "reject" });
+                    requestContainerAction(container, "reject");
                   }}
                 >
                   Reject
@@ -317,7 +313,7 @@ export default function Containers() {
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
-                  setActionTarget({ container, action: "accept" });
+                  requestContainerAction(container, "accept");
                 }}
               >
                 Accept
@@ -329,7 +325,7 @@ export default function Containers() {
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
-                  setActionTarget({ container, action: "remove" });
+                  requestContainerAction(container, "remove");
                 }}
               >
                 Remove
@@ -339,7 +335,7 @@ export default function Containers() {
         ),
       },
     ];
-  }, [params.status, nsName, addFilterTag]);
+  }, [params.status, nsName, addFilterTag, requestContainerAction]);
 
   return (
     <div>
@@ -469,29 +465,7 @@ export default function Containers() {
         }
       />
 
-      <ContainerActionDialog
-        key={
-          actionTarget
-            ? `${actionTarget.action}/${actionTarget.container.uid}`
-            : "closed"
-        }
-        open={!!actionTarget}
-        container={actionTarget?.container ?? null}
-        action={actionTarget?.action ?? "accept"}
-        onClose={() => setActionTarget(null)}
-        onBillingWarning={
-          getConfig().cloud
-            ? () => {
-                setActionTarget(null);
-                setBillingWarningOpen(true);
-              }
-            : undefined
-        }
-      />
-      <BillingWarning
-        open={billingWarningOpen}
-        onClose={() => setBillingWarningOpen(false)}
-      />
+      <ContainerActionsPortal controller={containerActions} />
 
       <ConnectDrawer
         open={!!connectTarget}

--- a/ui/apps/console/src/pages/devices/DeviceActionDialog.tsx
+++ b/ui/apps/console/src/pages/devices/DeviceActionDialog.tsx
@@ -7,11 +7,7 @@ import {
 } from "@/hooks/useDeviceMutations";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import { getAcceptDeviceErrorMessage } from "@/utils/deviceErrors";
-
-interface ActionDevice {
-  uid: string;
-  name: string;
-}
+import type { EntityBase } from "@/hooks/useActionDialogState";
 
 const ACTION_CONFIG = {
   accept: {
@@ -46,7 +42,7 @@ function DeviceActionDialog({
   onBillingWarning,
   open,
 }: {
-  device: ActionDevice | null;
+  device: EntityBase | null;
   action: "accept" | "reject" | "remove";
   onClose: () => void;
   onSuccess?: () => void;

--- a/ui/apps/console/src/pages/devices/DeviceActionsPortal.tsx
+++ b/ui/apps/console/src/pages/devices/DeviceActionsPortal.tsx
@@ -1,0 +1,31 @@
+import type { UseDeviceActionsResult } from "@/hooks/useDeviceActions";
+import BillingWarning from "@/components/billing/BillingWarning";
+import DeviceActionDialog from "./DeviceActionDialog";
+
+interface DeviceActionsPortalProps {
+  controller: UseDeviceActionsResult;
+}
+
+export default function DeviceActionsPortal({ controller }: DeviceActionsPortalProps) {
+  const { operation, close } = controller;
+
+  return (
+    <>
+      <DeviceActionDialog
+        key={operation ? `${operation.action}/${operation.entity.uid}` : "closed"}
+        open={!!operation}
+        device={operation?.entity ?? null}
+        action={operation?.action ?? "accept"}
+        onClose={close}
+        onBillingWarning={controller.onBillingWarning}
+        onSuccess={operation ? () => controller.runSuccess(operation.action) : undefined}
+      />
+      {controller.billingEnabled && (
+        <BillingWarning
+          open={controller.billingWarningOpen}
+          onClose={controller.closeBillingWarning}
+        />
+      )}
+    </>
+  );
+}

--- a/ui/apps/console/src/pages/devices/__tests__/DeviceActionsPortal.test.tsx
+++ b/ui/apps/console/src/pages/devices/__tests__/DeviceActionsPortal.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UseDeviceActionsResult } from "@/hooks/useDeviceActions";
+import type { EntityBase } from "@/hooks/useActionDialogState";
+
+// Stand-in for the real dialog: it surfaces the wiring the portal owns (open
+// state, entity, action, and the onClose/onSuccess callbacks) through the DOM
+// so tests can drive it the way a user would, instead of inspecting props.
+vi.mock("../DeviceActionDialog", () => ({
+  default: ({ open, device, action, onClose, onSuccess }: {
+    open: boolean;
+    device: EntityBase | null;
+    action: string;
+    onClose: () => void;
+    onSuccess?: () => void;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label={`${action} ${device?.name}`}>
+        <button type="button" onClick={onClose}>cancel</button>
+        {onSuccess && <button type="button" onClick={onSuccess}>confirm</button>}
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/billing/BillingWarning", () => ({
+  default: () => <div data-testid="billing-warning" />,
+}));
+
+import DeviceActionsPortal from "../DeviceActionsPortal";
+
+function renderPortal(overrides: Partial<UseDeviceActionsResult> = {}) {
+  const controller: UseDeviceActionsResult = {
+    operation: undefined,
+    requestAction: vi.fn(),
+    close: vi.fn(),
+    billingWarningOpen: false,
+    closeBillingWarning: vi.fn(),
+    onBillingWarning: undefined,
+    runSuccess: vi.fn(),
+    billingEnabled: false,
+    ...overrides,
+  };
+  render(<DeviceActionsPortal controller={controller} />);
+  return controller;
+}
+
+describe("DeviceActionsPortal", () => {
+  it("opens the dialog for the active operation", () => {
+    renderPortal({ operation: { entity: { uid: "uid-1", name: "my-device" }, action: "remove" } });
+
+    expect(screen.getByRole("dialog", { name: "remove my-device" })).toBeInTheDocument();
+  });
+
+  it("keeps the dialog closed when there is no operation", () => {
+    renderPortal();
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("runs the operation's action when the dialog confirms", async () => {
+    const controller = renderPortal({
+      operation: { entity: { uid: "uid-2", name: "d2" }, action: "remove" },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "confirm" }));
+
+    expect(controller.runSuccess).toHaveBeenCalledWith("remove");
+  });
+
+  it("closes when the dialog is cancelled", async () => {
+    const controller = renderPortal({
+      operation: { entity: { uid: "uid-3", name: "d3" }, action: "accept" },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "cancel" }));
+
+    expect(controller.close).toHaveBeenCalledOnce();
+  });
+
+  it("renders BillingWarning only when billing is enabled", () => {
+    renderPortal({ billingEnabled: true });
+    expect(screen.getByTestId("billing-warning")).toBeInTheDocument();
+  });
+
+  it("does not render BillingWarning when billing is disabled", () => {
+    renderPortal();
+    expect(screen.queryByTestId("billing-warning")).not.toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/pages/devices/__tests__/DeviceDetails.test.tsx
+++ b/ui/apps/console/src/pages/devices/__tests__/DeviceDetails.test.tsx
@@ -59,8 +59,27 @@ vi.mock("@/components/common/RestrictedAction", () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("@/pages/devices/DeviceActionDialog", () => ({
-  default: () => <div />,
+vi.mock("@/pages/devices/DeviceActionsPortal", () => ({
+  default: () => null,
+}));
+
+const mockRequestAction = vi.fn();
+let capturedOnSuccess: ((action: string) => void) | undefined;
+
+vi.mock("@/hooks/useDeviceActions", () => ({
+  useDeviceActions: (opts?: { onSuccess?: (action: string) => void }) => {
+    capturedOnSuccess = opts?.onSuccess;
+    return {
+      operation: undefined,
+      requestAction: mockRequestAction,
+      close: vi.fn(),
+      billingWarningOpen: false,
+      closeBillingWarning: vi.fn(),
+      onBillingWarning: undefined,
+      runSuccess: vi.fn(),
+      billingEnabled: false,
+    };
+  },
 }));
 
 vi.mock("@/utils/date", () => ({
@@ -72,12 +91,14 @@ vi.mock("@/utils/sshid", () => ({
   buildSshid: (ns: string, name: string) => `${ns}.${name}@localhost`,
 }));
 
+const mockNavigate = vi.fn();
+
 vi.mock("react-router-dom", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router-dom")>();
   return {
     ...actual,
     useParams: () => ({ uid: "test-uid" }),
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
     useSearchParams: () => [new URLSearchParams(), vi.fn()],
   };
 });
@@ -126,6 +147,9 @@ describe("DeviceDetails", () => {
   beforeEach(() => {
     mockSetCustomField.mockReset().mockResolvedValue({});
     mockDeleteCustomField.mockReset().mockResolvedValue({});
+    mockRequestAction.mockReset();
+    mockNavigate.mockReset();
+    capturedOnSuccess = undefined;
     vi.mocked(useDevice).mockReturnValue({
       device: null,
       isLoading: false,
@@ -304,6 +328,116 @@ describe("DeviceDetails", () => {
 
       expect(screen.getByText("This key already exists.")).toBeInTheDocument();
       expect(mockSetCustomField).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("action buttons delegate to useDeviceActions", () => {
+    it("calls requestAction('accept') when Accept is clicked on a pending device", async () => {
+      const user = userEvent.setup();
+      const device = makeDevice({ status: "pending", online: false });
+      vi.mocked(useDevice).mockReturnValue({
+        device,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      await user.click(screen.getByRole("button", { name: /Accept/i }));
+
+      expect(mockRequestAction).toHaveBeenCalledWith(
+        expect.objectContaining({ uid: "test-uid" }),
+        "accept",
+      );
+    });
+
+    it("calls requestAction('reject') when Reject is clicked on a pending device", async () => {
+      const user = userEvent.setup();
+      const device = makeDevice({ status: "pending", online: false });
+      vi.mocked(useDevice).mockReturnValue({
+        device,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      await user.click(screen.getByRole("button", { name: /Reject/i }));
+
+      expect(mockRequestAction).toHaveBeenCalledWith(
+        expect.objectContaining({ uid: "test-uid" }),
+        "reject",
+      );
+    });
+
+    it("calls requestAction('remove') when Remove is clicked on a rejected device", async () => {
+      const user = userEvent.setup();
+      const device = makeDevice({ status: "rejected", online: false });
+      vi.mocked(useDevice).mockReturnValue({
+        device,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      await user.click(screen.getByRole("button", { name: /Remove/i }));
+
+      expect(mockRequestAction).toHaveBeenCalledWith(
+        expect.objectContaining({ uid: "test-uid" }),
+        "remove",
+      );
+    });
+
+    it("calls requestAction('remove') when the Delete device trash button is clicked on an accepted device", async () => {
+      const user = userEvent.setup();
+      const device = makeDevice({ status: "accepted", online: true });
+      vi.mocked(useDevice).mockReturnValue({
+        device,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      await user.click(screen.getByRole("button", { name: "Delete device" }));
+
+      expect(mockRequestAction).toHaveBeenCalledWith(
+        expect.objectContaining({ uid: "test-uid" }),
+        "remove",
+      );
+    });
+  });
+
+  describe("onSuccess callback wiring", () => {
+    it("navigates to /devices when onSuccess is called with action 'remove'", () => {
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice(),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      expect(capturedOnSuccess).toBeDefined();
+      capturedOnSuccess!("remove");
+
+      expect(mockNavigate).toHaveBeenCalledWith("/devices");
+    });
+
+    it("does NOT navigate when onSuccess is called with a non-remove action", () => {
+      vi.mocked(useDevice).mockReturnValue({
+        device: makeDevice({ status: "pending", online: false }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      renderPage();
+
+      expect(capturedOnSuccess).toBeDefined();
+      capturedOnSuccess!("accept");
+
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/apps/console/src/pages/devices/__tests__/Devices.test.tsx
+++ b/ui/apps/console/src/pages/devices/__tests__/Devices.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { NormalizedDevice } from "@/hooks/useDevices";
+import type { UseDeviceActionsResult } from "@/hooks/useDeviceActions";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -95,8 +96,27 @@ vi.mock("../TagsPopover", () => ({
   ),
 }));
 
-vi.mock("../DeviceActionDialog", () => ({
-  default: () => <div />,
+const mockDeviceActionsPortal = vi.fn();
+vi.mock("../DeviceActionsPortal", () => ({
+  default: (props: { controller: UseDeviceActionsResult }) => {
+    mockDeviceActionsPortal(props);
+    return null;
+  },
+}));
+
+const mockRequestAction = vi.fn();
+const mockDeviceActionsController: UseDeviceActionsResult = {
+  operation: undefined,
+  requestAction: mockRequestAction,
+  close: vi.fn(),
+  billingWarningOpen: false,
+  closeBillingWarning: vi.fn(),
+  onBillingWarning: undefined,
+  runSuccess: vi.fn(),
+  billingEnabled: false,
+};
+vi.mock("@/hooks/useDeviceActions", () => ({
+  useDeviceActions: vi.fn(() => mockDeviceActionsController),
 }));
 
 vi.mock("@/components/common/RestrictedAction", () => ({
@@ -113,6 +133,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 import React from "react";
 import { useDevices } from "@/hooks/useDevices";
+import { useDeviceActions } from "@/hooks/useDeviceActions";
 import Devices from "../index";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -163,8 +184,11 @@ function renderPage(initialEntries: string[] = ["/"]) {
 describe("Devices list", () => {
   beforeEach(() => {
     vi.mocked(useDevices).mockReturnValue(defaultHookState);
+    vi.mocked(useDeviceActions).mockReturnValue(mockDeviceActionsController);
     mockNavigate.mockReset();
     mockManageTagsDrawer.mockReset();
+    mockDeviceActionsPortal.mockReset();
+    mockRequestAction.mockReset();
   });
 
   describe("rendering", () => {
@@ -342,6 +366,62 @@ describe("Devices list", () => {
       expect(vi.mocked(useDevices)).toHaveBeenCalledWith(
         expect.objectContaining({ search: "myhost" }),
       );
+    });
+  });
+
+  // ── DeviceActionsPortal integration ──────────────────────────────────────────
+
+  describe("DeviceActionsPortal integration — useDeviceActions + portal replace inline state", () => {
+    beforeEach(() => {
+      mockRequestAction.mockReset();
+      mockDeviceActionsPortal.mockReset();
+      vi.mocked(useDeviceActions).mockReturnValue(mockDeviceActionsController);
+    });
+
+    it("mounts DeviceActionsPortal with the controller returned by useDeviceActions", () => {
+      renderPage();
+      expect(mockDeviceActionsPortal).toHaveBeenCalledWith(
+        expect.objectContaining({ controller: mockDeviceActionsController }),
+      );
+    });
+
+    it("calls requestAction(device, 'accept') when the Accept button is clicked on a pending device", async () => {
+      const user = userEvent.setup();
+      const pending = makeDevice({ uid: "p-1", name: "pending-device", status: "pending", online: false });
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [pending],
+        totalCount: 1,
+      });
+      renderPage(["/?status=pending"]);
+      await user.click(screen.getByRole("button", { name: "Accept" }));
+      expect(mockRequestAction).toHaveBeenCalledWith(pending, "accept");
+    });
+
+    it("calls requestAction(device, 'reject') when the Reject button is clicked on a pending device", async () => {
+      const user = userEvent.setup();
+      const pending = makeDevice({ uid: "p-2", name: "pending-device-2", status: "pending", online: false });
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [pending],
+        totalCount: 1,
+      });
+      renderPage(["/?status=pending"]);
+      await user.click(screen.getByRole("button", { name: "Reject" }));
+      expect(mockRequestAction).toHaveBeenCalledWith(pending, "reject");
+    });
+
+    it("calls requestAction(device, 'remove') when the Remove button is clicked on a rejected device", async () => {
+      const user = userEvent.setup();
+      const rejected = makeDevice({ uid: "r-1", name: "rejected-device", status: "rejected", online: false });
+      vi.mocked(useDevices).mockReturnValue({
+        ...defaultHookState,
+        devices: [rejected],
+        totalCount: 1,
+      });
+      renderPage(["/?status=rejected"]);
+      await user.click(screen.getByRole("button", { name: "Remove" }));
+      expect(mockRequestAction).toHaveBeenCalledWith(rejected, "remove");
     });
   });
 

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -7,6 +7,7 @@ import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useAuthStore } from "@/stores/authStore";
 import { useTerminalStore } from "@/stores/terminalStore";
+import { useDeviceActions } from "@/hooks/useDeviceActions";
 import PageHeader from "@/components/common/PageHeader";
 import ConnectDrawer from "@/components/ConnectDrawer";
 import ManageTagsDrawer from "@/components/ManageTagsDrawer";
@@ -19,9 +20,7 @@ import SearchField from "@/components/common/fields/SearchField";
 import { buildSshid } from "@/utils/sshid";
 import TagFilterDropdown from "@/components/common/TagFilterDropdown";
 import TagsPopover from "./TagsPopover";
-import DeviceActionDialog from "./DeviceActionDialog";
-import BillingWarning from "@/components/billing/BillingWarning";
-import { getConfig } from "@/env";
+import DeviceActionsPortal from "./DeviceActionsPortal";
 import {
   PlusIcon,
   TagIcon,
@@ -81,17 +80,14 @@ export default function Devices() {
     SEARCH_DEBOUNCE_MS,
   );
 
-  const [actionTarget, setActionTarget] = useState<{
-    device: NormalizedDevice;
-    action: "accept" | "reject" | "remove";
-  } | null>(null);
+  const deviceActions = useDeviceActions();
+  const { requestAction: requestDeviceAction } = deviceActions;
   const [connectTarget, setConnectTarget] = useState<{
     uid: string;
     name: string;
     sshid: string;
   } | null>(null);
   const [manageTagsOpen, setManageTagsOpen] = useState(false);
-  const [billingWarningOpen, setBillingWarningOpen] = useState(false);
   const { sortBy, orderBy, handleSort } = useTableSort<SortField>({
     defaultField: "last_seen",
     onSortChange: () => setPage(1),
@@ -268,7 +264,7 @@ export default function Devices() {
                   size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setActionTarget({ device, action: "accept" });
+                    requestDeviceAction(device, "accept");
                   }}
                 >
                   Accept
@@ -280,7 +276,7 @@ export default function Devices() {
                   size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setActionTarget({ device, action: "reject" });
+                    requestDeviceAction(device, "reject");
                   }}
                 >
                   Reject
@@ -307,7 +303,7 @@ export default function Devices() {
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
-                  setActionTarget({ device, action: "accept" });
+                  requestDeviceAction(device, "accept");
                 }}
               >
                 Accept
@@ -319,7 +315,7 @@ export default function Devices() {
                 size="sm"
                 onClick={(e) => {
                   e.stopPropagation();
-                  setActionTarget({ device, action: "remove" });
+                  requestDeviceAction(device, "remove");
                 }}
               >
                 Remove
@@ -329,7 +325,7 @@ export default function Devices() {
         ),
       },
     ];
-  }, [params.status, nsName, addFilterTag]);
+  }, [params.status, nsName, addFilterTag, requestDeviceAction]);
 
   return (
     <div>
@@ -454,29 +450,7 @@ export default function Devices() {
         }
       />
 
-      <DeviceActionDialog
-        key={
-          actionTarget
-            ? `${actionTarget.action}/${actionTarget.device.uid}`
-            : "closed"
-        }
-        open={!!actionTarget}
-        device={actionTarget?.device ?? null}
-        action={actionTarget?.action ?? "accept"}
-        onClose={() => setActionTarget(null)}
-        onBillingWarning={
-          getConfig().cloud
-            ? () => {
-                setActionTarget(null);
-                setBillingWarningOpen(true);
-              }
-            : undefined
-        }
-      />
-      <BillingWarning
-        open={billingWarningOpen}
-        onClose={() => setBillingWarningOpen(false)}
-      />
+      <DeviceActionsPortal controller={deviceActions} />
 
       <ConnectDrawer
         open={!!connectTarget}


### PR DESCRIPTION
## What
Accept/reject/remove dialog wiring and the billing-warning gate were duplicated across `DeviceDetails`, `ContainerDetails`, and both list pages. This extracts a single shared implementation that all four pages consume.

## Why
Closes shellhub-io/team#153. Any bug in the action flow, loading state, or error handling previously had to be fixed in each page independently. (The audit named three files; the real duplication spans four — `admin/devices` has no action logic, while `ContainerDetails` does.)

## Changes
- **`hooks/useActionDialogState`**: generic state core — `operation` state, `requestAction`, `close`, the cloud-gated `onBillingWarning`, and `runSuccess(action)`. All returned callbacks are `useCallback`-stable so list-page column `useMemo`s don't churn.
- **`hooks/useDeviceActions` / `useContainerActions`**: thin typed wrappers (the issue-named public API); `enableBillingWarning` defaults to `!!getConfig().cloud`.
- **`DeviceActionsPortal` / `ContainerActionsPortal`**: render the existing `*ActionDialog` + `BillingWarning` from the controller, preserving the `key`-based reset and the entity→`device`/`container` prop mapping.
- **Pages**: `DeviceDetails`, `devices/index`, `ContainerDetails`, `containers/index` drop their inline state/render in favor of the hook + portal. `ContainerDetails` passes `enableBillingWarning: false` to keep its existing no-billing-warning flow.
- The `*ActionDialog` and `BillingWarning` components are unchanged — they already centralized the mutations and 402 handling.

## Testing
- New unit tests: `useActionDialogState` (state, billing gating, stable refs, action forwarding) and both portals (prop mapping; `ContainerActionsPortal` asserts `BillingWarning` is absent when `enableBillingWarning: false`).
- Existing page-test mocks were retargeted from the dialogs to the new portals.
- Full console suite: 2597 passing; `eslint` and `tsc -b` clean.
- Reviewer note: confirm `ContainerDetails` still shows the inline 402 error (not the billing dialog) on a cloud build — that asymmetry vs. the other pages is intentional and preserved.