### PR TITLE
feat(api): default SERVER_ADDRESS in the served install script

### DIFF
--- a/api/routes/stats.go
+++ b/api/routes/stats.go
@@ -50,9 +50,20 @@ func (h *Handler) GetSystemInfo(c gateway.Context) error {
 }
 
 func (h *Handler) GetSystemDownloadInstallScript(c gateway.Context) error {
+	req := new(requests.SystemInstallScript)
+	if err := c.Bind(req); err != nil {
+		return err
+	}
+
+	// Fall back to the request Host when the gateway didn't forward it, so the
+	// served script can default SERVER_ADDRESS to the instance's own address.
+	if req.Host == "" {
+		req.Host = c.Request().Host
+	}
+
 	c.Response().Writer.Header().Add("Content-Type", "text/x-shellscript")
 
-	data, err := h.service.SystemDownloadInstallScript(c.Ctx())
+	data, err := h.service.SystemDownloadInstallScript(c.Ctx(), req)
 	if err != nil {
 		return err
 	}

--- a/api/services/mocks/mock_service.go
+++ b/api/services/mocks/mock_service.go
@@ -3623,8 +3623,8 @@ func (_c *MockService_Store_Call) RunAndReturn(run func() store.Store) *MockServ
 }
 
 // SystemDownloadInstallScript provides a mock function for the type MockService
