### PR TITLE
refactor(ui): promote DataTable, Pagination, PageLoader to design-system

### DIFF
--- a/ui/apps/console/src/components/ManageTagsDrawer.tsx
+++ b/ui/apps/console/src/components/ManageTagsDrawer.tsx
@@ -18,7 +18,7 @@ import {
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 
 const TAG_PATTERN = /^[a-zA-Z0-9]+$/;
 

--- a/ui/apps/console/src/components/billing/BillingPayment.tsx
+++ b/ui/apps/console/src/components/billing/BillingPayment.tsx
@@ -33,7 +33,7 @@ import { stripeErrorMessage } from "@/utils/stripeErrors";
 import FieldLabel from "@/components/common/fields/FieldLabel";
 import InputField from "@/components/common/fields/InputField";
 import BillingIcon from "./BillingIcon";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 
 const ELEMENTS_OPTIONS: StripeElementsOptions = {
   appearance: { theme: "night" },

--- a/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
+++ b/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
@@ -9,7 +9,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { ExclamationCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import BaseDialog from "../common/BaseDialog";
-import DataTable, { type Column } from "../common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import DistroIcon from "../common/DistroIcon";
 import OnlineDot from "../common/OnlineDot";
 import LastSeenCell from "../common/LastSeenCell";

--- a/ui/apps/console/src/components/common/LicenseGuard.tsx
+++ b/ui/apps/console/src/components/common/LicenseGuard.tsx
@@ -1,6 +1,6 @@
 import { Outlet, Navigate } from "react-router-dom";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 
 export default function LicenseGuard() {
   const { isLoading, isError, isExpired } = useAdminLicense();

--- a/ui/apps/console/src/components/layout/InvitationsMenu.tsx
+++ b/ui/apps/console/src/components/layout/InvitationsMenu.tsx
@@ -22,7 +22,7 @@ import ConfirmDialog from "@/components/common/ConfirmDialog";
 import { formatRelative } from "@/utils/date";
 import { RoleBadge } from "@/pages/team/constants";
 import { isInvitationExpired } from "@/utils/invitations";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Button } from "@shellhub/design-system/primitives";
 
 function InvitationCard({

--- a/ui/apps/console/src/components/layout/PendingDevices.tsx
+++ b/ui/apps/console/src/components/layout/PendingDevices.tsx
@@ -11,7 +11,7 @@ import { useDevices } from "@/hooks/useDevices";
 import { useAcceptDevice, useRejectDevice } from "@/hooks/useDeviceMutations";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { getAcceptDeviceErrorMessage } from "@/utils/deviceErrors";
 
 export default function PendingDevices() {

--- a/ui/apps/console/src/pages/BannerEdit.tsx
+++ b/ui/apps/console/src/pages/BannerEdit.tsx
@@ -8,7 +8,7 @@ import { useEditNamespace } from "../hooks/useNamespaceMutations";
 import { useAuthStore } from "../stores/authStore";
 import { useHasPermission } from "../hooks/useHasPermission";
 import { Button } from "@shellhub/design-system/primitives";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 
 const MAX_LENGTH = 4096;
 

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -38,7 +38,7 @@ import { formatDateFull, formatRelative } from "../utils/date";
 import { buildSshid } from "../utils/sshid";
 import { useHasPermission } from "../hooks/useHasPermission";
 import RestrictedAction from "../components/common/RestrictedAction";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 /* ─── Shared styles ─── */

--- a/ui/apps/console/src/pages/Dashboard.tsx
+++ b/ui/apps/console/src/pages/Dashboard.tsx
@@ -18,7 +18,7 @@ import StatCard from "@/components/common/StatCard";
 import WelcomeScreen from "@/components/common/WelcomeScreen";
 import CopyButton from "@/components/common/CopyButton";
 import DeviceChip from "@/components/common/DeviceChip";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import { sessionType } from "@/utils/session";
 import type { Session } from "@/client";
 import { Card } from "@shellhub/design-system/primitives";

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -22,7 +22,7 @@ import PlatformBadge from "../components/common/PlatformBadge";
 import { formatDateFull, formatRelative } from "../utils/date";
 import { buildSshid } from "../utils/sshid";
 import RestrictedAction from "../components/common/RestrictedAction";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import InfoItem from "./devices/InfoItem";
 import TagsSection from "./devices/TagsSection";
 import RenameSection from "./devices/RenameSection";

--- a/ui/apps/console/src/pages/Profile.tsx
+++ b/ui/apps/console/src/pages/Profile.tsx
@@ -31,7 +31,7 @@ import MfaEnableDrawer from "../components/mfa/MfaEnableDrawer";
 import MfaDisableDialog from "../components/mfa/MfaDisableDialog";
 import { hasMfaSupport } from "../utils/features";
 import { Button } from "@shellhub/design-system/primitives";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import SettingsCard from "@/components/common/SettingsCard";
 import SettingsRow from "@/components/common/SettingsRow";
 

--- a/ui/apps/console/src/pages/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/SessionDetails.tsx
@@ -34,7 +34,7 @@ import DistroIcon from "../components/common/DistroIcon";
 import { formatDateFull, formatRelative, formatDuration } from "../utils/date";
 import type { Session } from "../client";
 import RestrictedAction from "../components/common/RestrictedAction";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import ConfirmDialog from "../components/common/ConfirmDialog";
 import {
   Badge,

--- a/ui/apps/console/src/pages/Settings.tsx
+++ b/ui/apps/console/src/pages/Settings.tsx
@@ -34,7 +34,7 @@ import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
 import { validateNamespaceName } from "@/utils/validation";
 import { getConfig } from "../env";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import SettingsCard from "@/components/common/SettingsCard";
 import SettingsRow from "@/components/common/SettingsRow";
 

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -36,9 +36,9 @@ import {
   PlusIcon,
 } from "@heroicons/react/24/outline";
 import RestrictedAction from "@/components/common/RestrictedAction";
-import PageLoader from "@/components/common/PageLoader";
-import Pagination from "@/components/common/Pagination";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Badge, Button, IconButton } from "@shellhub/design-system/primitives";
+import { Pagination } from "@shellhub/design-system/components";
 
 /* ─── Constants ─── */
 

--- a/ui/apps/console/src/pages/admin/Dashboard.tsx
+++ b/ui/apps/console/src/pages/admin/Dashboard.tsx
@@ -14,14 +14,14 @@ import {
 import PageHeader from "@/components/common/PageHeader";
 import StatCard from "@/components/common/StatCard";
 import DeviceChip from "@/components/common/DeviceChip";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import { useAdminStats } from "@/hooks/useAdminStats";
 import { useAdminSessions } from "@/hooks/useAdminSessions";
 import { formatDate } from "@/utils/date";
 import { Card } from "@shellhub/design-system/primitives";
 import { sessionType } from "@/utils/session";
 import type { Session } from "@/client";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 
 export default function AdminDashboard() {
   const {

--- a/ui/apps/console/src/pages/admin/License.tsx
+++ b/ui/apps/console/src/pages/admin/License.tsx
@@ -25,7 +25,7 @@ import {
   getLicenseAlertConfig,
 } from "@/utils/license";
 import type { GetLicenseResponse } from "@/client/types.gen";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 type HeroIcon = ComponentType<SVGProps<SVGSVGElement>>;

--- a/ui/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/admin/SessionDetails.tsx
@@ -9,7 +9,7 @@ import { useAdminSessionDetail } from "@/hooks/useAdminSessionDetail";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import { formatDateFull } from "@/utils/date";
 import { sessionType } from "@/utils/session";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Card } from "@shellhub/design-system/primitives";
 
 function Field({

--- a/ui/apps/console/src/pages/admin/Sessions.tsx
+++ b/ui/apps/console/src/pages/admin/Sessions.tsx
@@ -9,7 +9,7 @@ import { Callout } from "@shellhub/design-system/primitives";
 import { useAdminSessionsList } from "@/hooks/useAdminSessionsList";
 import type { Session } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import DeviceChip from "@/components/common/DeviceChip";
 import { formatDateFull } from "@/utils/date";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";

--- a/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
@@ -12,7 +12,7 @@ import CopyButton from "@/components/common/CopyButton";
 import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import AnnouncementContent from "./AnnouncementContent";
 import { formatDateFull } from "@/utils/date";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 const LABEL =

--- a/ui/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/EditAnnouncement.tsx
@@ -7,7 +7,7 @@ import AnnouncementEditor from "./AnnouncementEditor";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import InputField from "@/components/common/fields/InputField";
 import FieldLabel from "@/components/common/fields/FieldLabel";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Button, Callout, Card } from "@shellhub/design-system/primitives";
 
 const TITLE_MAX = 90;

--- a/ui/apps/console/src/pages/admin/announcements/index.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { useAdminAnnouncements } from "@/hooks/useAdminAnnouncements";
 import PageHeader from "@/components/common/PageHeader";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import { formatDateShort } from "@/utils/date";
 import type { AnnouncementShort } from "@/client";

--- a/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -14,7 +14,7 @@ import DistroIcon from "@/components/common/DistroIcon";
 import PlatformBadge from "@/components/common/PlatformBadge";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatDateFull, formatRelative } from "@/utils/date";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Card } from "@shellhub/design-system/primitives";
 
 const LABEL =

--- a/ui/apps/console/src/pages/admin/devices/index.tsx
+++ b/ui/apps/console/src/pages/admin/devices/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/hooks/useAdminDevices";
 import type { DeviceStatus } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import SearchField from "@/components/common/fields/SearchField";
 import DistroIcon from "@/components/common/DistroIcon";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";

--- a/ui/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
@@ -11,7 +11,7 @@ import ActiveBadge from "@/components/common/ActiveBadge";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
 import FilterBadge from "@/components/common/FilterBadge";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Card } from "@shellhub/design-system/primitives";
 
 const LABEL =

--- a/ui/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
@@ -11,15 +11,15 @@ vi.mock("@/hooks/useAdminFirewallRules", () => ({
 
 // Capture DataTable props on every render so we can assert pagination suppression.
 const capturedDataTableProps: Record<string, unknown>[] = [];
-vi.mock("@/components/common/DataTable", async (importOriginal) => {
+vi.mock("@shellhub/design-system/components", async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import("@/components/common/DataTable")>();
+    await importOriginal<typeof import("@shellhub/design-system/components")>();
   return {
     ...actual,
-    default: (props: Record<string, unknown>) => {
+    DataTable: (props: Record<string, unknown>) => {
       capturedDataTableProps.push({ ...props });
       // Render the real DataTable so existing tests keep working.
-      return actual.default(props as unknown as Parameters<typeof actual.default>[0]);
+      return actual.DataTable(props as unknown as Parameters<typeof actual.DataTable>[0]);
     },
   };
 });

--- a/ui/apps/console/src/pages/admin/firewall-rules/index.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/index.tsx
@@ -6,7 +6,7 @@ import {
   NoSymbolIcon,
 } from "@heroicons/react/24/outline";
 import ActiveBadge from "@/components/common/ActiveBadge";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import FilterBadge from "@/components/common/FilterBadge";
 import PageHeader from "@/components/common/PageHeader";
 import SearchField from "@/components/common/fields/SearchField";

--- a/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -10,12 +10,12 @@ import {
 import { useAdminNamespace } from "@/hooks/useAdminNamespaces";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import EditNamespaceDrawer from "./EditNamespaceDrawer";
 import DeleteNamespaceDialog from "./DeleteNamespaceDialog";
 import { formatDateFull } from "@/utils/date";
 import { formatMaxDevices } from "./utils";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import {
   Badge,
   Button,

--- a/ui/apps/console/src/pages/admin/namespaces/index.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/index.tsx
@@ -10,7 +10,7 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import type { Namespace } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import SearchField from "@/components/common/fields/SearchField";
 import EditNamespaceDrawer from "./EditNamespaceDrawer";
 import DeleteNamespaceDialog from "./DeleteNamespaceDialog";

--- a/ui/apps/console/src/pages/admin/settings/Authentication.tsx
+++ b/ui/apps/console/src/pages/admin/settings/Authentication.tsx
@@ -13,7 +13,7 @@ import { isSdkError } from "@/api/errors";
 import PageHeader from "@/components/common/PageHeader";
 import CopyButton from "@/components/common/CopyButton";
 import SamlConfigDrawer from "./SamlConfigDrawer";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import { Button, Callout, Card } from "@shellhub/design-system/primitives";
 
 type AuthSettings = GetAuthenticationSettingsResponse;

--- a/ui/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -18,7 +18,7 @@ import EditUserDrawer from "./EditUserDrawer";
 import ResetPasswordDialog from "./ResetPasswordDialog";
 import DeleteUserDialog from "./DeleteUserDialog";
 import { formatDateFull } from "@/utils/date";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "@shellhub/design-system/components";
 import {
   Badge,
   Button,

--- a/ui/apps/console/src/pages/admin/users/index.tsx
+++ b/ui/apps/console/src/pages/admin/users/index.tsx
@@ -13,7 +13,7 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import type { UserAdminResponse } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import SearchField from "@/components/common/fields/SearchField";
 import UserStatusChip from "./UserStatusChip";
 import CreateUserDrawer from "./CreateUserDrawer";

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -11,7 +11,7 @@ import PageHeader from "@/components/common/PageHeader";
 import ConnectDrawer from "@/components/ConnectDrawer";
 import ManageTagsDrawer from "@/components/ManageTagsDrawer";
 import CopyButton from "@/components/common/CopyButton";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import SearchField from "@/components/common/fields/SearchField";
 import TagFilterDropdown from "@/components/common/TagFilterDropdown";
 import { formatRelative } from "@/utils/date";

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -15,7 +15,7 @@ import CopyButton from "@/components/common/CopyButton";
 import PlatformBadge from "@/components/common/PlatformBadge";
 import OnlineDot from "@/components/common/OnlineDot";
 import LastSeenCell from "@/components/common/LastSeenCell";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import SearchField from "@/components/common/fields/SearchField";
 import { buildSshid } from "@/utils/sshid";
 import TagFilterDropdown from "@/components/common/TagFilterDropdown";

--- a/ui/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/__tests__/FirewallRules.test.tsx
@@ -60,14 +60,14 @@ vi.mock("@/components/common/ConfirmDialog", () => ({
 
 // Capture DataTable props on every render so we can assert pagination suppression.
 const capturedDataTableProps: Record<string, unknown>[] = [];
-vi.mock("@/components/common/DataTable", async (importOriginal) => {
+vi.mock("@shellhub/design-system/components", async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import("@/components/common/DataTable")>();
+    await importOriginal<typeof import("@shellhub/design-system/components")>();
   return {
     ...actual,
-    default: (props: Record<string, unknown>) => {
+    DataTable: (props: Record<string, unknown>) => {
       capturedDataTableProps.push({ ...props });
-      return actual.default(props as unknown as Parameters<typeof actual.default>[0]);
+      return actual.DataTable(props as unknown as Parameters<typeof actual.DataTable>[0]);
     },
   };
 });

--- a/ui/apps/console/src/pages/firewall-rules/index.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/index.tsx
@@ -13,7 +13,7 @@ import { Badge, Button, IconButton } from "@shellhub/design-system/primitives";
 import { type FirewallRulesResponse as FirewallRule } from "@/client";
 import ActiveBadge from "@/components/common/ActiveBadge";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import EmptyState from "@/components/common/EmptyState";
 import FilterBadge from "@/components/common/FilterBadge";
 import PageHeader from "@/components/common/PageHeader";

--- a/ui/apps/console/src/pages/public-keys/index.tsx
+++ b/ui/apps/console/src/pages/public-keys/index.tsx
@@ -7,7 +7,7 @@ import PageHeader from "@/components/common/PageHeader";
 import EmptyState from "@/components/common/EmptyState";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import CopyButton from "@/components/common/CopyButton";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import SearchField from "@/components/common/fields/SearchField";
 import KeyDrawer from "./KeyDrawer";
 import { formatDate } from "@/utils/date";

--- a/ui/apps/console/src/pages/secure-vault/index.tsx
+++ b/ui/apps/console/src/pages/secure-vault/index.tsx
@@ -24,7 +24,7 @@ import {
   isVaultServerEnabled,
   isVaultSyncPromoDismissed,
 } from "@/utils/vault-backend-factory";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import SearchField from "@/components/common/fields/SearchField";
 import KeyDrawer from "./KeyDrawer";
 import KeyDeleteDialog from "./KeyDeleteDialog";

--- a/ui/apps/console/src/pages/sessions/index.tsx
+++ b/ui/apps/console/src/pages/sessions/index.tsx
@@ -13,7 +13,7 @@ import { useSessionRecording } from "@/hooks/useSessionRecording";
 import type { Session } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import DeviceChip from "@/components/common/DeviceChip";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import SessionPlayerDialog from "./SessionPlayerDialog";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import { formatDate, formatDuration } from "@/utils/date";

--- a/ui/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -10,7 +10,7 @@ import { useDeleteApiKey } from "@/hooks/useApiKeyMutations";
 import { useTableSort } from "@/hooks/useTableSort";
 import { type ApiKey } from "@/client";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import { ExpiredBadge, RoleBadge } from "./constants";
 import { isExpired } from "./helpers";

--- a/ui/apps/console/src/pages/team/InvitationsTab.tsx
+++ b/ui/apps/console/src/pages/team/InvitationsTab.tsx
@@ -10,7 +10,7 @@ import {
 import type { MembershipInvitation } from "@/client";
 import { isSdkError } from "@/api/errors";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import { formatDateShort } from "@/utils/date";
 import { useNamespaceInvitations } from "@/hooks/useInvitations";

--- a/ui/apps/console/src/pages/team/MembersTab.tsx
+++ b/ui/apps/console/src/pages/team/MembersTab.tsx
@@ -10,7 +10,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { useNamespace, type NamespaceMember } from "@/hooks/useNamespaces";
 import { useRemoveMember } from "@/hooks/useMemberMutations";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
-import DataTable, { type Column } from "@/components/common/DataTable";
+import { DataTable, type Column } from "@shellhub/design-system/components";
 import { getConfig } from "@/env";
 import { RoleBadge } from "./constants";
 import { initials } from "./helpers";

--- a/ui/packages/design-system/__tests__/DataTable.test.tsx
+++ b/ui/packages/design-system/__tests__/DataTable.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import DataTable, { type Column } from "../DataTable";
+import { DataTable, type Column } from "../components/DataTable";
 
 // ---------------------------------------------------------------------------
 // Test type and fixtures
@@ -135,9 +135,9 @@ describe("DataTable", () => {
       renderTable({
         isLoading: true,
         data: [],
-        loadingMessage: "Fetching data\u2026",
+        loadingMessage: "Fetching data…",
       });
-      expect(screen.getByText("Fetching data\u2026")).toBeInTheDocument();
+      expect(screen.getByText("Fetching data…")).toBeInTheDocument();
     });
 
     it("does NOT show spinner when isLoading is true but data is non-empty", () => {

--- a/ui/packages/design-system/__tests__/PageLoader.test.tsx
+++ b/ui/packages/design-system/__tests__/PageLoader.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import PageLoader from "@/components/common/PageLoader";
+import { PageLoader } from "../components/PageLoader";
 
 describe("PageLoader", () => {
   it("renders a single status live region announced by the spinner's aria-label", () => {

--- a/ui/packages/design-system/__tests__/Pagination.test.tsx
+++ b/ui/packages/design-system/__tests__/Pagination.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import Pagination from "../Pagination";
+import { Pagination } from "../components/Pagination";
 
 describe("Pagination", () => {
   it("Prev and Next buttons have explicit type='button'", () => {

--- a/ui/packages/design-system/components/DataTable.tsx
+++ b/ui/packages/design-system/components/DataTable.tsx
@@ -4,10 +4,10 @@ import {
   ChevronDownIcon,
   ChevronUpDownIcon,
 } from "@heroicons/react/24/outline";
-import { Card } from "@shellhub/design-system/primitives";
-import { cn } from "@/utils/cn";
-import Pagination from "./Pagination";
-import PageLoader from "@/components/common/PageLoader";
+import { Card } from "../primitives";
+import { cn } from "../primitives/cn";
+import { Pagination } from "./Pagination";
+import { PageLoader } from "./PageLoader";
 
 const TH_CLASS =
   "px-4 py-3 text-left text-2xs font-mono font-semibold uppercase tracking-compact text-text-muted whitespace-nowrap";
@@ -15,6 +15,7 @@ const TH_CLASS =
 export interface Column<T> {
   key: string;
   header: string;
+  /** Additional class names merged onto the <th> via tailwind-merge. */
   headerClassName?: string;
   sortable?: boolean;
   render: (row: T) => ReactNode;
@@ -38,6 +39,7 @@ export interface DataTableProps<T> {
   onSort?: (field: string) => void;
 
   onRowClick?: (row: T) => void;
+  /** Additional class names merged onto each <tr> via tailwind-merge. */
   rowClassName?: (row: T) => string | undefined;
 
   isLoading?: boolean;
@@ -94,7 +96,7 @@ function getAriaSort(
   return "none";
 }
 
-export default function DataTable<T>({
+export function DataTable<T>({
   columns,
   data,
   rowKey,

--- a/ui/packages/design-system/components/PageLoader.tsx
+++ b/ui/packages/design-system/components/PageLoader.tsx
@@ -1,4 +1,4 @@
-import { Spinner, type SpinnerSize } from "@shellhub/design-system/primitives";
+import { Spinner, type SpinnerSize } from "../primitives";
 
 type Padding = "none" | "sm" | "md" | "lg" | "fill";
 
@@ -27,7 +27,7 @@ const PADDING: Record<Padding, string> = {
   fill: "flex-1",
 };
 
-export default function PageLoader({
+export function PageLoader({
   label,
   size,
   showLabel = false,

--- a/ui/packages/design-system/components/Pagination.tsx
+++ b/ui/packages/design-system/components/Pagination.tsx
@@ -6,7 +6,7 @@ interface Props {
   onPageChange: (page: number) => void;
 }
 
-export default function Pagination({
+export function Pagination({
   page,
   totalPages,
   totalCount,

--- a/ui/packages/design-system/components/index.ts
+++ b/ui/packages/design-system/components/index.ts
@@ -3,3 +3,7 @@ export { CopyButton } from "./CopyButton";
 export { ConnectionGrid } from "./ConnectionGrid";
 export { ShimmerCard } from "./ShimmerCard";
 export { Footer } from "./Footer";
+export { Pagination } from "./Pagination";
+export { PageLoader } from "./PageLoader";
+export { DataTable } from "./DataTable";
+export type { Column, DataTableProps } from "./DataTable";

--- a/ui/packages/design-system/package.json
+++ b/ui/packages/design-system/package.json
@@ -20,6 +20,7 @@
     "tailwind-merge": "^2.6.0"
   },
   "peerDependencies": {
+    "@heroicons/react": "^2.2.0",
     "react": "^18 || ^19"
   }
 }


### PR DESCRIPTION
## What
Promotes three reusable console components — `DataTable`, `Pagination`, and `PageLoader` — out of `@shellhub/console` and into `@shellhub/design-system/components`, so other apps can consume them. Pure relocation; the only behavioral change is `DataTable` adopting the package's `cn`.

## Why
`@shellhub/design-system` is the shared UI foundation, but these widely-used components were siloed in the console app. A design-system component cannot import from the console, so each transitive console dependency had to move with it.

Closes shellhub-io/team#151

Scope note: the issue also listed `Alert` (does **not** exist in the codebase) and `ConfirmDialog` (deferred — it drags `BaseDialog` plus the `useFocusTrap`/`useBackdropClose`/`useResetOnOpen` a11y hooks; better as its own PR). Issue #129 (Pagination ARIA) is already closed, so `Pagination` moved as-is.

## Changes
- **design-system**: added `DataTable`, `Pagination`, `PageLoader` under `components/` as **named exports** and to the barrel; relocated their test suites into the package. `DataTable` pulled in `PageLoader` (its only console-internal component dep).
- **cn**: `DataTable` now uses the package's `cn` (`twMerge(clsx(...))`) instead of the console's naive `filter(Boolean).join(" ")`. Class props (`Column.headerClassName`, `DataTableProps.rowClassName`) are now merged via `tailwind-merge` — conflicting utilities are deduplicated rather than concatenated. Behavior-preserving for current call sites.
- **package manifest**: declared the `@heroicons/react` peer dependency that `DataTable` requires (previously satisfied only by workspace hoisting).
- **importers**: repointed every console importer to `@shellhub/design-system/components` and deleted the old `common/` files. Default imports became named (`import { DataTable, type Column }`).
- **tests**: rewrote the two firewall page tests' `DataTable` `vi.mock` for the named export (mock path, `importOriginal` type, and factory key `default` → `DataTable`).

## Testing
- `tsc --noEmit` (console): clean — confirms no importer was missed (a default-vs-named mismatch would error).
- design-system vitest: 84 pass (`DataTable` 57, `Pagination` 16, `PageLoader` 11).
- console vitest for the rewritten mocks: `AdminFirewallRules` + `FirewallRules`, 38 pass.
- `eslint` on all touched console files: clean.
- No remaining `common/{DataTable,Pagination,PageLoader}` references in the console.