### PR TITLE
chore(ui): unify monorepo on React 19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ docker-compose.override.yml
 **/*.map
 **/*.tsbuildinfo
 **/vite.config.d.ts
+**/openapi-ts.config.d.ts
 
 api_private_key
 api_public_key

--- a/ui/apps/console/package.json
+++ b/ui/apps/console/package.json
@@ -19,7 +19,7 @@
     "@heroicons/react": "^2.2.0",
     "@hey-api/openapi-ts": "^0.94.5",
     "@shellhub/design-system": "*",
-    "@stripe/react-stripe-js": "^2.8.0",
+    "@stripe/react-stripe-js": "^3.1.1",
     "@stripe/stripe-js": "^4.8.0",
     "@tanstack/react-query": "^5.101.2",
     "@tiptap/extension-image": "^3.27.1",
@@ -36,8 +36,6 @@
     "axios": "^1.18.1",
     "font-logos": "^1.3.0",
     "node-rsa": "^1.1.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "react-router-dom": "^7.17.0",
     "sshpk": "^1.18.0",
     "zustand": "^5.0.14"

--- a/ui/apps/console/src/components/commandPalette/PaletteHeader.tsx
+++ b/ui/apps/console/src/components/commandPalette/PaletteHeader.tsx
@@ -4,7 +4,7 @@ import type { NormalizedDevice } from "@/hooks/useDevices";
 import { LISTBOX_ID, icons } from "./items";
 
 interface PaletteHeaderProps {
-  inputRef: React.RefObject<HTMLInputElement>;
+  inputRef: React.RefObject<HTMLInputElement | null>;
   query: string;
   drillDevice: NormalizedDevice | null;
   commandMode: boolean;

--- a/ui/apps/console/src/components/commandPalette/items.tsx
+++ b/ui/apps/console/src/components/commandPalette/items.tsx
@@ -20,6 +20,8 @@ import { formatRelative } from "@/utils/date";
 import type { NormalizedDevice } from "@/hooks/useDevices";
 import type { TerminalSession } from "@/stores/terminalStore";
 
+import type { JSX } from "react";
+
 export type BadgeVariant = "green" | "yellow" | "red" | "muted";
 
 export interface CommandItem {

--- a/ui/apps/console/src/components/common/BaseDialog.tsx
+++ b/ui/apps/console/src/components/common/BaseDialog.tsx
@@ -1,4 +1,4 @@
-import { Ref, ReactNode, RefObject, useCallback, useEffect, useRef } from "react";
+import { ReactNode, RefObject, useCallback, useEffect, useRef } from "react";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { useBackdropClose } from "@/hooks/useBackdropClose";
 
@@ -140,7 +140,7 @@ export default function BaseDialog({
 
   return (
     <dialog
-      ref={ref as Ref<HTMLDialogElement>}
+      ref={ref}
       data-custom-backdrop
       aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}

--- a/ui/apps/console/src/components/common/Drawer.tsx
+++ b/ui/apps/console/src/components/common/Drawer.tsx
@@ -47,7 +47,7 @@ export default function Drawer({
       <div
         ref={panelRef}
         aria-hidden={!open}
-        {...(!open ? { inert: "" } : {})}
+        {...(!open ? { inert: true } : {})}
         className={`fixed inset-y-0 right-0 z-[70] w-full ${WIDTH_MAP[width]} bg-surface border-l border-border shadow-2xl flex flex-col transition-transform duration-300 ease-out ${
           open ? "translate-x-0" : "translate-x-full"
         }`}

--- a/ui/apps/console/src/components/common/NoticeBanner.tsx
+++ b/ui/apps/console/src/components/common/NoticeBanner.tsx
@@ -44,7 +44,7 @@ export default function NoticeBanner({
   return (
     <div
       aria-hidden={!visible ? true : undefined}
-      {...(!visible ? { inert: "" } : {})}
+      {...(!visible ? { inert: true } : {})}
       className={`grid transition-[grid-template-rows] duration-300 ease-out ${
         visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
       }`}

--- a/ui/apps/console/src/components/common/RestrictedAction.tsx
+++ b/ui/apps/console/src/components/common/RestrictedAction.tsx
@@ -39,7 +39,7 @@ export default function RestrictedAction({
       className="inline-flex cursor-not-allowed"
     >
       {/* inert blocks all interaction (pointer and keyboard) with children */}
-      <span className="pointer-events-none opacity-50" {...{ inert: "" }}>
+      <span className="pointer-events-none opacity-50" inert>
         {children}
       </span>
     </span>

--- a/ui/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui/apps/console/src/components/layout/SidebarShell.tsx
@@ -86,7 +86,7 @@ export function SidebarMobileDrawer({
       aria-label="Navigation menu"
       className={`fixed inset-0 z-50 ${open ? "" : "pointer-events-none"}`}
       onKeyDown={onKeyDown}
-      {...(!open && { inert: "" })}
+      {...(!open && { inert: true })}
     >
       <div
         className={`absolute inset-0 bg-black/40 transition-opacity duration-200 ${

--- a/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
+++ b/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
@@ -156,7 +156,9 @@ export default function MfaDisableDialog({
                   {otp.code.map((digit, index) => (
                     <input
                       key={index}
-                      ref={(el) => (otp.inputRefs.current[index] = el)}
+                      ref={(el) => {
+                        (otp.inputRefs.current[index] = el);
+                      }}
                       type="text"
                       inputMode="numeric"
                       maxLength={1}

--- a/ui/apps/console/src/components/mfa/MfaEnableDrawer.tsx
+++ b/ui/apps/console/src/components/mfa/MfaEnableDrawer.tsx
@@ -436,7 +436,9 @@ export default function MfaEnableDrawer({
                 {otp.code.map((digit, index) => (
                   <input
                     key={index}
-                    ref={(el) => (otp.inputRefs.current[index] = el)}
+                    ref={(el) => {
+                      (otp.inputRefs.current[index] = el);
+                    }}
                     type="text"
                     inputMode="numeric"
                     maxLength={1}

--- a/ui/apps/console/src/hooks/useCommandPalette.ts
+++ b/ui/apps/console/src/hooks/useCommandPalette.ts
@@ -33,8 +33,8 @@ const RECENT_LIMIT = 5;
 export interface CommandPaletteViewModel {
   open: boolean;
   // Refs the JSX attaches; the hook reads `.current` only inside effects.
-  inputRef: React.RefObject<HTMLInputElement>;
-  listRef: React.RefObject<HTMLDivElement>;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  listRef: React.RefObject<HTMLDivElement | null>;
   // Derived view data (computed during render).
   query: string;
   drillDevice: NormalizedDevice | null;

--- a/ui/apps/console/src/hooks/useKeyFileInput.ts
+++ b/ui/apps/console/src/hooks/useKeyFileInput.ts
@@ -16,7 +16,7 @@ interface UseKeyFileInputOptions {
 }
 
 interface UseKeyFileInputReturn {
-  fileInputRef: RefObject<HTMLInputElement>;
+  fileInputRef: RefObject<HTMLInputElement | null>;
   dragging: boolean;
   inputMode: "file" | "text";
   setInputMode: (mode: "file" | "text") => void;

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import { Link } from "react-router-dom";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import { useAuthStore } from "../stores/authStore";

--- a/ui/apps/console/src/pages/MfaLogin.tsx
+++ b/ui/apps/console/src/pages/MfaLogin.tsx
@@ -63,7 +63,6 @@ export default function MfaLogin() {
           in.
         </p>
       </div>
-
       {/* Form card */}
       <div
         className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
@@ -85,7 +84,9 @@ export default function MfaLogin() {
               {otp.code.map((digit, index) => (
                 <input
                   key={index}
-                  ref={(el) => (otp.inputRefs.current[index] = el)}
+                  ref={(el) => {
+                    (otp.inputRefs.current[index] = el);
+                  }}
                   type="text"
                   inputMode="numeric"
                   maxLength={1}
@@ -121,7 +122,6 @@ export default function MfaLogin() {
           </div>
         </form>
       </div>
-
       {/* Footer links */}
       <AuthFooterLinks />
     </div>

--- a/ui/apps/console/src/pages/MfaResetComplete.tsx
+++ b/ui/apps/console/src/pages/MfaResetComplete.tsx
@@ -111,7 +111,6 @@ export default function MfaResetComplete() {
           Enter the codes from both emails to complete the MFA reset.
         </p>
       </div>
-
       {/* Form Card */}
       <div
         className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
@@ -134,7 +133,9 @@ export default function MfaResetComplete() {
               {otpMain.code.map((char, index) => (
                 <input
                   key={index}
-                  ref={(el) => (otpMain.inputRefs.current[index] = el)}
+                  ref={(el) => {
+                    (otpMain.inputRefs.current[index] = el);
+                  }}
                   type="text"
                   maxLength={1}
                   value={char}
@@ -164,7 +165,9 @@ export default function MfaResetComplete() {
               {otpRecovery.code.map((char, index) => (
                 <input
                   key={index}
-                  ref={(el) => (otpRecovery.inputRefs.current[index] = el)}
+                  ref={(el) => {
+                    (otpRecovery.inputRefs.current[index] = el);
+                  }}
                   type="text"
                   maxLength={1}
                   value={char}
@@ -195,7 +198,6 @@ export default function MfaResetComplete() {
           </Button>
         </form>
       </div>
-
       {/* Info Note */}
       <div
         className="w-full max-w-sm mt-6 p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg animate-fade-in"
@@ -207,7 +209,6 @@ export default function MfaResetComplete() {
           addresses. Codes expire after 24 hours.
         </p>
       </div>
-
       <AuthFooterLinks />
     </div>
   );

--- a/ui/apps/console/src/pages/MfaResetVerify.tsx
+++ b/ui/apps/console/src/pages/MfaResetVerify.tsx
@@ -72,7 +72,6 @@ export default function MfaResetVerify() {
           codes below.
         </p>
       </div>
-
       {/* Form Card */}
       <div
         className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
@@ -95,7 +94,9 @@ export default function MfaResetVerify() {
               {otpMain.code.map((char, index) => (
                 <input
                   key={index}
-                  ref={(el) => (otpMain.inputRefs.current[index] = el)}
+                  ref={(el) => {
+                    (otpMain.inputRefs.current[index] = el);
+                  }}
                   type="text"
                   maxLength={1}
                   value={char}
@@ -125,7 +126,9 @@ export default function MfaResetVerify() {
               {otpRecovery.code.map((char, index) => (
                 <input
                   key={index}
-                  ref={(el) => (otpRecovery.inputRefs.current[index] = el)}
+                  ref={(el) => {
+                    (otpRecovery.inputRefs.current[index] = el);
+                  }}
                   type="text"
                   maxLength={1}
                   value={char}
@@ -165,7 +168,6 @@ export default function MfaResetVerify() {
           </div>
         </form>
       </div>
-
       {/* Info Note */}
       <div
         className="w-full max-w-sm mt-6 p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg animate-fade-in"
@@ -177,7 +179,6 @@ export default function MfaResetVerify() {
           addresses. Codes expire after 24 hours.
         </p>
       </div>
-
       <AuthFooterLinks />
     </div>
   );

--- a/ui/apps/docs/package.json
+++ b/ui/apps/docs/package.json
@@ -17,10 +17,6 @@
     "@astrojs/react": "^4.2.1",
     "@astrojs/tailwind": "^6.0.2",
     "@shellhub/design-system": "*",
-    "@types/react": "^19.1.0",
-    "@types/react-dom": "^19.1.0",
-    "astro": "^5.7.5",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "astro": "^5.7.5"
   }
 }

--- a/ui/apps/website/package.json
+++ b/ui/apps/website/package.json
@@ -14,8 +14,6 @@
   "dependencies": {
     "@shellhub/design-system": "*",
     "axios": "^1.18.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0"
   }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,7 +14,9 @@
       "dependencies": {
         "@types/qrcode": "^1.5.6",
         "date-fns": "^4.1.0",
-        "qrcode": "^1.5.4"
+        "qrcode": "^1.5.4",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -24,8 +26,8 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.2.2",
-        "@types/react": "^18.3.12",
-        "@types/react-dom": "^18.3.1",
+        "@types/react": "^19.1.0",
+        "@types/react-dom": "^19.1.0",
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/eslint-plugin": "^1.1.44",
         "autoprefixer": "^10.4.20",
@@ -56,7 +58,7 @@
         "@heroicons/react": "^2.2.0",
         "@hey-api/openapi-ts": "^0.94.5",
         "@shellhub/design-system": "*",
-        "@stripe/react-stripe-js": "^2.8.0",
+        "@stripe/react-stripe-js": "^3.1.1",
         "@stripe/stripe-js": "^4.8.0",
         "@tanstack/react-query": "^5.101.2",
         "@tiptap/extension-image": "^3.27.1",
@@ -73,8 +75,6 @@
         "axios": "^1.18.1",
         "font-logos": "^1.3.0",
         "node-rsa": "^1.1.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
         "react-router-dom": "^7.17.0",
         "sshpk": "^1.18.0",
         "zustand": "^5.0.14"
@@ -185,57 +185,8 @@
         "@astrojs/react": "^4.2.1",
         "@astrojs/tailwind": "^6.0.2",
         "@shellhub/design-system": "*",
-        "@types/react": "^19.1.0",
-        "@types/react-dom": "^19.1.0",
-        "astro": "^5.7.5",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "astro": "^5.7.5"
       }
-    },
-    "apps/docs/node_modules/@types/react": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
-      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "apps/docs/node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
-      }
-    },
-    "apps/docs/node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/docs/node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
-    "apps/docs/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
     },
     "apps/website": {
       "name": "@shellhub/website",
@@ -243,8 +194,6 @@
       "dependencies": {
         "@shellhub/design-system": "*",
         "axios": "^1.18.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0"
       }
     },
@@ -3567,17 +3516,17 @@
       "license": "MIT"
     },
     "node_modules/@stripe/react-stripe-js": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-2.9.0.tgz",
-      "integrity": "sha512-+/j2g6qKAKuWSurhgRMfdlIdKM+nVVJCy/wl0US2Ccodlqx0WqfIIBhUkeONkCG+V/b+bZzcj4QVa3E/rXtT4Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
+      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@stripe/stripe-js": "^1.44.1 || ^2.0.0 || ^3.0.0 || ^4.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
       }
     },
     "node_modules/@stripe/stripe-js": {
@@ -4280,10 +4229,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "license": "MIT"
-    },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
       "license": "MIT",
@@ -4292,20 +4237,21 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/sshpk": {
@@ -12731,24 +12677,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -13514,11 +13460,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,8 +20,8 @@
     "@testing-library/user-event": "^14.6.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/node": "^25.2.2",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
     "@vitest/eslint-plugin": "^1.1.44",
     "@vitejs/plugin-react": "^5.1.4",
     "autoprefixer": "^10.4.20",
@@ -44,6 +44,8 @@
   "dependencies": {
     "@types/qrcode": "^1.5.6",
     "date-fns": "^4.1.0",
-    "qrcode": "^1.5.4"
+    "qrcode": "^1.5.4",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   }
 }


### PR DESCRIPTION
## What
Move every `ui/` workspace onto a single React 19 major. `react`/`react-dom` are now hoisted once at the workspace root, the per-app pins are removed, and the console source is migrated to React 19's type and runtime changes.

## Why
The monorepo pinned two React majors — `apps/docs` on `^19`, `apps/console` and `apps/website` on `^18`. Because npm workspaces hoist the most-shared version, React 18 landed at the root and `docs` nested its own React 19, so a root-hoisted React-18 component rendered by docs' React 19 `react-dom/server` crashed `astro build` ("Objects are not valid as a React child"), and the two `@types/react` copies disagreed (`bigint` in `ReactNode`), breaking `tsc`. This blocked bringing `@heroicons/react` into `docs` and was a latent footgun for any pre-compiled React dependency used across the boundary. This executes Option B from the issue (move everything forward) rather than downgrading `docs`.

Closes #6583

## Changes
- **deps**: hoist `react`/`react-dom`/`@types/react`/`@types/react-dom` `^19.1.0` to the root `package.json`; drop the redundant `react`/`react-dom`/`@types` pins from `console`, `website`, and `docs` so all apps resolve one major.
- **deps**: bump `@stripe/react-stripe-js` `^2.8.0` → `^3.1.1` — the only dependency without React 19 support. v3.1.x adds React 19 while still accepting `@stripe/stripe-js@^4`, so the existing `@stripe/stripe-js` pin is unchanged. Every other React-coupled dependency (`@tanstack/react-query`, `zustand`, `react-router-dom`, `@tiptap/react`, `@heroicons/react`, `@fortawesome/react-fontawesome`, `@testing-library/react`, `@astrojs/react`) already declares `^19` support.
- **console**: applied `types-react-codemod` for the three breaking type categories — the removed global `JSX` namespace (`JSX.Element` → `React.JSX.Element`), callback refs that may no longer return a value, and `RefObject<T>` widening to `RefObject<T | null>`.
- **console**: changed `inert` from a string to a boolean attribute (`inert={true}`), which React 19 now requires — this also fixed three tests asserting `closest("[inert]")` and silences a runtime warning that existed before.
- **build**: ignore the `tsc -b`-emitted `openapi-ts.config.d.ts`, a pre-existing `.gitignore` gap the build surfaced (the `vite.config.d.ts` sibling was already ignored).

## Testing
Run inside the `ui` container: `npm run build` (all workspaces, includes `tsc -b`), `npm run lint -w @shellhub/console` (0 errors), and `npm run test` (console 2536, website 71, design-system 192, docs 15 — all pass). Manually smoke the billing card form (`apps/console/src/components/billing/BillingPayment.tsx`), the only consumer of the bumped Stripe package.
