### PR TITLE
ci: pin sigstore/cosign-installer to v4.1.2

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -132,7 +132,7 @@ jobs:
           path: sbom-agent-*.cdx.json
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Attach SBOM to agent image
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,7 +65,7 @@ jobs:
           path: sbom-${{ matrix.project }}-*.cdx.json
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Attach SBOM to '${{ matrix.project }}' image
         run: |
@@ -137,7 +137,7 @@ jobs:
           path: sbom-api-enterprise-*.cdx.json
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Attach SBOM to api-enterprise image
         run: |


### PR DESCRIPTION
`sigstore/cosign-installer` does not publish a floating `v4` major tag, so `@v4` (introduced in 6cadf1b64) fails to resolve and cancels every matrix leg of `docker-publish` at the *Set up job* step. This blocked the v0.26.0-rc.1 image build. Pins to the latest concrete v4 release, `v4.1.2`.