### PR TITLE
feat: support a single namespace in Community Edition

### DIFF
--- a/api/app/server.go
+++ b/api/app/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shellhub-io/shellhub/api/store/pg"
 	pgoptions "github.com/shellhub-io/shellhub/api/store/pg/options"
 	"github.com/shellhub-io/shellhub/pkg/api/internalclient"
+	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/cache"
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/worker"
@@ -106,6 +107,10 @@ func (s *Server) Setup(ctx context.Context) error {
 		log.Info("Store wrapper applied")
 	}
 
+	if err := reconcileInstanceBinding(ctx, store); err != nil {
+		return errors.Join(errors.New("failed to reconcile instance binding"), err)
+	}
+
 	apiClient, err := internalclient.NewClient(nil, internalclient.WithAsynqWorker(s.env.RedisURI))
 	if err != nil {
 		return err
@@ -164,6 +169,41 @@ func (s *Server) Setup(ctx context.Context) error {
 	log.Info("Server setup completed successfully")
 
 	return nil
+}
+
+// reconcileInstanceBinding makes systems.instance_tenant_id reflect the current edition on every
+// boot, without an edition check — the mounted store decides. It reads the system, proposes the
+// oldest namespace as the binding when unset, and writes it back: the core store (Community)
+// persists it (activating single-namespace, and backfilling existing installs), while the
+// Enterprise/Cloud store wrapper strips it in SystemSet (keeping multi-tenant, and clearing a
+// binding inherited from a former Community install after an upgrade).
+func reconcileInstanceBinding(ctx context.Context, st store.Store) error {
+	system, err := st.SystemGet(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !system.Setup {
+		return nil
+	}
+
+	if system.InstanceTenantID == "" {
+		namespaces, _, err := st.NamespaceList(ctx,
+			st.Options().Sort(&query.Sorter{By: "created_at", Order: query.OrderAsc}),
+			st.Options().Paginate(&query.Paginator{Page: 1, PerPage: 1}),
+		)
+		if err != nil {
+			return err
+		}
+
+		if len(namespaces) == 0 {
+			return nil
+		}
+
+		system.InstanceTenantID = namespaces[0].TenantID
+	}
+
+	return st.SystemSet(ctx, system)
 }
 
 // Start begins serving API requests and processing background tasks. It blocks the current goroutine until the server stops

--- a/api/pkg/echo/handlers/pkg/converter/converter.go
+++ b/api/pkg/echo/handlers/pkg/converter/converter.go
@@ -28,6 +28,8 @@ func FromErrServiceToHTTPStatus(code int) int {
 		return http.StatusForbidden
 	case services.ErrCodeNoContentChange:
 		return http.StatusNoContent
+	case services.ErrCodeConflict:
+		return http.StatusConflict
 	default:
 		return http.StatusInternalServerError
 	}

--- a/api/routes/nsadm_test.go
+++ b/api/routes/nsadm_test.go
@@ -17,12 +17,32 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/query"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	envMocks "github.com/shellhub-io/shellhub/pkg/envs/mocks"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	gomock "github.com/stretchr/testify/mock"
 )
 
+// withEnterpriseEnv points envs.DefaultBackend at a backend reporting the Enterprise edition so
+// NewRouter registers the namespace-create route, which is dropped in Community. The previous
+// backend is restored on cleanup.
+func withEnterpriseEnv(t *testing.T) {
+	t.Helper()
+
+	prev := envs.DefaultBackend
+	t.Cleanup(func() { envs.DefaultBackend = prev })
+
+	envMock := envMocks.NewMockBackend(t)
+	envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("true").Maybe()
+	envMock.On("Get", "SHELLHUB_CLOUD").Return("false").Maybe()
+	envMock.On("Get", gomock.Anything).Return("").Maybe()
+	envs.DefaultBackend = envMock
+}
+
 func TestCreateNamespace(t *testing.T) {
+	withEnterpriseEnv(t)
+
 	mock := mocks.NewMockService(t)
 
 	type Expected struct {
@@ -654,6 +674,8 @@ func TestGetNamespaceListBlocksAPIKey(t *testing.T) {
 }
 
 func TestCreateNamespaceBlocksAPIKey(t *testing.T) {
+	withEnterpriseEnv(t)
+
 	mock := mocks.NewMockService(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/namespaces", strings.NewReader(`{}`))

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -194,7 +194,12 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	publicAPI.PUT(UpdatePublicKeyURL, gateway.Handler(handler.UpdatePublicKey), routesmiddleware.RequiresPermission(authorizer.PublicKeyEdit))
 	publicAPI.DELETE(DeletePublicKeyURL, gateway.Handler(handler.DeletePublicKey), routesmiddleware.RequiresPermission(authorizer.PublicKeyRemove))
 
-	publicAPI.POST(CreateNamespaceURL, gateway.Handler(handler.CreateNamespace), routesmiddleware.BlockAPIKey)
+	// Community is single-namespace: the one namespace is created at setup and the store refuses
+	// any further one (once the instance is bound). Drop the create route so CE returns 404
+	// instead of a confusing error; Enterprise/Cloud keep it.
+	if !envs.IsCommunity() {
+		publicAPI.POST(CreateNamespaceURL, gateway.Handler(handler.CreateNamespace), routesmiddleware.BlockAPIKey)
+	}
 	publicAPI.GET(GetNamespaceURL, gateway.Handler(handler.GetNamespace), routesmiddleware.RequiresTenant(ParamNamespaceTenant))
 	publicAPI.GET(ListNamespaceURL, gateway.Handler(handler.GetNamespaceList), routesmiddleware.BlockAPIKey)
 	publicAPI.PUT(EditNamespaceURL, gateway.Handler(handler.EditNamespace), routesmiddleware.RequiresTenant(ParamNamespaceTenant), routesmiddleware.RequiresPermission(authorizer.NamespaceUpdate))

--- a/api/routes/setup.go
+++ b/api/routes/setup.go
@@ -22,9 +22,10 @@ func (h *Handler) Setup(c gateway.Context) error {
 		return err
 	}
 
-	if err := h.service.Setup(c.Ctx(), req); err != nil {
+	res, err := h.service.Setup(c.Ctx(), req)
+	if err != nil {
 		return err
 	}
 
-	return c.NoContent(http.StatusOK)
+	return c.JSON(http.StatusOK, res)
 }

--- a/api/routes/setup_test.go
+++ b/api/routes/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	envMocks "github.com/shellhub-io/shellhub/pkg/envs/mocks"
+	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -20,6 +21,7 @@ func TestSetup(t *testing.T) {
 	envs.DefaultBackend = envMock
 
 	envMock.On("Get", "SHELLHUB_CLOUD").Return("false")
+	envMock.On("Get", "SHELLHUB_ENTERPRISE").Return("false")
 
 	servicesMock := serviceMocks.NewMockService(t)
 
@@ -52,15 +54,17 @@ func TestSetup(t *testing.T) {
                 "name": "John Doe",
                 "username": "john.doe",
                 "email": "john.doe@example.com",
-                "password": "password"
+                "password": "password",
+                "namespace": "john-doe"
             }`,
 			requiredMocks: func() {
 				servicesMock.On("Setup", mock.Anything, requests.Setup{
-					Name:     "John Doe",
-					Username: "john.doe",
-					Email:    "john.doe@example.com",
-					Password: "password",
-				}).Return(errors.New("")).Once()
+					Name:      "John Doe",
+					Username:  "john.doe",
+					Email:     "john.doe@example.com",
+					Password:  "password",
+					Namespace: "john-doe",
+				}).Return(nil, errors.New("")).Once()
 			},
 			expected: http.StatusInternalServerError,
 		},
@@ -70,15 +74,17 @@ func TestSetup(t *testing.T) {
                 "name": "John Doe",
                 "username": "john.doe",
                 "email": "john.doe@example.com",
-                "password": "password"
+                "password": "password",
+                "namespace": "john-doe"
             }`,
 			requiredMocks: func() {
 				servicesMock.On("Setup", mock.Anything, requests.Setup{
-					Name:     "John Doe",
-					Username: "john.doe",
-					Email:    "john.doe@example.com",
-					Password: "password",
-				}).Return(nil).Once()
+					Name:      "John Doe",
+					Username:  "john.doe",
+					Email:     "john.doe@example.com",
+					Password:  "password",
+					Namespace: "john-doe",
+				}).Return(&models.UserAuthResponse{Token: "token"}, nil).Once()
 			},
 			expected: http.StatusOK,
 		},

--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -36,6 +36,9 @@ const (
 	ErrCodeCreated
 	// ErrCodeNotImplemented is the error code to be used when the resource is not yet implemented.
 	ErrCodeNotImplemented
+	// ErrCodeConflict is the error code for when the request conflicts with the resource's
+	// current state (mapped to HTTP 409).
+	ErrCodeConflict
 )
 
 // ErrDataNotFound structure should be used to add errors.Data to an error when the resource is not found.
@@ -91,6 +94,8 @@ var (
 	ErrNamespaceMemberFillData         = errors.New("member fill data", ErrLayer, ErrCodeInvalid)
 	ErrNamespaceMemberDuplicated       = errors.New("member duplicated", ErrLayer, ErrCodeDuplicated)
 	ErrNamespaceCreateStore            = errors.New("namespace create store", ErrLayer, ErrCodeStore)
+	ErrNamespaceInstanceProtected      = errors.New("namespace is bound to the instance and cannot be deleted", ErrLayer, ErrCodeConflict)
+	ErrNamespaceSingle                 = errors.New("instance does not support multi-tenancy", ErrLayer, ErrCodeConflict)
 	ErrMaxTagReached                   = errors.New("tag limit reached", ErrLayer, ErrCodeLimit)
 	ErrDuplicateTagName                = errors.New("tag duplicated", ErrLayer, ErrCodeDuplicated)
 	ErrTagNameNotFound                 = errors.New("tag not found", ErrLayer, ErrCodeNotFound)
@@ -352,6 +357,18 @@ func NewErrNamespaceList(next error) error {
 // NewErrNamespaceInvalid returns an error to be used when the namespace is invalid.
 func NewErrNamespaceInvalid(next error) error {
 	return NewErrInvalid(ErrNamespaceInvalid, nil, next)
+}
+
+// NewErrNamespaceInstanceProtected returns an error to be used when deleting the namespace bound
+// to the instance is refused (single-namespace Community deployments).
+func NewErrNamespaceInstanceProtected(next error) error {
+	return errors.Wrap(ErrNamespaceInstanceProtected, next)
+}
+
+// NewErrNamespaceSingle returns an error to be used when creating a namespace is refused because
+// the instance is bound to a single namespace (single-namespace Community deployments).
+func NewErrNamespaceSingle(next error) error {
+	return errors.Wrap(ErrNamespaceSingle, next)
 }
 
 // NewErrNamespaceDuplicated returns an error to be used when the namespace is duplicated.

--- a/api/services/mocks/mock_service.go
+++ b/api/services/mocks/mock_service.go
@@ -3952,20 +3952,31 @@ func (_c *MockService_SetDeviceCustomField_Call) RunAndReturn(run func(ctx conte
 }
 
 // Setup provides a mock function for the type MockService
-func (_mock *MockService) Setup(ctx context.Context, req requests.Setup) error {
+func (_mock *MockService) Setup(ctx context.Context, req requests.Setup) (*models.UserAuthResponse, error) {
 	ret := _mock.Called(ctx, req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Setup")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.Setup) error); ok {
+	var r0 *models.UserAuthResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.Setup) (*models.UserAuthResponse, error)); ok {
+		return returnFunc(ctx, req)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.Setup) *models.UserAuthResponse); ok {
 		r0 = returnFunc(ctx, req)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.UserAuthResponse)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context, requests.Setup) error); ok {
+		r1 = returnFunc(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockService_Setup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Setup'
@@ -3998,12 +4009,12 @@ func (_c *MockService_Setup_Call) Run(run func(ctx context.Context, req requests
 	return _c
 }
 
-func (_c *MockService_Setup_Call) Return(err error) *MockService_Setup_Call {
-	_c.Call.Return(err)
+func (_c *MockService_Setup_Call) Return(userAuthResponse *models.UserAuthResponse, err error) *MockService_Setup_Call {
+	_c.Call.Return(userAuthResponse, err)
 	return _c
 }
 
-func (_c *MockService_Setup_Call) RunAndReturn(run func(ctx context.Context, req requests.Setup) error) *MockService_Setup_Call {
+func (_c *MockService_Setup_Call) RunAndReturn(run func(ctx context.Context, req requests.Setup) (*models.UserAuthResponse, error)) *MockService_Setup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/services/namespace.go
+++ b/api/services/namespace.go
@@ -119,6 +119,13 @@ func (s *service) CreateNamespace(ctx context.Context, req *requests.NamespaceCr
 			return nil, NewErrNamespaceDuplicated(err)
 		}
 
+		// Defense in depth: the route is dropped in Community, but if the edition env and the
+		// store binding ever disagree (e.g. an Enterprise env running against a bound CE store),
+		// surface the single-namespace refusal as a clean conflict instead of a 500.
+		if errors.Is(err, store.ErrNamespaceSingle) {
+			return nil, NewErrNamespaceSingle(err)
+		}
+
 		return nil, NewErrNamespaceCreateStore(err)
 	}
 
@@ -207,7 +214,17 @@ func (s *service) DeleteNamespace(ctx context.Context, tenantID string) error {
 		return err
 	}
 
-	return s.store.NamespaceDelete(ctx, n)
+	if err := s.store.NamespaceDelete(ctx, n); err != nil {
+		// The instance is bound to this namespace (single-namespace Community deployment); the
+		// FK's ON DELETE RESTRICT refuses it. Surface it as a 409 instead of a 500.
+		if errors.Is(err, store.ErrNamespaceInstanceProtected) {
+			return NewErrNamespaceInstanceProtected(err)
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 func (s *service) EditNamespace(ctx context.Context, req *requests.NamespaceEdit) (*models.Namespace, error) {

--- a/api/services/setup.go
+++ b/api/services/setup.go
@@ -3,23 +3,35 @@ package services
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/shellhub-io/shellhub/api/store"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/clock"
+	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/pkg/uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+// devNamespace / devTenantID are the well-known fixtures used across the development stack (e.g.
+// the built-in dev agent connects to the "dev" namespace on this tenant). In development, a setup
+// that keeps the default "dev" name binds to this tenant so those fixtures keep working; renaming
+// the namespace opts out and a fresh tenant is generated (to exercise the normal flow).
+const (
+	devNamespace = "dev"
+	devTenantID  = "00000000-0000-4000-0000-000000000000"
 )
 
 type SetupService interface {
-	Setup(ctx context.Context, req requests.Setup) error
+	Setup(ctx context.Context, req requests.Setup) (*models.UserAuthResponse, error)
 }
 
-func (s *service) Setup(ctx context.Context, req requests.Setup) error {
+func (s *service) Setup(ctx context.Context, req requests.Setup) (*models.UserAuthResponse, error) {
 	system, err := s.store.SystemGet(ctx)
 	if err != nil || system.Setup {
-		return NewErrSetupForbidden(err)
+		return nil, NewErrSetupForbidden(err)
 	}
 
 	data := models.UserData{
@@ -30,16 +42,16 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) error {
 	}
 
 	if ok, err := s.validator.Struct(data); !ok || err != nil {
-		return NewErrUserInvalid(nil, err)
+		return nil, NewErrUserInvalid(nil, err)
 	}
 
 	password, err := models.HashUserPassword(req.Password)
 	if err != nil {
-		return NewErrUserPasswordInvalid(err)
+		return nil, NewErrUserPasswordInvalid(err)
 	}
 
 	if ok, err := s.validator.Struct(password); !ok || err != nil {
-		return NewErrUserPasswordInvalid(err)
+		return nil, NewErrUserPasswordInvalid(err)
 	}
 
 	user := &models.User{
@@ -61,18 +73,27 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) error {
 	if err != nil {
 		if errors.Is(err, store.ErrDuplicate) {
 			if field, ok := store.DuplicatedField(err); ok {
-				return NewErrUserDuplicated([]string{field}, err)
+				return nil, NewErrUserDuplicated([]string{field}, err)
 			}
 
-			return NewErrUserUnhandledDuplicate()
+			return nil, NewErrUserUnhandledDuplicate()
 		}
 
-		return err
+		return nil, err
+	}
+
+	// Namespace names route SSHIDs and are matched case-insensitively, so normalize to
+	// lowercase here just like the regular namespace-creation path does.
+	namespaceName := strings.ToLower(req.Namespace)
+
+	tenantID := uuid.Generate()
+	if envs.IsDevelopment() && namespaceName == devNamespace {
+		tenantID = devTenantID
 	}
 
 	namespace := &models.Namespace{
-		Name:       req.Username,
-		TenantID:   uuid.Generate(),
+		Name:       namespaceName,
+		TenantID:   tenantID,
 		MaxDevices: -1,
 		Owner:      insertedID,
 		Type:       models.TypePersonal,
@@ -93,16 +114,32 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) error {
 	if _, err = s.store.NamespaceCreate(ctx, namespace); err != nil {
 		user.ID = insertedID
 		if err := s.store.UserDelete(ctx, user); err != nil {
-			return NewErrUserDelete(err)
+			return nil, NewErrUserDelete(err)
 		}
 
-		return NewErrNamespaceDuplicated(err)
+		return nil, NewErrNamespaceDuplicated(err)
 	}
 
 	system.Setup = true
+	// Bind the instance to the namespace just created. In Community this makes it the single
+	// namespace (NamespaceCreate refuses any further namespace once this is set). Enterprise/Cloud
+	// strip the binding in their store wrapper's SystemSet, so it stays empty there.
+	system.InstanceTenantID = namespace.TenantID
 	if err := s.store.SystemSet(ctx, system); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	// Issue an authenticated session for the admin we just created so the client can enter the
+	// instance without a second round-trip through the login screen. Setup is already committed
+	// at this point, so a token-minting failure must not turn a successful setup into an error
+	// (a retry would then hit ErrSetupForbidden); return without a token and let the client fall
+	// back to the login screen instead.
+	res, err := s.CreateUserToken(ctx, &requests.CreateUserToken{UserID: insertedID, TenantID: namespace.TenantID})
+	if err != nil {
+		log.WithError(err).Warn("setup completed but failed to issue an auto-login token")
+
+		return &models.UserAuthResponse{}, nil
+	}
+
+	return res, nil
 }

--- a/api/services/setup_test.go
+++ b/api/services/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/uuid"
 	uuidmock "github.com/shellhub-io/shellhub/pkg/uuid/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestSetup(t *testing.T) {
@@ -39,6 +40,9 @@ func TestSetup(t *testing.T) {
 	now := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
 	clockMock.On("Now").Return(now)
 
+	// Setup calls envs.IsDevelopment() to decide the namespace tenant; not development here.
+	envMock.On("Get", "SHELLHUB_ENV").Return("")
+
 	ctx := context.TODO()
 
 	cases := []struct {
@@ -50,10 +54,11 @@ func TestSetup(t *testing.T) {
 		{
 			description: "Fail when setup isn't allowed",
 			req: requests.Setup{
-				Email:    "teste@google.com",
-				Name:     "userteste",
-				Username: "userteste",
-				Password: "secret",
+				Email:     "teste@google.com",
+				Name:      "userteste",
+				Username:  "userteste",
+				Password:  "secret",
+				Namespace: "userteste",
 			},
 			requiredMocks: func() {
 				storeMock.On("SystemGet", ctx).Return(nil, errors.New("error", "", 0)).Once()
@@ -63,10 +68,11 @@ func TestSetup(t *testing.T) {
 		{
 			description: "Fail when cannot hash the password",
 			req: requests.Setup{
-				Email:    "teste@google.com",
-				Name:     "userteste",
-				Username: "userteste",
-				Password: "secret",
+				Email:     "teste@google.com",
+				Name:      "userteste",
+				Username:  "userteste",
+				Password:  "secret",
+				Namespace: "userteste",
 			},
 			requiredMocks: func() {
 				storeMock.On("SystemGet", ctx).Return(&models.System{
@@ -83,10 +89,11 @@ func TestSetup(t *testing.T) {
 		{
 			description: "Fail when cannot create the user due to duplicate field",
 			req: requests.Setup{
-				Email:    "teste@google.com",
-				Name:     "userteste",
-				Username: "userteste",
-				Password: "secret",
+				Email:     "teste@google.com",
+				Name:      "userteste",
+				Username:  "userteste",
+				Password:  "secret",
+				Namespace: "userteste",
 			},
 			requiredMocks: func() {
 				storeMock.On("SystemGet", ctx).Return(&models.System{
@@ -129,10 +136,11 @@ func TestSetup(t *testing.T) {
 		{
 			description: "Fail when cannot create the user due to unhandled duplicate (no field info)",
 			req: requests.Setup{
-				Email:    "teste@google.com",
-				Name:     "userteste",
-				Username: "userteste",
-				Password: "secret",
+				Email:     "teste@google.com",
+				Name:      "userteste",
+				Username:  "userteste",
+				Password:  "secret",
+				Namespace: "userteste",
 			},
 			requiredMocks: func() {
 				storeMock.On("SystemGet", ctx).Return(&models.System{
@@ -171,10 +179,11 @@ func TestSetup(t *testing.T) {
 		{
 			description: "Fail when cannot create the user due to a generic store error",
 			req: requests.Setup{
-				Email:    "teste@google.com",
-				Name:     "userteste",
-				Username: "userteste",
-				Password: "secret",
+				Email:     "teste@google.com",
+				Name:      "userteste",
+				Username:  "userteste",
+				Password:  "secret",
+				Namespace: "userteste",
 			},
 			requiredMocks: func() {
 				storeMock.On("SystemGet", ctx).Return(&models.System{
@@ -213,10 +222,11 @@ func TestSetup(t *testing.T) {
 		{
 			description: "Fail when cannot create namespace, and user deletion fails",
 			req: requests.Setup{
-				Email:    "teste@google.com",
-				Name:     "userteste",
-				Username: "userteste",
-				Password: "secret",
+				Email:     "teste@google.com",
+				Name:      "userteste",
+				Username:  "userteste",
+				Password:  "secret",
+				Namespace: "userteste",
 			},
 			requiredMocks: func() {
 				user := &models.User{
@@ -298,10 +308,11 @@ func TestSetup(t *testing.T) {
 		{
 			description: "Fail when cannot create namespace, and user deletion fails",
 			req: requests.Setup{
-				Email:    "teste@google.com",
-				Name:     "userteste",
-				Username: "userteste",
-				Password: "secret",
+				Email:     "teste@google.com",
+				Name:      "userteste",
+				Username:  "userteste",
+				Password:  "secret",
+				Namespace: "userteste",
 			},
 			requiredMocks: func() {
 				user := &models.User{
@@ -383,14 +394,15 @@ func TestSetup(t *testing.T) {
 		{
 			description: "Success to create the user and namespace",
 			req: requests.Setup{
-				Email:    "teste@google.com",
-				Name:     "userteste",
-				Username: "userteste",
-				Password: "secret",
+				Email:     "teste@google.com",
+				Name:      "userteste",
+				Username:  "userteste",
+				Password:  "secret",
+				Namespace: "userteste",
 			},
 			requiredMocks: func() {
 				initialSystem := &models.System{Setup: false}
-				finalSystem := &models.System{Setup: true}
+				finalSystem := &models.System{Setup: true, InstanceTenantID: tenant}
 
 				storeMock.On("SystemGet", ctx).Return(initialSystem, nil).Once()
 
@@ -441,6 +453,37 @@ func TestSetup(t *testing.T) {
 				}
 				storeMock.On("NamespaceCreate", ctx, namespace).Return(tenant, nil).Once()
 				storeMock.On("SystemSet", ctx, finalSystem).Return(nil).Once()
+
+				// Setup mints an authenticated session for the new admin (auto-login) by
+				// delegating to CreateUserToken, which resolves the user and namespace back.
+				createdUser := &models.User{
+					ID:        "000000000000000000000000",
+					Origin:    models.UserOriginLocal,
+					Status:    models.UserStatusConfirmed,
+					CreatedAt: now,
+					UserData: models.UserData{
+						Name:     "userteste",
+						Email:    "teste@google.com",
+						Username: "userteste",
+					},
+					MaxNamespaces: -1,
+					Preferences: models.UserPreferences{
+						AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+					Admin: true,
+				}
+				storeMock.On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(createdUser, nil).Once()
+				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenant).
+					Return(&models.Namespace{
+						Name:     "userteste",
+						TenantID: tenant,
+						Owner:    "000000000000000000000000",
+						Members: []models.Member{
+							{ID: "000000000000000000000000", Role: authorizer.RoleOwner, AddedAt: now},
+						},
+					}, nil).Once()
+				storeMock.On("UserUpdate", ctx, mock.Anything).Return(nil).Once()
 			},
 			expected: nil,
 		},
@@ -452,8 +495,12 @@ func TestSetup(t *testing.T) {
 
 			service := NewService(store.Store(storeMock), privateKey, publicKey, storecache.NewNullCache(), clientMock)
 
-			err := service.Setup(ctx, tc.req)
+			res, err := service.Setup(ctx, tc.req)
 			assert.Equal(t, tc.expected, err)
+			if tc.expected == nil {
+				assert.NotNil(t, res)
+				assert.NotEmpty(t, res.Token)
+			}
 		})
 	}
 }

--- a/api/store/errors.go
+++ b/api/store/errors.go
@@ -16,6 +16,7 @@ const (
 	ErrCodeDuplicated
 	ErrCodeInvalid
 	ErrCodeInternal
+	ErrCodeConstraint
 )
 
 var (
@@ -24,6 +25,13 @@ var (
 	ErrInvalidHex       = errors.New("the provided hex string is not a valid ObjectID", ErrLayer, ErrCodeInvalid)
 	ErrResolverNotFound = errors.New("resolver not found", ErrLayer, ErrCodeInvalid)
 	ErrInternal         = errors.New("internal store error", ErrLayer, ErrCodeInternal)
+	// ErrNamespaceInstanceProtected is returned when deleting the namespace bound to the
+	// instance (systems.instance_tenant_id) is refused by the FK's ON DELETE RESTRICT.
+	ErrNamespaceInstanceProtected = errors.New("namespace is bound to the instance", ErrLayer, ErrCodeConstraint)
+	// ErrNamespaceSingle is returned when creating an additional namespace on an instance already
+	// bound to one (systems.instance_tenant_id set — Community). Enterprise/Cloud never bind, so
+	// this is Community-specific and distinct from a plain duplicate-name conflict.
+	ErrNamespaceSingle = errors.New("instance does not support multi-tenancy", ErrLayer, ErrCodeConstraint)
 )
 
 // DuplicateFieldError carries the name of the field that caused a duplicate-key violation.

--- a/api/store/pg/entity/system.go
+++ b/api/store/pg/entity/system.go
@@ -8,9 +8,10 @@ import (
 type System struct {
 	bun.BaseModel `bun:"table:systems"`
 
-	ID             string               `bun:"id,pk,type:uuid"`
-	Setup          bool                 `bun:"setup"`
-	Authentication SystemAuthentication `bun:"embed:authentication_"`
+	ID               string               `bun:"id,pk,type:uuid"`
+	Setup            bool                 `bun:"setup"`
+	InstanceTenantID string               `bun:"instance_tenant_id,nullzero,type:uuid"`
+	Authentication   SystemAuthentication `bun:"embed:authentication_"`
 }
 
 type SystemAuthentication struct {
@@ -27,7 +28,8 @@ func SystemFromModel(model *models.System) *System {
 	}
 
 	entity := &System{
-		Setup: model.Setup,
+		Setup:            model.Setup,
+		InstanceTenantID: model.InstanceTenantID,
 	}
 
 	if model.Authentication != nil {
@@ -45,7 +47,8 @@ func SystemToModel(entity *System) *models.System {
 	}
 
 	return &models.System{
-		Setup: entity.Setup,
+		Setup:            entity.Setup,
+		InstanceTenantID: entity.InstanceTenantID,
 		Authentication: &models.SystemAuthentication{
 			Local: &models.SystemAuthenticationLocal{
 				Enabled: entity.Authentication.Local.Enabled,

--- a/api/store/pg/migrations/009_system_instance_tenant.tx.down.sql
+++ b/api/store/pg/migrations/009_system_instance_tenant.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE systems DROP COLUMN IF EXISTS instance_tenant_id;

--- a/api/store/pg/migrations/009_system_instance_tenant.tx.up.sql
+++ b/api/store/pg/migrations/009_system_instance_tenant.tx.up.sql
@@ -1,0 +1,16 @@
+-- Bind the ShellHub instance (the `systems` singleton) to its one namespace. In the
+-- Community Edition tenant = instance: a set instance_tenant_id makes NamespaceCreate
+-- refuse any further namespace, and the FK's ON DELETE RESTRICT protects the bound
+-- namespace from deletion. Enterprise/Cloud keep this NULL (the store wrapper strips it
+-- on write), leaving multi-tenant unchanged.
+
+-- No data backfill here: a migration can't tell the edition, and setting the binding on
+-- an Enterprise instance would break multi-tenant. The API server binds it at boot only
+-- when running the core store (Community); see the boot reconciliation step.
+-- The constraint is named explicitly so fromSQLError can map its ON DELETE RESTRICT
+-- violation (SQLSTATE 23001, or 23503) to store.ErrNamespaceInstanceProtected; renaming
+-- it here silently breaks that mapping.
+ALTER TABLE systems
+    ADD COLUMN IF NOT EXISTS instance_tenant_id uuid NULL
+    CONSTRAINT systems_instance_tenant_id_fkey
+    REFERENCES namespaces (id) ON DELETE RESTRICT;

--- a/api/store/pg/namespace.go
+++ b/api/store/pg/namespace.go
@@ -15,6 +15,21 @@ func (pg *Pg) NamespaceCreate(ctx context.Context, namespace *models.Namespace) 
 	db := pg.GetConnection(ctx)
 
 	namespace.CreatedAt = clock.Now()
+
+	// Single-namespace binding: once the instance is bound to a namespace
+	// (systems.instance_tenant_id, set in Community deployments), refuse any further namespace
+	// with a specific error — distinct from a duplicate-name conflict. Enterprise/Cloud keep the
+	// binding empty (their store wrapper strips it), so this never triggers there. Setup creates
+	// the first namespace while the binding is still empty.
+	system, err := pg.SystemGet(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if system.InstanceTenantID != "" {
+		return "", store.ErrNamespaceSingle
+	}
+
 	if namespace.TenantID == "" {
 		namespace.TenantID = uuid.Generate()
 	}

--- a/api/store/pg/utils.go
+++ b/api/store/pg/utils.go
@@ -37,6 +37,12 @@ const (
 	constraintUsersUsernameKey = "users_username_key"
 )
 
+// constraintSystemsInstanceTenantIDFkey is the FK from systems.instance_tenant_id to
+// namespaces.id, created ON DELETE RESTRICT by migration 009. A violation means a caller
+// tried to delete the namespace bound to the instance.
+// WARNING: renaming it in the migration silently breaks the mapping below.
+const constraintSystemsInstanceTenantIDFkey = "systems_instance_tenant_id_fkey"
+
 func fromSQLError(err error) error {
 	switch err {
 	case nil:
@@ -52,6 +58,13 @@ func fromSQLError(err error) error {
 				}
 
 				return store.ErrDuplicate
+			}
+
+			// Instance binding: deleting the namespace the instance is bound to is refused by
+			// ON DELETE RESTRICT. Postgres reports that as restrict_violation (23001); a plain
+			// foreign_key_violation (23503) is matched too for defensiveness.
+			if (pgErr.Code == "23001" || pgErr.Code == "23503") && pgErr.ConstraintName == constraintSystemsInstanceTenantIDFkey {
+				return store.ErrNamespaceInstanceProtected
 			}
 		}
 

--- a/api/store/pg/utils_test.go
+++ b/api/store/pg/utils_test.go
@@ -79,6 +79,32 @@ func TestFromSQLError(t *testing.T) {
 			},
 		},
 		{
+			name:  "restrict_violation (23001) on the instance FK maps to ErrNamespaceInstanceProtected",
+			input: &pgconn.PgError{Code: "23001", ConstraintName: "systems_instance_tenant_id_fkey"},
+			check: func(t *testing.T, result error) {
+				require.Error(t, result)
+				assert.True(t, errors.Is(result, store.ErrNamespaceInstanceProtected))
+				assert.False(t, errors.Is(result, store.ErrInternal))
+			},
+		},
+		{
+			name:  "foreign_key_violation (23503) on the instance FK maps to ErrNamespaceInstanceProtected",
+			input: &pgconn.PgError{Code: "23503", ConstraintName: "systems_instance_tenant_id_fkey"},
+			check: func(t *testing.T, result error) {
+				require.Error(t, result)
+				assert.True(t, errors.Is(result, store.ErrNamespaceInstanceProtected))
+			},
+		},
+		{
+			name:  "restrict_violation (23001) on an unrelated constraint stays internal",
+			input: &pgconn.PgError{Code: "23001", ConstraintName: "some_other_fkey"},
+			check: func(t *testing.T, result error) {
+				require.Error(t, result)
+				assert.True(t, errors.Is(result, store.ErrInternal))
+				assert.False(t, errors.Is(result, store.ErrNamespaceInstanceProtected))
+			},
+		},
+		{
 			name:  "generic unmapped error wraps with store.ErrInternal",
 			input: fmt.Errorf("some unexpected db error"),
 			check: func(t *testing.T, result error) {

--- a/cli/services/errors.go
+++ b/cli/services/errors.go
@@ -7,6 +7,8 @@ import (
 var (
 	ErrCreateNewUser               = errors.New("failed to create a new user")
 	ErrDuplicateNamespace          = errors.New("namespace already exists")
+	ErrNamespaceSingle             = errors.New("this instance does not support multi-tenancy")
+	ErrNamespaceInstanceProtected  = errors.New("this namespace is bound to the instance and cannot be removed")
 	ErrUserNotFound                = errors.New("user not found")
 	ErrNamespaceNotFound           = errors.New("namespace not found")
 	ErrFailedDeleteUser            = errors.New("failed to delete the user")

--- a/cli/services/namespaces.go
+++ b/cli/services/namespaces.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/shellhub-io/shellhub/api/store"
@@ -68,6 +69,10 @@ func (s *service) NamespaceCreate(ctx context.Context, input *inputs.NamespaceCr
 	}
 
 	if _, err = s.store.NamespaceCreate(ctx, ns); err != nil {
+		if errors.Is(err, store.ErrNamespaceSingle) {
+			return nil, ErrNamespaceSingle
+		}
+
 		return nil, ErrDuplicateNamespace
 	}
 
@@ -129,6 +134,12 @@ func (s *service) NamespaceDelete(ctx context.Context, input *inputs.NamespaceDe
 	}
 
 	if err := s.store.NamespaceDelete(ctx, ns); err != nil {
+		// Community binds the instance to its single namespace; the store's ON DELETE
+		// RESTRICT refuses to remove it. Report that plainly instead of a generic failure.
+		if errors.Is(err, store.ErrNamespaceInstanceProtected) {
+			return ErrNamespaceInstanceProtected
+		}
+
 		return ErrFailedDeleteNamespace
 	}
 

--- a/openapi/spec/paths/api@setup.yaml
+++ b/openapi/spec/paths/api@setup.yaml
@@ -1,7 +1,7 @@
 post:
   operationId: setup
   summary: User setup
-  description: Register an user and create namespace with the same name as username
+  description: Register the admin user and create the instance namespace.
   security: []
   tags:
     - community
@@ -20,14 +20,21 @@ post:
               $ref: ../components/schemas/userUsername.yaml
             password:
               $ref: ../components/schemas/userPassword.yaml
+            namespace:
+              $ref: ../components/schemas/namespaceName.yaml
           required:
             - name
             - email
             - username
             - password
+            - namespace
   responses:
     '200':
       description: Success to register user on setup.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/userAuth.yaml
     '409':
       $ref: ../components/responses/409.yaml
     '400':

--- a/pkg/api/requests/setup.go
+++ b/pkg/api/requests/setup.go
@@ -1,8 +1,9 @@
 package requests
 
 type Setup struct {
-	Email    string `json:"email" validate:"required,email"`
-	Name     string `json:"name" validate:"required,name"`
-	Username string `json:"username" validate:"required,username"`
-	Password string `json:"password" validate:"required,password"`
+	Email     string `json:"email" validate:"required,email"`
+	Name      string `json:"name" validate:"required,name"`
+	Username  string `json:"username" validate:"required,username"`
+	Password  string `json:"password" validate:"required,password"`
+	Namespace string `json:"namespace" validate:"required,hostname_rfc1123,excludes=."`
 }

--- a/pkg/models/system.go
+++ b/pkg/models/system.go
@@ -2,6 +2,10 @@ package models
 
 type System struct {
 	Setup bool `json:"setup"`
+	// InstanceTenantID binds the instance to its namespace in single-namespace (Community)
+	// deployments. When set, the store refuses any further namespace creation. Enterprise/Cloud
+	// leave it empty (the store wrapper strips it) to keep multi-tenant behavior.
+	InstanceTenantID string `json:"instance_tenant_id"`
 	// Authentication manages the settings for available authentication methods.
 	Authentication *SystemAuthentication `json:"authentication"`
 }

--- a/ui/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespace.tsx
@@ -111,7 +111,6 @@ function CommunityInstructions() {
   const [tenantId, setTenantId] = useState<string | null>(null);
 
   const addCmd = "./bin/cli member add <username> <namespace> <role>";
-  const createCmd = "./bin/cli namespace create <namespace> <owner-username>";
 
   // Poll for namespace assignment every 5 seconds (without updating the store)
   useEffect(() => {
@@ -140,22 +139,13 @@ function CommunityInstructions() {
   return (
     <div className="w-full space-y-5">
       <p className="text-sm text-text-secondary leading-relaxed">
-        Ask the instance administrator to create a new namespace for you, or add
-        you to an existing one.
+        Ask the instance administrator to add you to the namespace.
       </p>
 
-      {/* Option 1: Create new */}
+      {/* Add to the instance namespace */}
       <div>
         <p className="text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2">
-          Create a new namespace
-        </p>
-        <CopyBlock command={createCmd} />
-      </div>
-
-      {/* Option 2: Add to existing */}
-      <div>
-        <p className="text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2">
-          Or add to an existing namespace
+          Add a member to the namespace
         </p>
         <CopyBlock command={addCmd} />
         <p className="mt-1.5 text-2xs text-text-muted">

--- a/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespaceDialog.tsx
@@ -9,19 +9,15 @@ import {
   Button,
   IconBadge,
   IconButton,
-  WindowChrome,
 } from "@shellhub/design-system/primitives";
 import BaseDialog from "./BaseDialog";
-import CopyButton from "./CopyButton";
 import NamespaceNameField from "./fields/NamespaceNameField";
 import {
   NAMESPACE_NAME_MIN_LENGTH,
-  NAMESPACE_NAME_RULES,
   validateNamespaceName,
 } from "@/utils/validation";
 import { getConfig } from "@/env";
 import { useCreateNamespace } from "@/hooks/useNamespaceMutations";
-const CLI_COMMAND = "./bin/cli namespace create <namespace> <owner>";
 
 const FORM_ID = "create-namespace-form";
 
@@ -55,50 +51,6 @@ function CloudForm({
   );
 }
 
-function CeInstructions({ descriptionId }: { descriptionId: string }) {
-  return (
-    <>
-      <p id={descriptionId} className="text-sm text-text-muted leading-relaxed">
-        Community Edition uses the CLI to manage namespaces. Run this command on
-        your server:
-      </p>
-
-      {/* Command block */}
-      <WindowChrome
-        variant="terminal"
-        size="sm"
-        titleBarSlot={<CopyButton text={CLI_COMMAND} showLabel />}
-      >
-        <pre className="text-accent-cyan whitespace-pre-wrap break-all m-0">
-          <span className="text-text-muted select-none">$ </span>
-          {CLI_COMMAND}
-        </pre>
-      </WindowChrome>
-
-      {/* Name rules */}
-      <div>
-        <p className="text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5">
-          Naming rules
-        </p>
-        <ul className="space-y-1.5" aria-label="Namespace naming rules">
-          {NAMESPACE_NAME_RULES.map((rule) => (
-            <li
-              key={rule}
-              className="flex items-start gap-2 text-xs text-text-muted"
-            >
-              <span
-                className="w-1 h-1 rounded-full bg-border-light mt-1.5 shrink-0"
-                aria-hidden="true"
-              />
-              {rule}
-            </li>
-          ))}
-        </ul>
-      </div>
-    </>
-  );
-}
-
 interface CreateNamespaceDialogProps {
   open: boolean;
   onClose: () => void;
@@ -110,8 +62,9 @@ export default function CreateNamespaceDialog({
 }: CreateNamespaceDialogProps) {
   const autoId = useId();
   const titleId = `create-ns-title-${autoId}`;
-  const descriptionId = `create-ns-description-${autoId}`;
   const inputId = `create-ns-input-${autoId}`;
+  // Namespace creation is a premium (Cloud/Enterprise) feature. Community is single-namespace,
+  // so this dialog never renders there — the selector shows the upsell instead.
   const isCloud = getConfig().cloud || getConfig().enterprise;
 
   const [name, setName] = useState("");
@@ -144,7 +97,9 @@ export default function CreateNamespaceDialog({
         if (caught.status === 409) {
           setSubmitError("A namespace with this name already exists.");
         } else if (caught.status === 403) {
-          setSubmitError("You have reached the namespace limit or do not have permission.");
+          setSubmitError(
+            "You have reached the namespace limit or do not have permission.",
+          );
         } else if (caught.status === 400) {
           setSubmitError("The namespace name is invalid.");
         } else {
@@ -156,13 +111,14 @@ export default function CreateNamespaceDialog({
     }
   };
 
+  if (!isCloud) return null;
+
   return (
     <BaseDialog
       open={open}
       onClose={onClose}
       size="lg"
       aria-labelledby={titleId}
-      aria-describedby={isCloud ? undefined : descriptionId}
     >
       {/* Header */}
       <header className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-border shrink-0">
@@ -182,18 +138,14 @@ export default function CreateNamespaceDialog({
 
       {/* Body */}
       <div className="px-6 py-5 space-y-5">
-        {isCloud ? (
-          <CloudForm
-            inputId={inputId}
-            name={name}
-            setName={setName}
-            displayError={displayError}
-            resetError={resetError}
-            onSubmit={(e) => void handleSubmit(e)}
-          />
-        ) : (
-          <CeInstructions descriptionId={descriptionId} />
-        )}
+        <CloudForm
+          inputId={inputId}
+          name={name}
+          setName={setName}
+          displayError={displayError}
+          resetError={resetError}
+          onSubmit={(e) => void handleSubmit(e)}
+        />
       </div>
 
       {/* Footer */}
@@ -210,18 +162,16 @@ export default function CreateNamespaceDialog({
 
         <div className="flex items-center gap-2">
           <Button variant="ghost" onClick={onClose}>
-            {isCloud ? "Cancel" : "Close"}
+            Cancel
           </Button>
-          {isCloud && (
-            <Button
-              type="submit"
-              form={FORM_ID}
-              loading={createNs.isPending}
-              disabled={name.length < NAMESPACE_NAME_MIN_LENGTH}
-            >
-              Create
-            </Button>
-          )}
+          <Button
+            type="submit"
+            form={FORM_ID}
+            loading={createNs.isPending}
+            disabled={name.length < NAMESPACE_NAME_MIN_LENGTH}
+          >
+            Create
+          </Button>
         </div>
       </footer>
     </BaseDialog>

--- a/ui/apps/console/src/components/common/NamespaceUpsellDialog.tsx
+++ b/ui/apps/console/src/components/common/NamespaceUpsellDialog.tsx
@@ -1,0 +1,100 @@
+import {
+  ArrowTopRightOnSquareIcon,
+  CheckIcon,
+  RectangleStackIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import BaseDialog from "@/components/common/BaseDialog";
+
+const PRICING_URL = "https://www.shellhub.io/pricing";
+
+const HIGHLIGHTS = [
+  "Separate namespaces for teams, environments, or customers",
+  "Members and roles scoped to each namespace",
+  "Devices and access policies isolated per namespace",
+];
+
+interface NamespaceUpsellDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function NamespaceUpsellDialog({
+  open,
+  onClose,
+}: NamespaceUpsellDialogProps) {
+  return (
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      size="md"
+      aria-labelledby="namespace-upsell-title"
+    >
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute right-4 top-4 rounded-md p-1.5 text-text-muted transition-colors hover:text-text-secondary"
+      >
+        <XMarkIcon className="w-5 h-5" />
+      </button>
+
+      <div className="bg-gradient-to-b from-primary/[0.1] to-transparent px-7 pb-2 pt-8">
+        <span className="flex h-12 w-12 items-center justify-center rounded-xl border border-primary/25 bg-primary/10 text-primary shadow-lg shadow-primary/10">
+          <RectangleStackIcon className="w-6 h-6" />
+        </span>
+        <p className="mt-4 font-mono text-2xs font-semibold uppercase tracking-wider text-accent-yellow">
+          Premium
+        </p>
+        <h2
+          id="namespace-upsell-title"
+          className="mt-1 text-lg font-semibold text-balance text-text-primary"
+        >
+          Run more than one namespace
+        </h2>
+      </div>
+
+      <div className="px-7 pb-6 pt-2">
+        <p className="text-sm text-text-secondary">
+          This instance runs as a single namespace. Upgrade to keep separate
+          workspaces, each with its own devices, members, and access policies.
+        </p>
+        <ul className="mt-4 flex flex-col gap-2.5">
+          {HIGHLIGHTS.map((h) => (
+            <li
+              key={h}
+              className="flex items-start gap-2.5 text-sm text-text-secondary"
+            >
+              <CheckIcon className="mt-0.5 w-4 h-4 shrink-0 text-accent-green" />
+              {h}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 border-t border-border px-7 py-4">
+        <p className="text-2xs text-text-muted">
+          Available on Cloud and Enterprise
+        </p>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm font-medium text-text-secondary transition-colors hover:text-text-primary"
+          >
+            Not now
+          </button>
+          <a
+            href={PRICING_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+          >
+            See pricing
+            <ArrowTopRightOnSquareIcon className="w-4 h-4" strokeWidth={2} />
+          </a>
+        </div>
+      </div>
+    </BaseDialog>
+  );
+}

--- a/ui/apps/console/src/components/common/SetupGuard.tsx
+++ b/ui/apps/console/src/components/common/SetupGuard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Outlet, Navigate, useLocation } from "react-router-dom";
 import { getInfo } from "@/client";
 import { getConfig } from "@/env";
+import { useAuthStore } from "@/stores/authStore";
 import { Spinner } from "@shellhub/design-system/primitives";
 
 export default function SetupGuard() {
@@ -9,6 +10,7 @@ export default function SetupGuard() {
   const [loading, setLoading] = useState(!isCloud);
   const [setupDone, setSetupDone] = useState(true);
   const location = useLocation();
+  const token = useAuthStore((s) => s.token);
 
   useEffect(() => {
     if (isCloud) return;
@@ -19,7 +21,9 @@ export default function SetupGuard() {
       .finally(() => setLoading(false));
   }, [isCloud, location.pathname]);
 
-  if (loading) {
+  const authed = !!token;
+
+  if (loading && !authed) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="flex items-center gap-3">
@@ -32,10 +36,17 @@ export default function SetupGuard() {
 
   const isSetupPage = location.pathname === "/setup";
 
-  if (!setupDone && !isSetupPage) {
+  // Sending the user TO setup: an authenticated session means setup is already complete (you
+  // can't get a token otherwise), so trust it and don't bounce a just-authenticated user back
+  // to /setup while the getInfo refresh is still in flight.
+  if (!setupDone && !authed && !isSetupPage) {
     return <Navigate to="/setup" replace />;
   }
 
+  // Sending the user AWAY from /setup: key only on the real setup state, never the token.
+  // loginWithToken sets the token synchronously (before the "Instance ready" screen renders),
+  // so keying this on the token would fire mid-auto-login and force a trip through /login —
+  // exactly the second login round-trip this feature removes.
   if (setupDone && isSetupPage) {
     return <Navigate to="/login" replace />;
   }

--- a/ui/apps/console/src/components/common/__tests__/CreateNamespaceDialog.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/CreateNamespaceDialog.test.tsx
@@ -23,12 +23,6 @@ vi.mock("@/hooks/useNamespaceMutations", () => ({
   useCreateNamespace: vi.fn(),
 }));
 
-// CopyButton calls navigator.clipboard — stub it to avoid jsdom errors
-Object.defineProperty(navigator, "clipboard", {
-  value: { writeText: vi.fn().mockResolvedValue(undefined) },
-  configurable: true,
-});
-
 import { getConfig, defaultConfig } from "@/env";
 import { useCreateNamespace } from "@/hooks/useNamespaceMutations";
 import { ClipboardProvider } from "../ClipboardProvider";
@@ -61,7 +55,19 @@ function renderDialog(open: boolean, onClose = vi.fn()) {
   };
 }
 
-describe("CreateNamespaceDialog", () => {
+describe("CreateNamespaceDialog (community)", () => {
+  it("renders nothing — namespace creation is a premium feature", () => {
+    // Default config is community; the selector shows the upsell instead of this dialog.
+    renderDialog(true);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("CreateNamespaceDialog (cloud/enterprise)", () => {
+  beforeEach(() => {
+    mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
+  });
+
   describe("when open=false", () => {
     it("renders nothing", () => {
       renderDialog(false);
@@ -83,42 +89,6 @@ describe("CreateNamespaceDialog", () => {
     });
   });
 
-  describe("CLI command", () => {
-    it("displays the correct CLI command text", () => {
-      renderDialog(true);
-      expect(
-        screen.getByText("./bin/cli namespace create <namespace> <owner>"),
-      ).toBeInTheDocument();
-    });
-  });
-
-  describe("naming rules", () => {
-    it("displays the '3-30 characters' rule", () => {
-      renderDialog(true);
-      expect(screen.getByText("3-30 characters")).toBeInTheDocument();
-    });
-
-    it("displays the 'Lowercase letters, numbers, and hyphens only' rule", () => {
-      renderDialog(true);
-      expect(
-        screen.getByText("Lowercase letters, numbers, and hyphens only"),
-      ).toBeInTheDocument();
-    });
-
-    it("displays the 'Cannot begin or end with a hyphen' rule", () => {
-      renderDialog(true);
-      expect(
-        screen.getByText("Cannot begin or end with a hyphen"),
-      ).toBeInTheDocument();
-    });
-
-    it("renders all three naming rules inside the labelled list", () => {
-      renderDialog(true);
-      const list = screen.getByRole("list", { name: "Namespace naming rules" });
-      expect(list.querySelectorAll("li")).toHaveLength(3);
-    });
-  });
-
   describe("closing the dialog", () => {
     it("calls onClose when the X button is clicked", async () => {
       const user = userEvent.setup();
@@ -129,11 +99,11 @@ describe("CreateNamespaceDialog", () => {
       expect(onClose).toHaveBeenCalledOnce();
     });
 
-    it("calls onClose when the Close button in the footer is clicked", async () => {
+    it("calls onClose when the Cancel button in the footer is clicked", async () => {
       const user = userEvent.setup();
       const { onClose } = renderDialog(true);
 
-      await user.click(screen.getByRole("button", { name: "Close" }));
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
 
       expect(onClose).toHaveBeenCalledOnce();
     });
@@ -158,16 +128,6 @@ describe("CreateNamespaceDialog", () => {
       );
     });
 
-    it("dialog aria-describedby points to the description paragraph", () => {
-      renderDialog(true);
-      const dialog = screen.getByRole("dialog");
-      const descId = dialog.getAttribute("aria-describedby");
-      expect(descId).toBeTruthy();
-      expect(document.getElementById(descId!)).toHaveTextContent(
-        /Community Edition uses the CLI to manage namespaces/i,
-      );
-    });
-
     it("heading id matches dialog's aria-labelledby", () => {
       renderDialog(true);
       const dialog = screen.getByRole("dialog");
@@ -175,16 +135,6 @@ describe("CreateNamespaceDialog", () => {
       expect(
         screen.getByRole("heading", { name: "Create a Namespace" }),
       ).toHaveAttribute("id", labelId);
-    });
-
-    it("description paragraph id matches dialog's aria-describedby", () => {
-      renderDialog(true);
-      const dialog = screen.getByRole("dialog");
-      const descId = dialog.getAttribute("aria-describedby")!;
-      const description = screen.getByText(
-        /Community Edition uses the CLI to manage namespaces/i,
-      );
-      expect(description).toHaveAttribute("id", descId);
     });
   });
 
@@ -203,20 +153,6 @@ describe("CreateNamespaceDialog", () => {
       const link = screen.getByRole("link", { name: /administration guide/i });
       expect(link).toHaveAttribute("target", "_blank");
     });
-  });
-});
-
-describe("CreateNamespaceDialog (cloud/enterprise)", () => {
-  beforeEach(() => {
-    mockGetConfig.mockReturnValue({ ...defaultConfig, enterprise: true });
-  });
-
-  it("renders the creation form instead of CLI instructions", () => {
-    renderDialog(true);
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
-    expect(
-      screen.queryByText(/Community Edition uses the CLI/i),
-    ).not.toBeInTheDocument();
   });
 
   it("renders the name input and Create button", () => {
@@ -307,7 +243,9 @@ describe("CreateNamespaceDialog (cloud/enterprise)", () => {
 
   it("shows 'A namespace with this name already exists.' on 409 and does NOT call onClose", async () => {
     const sdkError = { status: 409 };
-    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    const mutateAsync = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(sdkError);
     mockUseCreateNamespace.mockReturnValue({
       mutateAsync,
       isPending: false,
@@ -331,7 +269,9 @@ describe("CreateNamespaceDialog (cloud/enterprise)", () => {
 
   it("shows the limit/permission message on 403", async () => {
     const sdkError = { status: 403 };
-    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    const mutateAsync = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(sdkError);
     mockUseCreateNamespace.mockReturnValue({
       mutateAsync,
       isPending: false,
@@ -347,14 +287,18 @@ describe("CreateNamespaceDialog (cloud/enterprise)", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText("You have reached the namespace limit or do not have permission."),
+        screen.getByText(
+          "You have reached the namespace limit or do not have permission.",
+        ),
       ).toBeInTheDocument(),
     );
   });
 
   it("shows the invalid-name message on 400", async () => {
     const sdkError = { status: 400 };
-    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    const mutateAsync = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(sdkError);
     mockUseCreateNamespace.mockReturnValue({
       mutateAsync,
       isPending: false,
@@ -377,7 +321,9 @@ describe("CreateNamespaceDialog (cloud/enterprise)", () => {
 
   it("shows the generic fallback message on 500", async () => {
     const sdkError = { status: 500 };
-    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    const mutateAsync = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(sdkError);
     mockUseCreateNamespace.mockReturnValue({
       mutateAsync,
       isPending: false,
@@ -400,7 +346,9 @@ describe("CreateNamespaceDialog (cloud/enterprise)", () => {
 
   it("clears the error text from the DOM when the user types after a failed submission", async () => {
     const sdkError = { status: 409 };
-    const mutateAsync = vi.fn<() => Promise<void>>().mockRejectedValue(sdkError);
+    const mutateAsync = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(sdkError);
     mockUseCreateNamespace.mockReturnValue({
       mutateAsync,
       isPending: false,

--- a/ui/apps/console/src/components/common/__tests__/SetupGuard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/SetupGuard.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { useAuthStore } from "@/stores/authStore";
+import SetupGuard from "../SetupGuard";
+
+vi.mock("@/client", () => ({ getInfo: vi.fn() }));
+vi.mock("@/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/env")>();
+  return {
+    ...actual,
+    getConfig: vi.fn(() => ({ ...actual.defaultConfig, cloud: false })),
+  };
+});
+
+import { getInfo } from "@/client";
+
+const mockedGetInfo = vi.mocked(getInfo);
+
+function mockSetup(done: boolean) {
+  mockedGetInfo.mockResolvedValue({
+    data: { setup: done },
+  } as Awaited<ReturnType<typeof getInfo>>);
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route element={<SetupGuard />}>
+          <Route path="/setup" element={<div>setup page</div>} />
+          <Route path="/" element={<div>app content</div>} />
+        </Route>
+        <Route path="/login" element={<div>login page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockedGetInfo.mockReset();
+  useAuthStore.setState({ token: null });
+});
+
+describe("SetupGuard", () => {
+  it("keeps a just-authenticated user on /setup so the success screen can show", async () => {
+    // Reproduce the auto-login sequence: getInfo resolves setup=false first (user is mid-setup),
+    // then loginWithToken sets the token synchronously. The guard must NOT bounce to /login.
+    mockSetup(false);
+    renderAt("/setup");
+    expect(await screen.findByText("setup page")).toBeInTheDocument();
+
+    await act(async () => {
+      useAuthStore.setState({ token: "issued-token" });
+    });
+
+    expect(screen.getByText("setup page")).toBeInTheDocument();
+    expect(screen.queryByText("login page")).not.toBeInTheDocument();
+  });
+
+  it("redirects away from /setup to /login once setup is already done", async () => {
+    mockSetup(true);
+    renderAt("/setup");
+    expect(await screen.findByText("login page")).toBeInTheDocument();
+  });
+
+  it("does not bounce an authenticated user on / back to /setup while setup state is stale", async () => {
+    // The post-setup redirect lands on / while getInfo still reports setup=false; the token
+    // must keep the user in the app instead of flashing the setup form.
+    mockSetup(false);
+    useAuthStore.setState({ token: "issued-token" });
+    renderAt("/");
+
+    expect(await screen.findByText("app content")).toBeInTheDocument();
+    expect(screen.queryByText("setup page")).not.toBeInTheDocument();
+  });
+
+  it("redirects an unauthenticated visitor to /setup on a fresh install", async () => {
+    mockSetup(false);
+    renderAt("/");
+    expect(await screen.findByText("setup page")).toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -11,6 +11,7 @@ import { useClickOutside } from "@/hooks/useClickOutside";
 import { getInitials } from "@/utils/string";
 import { isPremiumFeature } from "@/utils/features";
 import CreateNamespaceDialog from "../common/CreateNamespaceDialog";
+import NamespaceUpsellDialog from "../common/NamespaceUpsellDialog";
 import { useNavigate } from "react-router-dom";
 
 const ADMIN_SUBTITLE = "Super Admin \u00B7 Instance";
@@ -31,6 +32,7 @@ export default function NamespaceSelector({
 
   const [open, setOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [upsellOpen, setUpsellOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useClickOutside(containerRef, () => setOpen(false));
@@ -51,7 +53,13 @@ export default function NamespaceSelector({
 
   const handleCreate = () => {
     setOpen(false);
-    setCreateOpen(true);
+    // Community is single-namespace: creating another is a premium feature, so pitch the
+    // upgrade instead of the (CLI-only) create dialog.
+    if (isPremiumFeature()) {
+      setCreateOpen(true);
+    } else {
+      setUpsellOpen(true);
+    }
   };
 
   return (
@@ -228,6 +236,11 @@ export default function NamespaceSelector({
       <CreateNamespaceDialog
         open={createOpen}
         onClose={() => setCreateOpen(false)}
+      />
+
+      <NamespaceUpsellDialog
+        open={upsellOpen}
+        onClose={() => setUpsellOpen(false)}
       />
     </div>
   );

--- a/ui/apps/console/src/pages/Login.tsx
+++ b/ui/apps/console/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { isSdkError } from "../api/errors";
 import {
   useNavigate,
+  Navigate,
   Link,
   useLocation,
   useSearchParams,
@@ -103,6 +104,7 @@ export default function Login() {
   const [error, setError] = useState<string | null>(null);
   const [lockoutEndEpoch, setLockoutEndEpoch] = useState<number | null>(null);
   const { login, loading } = useAuthStore();
+  const token = useAuthStore((s) => s.token);
   const navigate = useNavigate();
   const { display: countdownDisplay, expired: lockoutExpired } =
     useLoginCountdown(lockoutEndEpoch);
@@ -197,6 +199,13 @@ export default function Login() {
   // flashing while authentication info is still loading (null state).
   const showLocalForm = !isEnterprise || authentication?.local === true;
   const ssoOnly = isEnterprise && authentication?.local === false;
+
+  // Already authenticated (e.g. straight after setup's auto-login): the login form
+  // has nothing to do here, so send the user into the app. Skipped while a query
+  // token is being exchanged, which deliberately re-authenticates.
+  if (token && !queryToken) {
+    return <Navigate to="/" replace />;
+  }
 
   if (tokenLoading) {
     return (

--- a/ui/apps/console/src/pages/Settings.tsx
+++ b/ui/apps/console/src/pages/Settings.tsx
@@ -15,6 +15,7 @@ import {
   ArrowRightStartOnRectangleIcon,
   DevicePhoneMobileIcon,
 } from "@heroicons/react/24/outline";
+import { isSdkError } from "../api/errors";
 import { useNamespace } from "../hooks/useNamespaces";
 import {
   useEditNamespace,
@@ -145,8 +146,14 @@ function DeleteDialog({
         setError("");
         try {
           await deleteNs.mutateAsync(tenantId);
-        } catch {
-          setError("Failed to delete namespace.");
+        } catch (err) {
+          // A single-namespace (Community) instance is bound to this namespace and
+          // refuses to remove it; the API answers 409. Say so plainly.
+          setError(
+            isSdkError(err) && err.status === 409
+              ? "This namespace is bound to the instance and can't be deleted."
+              : "Failed to delete namespace.",
+          );
           throw new Error();
         }
       }}

--- a/ui/apps/console/src/pages/Setup.tsx
+++ b/ui/apps/console/src/pages/Setup.tsx
@@ -1,11 +1,17 @@
 import { useState, useEffect, useCallback, FormEvent } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { isSdkError } from "../api/errors";
 import { useNavigate } from "react-router-dom";
-import { CheckIcon, ExclamationCircleIcon } from "@heroicons/react/24/outline";
+import {
+  CheckIcon,
+  ExclamationCircleIcon,
+  PencilSquareIcon,
+} from "@heroicons/react/24/outline";
 import { setup } from "../client";
 import { getConfig } from "../env";
+import { useAuthStore } from "@/stores/authStore";
 import { setupResolver, type SetupFormValues } from "./setup/setupResolver";
+import { suggestNamespace } from "./setup/validate";
 import {
   FormInputField,
   FormPasswordField,
@@ -18,6 +24,7 @@ const STEP_ACCOUNT = 2;
 export default function Setup() {
   const navigate = useNavigate();
   const config = getConfig();
+  const loginWithToken = useAuthStore((state) => state.loginWithToken);
 
   const isCommunity = !config.cloud && !config.enterprise;
   const showOnboarding = isCommunity && !!config.onboardingUrl;
@@ -30,17 +37,36 @@ export default function Setup() {
   const [success, setSuccess] = useState(false);
   const [surveyCompleted, setSurveyCompleted] = useState(false);
 
-  const { control, handleSubmit, formState } = useForm<SetupFormValues>({
-    resolver: setupResolver,
-    mode: "onTouched",
-    defaultValues: {
-      name: "",
-      username: "",
-      email: "",
-      password: "",
-      confirmPassword: "",
-    },
-  });
+  const { control, handleSubmit, formState, setValue } =
+    useForm<SetupFormValues>({
+      resolver: setupResolver,
+      mode: "onTouched",
+      defaultValues: {
+        name: "",
+        username: "",
+        // In development the namespace defaults to "dev" (and does not track the username) so the
+        // instance binds to the well-known dev tenant/fixtures.
+        namespace: import.meta.env.DEV ? "dev" : "",
+        email: "",
+        password: "",
+        confirmPassword: "",
+      },
+    });
+
+  // The namespace defaults to a slug of the username and stays in sync until the user opts to
+  // edit it (readonly + Edit button), so setup has a sensible name without an extra decision.
+  const [namespaceEdited, setNamespaceEdited] = useState(false);
+  const usernameValue = useWatch({ control, name: "username" });
+  const namespaceValue = useWatch({ control, name: "namespace" });
+
+  useEffect(() => {
+    // Skip the username-driven suggestion in development, where it stays fixed at "dev".
+    if (!import.meta.env.DEV && !namespaceEdited) {
+      setValue("namespace", suggestNamespace(usernameValue ?? ""), {
+        shouldValidate: true,
+      });
+    }
+  }, [usernameValue, namespaceEdited, setValue]);
 
   const disableCreateAccountButton = loading || !formState.isValid;
 
@@ -80,8 +106,10 @@ export default function Setup() {
 
   useEffect(() => {
     if (success) {
+      // Setup already authenticated us (auto-login), so land directly on the app
+      // instead of bouncing through the login screen.
       const timer = setTimeout(
-        () => void navigate("/login", { replace: true }),
+        () => void navigate("/", { replace: true }),
         3000,
       );
       return () => clearTimeout(timer);
@@ -92,23 +120,42 @@ export default function Setup() {
     setLoading(true);
     setError("");
 
+    let token: string | undefined;
     try {
-      await setup({
+      const { data } = await setup({
         body: {
           name: values.name,
           username: values.username,
+          namespace: values.namespace,
           email: values.email,
           password: values.password,
         },
         throwOnError: true,
       });
-      setSuccess(true);
+      token = data.token;
     } catch (err: unknown) {
-      if (isSdkError(err) && err.status === 409) {
-        setError("Setup has already been completed.");
-      } else {
-        setError("An error occurred. Please try again.");
-      }
+      setError(
+        isSdkError(err) && err.status === 409
+          ? "Setup has already been completed."
+          : "An error occurred. Please try again.",
+      );
+      setLoading(false);
+      return;
+    }
+
+    // Setup is committed at this point. Try to enter the app directly with the session it
+    // issued; if the auto-login fails (or no token was issued), setup is still done — route to
+    // the login screen with a notice instead of surfacing a misleading "setup failed" error
+    // that a retry would only turn into a 409.
+    try {
+      if (!token) throw new Error("no session issued");
+      await loginWithToken(token);
+      setSuccess(true);
+    } catch {
+      void navigate("/login", {
+        replace: true,
+        state: { notice: "Setup complete. Please sign in." },
+      });
     } finally {
       setLoading(false);
     }
@@ -142,10 +189,10 @@ export default function Setup() {
               />
             </div>
             <h3 className="text-sm font-semibold text-text-primary mb-2">
-              Account created successfully
+              Instance ready
             </h3>
             <p className="text-xs text-text-secondary leading-relaxed">
-              Redirecting to login in a few seconds...
+              Taking you to your instance...
             </p>
           </div>
         </div>
@@ -210,13 +257,23 @@ export default function Setup() {
               >
                 Continue
               </Button>
+
+              {import.meta.env.DEV && (
+                <button
+                  type="button"
+                  onClick={() => setStep(STEP_ACCOUNT)}
+                  className="w-full text-center text-2xs font-mono text-text-muted hover:text-text-secondary transition-colors"
+                >
+                  Skip survey (dev only)
+                </button>
+              )}
             </div>
           )}
 
           {step === STEP_ACCOUNT && (
             <form onSubmit={handleFormSubmit} className="space-y-4">
               <p className="text-xs text-text-secondary leading-relaxed mb-1">
-                Set up your admin account with your personal information.
+                Set up your ShellHub instance.
               </p>
 
               <FormInputField<SetupFormValues>
@@ -244,6 +301,37 @@ export default function Setup() {
                 control={control}
                 type="email"
                 placeholder="you@example.com"
+              />
+
+              <FormInputField<SetupFormValues>
+                id="namespace"
+                label="Namespace"
+                name="namespace"
+                control={control}
+                variant="mono"
+                maxLength={30}
+                readOnly={!namespaceEdited}
+                // Suppress the error only while the field is pristine/empty. If a non-empty
+                // auto-suggestion is invalid (e.g. a username that slugs too short), let the
+                // error show so the user knows why submit is disabled and can hit Edit to fix it.
+                error={!namespaceEdited && !namespaceValue ? "" : undefined}
+                hint={
+                  import.meta.env.DEV
+                    ? 'Keeping "dev" binds the well-known dev tenant; any other name generates a fresh one.'
+                    : undefined
+                }
+                labelAdornment={
+                  !namespaceEdited && (
+                    <button
+                      type="button"
+                      onClick={() => setNamespaceEdited(true)}
+                      className="inline-flex items-center gap-1 text-2xs font-medium text-primary hover:text-primary-300 transition-colors"
+                    >
+                      <PencilSquareIcon className="w-3 h-3" strokeWidth={2} />
+                      Edit
+                    </button>
+                  )
+                }
               />
 
               <FormPasswordField<SetupFormValues>
@@ -278,7 +366,7 @@ export default function Setup() {
                   disabled={disableCreateAccountButton}
                   className={showOnboarding ? "flex-[2]" : "w-full"}
                 >
-                  {loading ? "Creating..." : "Create Account"}
+                  {loading ? "Setting up..." : "Complete setup"}
                 </Button>
               </div>
             </form>

--- a/ui/apps/console/src/pages/__tests__/Setup.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Setup.test.tsx
@@ -15,6 +15,14 @@ vi.mock("@/client", () => ({
   setup: vi.fn(),
 }));
 
+const mockLoginWithToken = vi.hoisted(() => vi.fn());
+
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (
+    selector: (s: { loginWithToken: typeof mockLoginWithToken }) => unknown,
+  ) => selector({ loginWithToken: mockLoginWithToken }),
+}));
+
 vi.mock("@/env", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/env")>();
   return { ...actual, getConfig: vi.fn(() => actual.getConfig()) };
@@ -68,6 +76,8 @@ afterEach(cleanup);
 beforeEach(() => {
   mockNavigate.mockReset();
   mockedSetup.mockReset();
+  mockLoginWithToken.mockReset();
+  mockLoginWithToken.mockResolvedValue(undefined);
   mockedGetConfig.mockReturnValue({ ...defaultConfig });
 });
 
@@ -81,14 +91,14 @@ describe("Setup", () => {
       expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/^confirm password$/i)).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: /create account/i }),
+        screen.getByRole("button", { name: /complete setup/i }),
       ).toBeInTheDocument();
     });
 
     it("submit button is disabled when all fields are empty", () => {
       renderSetup();
       expect(
-        screen.getByRole("button", { name: /create account/i }),
+        screen.getByRole("button", { name: /complete setup/i }),
       ).toBeDisabled();
     });
   });
@@ -126,7 +136,9 @@ describe("Setup", () => {
 
     it("does not show email error before the field is touched", () => {
       renderSetup();
-      expect(screen.queryByText(/enter a valid email/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/enter a valid email/i),
+      ).not.toBeInTheDocument();
     });
 
     it("shows email error after blurring with an invalid address", async () => {
@@ -178,7 +190,7 @@ describe("Setup", () => {
       const user = userEvent.setup();
       renderSetup();
 
-      const submit = screen.getByRole("button", { name: /create account/i });
+      const submit = screen.getByRole("button", { name: /complete setup/i });
       expect(submit).toBeDisabled();
 
       await fillValidForm(user);
@@ -188,15 +200,20 @@ describe("Setup", () => {
   });
 
   describe("successful submission", () => {
+    // Setup responds with an authenticated session (auto-login); the token is what
+    // the page hands to loginWithToken before redirecting into the app.
+    const setupSuccess = () =>
+      mockSdkResponse({ token: "jwt-token" }) as Awaited<
+        ReturnType<typeof setupSdk>
+      >;
+
     it("calls setup() with the correct payload and shows the success screen", async () => {
-      mockedSetup.mockResolvedValue(mockSdkResponse({}));
+      mockedSetup.mockResolvedValue(setupSuccess());
       const user = userEvent.setup();
       renderSetup();
 
       await fillValidForm(user);
-      await user.click(
-        screen.getByRole("button", { name: /create account/i }),
-      );
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
 
       await waitFor(() => expect(mockedSetup).toHaveBeenCalledTimes(1));
       expect(mockedSetup).toHaveBeenCalledWith(
@@ -204,6 +221,8 @@ describe("Setup", () => {
           body: {
             name: "Alice Smith",
             username: "alice",
+            // Tests run with import.meta.env.DEV=true, so the namespace defaults to "dev".
+            namespace: "dev",
             email: "alice@example.com",
             password: "Secret123",
           },
@@ -211,34 +230,81 @@ describe("Setup", () => {
         }),
       );
 
-      expect(
-        await screen.findByText(/account created successfully/i),
-      ).toBeInTheDocument();
+      expect(await screen.findByText(/instance ready/i)).toBeInTheDocument();
     });
 
-    it("redirects to /login after 3 seconds on success", async () => {
+    it("logs in with the returned token", async () => {
+      mockedSetup.mockResolvedValue(setupSuccess());
+      const user = userEvent.setup();
+      renderSetup();
+
+      await fillValidForm(user);
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
+
+      await waitFor(() =>
+        expect(mockLoginWithToken).toHaveBeenCalledWith("jwt-token"),
+      );
+    });
+
+    it("redirects to the app after 3 seconds on success", async () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
 
-      mockedSetup.mockResolvedValue(mockSdkResponse({}));
+      mockedSetup.mockResolvedValue(setupSuccess());
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
       renderSetup();
 
       await fillValidForm(user);
-      await user.click(
-        screen.getByRole("button", { name: /create account/i }),
-      );
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
 
-      await screen.findByText(/account created successfully/i);
+      await screen.findByText(/instance ready/i);
 
       vi.advanceTimersByTime(3000);
 
       await waitFor(() =>
-        expect(mockNavigate).toHaveBeenCalledWith("/login", {
+        expect(mockNavigate).toHaveBeenCalledWith("/", {
           replace: true,
         }),
       );
 
       vi.useRealTimers();
+    });
+
+    it("routes to login with a notice when auto-login fails after setup", async () => {
+      mockedSetup.mockResolvedValue(setupSuccess());
+      mockLoginWithToken.mockRejectedValue(new Error("token login failed"));
+      const user = userEvent.setup();
+      renderSetup();
+
+      await fillValidForm(user);
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith("/login", {
+          replace: true,
+          state: { notice: "Setup complete. Please sign in." },
+        }),
+      );
+      // Setup succeeded, so the user must not see a failure error.
+      expect(screen.queryByText(/an error occurred/i)).not.toBeInTheDocument();
+    });
+
+    it("routes to login when setup issues no token", async () => {
+      mockedSetup.mockResolvedValue(
+        mockSdkResponse({ token: "" }) as Awaited<ReturnType<typeof setupSdk>>,
+      );
+      const user = userEvent.setup();
+      renderSetup();
+
+      await fillValidForm(user);
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith("/login", {
+          replace: true,
+          state: { notice: "Setup complete. Please sign in." },
+        }),
+      );
+      expect(mockLoginWithToken).not.toHaveBeenCalled();
     });
   });
 
@@ -249,9 +315,7 @@ describe("Setup", () => {
       renderSetup();
 
       await fillValidForm(user);
-      await user.click(
-        screen.getByRole("button", { name: /create account/i }),
-      );
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
 
       expect(
         await screen.findByText(/setup has already been completed/i),
@@ -264,13 +328,9 @@ describe("Setup", () => {
       renderSetup();
 
       await fillValidForm(user);
-      await user.click(
-        screen.getByRole("button", { name: /create account/i }),
-      );
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
 
-      expect(
-        await screen.findByText(/an error occurred/i),
-      ).toBeInTheDocument();
+      expect(await screen.findByText(/an error occurred/i)).toBeInTheDocument();
     });
   });
 
@@ -285,9 +345,7 @@ describe("Setup", () => {
     it("starts on the onboarding step and shows the survey iframe", () => {
       renderSetup();
       expect(screen.getByTitle(/onboarding survey/i)).toBeInTheDocument();
-      expect(
-        screen.queryByLabelText(/^name$/i),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/^name$/i)).not.toBeInTheDocument();
     });
 
     it("moves to the account step after Continue is clicked and survey is completed", async () => {

--- a/ui/apps/console/src/pages/setup/__tests__/setupResolver.test.ts
+++ b/ui/apps/console/src/pages/setup/__tests__/setupResolver.test.ts
@@ -5,6 +5,7 @@ import type { SetupFormValues } from "../setupResolver";
 const validInput: SetupFormValues = {
   name: "Admin User",
   username: "admin",
+  namespace: "my-namespace",
   email: "admin@example.com",
   password: "secret123",
   confirmPassword: "secret123",
@@ -17,7 +18,10 @@ const emptyOptions = {
   shouldUseNativeValidation: undefined,
 } as Parameters<typeof setupResolver>[2];
 
-type RhfErrors = Record<keyof SetupFormValues, { type: string; message: string }>;
+type RhfErrors = Record<
+  keyof SetupFormValues,
+  { type: string; message: string }
+>;
 
 const resolve = (input: SetupFormValues) =>
   setupResolver(input, undefined, emptyOptions);
@@ -50,16 +54,32 @@ describe("setupResolver", () => {
   });
 
   describe("validate() field error mapping", () => {
-    const invalidCases: { field: keyof SetupFormValues; input: SetupFormValues }[] = [
+    const invalidCases: {
+      field: keyof SetupFormValues;
+      input: SetupFormValues;
+    }[] = [
       { field: "name", input: { ...validInput, name: "" } },
       { field: "username", input: { ...validInput, username: "ab" } },
+      {
+        field: "namespace",
+        input: { ...validInput, namespace: "Invalid Name" },
+      },
       { field: "email", input: { ...validInput, email: "not-an-email" } },
-      { field: "password", input: { ...validInput, password: "123", confirmPassword: "123" } },
-      { field: "confirmPassword", input: { ...validInput, confirmPassword: "different" } },
+      {
+        field: "password",
+        input: { ...validInput, password: "123", confirmPassword: "123" },
+      },
+      {
+        field: "confirmPassword",
+        input: { ...validInput, confirmPassword: "different" },
+      },
     ];
 
-    it.each(invalidCases)("maps $field error to RHF error shape", async ({ field, input }) => {
-      await expectFieldError(input, field, "validate");
-    });
+    it.each(invalidCases)(
+      "maps $field error to RHF error shape",
+      async ({ field, input }) => {
+        await expectFieldError(input, field, "validate");
+      },
+    );
   });
 });

--- a/ui/apps/console/src/pages/setup/setupResolver.ts
+++ b/ui/apps/console/src/pages/setup/setupResolver.ts
@@ -1,9 +1,11 @@
 import type { FieldErrors, Resolver } from "react-hook-form";
+import { validateNamespaceName } from "@/utils/validation";
 import { validate, type FormErrors } from "./validate";
 
 export interface SetupFormValues {
   name: string;
   username: string;
+  namespace: string;
   email: string;
   password: string;
   confirmPassword: string;
@@ -29,6 +31,11 @@ export const setupResolver: Resolver<SetupFormValues> = (values) => {
     if (message) {
       errors[field] = { type: "validate", message };
     }
+  }
+
+  const namespaceError = validateNamespaceName(values.namespace);
+  if (namespaceError) {
+    errors.namespace = { type: "validate", message: namespaceError };
   }
 
   if (Object.keys(errors).length > 0) {

--- a/ui/apps/console/src/pages/setup/validate.ts
+++ b/ui/apps/console/src/pages/setup/validate.ts
@@ -1,4 +1,20 @@
+import { NAMESPACE_NAME_MAX_LENGTH } from "@/utils/validation";
+
 const USERNAME_REGEX = /^[a-z0-9\-_.@]+$/;
+
+// suggestNamespace derives a namespace name from the username, so setup can pre-fill it
+// (readonly) and let the user override it. Lowercases, turns runs of invalid characters into a
+// single hyphen, trims leading/trailing hyphens, and caps at the namespace max length. The
+// result is validated by the shared validateNamespaceName (see setupResolver).
+export function suggestNamespace(username: string): string {
+  return username
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+/, "")
+    .slice(0, NAMESPACE_NAME_MAX_LENGTH)
+    .replace(/-+$/, "");
+}
 
 export interface FormErrors {
   name?: string;


### PR DESCRIPTION
Community Edition becomes single-tenant. The instance binds to the one namespace created during setup, so a second namespace cannot be created and the bound namespace cannot be deleted. Enterprise and Cloud stay multi-tenant.

## How it works

The `systems` singleton gains an `instance_tenant_id` column (migration 009) with a foreign key to `namespaces(id)`, `ON DELETE RESTRICT`. When it is set:

- `NamespaceCreate` refuses any further namespace with a distinct error, which covers both the API and the CLI.
- The foreign key protects the bound namespace from deletion. The API surfaces this as a 409, the CLI as a plain message, and the console as an explanation.

Setup binds the instance and now collects the namespace name instead of reusing the username. It also returns an authenticated session, so the admin lands in the app without a second trip through the login screen (development keeps the well-known "dev" tenant).

A boot step reconciles the binding without an edition check: it backfills existing installs and, through the cloud store wrapper, clears the binding when an instance is upgraded to Enterprise or Cloud, restoring multi-tenant behavior.

`POST /namespaces` is dropped in Community, and the console shows an upgrade prompt in place of the create dialog.

## Editions

Community is single-namespace. Enterprise and Cloud keep the binding empty (their store wrapper strips it on write), so multi-tenant is unchanged. An existing Community install with several namespaces is grandfathered: the oldest becomes the bound one, the rest keep working and remain deletable down to the last.

Companion change: shellhub-io/cloud#2423
