### PR TITLE
docs(getting-started): add accessible labels to connectivity diagrams

### DIFF
--- a/ui/apps/docs/src/components/DiagramConnectionFlow.astro
+++ b/ui/apps/docs/src/components/DiagramConnectionFlow.astro
@@ -7,7 +7,11 @@ import {
 } from "@heroicons/react/24/outline";
 ---
 
-<div class="flow-container">
+<div
+  class="flow-container"
+  role="img"
+  aria-label="Diagram of an SSH session path: the SSH client connects to the Gateway, which routes to the SSH Service, which reaches the Agent over its reverse tunnel, and the Agent execs a shell on the device."
+>
   <div class="flow-pipeline">
     <!-- SSH Client -->
     <div class="flow-step">

--- a/ui/apps/docs/src/components/DiagramReverseConnectivity.astro
+++ b/ui/apps/docs/src/components/DiagramReverseConnectivity.astro
@@ -3,7 +3,11 @@ import { ServerIcon, UserIcon } from "@heroicons/react/24/outline";
 import { ShellHubCloudIcon } from "@shellhub/design-system/primitives";
 ---
 
-<div class="diagram-container">
+<div
+  class="diagram-container"
+  role="img"
+  aria-label="Diagram comparing two connection models. Traditional SSH: you connect directly to the device over SSH on port 22, which requires the device to have a public IP and breaks behind NAT, CGNAT, or firewalls. ShellHub: the device connects outbound to the ShellHub server over a WebSocket on port 443, and you connect to the server, which bridges the two."
+>
   <!-- Traditional SSH -->
   <div class="diagram-row">
     <div class="diagram-label">


### PR DESCRIPTION
## What
Add screen-reader descriptions to the two diagrams on the How It Works
page: reverse connectivity and connection flow.

## Why
Both were composed from `div`/`span`/`svg` with no overall description,
so assistive tech read a meaningless stream of node labels ("You,
Device, SSH port 22, ...") instead of the flow the diagram conveys.

## Changes
- Mark each diagram container as `role="img"` with an `aria-label` that
  describes the connection model / session path.
- `role="img"` makes the decorative inner SVGs presentational, so no
  per-icon `aria-hidden` is needed.

Part of shellhub-io/team#168 (GS-3) — do not close; other checkboxes remain.
