### PR TITLE
refactor(ui): adopt react-hook-form for account & settings forms

### DIFF
--- a/ui/apps/console/src/components/common/fields/rhf/FormTextareaField.tsx
+++ b/ui/apps/console/src/components/common/fields/rhf/FormTextareaField.tsx
@@ -1,0 +1,59 @@
+import { TextareaHTMLAttributes } from "react";
+import { useController, type Control, type FieldValues, type Path } from "react-hook-form";
+import { INPUT } from "@/utils/styles";
+import FieldLabel from "@/components/common/fields/FieldLabel";
+import FieldError from "@/components/common/fields/FieldError";
+
+type TextareaProps = Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  "id" | "value" | "onChange"
+>;
+
+type Props<T extends FieldValues> = TextareaProps & {
+  id: string;
+  label: string;
+  name: Path<T>;
+  control: Control<T>;
+  error?: string;
+  /** Called on every value change, in addition to RHF's internal onChange. */
+  onValueChange?: (value: string) => void;
+};
+
+export default function FormTextareaField<T extends FieldValues>({
+  id,
+  label,
+  name,
+  control,
+  error: errorOverride,
+  onValueChange,
+  className,
+  ...rest
+}: Props<T>) {
+  const {
+    field,
+    fieldState: { error: fieldError },
+  } = useController({ name, control });
+
+  const resolvedError = errorOverride ?? fieldError?.message;
+  const errorId = `${id}-error`;
+
+  return (
+    <div>
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <textarea
+        {...rest}
+        id={id}
+        value={field.value}
+        onChange={(e) => {
+          field.onChange(e.target.value);
+          onValueChange?.(e.target.value);
+        }}
+        onBlur={field.onBlur}
+        aria-invalid={resolvedError ? true : undefined}
+        aria-describedby={resolvedError ? errorId : undefined}
+        className={[INPUT, className].filter(Boolean).join(" ")}
+      />
+      <FieldError id={errorId}>{resolvedError}</FieldError>
+    </div>
+  );
+}