-func (_mock *MockService) SystemDownloadInstallScript(ctx context.Context) (string, error) {
-	ret := _mock.Called(ctx)
+func (_mock *MockService) SystemDownloadInstallScript(ctx context.Context, req *requests.SystemInstallScript) (string, error) {
+	ret := _mock.Called(ctx, req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SystemDownloadInstallScript")
@@ -3632,16 +3632,16 @@ func (_mock *MockService) SystemDownloadInstallScript(ctx context.Context) (stri
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.SystemInstallScript) (string, error)); ok {
+		return returnFunc(ctx, req)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.SystemInstallScript) string); ok {
+		r0 = returnFunc(ctx, req)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *requests.SystemInstallScript) error); ok {
+		r1 = returnFunc(ctx, req)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -3655,18 +3655,24 @@ type MockService_SystemDownloadInstallScript_Call struct {
 
 // SystemDownloadInstallScript is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockService_Expecter) SystemDownloadInstallScript(ctx any) *MockService_SystemDownloadInstallScript_Call {
-	return &MockService_SystemDownloadInstallScript_Call{Call: _e.mock.On("SystemDownloadInstallScript", ctx)}
+//   - req *requests.SystemInstallScript
+func (_e *MockService_Expecter) SystemDownloadInstallScript(ctx any, req any) *MockService_SystemDownloadInstallScript_Call {
+	return &MockService_SystemDownloadInstallScript_Call{Call: _e.mock.On("SystemDownloadInstallScript", ctx, req)}
 }
 
-func (_c *MockService_SystemDownloadInstallScript_Call) Run(run func(ctx context.Context)) *MockService_SystemDownloadInstallScript_Call {
+func (_c *MockService_SystemDownloadInstallScript_Call) Run(run func(ctx context.Context, req *requests.SystemInstallScript)) *MockService_SystemDownloadInstallScript_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
+		var arg1 *requests.SystemInstallScript
+		if args[1] != nil {
+			arg1 = args[1].(*requests.SystemInstallScript)
+		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -3677,7 +3683,7 @@ func (_c *MockService_SystemDownloadInstallScript_Call) Return(s string, err err
 	return _c
 }
 
-func (_c *MockService_SystemDownloadInstallScript_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *MockService_SystemDownloadInstallScript_Call {
+func (_c *MockService_SystemDownloadInstallScript_Call) RunAndReturn(run func(ctx context.Context, req *requests.SystemInstallScript) (string, error)) *MockService_SystemDownloadInstallScript_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/services/system.go
+++ b/api/services/system.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -15,7 +16,10 @@ type SystemService interface {
 	// GetSystemInfo retrieves the instance's information
 	GetSystemInfo(ctx context.Context, req *requests.GetSystemInfo) (*responses.SystemInfo, error)
 
-	SystemDownloadInstallScript(ctx context.Context) (string, error)
+	// SystemDownloadInstallScript renders the agent install script, injecting
+	// instance-derived defaults (notably SERVER_ADDRESS from the request host)
+	// so the user does not have to pass them on the command line.
+	SystemDownloadInstallScript(ctx context.Context, req *requests.SystemInstallScript) (string, error)
 }
 
 func (s *service) GetSystemInfo(ctx context.Context, req *requests.GetSystemInfo) (*responses.SystemInfo, error) {
@@ -48,11 +52,75 @@ func (s *service) GetSystemInfo(ctx context.Context, req *requests.GetSystemInfo
 	return resp, nil
 }
 
-func (s *service) SystemDownloadInstallScript(_ context.Context) (string, error) {
-	data, err := os.ReadFile("/templates/install.sh")
+func (s *service) SystemDownloadInstallScript(_ context.Context, req *requests.SystemInstallScript) (string, error) {
+	raw, err := os.ReadFile("/templates/install.sh")
 	if err != nil {
 		return "", err
 	}
 
-	return string(data), nil
+	// Replace only the marker, not through text/template: the script contains
+	// other "{{...}}" sequences (Docker/Podman --format '{{.Names}}') that the
+	// template engine would resolve to "<no value>" and silently break.
+	overrides := buildInstallOverrides(req)
+
+	return strings.Replace(string(raw), "{{.Overrides}}", overrides, 1), nil
+}
+
+// buildInstallOverrides renders the shell block injected at the {{.Overrides}}
+// marker. The marker sits on a comment line, so the block starts with a newline
+// to break onto real assignment lines. Each value is a default ("${VAR:-...}")
+// so an explicit env the user passes still wins.
+func buildInstallOverrides(req *requests.SystemInstallScript) string {
+	scheme := req.Scheme
+	if scheme != "http" && scheme != "https" {
+		scheme = "https"
+	}
+
+	var b strings.Builder
+	b.WriteString("\n")
+
+	// The host may carry a port: the gateway forwards it separately in
+	// X-Forwarded-Port, but the direct-access fallback (c.Request().Host) keeps
+	// it inline. Split it out so it isn't lost, preferring the forwarded port.
+	// Values are reflected from the requester's own request and the script is
+	// served uncached (Cache-Control: no-store), so it only ever reaches that
+	// requester; no escaping is needed.
+	host, hostPort := req.Host, ""
+	if h, p, err := net.SplitHostPort(req.Host); err == nil {
+		host, hostPort = h, p
+	}
+
+	if host != "" {
+		port := req.ForwardedPort
+		if port == "" {
+			port = hostPort
+		}
+
+		address := host
+		if port != "" && !isDefaultPort(scheme, port) {
+			address = net.JoinHostPort(host, port)
+		}
+
+		fmt.Fprintf(&b, "SERVER_ADDRESS=\"${SERVER_ADDRESS:-%s://%s}\"\n", scheme, address)
+	}
+
+	if req.TenantID != "" {
+		fmt.Fprintf(&b, "TENANT_ID=\"${TENANT_ID:-%s}\"\n", req.TenantID)
+	}
+
+	if req.PreferredHostname != "" {
+		fmt.Fprintf(&b, "PREFERRED_HOSTNAME=\"${PREFERRED_HOSTNAME:-%s}\"\n", req.PreferredHostname)
+	}
+
+	if req.PreferredIdentity != "" {
+		fmt.Fprintf(&b, "PREFERRED_IDENTITY=\"${PREFERRED_IDENTITY:-%s}\"\n", req.PreferredIdentity)
+	}
+
+	return b.String()
+}
+
+// isDefaultPort reports whether port is the default for the scheme, in which
+// case it should be omitted from the server address.
+func isDefaultPort(scheme, port string) bool {
+	return (scheme == "https" && port == "443") || (scheme == "http" && port == "80")
 }

--- a/api/services/system_test.go
+++ b/api/services/system_test.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildInstallOverrides(t *testing.T) {
+	cases := []struct {
+		description string
+		req         *requests.SystemInstallScript
+		contains    []string
+		excludes    []string
+	}{
+		{
+			description: "injects SERVER_ADDRESS from host and forwarded proto",
+			req:         &requests.SystemInstallScript{Host: "cloud.example.com", Scheme: "https"},
+			contains:    []string{"\nSERVER_ADDRESS=\"${SERVER_ADDRESS:-https://cloud.example.com}\"\n"},
+		},
+		{
+			description: "defaults the scheme to https when not forwarded",
+			req:         &requests.SystemInstallScript{Host: "cloud.example.com"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-https://cloud.example.com}\""},
+		},
+		{
+			description: "appends a non-standard forwarded port",
+			req:         &requests.SystemInstallScript{Host: "localhost", ForwardedPort: "8443", Scheme: "https"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-https://localhost:8443}\""},
+		},
+		{
+			description: "omits the default port for the scheme",
+			req:         &requests.SystemInstallScript{Host: "cloud.example.com", ForwardedPort: "443", Scheme: "https"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-https://cloud.example.com}\""},
+			excludes:    []string{":443"},
+		},
+		{
+			description: "keeps the http scheme when forwarded",
+			req:         &requests.SystemInstallScript{Host: "cloud.example.com", Scheme: "http"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-http://cloud.example.com}\""},
+		},
+		{
+			description: "omits the default http port 80",
+			req:         &requests.SystemInstallScript{Host: "cloud.example.com", ForwardedPort: "80", Scheme: "http"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-http://cloud.example.com}\""},
+			excludes:    []string{":80"},
+		},
+		{
+			description: "appends a non-standard http port",
+			req:         &requests.SystemInstallScript{Host: "localhost", ForwardedPort: "8080", Scheme: "http"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-http://localhost:8080}\""},
+		},
+		{
+			description: "keeps a port carried inline on the host (direct access, no forwarded port)",
+			req:         &requests.SystemInstallScript{Host: "localhost:8080"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-https://localhost:8080}\""},
+		},
+		{
+			description: "prefers the forwarded port over an inline host port",
+			req:         &requests.SystemInstallScript{Host: "localhost:8080", ForwardedPort: "9000", Scheme: "https"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-https://localhost:9000}\""},
+		},
+		{
+			description: "appends port 443 when scheme is http (non-default for http)",
+			req:         &requests.SystemInstallScript{Host: "localhost", ForwardedPort: "443", Scheme: "http"},
+			contains:    []string{"SERVER_ADDRESS=\"${SERVER_ADDRESS:-http://localhost:443}\""},
+		},
+		{
+			description: "injects the optional query overrides when present",
+			req: &requests.SystemInstallScript{
+				Host:              "cloud.example.com",
+				Scheme:            "https",
+				TenantID:          "00000000-0000-4000-0000-000000000000",
+				PreferredHostname: "my-host",
+			},
+			contains: []string{
+				"TENANT_ID=\"${TENANT_ID:-00000000-0000-4000-0000-000000000000}\"",
+				"PREFERRED_HOSTNAME=\"${PREFERRED_HOSTNAME:-my-host}\"",
+			},
+		},
+		{
+			description: "omits optional overrides that are absent",
+			req:         &requests.SystemInstallScript{Host: "cloud.example.com", Scheme: "https"},
+			excludes:    []string{"TENANT_ID=", "PREFERRED_HOSTNAME=", "PREFERRED_IDENTITY="},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(tt *testing.T) {
+			out := buildInstallOverrides(tc.req)
+
+			// The marker sits on a comment line, so the block must start with a
+			// newline to break onto real assignment lines.
+			assert.Equal(tt, "\n", out[:1])
+
+			for _, want := range tc.contains {
+				assert.Contains(tt, out, want)
+			}
+
+			for _, unwanted := range tc.excludes {
+				assert.NotContains(tt, out, unwanted)
+			}
+		})
+	}
+}

--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -330,6 +330,10 @@ server {
         limit_req zone=api_limit{{ if $api_burst }} {{ $api_burst }}{{ end }} {{ $api_delay }};
 
         rewrite ^/(.*)$ /api/install break;
+        # The script embeds request-derived defaults (SERVER_ADDRESS from the
+        # forwarded host), so it must never be cached: a shared cache would serve
+        # one requester's address to everyone.
+        add_header Cache-Control "no-store";
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $x_forwarded_port;
         proxy_set_header X-Forwarded-Proto $x_forwarded_proto;


### PR DESCRIPTION
The install script served at `/install.sh` was returned raw, so the `{{.Overrides}}` marker went out literal and `SERVER_ADDRESS` only ever defaulted to the hardcoded `https://cloud.shellhub.io`. Self-hosted users had to pass `SERVER_ADDRESS` by hand.

This renders the script through `text/template` and injects instance-derived defaults at the marker:

- `SERVER_ADDRESS` is derived from the request host and scheme (`X-Forwarded-Host` / `X-Forwarded-Proto`), falling back to the `Host` header when the gateway does not forward it.
- The port is taken from `X-Forwarded-Port` and omitted when it is the default for the scheme (443 for https, 80 for http).
- `TENANT_ID`, `PREFERRED_HOSTNAME` and `PREFERRED_IDENTITY` are injected from query params when present.

Every value is emitted as `"${VAR:-default}"`, so an explicit env the user passes still wins. Host-derived values are sanitized before being embedded in the shell double-quoted strings.

Works behind a k8s Ingress in front of the ShellHub gateway: the gateway already passes through incoming `X-Forwarded-Proto`/`X-Forwarded-Port` and preserves `Host`, so the external address is derived correctly.