### PR TITLE
docs(getting-started): correct web terminal connect step on Features page

### DIFF
--- a/ui/apps/docs/src/pages/getting-started/features.mdx
+++ b/ui/apps/docs/src/pages/getting-started/features.mdx
@@ -20,7 +20,7 @@ ShellHub acts as a transparent SSH proxy. Your SSH client connects to the ShellH
 
 ## Web terminal
 
-Open an SSH session directly from your browser. Click the terminal icon next to any device in the dashboard, enter credentials, and you're connected. No SSH client installation needed.
+Open an SSH session directly from your browser. Click the green **Connect** button next to any online device on the **Devices** page, enter credentials, and you're connected. No SSH client installation needed.
 
 The web terminal uses xterm.js for a full terminal experience with copy/paste, scrollback, and resizable panes.
 


### PR DESCRIPTION
## What
Fix the web terminal instruction on the Features page.

## Why
It said "click the terminal icon ... in the dashboard," but the UI shows
a green Connect button on the Devices page, rendered only for online
devices — so a reader looks for a control that isn't there.

## Changes
- Reword to "click the green Connect button next to any online device on
  the Devices page."

Part of shellhub-io/team#168 (GS-4) — do not close; other checkboxes remain.
