### PR TITLE
fix(ui): keep admin app bar dark in light mode

### DIFF
--- a/ui/apps/console/src/components/layout/AdminAppBar.tsx
+++ b/ui/apps/console/src/components/layout/AdminAppBar.tsx
@@ -24,7 +24,7 @@ export default function AdminAppBar({ onMenuToggle }: AdminAppBarProps) {
   };
 
   return (
-    <header className="h-14 bg-surface border-b border-border px-3 sm:px-5 flex items-center justify-between shrink-0">
+    <header className="theme-dark h-14 bg-surface border-b border-border px-3 sm:px-5 flex items-center justify-between shrink-0">
       <div className="flex items-center gap-1">
         {onMenuToggle && (
           <IconButton


### PR DESCRIPTION
## What

Pins `AdminAppBar` to the dark token set so the admin app bar stays dark under light mode, matching the main app bar and sidebar.

## Why

Light mode applies only to the main layout by design — the sidebar and app bar stay dark regardless of the chosen theme. The main `AppBar` and `SidebarShell` enforce this with the `theme-dark` class, but `AdminAppBar` was missing it, so its token-based colors (`bg-surface`, `border-border`, `text-text-secondary`, etc.) followed the active theme and flipped to light.

## Changes

- **ui**: added the `theme-dark` class to the `AdminAppBar` `<header>`. The class (defined in `design-system/css/base.css`) re-declares the dark token set locally, pinning the subtree dark independent of `html.light` — the same mechanism already used by `AppBar` and `SidebarShell`.