### PR TITLE
feat(ui): add prefers-reduced-motion reset to design-system

### DIFF
--- a/ui/packages/design-system/__tests__/reduced-motion.test.ts
+++ b/ui/packages/design-system/__tests__/reduced-motion.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const baseCss = readFileSync(
+  fileURLToPath(new URL("../css/base.css", import.meta.url)),
+  "utf8",
+);
+
+describe("base.css prefers-reduced-motion reset", () => {
+  it("contains a @media (prefers-reduced-motion: reduce) block", () => {
+    expect(baseCss).toMatch(/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/);
+  });
+
+  it("targets *, *::before, *::after inside the media block", () => {
+    const mediaIdx = baseCss.search(/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/);
+    expect(mediaIdx).toBeGreaterThan(-1);
+    const afterMedia = baseCss.slice(mediaIdx);
+    expect(afterMedia).toMatch(/\*\s*,\s*\*::before\s*,\s*\*::after/);
+  });
+
+  it("contains animation-duration with !important", () => {
+    const mediaIdx = baseCss.search(/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/);
+    expect(mediaIdx).toBeGreaterThan(-1);
+    const afterMedia = baseCss.slice(mediaIdx);
+    expect(afterMedia).toMatch(/animation-duration\s*:\s*[^;]+!important/);
+  });
+
+  it("contains animation-delay with !important", () => {
+    const mediaIdx = baseCss.search(/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/);
+    expect(mediaIdx).toBeGreaterThan(-1);
+    const afterMedia = baseCss.slice(mediaIdx);
+    expect(afterMedia).toMatch(/animation-delay\s*:\s*[^;]+!important/);
+  });
+
+  it("contains animation-iteration-count with !important", () => {
+    const mediaIdx = baseCss.search(/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/);
+    expect(mediaIdx).toBeGreaterThan(-1);
+    const afterMedia = baseCss.slice(mediaIdx);
+    expect(afterMedia).toMatch(/animation-iteration-count\s*:\s*[^;]+!important/);
+  });
+
+  it("contains transition-duration with !important", () => {
+    const mediaIdx = baseCss.search(/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/);
+    expect(mediaIdx).toBeGreaterThan(-1);
+    const afterMedia = baseCss.slice(mediaIdx);
+    expect(afterMedia).toMatch(/transition-duration\s*:\s*[^;]+!important/);
+  });
+
+  it("contains scroll-behavior: auto with !important", () => {
+    const mediaIdx = baseCss.search(/@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/);
+    expect(mediaIdx).toBeGreaterThan(-1);
+    const afterMedia = baseCss.slice(mediaIdx);
+    expect(afterMedia).toMatch(/scroll-behavior\s*:\s*auto\s*!important/);
+  });
+});

--- a/ui/packages/design-system/css/base.css
+++ b/ui/packages/design-system/css/base.css
@@ -247,3 +247,13 @@
     transform: translateY(0);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: -1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## What
Adds a global `prefers-reduced-motion` reset to the design-system so every app
that consumes it (console, website, docs) honors the OS-level "reduce motion"
setting.

## Why
The design-system exposes motion from two places, neither guarded by
`@media (prefers-reduced-motion: reduce)`:

- `tailwind.preset.js` — the `animate-fade-in`, `animate-slide-up`,
  `animate-slide-down`, `animate-pulse-subtle`, `animate-shake` utilities.
- `css/base.css` — CSS keyframes/classes (`connectionFlow`, `dotPulse`, `float`,
  `shimmer`, `pageEnter`, `bounceSub`) and the `landing-reveal` transitions.

Because these live in the shared package, users with vestibular-motion
sensitivity get unmuted animation across all consuming apps (WCAG 2.1 SC 2.3.3).

Closes shellhub-io/team#130

## Changes
- **design-system/css/base.css**: appended an unlayered
  `@media (prefers-reduced-motion: reduce)` block applying the Andy-Bell reset
  (near-zero animation/transition duration, `animation-delay: -1ms`,
  `animation-iteration-count: 1`, `scroll-behavior: auto`) to `*`, `*::before`,
  `*::after` with `!important`. Placed outside `@layer` so `!important` wins over
  every existing non-important animation/transition rule regardless of cascade
  layer, covering both the preset utilities and the base.css keyframes in one
  place. `animation-delay: -1ms` eliminates the pre-animation hold for delayed
  loops such as `.animate-bounce-subtle` (1s delay).
- **design-system/__tests__/reduced-motion.test.ts**: node-env regression guard
  asserting the block exists and each declared property is present with
  `!important` — the fix isn't lint-catchable, so a test is the only automated
  guard.

## Testing
The block is inert unless the OS reduce-motion setting is on, so there is no
normal-motion regression. `vitest run` in `packages/design-system` is green
(283 tests). To verify manually: enable "reduce motion" in the OS and confirm
design-system animations (welcome-screen connection grid, copy-button shimmer,
`animate-fade-in` entrances) no longer move.