### PR TITLE
feat(ui): record web terminal sessions

### DIFF
--- a/api/services/session.go
+++ b/api/services/session.go
@@ -80,6 +80,7 @@ func (s *service) CreateSession(ctx context.Context, session requests.SessionCre
 		IPAddress: session.IPAddress,
 		Type:      session.Type,
 		Term:      session.Term,
+		Web:       session.Web,
 		Position: models.SessionPosition{
 			Longitude: position.Longitude,
 			Latitude:  position.Latitude,

--- a/api/store/pg/entity/session.go
+++ b/api/store/pg/entity/session.go
@@ -26,6 +26,7 @@ type Session struct {
 	Recorded      bool      `bun:"recorded"`
 	Type          string    `bun:"type"`
 	Term          string    `bun:"term"`
+	Web           bool      `bun:"web"`
 	Longitude     float64   `bun:"longitude"`
 	Latitude      float64   `bun:"latitude"`
 	CreatedAt     time.Time `bun:"created_at"`
@@ -61,6 +62,7 @@ func SessionFromModel(model *models.Session) *Session {
 		Recorded:      model.Recorded,
 		Type:          sessionType,
 		Term:          model.Term,
+		Web:           model.Web,
 		Longitude:     model.Position.Longitude,
 		Latitude:      model.Position.Latitude,
 		UpdatedAt:     clock.Now(),
@@ -84,6 +86,7 @@ func SessionToModel(entity *Session) *models.Session {
 		Recorded:      entity.Recorded,
 		Type:          entity.Type,
 		Term:          entity.Term,
+		Web:           entity.Web,
 		Position: models.SessionPosition{
 			Longitude: entity.Longitude,
 			Latitude:  entity.Latitude,

--- a/api/store/pg/migrations/008_sessions_web.tx.down.sql
+++ b/api/store/pg/migrations/008_sessions_web.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN IF EXISTS web;

--- a/api/store/pg/migrations/008_sessions_web.tx.up.sql
+++ b/api/store/pg/migrations/008_sessions_web.tx.up.sql
@@ -1,0 +1,4 @@
+-- Mark sessions that originated from the web terminal. Origin (web console vs a
+-- native SSH client) is not represented by any existing column: the scalar `type`
+-- is unused and the channel (shell/exec/scp) lives in session_events.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS web boolean NOT NULL DEFAULT false;

--- a/openapi/spec/components/schemas/session.yaml
+++ b/openapi/spec/components/schemas/session.yaml
@@ -48,6 +48,9 @@ properties:
     description: Session's terminal
     type: string
     example: xterm.js
+  web:
+    description: Whether the session originated from the web terminal
+    type: boolean
   position:
     description: Session's geolocation position
     type: object
@@ -113,5 +116,6 @@ required:
   - recorded
   - type
   - term
+  - web
   - position
   - events

--- a/pkg/api/requests/session.go
+++ b/pkg/api/requests/session.go
@@ -37,6 +37,7 @@ type SessionCreate struct {
 	IPAddress string `json:"ip_address" validate:"required"`
 	Type      string `json:"type" validate:"required"`
 	Term      string `json:"term" validate:""`
+	Web       bool   `json:"web" validate:""`
 }
 
 // SessionFinish is the structure to represent the request data for finish session endpoint.

--- a/pkg/models/session.go
+++ b/pkg/models/session.go
@@ -24,6 +24,7 @@ type Session struct {
 	Recorded      bool            `json:"recorded"`
 	Type          string          `json:"type"`
 	Term          string          `json:"term"`
+	Web           bool            `json:"web"`
 	Position      SessionPosition `json:"position"`
 	Events        SessionEvents   `json:"events"`
 }

--- a/ssh/server/server.go
+++ b/ssh/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shellhub-io/shellhub/ssh/server/channels"
 	"github.com/shellhub-io/shellhub/ssh/session"
 	log "github.com/sirupsen/logrus"
+	gossh "golang.org/x/crypto/ssh"
 )
 
 type Options struct {
@@ -120,6 +121,13 @@ func NewServer(dialer *dialer.Dialer, cache cache.Cache, opts *Options) *Server 
 		ChannelHandlers: map[string]gliderssh.ChannelHandler{
 			channels.SessionChannel:     channels.DefaultSessionHandler(),
 			channels.DirectTCPIPChannel: channels.DefaultDirectTCPIPHandler,
+		},
+		// Answers the web terminal bridge with this connection's session UID, so a
+		// client-side recording can be tied to its server session.
+		RequestHandlers: map[string]gliderssh.RequestHandler{
+			"session-uid@shellhub.io": func(ctx gliderssh.Context, _ *gliderssh.Server, _ *gossh.Request) (bool, []byte) {
+				return true, []byte(ctx.SessionID())
+			},
 		},
 		LocalPortForwardingCallback: func(_ gliderssh.Context, _ string, _ uint32) bool {
 			return true

--- a/ssh/session/session.go
+++ b/ssh/session/session.go
@@ -39,6 +39,8 @@ type Data struct {
 	Type string
 	// Term is the terminal used for the client.
 	Term string
+	// Web reports whether the session originated from the web terminal.
+	Web bool
 	// Handled check if the session is already handling a "shell", "exec" or a "subsystem".
 	Handled bool
 }
@@ -260,6 +262,7 @@ func NewSession(ctx gliderssh.Context, dialer *dialer.Dialer, cache cache.Cache)
 	}
 
 	var namespaceName, deviceName string
+	web := false
 	if target.IsSSHID() {
 		namespaceName, deviceName, err = target.SplitSSHID()
 		if err != nil {
@@ -267,6 +270,8 @@ func NewSession(ctx gliderssh.Context, dialer *dialer.Dialer, cache cache.Cache)
 		}
 	} else {
 		if hos.IsLocalhost() {
+			web = true
+
 			var data string
 
 			if err := cache.Get(ctx, "web-ip/"+sshid, &data); err != nil {
@@ -327,6 +332,7 @@ func NewSession(ctx gliderssh.Context, dialer *dialer.Dialer, cache cache.Cache)
 			Target:    target,
 			Device:    lookupDevice,
 			Namespace: namespace,
+			Web:       web,
 			SSHID:     fmt.Sprintf("%s@%s.%s", target.Username, namespaceName, deviceName),
 		},
 		once:  new(sync.Once),
@@ -454,6 +460,7 @@ func (s *Session) register(ctx context.Context) error {
 		IPAddress: s.IPAddress,
 		Type:      "none",
 		Term:      "none",
+		Web:       s.Web,
 	})
 	if err != nil {
 		log.WithError(err).

--- a/ssh/web/messages.go
+++ b/ssh/web/messages.go
@@ -14,6 +14,9 @@ const (
 	// messageKindError is the identifier to output an erro rmessage. This kind of message contains data to be show
 	// in terminal for information propose.
 	messageKindError
+	// messageKindSession carries the server session UID to the web client, so a client-side recording can be tied
+	// to its session. This kind of message contains the session UID as a string.
+	messageKindSession
 )
 
 // MessageMinSize is the minimum size of a message in bytes. This is used to validate if the message is valid.

--- a/ssh/web/session.go
+++ b/ssh/web/session.go
@@ -206,6 +206,14 @@ func newSession(ctx context.Context, cache cache.Cache, conn *Conn, creds *Crede
 
 	defer connection.Close() //nolint:errcheck
 
+	// Ask the SSH server for this connection's session UID and relay it to the web
+	// client, so a client-side recording can be tied to its server session.
+	if ok, reply, err := connection.SendRequest("session-uid@shellhub.io", true, nil); err == nil && ok {
+		if _, err := conn.WriteMessage(&Message{Kind: messageKindSession, Data: string(reply)}); err != nil {
+			logger.WithError(err).Debug("failed to send the session UID to the web client")
+		}
+	}
+
 	agent, err := connection.NewSession()
 	if err != nil {
 		logger.WithError(err).Debug("failed to create a new session")

--- a/ui/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui/apps/console/src/components/ConnectDrawer.tsx
@@ -5,10 +5,16 @@ import {
   ChevronDoubleRightIcon,
   ShieldCheckIcon,
   ExclamationCircleIcon,
+  VideoCameraIcon,
+  CheckIcon,
 } from "@heroicons/react/24/outline";
 import { useTerminalStore } from "../stores/terminalStore";
+import type { TerminalSession } from "../stores/terminalStore";
 import { useVaultStore } from "../stores/vaultStore";
+import { useAuthStore } from "../stores/authStore";
+import { useNamespace } from "../hooks/useNamespaces";
 import { getFingerprint, validatePrivateKey } from "../utils/sshKeys";
+import { isRecordingSupported } from "../utils/recordings";
 import CopyButton from "./common/CopyButton";
 import Drawer from "./common/Drawer";
 import VaultLockedBanner from "./vault/VaultLockedBanner";
@@ -42,6 +48,7 @@ interface FormState {
   manualKeyEncrypted: boolean;
   passphrase: string;
   keyError: string | null;
+  recordSession: boolean;
 }
 
 type FormAction =
@@ -53,7 +60,8 @@ type FormAction =
   | { type: "setSelectedKeyId"; value: string }
   | { type: "setManualKey"; value: string; valid: boolean; encrypted: boolean }
   | { type: "setPassphrase"; value: string }
-  | { type: "setKeyError"; value: string | null };
+  | { type: "setKeyError"; value: string | null }
+  | { type: "setRecordSession"; value: boolean };
 
 const initialState: FormState = {
   username: "",
@@ -66,6 +74,7 @@ const initialState: FormState = {
   manualKeyEncrypted: false,
   passphrase: "",
   keyError: null,
+  recordSession: true,
 };
 
 function formReducer(state: FormState, action: FormAction): FormState {
@@ -94,6 +103,8 @@ function formReducer(state: FormState, action: FormAction): FormState {
       return { ...state, passphrase: action.value };
     case "setKeyError":
       return { ...state, keyError: action.value };
+    case "setRecordSession":
+      return { ...state, recordSession: action.value };
   }
 }
 
@@ -111,6 +122,11 @@ export default function ConnectDrawer({
 
   const [state, dispatch] = useReducer(formReducer, initialState);
   const [unlockOpen, setUnlockOpen] = useState(false);
+  const recordingSupported = isRecordingSupported();
+
+  const tenant = useAuthStore((s) => s.tenant);
+  const { namespace } = useNamespace(tenant ?? "");
+  const namespaceRecords = namespace?.settings?.session_record ?? false;
 
   useEffect(() => {
     if (!open) return;
@@ -159,13 +175,14 @@ export default function ConnectDrawer({
     e.preventDefault();
     if (!canConnect) return;
 
+    let params: Omit<TerminalSession, "id" | "state" | "connectionStatus">;
     if (state.authMethod === "password") {
-      openTerminal({
+      params = {
         deviceUid,
         deviceName,
         username: state.username.trim(),
         password: state.password,
-      });
+      };
     } else {
       const key =
         effectiveKeySource === "vault" && selectedVaultKey
@@ -204,7 +221,7 @@ export default function ConnectDrawer({
       }
       dispatch({ type: "setKeyError", value: null });
 
-      openTerminal({
+      params = {
         deviceUid,
         deviceName,
         username: state.username.trim(),
@@ -212,8 +229,16 @@ export default function ConnectDrawer({
         fingerprint,
         privateKey: key,
         passphrase: phrase,
-      });
+      };
     }
+
+    // Opt-in recording. Captured client-side to OPFS — no picker, no upload.
+    // Skip when the namespace already records server-side.
+    if (!namespaceRecords && state.recordSession && isRecordingSupported()) {
+      params = { ...params, record: true };
+    }
+
+    openTerminal(params);
     onClose();
   };
 
@@ -304,7 +329,6 @@ export default function ConnectDrawer({
             value={state.username}
             onChange={(v) => dispatch({ type: "setUsername", value: v })}
             placeholder="e.g. root"
-
           />
 
           {/* Auth Method */}
@@ -448,6 +472,83 @@ export default function ConnectDrawer({
               <ExclamationCircleIcon className="w-3.5 h-3.5 shrink-0" />
               {state.keyError}
             </p>
+          )}
+
+          {namespaceRecords && (
+            <div className="w-full px-3.5 py-3 rounded-lg border border-border bg-card text-left">
+              <div className="flex items-start gap-3">
+                <span
+                  aria-hidden="true"
+                  className="mt-0.5 shrink-0 text-text-secondary"
+                >
+                  <VideoCameraIcon className="w-5 h-5" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <span className="flex items-center gap-1.5 text-sm font-medium text-text-primary">
+                    <span className="inline-flex items-center gap-1 text-accent-red">
+                      <span className="w-1.5 h-1.5 rounded-full bg-accent-red animate-pulse-subtle" />
+                      <span className="text-[10px] font-bold tracking-wide">
+                        REC
+                      </span>
+                    </span>
+                    Session recording is on
+                  </span>
+                  <span className="block text-2xs text-text-muted mt-0.5">
+                    Recorded on the server by your namespace's policy.
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {!namespaceRecords && recordingSupported && (
+            <label
+              className={`flex items-start gap-3 w-full px-3.5 py-3 rounded-lg border text-left transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40 ${
+                state.recordSession
+                  ? "bg-primary/[0.06] border-primary/30 ring-1 ring-primary/10"
+                  : "bg-card border-border hover:border-border-light hover:bg-hover-subtle"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={state.recordSession}
+                onChange={(e) =>
+                  dispatch({
+                    type: "setRecordSession",
+                    value: e.target.checked,
+                  })
+                }
+                className="sr-only"
+              />
+              <span
+                aria-hidden="true"
+                className={`mt-0.5 shrink-0 transition-colors ${
+                  state.recordSession ? "text-primary" : "text-text-muted"
+                }`}
+              >
+                <VideoCameraIcon className="w-4 h-4" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <span className="block text-sm font-medium text-text-primary">
+                  Record this session
+                </span>
+                <span className="block text-2xs text-text-muted mt-0.5">
+                  Save this session in your browser to replay it locally later.
+                </span>
+              </div>
+              <span
+                aria-hidden="true"
+                className={`mt-0.5 shrink-0 w-4 h-4 rounded border flex items-center justify-center transition-all ${
+                  state.recordSession
+                    ? "bg-primary border-primary text-white"
+                    : "border-text-muted/40"
+                }`}
+              >
+                {state.recordSession && (
+                  <CheckIcon className="w-3 h-3" strokeWidth={3} />
+                )}
+              </span>
+            </label>
           )}
         </form>
       </Drawer>

--- a/ui/apps/console/src/components/sessions/RecordingPaywallDialog.tsx
+++ b/ui/apps/console/src/components/sessions/RecordingPaywallDialog.tsx
@@ -1,0 +1,101 @@
+import {
+  ArrowTopRightOnSquareIcon,
+  CheckIcon,
+  VideoCameraIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import BaseDialog from "@/components/common/BaseDialog";
+
+const PRICING_URL = "https://www.shellhub.io/pricing";
+
+const HIGHLIGHTS = [
+  "Recorded on the server, independent of anyone's browser",
+  "Retained centrally for audit and compliance",
+  "Replay any session later, keystroke by keystroke",
+];
+
+interface RecordingPaywallDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function RecordingPaywallDialog({
+  open,
+  onClose,
+}: RecordingPaywallDialogProps) {
+  return (
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      size="md"
+      aria-labelledby="recording-paywall-title"
+    >
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute right-4 top-4 rounded-md p-1.5 text-text-muted transition-colors hover:text-text-secondary"
+      >
+        <XMarkIcon className="w-5 h-5" />
+      </button>
+
+      <div className="bg-gradient-to-b from-primary/[0.1] to-transparent px-7 pb-2 pt-8">
+        <span className="flex h-12 w-12 items-center justify-center rounded-xl border border-primary/25 bg-primary/10 text-primary shadow-lg shadow-primary/10">
+          <VideoCameraIcon className="w-6 h-6" />
+        </span>
+        <p className="mt-4 font-mono text-2xs font-semibold uppercase tracking-wider text-accent-yellow">
+          Premium
+        </p>
+        <h2
+          id="recording-paywall-title"
+          className="mt-1 text-lg font-semibold text-balance text-text-primary"
+        >
+          Record and replay every session
+        </h2>
+      </div>
+
+      <div className="px-7 pb-6 pt-2">
+        <p className="text-sm text-text-secondary">
+          This session was not recorded. Advanced Session Recording captures
+          every terminal session on the server, so you never depend on a browser
+          copy that only lives on one machine.
+        </p>
+        <ul className="mt-4 flex flex-col gap-2.5">
+          {HIGHLIGHTS.map((h) => (
+            <li
+              key={h}
+              className="flex items-start gap-2.5 text-sm text-text-secondary"
+            >
+              <CheckIcon className="mt-0.5 w-4 h-4 shrink-0 text-accent-green" />
+              {h}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 border-t border-border px-7 py-4">
+        <p className="text-2xs text-text-muted">
+          Available on Cloud and Enterprise
+        </p>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm font-medium text-text-secondary transition-colors hover:text-text-primary"
+          >
+            Not now
+          </button>
+          <a
+            href={PRICING_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+          >
+            See pricing
+            <ArrowTopRightOnSquareIcon className="w-4 h-4" strokeWidth={2} />
+          </a>
+        </div>
+      </div>
+    </BaseDialog>
+  );
+}

--- a/ui/apps/console/src/components/terminal/RecordingSnackbar.tsx
+++ b/ui/apps/console/src/components/terminal/RecordingSnackbar.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { CheckCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useRecordingsStore } from "@/stores/recordingsStore";
+
+// Lightweight post-session notice. Driven by the recordings store, so it shows
+// the same way regardless of how the session ended (X button, exit, or dropped
+// connection). Non-blocking, announces politely, and auto-dismisses.
+export default function RecordingSnackbar() {
+  const notice = useRecordingsStore((s) => s.notice);
+  const clearNotice = useRecordingsStore((s) => s.clearNotice);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!notice) return;
+    const t = setTimeout(() => clearNotice(), 6000);
+    return () => clearTimeout(t);
+  }, [notice, clearNotice]);
+
+  if (!notice) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-16 right-4 z-50 w-80 max-w-[calc(100vw-2rem)] bg-card border border-accent-green/30 rounded-lg shadow-lg shadow-black/30 px-4 py-3 flex items-start gap-3 animate-slide-up"
+    >
+      <CheckCircleIcon
+        className="w-4 h-4 text-accent-green shrink-0 mt-0.5"
+        strokeWidth={1.5}
+      />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-text-primary">
+          Session recorded
+        </p>
+        <p className="text-2xs text-text-muted mt-0.5 truncate">
+          {notice.deviceName}
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            clearNotice();
+            void navigate("/sessions");
+          }}
+          className="mt-1.5 text-sm text-primary hover:text-primary-600 font-medium transition-colors"
+        >
+          View recordings
+        </button>
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={clearNotice}
+        className="text-text-muted hover:text-text-primary transition-colors p-0.5 shrink-0"
+      >
+        <XMarkIcon className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -19,6 +19,8 @@ import {
   parseMessage,
   resolveError,
 } from "./terminalErrors";
+import { OpfsCastRecorder } from "@/utils/recordings";
+import { useRecordingsStore } from "@/stores/recordingsStore";
 
 interface TerminalInstanceProps {
   session: TerminalSession;
@@ -36,6 +38,7 @@ export default function TerminalInstance({
   const observerRef = useRef<ResizeObserver | null>(null);
   const prevVisibleRef = useRef(visible);
   const resizeRegisteredRef = useRef(false);
+  const recorderRef = useRef<OpfsCastRecorder | null>(null);
   const [error, setError] = useState<TerminalError | null>(null);
 
   const { theme, fontFamilyWithFallback, fontSize } = useTerminalThemeStore();
@@ -56,6 +59,18 @@ export default function TerminalInstance({
       fontFamilyWithFallback: initFont,
       fontSize: initSize,
     } = useTerminalThemeStore.getState();
+
+    // Finalize the recording exactly once (guarded by nulling the ref before
+    // any await). Runs on EVERY connection close — ws.onclose (exit / dropped)
+    // and unmount cleanup (the X button) converge here, so the result is the
+    // same regardless of how the session ended.
+    async function finalizeRecording() {
+      const recorder = recorderRef.current;
+      if (!recorder) return;
+      recorderRef.current = null;
+      const meta = await recorder.finish();
+      if (meta) useRecordingsStore.getState().notify(meta);
+    }
 
     async function connect() {
       updateStatus("connecting");
@@ -131,19 +146,41 @@ export default function TerminalInstance({
               JSON.stringify({ kind: WS_KIND.RESIZE, data: { cols, rows } }),
             );
           }
+          recorderRef.current?.recordResize(cols, rows);
         });
       };
 
-      ws.onopen = () => {
+      ws.onopen = async () => {
         if (cancelled) return;
         updateStatus("connected");
+
+        // Opt-in recording, streamed to OPFS (no picker, no upload).
+        if (session.record) {
+          try {
+            const recorder = await OpfsCastRecorder.create(
+              session.deviceName,
+              session.deviceUid,
+              session.username,
+            );
+            if (cancelled) {
+              await recorder.discard();
+              return;
+            }
+            recorderRef.current = recorder;
+            recorder.start(cols, rows);
+          } catch (err) {
+            console.error("session recording: could not start", err);
+          }
+        }
       };
 
       ws.onmessage = async (event) => {
         if (cancelled) return;
         if (event.data instanceof Blob) {
           // Binary data = terminal output (password auth or post-signature)
-          term.write(await event.data.text());
+          const text = await event.data.text();
+          term.write(text);
+          recorderRef.current?.recordOutput(text);
           registerResizeHandler();
         } else {
           // JSON text message = challenge-response or error
@@ -164,9 +201,13 @@ export default function TerminalInstance({
                   challengeBuffer,
                   keyPassphrase,
                 );
-                ws.send(JSON.stringify({ kind: WS_KIND.SIGNATURE, data: signature }));
+                ws.send(
+                  JSON.stringify({ kind: WS_KIND.SIGNATURE, data: signature }),
+                );
               } catch {
-                term.write("\r\n\x1b[1;31mFailed to sign authentication challenge.\x1b[0m\r\n");
+                term.write(
+                  "\r\n\x1b[1;31mFailed to sign authentication challenge.\x1b[0m\r\n",
+                );
                 keyMaterial = undefined;
                 keyPassphrase = undefined;
                 useTerminalStore.getState().clearSensitiveData(session.id);
@@ -186,6 +227,10 @@ export default function TerminalInstance({
               setError(resolveError(msg.data, session.deviceUid));
               break;
             }
+            case WS_KIND.SESSION: {
+              recorderRef.current?.setSessionUid(msg.data);
+              break;
+            }
             default:
               break;
           }
@@ -198,6 +243,8 @@ export default function TerminalInstance({
         if (!lastError) {
           setError(WS_CLOSE_ERROR);
         }
+        // Connection closed (exit or dropped) — finalize the recording.
+        void finalizeRecording();
       };
 
       ws.onerror = () => {
@@ -228,6 +275,20 @@ export default function TerminalInstance({
 
     return () => {
       cancelled = true;
+      // Persist the recording only on a real close — i.e. the session is gone
+      // from the store. On a StrictMode remount (dev) or transient unmount the
+      // session still exists, so discard the throwaway recorder instead of
+      // emitting a spurious recording the moment the terminal opens.
+      const stillOpen = useTerminalStore
+        .getState()
+        .sessions.some((s) => s.id === session.id);
+      if (stillOpen) {
+        const recorder = recorderRef.current;
+        recorderRef.current = null;
+        void recorder?.discard();
+      } else {
+        void finalizeRecording();
+      }
       useTerminalStore.getState().clearSensitiveData(session.id);
       observerRef.current?.disconnect();
       observerRef.current = null;
@@ -291,6 +352,14 @@ export default function TerminalInstance({
     <div className="relative flex-1 flex flex-col overflow-hidden">
       {error !== null && (
         <TerminalErrorBanner error={error} sessionId={session.id} />
+      )}
+      {session.record && session.connectionStatus === "connected" && (
+        <div className="absolute top-2 right-3 z-10 flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-black/40 backdrop-blur-sm pointer-events-none select-none">
+          <span className="w-1.5 h-1.5 rounded-full bg-accent-red animate-pulse shadow-[0_0_4px_rgba(220,80,80,0.7)]" />
+          <span className="text-2xs font-semibold tracking-wide text-accent-red">
+            REC
+          </span>
+        </div>
       )}
       <div
         ref={containerRef}

--- a/ui/apps/console/src/components/terminal/TerminalManager.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalManager.tsx
@@ -7,6 +7,7 @@ import ConnectDrawer from "../ConnectDrawer";
 import { buildSshid } from "@/utils/sshid";
 import TerminalInstance from "./TerminalInstance";
 import TerminalTaskbar from "./TerminalTaskbar";
+import RecordingSnackbar from "./RecordingSnackbar";
 
 export default function TerminalManager({
   sidebarOffset,
@@ -85,6 +86,8 @@ export default function TerminalManager({
       })}
 
       <TerminalTaskbar sidebarOffset={sidebarOffset} />
+
+      <RecordingSnackbar />
     </>
   );
 }

--- a/ui/apps/console/src/components/terminal/terminalErrors.ts
+++ b/ui/apps/console/src/components/terminal/terminalErrors.ts
@@ -86,21 +86,19 @@ const errorMap: Record<string, ErrorEntry> = {
     ],
   },
   "connections using public keys are not permitted when the agent version is 0.5.x or earlier":
-  {
-    message: "This device does not support public key authentication.",
-    reconnect: true,
-    hints: [
-      "The ShellHub agent is v0.5.x or earlier. Update to v0.6.0+ for public key support, or reconnect using a password.",
-    ],
-    links: [{ label: "Device details", to: "/devices/$uid" }],
-  },
+    {
+      message: "This device does not support public key authentication.",
+      reconnect: true,
+      hints: [
+        "The ShellHub agent is v0.5.x or earlier. Update to v0.6.0+ for public key support, or reconnect using a password.",
+      ],
+      links: [{ label: "Device details", to: "/devices/$uid" }],
+    },
   "access to the device has been denied": {
     title: "Access denied",
     message: "You do not have permission to access this device.",
     reconnect: false,
-    hints: [
-      "Access may be restricted by a billing limit or namespace policy.",
-    ],
+    hints: ["Access may be restricted by a billing limit or namespace policy."],
   },
   "invalid sshid format": {
     title: "Invalid connection identifier",
@@ -113,7 +111,13 @@ const errorMap: Record<string, ErrorEntry> = {
 };
 
 // Values match ssh/web/messages.go messageKind iota.
-export const WS_KIND = { INPUT: 1, RESIZE: 2, SIGNATURE: 3, ERROR: 4 } as const;
+export const WS_KIND = {
+  INPUT: 1,
+  RESIZE: 2,
+  SIGNATURE: 3,
+  ERROR: 4,
+  SESSION: 5,
+} as const;
 
 export const HTTP_CONNECT_ERROR: TerminalError = {
   title: "Connection failed",
@@ -149,12 +153,12 @@ export function parseMessage(
   try {
     const msg: unknown = JSON.parse(data);
     if (
-      typeof msg === "object"
-      && msg !== null
-      && "kind" in msg
-      && "data" in msg
-      && typeof (msg as { kind: unknown }).kind === "number"
-      && typeof (msg as { data: unknown }).data === "string"
+      typeof msg === "object" &&
+      msg !== null &&
+      "kind" in msg &&
+      "data" in msg &&
+      typeof (msg as { kind: unknown }).kind === "number" &&
+      typeof (msg as { data: unknown }).data === "string"
     ) {
       return {
         kind: (msg as { kind: number }).kind,

--- a/ui/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
+++ b/ui/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
@@ -49,6 +49,12 @@ vi.mock("@/utils/sshKeys", () => ({
   getFingerprint: vi.fn(() => "fp"),
 }));
 
+// ConnectDrawer reads the namespace to show the session-record status; stub it
+// so the drawer renders without a QueryClient in these isolated tests.
+vi.mock("@/hooks/useNamespaces", () => ({
+  useNamespace: () => ({ namespace: undefined }),
+}));
+
 vi.mock("@/components/common/Drawer", () => ({
   default: ({
     open,
@@ -73,14 +79,18 @@ vi.mock("@/components/common/Drawer", () => ({
 vi.mock("@/components/vault/VaultLockedBanner", () => ({
   default: ({ onUnlock }: { onUnlock: () => void }) => (
     <div data-testid="vault-locked-banner">
-      <button type="button" onClick={onUnlock}>Unlock Vault</button>
+      <button type="button" onClick={onUnlock}>
+        Unlock Vault
+      </button>
     </div>
   ),
 }));
 
 vi.mock("@/components/common/CopyButton", () => ({
   default: ({ text }: { text: string }) => (
-    <button type="button" aria-label={`Copy ${text}`}>Copy</button>
+    <button type="button" aria-label={`Copy ${text}`}>
+      Copy
+    </button>
   ),
 }));
 
@@ -210,7 +220,9 @@ vi.mock("@/components/vault/VaultSetupDialog", () => ({
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
     open ? (
       <div role="dialog" aria-label="Setup Vault">
-        <button type="button" onClick={onClose}>Close Setup</button>
+        <button type="button" onClick={onClose}>
+          Close Setup
+        </button>
       </div>
     ) : null,
 }));
@@ -219,7 +231,9 @@ vi.mock("@/components/vault/VaultUnlockDialog", () => ({
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
     open ? (
       <div role="dialog" aria-label="Unlock Vault">
-        <button type="button" onClick={onClose}>Close Unlock</button>
+        <button type="button" onClick={onClose}>
+          Close Unlock
+        </button>
       </div>
     ) : null,
 }));
@@ -245,7 +259,9 @@ vi.mock("../KeyDrawer", () => ({
         role="dialog"
         aria-label={editKey ? "Edit Private Key" : "Add Private Key"}
       >
-        <button type="button" onClick={onClose}>Close Drawer</button>
+        <button type="button" onClick={onClose}>
+          Close Drawer
+        </button>
       </div>
     ) : null,
 }));
@@ -263,7 +279,9 @@ vi.mock("../KeyDeleteDialog", () => ({
     open ? (
       <div role="dialog" aria-label="Delete Key Dialog">
         {entry && <span>{entry.name}</span>}
-        <button type="button" onClick={onClose}>Close Delete</button>
+        <button type="button" onClick={onClose}>
+          Close Delete
+        </button>
       </div>
     ) : null,
 }));

--- a/ui/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
+++ b/ui/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
@@ -42,7 +42,9 @@ vi.mock("../SessionPlayerDialog", () => ({
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
     open ? (
       <div data-testid="player-dialog">
-        <button type="button" onClick={onClose}>Close Player</button>
+        <button type="button" onClick={onClose}>
+          Close Player
+        </button>
       </div>
     ) : null,
 }));
@@ -75,7 +77,7 @@ function makeSession(overrides: Record<string, any> = {}) {
     type: "shell",
     term: "xterm",
     position: { latitude: 0, longitude: 0 },
-    events: { types: [], seats: [] },
+    events: { types: ["shell"], seats: [] },
     ...overrides,
   };
 }
@@ -109,7 +111,11 @@ function renderSessions(initialEntries: string[] = ["/"]) {
   const result = render(
     <MemoryRouter initialEntries={initialEntries}>
       <Sessions />
-      <LocationProbe onLocation={(s) => { lastSearch = s; }} />
+      <LocationProbe
+        onLocation={(s) => {
+          lastSearch = s;
+        }}
+      />
     </MemoryRouter>,
   );
   return { ...result, getSearch: () => lastSearch };
@@ -118,7 +124,11 @@ function renderSessions(initialEntries: string[] = ["/"]) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(useSessions).mockReturnValue(makeSessions());
-  vi.mocked(useCloseSession).mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null } as unknown as ReturnType<typeof useCloseSession>);
+  vi.mocked(useCloseSession).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    error: null,
+  } as unknown as ReturnType<typeof useCloseSession>);
   vi.mocked(useSessionRecording).mockReturnValue(makeRecording());
 });
 
@@ -129,9 +139,7 @@ beforeEach(() => {
 describe("Sessions", () => {
   describe("initial load", () => {
     it("shows loading state while fetching", () => {
-      vi.mocked(useSessions).mockReturnValue(
-        makeSessions({ isLoading: true }),
-      );
+      vi.mocked(useSessions).mockReturnValue(makeSessions({ isLoading: true }));
 
       renderSessions();
 

--- a/ui/apps/console/src/pages/sessions/index.tsx
+++ b/ui/apps/console/src/pages/sessions/index.tsx
@@ -1,30 +1,38 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import {
   CommandLineIcon,
   ExclamationTriangleIcon,
+  GlobeAltIcon,
   XCircleIcon,
 } from "@heroicons/react/24/outline";
 import { PlayIcon } from "@heroicons/react/24/solid";
 import { useSessions } from "@/hooks/useSessions";
 import { useCloseSession } from "@/hooks/useSessionMutations";
 import { useSessionRecording } from "@/hooks/useSessionRecording";
+import { useRecordingsStore } from "@/stores/recordingsStore";
+import { isRecordingSupported, readRecording } from "@/utils/recordings";
 import type { Session } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import DeviceChip from "@/components/common/DeviceChip";
 import DataTable, { type Column } from "@/components/common/DataTable";
 import SessionPlayerDialog from "./SessionPlayerDialog";
+import RecordingPaywallDialog from "@/components/sessions/RecordingPaywallDialog";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import { formatDate, formatDuration } from "@/utils/date";
 import { sessionType } from "@/utils/session";
+import { isPremiumFeature } from "@/utils/features";
 import {
-  Button,
   Callout,
   IconButton,
+  Spinner,
 } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 10;
+
+const PLAY_BTN =
+  "inline-flex items-center gap-1.5 px-2.5 py-1.5 text-2xs font-semibold text-white bg-primary rounded-md hover:bg-primary-600 transition-colors disabled:opacity-dim disabled:cursor-not-allowed disabled:hover:bg-primary";
 
 type SessionsParams = {
   page: number;
@@ -68,7 +76,10 @@ export default function Sessions() {
   });
   const closeSession = useCloseSession();
   const navigate = useNavigate();
+  const premium = isPremiumFeature();
   const [playTarget, setPlayTarget] = useState<string | null>(null);
+  const [localLogs, setLocalLogs] = useState<string | null>(null);
+  const [upsellOpen, setUpsellOpen] = useState(false);
   const {
     logs: sessionLogs,
     isLoading: logsLoading,
@@ -77,12 +88,49 @@ export default function Sessions() {
     clearLogs,
   } = useSessionRecording();
 
+  // Local (OPFS) recordings live only in the browser that made them, keyed by
+  // session uid. Surfacing their playback here makes a session the single home
+  // for both server and local recordings.
+  const recordings = useRecordingsStore((s) => s.recordings);
+  const refreshRecordings = useRecordingsStore((s) => s.refresh);
+
+  useEffect(() => {
+    if (isRecordingSupported()) void refreshRecordings();
+  }, [refreshRecordings]);
+
+  const localBySessionUid = useMemo(
+    () =>
+      new Map(
+        recordings
+          .filter((r) => r.sessionUid)
+          .map((r) => [r.sessionUid, r] as const),
+      ),
+    [recordings],
+  );
+
   const totalPages = Math.ceil(totalCount / PER_PAGE);
 
-  const handlePlayClick = async (e: React.MouseEvent, uid: string) => {
+  // Play routing: prefer a local recording (inline read), fall back to the
+  // server recording, and on Community pitch the paid feature when a shell
+  // session has no recording at all.
+  const handlePlayClick = async (e: React.MouseEvent, s: Session) => {
     e.stopPropagation();
-    setPlayTarget(uid);
-    await fetchLogs(uid);
+    const local = localBySessionUid.get(s.uid);
+    if (local) {
+      setPlayTarget(s.uid);
+      try {
+        setLocalLogs(await readRecording(local));
+      } catch {
+        setPlayTarget(null);
+      }
+      return;
+    }
+    if (s.recorded) {
+      setPlayTarget(s.uid);
+      await fetchLogs(s.uid);
+      return;
+    }
+    setUpsellOpen(true);
   };
 
   const columns: Column<Session>[] = [
@@ -115,6 +163,28 @@ export default function Sessions() {
         ) : (
           <span className="text-xs font-mono text-text-primary">
             {s.device?.name ?? (s.device_uid ?? "").substring(0, 8)}
+          </span>
+        ),
+    },
+    {
+      key: "origin",
+      header: "Origin",
+      render: (s) =>
+        s.web ? (
+          <span className="inline-flex items-center gap-1.5 text-xs">
+            <GlobeAltIcon
+              className="w-3.5 h-3.5 text-text-muted"
+              strokeWidth={2}
+            />
+            <span className="text-text-secondary">Web</span>
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 text-xs">
+            <CommandLineIcon
+              className="w-3.5 h-3.5 text-text-muted"
+              strokeWidth={2}
+            />
+            <span className="text-text-secondary">SSH</span>
           </span>
         ),
     },
@@ -187,37 +257,56 @@ export default function Sessions() {
     {
       key: "actions",
       header: "",
-      headerClassName: "w-28",
-      render: (s) => (
-        <div className="flex items-center justify-end gap-1">
-          {s.recorded && (
-            <RestrictedAction action="session:play">
-              <Button
-                size="sm"
-                icon={<PlayIcon className="w-3 h-3" />}
-                loading={logsLoading && playTarget === s.uid}
-                disabled={logsLoading && playTarget === s.uid}
-                title="Play recording"
-                onClick={(e) => void handlePlayClick(e, s.uid)}
-              >
-                Play
-              </Button>
-            </RestrictedAction>
-          )}
-          {s.active && (
-            <RestrictedAction action="session:close">
-              <CloseButton
-                onClose={() =>
-                  closeSession.mutateAsync({
-                    path: { uid: s.uid },
-                    body: { device: s.device_uid ?? s.device?.uid ?? "" },
-                  })
-                }
-              />
-            </RestrictedAction>
-          )}
-        </div>
-      ),
+      render: (s) => {
+        const local = localBySessionUid.get(s.uid);
+        const isShell = sessionType(s)?.label === "shell";
+        const canPlay = Boolean(local) || s.recorded;
+        const playing = logsLoading && playTarget === s.uid;
+        // A local recording is the user's own browser data, so it plays without
+        // the server-side session:play permission; only server playback needs it.
+        const needsPermission = !local && s.recorded;
+        const playButton = (
+          <button
+            type="button"
+            className={PLAY_BTN}
+            disabled={playing || (!canPlay && premium)}
+            title={canPlay ? "Play recording" : "This session was not recorded"}
+            aria-label="Play recording"
+            onClick={(e) => void handlePlayClick(e, s)}
+          >
+            {playing ? (
+              <Spinner size="xs" tone="onPrimary" />
+            ) : (
+              <PlayIcon className="w-3.5 h-3.5" />
+            )}
+            Play
+          </button>
+        );
+        return (
+          <div className="flex items-center justify-end gap-1.5">
+            {isShell &&
+              (needsPermission ? (
+                <RestrictedAction action="session:play">
+                  {playButton}
+                </RestrictedAction>
+              ) : (
+                playButton
+              ))}
+            {s.active && (
+              <RestrictedAction action="session:close">
+                <CloseButton
+                  onClose={() =>
+                    closeSession.mutateAsync({
+                      path: { uid: s.uid },
+                      body: { device: s.device_uid ?? s.device?.uid ?? "" },
+                    })
+                  }
+                />
+              </RestrictedAction>
+            )}
+          </div>
+        );
+      },
     },
   ];
 
@@ -274,16 +363,22 @@ export default function Sessions() {
         }
       />
 
-      {playTarget && !logsLoading && sessionLogs && (
+      {playTarget && (localLogs || (!logsLoading && sessionLogs)) && (
         <SessionPlayerDialog
           open
           onClose={() => {
             setPlayTarget(null);
+            setLocalLogs(null);
             clearLogs();
           }}
-          logs={sessionLogs}
+          logs={localLogs ?? sessionLogs ?? ""}
         />
       )}
+
+      <RecordingPaywallDialog
+        open={upsellOpen}
+        onClose={() => setUpsellOpen(false)}
+      />
     </div>
   );
 }

--- a/ui/apps/console/src/stores/authStore.ts
+++ b/ui/apps/console/src/stores/authStore.ts
@@ -12,6 +12,8 @@ import {
 import { queryClient } from "../api/queryClient";
 import { tearDownChatwoot } from "../hooks/chatwootRuntime";
 import { useVaultStore } from "./vaultStore";
+import { useTerminalStore } from "./terminalStore";
+import { setRecordingsScope } from "../utils/recordings";
 
 interface AuthState {
   token: string | null;
@@ -155,6 +157,10 @@ export const useAuthStore = create<AuthState>()(
         // re-bootstrap with the new user's identity.
         tearDownChatwoot("logout");
         useVaultStore.getState().lock();
+        // Close terminal sessions so an in-progress local recording is
+        // finalized instead of discarded when the terminal unmounts.
+        const terminal = useTerminalStore.getState();
+        terminal.sessions.forEach((s) => terminal.close(s.id));
         set(initialState);
         localStorage.removeItem("shellhub-session");
         // Drop every cached query so the next user doesn't briefly see the
@@ -306,3 +312,10 @@ export const useAuthStore = create<AuthState>()(
     },
   ),
 );
+
+// Namespace local session recordings to the signed-in user. Synced here (not in
+// each userId write) so it also covers rehydration and logout.
+setRecordingsScope(useAuthStore.getState().userId);
+useAuthStore.subscribe((state, prev) => {
+  if (state.userId !== prev.userId) setRecordingsScope(state.userId);
+});

--- a/ui/apps/console/src/stores/recordingsStore.ts
+++ b/ui/apps/console/src/stores/recordingsStore.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+import {
+  listRecordings,
+  deleteRecording,
+  downloadRecording,
+  clearRecordings,
+  pruneRecordings,
+  type RecordingMeta,
+} from "@/utils/recordings";
+
+/** Local retention is a per-browser preference, so it lives in localStorage. */
+const RETENTION_KEY = "shellhub:recordings:retentionDays";
+
+function loadRetention(): number | null {
+  const raw = localStorage.getItem(RETENTION_KEY);
+  const days = raw ? Number(raw) : NaN;
+  return Number.isFinite(days) && days > 0 ? days : null;
+}
+
+interface RecordingsState {
+  recordings: RecordingMeta[];
+  loading: boolean;
+  /** Auto-delete recordings older than this many days; null = keep forever. */
+  retentionDays: number | null;
+  /** A just-finished recording surfaced in the post-session snackbar. */
+  notice: RecordingMeta | null;
+  refresh: () => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  clearAll: () => Promise<void>;
+  setRetentionDays: (days: number | null) => void;
+  download: (meta: RecordingMeta) => Promise<void>;
+  /** Called when a recording is finalized: refresh the list + raise a notice. */
+  notify: (meta: RecordingMeta) => void;
+  clearNotice: () => void;
+}
+
+export const useRecordingsStore = create<RecordingsState>((set, get) => ({
+  recordings: [],
+  loading: false,
+  retentionDays: loadRetention(),
+  notice: null,
+
+  refresh: async () => {
+    set({ loading: true });
+    try {
+      const { retentionDays } = get();
+      if (retentionDays) await pruneRecordings(retentionDays);
+      set({ recordings: await listRecordings() });
+    } finally {
+      set({ loading: false });
+    }
+  },
+
+  remove: async (id) => {
+    await deleteRecording(id);
+    set((s) => ({ recordings: s.recordings.filter((r) => r.id !== id) }));
+  },
+
+  clearAll: async () => {
+    await clearRecordings();
+    set({ recordings: [] });
+  },
+
+  setRetentionDays: (days) => {
+    if (days && days > 0) localStorage.setItem(RETENTION_KEY, String(days));
+    else localStorage.removeItem(RETENTION_KEY);
+    set({ retentionDays: days && days > 0 ? days : null });
+    void get().refresh();
+  },
+
+  download: async (meta) => {
+    await downloadRecording(meta);
+  },
+
+  notify: (meta) => {
+    set({ notice: meta });
+    void get().refresh();
+  },
+
+  clearNotice: () => set({ notice: null }),
+}));

--- a/ui/apps/console/src/stores/terminalStore.ts
+++ b/ui/apps/console/src/stores/terminalStore.ts
@@ -16,6 +16,8 @@ export interface TerminalSession {
   passphrase?: string;
   state: TerminalWindowState;
   connectionStatus: ConnectionStatus;
+  /** Opt-in: record this session client-side (to OPFS). */
+  record?: boolean;
 }
 
 export interface ReconnectTarget {

--- a/ui/apps/console/src/utils/recordings.ts
+++ b/ui/apps/console/src/utils/recordings.ts
@@ -1,0 +1,336 @@
+import { format } from "date-fns";
+import { generateRandomUUID } from "@/utils/random-uuid";
+
+// Client-side web-terminal session recording (Community Edition). Captures the
+// terminal output to an asciinema v2 (.cast) file streamed into the browser's
+// OPFS (Origin Private File System) — no server storage, no folder picker,
+// bounded memory. Recordings are listed in an in-app manager and exported via a
+// normal browser download.
+
+/** OPFS subdirectory holding `<id>.cast` payloads and `<id>.json` sidecars. */
+const DIR = "session-recordings";
+
+export interface RecordingMeta {
+  /** OPFS basename (uuid). */
+  id: string;
+  /** Friendly filename used for the browser download. */
+  filename: string;
+  deviceName: string;
+  /** Device UID — used to pair a local recording with its server session. */
+  deviceUid: string;
+  /** SSH username the session connected with. */
+  username: string;
+  /**
+   * Server session UID, when known. Lets a local recording dedupe exactly
+   * against its server-side counterpart. Absent until the server reports it.
+   */
+  sessionUid?: string;
+  /** Initial terminal dimensions (asciicast header). */
+  width: number;
+  height: number;
+  /** Recording length in seconds. */
+  durationSec: number;
+  /** Session start, epoch milliseconds. */
+  createdAt: number;
+  /** Size of the .cast payload in bytes (filled when listing). */
+  size: number;
+}
+
+function headerLine(cols: number, rows: number): string {
+  return `${JSON.stringify({
+    version: 2,
+    width: cols,
+    height: rows,
+    timestamp: Math.floor(Date.now() / 1000),
+  })}\n`;
+}
+
+function outputLine(elapsed: number, text: string): string {
+  return `${JSON.stringify([elapsed, "o", text])}\n`;
+}
+
+function resizeLine(elapsed: number, cols: number, rows: number): string {
+  return `${JSON.stringify([elapsed, "r", `${cols}x${rows}`])}\n`;
+}
+
+/** True when the browser can stream recordings to OPFS (the only backend). */
+export function isRecordingSupported(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    typeof navigator.storage?.getDirectory === "function" &&
+    typeof FileSystemFileHandle !== "undefined" &&
+    typeof FileSystemFileHandle.prototype.createWritable === "function"
+  );
+}
+
+// OPFS is scoped per browser origin, not per authenticated user, so recordings
+// are namespaced under the signed-in user's id: a second user on the same
+// profile never sees or can replay another user's recordings, even within a
+// shared namespace. Set by authStore as the session changes.
+let userScope: string | null = null;
+
+export function setRecordingsScope(userId: string | null): void {
+  userScope = userId;
+}
+
+async function recordingsDir(): Promise<FileSystemDirectoryHandle> {
+  if (!userScope) throw new Error("session recording: no user scope set");
+  const root = await navigator.storage.getDirectory();
+  const base = await root.getDirectoryHandle(DIR, { create: true });
+  return base.getDirectoryHandle(userScope, { create: true });
+}
+
+/** Build a filesystem-safe `.cast` download name for a device. */
+export function castFilename(deviceName: string): string {
+  const slug = (deviceName || "session")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `shellhub-${slug || "session"}-${format(new Date(), "yyyyMMdd-HHmmss")}.cast`;
+}
+
+/** Trigger a normal browser download (lands in the default Downloads dir). */
+export function downloadCast(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Streams a terminal recording to an OPFS file. Created via `create()` (async,
+ * opens the writable); `start()` writes the header; output/resize append event
+ * lines; `finish()` closes the file and writes the sidecar metadata.
+ */
+export class OpfsCastRecorder {
+  private startMs = 0;
+  private started = false;
+  private count = 0;
+  private failed = false;
+  private chain: Promise<void> = Promise.resolve();
+  private cols = 80;
+  private rows = 24;
+  private lastElapsed = 0;
+
+  private constructor(
+    private readonly id: string,
+    // Captured at create() so finalize/cleanup survive a userScope change (e.g.
+    // logout nulls the scope before the unmount runs finish()).
+    private readonly dir: FileSystemDirectoryHandle,
+    private readonly writable: FileSystemWritableFileStream,
+    private readonly deviceName: string,
+    private readonly deviceUid: string,
+    private readonly username: string,
+    private sessionUid?: string,
+  ) {}
+
+  static async create(
+    deviceName: string,
+    deviceUid: string,
+    username: string,
+    sessionUid?: string,
+  ): Promise<OpfsCastRecorder> {
+    const dir = await recordingsDir();
+    const id = generateRandomUUID();
+    const handle = await dir.getFileHandle(`${id}.cast`, { create: true });
+    const writable = await handle.createWritable();
+    return new OpfsCastRecorder(
+      id,
+      dir,
+      writable,
+      deviceName,
+      deviceUid,
+      username,
+      sessionUid,
+    );
+  }
+
+  /** Record the server session UID once the server reports it. */
+  setSessionUid(uid: string): void {
+    this.sessionUid = uid;
+  }
+
+  start(cols: number, rows: number): void {
+    if (this.started) return;
+    this.started = true;
+    this.startMs = Date.now();
+    this.cols = cols;
+    this.rows = rows;
+    this.write(headerLine(cols, rows));
+  }
+
+  recordOutput(text: string): void {
+    if (!this.started || this.failed) return;
+    this.count += 1;
+    this.lastElapsed = this.elapsed();
+    this.write(outputLine(this.lastElapsed, text));
+  }
+
+  recordResize(cols: number, rows: number): void {
+    if (!this.started || this.failed) return;
+    this.count += 1;
+    this.lastElapsed = this.elapsed();
+    this.write(resizeLine(this.lastElapsed, cols, rows));
+  }
+
+  get eventCount(): number {
+    return this.count;
+  }
+
+  /** Close the file and persist sidecar metadata. Returns null if empty. */
+  async finish(): Promise<RecordingMeta | null> {
+    try {
+      await this.chain;
+      await this.writable.close();
+    } catch (err) {
+      console.error("session recording: failed to close file", err);
+      return null;
+    }
+    if (this.count === 0) {
+      await this.removeFiles();
+      return null;
+    }
+    const meta: RecordingMeta = {
+      id: this.id,
+      filename: castFilename(this.deviceName),
+      deviceName: this.deviceName,
+      deviceUid: this.deviceUid,
+      username: this.username,
+      sessionUid: this.sessionUid,
+      width: this.cols,
+      height: this.rows,
+      durationSec: this.lastElapsed,
+      createdAt: this.startMs,
+      size: 0,
+    };
+    try {
+      const sidecar = await this.dir.getFileHandle(`${this.id}.json`, {
+        create: true,
+      });
+      const w = await sidecar.createWritable();
+      await w.write(JSON.stringify(meta));
+      await w.close();
+    } catch (err) {
+      console.error("session recording: failed to write metadata", err);
+    }
+    return meta;
+  }
+
+  /** Drop the file without keeping it (throwaway StrictMode remount, etc.). */
+  async discard(): Promise<void> {
+    this.failed = true;
+    try {
+      await this.writable.abort();
+    } catch {
+      // best-effort
+    }
+    await this.removeFiles();
+  }
+
+  private elapsed(): number {
+    return (Date.now() - this.startMs) / 1000;
+  }
+
+  private write(line: string): void {
+    this.chain = this.chain
+      .then(() => this.writable.write(line))
+      .catch((err) => {
+        if (!this.failed) {
+          this.failed = true;
+          console.error("session recording: write failed", err);
+        }
+      });
+  }
+
+  private async removeFiles(): Promise<void> {
+    try {
+      await this.dir.removeEntry(`${this.id}.cast`).catch(() => undefined);
+      await this.dir.removeEntry(`${this.id}.json`).catch(() => undefined);
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/** List stored recordings, newest first. Empty when OPFS is unsupported. */
+export async function listRecordings(): Promise<RecordingMeta[]> {
+  if (!isRecordingSupported() || !userScope) return [];
+  const dir = await recordingsDir();
+  const metas: RecordingMeta[] = [];
+  // `entries()` is an async iterator over [name, handle] pairs.
+  const entries = (
+    dir as unknown as {
+      entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+    }
+  ).entries();
+  for await (const [name, handle] of entries) {
+    if (!name.endsWith(".json") || handle.kind !== "file") continue;
+    try {
+      const metaFile = await (handle as FileSystemFileHandle).getFile();
+      const meta = JSON.parse(await metaFile.text()) as RecordingMeta;
+      const castHandle = await dir.getFileHandle(`${meta.id}.cast`);
+      meta.size = (await castHandle.getFile()).size;
+      metas.push(meta);
+    } catch {
+      // Skip orphaned/corrupt sidecars (e.g. .cast was removed).
+    }
+  }
+  return metas.sort((a, b) => b.createdAt - a.createdAt);
+}
+
+/** Read a recording's bytes and trigger a browser download. */
+export async function downloadRecording(meta: RecordingMeta): Promise<void> {
+  const dir = await recordingsDir();
+  const handle = await dir.getFileHandle(`${meta.id}.cast`);
+  const file = await handle.getFile();
+  downloadCast(
+    new Blob([await file.arrayBuffer()], { type: "application/x-asciicast" }),
+    meta.filename,
+  );
+}
+
+/** Read a recording's .cast content as a string (for inline playback). */
+export async function readRecording(meta: RecordingMeta): Promise<string> {
+  const dir = await recordingsDir();
+  const handle = await dir.getFileHandle(`${meta.id}.cast`);
+  return (await handle.getFile()).text();
+}
+
+/** Delete a recording (payload + sidecar). */
+export async function deleteRecording(id: string): Promise<void> {
+  const dir = await recordingsDir();
+  await dir.removeEntry(`${id}.cast`).catch(() => undefined);
+  await dir.removeEntry(`${id}.json`).catch(() => undefined);
+}
+
+/** Delete every stored recording (payloads + sidecars). */
+export async function clearRecordings(): Promise<void> {
+  if (!isRecordingSupported() || !userScope) return;
+  const dir = await recordingsDir();
+  const names: string[] = [];
+  const entries = (
+    dir as unknown as {
+      entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+    }
+  ).entries();
+  for await (const [name, handle] of entries) {
+    if (handle.kind === "file") names.push(name);
+  }
+  await Promise.all(
+    names.map((n) => dir.removeEntry(n).catch(() => undefined)),
+  );
+}
+
+/** Delete recordings whose start time is older than `maxAgeDays`. */
+export async function pruneRecordings(maxAgeDays: number): Promise<void> {
+  if (!isRecordingSupported() || !userScope || maxAgeDays <= 0) return;
+  const cutoff = Date.now() - maxAgeDays * 86_400_000;
+  const metas = await listRecordings();
+  await Promise.all(
+    metas.filter((m) => m.createdAt < cutoff).map((m) => deleteRecording(m.id)),
+  );
+}


### PR DESCRIPTION
## What

Adds session recording to the web terminal: sessions opened from the console can be captured and replayed later.

## Recording

- **Local recording** (Community): the web terminal streams the session to the browser (OPFS, asciicast) with no server storage, so self-hosted users get replay for free. Opt-in from the Connect drawer (on by default), skipped when the namespace already records server-side. Recordings are namespaced per signed-in user, so a shared browser profile never exposes one user's recording to another.
- **Advanced Session Recording** (Cloud/Enterprise): the existing server-side recording, gated by the namespace `session_record` setting.

The web terminal also learns the server session uid over an SSH global request (`session-uid@shellhub.io`) so a local recording can be paired to its session.

## Where recordings play

A recording is an attribute of a session, not a place of its own, so playback moved into the Sessions list and the standalone Recordings page is removed. Per shell session:

- Play uses the local copy when present, otherwise the server recording.
- On Community, a session with no recording opens an upsell for Advanced Session Recording; on Cloud and Enterprise it shows Play disabled.
- Local playback needs no `session:play` permission (it is the user's own browser data, scoped to them); server playback still requires it.

## Supporting changes

- A `sessions.web` flag (migration `008`) and a Web/SSH origin column, so a web-originated session is identifiable. The SSH server sets the flag for web-terminal connections.

## Notes

- Local retention moved out with the Recordings page; cleanup defaults to never and will get a dedicated settings page later.
- Migration is numbered `008` against master; renumber if another migration lands there first.
