### PR TITLE
refactor(ui): extract GlowOrbs backdrop into design-system

### DIFF
--- a/ui/apps/console/src/components/common/AmbientBackground.tsx
+++ b/ui/apps/console/src/components/common/AmbientBackground.tsx
@@ -1,4 +1,4 @@
-import { ConnectionGrid } from "@shellhub/design-system/components";
+import { ConnectionGrid, GlowOrbs } from "@shellhub/design-system/components";
 
 interface AmbientBackgroundProps {
   variant?: "default" | "error";
@@ -11,24 +11,7 @@ export default function AmbientBackground({
 
   return (
     <div className="absolute inset-0 overflow-hidden pointer-events-none">
-      {/* Gradient blobs */}
-      <div
-        className={`absolute -top-32 -left-32 w-[500px] h-[500px] rounded-full blur-[120px] animate-pulse-subtle ${
-          isError ? "bg-accent-red/[0.06]" : "bg-primary/10"
-        }`}
-      />
-      <div
-        className={`absolute -bottom-48 -right-32 w-[400px] h-[400px] rounded-full blur-[100px] animate-pulse-subtle ${
-          isError ? "bg-primary/[0.04]" : "bg-accent-cyan/8"
-        }`}
-        style={{ animationDelay: "1s" }}
-      />
-      <div
-        className={`absolute top-1/3 right-1/4 w-[300px] h-[300px] rounded-full blur-[80px] animate-pulse-subtle ${
-          isError ? "bg-accent-red/[0.03]" : "bg-accent-blue/5"
-        }`}
-        style={{ animationDelay: "2s" }}
-      />
+      <GlowOrbs preset="ambient" tone={isError ? "error" : "brand"} />
 
       <ConnectionGrid />
 

--- a/ui/apps/console/src/components/common/EmptyState.tsx
+++ b/ui/apps/console/src/components/common/EmptyState.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useId } from "react";
 import { IconBadge } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 
 export type EmptyStateAccent = "primary" | "yellow";
 
@@ -28,8 +29,6 @@ interface AccentStyles {
   badge: string;
   icon: string;
   overline: string;
-  orbPrimary: string;
-  orbSecondary: string;
 }
 
 /**
@@ -37,22 +36,19 @@ interface AccentStyles {
  * the Tailwind JIT keeps them. The hero icon inherits the badge's text color
  * via `currentColor`; feature-card icons stay primary-accented in all variants.
  * Typed as `Record<EmptyStateAccent, …>` so adding an accent without a matching
- * entry is a compile error rather than a runtime `undefined`.
+ * entry is a compile error rather than a runtime `undefined`. The decorative
+ * orbs are driven by `<GlowOrbs preset="ambient">` (see below), not these tokens.
  */
 const ACCENT = {
   primary: {
     badge: "bg-primary/10 border-primary/20 shadow-primary/5",
     icon: "text-primary",
     overline: "text-primary/80",
-    orbPrimary: "bg-primary/5",
-    orbSecondary: "bg-accent-blue/5",
   },
   yellow: {
     badge: "bg-accent-yellow/10 border-accent-yellow/20 shadow-accent-yellow/5",
     icon: "text-accent-yellow",
     overline: "text-accent-yellow/80",
-    orbPrimary: "bg-accent-yellow/5",
-    orbSecondary: "bg-primary/5",
   },
 } satisfies Record<EmptyStateAccent, AccentStyles>;
 
@@ -86,12 +82,9 @@ export default function EmptyState({
         aria-hidden="true"
         className="absolute inset-0 overflow-hidden pointer-events-none -mx-8 -mt-8 -mb-4"
       >
-        <div
-          className={`absolute -top-32 left-1/3 w-[500px] h-[500px] rounded-full blur-[120px] animate-pulse-subtle ${styles.orbPrimary}`}
-        />
-        <div
-          className={`absolute bottom-0 right-1/4 w-[400px] h-[400px] rounded-full blur-[100px] animate-pulse-subtle ${styles.orbSecondary}`}
-          style={{ animationDelay: "1s" }}
+        <GlowOrbs
+          preset="ambient"
+          tone={accent === "yellow" ? "warning" : "brand"}
         />
         <div className="absolute inset-0 grid-bg opacity-30" />
       </div>
@@ -123,9 +116,7 @@ export default function EmptyState({
 
         {/* Feature highlights */}
         {features?.length ? (
-          <ul
-            className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-10"
-          >
+          <ul className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-10">
             {features.map((feature, idx) => (
               <li
                 key={feature.title}

--- a/ui/apps/console/src/components/common/PageHeader.tsx
+++ b/ui/apps/console/src/components/common/PageHeader.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { IconBadge, type Palette } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 
 interface PageHeaderProps {
   icon: ReactNode;
@@ -28,12 +29,7 @@ export default function PageHeader({
           : "bg-surface page-header-band"
       }`}
     >
-      {variant === "decorated" && (
-        <>
-          <div className="absolute inset-0 bg-gradient-to-br from-primary/15 via-surface to-accent-cyan/10" />
-          <div className="absolute top-0 right-0 w-60 h-60 bg-primary/10 rounded-full blur-2xl -translate-y-1/3 translate-x-1/4" />
-        </>
-      )}
+      {variant === "decorated" && <GlowOrbs preset="corner" tone="primary" />}
 
       <div
         className={`${variant === "decorated" ? "relative " : ""}flex flex-col sm:flex-row sm:items-center justify-between gap-4`}

--- a/ui/apps/console/src/components/common/WelcomeScreen.tsx
+++ b/ui/apps/console/src/components/common/WelcomeScreen.tsx
@@ -7,7 +7,7 @@ import {
   ArrowRightIcon,
   BookOpenIcon,
 } from "@heroicons/react/24/outline";
-import { ConnectionGrid } from "@shellhub/design-system/components";
+import { ConnectionGrid, GlowOrbs } from "@shellhub/design-system/components";
 import { GithubIcon, IconBadge } from "@shellhub/design-system/primitives";
 
 interface WelcomeScreenProps {
@@ -49,9 +49,7 @@ export default function WelcomeScreen({ namespaceName }: WelcomeScreenProps) {
       {/* Hero */}
       <div className="relative pt-16 pb-12 overflow-hidden">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-primary/10 via-transparent to-transparent" />
-        <div className="absolute top-10 left-1/4 w-96 h-96 bg-primary/8 rounded-full blur-3xl" />
-        <div className="absolute bottom-0 right-1/4 w-72 h-72 bg-accent-cyan/6 rounded-full blur-3xl" />
+        <GlowOrbs preset="duo" tone="primary" />
 
         <div className="relative text-center max-w-lg mx-auto">
           <div className="animate-float mb-8 inline-block">

--- a/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
+++ b/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { Badge, Button } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ConnectionGrid } from "../landing/components";
 
@@ -7,8 +8,7 @@ export function HeroEnterprise() {
   return (
     <section className="relative pt-32 pb-24 overflow-hidden">
       <ConnectionGrid />
-      <div className="absolute inset-0 bg-gradient-radial from-primary/8 via-transparent to-transparent pointer-events-none" />
-      <div className="absolute top-1/3 right-1/4 w-96 h-96 bg-primary/6 rounded-full blur-3xl pointer-events-none" />
+      <GlowOrbs preset="section" tone="primary" />
 
       <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
         <Reveal>

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import {
   CheckIcon,
   PlayCircleIcon,
@@ -64,8 +65,7 @@ function Hero() {
   return (
     <section className="relative pt-32 pb-24 overflow-hidden">
       <ConnectionGrid />
-      <div className="absolute inset-0 bg-gradient-radial from-primary/8 via-transparent to-transparent pointer-events-none" />
-      <div className="absolute top-1/4 left-1/3 w-[500px] h-[500px] bg-accent-cyan/5 rounded-full blur-3xl pointer-events-none" />
+      <GlowOrbs preset="section" tone="cyan" />
 
       <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
         <Reveal>

--- a/ui/apps/website/src/pages/getting-started/StepPath.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepPath.tsx
@@ -4,6 +4,7 @@ import {
   BuildingOffice2Icon,
   ServerIcon,
 } from "@heroicons/react/24/outline";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import {
   Badge,
   Button,
@@ -27,8 +28,7 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
         <Reveal delay={0}>
           <ShimmerCard className="h-full">
             <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.15)] overflow-hidden">
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.08] via-primary/[0.02] to-transparent pointer-events-none" />
-              <div className="absolute top-0 right-0 w-40 h-40 bg-primary/[0.08] rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl pointer-events-none" />
+              <GlowOrbs preset="corner" tone="primary" />
               <div className="relative flex items-center gap-3 mb-4">
                 <IconBadge
                   color="primary"

--- a/ui/apps/website/src/pages/getting-started/index.tsx
+++ b/ui/apps/website/src/pages/getting-started/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { ConnectionGrid } from "@shellhub/design-system/components";
+import { ConnectionGrid, GlowOrbs } from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import { StepPath } from "./StepPath";
 import { StepSetup } from "./StepSetup";
@@ -21,7 +21,7 @@ export default function GettingStarted() {
     <SiteLayout className="flex flex-col">
       <main className="flex-1 flex flex-col items-center pt-24 pb-20 relative grid-bg">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-primary/10 via-transparent to-transparent pointer-events-none" />
+        <GlowOrbs preset="section" tone="primary" />
 
         <div className="relative z-10 w-full max-w-4xl flex flex-col items-center">
           {/* Progress indicator */}

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -17,6 +17,7 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
@@ -100,8 +101,7 @@ export default function HowItWorks() {
       {/* ── Hero ─────────────────────────────────────────────────── */}
       <section className="relative pt-32 pb-24 overflow-hidden">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-primary/8 via-transparent to-transparent pointer-events-none" />
-        <div className="absolute top-1/3 left-1/4 w-96 h-96 bg-accent-cyan/6 rounded-full blur-3xl pointer-events-none" />
+        <GlowOrbs preset="section" tone="cyan" />
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -20,6 +20,7 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
@@ -67,8 +68,7 @@ export default function Integrations() {
       {/* ─────────── Hero ─────────── */}
       <section className="relative pt-32 pb-24 overflow-hidden">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-primary/8 via-transparent to-transparent pointer-events-none" />
-        <div className="absolute top-1/3 left-1/4 w-96 h-96 bg-accent-cyan/6 rounded-full blur-3xl pointer-events-none" />
+        <GlowOrbs preset="section" tone="cyan" />
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>

--- a/ui/apps/website/src/pages/landing/CTA.tsx
+++ b/ui/apps/website/src/pages/landing/CTA.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { Section } from "@/components/marketing";
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ConnectionGrid } from "./components";
@@ -12,9 +13,7 @@ export function CTA() {
       className="text-center grid-bg relative overflow-hidden"
     >
       <ConnectionGrid />
-      <div className="absolute inset-0 bg-gradient-radial from-primary/8 via-transparent to-transparent pointer-events-none" />
-      <div className="absolute top-1/2 left-1/3 -translate-y-1/2 w-80 h-80 bg-primary/6 rounded-full blur-3xl pointer-events-none" />
-      <div className="absolute bottom-0 right-1/4 w-64 h-64 bg-accent-cyan/5 rounded-full blur-3xl pointer-events-none" />
+      <GlowOrbs preset="duo" tone="primary" />
       <div className="max-w-7xl mx-auto px-8 relative z-10">
         <Reveal>
           <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">

--- a/ui/apps/website/src/pages/landing/Hero.tsx
+++ b/ui/apps/website/src/pages/landing/Hero.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { Button, ShellHubCloudIcon } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { ConnectionGrid } from "./components";
 
@@ -7,10 +8,7 @@ export function Hero() {
   return (
     <section className="min-h-screen flex flex-col items-center justify-center text-center px-6 pt-28 pb-20 relative overflow-hidden grid-bg">
       <ConnectionGrid />
-      <div className="absolute inset-0 bg-gradient-radial from-primary/10 via-transparent to-transparent pointer-events-none" />
-      <div className="absolute top-16 left-1/4 w-[500px] h-[500px] bg-primary/8 rounded-full blur-3xl pointer-events-none" />
-      <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-accent-cyan/6 rounded-full blur-3xl pointer-events-none" />
-      <div className="absolute top-1/3 right-[10%] w-72 h-72 bg-primary/5 rounded-full blur-3xl pointer-events-none" />
+      <GlowOrbs preset="hero" />
 
       <div className="relative z-10 max-w-4xl flex flex-col items-center">
         {/* Floating ShellHub cloud */}

--- a/ui/apps/website/src/pages/pricing/HeroPricing.tsx
+++ b/ui/apps/website/src/pages/pricing/HeroPricing.tsx
@@ -1,9 +1,10 @@
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { Reveal } from "../landing/components";
 
 export function HeroPricing() {
   return (
-    <section className="relative pt-32 pb-16">
-      <div className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[600px] h-[600px] bg-primary/5 rounded-full blur-3xl pointer-events-none" />
+    <section className="relative pt-32 pb-16 overflow-hidden">
+      <GlowOrbs preset="section" tone="primary" />
 
       <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
         <Reveal>
@@ -13,7 +14,8 @@ export function HeroPricing() {
         </Reveal>
         <Reveal>
           <p className="text-sm text-text-secondary max-w-md mx-auto leading-relaxed">
-            Start free with the Community edition. Scale up as your team and fleet grow.
+            Start free with the Community edition. Scale up as your team and
+            fleet grow.
           </p>
         </Reveal>
       </div>

--- a/ui/apps/website/src/pages/pricing/TierCards.tsx
+++ b/ui/apps/website/src/pages/pricing/TierCards.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { Button } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { Section } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
@@ -83,10 +84,7 @@ export function TierCards() {
                 }`}
               >
                 {tier.highlighted && (
-                  <>
-                    <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.08] via-primary/[0.02] to-transparent pointer-events-none" />
-                    <div className="absolute top-0 right-0 w-40 h-40 bg-primary/[0.08] rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl pointer-events-none" />
-                  </>
+                  <GlowOrbs preset="corner" tone="primary" />
                 )}
 
                 <div className="relative">

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -16,6 +16,7 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
@@ -465,8 +466,7 @@ export default function ContainerManagement() {
       {/* ═══════ Hero ═══════ */}
       <section className="relative pt-32 pb-24 overflow-hidden">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-accent-cyan/8 via-transparent to-transparent pointer-events-none" />
-        <div className="absolute top-1/3 right-1/4 w-96 h-96 bg-accent-cyan/6 rounded-full blur-3xl pointer-events-none" />
+        <GlowOrbs preset="section" tone="cyan" />
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -15,6 +15,7 @@ import {
   Card,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
@@ -232,8 +233,7 @@ export default function DevopsCiCd() {
       {/* ── Hero ─────────────────────────────────────────────────── */}
       <section className="relative pt-32 pb-24 overflow-hidden">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-primary/8 via-transparent to-transparent pointer-events-none" />
-        <div className="absolute top-1/3 right-1/4 w-96 h-96 bg-primary/6 rounded-full blur-3xl pointer-events-none" />
+        <GlowOrbs preset="section" tone="primary" />
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -18,6 +18,7 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { SiteLayout } from "@/components/SiteLayout";
@@ -169,8 +170,7 @@ export default function EdgeComputing() {
       {/* ───── Hero ───── */}
       <section className="relative pt-32 pb-24 overflow-hidden">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-accent-blue/8 via-transparent to-transparent pointer-events-none" />
-        <div className="absolute top-1/3 right-1/4 w-96 h-96 bg-accent-blue/6 rounded-full blur-3xl pointer-events-none" />
+        <GlowOrbs preset="section" tone="blue" />
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -19,6 +19,7 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
@@ -114,8 +115,7 @@ export default function IotEmbedded() {
       {/* ═══════ Hero ═══════ */}
       <section className="relative pt-32 pb-24 overflow-hidden">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-accent-green/8 via-transparent to-transparent pointer-events-none" />
-        <div className="absolute top-1/3 left-1/4 w-96 h-96 bg-accent-green/6 rounded-full blur-3xl pointer-events-none" />
+        <GlowOrbs preset="section" tone="green" />
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -15,6 +15,7 @@ import {
   Card,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
@@ -161,8 +162,7 @@ export default function RemoteSupport() {
       {/* ── Hero ──────────────────────────────────────────────────── */}
       <section className="relative pt-32 pb-24 overflow-hidden">
         <ConnectionGrid />
-        <div className="absolute inset-0 bg-gradient-radial from-primary/8 via-transparent to-transparent pointer-events-none" />
-        <div className="absolute top-1/3 right-1/4 w-96 h-96 bg-accent-yellow/6 rounded-full blur-3xl pointer-events-none" />
+        <GlowOrbs preset="section" tone="yellow" />
 
         <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
           <Reveal>

--- a/ui/packages/design-system/__tests__/GlowOrbs.test.tsx
+++ b/ui/packages/design-system/__tests__/GlowOrbs.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { GlowOrbs } from "../components/GlowOrbs";
+
+describe("GlowOrbs", () => {
+  it.each([
+    { name: "hero", element: <GlowOrbs preset="hero" /> },
+    { name: "duo/primary", element: <GlowOrbs preset="duo" tone="primary" /> },
+    {
+      name: "section/primary",
+      element: <GlowOrbs preset="section" tone="primary" />,
+    },
+    {
+      name: "corner/primary",
+      element: <GlowOrbs preset="corner" tone="primary" />,
+    },
+    {
+      name: "ambient/brand",
+      element: <GlowOrbs preset="ambient" tone="brand" />,
+    },
+  ])("renders an aria-hidden, roleless root div for $name", ({ element }) => {
+    const { container } = render(element);
+    const root = container.firstElementChild;
+
+    expect(root).not.toBeNull();
+    expect(root).toHaveAttribute("aria-hidden", "true");
+    expect(root).not.toHaveAttribute("role");
+  });
+});

--- a/ui/packages/design-system/components/GlowOrbs.tsx
+++ b/ui/packages/design-system/components/GlowOrbs.tsx
@@ -1,0 +1,204 @@
+import type { CSSProperties } from "react";
+import { cn } from "../primitives/cn";
+
+export type GlowOrbsPreset = "hero" | "duo" | "section" | "corner" | "ambient";
+
+/** Solid-fill tones for the static presets (hero/duo/section/corner). */
+export type GlowOrbsTone = "primary" | "cyan" | "blue" | "green" | "yellow";
+
+/** Ambient recolors all three pulsing orbs together as a named set. */
+export type GlowOrbsAmbientTone = "brand" | "error" | "warning";
+
+export type GlowOrbsProps =
+  | { preset: "hero"; tone?: GlowOrbsTone; className?: string }
+  | {
+      preset: "duo" | "section" | "corner";
+      tone: GlowOrbsTone;
+      className?: string;
+    }
+  | { preset: "ambient"; tone: GlowOrbsAmbientTone; className?: string };
+
+type Layer = { className: string; style?: CSSProperties };
+
+// Tailwind only emits classes it finds spelled out in source, so each tone's color utilities are
+// listed as complete literals here; the geometry shared across tones lives in the layer builders.
+const HERO: Record<GlowOrbsTone, { wash: string; lg: string; sm: string }> = {
+  primary: { wash: "from-primary/10", lg: "bg-primary/8", sm: "bg-primary/5" },
+  cyan: {
+    wash: "from-accent-cyan/10",
+    lg: "bg-accent-cyan/8",
+    sm: "bg-accent-cyan/5",
+  },
+  blue: {
+    wash: "from-accent-blue/10",
+    lg: "bg-accent-blue/8",
+    sm: "bg-accent-blue/5",
+  },
+  green: {
+    wash: "from-accent-green/10",
+    lg: "bg-accent-green/8",
+    sm: "bg-accent-green/5",
+  },
+  yellow: {
+    wash: "from-accent-yellow/10",
+    lg: "bg-accent-yellow/8",
+    sm: "bg-accent-yellow/5",
+  },
+};
+
+const DUO: Record<GlowOrbsTone, { wash: string; orb: string }> = {
+  primary: { wash: "from-primary/8", orb: "bg-primary/8" },
+  cyan: { wash: "from-accent-cyan/8", orb: "bg-accent-cyan/8" },
+  blue: { wash: "from-accent-blue/8", orb: "bg-accent-blue/8" },
+  green: { wash: "from-accent-green/8", orb: "bg-accent-green/8" },
+  yellow: { wash: "from-accent-yellow/8", orb: "bg-accent-yellow/8" },
+};
+
+const SECTION: Record<GlowOrbsTone, { wash: string; orb: string }> = {
+  primary: { wash: "from-primary/8", orb: "bg-primary/6" },
+  cyan: { wash: "from-accent-cyan/8", orb: "bg-accent-cyan/6" },
+  blue: { wash: "from-accent-blue/8", orb: "bg-accent-blue/6" },
+  green: { wash: "from-accent-green/8", orb: "bg-accent-green/6" },
+  yellow: { wash: "from-accent-yellow/8", orb: "bg-accent-yellow/6" },
+};
+
+const CORNER: Record<GlowOrbsTone, { from: string; via: string; orb: string }> =
+  {
+    primary: {
+      from: "from-primary/[0.08]",
+      via: "via-primary/[0.02]",
+      orb: "bg-primary/[0.08]",
+    },
+    cyan: {
+      from: "from-accent-cyan/[0.08]",
+      via: "via-accent-cyan/[0.02]",
+      orb: "bg-accent-cyan/[0.08]",
+    },
+    blue: {
+      from: "from-accent-blue/[0.08]",
+      via: "via-accent-blue/[0.02]",
+      orb: "bg-accent-blue/[0.08]",
+    },
+    green: {
+      from: "from-accent-green/[0.08]",
+      via: "via-accent-green/[0.02]",
+      orb: "bg-accent-green/[0.08]",
+    },
+    yellow: {
+      from: "from-accent-yellow/[0.08]",
+      via: "via-accent-yellow/[0.02]",
+      orb: "bg-accent-yellow/[0.08]",
+    },
+  };
+
+// Ambient recolors all three orbs together; opacity descends with orb size.
+const AMBIENT: Record<GlowOrbsAmbientTone, [string, string, string]> = {
+  brand: ["bg-primary/10", "bg-accent-cyan/8", "bg-accent-blue/5"],
+  error: ["bg-accent-red/[0.06]", "bg-primary/[0.04]", "bg-accent-red/[0.03]"],
+  warning: ["bg-accent-yellow/10", "bg-primary/8", "bg-accent-blue/5"],
+};
+
+const WASH =
+  "absolute inset-0 bg-gradient-radial via-transparent to-transparent";
+const ORB = "absolute rounded-full blur-3xl";
+
+// Ambient orbs use pixel blurs and stagger their pulse so the set doesn't breathe in lockstep.
+const AMBIENT_ORBS = [
+  {
+    geometry: "-top-32 -left-32 w-[500px] h-[500px] blur-[120px]",
+    delay: "0s",
+  },
+  {
+    geometry: "-bottom-48 -right-32 w-[400px] h-[400px] blur-[100px]",
+    delay: "1s",
+  },
+  {
+    geometry: "top-1/3 right-1/4 w-[300px] h-[300px] blur-[80px]",
+    delay: "2s",
+  },
+] as const;
+
+function layersFor(props: GlowOrbsProps): Layer[] {
+  switch (props.preset) {
+    case "hero": {
+      const c = HERO[props.tone ?? "primary"];
+      return [
+        { className: cn(WASH, c.wash) },
+        { className: cn(ORB, "top-16 left-1/4 w-[500px] h-[500px]", c.lg) },
+        { className: cn(ORB, "bottom-0 right-1/4 w-96 h-96 bg-accent-cyan/6") },
+        { className: cn(ORB, "top-1/3 right-[10%] w-72 h-72", c.sm) },
+      ];
+    }
+    case "duo": {
+      const c = DUO[props.tone];
+      return [
+        { className: cn(WASH, c.wash) },
+        { className: cn(ORB, "top-1/4 left-1/4 w-96 h-96", c.orb) },
+        { className: cn(ORB, "bottom-0 right-1/4 w-72 h-72 bg-accent-cyan/6") },
+      ];
+    }
+    case "section": {
+      const c = SECTION[props.tone];
+      return [
+        { className: cn(WASH, c.wash) },
+        { className: cn(ORB, "top-1/3 right-1/4 w-96 h-96", c.orb) },
+      ];
+    }
+    case "corner": {
+      const c = CORNER[props.tone];
+      return [
+        {
+          className: cn(
+            "absolute inset-0 bg-gradient-to-br to-transparent",
+            c.from,
+            c.via,
+          ),
+        },
+        {
+          className: cn(
+            ORB,
+            "top-0 right-0 w-40 h-40 -translate-y-1/2 translate-x-1/2",
+            c.orb,
+          ),
+        },
+      ];
+    }
+    case "ambient": {
+      const colors = AMBIENT[props.tone];
+      return AMBIENT_ORBS.map(({ geometry, delay }, i) => ({
+        className: cn(
+          "absolute rounded-full animate-pulse-subtle",
+          geometry,
+          colors[i],
+        ),
+        style: { animationDelay: delay },
+      }));
+    }
+  }
+}
+
+/**
+ * Decorative blurred-orb backdrop. Each preset owns a fixed orb count, size, blur, and position;
+ * `tone` is the only per-site variable and resolves to design tokens (never a raw color). Purely
+ * ornamental — renders an `aria-hidden`, `pointer-events-none` layer meant to sit inside a
+ * `relative` container, alongside any `ConnectionGrid`/`.grid-bg` the consumer composes.
+ */
+export function GlowOrbs(props: GlowOrbsProps) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "absolute inset-0 overflow-hidden pointer-events-none",
+        props.className,
+      )}
+    >
+      {layersFor(props).map((layer) => (
+        <div
+          key={layer.className}
+          className={layer.className}
+          style={layer.style}
+        />
+      ))}
+    </div>
+  );
+}

--- a/ui/packages/design-system/components/index.ts
+++ b/ui/packages/design-system/components/index.ts
@@ -3,3 +3,9 @@ export { CopyButton } from "./CopyButton";
 export { ConnectionGrid } from "./ConnectionGrid";
 export { ShimmerCard } from "./ShimmerCard";
 export { Footer } from "./Footer";
+export { GlowOrbs } from "./GlowOrbs";
+export type {
+  GlowOrbsPreset,
+  GlowOrbsTone,
+  GlowOrbsAmbientTone,
+} from "./GlowOrbs";


### PR DESCRIPTION
## What
Replaced ~19 hand-rolled blurred-orb decorative backdrops across `apps/console` and `apps/website` with a single stateless `<GlowOrbs>` design-system primitive exposing a closed `preset` set and a token-only `tone`.

## Why
Every backdrop hand-picked its own orb count, size, blur, position, opacity, and color — the same duplication the design-system already eliminated for `Button` and `Badge`. Consolidating onto named presets makes the backdrops consistent and gives them one place to evolve. Part of shellhub-io/team#114 step 6.

## Changes
- **`packages/design-system` — new `<GlowOrbs>`**: five presets (`hero`/`duo`/`section`/`corner`/`ambient`), each owning a fixed orb count, size, blur, and position. `tone` is the only per-site variable and resolves to existing design tokens (`primary`, `accent-cyan/blue/green/yellow/red`) — no raw hex, no new tokens. Follows the `primitives/` closed-enum to class-map pattern (`Button`/`IconBadge`).
- **Type-safe API**: `GlowOrbsProps` is a discriminated union keyed on `preset`, so an ambient-only tone cannot reach a static preset (which would miss the class map and render a blank orb). `tone` is required except on `hero`.
- **Tailwind safety**: each tone's color utilities are spelled out as complete literals so the JIT never purges them; geometry is shared across tones.
- **Console/website migrations**: 19 call sites now render through `<GlowOrbs>`. `EmptyState` renders the same `ambient` preset as `AmbientBackground` instead of duplicating the orb markup locally.
- **Left inline**: `SupportedPlatforms` — its Docker-brand `#1D63ED` orb is a brand color, not a semantic token, so forcing it onto `tone` would regress it.

## Testing
Parity is at the shape/tone-family level, not pixel-identical, so some sites shift by design — worth an eyeball pass:
- **Mixed-tone sections** (`features`, `how-it-works`, `integrations`, `RemoteSupport`): these were primary-wash + accent-orb; the mono-tone preset follows the orb color, so the faint wash recolors to match.
- **`getting-started` gains an orb**, **`HeroPricing` gains a wash**, and **`EmptyState`/`WelcomeScreen`** normalize onto the shared shapes.
- `PageHeader`'s `decorated` variant has no consumer today (unrenderable in-app).
- Verified: `tsc -b` + build clean for both apps, lint clean, 197 design-system tests pass (`GlowOrbs`: 5).