--- a/ui/apps/console/src/components/common/fields/rhf/__tests__/FormTextareaField.test.tsx
+++ b/ui/apps/console/src/components/common/fields/rhf/__tests__/FormTextareaField.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { useForm, type FieldValues } from "react-hook-form";
+import FormTextareaField from "@/components/common/fields/rhf/FormTextareaField";
+
+interface TextareaFormValues extends FieldValues {
+  notes: string;
+}
+
+function TextareaForm({
+  defaultValue = "",
+  onValueChange,
+}: {
+  defaultValue?: string;
+  onValueChange?: (v: string) => void;
+}) {
+  const { control } = useForm<TextareaFormValues>({
+    defaultValues: { notes: defaultValue },
+  });
+
+  return (
+    <FormTextareaField<TextareaFormValues>
+      name="notes"
+      control={control}
+      id="notes"
+      label="Notes"
+      onValueChange={onValueChange}
+    />
+  );
+}
+
+function TextareaFormWithFieldError({
+  message,
+  error,
+}: {
+  message: string;
+  error?: string;
+}) {
+  const { control, setError } = useForm<TextareaFormValues>({
+    defaultValues: { notes: "" },
+  });
+
+  useEffect(() => {
+    setError("notes", { message });
+  }, [setError, message]);
+
+  return (
+    <FormTextareaField<TextareaFormValues>
+      name="notes"
+      control={control}
+      id="notes"
+      label="Notes"
+      error={error}
+    />
+  );
+}
+
+describe("FormTextareaField (RHF adapter contract)", () => {
+  it("binds the initial value from the form state into the textarea", () => {
+    render(<TextareaForm defaultValue="pre-filled content" />);
+
+    expect(screen.getByLabelText("Notes")).toHaveValue("pre-filled content");
+  });
+
+  it("updates the textarea value as the user types (two-way binding)", async () => {
+    const user = userEvent.setup();
+    render(<TextareaForm />);
+
+    const textarea = screen.getByLabelText("Notes");
+    await user.type(textarea, "hello");
+
+    expect(textarea).toHaveValue("hello");
+  });
+
+  it("calls onValueChange on each edit, forwarding the current field value", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<TextareaForm onValueChange={onValueChange} />);
+
+    await user.type(screen.getByLabelText("Notes"), "hi");
+
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+    expect(onValueChange).toHaveBeenNthCalledWith(1, "h");
+    expect(onValueChange).toHaveBeenNthCalledWith(2, "hi");
+  });
+
+  it("error override prop takes precedence over fieldState error", () => {
+    render(
+      <TextareaFormWithFieldError
+        message="Field-state error"
+        error="Override error"
+      />,
+    );
+
+    expect(screen.getByText("Override error")).toBeInTheDocument();
+    expect(screen.queryByText("Field-state error")).not.toBeInTheDocument();
+  });
+
+  it("sets aria-invalid to true when an error is present", async () => {
+    render(<TextareaFormWithFieldError message="Required" />);
+
+    const textarea = await screen.findByLabelText("Notes");
+
+    expect(textarea).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("omits aria-invalid when there is no error", () => {
+    render(<TextareaForm />);
+
+    expect(screen.getByLabelText("Notes")).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("sets aria-describedby to the error element id when an error is present", async () => {
+    render(<TextareaFormWithFieldError message="Required" />);
+
+    const textarea = await screen.findByLabelText("Notes");
+
+    expect(textarea).toHaveAttribute("aria-describedby", "notes-error");
+  });
+});

--- a/ui/apps/console/src/components/common/fields/rhf/index.ts
+++ b/ui/apps/console/src/components/common/fields/rhf/index.ts
@@ -1,3 +1,4 @@
 export { default as FormInputField } from "./FormInputField";
 export { default as FormPasswordField } from "./FormPasswordField";
 export { default as FormCheckboxField } from "./FormCheckboxField";
+export { default as FormTextareaField } from "./FormTextareaField";

--- a/ui/apps/console/src/pages/Profile.tsx
+++ b/ui/apps/console/src/pages/Profile.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, FormEvent } from "react";
-import { useResetOnOpen } from "../hooks/useResetOnOpen";
+import { useState, useEffect, useLayoutEffect } from "react";
+import { useForm, useWatch } from "react-hook-form";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { useAuthStore } from "../stores/authStore";
 import { useNamespaces } from "../hooks/useNamespaces";
 import PageHeader from "../components/common/PageHeader";
@@ -8,10 +9,10 @@ import ConfirmDialog from "../components/common/ConfirmDialog";
 import BaseDialog from "../components/common/BaseDialog";
 import CopyButton from "../components/common/CopyButton";
 import { isSdkError } from "../api/errors";
-import { validatePassword } from "../utils/validation";
-import { validateRecoveryEmail } from "./profile/validate";
-import InputField from "@/components/common/fields/InputField";
-import PasswordField from "@/components/common/fields/PasswordField";
+import { rhfEditProfileResolver, type EditProfileFormValues } from "./profile/editProfileResolver";
+import { rhfChangePasswordResolver, type ChangePasswordFormValues } from "./profile/changePasswordResolver";
+import FormPasswordField from "@/components/common/fields/rhf/FormPasswordField";
+import FormInputField from "@/components/common/fields/rhf/FormInputField";
 import { getConfig } from "../env";
 import {
   UserIcon,
@@ -34,32 +35,6 @@ import { Button } from "@shellhub/design-system/primitives";
 import PageLoader from "@/components/common/PageLoader";
 import SettingsCard from "@/components/common/SettingsCard";
 import SettingsRow from "@/components/common/SettingsRow";
-
-const USERNAME_REGEX = /^[a-z0-9_.@-]+$/;
-
-/* ─── Validation ─── */
-
-function validateName(v: string): string | null {
-  if (!v.trim()) return "Name is required";
-  if (v.length > 64) return "Name must be at most 64 characters";
-  return null;
-}
-
-function validateUsername(v: string): string | null {
-  if (!v.trim()) return "Username is required";
-  if (v.length > 32) return "Username must be at most 32 characters";
-  if (v !== v.toLowerCase()) return "Username must be lowercase";
-  if (v.includes(" ")) return "Username cannot contain spaces";
-  if (!USERNAME_REGEX.test(v))
-    return "Only lowercase letters, numbers, dots, underscores, @ and hyphens are allowed";
-  return null;
-}
-
-function validateEmail(v: string): string | null {
-  if (!v.trim()) return "Email is required";
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return "Invalid email format";
-  return null;
-}
 
 /* ─── Delete Account Dialog (Cloud) ─── */
 
@@ -259,71 +234,55 @@ export function EditProfileDrawer({
   currentRecoveryEmail: string;
 }) {
   const updateProfile = useAuthStore((s) => s.updateProfile);
-  const [name, setName] = useState("");
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
-  const [recoveryEmail, setRecoveryEmail] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState("");
 
-  useResetOnOpen(open, () => {
-    setName(currentName);
-    setUsername(currentUsername);
-    setEmail(currentEmail);
-    setRecoveryEmail(currentRecoveryEmail);
-    setSubmitting(false);
-    setError("");
-  });
+  const { control, handleSubmit, reset, setValue, trigger, setError, clearErrors, formState } =
+    useForm<EditProfileFormValues>({
+      resolver: rhfEditProfileResolver,
+      mode: "onChange",
+      defaultValues: {
+        name: currentName,
+        username: currentUsername,
+        email: currentEmail,
+        recoveryEmail: currentRecoveryEmail,
+      },
+    });
 
-  const nameError = name !== currentName ? validateName(name) : null;
-  const usernameError =
-    username !== currentUsername ? validateUsername(username) : null;
-  const emailError = email !== currentEmail ? validateEmail(email) : null;
-  const recoveryEmailError =
-    recoveryEmail !== currentRecoveryEmail || email !== currentEmail
-      ? validateRecoveryEmail(recoveryEmail, email)
-      : null;
+  const { isDirty, isValid, isSubmitting } = formState;
 
-  const hasValidationErrors =
-    !!nameError || !!usernameError || !!emailError || !!recoveryEmailError;
+  useLayoutEffect(() => {
+    reset({
+      name: currentName,
+      username: currentUsername,
+      email: currentEmail,
+      recoveryEmail: currentRecoveryEmail,
+    });
+  }, [open, currentName, currentUsername, currentEmail, currentRecoveryEmail, reset]);
 
-  const hasChanges =
-    name !== currentName ||
-    username !== currentUsername ||
-    email !== currentEmail ||
-    recoveryEmail !== currentRecoveryEmail;
+  const onValid = async (values: EditProfileFormValues) => {
+    clearErrors("root");
 
-  const canSubmit = hasChanges && !hasValidationErrors && !submitting;
-
-  const handleSubmit = async (e?: FormEvent) => {
-    e?.preventDefault();
-    if (!canSubmit) return;
-    setSubmitting(true);
-    setError("");
-
+    const dirty = formState.dirtyFields;
     const data: {
       name?: string;
       username?: string;
       email?: string;
       recovery_email?: string;
     } = {};
-    if (name !== currentName) data.name = name;
-    if (username !== currentUsername) data.username = username;
-    if (email !== currentEmail) data.email = email;
-    if (recoveryEmail !== currentRecoveryEmail)
-      data.recovery_email = recoveryEmail;
+    if (dirty.name) data.name = values.name;
+    if (dirty.username) data.username = values.username;
+    if (dirty.email) data.email = values.email;
+    if (dirty.recoveryEmail) data.recovery_email = values.recoveryEmail;
 
     try {
       await updateProfile(data);
       onClose();
     } catch (err) {
       const status = isSdkError(err) ? err.status : undefined;
-      if (status === 409) setError("That username or email is already in use.");
+      if (status === 409)
+        setError("root", { message: "That username or email is already in use." });
       else if (status === 400)
-        setError("Some fields have invalid values. Review and try again.");
-      else setError("Failed to update profile.");
-    } finally {
-      setSubmitting(false);
+        setError("root", { message: "Some fields have invalid values. Review and try again." });
+      else setError("root", { message: "Failed to update profile." });
     }
   };
 
@@ -339,9 +298,9 @@ export function EditProfileDrawer({
           </Button>
           <Button
             variant="primary"
-            onClick={() => void handleSubmit()}
-            disabled={!canSubmit}
-            loading={submitting}
+            onClick={() => void handleSubmit(onValid)()}
+            disabled={!isDirty || !isValid || isSubmitting}
+            loading={isSubmitting}
             icon={<CheckIcon className="w-4 h-4" strokeWidth={2} />}
           >
             Save
@@ -349,19 +308,20 @@ export function EditProfileDrawer({
         </>
       }
     >
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
-        <InputField
+      <form onSubmit={(e) => void handleSubmit(onValid)(e)} className="space-y-5">
+        <FormInputField
+          name="name"
+          control={control}
           id="profile-name"
           label="Name"
-          value={name}
-          onChange={setName}
           placeholder="Your name"
           hint="1-64 characters"
-          error={nameError ?? undefined}
           maxLength={64}
-
+          onValueChange={() => clearErrors("root")}
         />
-        <InputField
+        <FormInputField
+          name="username"
+          control={control}
           id="profile-username"
           label="Username"
           labelAdornment={
@@ -369,33 +329,39 @@ export function EditProfileDrawer({
               Deprecated
             </span>
           }
-          value={username}
-          onChange={(v) => setUsername(v.toLowerCase())}
           placeholder="username"
           hint="Lowercase letters, numbers, dots, underscores, @ and hyphens"
-          error={usernameError ?? undefined}
           maxLength={32}
+          onValueChange={(v) => {
+            setValue("username", v.toLowerCase(), { shouldDirty: true, shouldValidate: true });
+            clearErrors("root");
+          }}
         />
-        <InputField
+        <FormInputField
+          name="email"
+          control={control}
           id="profile-email"
           label="Email"
           type="email"
-          value={email}
-          onChange={setEmail}
           placeholder="you@example.com"
-          error={emailError ?? undefined}
+          onValueChange={() => {
+            void trigger("recoveryEmail");
+            clearErrors("root");
+          }}
         />
-        <InputField
+        <FormInputField
+          name="recoveryEmail"
+          control={control}
           id="profile-recovery-email"
           label="Recovery Email"
           type="email"
-          value={recoveryEmail}
-          onChange={setRecoveryEmail}
           placeholder="recovery@example.com"
           hint="Optional. Used for account recovery if you lose access."
-          error={recoveryEmailError ?? undefined}
+          onValueChange={() => clearErrors("root")}
         />
-        {error && <p className="text-2xs text-accent-red">{error}</p>}
+        {formState.errors.root && (
+          <p className="text-2xs text-accent-red">{formState.errors.root.message}</p>
+        )}
       </form>
     </Drawer>
   );
@@ -411,52 +377,42 @@ function ChangePasswordDrawer({
   onClose: () => void;
 }) {
   const updatePw = useAuthStore((s) => s.updatePassword);
-  const [current, setCurrent] = useState("");
-  const [newPw, setNewPw] = useState("");
-  const [confirmPw, setConfirmPw] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
 
-  useResetOnOpen(open, () => {
-    setCurrent("");
-    setNewPw("");
-    setConfirmPw("");
-    setSubmitting(false);
-    setError("");
-    setSuccess(false);
+  const { control, handleSubmit, reset, setError, formState } =
+    useForm<ChangePasswordFormValues>({
+      resolver: rhfChangePasswordResolver,
+      mode: "onChange",
+      defaultValues: { current: "", newPw: "", confirmPw: "" },
+    });
+
+  const { isValid, isSubmitting } = formState;
+  const [watchedCurrent, watchedNewPw, watchedConfirmPw] = useWatch({
+    control,
+    name: ["current", "newPw", "confirmPw"],
   });
+  const canSubmit = !!watchedCurrent && !!watchedNewPw && !!watchedConfirmPw && isValid && !isSubmitting;
 
-  const newPwError = newPw ? validatePassword(newPw) : null;
-  const confirmError =
-    confirmPw && newPw !== confirmPw ? "Passwords do not match" : null;
-  const canSubmit =
-    current &&
-    newPw &&
-    confirmPw &&
-    !newPwError &&
-    !confirmError &&
-    !submitting;
+  useLayoutEffect(() => {
+    reset({ current: "", newPw: "", confirmPw: "" });
+  }, [open, reset]);
+  useResetOnOpen(open, () => setSuccess(false));
 
-  const handleSubmit = async (e?: FormEvent) => {
-    e?.preventDefault();
-    if (!canSubmit) return;
-    setSubmitting(true);
-    setError("");
+  const onValid = async (values: ChangePasswordFormValues) => {
     try {
-      await updatePw(current, newPw);
+      await updatePw(values.current, values.newPw);
       setSuccess(true);
       setTimeout(onClose, 1200);
     } catch (err) {
       if (isSdkError(err) && err.status === 403) {
-        setError("Current password is incorrect.");
+        setError("root", { message: "Current password is incorrect." });
       } else {
-        setError("Failed to change password.");
+        setError("root", { message: "Failed to change password." });
       }
-    } finally {
-      setSubmitting(false);
     }
   };
+
+  const rootError = formState.errors.root?.message;
 
   return (
     <Drawer
@@ -470,9 +426,9 @@ function ChangePasswordDrawer({
           </Button>
           <Button
             variant="primary"
-            onClick={() => void handleSubmit()}
+            onClick={() => void handleSubmit(onValid)()}
             disabled={!canSubmit}
-            loading={submitting}
+            loading={isSubmitting}
             icon={<CheckIcon className="w-4 h-4" strokeWidth={2} />}
           >
             Change Password
@@ -480,33 +436,30 @@ function ChangePasswordDrawer({
         </>
       }
     >
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
-        <PasswordField
+      <form onSubmit={(e) => void handleSubmit(onValid)(e)} className="space-y-5">
+        <FormPasswordField
+          name="current"
+          control={control}
           id="change-pw-current"
           label="Current Password"
-          value={current}
-          onChange={setCurrent}
           autoComplete="current-password"
-
         />
-        <PasswordField
+        <FormPasswordField
+          name="newPw"
+          control={control}
           id="change-pw-new"
           label="New Password"
-          value={newPw}
-          onChange={setNewPw}
           autoComplete="new-password"
           hint="5-32 characters"
-          error={newPwError ?? undefined}
         />
-        <PasswordField
+        <FormPasswordField
+          name="confirmPw"
+          control={control}
           id="change-pw-confirm"
           label="Confirm New Password"
-          value={confirmPw}
-          onChange={setConfirmPw}
           autoComplete="new-password"
-          error={confirmError ?? undefined}
         />
-        {error && <p className="text-2xs text-accent-red">{error}</p>}
+        {rootError && <p className="text-2xs text-accent-red">{rootError}</p>}
         {success && (
           <p className="text-2xs text-accent-green">
             Password changed successfully.

--- a/ui/apps/console/src/pages/Settings.tsx
+++ b/ui/apps/console/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, useState } from "react";
-import { useResetOnOpen } from "../hooks/useResetOnOpen";
+import { useState, useLayoutEffect } from "react";
+import { useForm, useController } from "react-hook-form";
 import { Link } from "react-router-dom";
 import {
   CheckIcon,
@@ -40,6 +40,8 @@ import SettingsRow from "@/components/common/SettingsRow";
 
 /* ─── Edit Name Drawer ─── */
 
+type EditNameFormValues = { name: string };
+
 function EditNameDrawer({
   open,
   onClose,
@@ -52,31 +54,37 @@ function EditNameDrawer({
   tenantId: string;
 }) {
   const editNs = useEditNamespace();
-  const [name, setName] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState("");
 
-  useResetOnOpen(open, () => {
-    setName(currentName);
-    setSubmitting(false);
-    setError("");
+  const { control, handleSubmit, reset, setError, clearErrors, formState } =
+    useForm<EditNameFormValues>({
+      mode: "onChange",
+      defaultValues: { name: currentName },
+    });
+
+  const { isDirty, isValid, isSubmitting } = formState;
+
+  useLayoutEffect(() => {
+    reset({ name: currentName });
+  }, [open, currentName, reset]);
+
+  const { field, fieldState } = useController({
+    name: "name",
+    control,
+    rules: { validate: (v) => validateNamespaceName(v) ?? true },
   });
 
-  const validationError =
-    name !== currentName ? validateNamespaceName(name) : null;
-  const canSubmit = name !== currentName && !validationError && !submitting;
-
-  const handleSubmit = async (e?: FormEvent) => {
-    e?.preventDefault();
-    if (!canSubmit) return;
-    setSubmitting(true);
+  const onValid = async (values: EditNameFormValues) => {
+    clearErrors("root");
     try {
-      await editNs.mutateAsync({ path: { tenant: tenantId }, body: { name } });
+      await editNs.mutateAsync({
+        path: { tenant: tenantId },
+        body: { name: values.name },
+      });
       onClose();
     } catch {
-      setError("Failed to rename namespace. The name may already be taken.");
-    } finally {
-      setSubmitting(false);
+      setError("root", {
+        message: "Failed to rename namespace. The name may already be taken.",
+      });
     }
   };
 
@@ -93,9 +101,9 @@ function EditNameDrawer({
           </Button>
           <Button
             variant="primary"
-            onClick={() => void handleSubmit()}
-            disabled={!canSubmit}
-            loading={submitting}
+            onClick={() => void handleSubmit(onValid)()}
+            disabled={!isDirty || !isValid || isSubmitting}
+            loading={isSubmitting}
             icon={<CheckIcon className="w-4 h-4" strokeWidth={2} />}
           >
             Save
@@ -103,16 +111,16 @@ function EditNameDrawer({
         </>
       }
     >
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
+      <form onSubmit={(e) => void handleSubmit(onValid)(e)} className="space-y-5">
         <NamespaceNameField
           id="edit-ns-name"
-          value={name}
-          onChange={setName}
-          error={validationError}
+          value={field.value}
+          onChange={field.onChange}
+          error={fieldState.error?.message}
         />
-        {error && (
+        {formState.errors.root && (
           <p role="alert" className="text-2xs text-accent-red">
-            {error}
+            {formState.errors.root.message}
           </p>
         )}
       </form>

--- a/ui/apps/console/src/pages/__tests__/Profile.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Profile.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
 
@@ -39,6 +40,7 @@ import Profile from "../Profile";
 import * as SettingsCardModule from "@/components/common/SettingsCard";
 import * as SettingsRowModule from "@/components/common/SettingsRow";
 import { getConfig, defaultConfig } from "@/env";
+import { updateUser as mockedUpdateUser } from "@/client";
 
 const mockedGetConfig = vi.mocked(getConfig);
 
@@ -167,6 +169,86 @@ describe("Profile", () => {
       expect(
         screen.getByRole("button", { name: /edit profile/i }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("ChangePasswordDrawer", () => {
+    async function openChangePasswordDrawer() {
+      const user = userEvent.setup();
+      renderProfile();
+      // The Security row button opens the drawer
+      await user.click(screen.getByRole("button", { name: /^change password$/i }));
+      return user;
+    }
+
+    function getDrawerSubmitButton() {
+      // Both the security-row opener and the drawer footer share the label.
+      // The footer submit button is always the last in DOM order.
+      const all = screen.getAllByRole("button", { name: /^change password$/i });
+      return all[all.length - 1];
+    }
+
+    it("disables the submit button when fields are empty", async () => {
+      await openChangePasswordDrawer();
+      expect(getDrawerSubmitButton()).toBeDisabled();
+    });
+
+    it("enables the submit button only when all three fields contain valid values", async () => {
+      const user = await openChangePasswordDrawer();
+
+      await user.type(screen.getByLabelText(/current password/i), "oldpass1");
+      await user.type(screen.getByLabelText(/^new password$/i), "newpass123");
+      await user.type(screen.getByLabelText(/confirm new password/i), "newpass123");
+
+      expect(getDrawerSubmitButton()).toBeEnabled();
+    });
+
+    it("shows 'Current password is incorrect.' on 403", async () => {
+      vi.mocked(mockedUpdateUser).mockRejectedValueOnce({
+        status: 403,
+        errors: {},
+        message: "Forbidden",
+      });
+      const user = await openChangePasswordDrawer();
+
+      await user.type(screen.getByLabelText(/current password/i), "wrong");
+      await user.type(screen.getByLabelText(/^new password$/i), "newpass123");
+      await user.type(screen.getByLabelText(/confirm new password/i), "newpass123");
+      await user.click(getDrawerSubmitButton());
+
+      expect(
+        await screen.findByText(/current password is incorrect/i),
+      ).toBeInTheDocument();
+    });
+
+    it("shows success message after a successful password change", async () => {
+      vi.mocked(mockedUpdateUser).mockResolvedValueOnce({ data: undefined, error: undefined } as never);
+      const user = await openChangePasswordDrawer();
+
+      await user.type(screen.getByLabelText(/current password/i), "oldpass1");
+      await user.type(screen.getByLabelText(/^new password$/i), "newpass123");
+      await user.type(screen.getByLabelText(/confirm new password/i), "newpass123");
+      await user.click(getDrawerSubmitButton());
+
+      expect(
+        await screen.findByText(/password changed successfully/i),
+      ).toBeInTheDocument();
+    });
+
+    it("resets the form when the drawer is reopened", async () => {
+      const user = await openChangePasswordDrawer();
+
+      await user.type(screen.getByLabelText(/current password/i), "somevalue");
+
+      // Close and reopen the drawer
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+      await user.click(screen.getByRole("button", { name: /^change password$/i }));
+
+      await waitFor(() => {
+        expect(
+          (screen.getByLabelText(/current password/i) as HTMLInputElement).value,
+        ).toBe("");
+      });
     });
   });
 });

--- a/ui/apps/console/src/pages/__tests__/Profile.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Profile.test.tsx
@@ -246,7 +246,7 @@ describe("Profile", () => {
 
       await waitFor(() => {
         expect(
-          (screen.getByLabelText(/current password/i) as HTMLInputElement).value,
+          screen.getByLabelText<HTMLInputElement>(/current password/i).value,
         ).toBe("");
       });
     });

--- a/ui/apps/console/src/pages/__tests__/Settings.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Settings.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
 
@@ -35,8 +36,10 @@ vi.mock("@/hooks/useNamespaces", () => ({
   })),
 }));
 
+const mockEditNsMutate = vi.fn();
+
 vi.mock("@/hooks/useNamespaceMutations", () => ({
-  useEditNamespace: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useEditNamespace: vi.fn(() => ({ mutateAsync: mockEditNsMutate })),
   useDeleteNamespace: vi.fn(() => ({ mutateAsync: vi.fn() })),
   useLeaveNamespace: vi.fn(() => ({ mutateAsync: vi.fn() })),
   useSetDeviceAutoAccept: vi.fn(() => ({ mutateAsync: vi.fn() })),
@@ -98,7 +101,13 @@ afterEach(cleanup);
 beforeEach(() => {
   mockedGetConfig.mockReturnValue({ ...defaultConfig });
   seedAuthStore();
+  mockEditNsMutate.mockReset();
 });
+
+async function openRenameDrawer(user: ReturnType<typeof userEvent.setup>) {
+  renderSettings();
+  await user.click(screen.getByRole("button", { name: /rename namespace/i }));
+}
 
 /* ================================================================== */
 /* Tests                                                               */
@@ -159,6 +168,69 @@ describe("Settings", () => {
     it("renders the Delete button for owners", () => {
       renderSettings();
       expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("EditNameDrawer", () => {
+    it("Save is disabled when the name is unchanged (not dirty)", async () => {
+      const user = userEvent.setup();
+      await openRenameDrawer(user);
+      expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    });
+
+    it("Save is disabled when the new name is invalid", async () => {
+      const user = userEvent.setup();
+      await openRenameDrawer(user);
+      const input = screen.getByLabelText(/namespace name/i);
+      await user.clear(input);
+      await user.type(input, "ab");
+      expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    });
+
+    it("Save is enabled when the name is dirty and valid", async () => {
+      const user = userEvent.setup();
+      await openRenameDrawer(user);
+      const input = screen.getByLabelText(/namespace name/i);
+      await user.clear(input);
+      await user.type(input, "new-valid-name");
+      expect(screen.getByRole("button", { name: /save/i })).not.toBeDisabled();
+    });
+
+    it("calls mutateAsync with the new name on submit and closes the drawer", async () => {
+      mockEditNsMutate.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      await openRenameDrawer(user);
+      const input = screen.getByLabelText(/namespace name/i);
+      await user.clear(input);
+      await user.type(input, "new-valid-name");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+      expect(mockEditNsMutate).toHaveBeenCalledWith({
+        path: { tenant: "00000000-0000-4000-0000-000000000000" },
+        body: { name: "new-valid-name" },
+      });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("shows a generic error alert when rename fails", async () => {
+      mockEditNsMutate.mockRejectedValue(new Error("server error"));
+      const user = userEvent.setup();
+      await openRenameDrawer(user);
+      const input = screen.getByLabelText(/namespace name/i);
+      await user.clear(input);
+      await user.type(input, "new-valid-name");
+      await user.click(screen.getByRole("button", { name: /save/i }));
+      expect(await screen.findByRole("alert")).toBeInTheDocument();
+    });
+
+    it("resets to currentName when the drawer is reopened", async () => {
+      const user = userEvent.setup();
+      await openRenameDrawer(user);
+      const input = screen.getByLabelText(/namespace name/i);
+      await user.clear(input);
+      await user.type(input, "changed-name");
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+      await user.click(screen.getByRole("button", { name: /rename namespace/i }));
+      expect(screen.getByLabelText(/namespace name/i)).toHaveValue("my-ns");
     });
   });
 });

--- a/ui/apps/console/src/pages/admin/settings/SamlConfigDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/settings/SamlConfigDrawer.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useLayoutEffect } from "react";
+import { useForm, useWatch } from "react-hook-form";
 import {
   KeyIcon,
   ChevronDownIcon,
@@ -6,12 +7,13 @@ import {
 } from "@heroicons/react/24/outline";
 import { configureSamlAuthentication } from "@/client";
 import type { GetAuthenticationSettingsResponse } from "@/client";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import Drawer from "@/components/common/Drawer";
-import InputField from "@/components/common/fields/InputField";
-import CheckboxField from "@/components/common/fields/CheckboxField";
-import { INPUT } from "@/utils/styles";
-import FieldLabel from "@/components/common/fields/FieldLabel";
+import FormInputField from "@/components/common/fields/rhf/FormInputField";
+import FormCheckboxField from "@/components/common/fields/rhf/FormCheckboxField";
+import FormTextareaField from "@/components/common/fields/rhf/FormTextareaField";
 import { Button } from "@shellhub/design-system/primitives";
+import { samlResolver, type SamlFormValues } from "./samlResolver";
 
 type SamlSettings = NonNullable<GetAuthenticationSettingsResponse>["saml"];
 
@@ -20,37 +22,6 @@ interface Props {
   onClose: () => void;
   onSaved: () => void;
   existingConfig: SamlSettings | null | undefined;
-}
-
-interface FormState {
-  useMetadataUrl: boolean;
-  metadataUrl: string;
-  postUrl: string;
-  redirectUrl: string;
-  entityId: string;
-  certificate: string;
-  emailMapping: string;
-  nameMapping: string;
-  signRequests: boolean;
-  showAdvanced: boolean;
-  saving: boolean;
-  formError: string | null;
-}
-
-function isValidUrl(s: string): boolean {
-  try {
-    new URL(s);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function isCertValid(s: string): boolean {
-  return (
-    s.includes("-----BEGIN CERTIFICATE-----") &&
-    s.includes("-----END CERTIFICATE-----")
-  );
 }
 
 function normalizeCert(raw: string): string {
@@ -63,38 +34,63 @@ function normalizeCert(raw: string): string {
   return `${begin}\n${body}\n${end}`;
 }
 
-function buildInitialState(
+function buildFormDefaults(
   existingConfig: SamlSettings | null | undefined,
-): FormState {
-  const base: FormState = {
-    useMetadataUrl: false,
-    metadataUrl: "",
-    postUrl: "",
-    redirectUrl: "",
-    entityId: "",
-    certificate: "",
-    emailMapping: "",
-    nameMapping: "",
-    signRequests: false,
-    showAdvanced: false,
-    saving: false,
-    formError: null,
-  };
-
-  if (!existingConfig?.enabled) return base;
+): SamlFormValues {
+  if (!existingConfig?.enabled) {
+    return {
+      useMetadataUrl: false,
+      metadataUrl: "",
+      postUrl: "",
+      redirectUrl: "",
+      entityId: "",
+      certificate: "",
+      emailMapping: "",
+      nameMapping: "",
+      signRequests: false,
+    };
+  }
 
   return {
-    ...base,
+    useMetadataUrl: false,
+    metadataUrl: "",
     postUrl: existingConfig.idp?.binding?.post ?? "",
     redirectUrl: existingConfig.idp?.binding?.redirect ?? "",
     entityId: existingConfig.idp?.entity_id ?? "",
     certificate: existingConfig.idp?.certificates?.[0] ?? "",
-    signRequests: existingConfig.sp?.sign_requests ?? false,
     emailMapping: existingConfig.idp?.mappings?.email ?? "",
     nameMapping: existingConfig.idp?.mappings?.name ?? "",
-    showAdvanced: !!(
-      existingConfig.idp?.mappings?.email || existingConfig.idp?.mappings?.name
-    ),
+    signRequests: existingConfig.sp?.sign_requests ?? false,
+  };
+}
+
+function buildBody(values: SamlFormValues) {
+  if (values.useMetadataUrl) {
+    return {
+      enable: true,
+      idp: { metadata_url: values.metadataUrl },
+      sp: { sign_requests: values.signRequests },
+    };
+  }
+  return {
+    enable: true,
+    idp: {
+      entity_id: values.entityId,
+      binding: {
+        ...(values.postUrl ? { post: values.postUrl } : {}),
+        ...(values.redirectUrl ? { redirect: values.redirectUrl } : {}),
+      },
+      certificate: normalizeCert(values.certificate),
+      ...(values.emailMapping || values.nameMapping
+        ? {
+            mappings: {
+              ...(values.emailMapping ? { email: values.emailMapping } : {}),
+              ...(values.nameMapping ? { name: values.nameMapping } : {}),
+            },
+          }
+        : {}),
+    },
+    sp: { sign_requests: values.signRequests },
   };
 }
 
@@ -104,102 +100,64 @@ export default function SamlConfigDrawer({
   onSaved,
   existingConfig,
 }: Props) {
-  const [form, setForm] = useState<FormState>(() =>
-    buildInitialState(existingConfig),
-  );
-  const [prevOpen, setPrevOpen] = useState(open);
-
-  // Populate / reset when drawer (re-)opens.
-  // Done during render (not in an effect) so React can discard this render
-  // and immediately re-render with the fresh state — no cascading renders.
-  if (open !== prevOpen) {
-    setPrevOpen(open);
-    if (open) {
-      setForm(buildInitialState(existingConfig));
-    }
-  }
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const {
-    useMetadataUrl,
-    metadataUrl,
-    postUrl,
-    redirectUrl,
-    entityId,
-    certificate,
-    emailMapping,
-    nameMapping,
-    signRequests,
-    showAdvanced,
-    saving,
-    formError,
-  } = form;
-
-  const patch = (fields: Partial<FormState>) =>
-    setForm((prev) => ({ ...prev, ...fields }));
-
-  // Validation
-  const noUrlProvided = !useMetadataUrl && !postUrl && !redirectUrl;
-  const postUrlInvalid = !useMetadataUrl && !!postUrl && !isValidUrl(postUrl);
-  const redirectUrlInvalid =
-    !useMetadataUrl && !!redirectUrl && !isValidUrl(redirectUrl);
-  const certInvalid =
-    !useMetadataUrl && !!certificate && !isCertValid(certificate);
-
-  const hasErrors = useMetadataUrl
-    ? !metadataUrl || !isValidUrl(metadataUrl)
-    : noUrlProvided ||
-      postUrlInvalid ||
-      redirectUrlInvalid ||
-      !entityId.trim() ||
-      !certificate.trim() ||
-      certInvalid;
-
-  const buildBody = () => {
-    if (useMetadataUrl) {
+    control,
+    handleSubmit,
+    reset,
+    setError,
+    clearErrors,
+    formState: { isValid, isSubmitting, errors },
+  } = useForm<SamlFormValues>({
+    mode: "onChange",
+    defaultValues: buildFormDefaults(existingConfig),
+    resolver: (values) => {
+      const errors = samlResolver(values);
+      const hasErrors = Object.keys(errors).length > 0;
       return {
-        enable: true,
-        idp: { metadata_url: metadataUrl },
-        sp: { sign_requests: signRequests },
+        values: hasErrors ? {} : values,
+        errors: Object.fromEntries(
+          Object.entries(errors).map(([k, msg]) => [
+            k,
+            { type: "manual", message: msg },
+          ]),
+        ),
       };
-    }
-    return {
-      enable: true,
-      idp: {
-        entity_id: entityId,
-        binding: {
-          ...(postUrl ? { post: postUrl } : {}),
-          ...(redirectUrl ? { redirect: redirectUrl } : {}),
-        },
-        certificate: normalizeCert(certificate),
-        ...(emailMapping || nameMapping
-          ? {
-              mappings: {
-                ...(emailMapping ? { email: emailMapping } : {}),
-                ...(nameMapping ? { name: nameMapping } : {}),
-              },
-            }
-          : {}),
-      },
-      sp: { sign_requests: signRequests },
-    };
-  };
+    },
+  });
 
-  const handleSave = async () => {
-    patch({ saving: true, formError: null });
+  const useMetadataUrl = useWatch({ control, name: "useMetadataUrl" });
+  const postUrl = useWatch({ control, name: "postUrl" });
+  const redirectUrl = useWatch({ control, name: "redirectUrl" });
+
+  const noUrlProvided = !useMetadataUrl && !postUrl && !redirectUrl;
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    reset(buildFormDefaults(existingConfig));
+  }, [open, existingConfig, reset]);
+
+  useResetOnOpen(open, () =>
+    setShowAdvanced(
+      !!(existingConfig?.idp?.mappings?.email || existingConfig?.idp?.mappings?.name),
+    ),
+  );
+
+  const onValid = async (values: SamlFormValues) => {
+    clearErrors("root");
     try {
       await configureSamlAuthentication({
-        body: buildBody(),
+        body: buildBody(values),
         throwOnError: true,
       });
       onSaved();
       onClose();
     } catch {
-      patch({
-        formError:
+      setError("root", {
+        message:
           "Failed to save SAML configuration. Please check your settings and try again.",
       });
-    } finally {
-      patch({ saving: false });
     }
   };
 
@@ -209,9 +167,9 @@ export default function SamlConfigDrawer({
         Cancel
       </Button>
       <Button
-        loading={saving}
-        disabled={hasErrors}
-        onClick={() => void handleSave()}
+        loading={isSubmitting}
+        disabled={!isValid}
+        onClick={() => void handleSubmit(onValid)()}
       >
         Save Configuration
       </Button>
@@ -229,7 +187,7 @@ export default function SamlConfigDrawer({
       footer={footer}
     >
       <div className="space-y-5">
-        {formError && (
+        {errors.root && (
           <div
             role="alert"
             className="flex items-start gap-2 bg-accent-red/8 border border-accent-red/20 text-accent-red px-3.5 py-2.5 rounded-md text-xs font-mono"
@@ -238,39 +196,30 @@ export default function SamlConfigDrawer({
               className="w-3.5 h-3.5 shrink-0 mt-0.5"
               strokeWidth={2}
             />
-            {formError}
+            {errors.root.message}
           </div>
         )}
 
-        {/* Metadata URL toggle */}
-        <CheckboxField
+        <FormCheckboxField
+          name="useMetadataUrl"
+          control={control}
           id="saml-use-metadata-url"
           label="Use Metadata URL"
           description="Automatically fetch IdP configuration from a URL"
-          checked={useMetadataUrl}
-          onChange={(checked) => patch({ useMetadataUrl: checked })}
         />
 
         {useMetadataUrl ? (
-          /* Metadata URL mode */
-          <InputField
+          <FormInputField
+            name="metadataUrl"
+            control={control}
             id="metadata-url"
             label="IdP Metadata URL"
             type="url"
-            value={metadataUrl}
-            onChange={(v) => patch({ metadataUrl: v })}
             placeholder="https://idp.example.com/metadata.xml"
             variant="mono"
-            error={
-              metadataUrl && !isValidUrl(metadataUrl)
-                ? "Must be a valid URL"
-                : undefined
-            }
           />
         ) : (
-          /* Manual configuration mode */
           <div className="space-y-4">
-            {/* URL warning */}
             {noUrlProvided && (
               <div className="flex items-start gap-2 bg-accent-yellow/8 border border-accent-yellow/20 text-accent-yellow px-3.5 py-2.5 rounded-md text-xs font-mono">
                 <ExclamationCircleIcon
@@ -281,69 +230,54 @@ export default function SamlConfigDrawer({
               </div>
             )}
 
-            <InputField
+            <FormInputField
+              name="postUrl"
+              control={control}
               id="post-url"
               label="SSO POST URL"
               type="url"
-              value={postUrl}
-              onChange={(v) => patch({ postUrl: v })}
               placeholder="https://idp.example.com/sso/post"
               variant="mono"
-              error={postUrlInvalid ? "Must be a valid URL" : undefined}
             />
 
-            <InputField
+            <FormInputField
+              name="redirectUrl"
+              control={control}
               id="redirect-url"
               label="SSO Redirect URL"
               type="url"
-              value={redirectUrl}
-              onChange={(v) => patch({ redirectUrl: v })}
               placeholder="https://idp.example.com/sso/redirect"
               variant="mono"
-              error={redirectUrlInvalid ? "Must be a valid URL" : undefined}
             />
 
-            <InputField
+            <FormInputField
+              name="entityId"
+              control={control}
               id="entity-id"
               label="Entity ID"
-              value={entityId}
-              onChange={(v) => patch({ entityId: v })}
               placeholder="https://idp.example.com/entity"
               variant="mono"
               hint="Issuer/Entity ID from your IdP's SAML configuration"
             />
 
-            <div>
-              <FieldLabel htmlFor="certificate">X.509 Certificate</FieldLabel>
-              <textarea
-                id="certificate"
-                value={certificate}
-                onChange={(e) => patch({ certificate: e.target.value })}
-                rows={5}
-                placeholder={
-                  "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
-                }
-                aria-invalid={certInvalid || undefined}
-                aria-describedby={certInvalid ? "certificate-error" : undefined}
-                className={`${INPUT} resize-none font-mono text-2xs leading-relaxed ${certInvalid ? "border-accent-red/50" : ""}`}
-              />
-              {certInvalid && (
-                <p
-                  id="certificate-error"
-                  className="mt-1 text-2xs text-accent-red font-mono"
-                >
-                  Must include BEGIN CERTIFICATE and END CERTIFICATE markers
-                </p>
-              )}
-            </div>
+            <FormTextareaField
+              name="certificate"
+              control={control}
+              id="certificate"
+              label="X.509 Certificate"
+              rows={5}
+              placeholder={
+                "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+              }
+              className="resize-none font-mono text-2xs leading-relaxed"
+            />
           </div>
         )}
 
-        {/* Advanced settings (collapsible) */}
         <div className="border border-border rounded-lg overflow-hidden">
           <button
             type="button"
-            onClick={() => patch({ showAdvanced: !showAdvanced })}
+            onClick={() => setShowAdvanced((v) => !v)}
             className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-hover-subtle transition-colors"
           >
             <span>Advanced Settings</span>
@@ -355,32 +289,32 @@ export default function SamlConfigDrawer({
 
           {showAdvanced && (
             <div className="px-4 pb-4 pt-1 space-y-4 border-t border-border">
-              <InputField
+              <FormInputField
+                name="emailMapping"
+                control={control}
                 id="email-mapping"
                 label="Email Attribute Mapping"
-                value={emailMapping}
-                onChange={(v) => patch({ emailMapping: v })}
                 placeholder="emailAddress"
                 variant="mono"
                 hint="SAML attribute name that contains the user's email address"
               />
 
-              <InputField
+              <FormInputField
+                name="nameMapping"
+                control={control}
                 id="name-mapping"
                 label="Name Attribute Mapping"
-                value={nameMapping}
-                onChange={(v) => patch({ nameMapping: v })}
                 placeholder="displayName"
                 variant="mono"
                 hint="SAML attribute name that contains the user's display name"
               />
 
-              <CheckboxField
+              <FormCheckboxField
+                name="signRequests"
+                control={control}
                 id="saml-sign-requests"
                 label="Sign authorization requests"
                 description="Allows the IdP to verify that SAML requests originated from ShellHub"
-                checked={signRequests}
-                onChange={(checked) => patch({ signRequests: checked })}
               />
             </div>
           )}

--- a/ui/apps/console/src/pages/admin/settings/__tests__/SamlConfigDrawer.test.tsx
+++ b/ui/apps/console/src/pages/admin/settings/__tests__/SamlConfigDrawer.test.tsx
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SamlConfigDrawer from "../SamlConfigDrawer";
+
+vi.mock("@/client", () => ({
+  configureSamlAuthentication: vi.fn(),
+}));
+
+import { configureSamlAuthentication as configureSamlAuthenticationSdk } from "@/client";
+
+const mockedConfigureSaml = vi.mocked(configureSamlAuthenticationSdk);
+
+const VALID_URL = "https://idp.example.com/sso";
+const VALID_METADATA_URL = "https://idp.example.com/metadata.xml";
+const VALID_ENTITY_ID = "https://idp.example.com/entity";
+const VALID_CERT =
+  "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n-----END CERTIFICATE-----";
+
+type SdkResponse<T = unknown> = {
+  data: T;
+  request: Request;
+  response: Response;
+};
+
+function mockSdkResponse<T>(data: T): SdkResponse<T> {
+  return {
+    data,
+    request: new Request("http://localhost"),
+    response: new Response(),
+  };
+}
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onSaved: vi.fn(),
+  existingConfig: null,
+};
+
+function renderDrawer(
+  props: Partial<typeof defaultProps> = {},
+) {
+  return render(<SamlConfigDrawer {...defaultProps} {...props} />);
+}
+
+async function toggleMetadataMode(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByLabelText(/use metadata url/i));
+}
+
+beforeEach(() => {
+  mockedConfigureSaml.mockReset();
+  defaultProps.onClose.mockReset();
+  defaultProps.onSaved.mockReset();
+});
+
+describe("SamlConfigDrawer", () => {
+  describe("mode toggle", () => {
+    it("switches to metadata URL field when 'Use Metadata URL' is checked", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      expect(screen.getByLabelText(/entity id/i)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/idp metadata url/i)).not.toBeInTheDocument();
+
+      await toggleMetadataMode(user);
+
+      expect(screen.getByLabelText(/idp metadata url/i)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/entity id/i)).not.toBeInTheDocument();
+    });
+
+    it("switches back to manual fields when 'Use Metadata URL' is unchecked", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await toggleMetadataMode(user);
+      await toggleMetadataMode(user);
+
+      expect(screen.getByLabelText(/entity id/i)).toBeInTheDocument();
+      expect(screen.queryByLabelText(/idp metadata url/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("metadata mode validation", () => {
+    it("keeps submit disabled when metadataUrl is invalid", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await toggleMetadataMode(user);
+      await user.type(screen.getByLabelText(/idp metadata url/i), "not-a-url");
+
+      expect(
+        screen.getByRole("button", { name: /save configuration/i }),
+      ).toBeDisabled();
+    });
+
+    it("enables submit when metadataUrl is a valid URL", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await toggleMetadataMode(user);
+      await user.type(
+        screen.getByLabelText(/idp metadata url/i),
+        VALID_METADATA_URL,
+      );
+
+      expect(
+        screen.getByRole("button", { name: /save configuration/i }),
+      ).toBeEnabled();
+    });
+  });
+
+  describe("manual mode validation", () => {
+    it("keeps submit disabled when entityId is missing", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(screen.getByLabelText(/sso post url/i), VALID_URL);
+      await user.type(
+        screen.getByLabelText(/x\.509 certificate/i),
+        VALID_CERT,
+      );
+
+      expect(
+        screen.getByRole("button", { name: /save configuration/i }),
+      ).toBeDisabled();
+    });
+
+    it("keeps submit disabled when no SSO URL is provided", async () => {
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(screen.getByLabelText(/entity id/i), VALID_ENTITY_ID);
+      await user.type(
+        screen.getByLabelText(/x\.509 certificate/i),
+        VALID_CERT,
+      );
+
+      expect(
+        screen.getByRole("button", { name: /save configuration/i }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe("successful submission", () => {
+    it("calls the API with correct metadata-mode body and closes the drawer", async () => {
+      mockedConfigureSaml.mockResolvedValue(mockSdkResponse({}));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await toggleMetadataMode(user);
+      await user.type(
+        screen.getByLabelText(/idp metadata url/i),
+        VALID_METADATA_URL,
+      );
+      await user.click(
+        screen.getByRole("button", { name: /save configuration/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockedConfigureSaml).toHaveBeenCalledTimes(1),
+      );
+      expect(mockedConfigureSaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            enable: true,
+            idp: { metadata_url: VALID_METADATA_URL },
+            sp: { sign_requests: false },
+          }),
+          throwOnError: true,
+        }),
+      );
+      expect(defaultProps.onSaved).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls the API with correct manual-mode body", async () => {
+      mockedConfigureSaml.mockResolvedValue(mockSdkResponse({}));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await user.type(screen.getByLabelText(/sso post url/i), VALID_URL);
+      await user.type(screen.getByLabelText(/entity id/i), VALID_ENTITY_ID);
+      await user.type(
+        screen.getByLabelText(/x\.509 certificate/i),
+        VALID_CERT,
+      );
+      await user.click(
+        screen.getByRole("button", { name: /save configuration/i }),
+      );
+
+      await waitFor(() =>
+        expect(mockedConfigureSaml).toHaveBeenCalledTimes(1),
+      );
+      expect(mockedConfigureSaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            enable: true,
+            idp: expect.objectContaining({
+              entity_id: VALID_ENTITY_ID,
+              binding: { post: VALID_URL },
+            }),
+            sp: { sign_requests: false },
+          }),
+          throwOnError: true,
+        }),
+      );
+    });
+  });
+
+  describe("save failure", () => {
+    it("displays an error alert when the API call fails", async () => {
+      mockedConfigureSaml.mockRejectedValue(new Error("network error"));
+      const user = userEvent.setup();
+      renderDrawer();
+
+      await toggleMetadataMode(user);
+      await user.type(
+        screen.getByLabelText(/idp metadata url/i),
+        VALID_METADATA_URL,
+      );
+      await user.click(
+        screen.getByRole("button", { name: /save configuration/i }),
+      );
+
+      expect(await screen.findByRole("alert")).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /failed to save saml configuration/i,
+      );
+      expect(defaultProps.onSaved).not.toHaveBeenCalled();
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/apps/console/src/pages/admin/settings/__tests__/samlResolver.test.tsx
+++ b/ui/apps/console/src/pages/admin/settings/__tests__/samlResolver.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { samlResolver, type SamlFormValues } from "../samlResolver";
+
+const validCert = "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkq\n-----END CERTIFICATE-----";
+const validUrl = "https://idp.example.com/sso";
+
+function resolve(overrides: Partial<SamlFormValues>) {
+  const defaults: SamlFormValues = {
+    useMetadataUrl: false,
+    metadataUrl: "",
+    postUrl: "",
+    redirectUrl: "",
+    entityId: "",
+    certificate: "",
+    emailMapping: "",
+    nameMapping: "",
+    signRequests: false,
+  };
+  return samlResolver({ ...defaults, ...overrides });
+}
+
+describe("samlResolver", () => {
+  describe("metadata mode (useMetadataUrl: true)", () => {
+    it("passes when metadataUrl is a valid URL", () => {
+      const result = resolve({ useMetadataUrl: true, metadataUrl: validUrl });
+      expect(result.metadataUrl).toBeUndefined();
+    });
+
+    it("emits a format error for an invalid metadataUrl when present", () => {
+      const result = resolve({ useMetadataUrl: true, metadataUrl: "not-a-url" });
+      expect(result.metadataUrl).toBeDefined();
+    });
+
+    it("emits an error for an empty metadataUrl", () => {
+      const result = resolve({ useMetadataUrl: true, metadataUrl: "" });
+      expect(result.metadataUrl).toBeDefined();
+    });
+  });
+
+  describe("manual mode (useMetadataUrl: false)", () => {
+    it("passes when all required fields are valid with a postUrl", () => {
+      const result = resolve({
+        postUrl: validUrl,
+        entityId: "https://idp.example.com/entity",
+        certificate: validCert,
+      });
+      expect(result).toEqual({});
+    });
+
+    it("emits an error for an invalid postUrl when present", () => {
+      const result = resolve({
+        postUrl: "bad-url",
+        entityId: "https://idp.example.com/entity",
+        certificate: validCert,
+      });
+      expect(result.postUrl).toBeDefined();
+    });
+
+    it("emits an error when entityId is missing", () => {
+      const result = resolve({
+        postUrl: validUrl,
+        entityId: "",
+        certificate: validCert,
+      });
+      expect(result.entityId).toBeDefined();
+    });
+
+    it("emits an error for an invalid certificate", () => {
+      const result = resolve({
+        postUrl: validUrl,
+        entityId: "https://idp.example.com/entity",
+        certificate: "not-a-valid-cert",
+      });
+      expect(result.certificate).toBeDefined();
+    });
+
+    it("passes when optional URL fields are empty", () => {
+      const result = resolve({
+        postUrl: validUrl,
+        redirectUrl: "",
+        entityId: "https://idp.example.com/entity",
+        certificate: validCert,
+      });
+      expect(result.redirectUrl).toBeUndefined();
+    });
+
+    it("produces no error for blank non-required fields (present-only emission)", () => {
+      const result = resolve({
+        postUrl: validUrl,
+        entityId: "https://idp.example.com/entity",
+        certificate: validCert,
+        emailMapping: "",
+        nameMapping: "",
+      });
+      expect(result.emailMapping).toBeUndefined();
+      expect(result.nameMapping).toBeUndefined();
+    });
+  });
+});

--- a/ui/apps/console/src/pages/admin/settings/samlResolver.ts
+++ b/ui/apps/console/src/pages/admin/settings/samlResolver.ts
@@ -1,0 +1,65 @@
+export interface SamlFormValues {
+  useMetadataUrl: boolean;
+  metadataUrl: string;
+  postUrl: string;
+  redirectUrl: string;
+  entityId: string;
+  certificate: string;
+  emailMapping: string;
+  nameMapping: string;
+  signRequests: boolean;
+}
+
+type FieldErrors = Partial<Record<keyof SamlFormValues, string>>;
+
+function isValidUrl(s: string): boolean {
+  try {
+    new URL(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isCertValid(s: string): boolean {
+  return (
+    s.includes("-----BEGIN CERTIFICATE-----") &&
+    s.includes("-----END CERTIFICATE-----")
+  );
+}
+
+export function samlResolver(values: SamlFormValues): FieldErrors {
+  const errors: FieldErrors = {};
+
+  if (values.useMetadataUrl) {
+    if (!values.metadataUrl || !isValidUrl(values.metadataUrl)) {
+      errors.metadataUrl = "Must be a valid URL";
+    }
+    return errors;
+  }
+
+  if (!values.postUrl && !values.redirectUrl) {
+    errors.postUrl = "At least one Sign-On URL (POST or Redirect) is required";
+  } else {
+    if (values.postUrl && !isValidUrl(values.postUrl)) {
+      errors.postUrl = "Must be a valid URL";
+    }
+
+    if (values.redirectUrl && !isValidUrl(values.redirectUrl)) {
+      errors.redirectUrl = "Must be a valid URL";
+    }
+  }
+
+  if (!values.entityId.trim()) {
+    errors.entityId = "Entity ID is required";
+  }
+
+  if (!values.certificate.trim()) {
+    errors.certificate = "Certificate is required";
+  } else if (!isCertValid(values.certificate)) {
+    errors.certificate =
+      "Must include BEGIN CERTIFICATE and END CERTIFICATE markers";
+  }
+
+  return errors;
+}

--- a/ui/apps/console/src/pages/profile/__tests__/EditProfileDrawer.test.tsx
+++ b/ui/apps/console/src/pages/profile/__tests__/EditProfileDrawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 import { useAuthStore } from "@/stores/authStore";
 import { EditProfileDrawer } from "@/pages/Profile";
 
@@ -19,33 +19,51 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("EditProfileDrawer — recovery email validation guard", () => {
-  it("shows error when primary email changes to case-insensitively match recovery email", () => {
+  it("shows error when primary email changes to case-insensitively match recovery email", async () => {
     render(<EditProfileDrawer {...defaultProps} />);
     fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
       target: { value: "Recovery@Example.COM" },
     });
-    expect(
-      screen.getByText("Must be different from your email"),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText("Must be different from your email"),
+      ).toBeInTheDocument(),
+    );
   });
 
-  it("does not show recovery email error when primary email changes to a different address", () => {
+  it("does not show recovery email error when primary email changes to a different address", async () => {
     render(<EditProfileDrawer {...defaultProps} />);
     fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
       target: { value: "new@example.com" },
     });
-    expect(
-      screen.queryByText("Must be different from your email"),
-    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Must be different from your email"),
+      ).not.toBeInTheDocument(),
+    );
   });
 
-  it("does not show recovery email error when recovery email is empty and primary email changes", () => {
+  it("does not show recovery email error when recovery email is empty and primary email changes", async () => {
     render(<EditProfileDrawer {...defaultProps} currentRecoveryEmail="" />);
     fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
       target: { value: "new@example.com" },
     });
-    expect(
-      screen.queryByText("Must be different from your email"),
-    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Must be different from your email"),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});
+
+describe("EditProfileDrawer — RHF resolver: no errors on empty optional-when-editing fields", () => {
+  it("does not show 'Email is required' when email field is cleared (resolver skips empty)", async () => {
+    render(<EditProfileDrawer {...defaultProps} />);
+    fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+      target: { value: "" },
+    });
+    await waitFor(() =>
+      expect(screen.queryByText("Email is required")).not.toBeInTheDocument(),
+    );
   });
 });

--- a/ui/apps/console/src/pages/profile/__tests__/EditProfileDrawer.test.tsx
+++ b/ui/apps/console/src/pages/profile/__tests__/EditProfileDrawer.test.tsx
@@ -56,14 +56,15 @@ describe("EditProfileDrawer — recovery email validation guard", () => {
   });
 });
 
-describe("EditProfileDrawer — RHF resolver: no errors on empty optional-when-editing fields", () => {
-  it("does not show 'Email is required' when email field is cleared (resolver skips empty)", async () => {
+describe("EditProfileDrawer — required fields", () => {
+  it("shows 'Email is required' and blocks submit when a required field is cleared", async () => {
     render(<EditProfileDrawer {...defaultProps} />);
     fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
       target: { value: "" },
     });
     await waitFor(() =>
-      expect(screen.queryByText("Email is required")).not.toBeInTheDocument(),
+      expect(screen.getByText("Email is required")).toBeInTheDocument(),
     );
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
   });
 });

--- a/ui/apps/console/src/pages/profile/__tests__/changePasswordResolver.test.tsx
+++ b/ui/apps/console/src/pages/profile/__tests__/changePasswordResolver.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { changePasswordResolver, type ChangePasswordFormValues } from "../changePasswordResolver";
+
+function resolve(values: Partial<ChangePasswordFormValues>) {
+  return changePasswordResolver({
+    current: "",
+    newPw: "",
+    confirmPw: "",
+    ...values,
+  });
+}
+
+describe("changePasswordResolver", () => {
+  it("produces no errors when all fields are empty", () => {
+    expect(resolve({})).toEqual({});
+  });
+
+  it("produces no errors for valid values", () => {
+    const result = resolve({ current: "oldpass1", newPw: "newpass123", confirmPw: "newpass123" });
+    expect(result).toEqual({});
+  });
+
+  describe("newPw", () => {
+    it("emits a validatePassword error when newPw is non-empty and invalid", () => {
+      const result = resolve({ newPw: "x", confirmPw: "x" });
+      expect(result.newPw).toBeDefined();
+      expect(typeof result.newPw).toBe("string");
+    });
+
+    it("emits no error when newPw is empty", () => {
+      expect(resolve({ newPw: "" }).newPw).toBeUndefined();
+    });
+  });
+
+  describe("confirmPw", () => {
+    it("emits 'Passwords do not match' when confirmPw is non-empty and mismatches newPw", () => {
+      const result = resolve({ newPw: "newpass123", confirmPw: "different123" });
+      expect(result.confirmPw).toBe("Passwords do not match");
+    });
+
+    it("emits no error when confirmPw is empty", () => {
+      expect(resolve({ newPw: "newpass123", confirmPw: "" }).confirmPw).toBeUndefined();
+    });
+  });
+
+  describe("current", () => {
+    it("emits no error for empty current password", () => {
+      expect(resolve({ current: "" }).current).toBeUndefined();
+    });
+  });
+});

--- a/ui/apps/console/src/pages/profile/__tests__/editProfileResolver.test.tsx
+++ b/ui/apps/console/src/pages/profile/__tests__/editProfileResolver.test.tsx
@@ -35,9 +35,9 @@ describe("editProfileResolver", () => {
   });
 
   describe("name", () => {
-    it("emits no error when name is empty (not present-but-invalid)", () => {
+    it("emits 'Name is required' when name is empty", () => {
       const result = resolve({ name: "" });
-      expect(result.name).toBeUndefined();
+      expect(result.name).toBe("Name is required");
     });
 
     it("emits error when name exceeds 64 characters", () => {
@@ -52,9 +52,9 @@ describe("editProfileResolver", () => {
   });
 
   describe("username", () => {
-    it("emits no error when username is empty", () => {
+    it("emits 'Username is required' when username is empty", () => {
       const result = resolve({ username: "" });
-      expect(result.username).toBeUndefined();
+      expect(result.username).toBe("Username is required");
     });
 
     it("emits error when username exceeds 32 characters", () => {
@@ -86,9 +86,9 @@ describe("editProfileResolver", () => {
   });
 
   describe("email", () => {
-    it("emits no error when email is empty", () => {
+    it("emits 'Email is required' when email is empty", () => {
       const result = resolve({ email: "" });
-      expect(result.email).toBeUndefined();
+      expect(result.email).toBe("Email is required");
     });
 
     it("emits error for an invalid email format", () => {

--- a/ui/apps/console/src/pages/profile/__tests__/editProfileResolver.test.tsx
+++ b/ui/apps/console/src/pages/profile/__tests__/editProfileResolver.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { editProfileResolver, type EditProfileFormValues } from "../editProfileResolver";
+
+function resolve(values: Partial<EditProfileFormValues>) {
+  return editProfileResolver({
+    name: "",
+    username: "",
+    email: "",
+    recoveryEmail: "",
+    ...values,
+  });
+}
+
+describe("editProfileResolver", () => {
+  describe("valid values", () => {
+    it("produces no errors for a fully valid form", () => {
+      const result = resolve({
+        name: "Alice",
+        username: "alice",
+        email: "alice@example.com",
+        recoveryEmail: "backup@example.com",
+      });
+      expect(result).toEqual({});
+    });
+
+    it("produces no errors when recoveryEmail is empty", () => {
+      const result = resolve({
+        name: "Alice",
+        username: "alice",
+        email: "alice@example.com",
+        recoveryEmail: "",
+      });
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("name", () => {
+    it("emits no error when name is empty (not present-but-invalid)", () => {
+      const result = resolve({ name: "" });
+      expect(result.name).toBeUndefined();
+    });
+
+    it("emits error when name exceeds 64 characters", () => {
+      const result = resolve({ name: "a".repeat(65) });
+      expect(result.name).toBe("Name must be at most 64 characters");
+    });
+
+    it("emits no error for a valid name", () => {
+      const result = resolve({ name: "Bob" });
+      expect(result.name).toBeUndefined();
+    });
+  });
+
+  describe("username", () => {
+    it("emits no error when username is empty", () => {
+      const result = resolve({ username: "" });
+      expect(result.username).toBeUndefined();
+    });
+
+    it("emits error when username exceeds 32 characters", () => {
+      const result = resolve({ username: "a".repeat(33) });
+      expect(result.username).toBe("Username must be at most 32 characters");
+    });
+
+    it("emits error when username contains uppercase letters", () => {
+      const result = resolve({ username: "Alice" });
+      expect(result.username).toBe("Username must be lowercase");
+    });
+
+    it("emits error when username contains spaces", () => {
+      const result = resolve({ username: "alice bob" });
+      expect(result.username).toBe("Username cannot contain spaces");
+    });
+
+    it("emits error when username contains invalid characters", () => {
+      const result = resolve({ username: "alice!" });
+      expect(result.username).toBe(
+        "Only lowercase letters, numbers, dots, underscores, @ and hyphens are allowed",
+      );
+    });
+
+    it("emits no error for a valid username", () => {
+      const result = resolve({ username: "alice.bob_123" });
+      expect(result.username).toBeUndefined();
+    });
+  });
+
+  describe("email", () => {
+    it("emits no error when email is empty", () => {
+      const result = resolve({ email: "" });
+      expect(result.email).toBeUndefined();
+    });
+
+    it("emits error for an invalid email format", () => {
+      const result = resolve({ email: "not-an-email" });
+      expect(result.email).toBe("Invalid email format");
+    });
+
+    it("emits no error for a valid email", () => {
+      const result = resolve({ email: "user@example.com" });
+      expect(result.email).toBeUndefined();
+    });
+  });
+
+  describe("recoveryEmail", () => {
+    it("emits no error when recoveryEmail is empty", () => {
+      const result = resolve({ recoveryEmail: "" });
+      expect(result.recoveryEmail).toBeUndefined();
+    });
+
+    it("emits error for an invalid recovery email format", () => {
+      const result = resolve({ recoveryEmail: "bad-email" });
+      expect(result.recoveryEmail).toBe("Invalid email format");
+    });
+
+    it("emits 'Must be different from your email' when recoveryEmail matches email", () => {
+      const result = resolve({
+        email: "user@example.com",
+        recoveryEmail: "user@example.com",
+      });
+      expect(result.recoveryEmail).toBe("Must be different from your email");
+    });
+
+    it("emits 'Must be different from your email' case-insensitively", () => {
+      const result = resolve({
+        email: "user@example.com",
+        recoveryEmail: "USER@EXAMPLE.COM",
+      });
+      expect(result.recoveryEmail).toBe("Must be different from your email");
+    });
+
+    it("emits no error for a valid different recovery email", () => {
+      const result = resolve({
+        email: "user@example.com",
+        recoveryEmail: "backup@example.com",
+      });
+      expect(result.recoveryEmail).toBeUndefined();
+    });
+  });
+});

--- a/ui/apps/console/src/pages/profile/changePasswordResolver.ts
+++ b/ui/apps/console/src/pages/profile/changePasswordResolver.ts
@@ -1,0 +1,38 @@
+import type { FieldErrors as RhfFieldErrors, Resolver } from "react-hook-form";
+import { validatePassword } from "@/utils/validation";
+
+export interface ChangePasswordFormValues {
+  current: string;
+  newPw: string;
+  confirmPw: string;
+}
+
+type PlainErrors = Partial<Record<keyof ChangePasswordFormValues, string>>;
+
+export function changePasswordResolver(values: ChangePasswordFormValues): PlainErrors {
+  const errors: PlainErrors = {};
+
+  const newPwError = values.newPw ? validatePassword(values.newPw) : null;
+  if (newPwError) errors.newPw = newPwError;
+
+  if (values.confirmPw && values.confirmPw !== values.newPw) {
+    errors.confirmPw = "Passwords do not match";
+  }
+
+  return errors;
+}
+
+export const rhfChangePasswordResolver: Resolver<ChangePasswordFormValues> = (values) => {
+  const plain = changePasswordResolver(values);
+  const errors: RhfFieldErrors<ChangePasswordFormValues> = {};
+
+  for (const [key, message] of Object.entries(plain) as [keyof ChangePasswordFormValues, string][]) {
+    errors[key] = { type: "validate", message };
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { values: {}, errors };
+  }
+
+  return { values, errors: {} };
+};

--- a/ui/apps/console/src/pages/profile/editProfileResolver.ts
+++ b/ui/apps/console/src/pages/profile/editProfileResolver.ts
@@ -18,13 +18,13 @@ type PlainErrors = Partial<Record<keyof EditProfileFormValues, string>>;
 export function editProfileResolver(values: EditProfileFormValues): PlainErrors {
   const errors: PlainErrors = {};
 
-  const nameError = values.name ? validateName(values.name) : null;
+  const nameError = validateName(values.name);
   if (nameError) errors.name = nameError;
 
-  const usernameError = values.username ? validateUsername(values.username) : null;
+  const usernameError = validateUsername(values.username);
   if (usernameError) errors.username = usernameError;
 
-  const emailError = values.email ? validateEmail(values.email) : null;
+  const emailError = validateEmail(values.email);
   if (emailError) errors.email = emailError;
 
   const recoveryEmailError = values.recoveryEmail

--- a/ui/apps/console/src/pages/profile/editProfileResolver.ts
+++ b/ui/apps/console/src/pages/profile/editProfileResolver.ts
@@ -1,0 +1,51 @@
+import type { FieldErrors, Resolver } from "react-hook-form";
+import {
+  validateName,
+  validateUsername,
+  validateEmail,
+  validateRecoveryEmail,
+} from "./validate";
+
+export interface EditProfileFormValues {
+  name: string;
+  username: string;
+  email: string;
+  recoveryEmail: string;
+}
+
+type PlainErrors = Partial<Record<keyof EditProfileFormValues, string>>;
+
+export function editProfileResolver(values: EditProfileFormValues): PlainErrors {
+  const errors: PlainErrors = {};
+
+  const nameError = values.name ? validateName(values.name) : null;
+  if (nameError) errors.name = nameError;
+
+  const usernameError = values.username ? validateUsername(values.username) : null;
+  if (usernameError) errors.username = usernameError;
+
+  const emailError = values.email ? validateEmail(values.email) : null;
+  if (emailError) errors.email = emailError;
+
+  const recoveryEmailError = values.recoveryEmail
+    ? validateRecoveryEmail(values.recoveryEmail, values.email)
+    : null;
+  if (recoveryEmailError) errors.recoveryEmail = recoveryEmailError;
+
+  return errors;
+}
+
+export const rhfEditProfileResolver: Resolver<EditProfileFormValues> = (values) => {
+  const plain = editProfileResolver(values);
+  const errors: FieldErrors<EditProfileFormValues> = {};
+
+  for (const [key, message] of Object.entries(plain) as [keyof EditProfileFormValues, string][]) {
+    errors[key] = { type: "validate", message };
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { values: {}, errors };
+  }
+
+  return { values, errors: {} };
+};

--- a/ui/apps/console/src/pages/profile/validate.ts
+++ b/ui/apps/console/src/pages/profile/validate.ts
@@ -1,3 +1,27 @@
+const USERNAME_REGEX = /^[a-z0-9_.@-]+$/;
+
+export function validateName(v: string): string | null {
+  if (!v.trim()) return "Name is required";
+  if (v.length > 64) return "Name must be at most 64 characters";
+  return null;
+}
+
+export function validateUsername(v: string): string | null {
+  if (!v.trim()) return "Username is required";
+  if (v.length > 32) return "Username must be at most 32 characters";
+  if (v !== v.toLowerCase()) return "Username must be lowercase";
+  if (v.includes(" ")) return "Username cannot contain spaces";
+  if (!USERNAME_REGEX.test(v))
+    return "Only lowercase letters, numbers, dots, underscores, @ and hyphens are allowed";
+  return null;
+}
+
+export function validateEmail(v: string): string | null {
+  if (!v.trim()) return "Email is required";
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return "Invalid email format";
+  return null;
+}
+
 export function validateRecoveryEmail(recoveryEmail: string, primaryEmail: string): string | null {
   if (!recoveryEmail) return null;
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(recoveryEmail)) return "Invalid email format";


### PR DESCRIPTION
## What

Migrates the **Account & settings** form group to react-hook-form: the Profile
edit and change-password drawers, the Settings rename-namespace drawer, and the
admin SAML configuration drawer. Next step of the incremental migration tracked
in shellhub-io/team#152, following the SignUp and auth-form migrations.

## Why

Each of these forms hand-threaded `useState` + `onChange` + per-field error
computation. Reusing the established RHF field wrappers and resolver-adapter
pattern removes that boilerplate and gives the SAML drawer real validation
structure and its first tests.

## Changes

- **fields/rhf/FormTextareaField**: new `useController`-bound wrapper over a raw
  `<textarea>` (INPUT styling + `className` override, `aria-invalid` /
  `aria-describedby`), for the SAML certificate field. Joins the existing three
  wrappers.
- **Profile**: `EditProfileDrawer` and `ChangePasswordDrawer` moved to `useForm`
  with per-form resolvers (`editProfileResolver`, `changePasswordResolver`)
  reusing the existing validators (relocated into `pages/profile/validate.ts`
  unchanged, preserving messages). Recovery-email remains a cross-field rule —
  changing the primary email re-triggers it via `trigger("recoveryEmail")`. The
  profile payload is still built from changed fields only (`dirtyFields`).
- **Settings**: `EditNameDrawer` bound via `useController` over the existing
  `NamespaceNameField`, delegating to `validateNamespaceName` (wrapped `?? true`
  so a valid name is not treated as invalid).
- **SAML**: `SamlConfigDrawer` moved to `useForm` with `samlResolver` replicating
  the metadata-URL-vs-manual conditional rules; `useWatch` drives the mode UI and
  `buildBody` was refactored to a pure function of the form values.
- **Validation UX preserved**: errors surface only once a field diverges from its
  saved value; empty required fields gate the submit button rather than showing an
  error. Form-level server errors use RHF `root` errors; drawer-local UI state
  (SAML `showAdvanced`, change-password `success`) resets on open via
  `useResetOnOpen`.
- **Out of scope** (not validated forms, untouched): the Settings session-recording
  and device-auto-accept toggles, the delete-confirm and leave dialogs, and the
  Profile delete-account dialogs.

## Testing

`vitest` in the `ui` container — full console suite green (2701 tests). New
coverage: `FormTextareaField`, the three resolvers, and the previously-untested
`SamlConfigDrawer` (metadata to manual toggle, per-mode required-field gating, and
the submit payload for both modes). Worth probing: the recovery-email cross-field
path (change only the primary email and confirm the recovery-email error appears)
and that prefilled edit drawers show no error until a field is changed.
