### PR TITLE
fix(api): enforce one accepted device per MAC in a namespace

### DIFF
--- a/api/services/device.go
+++ b/api/services/device.go
@@ -367,6 +367,12 @@ func (s *service) updateDeviceStatus(req *requests.DeviceUpdateStatus) store.Tra
 		device.Status = newStatus
 		device.StatusUpdatedAt = clock.Now()
 		if err := s.store.DeviceUpdate(ctx, device); err != nil {
+			// The devices_accepted_mac_unique index can reject a concurrent accept of
+			// a same-MAC device; surface that as a duplicate (409), not a bare 500.
+			if newStatus == models.DeviceStatusAccepted && errors.Is(err, store.ErrDuplicate) {
+				return NewErrDeviceDuplicated(device.Name, err)
+			}
+
 			return err
 		}
 

--- a/api/services/device_test.go
+++ b/api/services/device_test.go
@@ -2013,6 +2013,69 @@ func TestUpdateDeviceStatus(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			description: "failure (accepted) - duplicate accepted MAC index maps to device duplicated",
+			req: &requests.DeviceUpdateStatus{
+				TenantID: "00000000-0000-0000-0000-000000000000",
+				UID:      "pending-device",
+				Status:   "accepted",
+			},
+			requiredMocks: func() {
+				device := &models.Device{
+					UID:      "pending-device",
+					Name:     "test-device",
+					TenantID: "00000000-0000-0000-0000-000000000000",
+					Status:   models.DeviceStatusPending,
+					Identity: &models.DeviceIdentity{MAC: "aa:bb:cc:dd:ee:ff"},
+				}
+				updatedDevice := &models.Device{
+					UID:             "pending-device",
+					Name:            "test-device",
+					TenantID:        "00000000-0000-0000-0000-000000000000",
+					Status:          models.DeviceStatusAccepted,
+					StatusUpdatedAt: now,
+					Identity:        &models.DeviceIdentity{MAC: "aa:bb:cc:dd:ee:ff"},
+				}
+
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-0000-0000-000000000000").
+					Return(&models.Namespace{TenantID: "00000000-0000-0000-0000-000000000000"}, nil).
+					Once()
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-0000-0000-000000000000").
+					Return(nil).
+					Once()
+				storeMock.
+					On("DeviceResolve", ctx, store.DeviceUIDResolver, "pending-device", mock.AnythingOfType("[]store.QueryOption")).
+					Return(device, nil).
+					Once()
+				queryOptionsMock.
+					On("WithDeviceStatus", models.DeviceStatusAccepted).
+					Return(nil).
+					Once()
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-0000-0000-000000000000").
+					Return(nil).
+					Once()
+				storeMock.
+					On("DeviceResolve", ctx, store.DeviceMACResolver, "aa:bb:cc:dd:ee:ff", mock.AnythingOfType("[]store.QueryOption")).
+					Return(nil, store.ErrNoDocuments).
+					Once()
+				storeMock.
+					On("DeviceResolve", ctx, store.DeviceHostnameResolver, "test-device", mock.AnythingOfType("[]store.QueryOption")).
+					Return(nil, store.ErrNoDocuments).
+					Once()
+				envMock.
+					On("Get", "SHELLHUB_CLOUD").
+					Return("false").
+					Once()
+				storeMock.
+					On("DeviceUpdate", ctx, updatedDevice).
+					Return(store.ErrDuplicate).
+					Once()
+			},
+			expectedError: NewErrDeviceDuplicated("test-device", store.ErrDuplicate),
+		},
+		{
 			description: "failure (accepted) (different MAC) - device limit reached [enterprise]",
 			req: &requests.DeviceUpdateStatus{
 				TenantID: "00000000-0000-0000-0000-000000000000",

--- a/api/store/pg/migrations/007_devices_accepted_mac_unique.tx.down.sql
+++ b/api/store/pg/migrations/007_devices_accepted_mac_unique.tx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS devices_accepted_mac_unique;

--- a/api/store/pg/migrations/007_devices_accepted_mac_unique.tx.up.sql
+++ b/api/store/pg/migrations/007_devices_accepted_mac_unique.tx.up.sql
@@ -1,0 +1,40 @@
+-- Enforce at most one accepted device per (namespace_id, mac). A device's uid is
+-- derived from its public key, so reinstalling the agent registers a new row with
+-- the same MAC; without this two accepted rows can coexist and a connect resolving
+-- by hostname may pick the offline one ("no connection").
+
+-- Step a: keep the most-recently-seen accepted device per (namespace_id, mac) and
+-- demote the rest. removed_at is set so the DeviceCleanup cron can later purge them
+-- (it filters removed_at < now-30d); the namespace counters are kept in sync.
+WITH winners AS (
+    SELECT DISTINCT ON (namespace_id, mac) id
+    FROM devices
+    WHERE status = 'accepted'
+    ORDER BY namespace_id, mac, last_seen DESC, id ASC
+),
+demoted AS (
+    UPDATE devices
+    SET status = 'removed',
+        status_updated_at = now(),
+        removed_at = now()
+    WHERE status = 'accepted'
+      AND id NOT IN (SELECT id FROM winners)
+    RETURNING namespace_id
+),
+counts AS (
+    SELECT namespace_id, count(*) AS n
+    FROM demoted
+    GROUP BY namespace_id
+)
+UPDATE namespaces ns
+SET devices_accepted_count = ns.devices_accepted_count - c.n,
+    devices_removed_count  = ns.devices_removed_count  + c.n
+FROM counts c
+WHERE ns.id = c.namespace_id;
+
+--bun:split
+
+-- Step b: only accepted rows are constrained; pending/rejected/removed are free.
+CREATE UNIQUE INDEX devices_accepted_mac_unique
+    ON devices USING btree (namespace_id, mac)
+    WHERE status = 'accepted';


### PR DESCRIPTION
## Problem

A device's `uid` is derived from the agent's public key (`sha256` over MAC + public key + tenant). Reinstalling the agent with a fresh keypair therefore registers a **new** device row that keeps the same MAC and hostname.

The accept flow already supersedes a same-MAC accepted device (`services.mergeDevice` deletes the old one on accept), but that invariant lived only in application code. A check-then-act race between two near-simultaneous accepts, or data accepted before the merge logic existed, can leave **two accepted rows sharing a MAC** in one namespace.

When that happens, `LookupDevice` resolves the connection by hostname with `status = accepted` but no ordering, so it returns an arbitrary accepted row. If it lands on an offline duplicate, the SSH server has no tunnel bound for that `uid` and the connection fails with `no connection` intermittently, even though the device is online under a different row.

## Change

Migration `007`:

- **Step a:** deduplicate existing accepted devices. For each `(namespace_id, mac)` group keep the most recently seen accepted device and demote the rest to `removed`, adjusting the namespace's denormalized status counters in the same statement. No-op on a clean database; a safety net for legacy data.
- **Step b:** partial unique index `(namespace_id, mac) WHERE status = 'accepted'`.

Uniqueness is scoped to accepted rows only, so pending/rejected/removed rows stay unconstrained and a reinstalled agent can still register a fresh pending device freely. The existing accept-time merge continues to be the normal path; the index is the database-level backstop that makes the duplicate state impossible.

## Notes

The index is compatible with `mergeDevice`: on accept the old accepted row is deleted while the new row is still pending, and the new row only flips to accepted after the merge returns, so the two never coexist within the transaction.