### PR TITLE
docs(compose): document SHELLHUB_LICENSE_FILE for enterprise dev

### DIFF
--- a/.env.enterprise
+++ b/.env.enterprise
@@ -50,3 +50,10 @@ SHELLHUB_OBJECT_STORAGE_REGION=default
 SHELLHUB_OBJECT_STORAGE_BUCKET=shellhub
 SHELLHUB_OBJECT_STORAGE_ACCESS_KEY=username
 SHELLHUB_OBJECT_STORAGE_SECRET_KEY=password
+
+# Absolute host path to an enterprise license file, for development only.
+# When set, the dev API mounts it read-only and loads it once at startup,
+# enabling license-gated features (firewall, web endpoints).
+# NOTICE: Leave empty for license-less development; the API then starts
+# without a license and gated features stay disabled.
+SHELLHUB_LICENSE_FILE=


### PR DESCRIPTION
## What

Document the `SHELLHUB_LICENSE_FILE` environment variable in
`shellhub/.env.enterprise`, with an empty default and a comment
explaining its purpose and behavior when unset.

Follow-up to shellhub-io/cloud#2409.

## Why

cloud#2409 taught the enterprise **dev** API to load its license from a
single variable, `SHELLHUB_LICENSE_FILE`, replacing the hand-written
`docker-compose.override.yml`. But it added the variable only to
`docker-compose.enterprise.dev.yml` and documented it nowhere: the name
appears in no `.env` file and no tracked compose file on the shellhub
side, so a developer has no way to discover it exists short of reading
that overlay. `.env.enterprise` is the catalog of enterprise-only
variables developers actually read, so that is where it belongs.

## Changes

- `.env.enterprise`: declare `SHELLHUB_LICENSE_FILE=` with a comment
  describing that setting it mounts a license for the dev API (enabling
  license-gated features), and that leaving it empty runs license-less
  development. The empty default preserves the no-regression path from
  cloud#2409 — an unset value mounts nothing and the API starts without
  a license.

## Testing

Documentation-only change; no runtime behavior is affected. Verified the
enterprise dev stack still boots with `SHELLHUB_LICENSE_FILE` unset
(license-less) and with it set to a host license path (license loaded).