### PR TITLE
refactor(ui): adopt react-hook-form for the SignUp form

### DIFF
--- a/ui/apps/console/package.json
+++ b/ui/apps/console/package.json
@@ -35,6 +35,7 @@
     "axios": "^1.18.1",
     "font-logos": "^1.3.0",
     "node-rsa": "^1.1.1",
+    "react-hook-form": "^7.0.0",
     "react-router-dom": "^7.17.0",
     "sshpk": "^1.18.0",
     "zustand": "^5.0.14"

--- a/ui/apps/console/src/components/common/fields/rhf/FormCheckboxField.tsx
+++ b/ui/apps/console/src/components/common/fields/rhf/FormCheckboxField.tsx
@@ -1,0 +1,43 @@
+import { useController, type Control, type FieldValues, type Path } from "react-hook-form";
+import CheckboxField from "@/components/common/fields/CheckboxField";
+import type { ComponentProps } from "react";
+
+type CheckboxFieldProps = Omit<
+  ComponentProps<typeof CheckboxField>,
+  "checked" | "onChange"
+>;
+
+type Props<T extends FieldValues> = CheckboxFieldProps & {
+  name: Path<T>;
+  control: Control<T>;
+  /** Called on every value change, in addition to RHF's internal onChange. */
+  onValueChange?: (value: boolean) => void;
+};
+
+export default function FormCheckboxField<T extends FieldValues>({
+  name,
+  control,
+  error: errorOverride,
+  onValueChange,
+  ...rest
+}: Props<T>) {
+  const {
+    field,
+    fieldState: { error: fieldError },
+  } = useController({ name, control });
+
+  const resolvedError = errorOverride ?? fieldError?.message;
+
+  return (
+    <CheckboxField
+      {...rest}
+      checked={field.value}
+      onChange={(v) => {
+        field.onChange(v);
+        onValueChange?.(v);
+      }}
+      onBlur={field.onBlur}
+      error={resolvedError}
+    />
+  );
+}

--- a/ui/apps/console/src/components/common/fields/rhf/FormInputField.tsx
+++ b/ui/apps/console/src/components/common/fields/rhf/FormInputField.tsx
@@ -1,0 +1,43 @@
+import { useController, type Control, type FieldValues, type Path } from "react-hook-form";
+import InputField from "@/components/common/fields/InputField";
+import type { ComponentProps } from "react";
+
+type InputFieldProps = Omit<
+  ComponentProps<typeof InputField>,
+  "value" | "onChange"
+>;
+
+type Props<T extends FieldValues> = InputFieldProps & {
+  name: Path<T>;
+  control: Control<T>;
+  /** Called on every value change, in addition to RHF's internal onChange. */
+  onValueChange?: (value: string) => void;
+};
+
+export default function FormInputField<T extends FieldValues>({
+  name,
+  control,
+  error: errorOverride,
+  onValueChange,
+  ...rest
+}: Props<T>) {
+  const {
+    field,
+    fieldState: { error: fieldError },
+  } = useController({ name, control });
+
+  const resolvedError = errorOverride ?? fieldError?.message;
+
+  return (
+    <InputField
+      {...rest}
+      value={field.value}
+      onChange={(v) => {
+        field.onChange(v);
+        onValueChange?.(v);
+      }}
+      onBlur={field.onBlur}
+      error={resolvedError}
+    />
+  );
+}

--- a/ui/apps/console/src/components/common/fields/rhf/FormPasswordField.tsx
+++ b/ui/apps/console/src/components/common/fields/rhf/FormPasswordField.tsx
@@ -1,0 +1,43 @@
+import { useController, type Control, type FieldValues, type Path } from "react-hook-form";
+import PasswordField from "@/components/common/fields/PasswordField";
+import type { ComponentProps } from "react";
+
+type PasswordFieldProps = Omit<
+  ComponentProps<typeof PasswordField>,
+  "value" | "onChange"
+>;
+
+type Props<T extends FieldValues> = PasswordFieldProps & {
+  name: Path<T>;
+  control: Control<T>;
+  /** Called on every value change, in addition to RHF's internal onChange. */
+  onValueChange?: (value: string) => void;
+};
+
+export default function FormPasswordField<T extends FieldValues>({
+  name,
+  control,
+  error: errorOverride,
+  onValueChange,
+  ...rest
+}: Props<T>) {
+  const {
+    field,
+    fieldState: { error: fieldError },
+  } = useController({ name, control });
+
+  const resolvedError = errorOverride ?? fieldError?.message;
+
+  return (
+    <PasswordField
+      {...rest}
+      value={field.value}
+      onChange={(v) => {
+        field.onChange(v);
+        onValueChange?.(v);
+      }}
+      onBlur={field.onBlur}
+      error={resolvedError}
+    />
+  );
+}

