### PR TITLE
fix(api): restore deprecated info.platform/identity.mac device filters

### DIFF
--- a/api/services/device.go
+++ b/api/services/device.go
@@ -29,6 +29,11 @@ var DeviceFilterFields = query.NewFieldConstraints(map[string][]string{
 	"tags.name":     {"contains", "eq"},
 	"online":        {"bool", "eq"},
 	"custom_fields": {"contains"},
+
+	// Deprecated: legacy Mongo-style aliases for "platform" and "mac", kept for
+	// backward compatibility and slated for removal in the next major API version.
+	"info.platform": {"contains", "eq", "ne"},
+	"identity.mac":  {"contains", "eq", "ne"},
 },
 	// Virtual bool-backed fields intercepted by ParseFilterProperty before any
 	// SQL column binding — safe to accept bool-convertible values with eq/ne.

--- a/api/store/pg/internal/filters.go
+++ b/api/store/pg/internal/filters.go
@@ -18,6 +18,21 @@ var (
 	ErrUnsupportedNumericType  = errors.New("unsupported value type for numeric comparison")  // ErrUnsupportedNumericType is returned when a 'gt' filter receives an unsupported value type
 )
 
+// Deprecated: legacy Mongo-style device filter field names mapped to their real
+// columns, kept for backward compatibility. Slated for removal in the next major
+// API version.
+var legacyDeviceFieldAliases = map[string]string{
+	"info.platform": "platform",
+	"identity.mac":  "mac",
+}
+
+func renameFilterField(fp *query.FilterProperty, name string) *query.FilterProperty {
+	adjusted := *fp
+	adjusted.Name = name
+
+	return &adjusted
+}
+
 // qualifyColumn returns a bun.Ident for the given column, optionally prefixed
 // with a table alias (e.g. "device.name") to avoid ambiguity in JOINed queries.
 func qualifyColumn(column, tableAlias string) bun.Ident {
@@ -138,9 +153,11 @@ func ParseFilterProperty(fp *query.FilterProperty, tableAlias string) (string, [
 	// only so it cannot silently affect other filter contexts that happen to
 	// expose a device_uid field but use a different column name or no column at all.
 	if tableAlias == "session" && fp.Name == "device_uid" {
-		adjusted := *fp
-		adjusted.Name = "device_id"
-		fp = &adjusted
+		fp = renameFilterField(fp, "device_id")
+	}
+
+	if column, ok := legacyDeviceFieldAliases[fp.Name]; ok {
+		fp = renameFilterField(fp, column)
 	}
 
 	// tags.name requires an EXISTS subquery through the device_tags junction table,

--- a/api/store/pg/internal/filters_test.go
+++ b/api/store/pg/internal/filters_test.go
@@ -55,6 +55,81 @@ func TestParseFilterProperty_DeviceUID(t *testing.T) {
 	}
 }
 
+// Regression guard for shellhub-io/shellhub#6574: the deprecated "info.platform"
+// and "identity.mac" aliases must resolve to their real columns for every operator.
+func TestParseFilterProperty_LegacyDeviceFieldAliases(t *testing.T) {
+	cases := []struct {
+		description string
+		fieldName   string
+		operator    string
+		wantCond    string
+		wantCol     bun.Ident
+		wantValue   any
+	}{
+		{
+			description: "info.platform eq maps to platform",
+			fieldName:   "info.platform",
+			operator:    "eq",
+			wantCond:    "? = ?",
+			wantCol:     bun.Ident("platform"),
+			wantValue:   "manjaro",
+		},
+		{
+			description: "info.platform contains maps to platform",
+			fieldName:   "info.platform",
+			operator:    "contains",
+			wantCond:    "? ILIKE ?",
+			wantCol:     bun.Ident("platform"),
+			wantValue:   "%manjaro%",
+		},
+		{
+			description: "info.platform ne maps to platform",
+			fieldName:   "info.platform",
+			operator:    "ne",
+			wantCond:    "? <> ?",
+			wantCol:     bun.Ident("platform"),
+			wantValue:   "manjaro",
+		},
+		{
+			description: "identity.mac eq maps to mac",
+			fieldName:   "identity.mac",
+			operator:    "eq",
+			wantCond:    "? = ?",
+			wantCol:     bun.Ident("mac"),
+			wantValue:   "manjaro",
+		},
+		{
+			description: "identity.mac contains maps to mac",
+			fieldName:   "identity.mac",
+			operator:    "contains",
+			wantCond:    "? ILIKE ?",
+			wantCol:     bun.Ident("mac"),
+			wantValue:   "%manjaro%",
+		},
+		{
+			description: "identity.mac ne maps to mac",
+			fieldName:   "identity.mac",
+			operator:    "ne",
+			wantCond:    "? <> ?",
+			wantCol:     bun.Ident("mac"),
+			wantValue:   "manjaro",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			fp := &query.FilterProperty{Name: tc.fieldName, Operator: tc.operator, Value: "manjaro"}
+			sqlCond, args, ok, err := ParseFilterProperty(fp, "")
+			require.NoError(t, err)
+			assert.True(t, ok)
+			assert.Equal(t, tc.wantCond, sqlCond)
+			require.Len(t, args, 2)
+			assert.Equal(t, tc.wantCol, args[0])
+			assert.Equal(t, tc.wantValue, args[1])
+		})
+	}
+}
+
 func TestFromActiveFilter(t *testing.T) {
 	const deviceExistsSQL = `EXISTS (SELECT 1 FROM "active_sessions" JOIN "sessions" ON "sessions"."id" = "active_sessions"."session_id" WHERE "sessions"."device_id" = "device"."id")`
 	const deviceNotExistsSQL = `NOT EXISTS (SELECT 1 FROM "active_sessions" JOIN "sessions" ON "sessions"."id" = "active_sessions"."session_id" WHERE "sessions"."device_id" = "device"."id")`

--- a/openapi/spec/paths/api@devices.yaml
+++ b/openapi/spec/paths/api@devices.yaml
@@ -1,7 +1,14 @@
 get:
   operationId: getDevices
   summary: List devices
-  description: List devices.
+  description: |-
+    List devices.
+
+    **Deprecated filter field names.** The `filter` parameter still accepts the
+    legacy Mongo-style field names `info.platform` and `identity.mac`, which are
+    duplicates of `platform` and `mac` respectively. These aliases are kept for
+    backward compatibility and will be removed in the next major API version.
+    Update integrations to use the flat names (`platform`, `mac`).
   tags:
     - community
     - devices


### PR DESCRIPTION
## Description

#6569 ("refactor(api): remove MongoDB remnants") dropped the Mongo-style dotted filter field names from the device list endpoint: `info.platform` and `identity.mac` were removed from `DeviceFilterFields` and the `legacyMongoFieldMapping` translation layer was deleted.

These dotted names are part of the public device-list filter contract, so external integrations that send `info.platform` / `identity.mac` started getting **HTTP 400** after #6569. This restores backward compatibility for the two live fields without bringing back the dead code, and turns the removal into a proper deprecation cycle.

## Changes

- **`api/services/device.go`** — re-accept `info.platform` and `identity.mac` in `DeviceFilterFields` as deprecated aliases.
- **`api/store/pg/internal/filters.go`** — add a minimal `legacyDeviceFieldAliases` map (`info.platform`→`platform`, `identity.mac`→`mac`) and rewrite the field name once in `ParseFilterProperty`, before any SQL binding, so every operator is covered. Extracted a shared `renameFilterField` helper reused by the existing `device_uid` alias.
- **`openapi/spec/paths/api@devices.yaml`** — document the deprecated aliases and announce removal in the next major API version.
- **`api/store/pg/internal/filters_test.go`** — regression test covering both aliases across `eq`/`contains`/`ne`.

The other six aliases removed in #6569 (`info.id`, `info.pretty_name`, `info.version`, `info.arch`, `position.longitude`, `position.latitude`) were never in the allowlist and stay removed.

## Verification

- `go build ./...`, `go test ./store/pg/internal/...`, `golangci-lint run` — all clean
- OpenAPI: Prettier + Redocly lint pass

Fixes: shellhub-io/shellhub#6574