### PR TITLE
docs(openapi): document 409 response for MFA generate

### DIFF
--- a/openapi/spec/paths/api@user@mfa@generate.yaml
+++ b/openapi/spec/paths/api@user@mfa@generate.yaml
@@ -23,5 +23,7 @@ get:
       $ref: '../components/responses/403.yaml'
     '404':
       $ref: '../components/responses/404.yaml'
+    '409':
+      $ref: '../components/responses/409.yaml'
     '500':
       $ref: '../components/responses/500.yaml'


### PR DESCRIPTION
## What

Document the `409 Conflict` response on the `GET /api/user/mfa/generate`
OpenAPI path.

## Why

The endpoint now returns `409` when the user already has MFA enabled
(implemented in shellhub-io/cloud#2422). Adding it to the spec keeps our
public API contract accurate and lets generated clients and consumers
handle the case explicitly, which the linked issue calls for.

## Changes

- Added the `409` response, referencing the shared
  `components/responses/409.yaml`, to the MFA generate path.

## Testing

Spec-only change; no runtime behavior. Confirm the OpenAPI spec still
builds/validates and the `409` ref resolves.

## Related

- shellhub-io/cloud#2422 — implements the `409` behavior
- shellhub-io/team#82 — original issue
