### PR TITLE
fix(ui): correct firewall rules link in terminal error banner

### DIFF
--- a/ui/apps/console/src/components/terminal/terminalErrors.test.ts
+++ b/ui/apps/console/src/components/terminal/terminalErrors.test.ts
@@ -10,49 +10,81 @@ import { getConfig } from "@/env";
 const mockGetConfig = vi.mocked(getConfig);
 
 beforeEach(() => {
-  mockGetConfig.mockReturnValue({ cloud: false, enterprise: false } as ReturnType<typeof getConfig>);
+  mockGetConfig.mockReturnValue({
+    cloud: false,
+    enterprise: false,
+  } as ReturnType<typeof getConfig>);
 });
 
 describe("resolveError", () => {
   describe("access to the device has been denied", () => {
     it("resolves with reconnect false", () => {
-      const result = resolveError("access to the device has been denied", "uid-1");
+      const result = resolveError(
+        "access to the device has been denied",
+        "uid-1",
+      );
       expect(result.reconnect).toBe(false);
     });
 
     it("uses an 'Access denied' title, not 'Connection failed'", () => {
-      const result = resolveError("access to the device has been denied", "uid-1");
+      const result = resolveError(
+        "access to the device has been denied",
+        "uid-1",
+      );
       expect(result.title).toBe("Access denied");
     });
 
     it("includes the permission-denied message", () => {
-      const result = resolveError("access to the device has been denied", "uid-1");
+      const result = resolveError(
+        "access to the device has been denied",
+        "uid-1",
+      );
       expect(result.message).toContain("permission");
     });
 
     it("includes a hint about billing or namespace policy on community edition", () => {
-      const result = resolveError("access to the device has been denied", "uid-1");
+      const result = resolveError(
+        "access to the device has been denied",
+        "uid-1",
+      );
       const hintText = result.hints.join(" ").toLowerCase();
-      expect(hintText.includes("billing") || hintText.includes("policy")).toBe(true);
+      expect(hintText.includes("billing") || hintText.includes("policy")).toBe(
+        true,
+      );
     });
 
     it("does not show the word 'firewall' twice when cloud edition appends its hint", () => {
-      mockGetConfig.mockReturnValue({ cloud: true, enterprise: false } as ReturnType<typeof getConfig>);
-      const result = resolveError("access to the device has been denied", "uid-1");
+      mockGetConfig.mockReturnValue({
+        cloud: true,
+        enterprise: false,
+      } as ReturnType<typeof getConfig>);
+      const result = resolveError(
+        "access to the device has been denied",
+        "uid-1",
+      );
       const allHintText = result.hints.join(" ").toLowerCase();
       const count = (allHintText.match(/firewall/g) ?? []).length;
       expect(count).toBeLessThanOrEqual(1);
     });
 
     it("includes a firewall/rules link when cloud or enterprise is enabled", () => {
-      mockGetConfig.mockReturnValue({ cloud: true, enterprise: false } as ReturnType<typeof getConfig>);
-      const result = resolveError("access to the device has been denied", "uid-1");
-      expect(result.links.some((l) => l.to === "/firewall/rules")).toBe(true);
+      mockGetConfig.mockReturnValue({
+        cloud: true,
+        enterprise: false,
+      } as ReturnType<typeof getConfig>);
+      const result = resolveError(
+        "access to the device has been denied",
+        "uid-1",
+      );
+      expect(result.links.some((l) => l.to === "/firewall-rules")).toBe(true);
     });
 
     it("does not include a firewall/rules link on community edition", () => {
-      const result = resolveError("access to the device has been denied", "uid-1");
-      expect(result.links.some((l) => l.to === "/firewall/rules")).toBe(false);
+      const result = resolveError(
+        "access to the device has been denied",
+        "uid-1",
+      );
+      expect(result.links.some((l) => l.to === "/firewall-rules")).toBe(false);
     });
   });
 
@@ -86,13 +118,16 @@ describe("resolveError", () => {
   describe("firewall link behavior for other known errors", () => {
     it("does not include firewall/rules link for authentication errors on community edition", () => {
       const result = resolveError("failed to authenticate to device", "uid-4");
-      expect(result.links.some((l) => l.to === "/firewall/rules")).toBe(false);
+      expect(result.links.some((l) => l.to === "/firewall-rules")).toBe(false);
     });
 
     it("includes firewall/rules link for authentication errors on cloud edition", () => {
-      mockGetConfig.mockReturnValue({ cloud: true, enterprise: false } as ReturnType<typeof getConfig>);
+      mockGetConfig.mockReturnValue({
+        cloud: true,
+        enterprise: false,
+      } as ReturnType<typeof getConfig>);
       const result = resolveError("failed to authenticate to device", "uid-4");
-      expect(result.links.some((l) => l.to === "/firewall/rules")).toBe(true);
+      expect(result.links.some((l) => l.to === "/firewall-rules")).toBe(true);
     });
   });
 });

--- a/ui/apps/console/src/components/terminal/terminalErrors.ts
+++ b/ui/apps/console/src/components/terminal/terminalErrors.ts
@@ -191,7 +191,7 @@ export function resolveError(raw: string, deviceUid: string): TerminalError {
     to: l.to.split("$uid").join(deviceUid),
   }));
   if (hasFirewall) {
-    links.push({ label: "Firewall rules", to: "/firewall/rules" });
+    links.push({ label: "Firewall rules", to: "/firewall-rules" });
   }
 
   return {


### PR DESCRIPTION
## What

Fix the "Firewall rules" link in the terminal error banner, which led to
a 404 instead of the firewall rules page.

## Why

The link pointed at `/firewall/rules`, but the app registers the route as
`/firewall-rules`. React Router matched no route and rendered the 404
page. This is a pre-existing bug (introduced in 50454f20a) that #6586
surfaced by routing the access-denied banner through this path.

## Changes

- Point the appended firewall link at `/firewall-rules`.

## Testing

1. On a cloud/enterprise deployment, trigger an access-denied terminal
   error.
2. Click "Firewall rules" in the banner.
3. Confirm it opens the firewall rules page instead of the 404.