--- a/ui/apps/console/src/components/common/fields/rhf/__tests__/formFields.test.tsx
+++ b/ui/apps/console/src/components/common/fields/rhf/__tests__/formFields.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect, type ReactElement } from "react";
+import { useForm, type Control, type FieldValues } from "react-hook-form";
+import FormInputField from "@/components/common/fields/rhf/FormInputField";
+import FormPasswordField from "@/components/common/fields/rhf/FormPasswordField";
+import FormCheckboxField from "@/components/common/fields/rhf/FormCheckboxField";
+
+// ---------------------------------------------------------------------------
+// Shared adapter contract — text-like fields (FormInputField, FormPasswordField)
+//
+// FormInputField and FormPasswordField are near-identical react-hook-form
+// adapters over a controlled text input. Rather than copy the same suite into
+// two files, we describe the contract once and run it against each wrapper. The
+// only thing that differs is which component renders the input, so each case
+// provides a `render` closure that keeps full generic typing (no casts).
+// ---------------------------------------------------------------------------
+
+interface TextFormValues extends FieldValues {
+  value: string;
+}
+
+type TextFieldRenderer = (props: {
+  control: Control<TextFormValues>;
+  label: string;
+  error?: string;
+  onValueChange?: (v: string) => void;
+}) => ReactElement;
+
+const TEXT_CASES: { name: string; label: string; render: TextFieldRenderer }[] = [
+  {
+    name: "FormInputField",
+    label: "Username",
+    render: ({ control, label, error, onValueChange }) => (
+      <FormInputField<TextFormValues>
+        name="value"
+        control={control}
+        id="value"
+        label={label}
+        error={error}
+        onValueChange={onValueChange}
+      />
+    ),
+  },
+  {
+    name: "FormPasswordField",
+    label: "Password",
+    render: ({ control, label, error, onValueChange }) => (
+      <FormPasswordField<TextFormValues>
+        name="value"
+        control={control}
+        id="value"
+        label={label}
+        error={error}
+        onValueChange={onValueChange}
+      />
+    ),
+  },
+];
+
+/** Wires a text field into a real RHF form so we can assert against real usage. */
+function TextForm({
+  render: renderField,
+  label,
+  defaultValue = "",
+  onValueChange,
+}: {
+  render: TextFieldRenderer;
+  label: string;
+  defaultValue?: string;
+  onValueChange?: (v: string) => void;
+}) {
+  const { control } = useForm<TextFormValues>({
+    defaultValues: { value: defaultValue },
+  });
+
+  return renderField({ control, label, onValueChange });
+}
+
+/** Same harness, but seeds a fieldState error (and optionally an override). */
+function TextFormWithFieldError({
+  render: renderField,
+  label,
+  message,
+  error,
+}: {
+  render: TextFieldRenderer;
+  label: string;
+  message: string;
+  error?: string;
+}) {
+  const { control, setError } = useForm<TextFormValues>({
+    defaultValues: { value: "" },
+  });
+
+  useEffect(() => {
+    setError("value", { message });
+  }, [setError, message]);
+
+  return renderField({ control, label, error });
+}
+
+describe.each(TEXT_CASES)("$name (RHF adapter contract)", ({ label, render: renderField }) => {
+  it("binds the initial value from the form state into the input", () => {
+    render(<TextForm render={renderField} label={label} defaultValue="preset" />);
+
+    expect(screen.getByLabelText(label)).toHaveValue("preset");
+  });
+
+  it("updates the input value as the user types (two-way binding)", async () => {
+    const user = userEvent.setup();
+    render(<TextForm render={renderField} label={label} />);
+
+    const input = screen.getByLabelText(label);
+    await user.type(input, "bob");
+
+    expect(input).toHaveValue("bob");
+  });
+
+  it("surfaces fieldState.error.message via the underlying field", async () => {
+    render(
+      <TextFormWithFieldError
+        render={renderField}
+        label={label}
+        message="This field is required"
+      />,
+    );
+
+    expect(
+      await screen.findByText("This field is required"),
+    ).toBeInTheDocument();
+  });
+
+  it("error override prop takes precedence over fieldState error", () => {
+    render(
+      <TextFormWithFieldError
+        render={renderField}
+        label={label}
+        message="Field-state error"
+        error="Override error"
+      />,
+    );
+
+    expect(screen.getByText("Override error")).toBeInTheDocument();
+    expect(screen.queryByText("Field-state error")).not.toBeInTheDocument();
+  });
+
+  it("calls onValueChange on each edit, forwarding the current field value", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TextForm render={renderField} label={label} onValueChange={onValueChange} />,
+    );
+
+    await user.type(screen.getByLabelText(label), "hi");
+
+    // RHF's controlled onChange fires per keystroke with the accumulated value.
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+    expect(onValueChange).toHaveBeenNthCalledWith(1, "h");
+    expect(onValueChange).toHaveBeenNthCalledWith(2, "hi");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FormCheckboxField — same contract, but boolean/checked semantics differ
+// enough (toggle via click, checked instead of value) to warrant its own block.
+// ---------------------------------------------------------------------------
+
+interface CheckboxFormValues extends FieldValues {
+  agree: boolean;
+}
+
+function CheckboxForm({
+  defaultValue = false,
+  error,
+  onValueChange,
+}: {
+  defaultValue?: boolean;
+  error?: string;
+  onValueChange?: (v: boolean) => void;
+}) {
+  const { control } = useForm<CheckboxFormValues>({
+    defaultValues: { agree: defaultValue },
+  });
+
+  return (
+    <FormCheckboxField
+      name="agree"
+      control={control}
+      id="agree"
+      label="I agree"
+      error={error}
+      onValueChange={onValueChange}
+    />
+  );
+}
+
+function CheckboxFormWithFieldError({
+  message,
+  error,
+}: {
+  message: string;
+  error?: string;
+}) {
+  const { control, setError } = useForm<CheckboxFormValues>({
+    defaultValues: { agree: false },
+  });
+
+  useEffect(() => {
+    setError("agree", { message });
+  }, [setError, message]);
+
+  return (
+    <FormCheckboxField
+      name="agree"
+      control={control}
+      id="agree"
+      label="I agree"
+      error={error}
+    />
+  );
+}
+
+describe("FormCheckboxField (RHF adapter contract)", () => {
+  it("binds the checked state from the form default value (false)", () => {
+    render(<CheckboxForm defaultValue={false} />);
+
+    expect(screen.getByLabelText("I agree")).not.toBeChecked();
+  });
+
+  it("binds the checked state from the form default value (true)", () => {
+    render(<CheckboxForm defaultValue />);
+
+    expect(screen.getByLabelText("I agree")).toBeChecked();
+  });
+
+  it("toggles the checkbox on click (two-way binding)", async () => {
+    const user = userEvent.setup();
+    render(<CheckboxForm defaultValue={false} />);
+
+    const checkbox = screen.getByLabelText("I agree");
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("surfaces fieldState.error.message via the underlying field", async () => {
+    render(<CheckboxFormWithFieldError message="You must agree to continue" />);
+
+    expect(
+      await screen.findByText("You must agree to continue"),
+    ).toBeInTheDocument();
+  });
+
+  it("error override prop takes precedence over fieldState error", () => {
+    render(
+      <CheckboxFormWithFieldError
+        message="Field-state error"
+        error="Override error"
+      />,
+    );
+
+    expect(screen.getByText("Override error")).toBeInTheDocument();
+    expect(screen.queryByText("Field-state error")).not.toBeInTheDocument();
+  });
+
+  it("calls onValueChange with the new boolean on each toggle", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<CheckboxForm onValueChange={onValueChange} />);
+
+    const checkbox = screen.getByLabelText("I agree");
+
+    await user.click(checkbox);
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenNthCalledWith(1, true);
+
+    await user.click(checkbox);
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+    expect(onValueChange).toHaveBeenNthCalledWith(2, false);
+  });
+});

--- a/ui/apps/console/src/components/common/fields/rhf/index.ts
+++ b/ui/apps/console/src/components/common/fields/rhf/index.ts
@@ -1,0 +1,3 @@
+export { default as FormInputField } from "./FormInputField";
+export { default as FormPasswordField } from "./FormPasswordField";
+export { default as FormCheckboxField } from "./FormCheckboxField";

--- a/ui/apps/console/src/pages/SignUp.tsx
+++ b/ui/apps/console/src/pages/SignUp.tsx
@@ -1,15 +1,20 @@
-import { useState, useMemo, FormEvent, useEffect } from "react";
+import { useState, useEffect, FormEvent } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { UserPlusIcon } from "@heroicons/react/24/outline";
-import { validate, type FormErrors } from "./setup/validate";
+import { useForm } from "react-hook-form";
+import { signUpResolver } from "./setup/signUpResolver";
+import type { SignUpFormValues } from "./setup/signUpResolver";
 import { useSignUpStore } from "../stores/signUpStore";
 import AccountCreated from "../components/auth/AccountCreated";
 import { Button, Callout } from "@shellhub/design-system/primitives";
-import InputField from "@/components/common/fields/InputField";
-import PasswordField from "@/components/common/fields/PasswordField";
+import {
+  FormInputField,
+  FormPasswordField,
+  FormCheckboxField,
+} from "@/components/common/fields/rhf";
 import CheckboxField from "@/components/common/fields/CheckboxField";
 
-const SERVER_FIELD_MAP: Record<string, keyof FormErrors> = {
+const SERVER_FIELD_MAP: Record<string, keyof SignUpFormValues> = {
   username: "username",
   email: "email",
   name: "name",
@@ -43,80 +48,47 @@ export default function SignUp() {
   const sigFromQuery = searchParams.get("sig") ?? "";
   const isInvite = Boolean(emailFromQuery && sigFromQuery);
 
-  const [name, setName] = useState("");
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState(emailFromQuery);
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [acceptPrivacyPolicy, setAcceptPrivacyPolicy] = useState(false);
+  // acceptMarketing is optional and not part of the validated form values
   const [acceptMarketing, setAcceptMarketing] = useState(false);
-  const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [accountCreated, setAccountCreated] = useState(false);
 
-  const serverFieldErrors = useMemo(() => {
-    const mapped: Partial<FormErrors> = {};
+  const { control, handleSubmit, setError, formState } =
+    useForm<SignUpFormValues>({
+      resolver: signUpResolver,
+      mode: "onTouched",
+      defaultValues: {
+        name: "",
+        username: "",
+        email: emailFromQuery,
+        password: "",
+        confirmPassword: "",
+        acceptPrivacyPolicy: false,
+      },
+    });
+
+  // Sync server-side field errors into RHF field state whenever the store changes
+  useEffect(() => {
     for (const field of signUpServerFields) {
       const key = SERVER_FIELD_MAP[field];
-      if (key) mapped[key] = SERVER_FIELD_MESSAGES[field];
+      const message = SERVER_FIELD_MESSAGES[field];
+
+      if (key && message) {
+        setError(key, { type: "server", message });
+      }
     }
-    return mapped;
-  }, [signUpServerFields]);
+  }, [signUpServerFields, setError]);
 
-  const validationErrors = useMemo(
-    () => validate({ name, username, email, password, confirmPassword }),
-    [name, username, email, password, confirmPassword],
-  );
-
-  const fieldError = (field: keyof FormErrors): string | undefined => {
-    if (serverFieldErrors[field]) return serverFieldErrors[field];
-    return touched[field] ? validationErrors[field] : undefined;
-  };
-
-  const handleBlur = (field: string) =>
-    setTouched((prev) => ({ ...prev, [field]: true }));
-
-  const isFormValid = useMemo(
-    () =>
-      Object.keys(validationErrors).length === 0 &&
-      !Object.values(serverFieldErrors).some(Boolean) &&
-      acceptPrivacyPolicy,
-    [validationErrors, serverFieldErrors, acceptPrivacyPolicy],
-  );
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-
-    setTouched({
-      name: true,
-      username: true,
-      email: true,
-      password: true,
-      confirmPassword: true,
-    });
-
-    // Compute validity from source of truth rather than the memoized `isFormValid`,
-    // which reflects the previous render and would be stale after `setTouched`.
-    const errors = validate({
-      name,
-      username,
-      email,
-      password,
-      confirmPassword,
-    });
-    if (
-      Object.keys(errors).length > 0 ||
-      !acceptPrivacyPolicy ||
-      signUpServerFields.length > 0
-    )
-      return;
+  const onSubmit = async (values: SignUpFormValues) => {
+    // Guard: still block if server field errors haven't been cleared yet
+    if (signUpServerFields.length > 0) return;
 
     resetSignUpErrors();
 
     const token = await signUp({
-      name,
-      email,
-      username,
-      password,
+      name: values.name,
+      email: values.email,
+      username: values.username,
+      password: values.password,
       email_marketing: acceptMarketing,
       ...(sigFromQuery ? { sig: sigFromQuery } : {}),
     });
@@ -124,17 +96,22 @@ export default function SignUp() {
     // signUp absorbed any errors into the store; bail out if errors were set
     const { signUpError: err, signUpServerFields: fields } =
       useSignUpStore.getState();
+
     if (err !== null || fields.length > 0) return;
 
     if (!token) {
       void navigate(
-        `/confirm-account?username=${encodeURIComponent(username)}`,
+        `/confirm-account?username=${encodeURIComponent(values.username)}`,
       );
       return;
     }
 
     // Invite flow: token returned — show AccountCreated
     setAccountCreated(true);
+  };
+
+  const handleFormSubmit = (e: FormEvent) => {
+    void handleSubmit(onSubmit)(e);
   };
 
   if (accountCreated) {
@@ -190,82 +167,64 @@ export default function SignUp() {
           )}
 
           <form
-            onSubmit={(e) => void handleSubmit(e)}
+            onSubmit={handleFormSubmit}
             className="space-y-4"
             aria-label="Create account"
           >
-            <InputField
+            <FormInputField<SignUpFormValues>
               id="name"
               label="Name"
-              value={name}
-              onChange={(v) => {
-                setName(v);
-                clearSignUpServerField("name");
-              }}
-              onBlur={() => handleBlur("name")}
-              error={fieldError("name")}
+              name="name"
+              control={control}
               placeholder="Your name"
               autoComplete="name"
+              onValueChange={() => clearSignUpServerField("name")}
             />
 
-            <InputField
+            <FormInputField<SignUpFormValues>
               id="username"
               label="Username"
-              value={username}
-              onChange={(v) => {
-                setUsername(v);
-                clearSignUpServerField("username");
-              }}
-              onBlur={() => handleBlur("username")}
-              error={fieldError("username")}
+              name="username"
+              control={control}
               placeholder="username"
               autoComplete="username"
+              onValueChange={() => clearSignUpServerField("username")}
             />
 
-            <InputField
+            <FormInputField<SignUpFormValues>
               id="email"
               label="Email"
+              name="email"
+              control={control}
               type="email"
-              value={email}
-              onChange={(v) => {
-                setEmail(v);
-                clearSignUpServerField("email");
-              }}
-              onBlur={() => handleBlur("email")}
-              error={fieldError("email")}
               placeholder="you@example.com"
               autoComplete="email"
               disabled={isInvite}
+              onValueChange={() => clearSignUpServerField("email")}
             />
 
-            <PasswordField
+            <FormPasswordField<SignUpFormValues>
               id="password"
               label="Password"
-              value={password}
-              onChange={(v) => {
-                setPassword(v);
-                clearSignUpServerField("password");
-              }}
-              onBlur={() => handleBlur("password")}
-              error={fieldError("password")}
+              name="password"
+              control={control}
               placeholder="Min. 5 characters"
+              onValueChange={() => clearSignUpServerField("password")}
             />
 
-            <PasswordField
+            <FormPasswordField<SignUpFormValues>
               id="confirmPassword"
               label="Confirm Password"
-              value={confirmPassword}
-              onChange={setConfirmPassword}
-              onBlur={() => handleBlur("confirmPassword")}
-              error={fieldError("confirmPassword")}
+              name="confirmPassword"
+              control={control}
               placeholder="Re-enter password"
             />
 
             {/* Privacy Policy checkbox (required) */}
-            <CheckboxField
+            <FormCheckboxField<SignUpFormValues>
               id="signup-accept-privacy"
-              checked={acceptPrivacyPolicy}
-              onChange={setAcceptPrivacyPolicy}
+              name="acceptPrivacyPolicy"
+              control={control}
               required
               label={
                 <>
@@ -282,7 +241,7 @@ export default function SignUp() {
               }
             />
 
-            {/* Marketing checkbox (optional) */}
+            {/* Marketing checkbox (optional) — not validated, kept as local state */}
             <CheckboxField
               id="signup-accept-marketing"
               checked={acceptMarketing}
@@ -297,7 +256,11 @@ export default function SignUp() {
               type="submit"
               className="px-4"
               loading={signUpLoading}
-              disabled={signUpLoading || !isFormValid}
+              disabled={
+                signUpLoading ||
+                !formState.isValid ||
+                signUpServerFields.length > 0
+              }
             >
               {signUpLoading ? "Creating account..." : "Create Account"}
             </Button>

--- a/ui/apps/console/src/pages/__tests__/SignUp.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/SignUp.test.tsx
@@ -1,0 +1,385 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { useSignUpStore } from "@/stores/signUpStore";
+import SignUp from "../SignUp";
+
+/* ------------------------------------------------------------------ */
+/* Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("@/client", () => ({
+  registerUser: vi.fn(),
+  resendEmail: vi.fn(),
+  getValidateAccount: vi.fn(),
+}));
+
+import { registerUser as registerUserSdk } from "@/client";
+
+const mockedRegisterUser = vi.mocked(registerUserSdk);
+
+type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };
+
+function mockSdkResponse<T>(data: T): SdkResponse<T> {
+  return {
+    data,
+    request: new Request("http://localhost"),
+    response: new Response(),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function renderSignUp(search = "") {
+  return render(
+    <MemoryRouter initialEntries={[`/signup${search}`]}>
+      <SignUp />
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Fill all required fields with valid data and check privacy policy.
+ * Does NOT submit.
+ */
+async function fillValidForm(
+  user: ReturnType<typeof userEvent.setup>,
+  overrides: {
+    name?: string;
+    username?: string;
+    email?: string;
+    password?: string;
+    confirmPassword?: string;
+    acceptMarketing?: boolean;
+  } = {},
+) {
+  const {
+    name = "Alice Smith",
+    username = "alice",
+    email = "alice@example.com",
+    password = "Secret123",
+    confirmPassword = "Secret123",
+    acceptMarketing = false,
+  } = overrides;
+
+  await user.type(screen.getByLabelText(/^name$/i), name);
+  await user.type(screen.getByLabelText(/^username$/i), username);
+  await user.type(screen.getByLabelText(/^email$/i), email);
+  await user.type(screen.getByLabelText(/^password$/i), password);
+  await user.type(screen.getByLabelText(/^confirm password$/i), confirmPassword);
+
+  // Accept privacy policy (required)
+  await user.click(screen.getByLabelText(/privacy policy/i));
+
+  if (acceptMarketing) {
+    await user.click(screen.getByLabelText(/receive news and updates/i));
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Setup / teardown                                                    */
+/* ------------------------------------------------------------------ */
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+  mockedRegisterUser.mockReset();
+  useSignUpStore.setState({
+    signUpLoading: false,
+    signUpError: null,
+    signUpServerFields: [],
+    signUpToken: null,
+    signUpTenant: null,
+  });
+});
+
+/* ================================================================== */
+/* Tests                                                               */
+/* ================================================================== */
+
+describe("SignUp", () => {
+  /* ---------------------------------------------------------------- */
+  /* 1. Submit button disabled on initial render with empty defaults   */
+  /* ---------------------------------------------------------------- */
+  describe("initial render", () => {
+    it("disables the submit button when all fields are empty", () => {
+      renderSignUp();
+
+      const submit = screen.getByRole("button", { name: /create account/i });
+      expect(submit).toBeDisabled();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* 2. Filling valid data + checking privacy policy calls signUp     */
+  /*    with correct payload including email_marketing                 */
+  /* ---------------------------------------------------------------- */
+  describe("successful submission", () => {
+    it("calls signUp with correct payload including email_marketing when form is valid", async () => {
+      mockedRegisterUser.mockResolvedValue(mockSdkResponse({}));
+      const user = userEvent.setup();
+      renderSignUp();
+
+      await fillValidForm(user, { acceptMarketing: true });
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => expect(mockedRegisterUser).toHaveBeenCalledTimes(1));
+      expect(mockedRegisterUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            name: "Alice Smith",
+            username: "alice",
+            email: "alice@example.com",
+            password: "Secret123",
+            email_marketing: true,
+          }),
+        }),
+      );
+    });
+
+    it("calls signUp with email_marketing: false when marketing checkbox is unchecked", async () => {
+      mockedRegisterUser.mockResolvedValue(mockSdkResponse({}));
+      const user = userEvent.setup();
+      renderSignUp();
+
+      await fillValidForm(user, { acceptMarketing: false });
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => expect(mockedRegisterUser).toHaveBeenCalledTimes(1));
+      expect(mockedRegisterUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ email_marketing: false }),
+        }),
+      );
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* 3. Field errors appear after blur not before                     */
+  /* ---------------------------------------------------------------- */
+  describe("field validation on blur", () => {
+    it("does not show a name error before the field is touched", () => {
+      renderSignUp();
+      expect(screen.queryByText(/name must be/i)).not.toBeInTheDocument();
+    });
+
+    it("shows name error after blur when field is empty", async () => {
+      const user = userEvent.setup();
+      renderSignUp();
+
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await user.click(nameInput);
+      await user.tab(); // blur
+
+      expect(await screen.findByText(/name must be/i)).toBeInTheDocument();
+    });
+
+    it("does not show username error before the field is touched", () => {
+      renderSignUp();
+      expect(screen.queryByText(/username must be/i)).not.toBeInTheDocument();
+    });
+
+    it("shows username error after blur when field is too short", async () => {
+      const user = userEvent.setup();
+      renderSignUp();
+
+      await user.type(screen.getByLabelText(/^username$/i), "ab");
+      await user.tab();
+
+      expect(await screen.findByText(/username must be/i)).toBeInTheDocument();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* 4. Privacy unchecked keeps submit disabled                       */
+  /* ---------------------------------------------------------------- */
+  describe("privacy policy gate", () => {
+    it("keeps submit disabled when all text fields are valid but privacy policy is unchecked", async () => {
+      const user = userEvent.setup();
+      renderSignUp();
+
+      // Fill all required text fields but skip checking the privacy checkbox
+      await user.type(screen.getByLabelText(/^name$/i), "Alice Smith");
+      await user.type(screen.getByLabelText(/^username$/i), "alice");
+      await user.type(screen.getByLabelText(/^email$/i), "alice@example.com");
+      await user.type(screen.getByLabelText(/^password$/i), "Secret123");
+      await user.type(screen.getByLabelText(/^confirm password$/i), "Secret123");
+
+      const submit = screen.getByRole("button", { name: /create account/i });
+      expect(submit).toBeDisabled();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* 5. Password mismatch shows 'Passwords do not match'              */
+  /* ---------------------------------------------------------------- */
+  describe("password mismatch", () => {
+    it("shows 'Passwords do not match' when confirmPassword differs from password", async () => {
+      const user = userEvent.setup();
+      renderSignUp();
+
+      await user.type(screen.getByLabelText(/^password$/i), "Secret123");
+      await user.type(screen.getByLabelText(/^confirm password$/i), "DifferentPass");
+      await user.tab();
+
+      expect(
+        await screen.findByText(/passwords do not match/i),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show mismatch error before confirmPassword is touched", async () => {
+      const user = userEvent.setup();
+      renderSignUp();
+
+      await user.type(screen.getByLabelText(/^password$/i), "Secret123");
+      // No blur on confirmPassword
+
+      expect(screen.queryByText(/passwords do not match/i)).not.toBeInTheDocument();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* 6. Server field errors render on correct fields, disable submit,  */
+  /*    and clear after field edit                                      */
+  /* ---------------------------------------------------------------- */
+  describe("server field errors", () => {
+    /**
+     * Simulate a 400 server response with field errors, matching the shape
+     * that isSdkError accepts: an error with numeric `status` that is also
+     * Array-like (the store checks `Array.isArray(error)`).
+     */
+    function makeServerFieldError(fields: string[], status = 400) {
+      // The store does: isSdkError(error) && Array.isArray(error)
+      // isSdkError checks for numeric `status` on the object
+      // Array.isArray requires the value to actually be an array
+      const err = Object.assign([...fields], { status }) as unknown as Error;
+      return err;
+    }
+
+    it("shows server-side username error on the username field and disables submit", async () => {
+      mockedRegisterUser.mockRejectedValue(makeServerFieldError(["username"]));
+      const user = userEvent.setup();
+      renderSignUp();
+
+      await fillValidForm(user);
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      // The server error should appear on the username field
+      expect(
+        await screen.findByText(/this username already exists/i),
+      ).toBeInTheDocument();
+
+      // Submit should be disabled because of the server field error
+      expect(screen.getByRole("button", { name: /create account/i })).toBeDisabled();
+    });
+
+    it("shows server-side email error on the email field", async () => {
+      mockedRegisterUser.mockRejectedValue(makeServerFieldError(["email"]));
+      const user = userEvent.setup();
+      renderSignUp();
+
+      await fillValidForm(user);
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      expect(
+        await screen.findByText(/this email is invalid or already in use/i),
+      ).toBeInTheDocument();
+    });
+
+    it("clears the server field error after the user edits that field", async () => {
+      mockedRegisterUser.mockRejectedValue(makeServerFieldError(["username"]));
+      const user = userEvent.setup();
+      renderSignUp();
+
+      await fillValidForm(user);
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await screen.findByText(/this username already exists/i);
+
+      // Edit the username field — server error should be cleared. The clear is
+      // synchronous with the keystroke, so waitForElementToBeRemoved can't be
+      // used (the element is already gone by call time); assert absence instead.
+      await user.type(screen.getByLabelText(/^username$/i), "a");
+
+      await waitFor(() =>
+        expect(
+          screen.queryByText(/this username already exists/i),
+        ).not.toBeInTheDocument(),
+      );
+
+      // The re-enable is the headline behavior: editing the field must clear the
+      // server-field gate (clearSignUpServerField), not just RHF's error text.
+      expect(
+        screen.getByRole("button", { name: /create account/i }),
+      ).toBeEnabled();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* 7. Invite flow: prefills and disables email, includes sig        */
+  /* ---------------------------------------------------------------- */
+  describe("invite flow", () => {
+    const INVITE_EMAIL = "invited@example.com";
+    const INVITE_SIG = "abc123signature";
+
+    function renderInviteSignUp() {
+      return renderSignUp(
+        `?email=${encodeURIComponent(INVITE_EMAIL)}&sig=${INVITE_SIG}`,
+      );
+    }
+
+    it("prefills the email field from the query param", () => {
+      renderInviteSignUp();
+      expect(screen.getByLabelText(/^email$/i)).toHaveValue(INVITE_EMAIL);
+    });
+
+    it("disables the email field in invite mode", () => {
+      renderInviteSignUp();
+      expect(screen.getByLabelText(/^email$/i)).toBeDisabled();
+    });
+
+    it("includes sig in the signUp payload during invite flow", async () => {
+      mockedRegisterUser.mockResolvedValue(mockSdkResponse({ token: "tok", tenant: "t1" }));
+      const user = userEvent.setup();
+      renderInviteSignUp();
+
+      // Fill all other fields (email is prefilled)
+      await user.type(screen.getByLabelText(/^name$/i), "Alice Smith");
+      await user.type(screen.getByLabelText(/^username$/i), "alice");
+      // email is already filled via query param and disabled
+      await user.type(screen.getByLabelText(/^password$/i), "Secret123");
+      await user.type(screen.getByLabelText(/^confirm password$/i), "Secret123");
+      await user.click(screen.getByLabelText(/privacy policy/i));
+
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => expect(mockedRegisterUser).toHaveBeenCalledTimes(1));
+      expect(mockedRegisterUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            email: INVITE_EMAIL,
+            sig: INVITE_SIG,
+          }),
+        }),
+      );
+    });
+
+    it("shows the invite warning callout", () => {
+      renderInviteSignUp();
+      expect(
+        screen.getByText(/please create your account before accepting/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/apps/console/src/pages/setup/__tests__/signUpResolver.test.ts
+++ b/ui/apps/console/src/pages/setup/__tests__/signUpResolver.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { signUpResolver } from "../signUpResolver";
+import type { SignUpFormValues } from "../signUpResolver";
+
+const validInput: SignUpFormValues = {
+  name: "Admin User",
+  username: "admin",
+  email: "admin@example.com",
+  password: "secret123",
+  confirmPassword: "secret123",
+  acceptPrivacyPolicy: true,
+};
+
+const emptyOptions = {
+  criteriaMode: undefined,
+  fields: {},
+  names: undefined,
+  shouldUseNativeValidation: undefined,
+} as Parameters<typeof signUpResolver>[2];
+
+type RhfErrors = Record<keyof SignUpFormValues, { type: string; message: string }>;
+
+const resolve = (input: SignUpFormValues) =>
+  signUpResolver(input, undefined, emptyOptions);
+
+/**
+ * Every invalid-field case shares the same shape: the resolver should surface a
+ * single RHF error on `field` with the expected `type`, a string message, and
+ * empty `values`. Asserting that contract in one place keeps the cases below to
+ * just the input that triggers each error.
+ */
+async function expectFieldError(
+  input: SignUpFormValues,
+  field: keyof SignUpFormValues,
+  type: string,
+) {
+  const result = await resolve(input);
+  const errors = result.errors as Partial<RhfErrors>;
+
+  expect(errors).toHaveProperty(field);
+  expect(errors[field]?.type).toBe(type);
+  expect(typeof errors[field]?.message).toBe("string");
+  expect(result.values).toEqual({});
+}
+
+describe("signUpResolver", () => {
+  it("returns values with no errors for valid input", async () => {
+    const result = await resolve(validInput);
+    expect(result.values).toEqual(validInput);
+    expect(result.errors).toEqual({});
+  });
+
+  describe("validate() field error mapping", () => {
+    const invalidCases: { field: keyof SignUpFormValues; input: SignUpFormValues }[] = [
+      { field: "name", input: { ...validInput, name: "" } },
+      { field: "username", input: { ...validInput, username: "ab" } },
+      { field: "email", input: { ...validInput, email: "not-an-email" } },
+      { field: "password", input: { ...validInput, password: "123", confirmPassword: "123" } },
+      { field: "confirmPassword", input: { ...validInput, confirmPassword: "different" } },
+    ];
+
+    it.each(invalidCases)("maps $field error to RHF error shape", async ({ field, input }) => {
+      await expectFieldError(input, field, "validate");
+    });
+  });
+
+  describe("acceptPrivacyPolicy", () => {
+    it("returns error on acceptPrivacyPolicy when false", async () => {
+      await expectFieldError(
+        { ...validInput, acceptPrivacyPolicy: false },
+        "acceptPrivacyPolicy",
+        "required",
+      );
+    });
+
+    it("clears acceptPrivacyPolicy error when true", async () => {
+      const result = await resolve(validInput);
+      expect(result.errors).not.toHaveProperty("acceptPrivacyPolicy");
+    });
+  });
+});

--- a/ui/apps/console/src/pages/setup/signUpResolver.ts
+++ b/ui/apps/console/src/pages/setup/signUpResolver.ts
@@ -1,0 +1,47 @@
+import type { FieldErrors, Resolver } from "react-hook-form";
+import { validate, type FormErrors } from "./validate";
+
+export interface SignUpFormValues {
+  name: string;
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  acceptPrivacyPolicy: boolean;
+}
+
+type ValidateField = keyof FormErrors;
+
+const VALIDATE_FIELDS: ValidateField[] = [
+  "name",
+  "username",
+  "email",
+  "password",
+  "confirmPassword",
+];
+
+export const signUpResolver: Resolver<SignUpFormValues> = (values) => {
+  const formErrors = validate(values);
+  const errors: FieldErrors<SignUpFormValues> = {};
+
+  for (const field of VALIDATE_FIELDS) {
+    const message = formErrors[field];
+
+    if (message) {
+      errors[field] = { type: "validate", message };
+    }
+  }
+
+  if (!values.acceptPrivacyPolicy) {
+    errors.acceptPrivacyPolicy = {
+      type: "required",
+      message: "You must accept the privacy policy",
+    };
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { values: {}, errors };
+  }
+
+  return { values, errors: {} };
+};

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -75,6 +75,7 @@
         "axios": "^1.18.1",
         "font-logos": "^1.3.0",
         "node-rsa": "^1.1.1",
+        "react-hook-form": "^7.0.0",
         "react-router-dom": "^7.17.0",
         "sshpk": "^1.18.0",
         "zustand": "^5.0.14"
@@ -12695,6 +12696,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.80.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.80.0.tgz",
+      "integrity": "sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
## What

Introduce [react-hook-form](https://react-hook-form.com/) as the shared
form-management solution for `@shellhub/console`, and migrate the SignUp form to
it as the pilot. Establishes a reusable pattern (RHF-bound field wrappers + a
resolver adapter) that subsequent forms reuse.

## Why

Every form in the console hand-threads `useState` + `onChange` + `touched` +
memoized validation. As forms grow (firewall rules, SAML, multi-step MFA) this
repetition becomes a maintenance burden. This is the first step of the
incremental migration tracked in `shellhub-io/team#152`, which now carries a
checklist of the remaining forms — each to be migrated in its own PR.

The `Controller`/`useController` pattern is used because the design-system field
components (`InputField`, `PasswordField`, `CheckboxField`) are controlled and
do not forward refs, so RHF's uncontrolled `register` mode does not apply.
Validation reuses the existing `validate()` via a thin resolver adapter rather
than adopting zod, keeping a single source of validation truth and avoiding a
new dependency for the pilot.

## Changes

- **fields/rhf**: new `FormInputField`, `FormPasswordField`, `FormCheckboxField`
  wrappers (generic over the form values type) that bind the existing controlled
  field components to RHF via `useController`. Each accepts an `error` override
  and an `onValueChange` hook so store-driven server errors stay orthogonal to
  client validation.
- **signUpResolver**: resolver adapter that calls the existing `validate()`,
  maps `FormErrors` to RHF's error shape, and adds the privacy-policy-required
  rule. Exports the `SignUpFormValues` type used as the form's generic.
- **SignUp**: replaced the manual field `useState` + `touched` + validation
  memos with `useForm`. Behavior is preserved: errors surface after blur, the
  invite flow keeps the email prefilled/disabled and present in the payload, and
  the submit button stays gated on server errors (`signUpServerFields`) in
  addition to `formState.isValid`. `acceptMarketing` stays local state since it
  is unvalidated.

## Testing

`vitest` (run inside the `ui` container). 45 tests added across the wrappers,
the resolver, and SignUp. Worth probing: the server-error path — the submit
button must stay disabled while a server-side field error is shown and
re-enable once that field is edited.
