### PR TITLE
refactor(ui): extract shared ArrowMarker and font constants from website diagrams

### DIFF
--- a/ui/apps/website/src/components/marketing/ArrowMarker.tsx
+++ b/ui/apps/website/src/components/marketing/ArrowMarker.tsx
@@ -1,0 +1,33 @@
+interface ArrowMarkerProps {
+  id: string;
+  fill: string;
+  markerWidth?: number;
+  markerHeight?: number;
+  refX?: number;
+  refY?: number;
+}
+
+export function ArrowMarker({
+  id,
+  fill,
+  markerWidth = 8,
+  markerHeight = 6,
+  refX = 8,
+  refY = 3,
+}: ArrowMarkerProps) {
+  return (
+    <marker
+      id={id}
+      markerWidth={markerWidth}
+      markerHeight={markerHeight}
+      refX={refX}
+      refY={refY}
+      orient="auto"
+    >
+      <path
+        d={`M0,0 L${markerWidth},${markerHeight / 2} L0,${markerHeight}`}
+        fill={fill}
+      />
+    </marker>
+  );
+}

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -20,8 +20,9 @@ import {
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
+import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C } from "../landing/constants";
+import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
 
 /* ------------------------------------------------------------------ */
 /*  Data                                                               */
@@ -162,43 +163,16 @@ export default function HowItWorks() {
                 className="w-full h-auto min-w-[720px]"
               >
                 <defs>
-                  <marker
-                    id="hw-a-pri"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.primary} />
-                  </marker>
-                  <marker
-                    id="hw-a-grn"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.green} />
-                  </marker>
-                  <marker
-                    id="hw-a-dim"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={`${C.primary}60`} />
-                  </marker>
+                  <ArrowMarker id="hw-a-pri" fill={C.primary} />
+                  <ArrowMarker id="hw-a-grn" fill={C.green} />
+                  <ArrowMarker id="hw-a-dim" fill={`${C.primary}60`} />
                 </defs>
 
                 {/* ── User ── */}
                 <text
                   x="70"
                   y="24"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -234,7 +208,7 @@ export default function HowItWorks() {
                 <text
                   x="70"
                   y="100"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -244,7 +218,7 @@ export default function HowItWorks() {
                 <text
                   x="70"
                   y="114"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="8"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -274,7 +248,7 @@ export default function HowItWorks() {
                 <text
                   x="189"
                   y="70"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="8"
                   fill={C.primary}
                   textAnchor="middle"
@@ -296,7 +270,7 @@ export default function HowItWorks() {
                 <text
                   x="430"
                   y="14"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="12"
                   fill={C.primary}
                   textAnchor="middle"
@@ -320,7 +294,7 @@ export default function HowItWorks() {
                 <text
                   x="430"
                   y="62"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="16"
                   fill={C.primary}
                   textAnchor="middle"
@@ -409,7 +383,7 @@ export default function HowItWorks() {
                     <text
                       x={m.x + 32}
                       y={m.y + 19}
-                      fontFamily="IBM Plex Sans"
+                      fontFamily={FONT_SANS}
                       fontSize="9"
                       fill={C.textSec}
                     >
@@ -422,7 +396,7 @@ export default function HowItWorks() {
                 <text
                   x="430"
                   y="278"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="8"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -450,7 +424,7 @@ export default function HowItWorks() {
                 <text
                   x="634"
                   y="22"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -514,7 +488,7 @@ export default function HowItWorks() {
                 <text
                   x="658"
                   y="170"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={`${C.primary}50`}
                   textAnchor="middle"
@@ -527,7 +501,7 @@ export default function HowItWorks() {
                 <text
                   x="790"
                   y="22"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -598,7 +572,7 @@ export default function HowItWorks() {
                       fontSize="9"
                       fill={d.iconBg}
                       textAnchor="middle"
-                      fontFamily="IBM Plex Mono"
+                      fontFamily={FONT_MONO}
                       fontWeight="600"
                     >
                       {d.icon === "Pi"
@@ -613,7 +587,7 @@ export default function HowItWorks() {
                     <text
                       x="736"
                       y={d.y + 24}
-                      fontFamily="IBM Plex Sans"
+                      fontFamily={FONT_SANS}
                       fontSize="10"
                       fill={C.text}
                     >
@@ -622,7 +596,7 @@ export default function HowItWorks() {
                     <text
                       x="736"
                       y={d.y + 38}
-                      fontFamily="IBM Plex Mono"
+                      fontFamily={FONT_MONO}
                       fontSize="7"
                       fill={C.textMuted}
                     >
@@ -631,7 +605,7 @@ export default function HowItWorks() {
                     <text
                       x="736"
                       y={d.y + 50}
-                      fontFamily="IBM Plex Mono"
+                      fontFamily={FONT_MONO}
                       fontSize="7"
                       fill={C.textMuted}
                     >
@@ -798,16 +772,14 @@ export default function HowItWorks() {
                         className="w-full h-auto"
                       >
                         <defs>
-                          <marker
+                          <ArrowMarker
                             id="hw-s2-a"
-                            markerWidth="7"
-                            markerHeight="5"
-                            refX="7"
-                            refY="2.5"
-                            orient="auto"
-                          >
-                            <path d="M0,0 L7,2.5 L0,5" fill={C.cyan} />
-                          </marker>
+                            fill={C.cyan}
+                            markerWidth={7}
+                            markerHeight={5}
+                            refX={7}
+                            refY={2.5}
+                          />
                         </defs>
 
                         {/* Device */}
@@ -836,7 +808,7 @@ export default function HowItWorks() {
                           fontSize="8"
                           fill={C.green}
                           textAnchor="middle"
-                          fontFamily="IBM Plex Mono"
+                          fontFamily={FONT_MONO}
                           fontWeight="600"
                         >
                           Pi
@@ -844,7 +816,7 @@ export default function HowItWorks() {
                         <text
                           x="65"
                           y="110"
-                          fontFamily="IBM Plex Sans"
+                          fontFamily={FONT_SANS}
                           fontSize="9"
                           fill={C.textSec}
                           textAnchor="middle"
@@ -854,7 +826,7 @@ export default function HowItWorks() {
                         <text
                           x="65"
                           y="124"
-                          fontFamily="IBM Plex Mono"
+                          fontFamily={FONT_MONO}
                           fontSize="7"
                           fill={C.textMuted}
                           textAnchor="middle"
@@ -890,7 +862,7 @@ export default function HowItWorks() {
                         <text
                           x="148"
                           y="34"
-                          fontFamily="IBM Plex Mono"
+                          fontFamily={FONT_MONO}
                           fontSize="8"
                           fill={C.textMuted}
                           textAnchor="middle"
@@ -921,7 +893,7 @@ export default function HowItWorks() {
                         <text
                           x="190"
                           y="92"
-                          fontFamily="IBM Plex Mono"
+                          fontFamily={FONT_MONO}
                           fontSize="7"
                           fill={C.cyan}
                           textAnchor="middle"
@@ -953,7 +925,7 @@ export default function HowItWorks() {
                         <text
                           x="305"
                           y="87"
-                          fontFamily="IBM Plex Mono"
+                          fontFamily={FONT_MONO}
                           fontSize="12"
                           fill={C.primary}
                           textAnchor="middle"
@@ -964,7 +936,7 @@ export default function HowItWorks() {
                         <text
                           x="305"
                           y="118"
-                          fontFamily="IBM Plex Sans"
+                          fontFamily={FONT_SANS}
                           fontSize="9"
                           fill={C.textSec}
                           textAnchor="middle"
@@ -974,7 +946,7 @@ export default function HowItWorks() {
                         <text
                           x="305"
                           y="132"
-                          fontFamily="IBM Plex Mono"
+                          fontFamily={FONT_MONO}
                           fontSize="7"
                           fill={C.textMuted}
                           textAnchor="middle"
@@ -986,7 +958,7 @@ export default function HowItWorks() {
                         <text
                           x="65"
                           y="170"
-                          fontFamily="IBM Plex Mono"
+                          fontFamily={FONT_MONO}
                           fontSize="7"
                           fill={C.textMuted}
                           textAnchor="middle"
@@ -996,7 +968,7 @@ export default function HowItWorks() {
                         <text
                           x="305"
                           y="170"
-                          fontFamily="IBM Plex Mono"
+                          fontFamily={FONT_MONO}
                           fontSize="7"
                           fill={C.textMuted}
                           textAnchor="middle"

--- a/ui/apps/website/src/pages/landing/Architecture.tsx
+++ b/ui/apps/website/src/pages/landing/Architecture.tsx
@@ -1,6 +1,7 @@
 import { Section, SectionHeader } from "@/components/marketing";
+import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { Reveal } from "./components";
-import { C } from "./constants";
+import { C, FONT_SANS, FONT_MONO } from "./constants";
 
 export function Architecture() {
   return (
@@ -20,31 +21,13 @@ export function Architecture() {
           className="w-full h-auto min-w-[700px]"
         >
           <defs>
-            <marker
-              id="aa"
-              markerWidth="8"
-              markerHeight="6"
-              refX="8"
-              refY="3"
-              orient="auto"
-            >
-              <path d="M0,0 L8,3 L0,6" fill={C.primary} />
-            </marker>
-            <marker
-              id="aad"
-              markerWidth="8"
-              markerHeight="6"
-              refX="8"
-              refY="3"
-              orient="auto"
-            >
-              <path d="M0,0 L8,3 L0,6" fill={`${C.primary}60`} />
-            </marker>
+            <ArrowMarker id="aa" fill={C.primary} />
+            <ArrowMarker id="aad" fill={`${C.primary}60`} />
           </defs>
           <text
             x="100"
             y="30"
-            fontFamily="IBM Plex Sans"
+            fontFamily={FONT_SANS}
             fontSize="12"
             fill={C.textMuted}
             textAnchor="middle"
@@ -121,7 +104,7 @@ export function Architecture() {
           <text
             x="100"
             y="225"
-            fontFamily="IBM Plex Sans"
+            fontFamily={FONT_SANS}
             fontSize="10"
             fill={C.textSec}
             textAnchor="middle"
@@ -149,7 +132,7 @@ export function Architecture() {
           <text
             x="220"
             y="178"
-            fontFamily="IBM Plex Mono"
+            fontFamily={FONT_MONO}
             fontSize="8"
             fill={C.primary}
             textAnchor="middle"
@@ -169,7 +152,7 @@ export function Architecture() {
           <text
             x="440"
             y="30"
-            fontFamily="IBM Plex Sans"
+            fontFamily={FONT_SANS}
             fontSize="12"
             fill={C.primary}
             textAnchor="middle"
@@ -191,7 +174,7 @@ export function Architecture() {
           <text
             x="440"
             y="107"
-            fontFamily="IBM Plex Mono"
+            fontFamily={FONT_MONO}
             fontSize="14"
             fill={C.primary}
             textAnchor="middle"
@@ -259,7 +242,7 @@ export function Architecture() {
               <text
                 x={b.x + 30}
                 y={b.y + 18}
-                fontFamily="IBM Plex Sans"
+                fontFamily={FONT_SANS}
                 fontSize="9"
                 fill={C.textSec}
               >
@@ -270,7 +253,7 @@ export function Architecture() {
           <text
             x="750"
             y="30"
-            fontFamily="IBM Plex Sans"
+            fontFamily={FONT_SANS}
             fontSize="12"
             fill={C.textMuted}
             textAnchor="middle"
@@ -282,7 +265,7 @@ export function Architecture() {
           <text
             x="633"
             y="44"
-            fontFamily="IBM Plex Mono"
+            fontFamily={FONT_MONO}
             fontSize="8"
             fill={C.textMuted}
             textAnchor="middle"
@@ -331,7 +314,7 @@ export function Architecture() {
           <text
             x="618"
             y="130"
-            fontFamily="IBM Plex Mono"
+            fontFamily={FONT_MONO}
             fontSize="7"
             fill={`${C.primary}60`}
             textAnchor="middle"
@@ -463,7 +446,7 @@ export function Architecture() {
               <text
                 x="740"
                 y={d.y + 24}
-                fontFamily="IBM Plex Sans"
+                fontFamily={FONT_SANS}
                 fontSize="10"
                 fill={C.text}
                 textAnchor="start"
@@ -473,7 +456,7 @@ export function Architecture() {
               <text
                 x="740"
                 y={d.y + 38}
-                fontFamily="IBM Plex Mono"
+                fontFamily={FONT_MONO}
                 fontSize="7"
                 fill={C.textMuted}
                 textAnchor="start"
@@ -503,7 +486,7 @@ export function Architecture() {
           <text
             x="574"
             y="98"
-            fontFamily="IBM Plex Mono"
+            fontFamily={FONT_MONO}
             fontSize="7"
             fill={C.primary}
             textAnchor="middle"

--- a/ui/apps/website/src/pages/landing/HowItWorks.tsx
+++ b/ui/apps/website/src/pages/landing/HowItWorks.tsx
@@ -1,7 +1,8 @@
 import { Card } from "@shellhub/design-system/primitives";
 import { Section, SectionHeader } from "@/components/marketing";
+import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { Reveal, ShimmerCard } from "./components";
-import { C } from "./constants";
+import { C, FONT_SANS, FONT_MONO } from "./constants";
 
 export function HowItWorks() {
   return (
@@ -35,16 +36,7 @@ export function HowItWorks() {
                 className="w-full h-auto"
               >
                 <defs>
-                  <marker
-                    id="arrow-pri"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.primary} />
-                  </marker>
+                  <ArrowMarker id="arrow-pri" fill={C.primary} />
                 </defs>
                 <rect
                   x="10"
@@ -73,7 +65,7 @@ export function HowItWorks() {
                 <text
                   x="50"
                   y="125"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -93,7 +85,7 @@ export function HowItWorks() {
                 <text
                   x="122"
                   y="92"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.primaryGlow}
                   textAnchor="middle"
@@ -122,7 +114,7 @@ export function HowItWorks() {
                 <text
                   x="197"
                   y="95"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="8"
                   fill={C.primary}
                   textAnchor="middle"
@@ -132,7 +124,7 @@ export function HowItWorks() {
                 <text
                   x="197"
                   y="107"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -142,7 +134,7 @@ export function HowItWorks() {
                 <text
                   x="197"
                   y="125"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -179,7 +171,7 @@ export function HowItWorks() {
                 <text
                   x="344"
                   y="89"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.primary}
                   textAnchor="middle"
@@ -190,7 +182,7 @@ export function HowItWorks() {
                 <text
                   x="344"
                   y="115"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.primary}
                   textAnchor="middle"
@@ -201,7 +193,7 @@ export function HowItWorks() {
                 <text
                   x="344"
                   y="130"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="9"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -236,7 +228,7 @@ export function HowItWorks() {
                 <text
                   x="436"
                   y="55"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -283,7 +275,7 @@ export function HowItWorks() {
                 <text
                   x="489"
                   y="125"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -317,16 +309,7 @@ export function HowItWorks() {
                 className="w-full h-auto"
               >
                 <defs>
-                  <marker
-                    id="arrow-cyan"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.cyan} />
-                  </marker>
+                  <ArrowMarker id="arrow-cyan" fill={C.cyan} />
                 </defs>
                 <rect
                   x="10"
@@ -349,7 +332,7 @@ export function HowItWorks() {
                 <text
                   x="60"
                   y="94"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={C.cyan}
                   textAnchor="middle"
@@ -359,7 +342,7 @@ export function HowItWorks() {
                 <text
                   x="60"
                   y="106"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="6"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -377,7 +360,7 @@ export function HowItWorks() {
                 <text
                   x="60"
                   y="125"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -414,7 +397,7 @@ export function HowItWorks() {
                 <text
                   x="220"
                   y="89"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.cyan}
                   textAnchor="middle"
@@ -425,7 +408,7 @@ export function HowItWorks() {
                 <text
                   x="220"
                   y="115"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.cyan}
                   textAnchor="middle"
@@ -436,7 +419,7 @@ export function HowItWorks() {
                 <text
                   x="220"
                   y="130"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="9"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -489,7 +472,7 @@ export function HowItWorks() {
                 <text
                   x="395"
                   y="93"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -520,7 +503,7 @@ export function HowItWorks() {
                 <text
                   x="494"
                   y="103"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="9"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -547,7 +530,7 @@ export function HowItWorks() {
                 <text
                   x="395"
                   y="137"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={C.cyan}
                   textAnchor="middle"
@@ -557,7 +540,7 @@ export function HowItWorks() {
                 <text
                   x="395"
                   y="147"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="6"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -567,7 +550,7 @@ export function HowItWorks() {
                 <text
                   x="395"
                   y="175"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -601,36 +584,9 @@ export function HowItWorks() {
                 className="w-full h-auto"
               >
                 <defs>
-                  <marker
-                    id="arrow-yel"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.yellow} />
-                  </marker>
-                  <marker
-                    id="arrow-grn"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.green} />
-                  </marker>
-                  <marker
-                    id="arrow-red"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.red} />
-                  </marker>
+                  <ArrowMarker id="arrow-yel" fill={C.yellow} />
+                  <ArrowMarker id="arrow-grn" fill={C.green} />
+                  <ArrowMarker id="arrow-red" fill={C.red} />
                 </defs>
                 <rect
                   x="10"
@@ -644,7 +600,7 @@ export function HowItWorks() {
                 <text
                   x="60"
                   y="80"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.text}
                   textAnchor="middle"
@@ -655,7 +611,7 @@ export function HowItWorks() {
                 <text
                   x="60"
                   y="95"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.text}
                   textAnchor="middle"
@@ -675,7 +631,7 @@ export function HowItWorks() {
                 <text
                   x="56"
                   y="116"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="6"
                   fill={C.textMuted}
                 >
@@ -693,7 +649,7 @@ export function HowItWorks() {
                 <text
                   x="56"
                   y="130"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="6"
                   fill={C.textMuted}
                 >
@@ -721,7 +677,7 @@ export function HowItWorks() {
                 <text
                   x="252"
                   y="62"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.yellow}
                   textAnchor="middle"
@@ -757,7 +713,7 @@ export function HowItWorks() {
                 <text
                   x="252"
                   y="86"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -792,7 +748,7 @@ export function HowItWorks() {
                 <text
                   x="252"
                   y="114"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -827,7 +783,7 @@ export function HowItWorks() {
                 <text
                   x="252"
                   y="142"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -866,7 +822,7 @@ export function HowItWorks() {
                 <text
                   x="424"
                   y="57"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.green}
                   textAnchor="middle"
@@ -906,7 +862,7 @@ export function HowItWorks() {
                 <text
                   x="424"
                   y="148"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.red}
                   textAnchor="middle"
@@ -957,16 +913,7 @@ export function HowItWorks() {
                 className="w-full h-auto"
               >
                 <defs>
-                  <marker
-                    id="arrow-green"
-                    markerWidth="8"
-                    markerHeight="6"
-                    refX="8"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M0,0 L8,3 L0,6" fill={C.green} />
-                  </marker>
+                  <ArrowMarker id="arrow-green" fill={C.green} />
                 </defs>
                 <rect
                   x="10"
@@ -994,7 +941,7 @@ export function HowItWorks() {
                 <text
                   x="65"
                   y="98"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={C.green}
                   textAnchor="middle"
@@ -1004,7 +951,7 @@ export function HowItWorks() {
                 <text
                   x="65"
                   y="112"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="6"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -1030,7 +977,7 @@ export function HowItWorks() {
                 <text
                   x="65"
                   y="157"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -1049,7 +996,7 @@ export function HowItWorks() {
                 <text
                   x="148"
                   y="92"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={`${C.green}60`}
                   textAnchor="middle"
@@ -1078,7 +1025,7 @@ export function HowItWorks() {
                 <text
                   x="231"
                   y="85"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.green}
                   textAnchor="middle"
@@ -1089,7 +1036,7 @@ export function HowItWorks() {
                 <text
                   x="231"
                   y="115"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="11"
                   fill={C.green}
                   textAnchor="middle"
@@ -1100,7 +1047,7 @@ export function HowItWorks() {
                 <text
                   x="231"
                   y="130"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="9"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -1137,7 +1084,7 @@ export function HowItWorks() {
                 <text
                   x="318"
                   y="68"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={`${C.green}40`}
                   textAnchor="middle"
@@ -1147,7 +1094,7 @@ export function HowItWorks() {
                 <text
                   x="318"
                   y="94"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={`${C.green}40`}
                   textAnchor="middle"
@@ -1157,7 +1104,7 @@ export function HowItWorks() {
                 <text
                   x="318"
                   y="142"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="7"
                   fill={`${C.green}40`}
                   textAnchor="middle"
@@ -1195,7 +1142,7 @@ export function HowItWorks() {
                 <text
                   x="415"
                   y="42"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="9"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -1205,7 +1152,7 @@ export function HowItWorks() {
                 <text
                   x="415"
                   y="55"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -1243,7 +1190,7 @@ export function HowItWorks() {
                 <text
                   x="415"
                   y="100"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="9"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -1253,7 +1200,7 @@ export function HowItWorks() {
                 <text
                   x="415"
                   y="113"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.textMuted}
                   textAnchor="middle"
@@ -1282,7 +1229,7 @@ export function HowItWorks() {
                 <text
                   x="415"
                   y="158"
-                  fontFamily="IBM Plex Sans"
+                  fontFamily={FONT_SANS}
                   fontSize="9"
                   fill={C.textSec}
                   textAnchor="middle"
@@ -1292,7 +1239,7 @@ export function HowItWorks() {
                 <text
                   x="415"
                   y="171"
-                  fontFamily="IBM Plex Mono"
+                  fontFamily={FONT_MONO}
                   fontSize="9"
                   fill={C.textMuted}
                   textAnchor="middle"

--- a/ui/apps/website/src/pages/landing/constants.ts
+++ b/ui/apps/website/src/pages/landing/constants.ts
@@ -1,1 +1,1 @@
-export { C } from "@shellhub/design-system/constants";
+export { C, FONT_SANS, FONT_MONO } from "@shellhub/design-system/constants";

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -21,7 +21,7 @@ import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C } from "../landing/constants";
+import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
 
 /* ═══════ Pain Points ═══════ */
 const painPoints = [
@@ -203,7 +203,7 @@ function ArchitectureDiagram() {
         fill={C.text}
         fontSize="12"
         fontWeight="600"
-        fontFamily="IBM Plex Sans, sans-serif"
+        fontFamily={FONT_SANS}
       >
         User
       </text>
@@ -213,7 +213,7 @@ function ArchitectureDiagram() {
         textAnchor="middle"
         fill={C.textMuted}
         fontSize="9"
-        fontFamily="IBM Plex Mono, monospace"
+        fontFamily={FONT_MONO}
       >
         ssh user@ctr
       </text>
@@ -274,7 +274,7 @@ function ArchitectureDiagram() {
         fill={C.text}
         fontSize="12"
         fontWeight="600"
-        fontFamily="IBM Plex Sans, sans-serif"
+        fontFamily={FONT_SANS}
       >
         ShellHub Gateway
       </text>
@@ -284,7 +284,7 @@ function ArchitectureDiagram() {
         textAnchor="middle"
         fill={C.textMuted}
         fontSize="9"
-        fontFamily="IBM Plex Mono, monospace"
+        fontFamily={FONT_MONO}
       >
         auth + routing
       </text>
@@ -294,7 +294,7 @@ function ArchitectureDiagram() {
         textAnchor="middle"
         fill={C.textMuted}
         fontSize="9"
-        fontFamily="IBM Plex Mono, monospace"
+        fontFamily={FONT_MONO}
       >
         session recording
       </text>
@@ -329,7 +329,7 @@ function ArchitectureDiagram() {
         fill={C.text}
         fontSize="12"
         fontWeight="600"
-        fontFamily="IBM Plex Sans, sans-serif"
+        fontFamily={FONT_SANS}
       >
         Docker Host
       </text>
@@ -366,7 +366,7 @@ function ArchitectureDiagram() {
         fill={C.primary}
         fontSize="10"
         fontWeight="600"
-        fontFamily="IBM Plex Mono, monospace"
+        fontFamily={FONT_MONO}
       >
         ShellHub Agent
       </text>
@@ -417,7 +417,7 @@ function ArchitectureDiagram() {
             fill={C.text}
             fontSize="11"
             fontWeight="500"
-            fontFamily="IBM Plex Sans, sans-serif"
+            fontFamily={FONT_SANS}
           >
             {ctr.name}
           </text>
@@ -438,7 +438,7 @@ function ArchitectureDiagram() {
             fill={ctr.color}
             fontSize="8"
             fontWeight="600"
-            fontFamily="IBM Plex Mono, monospace"
+            fontFamily={FONT_MONO}
           >
             running
           </text>

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -22,6 +22,7 @@ import {
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
 import { Section, SectionHeader } from "@/components/marketing";
+import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -569,28 +570,9 @@ export default function IotEmbedded() {
                         You (SSH)
                       </text>
 
-                      {/* Arrow markers */}
                       <defs>
-                        <marker
-                          id="arrowGreen"
-                          markerWidth="8"
-                          markerHeight="6"
-                          refX="8"
-                          refY="3"
-                          orient="auto"
-                        >
-                          <polygon points="0 0, 8 3, 0 6" fill={C.green} />
-                        </marker>
-                        <marker
-                          id="arrowCyan"
-                          markerWidth="8"
-                          markerHeight="6"
-                          refX="4"
-                          refY="3"
-                          orient="auto"
-                        >
-                          <polygon points="0 0, 8 3, 0 6" fill={C.cyan} />
-                        </marker>
+                        <ArrowMarker id="arrowGreen" fill={C.green} />
+                        <ArrowMarker id="arrowCyan" fill={C.cyan} refX={4} />
                       </defs>
                     </svg>
                   </div>

--- a/ui/packages/design-system/constants.ts
+++ b/ui/packages/design-system/constants.ts
@@ -1,4 +1,6 @@
-/* ═══════ SVG color constants ═══════ */
+export const FONT_SANS = "IBM Plex Sans, sans-serif";
+export const FONT_MONO = "IBM Plex Mono, monospace";
+
 export const C = {
   primary: "#667ACC",
   primaryDim: "#667ACC20",


### PR DESCRIPTION
## Summary

- Add a shared `ArrowMarker` component that replaces the 14 duplicated inline `<marker>` SVG defs scattered across 4 website diagram files (`Architecture`, `HowItWorks`, `how-it-works/index`, `IotEmbedded`)
- Centralize the 93 hardcoded `IBM Plex Sans`/`IBM Plex Mono` font-family strings into `FONT_SANS`/`FONT_MONO` constants in `packages/design-system/constants.ts`, used by 4 files (`Architecture`, `HowItWorks`, `how-it-works/index`, `ContainerManagement`)
- `ArrowMarker` accepts explicit geometry props (`markerWidth`/`markerHeight`/`refX`/`refY`, default `8/6/8/3`) to preserve the two non-standard markers: `hw-s2-a` at 7×5 in `how-it-works/index` and `arrowCyan` with `refX=4` in `IotEmbedded`
- Callers supply a unique `id` prop — SVG `marker-end="url(#id)"` resolves DOM-globally, so pages rendering multiple diagrams (e.g. `landing/index.tsx` mounts both `Architecture` and `HowItWorks`) need distinct ids to avoid silent arrow-color collisions
- No visual changes — per-diagram composition (coordinates, fills, font sizes, weights) is untouched; only the repeated boilerplate is collapsed

## Files

| File | Change |
|------|--------|
| `packages/design-system/constants.ts` | Add `FONT_SANS`, `FONT_MONO` |
| `components/marketing/ArrowMarker.tsx` | New shared marker component |
| `landing/constants.ts` | Re-export font constants |
| `landing/Architecture.tsx` | Markers + fonts |
| `landing/HowItWorks.tsx` | Markers + fonts |
| `how-it-works/index.tsx` | Markers + fonts |
| `use-cases/ContainerManagement.tsx` | Fonts only |
| `use-cases/IotEmbedded.tsx` | Markers only (uses `monospace`, not IBM Plex) |

## Test plan

- [ ] Website `tsc --noEmit` passes (verified locally)
- [ ] Website `eslint` clean (verified locally — only pre-existing `Navbar.tsx` a11y warnings)
- [ ] Visual parity: each affected diagram renders identically to `master` (landing, how-it-works, container-management, iot-embedded pages)
- [ ] Landing page: verify `Architecture` + `HowItWorks` arrows render correct colors (they share one DOM, different marker ids)