### PR TITLE
feat: provision, activate, and reclaim namespace member accounts

### DIFF
--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -141,6 +141,12 @@ func NewRouter(service services.Service, opts ...Option) *echo.Echo {
 	publicAPI.PATCH(URLDeprecatedUpdateUser, gateway.Handler(handler.UpdateUser), routesmiddleware.BlockAPIKey)                 // WARN: DEPRECATED.
 	publicAPI.PATCH(URLDeprecatedUpdateUserPassword, gateway.Handler(handler.UpdateUserPassword), routesmiddleware.BlockAPIKey) // WARN: DEPRECATED.
 
+	// Account activation for admin-provisioned members: the admin mints a one-time link
+	// (admin-gated) and the invitee completes their account by setting a password (public,
+	// the token is the credential).
+	publicAPI.POST(URLCreateUserActivationToken, gateway.Handler(handler.CreateUserActivationToken), routesmiddleware.BlockAPIKey)
+	publicAPI.POST(URLActivateUser, gateway.Handler(handler.ActivateUser))
+
 	publicAPI.GET(GetDeviceListURL, routesmiddleware.Authorize(gateway.Handler(handler.GetDeviceList)))
 	publicAPI.GET(GetDeviceURL, routesmiddleware.Authorize(gateway.Handler(handler.GetDevice)))
 	publicAPI.GET(ResolveDeviceURL, routesmiddleware.Authorize(gateway.Handler(handler.ResolveDevice)))

--- a/api/routes/user.go
+++ b/api/routes/user.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/shellhub-io/shellhub/api/pkg/gateway"
 	"github.com/shellhub-io/shellhub/api/services"
@@ -12,7 +13,9 @@ import (
 const (
 	URLUpdateUser                   = "/users"
 	URLDeprecatedUpdateUser         = "/users/:id/data"
-	URLDeprecatedUpdateUserPassword = "/users/:id/password" //nolint:gosec
+	URLDeprecatedUpdateUserPassword = "/users/:id/password"   //nolint:gosec
+	URLCreateUserActivationToken    = "/users/:id/activation" //nolint:gosec
+	URLActivateUser                 = "/users/:id/activate"
 )
 
 const (
@@ -52,6 +55,50 @@ func (h *Handler) UpdateUser(c gateway.Context) error {
 		default:
 			return err
 		}
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// CreateUserActivationToken mints a one-time activation link token for a provisioned account.
+// It is restricted to admins (enforced in the service on the resolved actor): the admin
+// provisions the account and hands the resulting link to the user out of band, so the admin
+// never learns or sets the password.
+func (h *Handler) CreateUserActivationToken(c gateway.Context) error {
+	req := new(requests.CreateUserActivation)
+	if err := c.Bind(req); err != nil {
+		return err
+	}
+
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	token, expiresAt, err := h.service.CreateUserActivationToken(c.Ctx(), req)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}{Token: token, ExpiresAt: expiresAt})
+}
+
+// ActivateUser completes a provisioned account from the activation link: it is public because
+// the one-time token in the body is the credential (the user has no password yet).
+func (h *Handler) ActivateUser(c gateway.Context) error {
+	req := new(requests.ActivateUser)
+	if err := c.Bind(req); err != nil {
+		return err
+	}
+
+	if err := c.Validate(req); err != nil {
+		return err
+	}
+
+	if err := h.service.ActivateUser(c.Ctx(), req); err != nil {
+		return err
 	}
 
 	return c.NoContent(http.StatusOK)

--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -92,6 +92,7 @@ var (
 	ErrNamespaceMemberNotFound         = errors.New("member not found", ErrLayer, ErrCodeNotFound)
 	ErrNamespaceMemberInvalid          = errors.New("member invalid", ErrLayer, ErrCodeInvalid)
 	ErrNamespaceMemberFillData         = errors.New("member fill data", ErrLayer, ErrCodeInvalid)
+	ErrNamespaceMemberProvisionProfile = errors.New("provisioning a new member requires a name and username", ErrLayer, ErrCodeInvalid)
 	ErrNamespaceMemberDuplicated       = errors.New("member duplicated", ErrLayer, ErrCodeDuplicated)
 	ErrNamespaceCreateStore            = errors.New("namespace create store", ErrLayer, ErrCodeStore)
 	ErrNamespaceInstanceProtected      = errors.New("namespace is bound to the instance and cannot be deleted", ErrLayer, ErrCodeConflict)
@@ -395,6 +396,12 @@ func NewErrNamespaceMemberNotFound(id string, next error) error {
 // role set, to a complete structure, fails.
 func NewErrNamespaceMemberFillData(next error) error {
 	return NewErrInvalid(ErrNamespaceMemberFillData, nil, next)
+}
+
+// NewErrNamespaceMemberProvisionProfile returns an error to be used when an admin provisions a
+// brand-new member inline but does not supply the name and username the account requires.
+func NewErrNamespaceMemberProvisionProfile(next error) error {
+	return NewErrInvalid(ErrNamespaceMemberProvisionProfile, nil, next)
 }
 
 // NewErrNamespaceMemberDuplicated returns an error to be used when the namespace member already exist in the namespace.

--- a/api/services/member.go
+++ b/api/services/member.go
@@ -79,7 +79,20 @@ func (s *service) AddNamespaceMember(ctx context.Context, req *requests.Namespac
 	} else {
 		passiveUser, err := s.store.UserResolve(ctx, store.UserEmailResolver, strings.ToLower(req.MemberEmail))
 		if err != nil {
-			return nil, NewErrUserNotFound(req.MemberEmail, err)
+			// The email has no account. Creating one is gated on the instance-admin flag,
+			// except on enterprise where a namespace admin may provision an account that a
+			// system admin then approves. Community keeps the "must already exist" dead end.
+			if !user.Admin && !nonAdminProvisioningAllowed() {
+				return nil, NewErrUserNotFound(req.MemberEmail, err)
+			}
+
+			if req.MemberName == "" || req.MemberUsername == "" {
+				return nil, NewErrNamespaceMemberProvisionProfile(nil)
+			}
+
+			// A non-admin's account is created awaiting approval (inert until an admin
+			// approves it); an admin's account is created ready (auto-approved).
+			return s.provisionNamespaceMember(ctx, req, !user.Admin)
 		}
 
 		if _, ok := namespace.FindMember(passiveUser.ID); ok {
@@ -93,6 +106,53 @@ func (s *service) AddNamespaceMember(ctx context.Context, req *requests.Namespac
 		}); err != nil {
 			return nil, err
 		}
+	}
+
+	return s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+}
+
+// provisionNamespaceMember creates a pending account for an as-yet-unregistered invitee and
+// attaches it to the namespace in a single transaction. The account is created not-confirmed
+// (the auth status gate blocks it from logging in) and without a password; it is completed
+// later when the invitee follows a set-password activation link. Used when an admin invites an
+// email with no account, or when the enterprise capability lets a namespace admin do so. When
+// awaitingApproval is true the account is inert until a system admin approves it (only an admin
+// can mint its activation link); an admin-created account is auto-approved (false).
+func (s *service) provisionNamespaceMember(ctx context.Context, req *requests.NamespaceAddMember, awaitingApproval bool) (*models.Namespace, error) {
+	if err := s.store.WithTransaction(ctx, func(ctx context.Context) error {
+		user := &models.User{
+			Origin: models.UserOriginLocal,
+			Status: models.UserStatusNotConfirmed,
+			UserData: models.UserData{
+				Name:     req.MemberName,
+				Username: strings.ToLower(req.MemberUsername),
+				Email:    strings.ToLower(req.MemberEmail),
+			},
+			MaxNamespaces:    0,
+			AwaitingApproval: awaitingApproval,
+			Preferences: models.UserPreferences{
+				AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+			},
+		}
+
+		insertedID, err := s.store.UserCreate(ctx, user)
+		if err != nil {
+			if errors.Is(err, store.ErrDuplicate) {
+				if field, ok := store.DuplicatedField(err); ok {
+					return NewErrUserDuplicated([]string{field}, err)
+				}
+
+				return NewErrUserUnhandledDuplicate()
+			}
+
+			return err
+		}
+
+		member := &models.Member{ID: insertedID, AddedAt: clock.Now(), Role: req.MemberRole}
+
+		return s.store.NamespaceCreateMembership(ctx, req.TenantID, member)
+	}); err != nil {
+		return nil, err
 	}
 
 	return s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
@@ -196,6 +256,13 @@ func (s *service) RemoveNamespaceMember(ctx context.Context, req *requests.Names
 		return nil, err
 	}
 
+	if err := s.deleteOrphanedMemberAccount(ctx, passive.ID); err != nil {
+		log.WithError(err).
+			WithField("tenant_id", req.TenantID).
+			WithField("user_id", passive.ID).
+			Warn("failed to clean up orphaned member account")
+	}
+
 	if err := s.AuthUncacheToken(ctx, req.TenantID, req.UserID); err != nil {
 		log.WithError(err).
 			WithField("tenant_id", req.TenantID).
@@ -261,4 +328,38 @@ func (s *service) removeMember(ctx context.Context, ns *models.Namespace, member
 	}
 
 	return nil
+}
+
+// deleteOrphanedMemberAccount deletes a user's account when removing this membership left
+// them with no namespace at all, but only on a single-namespace Community instance. There,
+// adding a member creates the account, so removing their last tie should reclaim it: an
+// account with no namespace can neither create one (the instance binding refuses it) nor
+// self-register, so it is dead weight.
+//
+// It is deliberately gated on the instance binding, not on the edition: multi-tenant
+// deployments (Cloud, Enterprise, and legacy Community instances never bound to a single
+// namespace) keep accounts that legitimately outlive a single membership, so there the
+// account is preserved and only the membership is detached. The remaining-namespace count
+// is the second guard, so a user still present in another namespace is never deleted, which
+// keeps legacy multi-namespace Community instances safe.
+func (s *service) deleteOrphanedMemberAccount(ctx context.Context, userID string) error {
+	system, err := s.store.SystemGet(ctx)
+	if err != nil {
+		return err
+	}
+
+	if system.InstanceTenantID == "" {
+		return nil
+	}
+
+	_, remaining, err := s.store.NamespaceList(ctx, s.store.Options().WithMember(userID))
+	if err != nil {
+		return err
+	}
+
+	if remaining > 0 {
+		return nil
+	}
+
+	return s.store.UserDelete(ctx, &models.User{ID: userID})
 }

--- a/api/services/member_hooks.go
+++ b/api/services/member_hooks.go
@@ -39,3 +39,20 @@ func fireMemberAdd(ctx context.Context, namespace *models.Namespace, req *reques
 
 	return nil
 }
+
+// nonAdminProvisioningEnabled reports whether a namespace admin who is not an instance admin
+// may provision a brand-new account by email. When enabled, such an add creates an account
+// awaiting a system admin's approval instead of returning a dead-end "user not found".
+// Enterprise turns this on at init; Community leaves it off (only instance admins provision).
+var nonAdminProvisioningEnabled bool
+
+// EnableNonAdminProvisioning turns on the enterprise capability that lets a namespace admin
+// provision an approval-pending account. It must be called during package init.
+func EnableNonAdminProvisioning() {
+	nonAdminProvisioningEnabled = true
+}
+
+// nonAdminProvisioningAllowed reports whether the non-admin provisioning capability is on.
+func nonAdminProvisioningAllowed() bool {
+	return nonAdminProvisioningEnabled
+}

--- a/api/services/member_test.go
+++ b/api/services/member_test.go
@@ -230,6 +230,122 @@ func TestService_AddNamespaceMember(t *testing.T) {
 			},
 		},
 		{
+			description: "admin provisions a new account inline when the email has no account",
+			req: &requests.NamespaceAddMember{
+				FowardedHost:   "localhost",
+				UserID:         "000000000000000000000000",
+				TenantID:       "00000000-0000-4000-0000-000000000000",
+				MemberEmail:    "john.doe@test.com",
+				MemberRole:     authorizer.RoleObserver,
+				MemberName:     "John Doe",
+				MemberUsername: "john_doe",
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "namespace",
+						Owner:    "000000000000000000000000",
+						Members: []models.Member{
+							{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+						},
+					}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(&models.User{ID: "000000000000000000000000", Admin: true, UserData: models.UserData{Username: "jane_doe"}}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
+					Return(nil, errors.New("not found")).
+					Once()
+				storeMock.
+					On("WithTransaction", ctx, mock.Anything).
+					Run(func(args mock.Arguments) { _ = args.Get(1).(store.TransactionCb)(ctx) }).
+					Return(nil).
+					Once()
+				// An admin's inline provisioning is auto-approved: the account is created
+				// not-confirmed but not awaiting approval, so its link can be minted at once.
+				storeMock.
+					On("UserCreate", ctx, mock.MatchedBy(func(u *models.User) bool {
+						return u.Status == models.UserStatusNotConfirmed &&
+							!u.AwaitingApproval &&
+							u.Password.Hash == "" &&
+							u.Email == "john.doe@test.com" &&
+							u.Username == "john_doe"
+					})).
+					Return("000000000000000000000001", nil).
+					Once()
+				clockMock.On("Now").Return(now).Once()
+				storeMock.
+					On("NamespaceCreateMembership", ctx, "00000000-0000-4000-0000-000000000000", mock.MatchedBy(func(m *models.Member) bool {
+						return m.ID == "000000000000000000000001" && m.Role == authorizer.RoleObserver
+					})).
+					Return(nil).
+					Once()
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "namespace",
+						Owner:    "000000000000000000000000",
+						Members: []models.Member{
+							{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+							{ID: "000000000000000000000001", Role: authorizer.RoleObserver},
+						},
+					}, nil).
+					Once()
+			},
+			expected: Expected{
+				namespace: &models.Namespace{
+					TenantID: "00000000-0000-4000-0000-000000000000",
+					Name:     "namespace",
+					Owner:    "000000000000000000000000",
+					Members: []models.Member{
+						{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+						{ID: "000000000000000000000001", Role: authorizer.RoleObserver},
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			description: "fails when an admin provisions inline without a name and username",
+			req: &requests.NamespaceAddMember{
+				FowardedHost: "localhost",
+				UserID:       "000000000000000000000000",
+				TenantID:     "00000000-0000-4000-0000-000000000000",
+				MemberEmail:  "john.doe@test.com",
+				MemberRole:   authorizer.RoleObserver,
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "namespace",
+						Owner:    "000000000000000000000000",
+						Members: []models.Member{
+							{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+						},
+					}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(&models.User{ID: "000000000000000000000000", Admin: true, UserData: models.UserData{Username: "jane_doe"}}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
+					Return(nil, errors.New("not found")).
+					Once()
+			},
+			expected: Expected{
+				namespace: nil,
+				err:       NewErrNamespaceMemberProvisionProfile(nil),
+			},
+		},
+		{
 			description: "fails when the member is duplicated",
 			req: &requests.NamespaceAddMember{
 				FowardedHost: "localhost",
@@ -411,6 +527,219 @@ func TestService_AddNamespaceMember(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			tc.requiredMocks(ctx)
+			ns, err := s.AddNamespaceMember(ctx, tc.req)
+			assert.Equal(t, tc.expected, Expected{ns, err})
+		})
+	}
+
+	storeMock.AssertExpectations(t)
+}
+
+// TestService_AddNamespaceMember_ProvisionRequest covers the enterprise seam where a
+// namespace admin who is *not* an instance admin adds an unknown email: with the non-admin
+// provisioning capability enabled the account is provisioned awaiting approval instead of
+// hitting the community "must already have an account" dead end.
+func TestService_AddNamespaceMember_ProvisionRequest(t *testing.T) {
+	type Expected struct {
+		namespace *models.Namespace
+		err       error
+	}
+
+	errNotFound := errors.New("not found")
+
+	// The actor is a namespace administrator (Admin: false), so it cannot provision inline.
+	nonAdminActor := &models.User{
+		ID:       "000000000000000000000000",
+		Admin:    false,
+		UserData: models.UserData{Username: "jane_doe"},
+	}
+	namespace := &models.Namespace{
+		TenantID: "00000000-0000-4000-0000-000000000000",
+		Name:     "namespace",
+		Owner:    "000000000000000000000000",
+		Members: []models.Member{
+			{ID: "000000000000000000000000", Role: authorizer.RoleAdministrator},
+		},
+	}
+
+	storeMock := storemock.NewMockStore(t)
+
+	cases := []struct {
+		description    string
+		withCapability bool
+		req            *requests.NamespaceAddMember
+		requiredMocks  func(context.Context)
+		expected       Expected
+	}{
+		{
+			description:    "returns not found when a non-admin adds an unknown email and the capability is off",
+			withCapability: false,
+			req: &requests.NamespaceAddMember{
+				FowardedHost:   "localhost",
+				UserID:         "000000000000000000000000",
+				TenantID:       "00000000-0000-4000-0000-000000000000",
+				MemberEmail:    "john.doe@test.com",
+				MemberRole:     authorizer.RoleObserver,
+				MemberName:     "John Doe",
+				MemberUsername: "john_doe",
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(namespace, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nonAdminActor, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
+					Return(nil, errNotFound).
+					Once()
+			},
+			expected: Expected{
+				namespace: nil,
+				err:       NewErrUserNotFound("john.doe@test.com", errNotFound),
+			},
+		},
+		{
+			description:    "requires name and username before provisioning",
+			withCapability: true,
+			req: &requests.NamespaceAddMember{
+				FowardedHost: "localhost",
+				UserID:       "000000000000000000000000",
+				TenantID:     "00000000-0000-4000-0000-000000000000",
+				MemberEmail:  "john.doe@test.com",
+				MemberRole:   authorizer.RoleObserver,
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(namespace, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nonAdminActor, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
+					Return(nil, errNotFound).
+					Once()
+			},
+			expected: Expected{
+				namespace: nil,
+				err:       NewErrNamespaceMemberProvisionProfile(nil),
+			},
+		},
+		{
+			description:    "provisions an awaiting-approval account instead of returning not found",
+			withCapability: true,
+			req: &requests.NamespaceAddMember{
+				FowardedHost:   "localhost",
+				UserID:         "000000000000000000000000",
+				TenantID:       "00000000-0000-4000-0000-000000000000",
+				MemberEmail:    "john.doe@test.com",
+				MemberRole:     authorizer.RoleObserver,
+				MemberName:     "John Doe",
+				MemberUsername: "john_doe",
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(namespace, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nonAdminActor, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
+					Return(nil, errNotFound).
+					Once()
+				storeMock.
+					On("WithTransaction", ctx, mock.Anything).
+					Run(func(args mock.Arguments) { _ = args.Get(1).(store.TransactionCb)(ctx) }).
+					Return(nil).
+					Once()
+				// A non-admin's provisioned account must be created not-confirmed, without a
+				// password, and awaiting approval — this is the enterprise approval gate.
+				storeMock.
+					On("UserCreate", ctx, mock.MatchedBy(func(u *models.User) bool {
+						return u.Status == models.UserStatusNotConfirmed &&
+							u.AwaitingApproval &&
+							u.Password.Hash == "" &&
+							u.Origin == models.UserOriginLocal &&
+							u.Email == "john.doe@test.com" &&
+							u.Username == "john_doe"
+					})).
+					Return("000000000000000000000001", nil).
+					Once()
+				clockMock.On("Now").Return(now).Once()
+				storeMock.
+					On("NamespaceCreateMembership", ctx, "00000000-0000-4000-0000-000000000000", mock.MatchedBy(func(m *models.Member) bool {
+						return m.ID == "000000000000000000000001" && m.Role == authorizer.RoleObserver
+					})).
+					Return(nil).
+					Once()
+				// provisionNamespaceMember re-resolves and returns the namespace.
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(namespace, nil).
+					Once()
+			},
+			expected: Expected{
+				namespace: namespace,
+				err:       nil,
+			},
+		},
+		{
+			description:    "propagates the error when provisioning fails",
+			withCapability: true,
+			req: &requests.NamespaceAddMember{
+				FowardedHost:   "localhost",
+				UserID:         "000000000000000000000000",
+				TenantID:       "00000000-0000-4000-0000-000000000000",
+				MemberEmail:    "john.doe@test.com",
+				MemberRole:     authorizer.RoleObserver,
+				MemberName:     "John Doe",
+				MemberUsername: "john_doe",
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(namespace, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nonAdminActor, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
+					Return(nil, errNotFound).
+					Once()
+				storeMock.
+					On("WithTransaction", ctx, mock.Anything).
+					Return(errors.New("tx failed")).
+					Once()
+			},
+			expected: Expected{
+				namespace: nil,
+				err:       errors.New("tx failed"),
+			},
+		},
+	}
+
+	s := NewService(store.Store(storeMock), privateKey, publicKey, storecache.NewNullCache(), clientMock)
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.withCapability {
+				EnableNonAdminProvisioning()
+			}
+			t.Cleanup(func() { nonAdminProvisioningEnabled = false })
+
 			ctx := context.TODO()
 			tc.requiredMocks(ctx)
 			ns, err := s.AddNamespaceMember(ctx, tc.req)
@@ -1060,6 +1389,140 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 		expected      Expected
 	}{
 		{
+			description: "[community single-namespace] deletes the orphaned account after removing its last membership",
+			req: &requests.NamespaceRemoveMember{
+				UserID:   "000000000000000000000000",
+				TenantID: "00000000-0000-4000-0000-000000000000",
+				MemberID: "000000000000000000000001",
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "namespace",
+						Owner:    "000000000000000000000000",
+						Members: []models.Member{
+							{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+							{ID: "000000000000000000000001", Role: authorizer.RoleAdministrator},
+						},
+					}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(&models.User{ID: "000000000000000000000000", UserData: models.UserData{Username: "jane_doe"}}, nil).
+					Once()
+				storeMock.
+					On("NamespaceDeleteMembership", ctx, "00000000-0000-4000-0000-000000000000", &models.Member{ID: "000000000000000000000001", Role: authorizer.RoleAdministrator}).
+					Return(nil).
+					Once()
+				// Instance bound to this namespace: single-tenant Community.
+				storeMock.
+					On("SystemGet", ctx).
+					Return(&models.System{InstanceTenantID: "00000000-0000-4000-0000-000000000000"}, nil).
+					Once()
+				queryOptionsMock := new(storemock.MockQueryOptions)
+				storeMock.On("Options").Return(queryOptionsMock).Once()
+				queryOptionsMock.On("WithMember", "000000000000000000000001").Return(nil).Once()
+				// The removed member has no remaining namespace, so the account is reclaimed.
+				storeMock.
+					On("NamespaceList", ctx, mock.Anything).
+					Return([]models.Namespace{}, 0, nil).
+					Once()
+				storeMock.
+					On("UserDelete", ctx, &models.User{ID: "000000000000000000000001"}).
+					Return(nil).
+					Once()
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "namespace",
+						Owner:    "000000000000000000000000",
+						Members: []models.Member{
+							{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+						},
+					}, nil).
+					Once()
+			},
+			expected: Expected{
+				namespace: &models.Namespace{
+					TenantID: "00000000-0000-4000-0000-000000000000",
+					Name:     "namespace",
+					Owner:    "000000000000000000000000",
+					Members: []models.Member{
+						{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			description: "[community single-namespace] keeps the account when the removed member still belongs to another namespace",
+			req: &requests.NamespaceRemoveMember{
+				UserID:   "000000000000000000000000",
+				TenantID: "00000000-0000-4000-0000-000000000000",
+				MemberID: "000000000000000000000001",
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "namespace",
+						Owner:    "000000000000000000000000",
+						Members: []models.Member{
+							{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+							{ID: "000000000000000000000001", Role: authorizer.RoleAdministrator},
+						},
+					}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(&models.User{ID: "000000000000000000000000", UserData: models.UserData{Username: "jane_doe"}}, nil).
+					Once()
+				storeMock.
+					On("NamespaceDeleteMembership", ctx, "00000000-0000-4000-0000-000000000000", &models.Member{ID: "000000000000000000000001", Role: authorizer.RoleAdministrator}).
+					Return(nil).
+					Once()
+				storeMock.
+					On("SystemGet", ctx).
+					Return(&models.System{InstanceTenantID: "00000000-0000-4000-0000-000000000000"}, nil).
+					Once()
+				queryOptionsMock := new(storemock.MockQueryOptions)
+				storeMock.On("Options").Return(queryOptionsMock).Once()
+				queryOptionsMock.On("WithMember", "000000000000000000000001").Return(nil).Once()
+				// The removed member is still in another namespace, so the guard preserves
+				// the account and UserDelete must never be called.
+				storeMock.
+					On("NamespaceList", ctx, mock.Anything).
+					Return([]models.Namespace{{TenantID: "00000000-0000-4000-0000-000000000001"}}, 1, nil).
+					Once()
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Name:     "namespace",
+						Owner:    "000000000000000000000000",
+						Members: []models.Member{
+							{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+						},
+					}, nil).
+					Once()
+			},
+			expected: Expected{
+				namespace: &models.Namespace{
+					TenantID: "00000000-0000-4000-0000-000000000000",
+					Name:     "namespace",
+					Owner:    "000000000000000000000000",
+					Members: []models.Member{
+						{ID: "000000000000000000000000", Role: authorizer.RoleOwner},
+					},
+				},
+				err: nil,
+			},
+		},
+		{
 			description: "[community|enterprise|cloud] fails when the namespace was not found",
 			req: &requests.NamespaceRemoveMember{
 				UserID:   "000000000000000000000000",
@@ -1328,6 +1791,10 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 					Return(nil).
 					Once()
 				storeMock.
+					On("SystemGet", ctx).
+					Return(&models.System{}, nil).
+					Once()
+				storeMock.
 					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
 					Return(&models.Namespace{
 						TenantID: "00000000-0000-4000-0000-000000000000",
@@ -1447,6 +1914,10 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 				storeMock.
 					On("NamespaceDeleteMembership", ctx, "00000000-0000-4000-0000-000000000000", &models.Member{ID: "000000000000000000000001", Role: authorizer.RoleInvalid}).
 					Return(nil).
+					Once()
+				storeMock.
+					On("SystemGet", ctx).
+					Return(&models.System{}, nil).
 					Once()
 				storeMock.
 					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").

--- a/api/services/mocks/mock_service.go
+++ b/api/services/mocks/mock_service.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"context"
 	"crypto/rsa"
+	"time"
 
 	responses0 "github.com/shellhub-io/shellhub/api/pkg/responses"
 	"github.com/shellhub-io/shellhub/api/store"
@@ -113,6 +114,63 @@ func (_c *MockService_AcceptDevicePairing_Call) Return(devicePairingAccepted *mo
 }
 
 func (_c *MockService_AcceptDevicePairing_Call) RunAndReturn(run func(ctx context.Context, userID string, req *requests.DevicePairingAccept) (*models.DevicePairingAccepted, error)) *MockService_AcceptDevicePairing_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ActivateUser provides a mock function for the type MockService
+func (_mock *MockService) ActivateUser(ctx context.Context, req *requests.ActivateUser) error {
+	ret := _mock.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ActivateUser")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.ActivateUser) error); ok {
+		r0 = returnFunc(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockService_ActivateUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ActivateUser'
+type MockService_ActivateUser_Call struct {
+	*mock.Call
+}
+
+// ActivateUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *requests.ActivateUser
+func (_e *MockService_Expecter) ActivateUser(ctx any, req any) *MockService_ActivateUser_Call {
+	return &MockService_ActivateUser_Call{Call: _e.mock.On("ActivateUser", ctx, req)}
+}
+
+func (_c *MockService_ActivateUser_Call) Run(run func(ctx context.Context, req *requests.ActivateUser)) *MockService_ActivateUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *requests.ActivateUser
+		if args[1] != nil {
+			arg1 = args[1].(*requests.ActivateUser)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_ActivateUser_Call) Return(err error) *MockService_ActivateUser_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockService_ActivateUser_Call) RunAndReturn(run func(ctx context.Context, req *requests.ActivateUser) error) *MockService_ActivateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1231,6 +1289,78 @@ func (_c *MockService_CreateTag_Call) Return(insertedID string, conflicts []stri
 }
 
 func (_c *MockService_CreateTag_Call) RunAndReturn(run func(ctx context.Context, req *requests.CreateTag) (string, []string, error)) *MockService_CreateTag_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateUserActivationToken provides a mock function for the type MockService
+func (_mock *MockService) CreateUserActivationToken(ctx context.Context, req *requests.CreateUserActivation) (string, time.Time, error) {
+	ret := _mock.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateUserActivationToken")
+	}
+
+	var r0 string
+	var r1 time.Time
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.CreateUserActivation) (string, time.Time, error)); ok {
+		return returnFunc(ctx, req)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.CreateUserActivation) string); ok {
+		r0 = returnFunc(ctx, req)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *requests.CreateUserActivation) time.Time); ok {
+		r1 = returnFunc(ctx, req)
+	} else {
+		r1 = ret.Get(1).(time.Time)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, *requests.CreateUserActivation) error); ok {
+		r2 = returnFunc(ctx, req)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockService_CreateUserActivationToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateUserActivationToken'
+type MockService_CreateUserActivationToken_Call struct {
+	*mock.Call
+}
+
+// CreateUserActivationToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *requests.CreateUserActivation
+func (_e *MockService_Expecter) CreateUserActivationToken(ctx any, req any) *MockService_CreateUserActivationToken_Call {
+	return &MockService_CreateUserActivationToken_Call{Call: _e.mock.On("CreateUserActivationToken", ctx, req)}
+}
+
+func (_c *MockService_CreateUserActivationToken_Call) Run(run func(ctx context.Context, req *requests.CreateUserActivation)) *MockService_CreateUserActivationToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *requests.CreateUserActivation
+		if args[1] != nil {
+			arg1 = args[1].(*requests.CreateUserActivation)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_CreateUserActivationToken_Call) Return(token string, expiresAt time.Time, err error) *MockService_CreateUserActivationToken_Call {
+	_c.Call.Return(token, expiresAt, err)
+	return _c
+}
+
+func (_c *MockService_CreateUserActivationToken_Call) RunAndReturn(run func(ctx context.Context, req *requests.CreateUserActivation) (string, time.Time, error)) *MockService_CreateUserActivationToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/api/services/user.go
+++ b/api/services/user.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/shellhub-io/shellhub/api/store"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/pkg/uuid"
 )
+
+// userActivationTokenTTL is how long a one-time account-activation token stays valid.
+const userActivationTokenTTL = 24 * time.Hour
 
 type UserService interface {
 	// UpdateUser updates the user's data, such as email and username. Since some attributes must be unique per user,
@@ -21,6 +28,15 @@ type UserService interface {
 	UpdateUser(ctx context.Context, req *requests.UpdateUser) (conflicts []string, err error)
 
 	UpdatePasswordUser(ctx context.Context, id string, currentPassword, newPassword string) error
+
+	// CreateUserActivationToken mints a one-time token for a provisioned account so an admin can
+	// hand the user a set-password activation link out of band (no email needed). The actor
+	// (req.UserID) must be an admin. It returns the token and its expiration.
+	CreateUserActivationToken(ctx context.Context, req *requests.CreateUserActivation) (token string, expiresAt time.Time, err error)
+
+	// ActivateUser completes a provisioned account: it validates the one-time token, sets the
+	// user's initial password and moves them to confirmed.
+	ActivateUser(ctx context.Context, req *requests.ActivateUser) error
 }
 
 func (s *service) UpdateUser(ctx context.Context, req *requests.UpdateUser) ([]string, error) {
@@ -76,6 +92,122 @@ func (s *service) UpdatePasswordUser(ctx context.Context, id, currentPassword, n
 	if err := s.store.UserUpdate(ctx, user); err != nil {
 		return NewErrUserUpdate(user, err)
 	}
+
+	return nil
+}
+
+// activationTokenKey is the cache key holding a user's pending activation/recovery token. It
+// matches the cloud recover-password key so the two flows can later be deduplicated.
+func activationTokenKey(userID string) string {
+	return "recover-password={" + userID + "}"
+}
+
+func (s *service) CreateUserActivationToken(ctx context.Context, req *requests.CreateUserActivation) (string, time.Time, error) {
+	// Authorize on the resolved actor's Admin flag rather than the X-Admin header: the gateway
+	// only forwards X-Admin on a subset of routes, but always forwards X-ID.
+	actor, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
+	if err != nil {
+		return "", time.Time{}, NewErrUserNotFound(req.UserID, err)
+	}
+
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.ID)
+	if err != nil {
+		return "", time.Time{}, NewErrUserNotFound(req.ID, err)
+	}
+
+	// Activation is only for a freshly provisioned, password-less account. Refuse an
+	// already-activated account so a mint can never overwrite a real user's password:
+	// otherwise an admin (or a namespace admin managing the target) could take over any
+	// confirmed account through the public /activate endpoint.
+	if user.Status != models.UserStatusNotConfirmed {
+		return "", time.Time{}, NewErrAuthForbidden()
+	}
+
+	// An instance admin can always mint. A non-admin may mint only for an already-approved
+	// account (awaiting_approval == false) that they manage: releasing an unapproved account
+	// is an admin-only act, and minting for an account you don't manage would let you hijack it.
+	if !actor.Admin {
+		if user.AwaitingApproval {
+			return "", time.Time{}, NewErrAuthForbidden()
+		}
+
+		manages, err := s.actorManagesMember(ctx, actor.ID, user.ID)
+		if err != nil {
+			return "", time.Time{}, err
+		}
+
+		if !manages {
+			return "", time.Time{}, NewErrAuthForbidden()
+		}
+	}
+
+	token := uuid.Generate()
+	if err := s.cache.Set(ctx, activationTokenKey(user.ID), token, userActivationTokenTTL); err != nil {
+		return "", time.Time{}, err
+	}
+
+	return token, clock.Now().Add(userActivationTokenTTL), nil
+}
+
+// actorManagesMember reports whether the actor shares a namespace with the target user in
+// which the actor is allowed to add members. It lets a namespace admin mint an activation
+// link for an approved account they are responsible for, without exposing arbitrary accounts.
+func (s *service) actorManagesMember(ctx context.Context, actorID, targetID string) (bool, error) {
+	namespaces, _, err := s.store.NamespaceList(ctx, s.store.Options().WithMember(targetID))
+	if err != nil {
+		return false, err
+	}
+
+	for _, ns := range namespaces {
+		// NamespaceList doesn't populate members; resolve to get the actor's role.
+		resolved, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, ns.TenantID)
+		if err != nil {
+			return false, err
+		}
+
+		if active, ok := resolved.FindMember(actorID); ok && active.Role.HasPermission(authorizer.NamespaceAddMember) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (s *service) ActivateUser(ctx context.Context, req *requests.ActivateUser) error {
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.ID)
+	if err != nil {
+		return NewErrUserNotFound(req.ID, err)
+	}
+
+	// Defense-in-depth against replacing a real user's password: activation only ever
+	// completes a not-confirmed provisioned account, never an already-activated one.
+	if user.Status != models.UserStatusNotConfirmed {
+		return NewErrAuthForbidden()
+	}
+
+	var token string
+	if err := s.cache.Get(ctx, activationTokenKey(user.ID), &token); err != nil || token == "" || token != req.Token {
+		return NewErrAuthUnathorized(nil)
+	}
+
+	password, err := models.HashUserPassword(req.Password)
+	if err != nil {
+		return NewErrUserPasswordInvalid(err)
+	}
+
+	user.Password = password
+	user.Status = models.UserStatusConfirmed
+	// Once activated the account is a real user; drop the approval flag so an admin-minted
+	// account can't stay stuck in the pending-approval queue after it goes live.
+	user.AwaitingApproval = false
+
+	if err := s.store.UserUpdate(ctx, user); err != nil {
+		return NewErrUserUpdate(user, err)
+	}
+
+	// One-time: drop the token so the activation link cannot be replayed. Stricter than the
+	// cloud recover-password flow, which relies on TTL expiry alone.
+	s.cache.Delete(ctx, activationTokenKey(user.ID)) //nolint:errcheck
 
 	return nil
 }

--- a/api/services/user_activation_test.go
+++ b/api/services/user_activation_test.go
@@ -1,0 +1,287 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/store"
+	storemock "github.com/shellhub-io/shellhub/api/store/mocks"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	cachemock "github.com/shellhub-io/shellhub/pkg/cache/mocks"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/pkg/uuid"
+	uuidmock "github.com/shellhub-io/shellhub/pkg/uuid/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestService_CreateUserActivationToken(t *testing.T) {
+	storeMock := storemock.NewMockStore(t)
+	cacheMock := cachemock.NewMockCache(t)
+
+	uuidMock := uuidmock.NewMockUUID(t)
+	prevUUID := uuid.DefaultBackend
+	t.Cleanup(func() { uuid.DefaultBackend = prevUUID })
+	uuid.DefaultBackend = uuidMock
+
+	const actorID = "000000000000000000000001"
+	const targetID = "000000000000000000000000"
+
+	cases := []struct {
+		description   string
+		req           *requests.CreateUserActivation
+		requiredMocks func(ctx context.Context)
+		expectedErr   error
+	}{
+		{
+			description: "fails when a non-admin mints for an unapproved account",
+			req:         &requests.CreateUserActivation{UserParam: requests.UserParam{ID: targetID}, UserID: actorID},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, actorID).
+					Return(&models.User{ID: actorID, Admin: false}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, targetID).
+					Return(&models.User{ID: targetID, Status: models.UserStatusNotConfirmed, AwaitingApproval: true}, nil).
+					Once()
+			},
+			expectedErr: NewErrAuthForbidden(),
+		},
+		{
+			description: "fails when a non-admin mints for an approved account they don't manage",
+			req:         &requests.CreateUserActivation{UserParam: requests.UserParam{ID: targetID}, UserID: actorID},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, actorID).
+					Return(&models.User{ID: actorID, Admin: false}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, targetID).
+					Return(&models.User{ID: targetID, Status: models.UserStatusNotConfirmed, AwaitingApproval: false}, nil).
+					Once()
+				queryOptionsMock := new(storemock.MockQueryOptions)
+				storeMock.On("Options").Return(queryOptionsMock).Once()
+				queryOptionsMock.On("WithMember", targetID).Return(nil).Once()
+				storeMock.
+					On("NamespaceList", ctx, mock.Anything).
+					Return([]models.Namespace{{TenantID: "00000000-0000-4000-0000-000000000000"}}, 1, nil).
+					Once()
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Members:  []models.Member{{ID: actorID, Role: authorizer.RoleObserver}},
+					}, nil).
+					Once()
+			},
+			expectedErr: NewErrAuthForbidden(),
+		},
+		{
+			description: "lets a namespace admin mint for an approved account they manage",
+			req:         &requests.CreateUserActivation{UserParam: requests.UserParam{ID: targetID}, UserID: actorID},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, actorID).
+					Return(&models.User{ID: actorID, Admin: false}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, targetID).
+					Return(&models.User{ID: targetID, Status: models.UserStatusNotConfirmed, AwaitingApproval: false}, nil).
+					Once()
+				queryOptionsMock := new(storemock.MockQueryOptions)
+				storeMock.On("Options").Return(queryOptionsMock).Once()
+				queryOptionsMock.On("WithMember", targetID).Return(nil).Once()
+				storeMock.
+					On("NamespaceList", ctx, mock.Anything).
+					Return([]models.Namespace{{TenantID: "00000000-0000-4000-0000-000000000000"}}, 1, nil).
+					Once()
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{
+						TenantID: "00000000-0000-4000-0000-000000000000",
+						Members:  []models.Member{{ID: actorID, Role: authorizer.RoleAdministrator}},
+					}, nil).
+					Once()
+				uuidMock.On("Generate").Return("00000000-0000-0000-0000-000000000000").Once()
+				cacheMock.
+					On("Set", ctx, "recover-password={"+targetID+"}", "00000000-0000-0000-0000-000000000000", userActivationTokenTTL).
+					Return(nil).
+					Once()
+				clockMock.On("Now").Return(now)
+			},
+			expectedErr: nil,
+		},
+		{
+			description: "fails when the target user does not exist",
+			req:         &requests.CreateUserActivation{UserParam: requests.UserParam{ID: targetID}, UserID: actorID},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, actorID).
+					Return(&models.User{ID: actorID, Admin: true}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, targetID).
+					Return(nil, store.ErrNoDocuments).
+					Once()
+			},
+			expectedErr: NewErrUserNotFound(targetID, store.ErrNoDocuments),
+		},
+		{
+			description: "fails when an admin mints for an already-activated account",
+			req:         &requests.CreateUserActivation{UserParam: requests.UserParam{ID: targetID}, UserID: actorID},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, actorID).
+					Return(&models.User{ID: actorID, Admin: true}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, targetID).
+					Return(&models.User{ID: targetID, Status: models.UserStatusConfirmed}, nil).
+					Once()
+			},
+			expectedErr: NewErrAuthForbidden(),
+		},
+		{
+			description: "mints a token when an admin requests it for an existing user",
+			req:         &requests.CreateUserActivation{UserParam: requests.UserParam{ID: targetID}, UserID: actorID},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, actorID).
+					Return(&models.User{ID: actorID, Admin: true}, nil).
+					Once()
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, targetID).
+					Return(&models.User{ID: targetID, Status: models.UserStatusNotConfirmed}, nil).
+					Once()
+				uuidMock.On("Generate").Return("00000000-0000-0000-0000-000000000000").Once()
+				cacheMock.
+					On("Set", ctx, "recover-password={"+targetID+"}", "00000000-0000-0000-0000-000000000000", userActivationTokenTTL).
+					Return(nil).
+					Once()
+				clockMock.On("Now").Return(now)
+			},
+			expectedErr: nil,
+		},
+	}
+
+	s := NewService(store.Store(storeMock), privateKey, publicKey, cacheMock, clientMock)
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			tc.requiredMocks(ctx)
+
+			token, expiresAt, err := s.CreateUserActivationToken(ctx, tc.req)
+			assert.Equal(t, tc.expectedErr, err)
+
+			if tc.expectedErr == nil {
+				assert.NotEmpty(t, token)
+				assert.False(t, expiresAt.IsZero())
+			}
+		})
+	}
+
+	storeMock.AssertExpectations(t)
+	cacheMock.AssertExpectations(t)
+}
+
+func TestService_ActivateUser(t *testing.T) {
+	storeMock := storemock.NewMockStore(t)
+	cacheMock := cachemock.NewMockCache(t)
+
+	cases := []struct {
+		description   string
+		req           *requests.ActivateUser
+		requiredMocks func(ctx context.Context)
+		expectedErr   error
+	}{
+		{
+			description: "fails when the user does not exist",
+			req:         &requests.ActivateUser{UserParam: requests.UserParam{ID: "000000000000000000000000"}, Token: "token", Password: "newpassword"},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(nil, store.ErrNoDocuments).
+					Once()
+			},
+			expectedErr: NewErrUserNotFound("000000000000000000000000", store.ErrNoDocuments),
+		},
+		{
+			description: "fails when the account is already activated",
+			req:         &requests.ActivateUser{UserParam: requests.UserParam{ID: "000000000000000000000000"}, Token: "stored-token", Password: "newpassword"},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(&models.User{ID: "000000000000000000000000", Status: models.UserStatusConfirmed}, nil).
+					Once()
+			},
+			expectedErr: NewErrAuthForbidden(),
+		},
+		{
+			description: "fails when the token does not match",
+			req:         &requests.ActivateUser{UserParam: requests.UserParam{ID: "000000000000000000000000"}, Token: "wrong-token", Password: "newpassword"},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(&models.User{ID: "000000000000000000000000", Status: models.UserStatusNotConfirmed}, nil).
+					Once()
+				cacheMock.
+					On("Get", ctx, "recover-password={000000000000000000000000}", mock.Anything).
+					Run(func(args mock.Arguments) { *args.Get(2).(*string) = "stored-token" }).
+					Return(nil).
+					Once()
+			},
+			expectedErr: NewErrAuthUnathorized(nil),
+		},
+		{
+			description: "sets the password and confirms the account with a valid token",
+			req:         &requests.ActivateUser{UserParam: requests.UserParam{ID: "000000000000000000000000"}, Token: "stored-token", Password: "newpassword"},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+					Return(&models.User{ID: "000000000000000000000000", Status: models.UserStatusNotConfirmed, AwaitingApproval: true}, nil).
+					Once()
+				cacheMock.
+					On("Get", ctx, "recover-password={000000000000000000000000}", mock.Anything).
+					Run(func(args mock.Arguments) { *args.Get(2).(*string) = "stored-token" }).
+					Return(nil).
+					Once()
+				hashMock.
+					On("Do", "newpassword").
+					Return("$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YVVCIa2UYuFV4OJby7Yv", nil).
+					Once()
+				storeMock.
+					On("UserUpdate", ctx, mock.MatchedBy(func(u *models.User) bool {
+						return u.ID == "000000000000000000000000" &&
+							u.Status == models.UserStatusConfirmed &&
+							!u.AwaitingApproval &&
+							u.Password.Hash != ""
+					})).
+					Return(nil).
+					Once()
+				cacheMock.
+					On("Delete", ctx, "recover-password={000000000000000000000000}").
+					Return(nil).
+					Once()
+			},
+			expectedErr: nil,
+		},
+	}
+
+	s := NewService(store.Store(storeMock), privateKey, publicKey, cacheMock, clientMock)
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.TODO()
+			tc.requiredMocks(ctx)
+
+			err := s.ActivateUser(ctx, tc.req)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+
+	storeMock.AssertExpectations(t)
+	cacheMock.AssertExpectations(t)
+}

--- a/api/store/pg/entity/membership.go
+++ b/api/store/pg/entity/membership.go
@@ -46,6 +46,8 @@ func MembershipToModel(entity *Membership) *models.Member {
 
 	if entity.User != nil {
 		member.Email = entity.User.Email
+		member.AccountStatus = models.UserStatus(entity.User.Status)
+		member.AwaitingApproval = entity.User.AwaitingApproval
 	}
 
 	return member

--- a/api/store/pg/entity/user.go
+++ b/api/store/pg/entity/user.go
@@ -10,20 +10,21 @@ import (
 type User struct {
 	bun.BaseModel `bun:"table:users"`
 
-	ID             string          `bun:"id,pk,type:uuid"`
-	CreatedAt      time.Time       `bun:"created_at"`
-	UpdatedAt      time.Time       `bun:"updated_at"`
-	LastLogin      time.Time       `bun:"last_login,nullzero"`
-	Origin         string          `bun:"origin"`
-	ExternalID     string          `bun:"external_id,nullzero"`
-	Status         string          `bun:"status"`
-	Name           string          `bun:"name"`
-	Username       string          `bun:"username"`
-	Email          string          `bun:"email"`
-	PasswordDigest string          `bun:"password_digest"`
-	Preferences    UserPreferences `bun:"embed:"`
-	Admin          bool            `bun:"admin"`
-	Namespaces     int             `bun:"namespaces,scanonly"`
+	ID               string          `bun:"id,pk,type:uuid"`
+	CreatedAt        time.Time       `bun:"created_at"`
+	UpdatedAt        time.Time       `bun:"updated_at"`
+	LastLogin        time.Time       `bun:"last_login,nullzero"`
+	Origin           string          `bun:"origin"`
+	ExternalID       string          `bun:"external_id,nullzero"`
+	Status           string          `bun:"status"`
+	Name             string          `bun:"name"`
+	Username         string          `bun:"username"`
+	Email            string          `bun:"email"`
+	PasswordDigest   string          `bun:"password_digest"`
+	Preferences      UserPreferences `bun:"embed:"`
+	Admin            bool            `bun:"admin"`
+	AwaitingApproval bool            `bun:"awaiting_approval"`
+	Namespaces       int             `bun:"namespaces,scanonly"`
 }
 
 type UserPreferences struct {
@@ -53,18 +54,19 @@ func UserFromModel(model *models.User) *User {
 	}
 
 	return &User{
-		ID:             model.ID,
-		CreatedAt:      model.CreatedAt,
-		UpdatedAt:      time.Time{},
-		LastLogin:      model.LastLogin,
-		Origin:         origin,
-		ExternalID:     model.ExternalID,
-		Status:         status,
-		Name:           model.Name,
-		Username:       model.Username,
-		Email:          model.Email,
-		PasswordDigest: model.Password.Hash,
-		Admin:          model.Admin,
+		ID:               model.ID,
+		CreatedAt:        model.CreatedAt,
+		UpdatedAt:        time.Time{},
+		LastLogin:        model.LastLogin,
+		Origin:           origin,
+		ExternalID:       model.ExternalID,
+		Status:           status,
+		Name:             model.Name,
+		Username:         model.Username,
+		Email:            model.Email,
+		PasswordDigest:   model.Password.Hash,
+		Admin:            model.Admin,
+		AwaitingApproval: model.AwaitingApproval,
 		Preferences: UserPreferences{
 			PreferredNamespace: model.Preferences.PreferredNamespace,
 			AuthMethods:        authMethods,
@@ -82,15 +84,16 @@ func UserToModel(entity *User) *models.User {
 	}
 
 	return &models.User{
-		ID:             entity.ID,
-		Origin:         models.UserOrigin(entity.Origin),
-		ExternalID:     entity.ExternalID,
-		Status:         models.UserStatus(entity.Status),
-		MaxNamespaces:  entity.Preferences.MaxNamespaces,
-		CreatedAt:      entity.CreatedAt,
-		LastLogin:      entity.LastLogin,
-		EmailMarketing: entity.Preferences.EmailMarketing,
-		Admin:          entity.Admin,
+		ID:               entity.ID,
+		Origin:           models.UserOrigin(entity.Origin),
+		ExternalID:       entity.ExternalID,
+		Status:           models.UserStatus(entity.Status),
+		MaxNamespaces:    entity.Preferences.MaxNamespaces,
+		CreatedAt:        entity.CreatedAt,
+		LastLogin:        entity.LastLogin,
+		EmailMarketing:   entity.Preferences.EmailMarketing,
+		Admin:            entity.Admin,
+		AwaitingApproval: entity.AwaitingApproval,
 		UserData: models.UserData{
 			Name:          entity.Name,
 			Username:      entity.Username,

--- a/api/store/pg/migrations/010_users_awaiting_approval.tx.down.sql
+++ b/api/store/pg/migrations/010_users_awaiting_approval.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN IF EXISTS awaiting_approval;

--- a/api/store/pg/migrations/010_users_awaiting_approval.tx.up.sql
+++ b/api/store/pg/migrations/010_users_awaiting_approval.tx.up.sql
@@ -1,0 +1,7 @@
+-- Track accounts a namespace admin provisioned but a system admin has not approved yet.
+-- While awaiting_approval is true the account is inert: it exists as not-confirmed and only
+-- an admin can mint its activation link. It is set false when an admin creates the account
+-- directly (auto-approved) or approves a pending one. Community never sets it true (non-admin
+-- provisioning is an enterprise capability), so the default false keeps existing rows correct.
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS awaiting_approval boolean NOT NULL DEFAULT false;

--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -204,6 +204,16 @@ server {
         proxy_pass         http://$upstream;
     }
 
+    # Public: the invitee completes a provisioned account with the one-time token
+    # in the body, so this must not go through the authenticated /api/user block.
+    location ~ ^/api/users/[^/]+/activate$ {
+        set $upstream {{ $cfg.APIBackend }};
+        limit_req zone=api_limit{{ if $api_burst }} {{ $api_burst }}{{ end }} {{ $api_delay }};
+
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass http://$upstream;
+    }
+
     location ~^/api/namespaces/[^/]+/members/accept-invite$ {
         set $upstream {{ $cfg.APIBackend }};
         limit_req zone=api_limit{{ if $api_burst }} {{ $api_burst }}{{ end }} {{ $api_delay }};

--- a/openapi/spec/cloud-openapi.yaml
+++ b/openapi/spec/cloud-openapi.yaml
@@ -189,6 +189,8 @@ paths:
     $ref: paths/admin@api@users@{id}.yaml
   /admin/api/users/{id}/password/reset:
     $ref: paths/admin@api@users@{id}@password@reset.yaml
+  /admin/api/users/{id}/approve:
+    $ref: paths/admin@api@users@{id}@approve.yaml
   /admin/api/stats:
     $ref: paths/admin@api@stats.yaml
   /admin/api/license:

--- a/openapi/spec/community-openapi.yaml
+++ b/openapi/spec/community-openapi.yaml
@@ -86,6 +86,10 @@ paths:
     $ref: paths/api@users@{id}@data.yaml
   /api/users/{id}/password:
     $ref: paths/api@users@{id}@password.yaml
+  /api/users/{id}/activation:
+    $ref: paths/api@users@{id}@activation.yaml
+  /api/users/{id}/activate:
+    $ref: paths/api@users@{id}@activate.yaml
   /api/users/security/{tenant}:
     $ref: paths/api@users@security@{tenant}.yaml
   /api/devices:

--- a/openapi/spec/components/schemas/namespace.yaml
+++ b/openapi/spec/components/schemas/namespace.yaml
@@ -26,6 +26,23 @@ properties:
           type: string
           description: Member's email.
           example: john.doe@test.com
+        account_status:
+          type: string
+          enum:
+            - confirmed
+            - not-confirmed
+          description: >-
+            The member's underlying user account status. A not-confirmed
+            member was provisioned inline and still has to complete their
+            account through an activation link.
+          example: not-confirmed
+        awaiting_approval:
+          type: boolean
+          description: >-
+            True while a namespace admin provisioned the member but a system
+            admin has not approved the account yet. The activation link cannot
+            be minted until an admin approves.
+          example: true
   settings:
     type: object
     nullable: true

--- a/openapi/spec/components/schemas/userAdminResponse.yaml
+++ b/openapi/spec/components/schemas/userAdminResponse.yaml
@@ -13,6 +13,11 @@ properties:
   admin:
     description: User's admin status.
     type: boolean
+  awaiting_approval:
+    description: >-
+      True while a namespace admin provisioned the account but a system admin
+      has not approved it yet. No activation link can be minted until approval.
+    type: boolean
   max_namespaces:
     description: Maximum number of namespaces the user can own.
     type: integer

--- a/openapi/spec/enterprise-openapi.yaml
+++ b/openapi/spec/enterprise-openapi.yaml
@@ -152,6 +152,8 @@ paths:
     $ref: paths/admin@api@users@{id}.yaml
   /admin/api/users/{id}/password/reset:
     $ref: paths/admin@api@users@{id}@password@reset.yaml
+  /admin/api/users/{id}/approve:
+    $ref: paths/admin@api@users@{id}@approve.yaml
   /admin/api/stats:
     $ref: paths/admin@api@stats.yaml
   /admin/api/license:

--- a/openapi/spec/openapi.yaml
+++ b/openapi/spec/openapi.yaml
@@ -112,6 +112,10 @@ paths:
     $ref: paths/api@users@{id}@data.yaml
   /api/users/{id}/password:
     $ref: paths/api@users@{id}@password.yaml
+  /api/users/{id}/activation:
+    $ref: paths/api@users@{id}@activation.yaml
+  /api/users/{id}/activate:
+    $ref: paths/api@users@{id}@activate.yaml
   /api/users/security/{tenant}:
     $ref: paths/api@users@security@{tenant}.yaml
   /api/namespaces/device-auto-accept/{tenant}:
@@ -318,6 +322,8 @@ paths:
     $ref: paths/admin@api@users@{id}.yaml
   /admin/api/users/{id}/password/reset:
     $ref: paths/admin@api@users@{id}@password@reset.yaml
+  /admin/api/users/{id}/approve:
+    $ref: paths/admin@api@users@{id}@approve.yaml
   /admin/api/stats:
     $ref: paths/admin@api@stats.yaml
   /admin/api/license:

--- a/openapi/spec/paths/admin@api@users@{id}@approve.yaml
+++ b/openapi/spec/paths/admin@api@users@{id}@approve.yaml
@@ -1,0 +1,31 @@
+post:
+  operationId: approveUser
+  summary: Approve a provisioned account
+  description: |
+    Clear the awaiting-approval flag on an account a namespace admin provisioned.
+    Once approved, an activation link can be minted for the account (by an admin or
+    by a namespace admin who manages it). Enterprise only.
+  tags:
+    - admin
+    - enterprise
+    - users
+  security:
+    - jwt: []
+  parameters:
+    - name: id
+      description: The user ID.
+      schema:
+        type: string
+      required: true
+      in: path
+  responses:
+    '200':
+      $ref: ../components/responses/200.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '404':
+      $ref: ../components/responses/404.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/api@namespaces@{tenant}@members.yaml
+++ b/openapi/spec/paths/api@namespaces@{tenant}@members.yaml
@@ -36,9 +36,13 @@ post:
     Adds a member to a namespace.
 
     In enterprise and community instances, the member is added directly
-    to the namespace without any invitation step.
+    to the namespace without any invitation step. If the email has no
+    account yet and the requester is an admin, a pending account is
+    provisioned inline; supply `name` and `username` for it, and the user
+    completes the account through an activation link (see
+    `/api/users/{id}/activation`).
 
-    In cloud instances, an invitation email is sent to the member. 
+    In cloud instances, an invitation email is sent to the member.
     The invite is valid for **7 days**. If the member was previously invited
     and the invite is no longer valid, the same route will resend the invite.
   tags:
@@ -61,6 +65,10 @@ post:
               example: john.doe@test.com
             role:
               $ref: ../components/schemas/namespaceMemberRole.yaml
+            name:
+              $ref: ../components/schemas/userName.yaml
+            username:
+              $ref: ../components/schemas/userUsername.yaml
           required:
             - email
             - role

--- a/openapi/spec/paths/api@users@{id}@activate.yaml
+++ b/openapi/spec/paths/api@users@{id}@activate.yaml
@@ -1,0 +1,44 @@
+post:
+  operationId: activateUser
+  summary: Activate user
+  description: |
+    Completes a provisioned (not-confirmed) account from an activation link:
+    validates the one-time token and sets the user's initial password, moving
+    the account to confirmed. Public, since the token in the body is the
+    credential (the user has no password yet).
+  tags:
+    - community
+    - users
+  security: []
+  parameters:
+    - name: id
+      description: User ID
+      schema:
+        type: string
+      required: true
+      in: path
+  requestBody:
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            token:
+              description: The one-time activation token.
+              type: string
+            password:
+              $ref: ../components/schemas/userPassword.yaml
+          required:
+            - token
+            - password
+  responses:
+    '200':
+      $ref: ../components/responses/200.yaml
+    '400':
+      $ref: ../components/responses/400.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '404':
+      $ref: ../components/responses/404.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/api@users@{id}@activation.yaml
+++ b/openapi/spec/paths/api@users@{id}@activation.yaml
@@ -1,0 +1,43 @@
+post:
+  operationId: createUserActivationToken
+  summary: Create user activation token
+  description: |
+    Mints a one-time activation token for a provisioned (not-confirmed)
+    account so an admin can hand the user a set-password activation link out
+    of band, without depending on email. Admin only.
+  tags:
+    - community
+    - users
+  x-internal: true
+  security:
+    - jwt: []
+  parameters:
+    - name: id
+      description: User ID
+      schema:
+        type: string
+      required: true
+      in: path
+  responses:
+    '200':
+      description: Activation token successfully created.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              token:
+                description: The one-time activation token.
+                type: string
+              expires_at:
+                description: When the token expires (RFC3339).
+                type: string
+                format: date-time
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '404':
+      $ref: ../components/responses/404.yaml
+    '500':
+      $ref: ../components/responses/500.yaml

--- a/pkg/api/requests/namespace.go
+++ b/pkg/api/requests/namespace.go
@@ -64,6 +64,11 @@ type NamespaceAddMember struct {
 	TenantID     string          `param:"tenant" validate:"required,uuid"`
 	MemberEmail  string          `json:"email" validate:"required"`
 	MemberRole   authorizer.Role `json:"role" validate:"required,member_role"`
+	// MemberName and MemberUsername are only used when an admin provisions a brand-new
+	// account inline (the invited email has no account yet). They are ignored when the
+	// email already resolves to an existing user.
+	MemberName     string `json:"name" validate:"omitempty,name"`
+	MemberUsername string `json:"username" validate:"omitempty,username"`
 }
 
 type NamespaceUpdateMember struct {

--- a/pkg/api/requests/user.go
+++ b/pkg/api/requests/user.go
@@ -26,6 +26,22 @@ type UserPasswordUpdate struct {
 	NewPassword     string `json:"new_password" validate:"required,password,nefield=CurrentPassword"`
 }
 
+// CreateUserActivation is the request for minting an activation token for a provisioned
+// account. UserID is the actor (from the X-ID header, set by the gateway) and must belong to
+// an admin; ID is the target user the token is minted for.
+type CreateUserActivation struct {
+	UserParam
+	UserID string `header:"X-ID" validate:"required"`
+}
+
+// ActivateUser is the request body for completing a provisioned (not-confirmed) account: it
+// validates the one-time activation token and sets the user's initial password.
+type ActivateUser struct {
+	UserParam
+	Token    string `json:"token" validate:"required"`
+	Password string `json:"password" validate:"required,password"`
+}
+
 // AuthLocalUser is the structure to represent the request body for the user auth endpoint.
 type AuthLocalUser struct {
 	// Identifier represents an username or email.

--- a/pkg/models/member.go
+++ b/pkg/models/member.go
@@ -11,4 +11,13 @@ type Member struct {
 	AddedAt time.Time       `json:"added_at"`
 	Email   string          `json:"email" validate:"email"`
 	Role    authorizer.Role `json:"role" validate:"required,oneof=administrator operator observer"`
+	// AccountStatus is the member's underlying user account status (confirmed or
+	// not-confirmed). A not-confirmed member was provisioned inline and still has to
+	// complete their account through an activation link. It is the account status, not the
+	// cloud membership-invitation status (accepted/pending), which is a separate concept.
+	AccountStatus UserStatus `json:"account_status,omitempty"`
+	// AwaitingApproval mirrors the member's user account flag: true while a namespace admin
+	// provisioned them but a system admin has not approved the account yet. The activation
+	// link cannot be minted for them until an admin approves.
+	AwaitingApproval bool `json:"awaiting_approval,omitempty"`
 }

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -77,6 +77,10 @@ type User struct {
 	Password    UserPassword
 	// Admin indicates whether the user has administrative privileges.
 	Admin bool `json:"admin"`
+	// AwaitingApproval marks a provisioned account that a namespace admin created but a system
+	// admin has not approved yet. While true the account is inert: only an admin can mint its
+	// activation link. It is set false when an admin creates the account directly or approves it.
+	AwaitingApproval bool `json:"awaiting_approval"`
 }
 
 type UserData struct {

--- a/ui/apps/console/src/App.tsx
+++ b/ui/apps/console/src/App.tsx
@@ -44,6 +44,7 @@ const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const UpdatePassword = lazy(() => import("./pages/UpdatePassword"));
 const AcceptInvite = lazy(() => import("./pages/AcceptInvite"));
 const AcceptDevice = lazy(() => import("./pages/AcceptDevice"));
+const ActivateAccount = lazy(() => import("./pages/ActivateAccount"));
 const SecureVault = lazy(() => import("./pages/secure-vault"));
 const AdminDashboard = lazy(() => import("./pages/admin/Dashboard"));
 const AdminSessions = lazy(() => import("./pages/admin/Sessions"));
@@ -102,6 +103,7 @@ export default function App() {
                 />
               </Route>
               <Route path="/accept-device" element={<AcceptDevice />} />
+              <Route path="/activate" element={<ActivateAccount />} />
               {getConfig().cloud && (
                 <>
                   <Route path="/forgot-password" element={<ForgotPassword />} />

--- a/ui/apps/console/src/hooks/useAdminAccountRequestMutations.ts
+++ b/ui/apps/console/src/hooks/useAdminAccountRequestMutations.ts
@@ -1,0 +1,25 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  approveUserMutation,
+  adminDeleteUserMutation,
+} from "../client/@tanstack/react-query.gen";
+import { useInvalidateByIds } from "./useInvalidateQueries";
+
+// Approving clears the awaiting_approval flag; the account stays not-confirmed until the
+// person activates it, so an activation link can then be minted from the members list.
+export function useApproveAccountRequest() {
+  const invalidate = useInvalidateByIds("getUsers", "getUser");
+  return useMutation({
+    ...approveUserMutation(),
+    onSuccess: invalidate,
+  });
+}
+
+// Rejecting deletes the provisioned account outright.
+export function useRejectAccountRequest() {
+  const invalidate = useInvalidateByIds("getUsers", "getUser");
+  return useMutation({
+    ...adminDeleteUserMutation(),
+    onSuccess: invalidate,
+  });
+}

--- a/ui/apps/console/src/hooks/useAdminAccountRequests.ts
+++ b/ui/apps/console/src/hooks/useAdminAccountRequests.ts
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getUsers as getUsersSdk,
+  type GetUsersData,
+  type UserAdminResponse,
+} from "../client";
+import { getUsersQueryKey } from "../client/@tanstack/react-query.gen";
+import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
+import { useAuthStore } from "../stores/authStore";
+import { isSdkError } from "../api/errors";
+import { toBase64Json } from "@/utils/encoding";
+
+// Accounts a namespace admin provisioned that a system admin has not approved yet
+// are just users flagged awaiting_approval; the "requests" queue is that filter.
+const AWAITING_APPROVAL_FILTER = toBase64Json([
+  {
+    type: "property",
+    params: { name: "awaiting_approval", operator: "bool", value: true },
+  },
+]);
+
+interface UseAdminAccountRequestsParams {
+  page?: number;
+  perPage?: number;
+  enabled?: boolean;
+}
+
+export function useAdminAccountRequests({
+  page = 1,
+  perPage = 10,
+  enabled = true,
+}: UseAdminAccountRequestsParams = {}) {
+  const isAdmin = useAuthStore((s) => s.isAdmin);
+
+  const query: GetUsersData["query"] = {
+    page,
+    per_page: perPage,
+    filter: AWAITING_APPROVAL_FILTER,
+  };
+  const options = { query };
+
+  const result = useQuery<PaginatedResult<UserAdminResponse>>({
+    queryKey: getUsersQueryKey(options),
+    queryFn: paginatedQueryFn(getUsersSdk, options),
+    enabled: isAdmin && enabled,
+    staleTime: 60 * 1000, // 1 minute
+    retry: (count, err) =>
+      isSdkError(err) && err.status === 401 ? false : count < 1,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    requests: result.data?.data ?? [],
+    totalCount: result.data?.totalCount ?? 0,
+    isLoading: result.isLoading,
+    error: result.error,
+    refetch: result.refetch,
+  };
+}

--- a/ui/apps/console/src/hooks/useMemberMutations.ts
+++ b/ui/apps/console/src/hooks/useMemberMutations.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import {
   addNamespaceMemberMutation,
+  createUserActivationTokenMutation,
   removeNamespaceMemberMutation,
   updateNamespaceMemberMutation,
 } from "../client/@tanstack/react-query.gen";
@@ -28,4 +29,10 @@ export function useRemoveMember() {
     ...removeNamespaceMemberMutation(),
     onSuccess: invalidate,
   });
+}
+
+// Mints a one-time activation link token for a provisioned (not-confirmed)
+// account. No cache invalidation: it doesn't change the member list.
+export function useCreateActivationToken() {
+  return useMutation(createUserActivationTokenMutation());
 }

--- a/ui/apps/console/src/hooks/useNamespaces.ts
+++ b/ui/apps/console/src/hooks/useNamespaces.ts
@@ -5,7 +5,10 @@ import {
   getNamespaceOptions,
   getNamespaceTokenOptions,
 } from "../client/@tanstack/react-query.gen";
-import type { Namespace as GeneratedNamespace, NamespaceMemberRole } from "../client";
+import type {
+  Namespace as GeneratedNamespace,
+  NamespaceMemberRole,
+} from "../client";
 import { useAuthStore } from "../stores/authStore";
 
 export type Namespace = GeneratedNamespace & { type?: string };
@@ -16,6 +19,14 @@ export interface NamespaceMember {
   email: string;
   added_at?: string;
   status?: "accepted" | "pending";
+  /** Underlying user account status. "not-confirmed" means the member was
+   *  provisioned inline and still has to complete their account via an
+   *  activation link. Distinct from the cloud invitation `status` above. */
+  account_status?: "confirmed" | "not-confirmed";
+  /** True while a namespace admin provisioned the member but a system admin
+   *  has not approved the account yet. No activation link can be minted until
+   *  an admin approves. */
+  awaiting_approval?: boolean;
 }
 
 export function useNamespaces() {
@@ -49,7 +60,9 @@ export function useInitRole() {
 
   useEffect(() => {
     if (!data || !tenant) return;
-    useAuthStore.getState().setSession({ token: data.token, tenant, role: data.role });
+    useAuthStore
+      .getState()
+      .setSession({ token: data.token, tenant, role: data.role });
   }, [data, tenant]);
 }
 
@@ -60,7 +73,7 @@ export function useNamespace(tenantId: string) {
   });
 
   return {
-    namespace: (result.data ?? null),
+    namespace: result.data ?? null,
     isLoading: result.isLoading,
     error: result.error,
     refetch: result.refetch,

--- a/ui/apps/console/src/pages/ActivateAccount.tsx
+++ b/ui/apps/console/src/pages/ActivateAccount.tsx
@@ -1,0 +1,168 @@
+import { useState, FormEvent } from "react";
+import { Link, useSearchParams, useNavigate } from "react-router-dom";
+import {
+  ExclamationCircleIcon,
+  LockClosedIcon,
+} from "@heroicons/react/24/outline";
+import { useForm } from "react-hook-form";
+import { Button } from "@shellhub/design-system/primitives";
+import { activateUser } from "@/client";
+import { updatePasswordResolver } from "./setup/updatePasswordResolver";
+import type { UpdatePasswordFormValues } from "./setup/updatePasswordResolver";
+import { FormPasswordField } from "@/components/common/fields/rhf";
+
+export default function ActivateAccount() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const id = searchParams.get("id") ?? "";
+  const token = searchParams.get("token") ?? "";
+
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const { control, handleSubmit, formState } =
+    useForm<UpdatePasswordFormValues>({
+      resolver: updatePasswordResolver,
+      mode: "onTouched",
+      defaultValues: { password: "", confirmPassword: "" },
+    });
+
+  const onSubmit = async (values: UpdatePasswordFormValues) => {
+    setError("");
+    setLoading(true);
+    try {
+      await activateUser({
+        path: { id },
+        body: { token, password: values.password },
+        throwOnError: true,
+      });
+      void navigate("/login", {
+        state: { notice: "Account activated. Please sign in." },
+      });
+    } catch {
+      setError(
+        "Failed to activate the account. The link may have expired. Ask your administrator for a new one.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFormSubmit = (e: FormEvent) => {
+    void handleSubmit(onSubmit)(e);
+  };
+
+  if (!id || !token) {
+    return (
+      <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+        <div className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 text-center animate-fade-in">
+          <ExclamationCircleIcon
+            className="w-10 h-10 text-accent-red mx-auto mb-4"
+            strokeWidth={1.5}
+          />
+          <p className="text-sm font-semibold text-text-primary mb-2">
+            Invalid activation link
+          </p>
+          <p className="text-xs text-text-muted mb-6">
+            This activation link is invalid or has expired.
+          </p>
+          <Link
+            to="/login"
+            className="text-xs text-primary hover:text-primary-400 transition-colors"
+          >
+            Back to login
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+      {/* Hero */}
+      <div className="text-center mb-12 animate-fade-in">
+        <div className="animate-float mb-6 inline-block">
+          <div className="w-20 h-20 rounded-2xl bg-primary/15 border border-primary/25 flex items-center justify-center shadow-lg shadow-primary/10">
+            <LockClosedIcon
+              className="w-10 h-10 text-primary"
+              strokeWidth={1.2}
+            />
+          </div>
+        </div>
+
+        <p className="text-2xs font-mono font-semibold uppercase tracking-wide text-primary/80 mb-2">
+          Account Activation
+        </p>
+        <h1 className="text-3xl font-bold text-text-primary mb-3">
+          Activate your account
+        </h1>
+        <p className="text-sm text-text-muted max-w-md mx-auto leading-relaxed">
+          Choose a password to finish setting up your account.
+        </p>
+      </div>
+
+      {/* Card */}
+      <div
+        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
+        style={{ animationDelay: "200ms" }}
+      >
+        <form onSubmit={handleFormSubmit} className="space-y-5">
+          {error && (
+            <div
+              role="alert"
+              className="flex items-start gap-2 bg-accent-red/8 border border-accent-red/20 text-accent-red px-3.5 py-2.5 rounded-md text-xs font-mono animate-slide-down"
+            >
+              <ExclamationCircleIcon
+                className="w-3.5 h-3.5 shrink-0 mt-0.5"
+                strokeWidth={2}
+              />
+              {error}
+            </div>
+          )}
+
+          <FormPasswordField<UpdatePasswordFormValues>
+            id="password"
+            label="Password"
+            name="password"
+            control={control}
+            placeholder="••••••••"
+            hint="5–32 characters"
+            required
+          />
+
+          <FormPasswordField<UpdatePasswordFormValues>
+            id="confirmPassword"
+            label="Confirm Password"
+            name="confirmPassword"
+            control={control}
+            placeholder="••••••••"
+            required
+          />
+
+          <Button
+            variant="primary"
+            size="lg"
+            fullWidth
+            type="submit"
+            className="px-4"
+            loading={loading}
+            disabled={loading || !formState.isValid}
+          >
+            {loading ? "Activating..." : "Activate Account"}
+          </Button>
+        </form>
+      </div>
+
+      {/* Back to login */}
+      <div className="mt-8 animate-fade-in" style={{ animationDelay: "600ms" }}>
+        <Link
+          to="/login"
+          className="text-xs text-text-muted hover:text-text-secondary transition-colors"
+        >
+          &larr; Back to login
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/ui/apps/console/src/pages/admin/users/AccountRequestsTab.tsx
+++ b/ui/apps/console/src/pages/admin/users/AccountRequestsTab.tsx
@@ -1,0 +1,211 @@
+import { useState, type MouseEvent } from "react";
+import {
+  UserPlusIcon,
+  CheckIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { useAdminAccountRequests } from "@/hooks/useAdminAccountRequests";
+import {
+  useApproveAccountRequest,
+  useRejectAccountRequest,
+} from "@/hooks/useAdminAccountRequestMutations";
+import { usePaginatedListState } from "@/hooks/usePaginatedListState";
+import type { UserAdminResponse } from "@/client";
+import DataTable, { type Column } from "@/components/common/DataTable";
+import ConfirmDialog from "@/components/common/ConfirmDialog";
+import { Callout, IconButton } from "@shellhub/design-system/primitives";
+
+const PER_PAGE = 10;
+
+type AccountRequestsParams = { page: number };
+
+const DEFAULTS: AccountRequestsParams = { page: 1 };
+
+export default function AccountRequestsTab() {
+  const { params, setPage } = usePaginatedListState<AccountRequestsParams>({
+    prefix: "req",
+    defaults: DEFAULTS,
+  });
+  const [approveTarget, setApproveTarget] = useState<UserAdminResponse | null>(
+    null,
+  );
+  const [rejectTarget, setRejectTarget] = useState<UserAdminResponse | null>(
+    null,
+  );
+  const [error, setError] = useState("");
+
+  const {
+    requests,
+    totalCount,
+    isLoading,
+    error: loadError,
+  } = useAdminAccountRequests({ page: params.page, perPage: PER_PAGE });
+  const approve = useApproveAccountRequest();
+  const reject = useRejectAccountRequest();
+
+  const totalPages = Math.ceil(totalCount / PER_PAGE);
+
+  const columns: Column<UserAdminResponse>[] = [
+    {
+      key: "name",
+      header: "Name",
+      render: (u) => (
+        <span className="text-sm font-medium text-text-primary">{u.name}</span>
+      ),
+    },
+    {
+      key: "email",
+      header: "Email",
+      render: (u) => (
+        <span className="text-xs text-text-secondary">{u.email}</span>
+      ),
+    },
+    {
+      key: "username",
+      header: "Username",
+      render: (u) => (
+        <code className="text-2xs font-mono text-text-muted">{u.username}</code>
+      ),
+    },
+    {
+      key: "actions",
+      header: "Actions",
+      headerClassName: "text-right",
+      render: (u) => (
+        <div className="flex items-center justify-end gap-1">
+          <IconButton
+            variant="primary"
+            title="Approve account"
+            aria-label={`Approve account for ${u.email}`}
+            onClick={(e: MouseEvent) => {
+              e.stopPropagation();
+              setApproveTarget(u);
+            }}
+          >
+            <CheckIcon className="w-4 h-4" />
+          </IconButton>
+          <IconButton
+            variant="danger"
+            title="Reject account"
+            aria-label={`Reject account for ${u.email}`}
+            onClick={(e: MouseEvent) => {
+              e.stopPropagation();
+              setRejectTarget(u);
+            }}
+          >
+            <XMarkIcon className="w-4 h-4" />
+          </IconButton>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="animate-fade-in">
+      <p className="text-sm text-text-muted mb-5">
+        Accounts a namespace admin provisioned, awaiting your approval.
+        Approving lets an activation link be issued from the namespace's members
+        list.
+      </p>
+
+      {loadError && (
+        <Callout variant="error" className="mb-4">
+          {loadError.message}
+        </Callout>
+      )}
+
+      <DataTable
+        columns={columns}
+        data={requests}
+        rowKey={(u) => u.id}
+        isLoading={isLoading}
+        loadingMessage="Loading requests..."
+        page={params.page}
+        totalPages={totalPages}
+        totalCount={totalCount}
+        itemLabel="request"
+        onPageChange={setPage}
+        emptyState={
+          <div className="text-center">
+            <UserPlusIcon
+              className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
+              strokeWidth={1}
+            />
+            <p className="text-xs font-mono text-text-muted">
+              No accounts awaiting approval
+            </p>
+          </div>
+        }
+      />
+
+      <ConfirmDialog
+        open={!!approveTarget}
+        onClose={() => {
+          setError("");
+          setApproveTarget(null);
+        }}
+        onConfirm={async () => {
+          if (!approveTarget) return;
+          setError("");
+          try {
+            await approve.mutateAsync({ path: { id: approveTarget.id } });
+            setApproveTarget(null);
+          } catch {
+            setError("Failed to approve the account. Please try again.");
+          }
+        }}
+        title="Approve Account"
+        description={
+          <>
+            Approve the account for{" "}
+            <span className="font-medium text-text-primary">
+              {approveTarget?.email}
+            </span>
+            ? An activation link can then be issued from the members list.
+            {error && (
+              <span className="block mt-2 text-accent-red text-2xs">
+                {error}
+              </span>
+            )}
+          </>
+        }
+        confirmLabel="Approve"
+        variant="primary"
+      />
+
+      <ConfirmDialog
+        open={!!rejectTarget}
+        onClose={() => {
+          setError("");
+          setRejectTarget(null);
+        }}
+        onConfirm={async () => {
+          if (!rejectTarget) return;
+          setError("");
+          try {
+            await reject.mutateAsync({ path: { id: rejectTarget.id } });
+            setRejectTarget(null);
+          } catch {
+            setError("Failed to reject the account. Please try again.");
+          }
+        }}
+        title="Reject Account"
+        description={
+          <>
+            Reject and delete the provisioned account for{" "}
+            <span className="font-medium text-text-primary">
+              {rejectTarget?.email}
+            </span>
+            ? This cannot be undone.
+            {error && (
+              <span className="block mt-2 text-accent-red text-2xs">
+                {error}
+              </span>
+            )}
+          </>
+        }
+        confirmLabel="Reject"
+      />
+    </div>
+  );
+}

--- a/ui/apps/console/src/pages/admin/users/__tests__/AdminUsers.test.tsx
+++ b/ui/apps/console/src/pages/admin/users/__tests__/AdminUsers.test.tsx
@@ -14,6 +14,18 @@ vi.mock("@/hooks/useLoginAsUser", () => ({
   useLoginAsUser: vi.fn(),
 }));
 
+vi.mock("@/hooks/useAdminAccountRequests", () => ({
+  useAdminAccountRequests: () => ({ totalCount: 0 }),
+}));
+
+vi.mock("@/env", () => ({
+  getConfig: () => ({ enterprise: false, cloud: false }),
+}));
+
+vi.mock("../AccountRequestsTab", () => ({
+  default: () => null,
+}));
+
 vi.mock("./mocks", () => ({}));
 
 // Drawer/Dialog mocks — keep tests fast and focused
@@ -28,13 +40,8 @@ vi.mock("../EditUserDrawer", () => ({
 }));
 
 vi.mock("../DeleteUserDialog", () => ({
-  default: ({
-    open,
-  }: {
-    open: boolean;
-    user: unknown;
-    onClose: () => void;
-  }) => (open ? <div data-testid="delete-dialog" /> : null),
+  default: ({ open }: { open: boolean; user: unknown; onClose: () => void }) =>
+    open ? <div data-testid="delete-dialog" /> : null,
 }));
 
 const mockNavigate = vi.fn();
@@ -65,7 +72,9 @@ const defaultLoginAsState = {
   errorId: null as string | null,
 };
 
-function makeUser(overrides: Partial<UserAdminResponse> = {}): UserAdminResponse {
+function makeUser(
+  overrides: Partial<UserAdminResponse> = {},
+): UserAdminResponse {
   return {
     id: "user-id-1",
     name: "Alice Smith",
@@ -97,7 +106,9 @@ describe("AdminUsers", () => {
   describe("rendering", () => {
     it("renders the page heading", () => {
       renderPage();
-      expect(screen.getByRole("heading", { name: "Users" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Users" }),
+      ).toBeInTheDocument();
     });
 
     it("renders the search input with correct aria-label", () => {

--- a/ui/apps/console/src/pages/admin/users/index.tsx
+++ b/ui/apps/console/src/pages/admin/users/index.tsx
@@ -8,9 +8,11 @@ import {
   ArrowRightStartOnRectangleIcon,
 } from "@heroicons/react/24/outline";
 import { useAdminUsers } from "@/hooks/useAdminUsers";
+import { useAdminAccountRequests } from "@/hooks/useAdminAccountRequests";
 import { useLoginAsUser } from "@/hooks/useLoginAsUser";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
+import { getConfig } from "@/env";
 import type { UserAdminResponse } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import DataTable, { type Column } from "@/components/common/DataTable";
@@ -19,6 +21,7 @@ import UserStatusChip from "./UserStatusChip";
 import CreateUserDrawer from "./CreateUserDrawer";
 import EditUserDrawer from "./EditUserDrawer";
 import DeleteUserDialog from "./DeleteUserDialog";
+import AccountRequestsTab from "./AccountRequestsTab";
 import {
   Badge,
   Button,
@@ -41,6 +44,10 @@ const DEFAULTS: AdminUsersParams = {
 
 export default function AdminUsers() {
   const navigate = useNavigate();
+  // Account provisioning requests are an enterprise-only queue; on Cloud a new
+  // member self-serves via email invitation, so there is nothing to approve.
+  const showRequestsTab = getConfig().enterprise && !getConfig().cloud;
+  const [tab, setTab] = useState<"users" | "account-requests">("users");
   const { params, setPage, setSearch } =
     usePaginatedListState<AdminUsersParams>({ defaults: DEFAULTS });
   const debouncedSearch = useDebouncedValue(params.search, SEARCH_DEBOUNCE_MS);
@@ -59,6 +66,11 @@ export default function AdminUsers() {
     page: params.page,
     perPage: PER_PAGE,
     search: debouncedSearch,
+  });
+
+  // Pending-request count drives the tab badge; only queried in enterprise.
+  const { totalCount: requestsCount } = useAdminAccountRequests({
+    enabled: showRequestsTab,
   });
 
   const totalPages = Math.ceil(totalCount / PER_PAGE);
@@ -152,6 +164,8 @@ export default function AdminUsers() {
     },
   ];
 
+  const onUsersTab = !showRequestsTab || tab === "users";
+
   return (
     <div>
       <PageHeader
@@ -160,54 +174,89 @@ export default function AdminUsers() {
         title="Users"
         description="Manage all user accounts in the instance"
       >
-        <Button
-          onClick={() => setCreateOpen(true)}
-          icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
-        >
-          Create User
-        </Button>
+        {onUsersTab && (
+          <Button
+            onClick={() => setCreateOpen(true)}
+            icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
+          >
+            Create User
+          </Button>
+        )}
       </PageHeader>
 
-      <SearchField
-        className="mb-5"
-        value={params.search}
-        onChange={setSearch}
-        placeholder="Search by username..."
-        aria-label="Search users by username"
-      />
-
-      {error && (
-        <Callout variant="error" className="mb-4">
-          {error.message}
-        </Callout>
+      {showRequestsTab && (
+        <div className="flex items-center h-8 bg-card border border-border rounded-md p-0.5 w-fit mb-6 animate-fade-in">
+          {[
+            { label: "Users", value: "users" as const },
+            {
+              label: "Account Requests",
+              value: "account-requests" as const,
+              count: requestsCount,
+            },
+          ].map((t) => (
+            <button
+              type="button"
+              key={t.value}
+              onClick={() => setTab(t.value)}
+              className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 flex items-center gap-1.5 ${
+                tab === t.value
+                  ? "bg-primary/15 text-primary border border-primary/25"
+                  : "text-text-muted hover:text-text-secondary border border-transparent"
+              }`}
+            >
+              {t.label}
+              {t.count ? <Badge color="yellow">{t.count}</Badge> : null}
+            </button>
+          ))}
+        </div>
       )}
 
-      <DataTable
-        columns={columns}
-        data={users}
-        rowKey={(user) => user.id}
-        isLoading={isLoading}
-        loadingMessage="Loading users..."
-        page={params.page}
-        totalPages={totalPages}
-        totalCount={totalCount}
-        itemLabel="user"
-        onPageChange={setPage}
-        onRowClick={(user) => void navigate(`/admin/users/${user.id}`)}
-        emptyState={
-          <div className="text-center">
-            <UsersIcon
-              className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
-              strokeWidth={1}
-            />
-            <p className="text-xs font-mono text-text-muted">
-              {debouncedSearch
-                ? `No users matching "${debouncedSearch}"`
-                : "No users found"}
-            </p>
-          </div>
-        }
-      />
+      {onUsersTab ? (
+        <>
+          <SearchField
+            className="mb-5"
+            value={params.search}
+            onChange={setSearch}
+            placeholder="Search by username..."
+            aria-label="Search users by username"
+          />
+
+          {error && (
+            <Callout variant="error" className="mb-4">
+              {error.message}
+            </Callout>
+          )}
+
+          <DataTable
+            columns={columns}
+            data={users}
+            rowKey={(user) => user.id}
+            isLoading={isLoading}
+            loadingMessage="Loading users..."
+            page={params.page}
+            totalPages={totalPages}
+            totalCount={totalCount}
+            itemLabel="user"
+            onPageChange={setPage}
+            onRowClick={(user) => void navigate(`/admin/users/${user.id}`)}
+            emptyState={
+              <div className="text-center">
+                <UsersIcon
+                  className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
+                  strokeWidth={1}
+                />
+                <p className="text-xs font-mono text-text-muted">
+                  {debouncedSearch
+                    ? `No users matching "${debouncedSearch}"`
+                    : "No users found"}
+                </p>
+              </div>
+            }
+          />
+        </>
+      ) : (
+        <AccountRequestsTab />
+      )}
 
       <CreateUserDrawer
         open={createOpen}

--- a/ui/apps/console/src/pages/team/ActivationLinkDialog.tsx
+++ b/ui/apps/console/src/pages/team/ActivationLinkDialog.tsx
@@ -1,0 +1,144 @@
+import { useState, useId } from "react";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { useCreateActivationToken } from "@/hooks/useMemberMutations";
+import CopyButton from "@/components/common/CopyButton";
+import BaseDialog from "@/components/common/BaseDialog";
+import InputField from "@/components/common/fields/InputField";
+import { Button } from "@shellhub/design-system/primitives";
+import { buildActivationLink } from "./helpers";
+
+interface ActivationLinkDialogProps {
+  open: boolean;
+  onClose: () => void;
+  userId: string;
+  email: string;
+}
+
+export default function ActivationLinkDialog({
+  open,
+  onClose,
+  userId,
+  email,
+}: ActivationLinkDialogProps) {
+  const createToken = useCreateActivationToken();
+  const [step, setStep] = useState<"confirm" | "result">("confirm");
+  const [link, setLink] = useState("");
+  const [error, setError] = useState("");
+
+  const autoId = useId();
+  const titleId = `activation-link-title-${autoId}`;
+  const descId = `activation-link-desc-${autoId}`;
+
+  useResetOnOpen(open, () => {
+    setStep("confirm");
+    setLink("");
+    setError("");
+  });
+
+  const handleGenerate = async () => {
+    setError("");
+    try {
+      const data = await createToken.mutateAsync({ path: { id: userId } });
+      setLink(buildActivationLink(userId, data?.token ?? ""));
+      setStep("result");
+    } catch {
+      setError("Failed to generate the activation link. Please try again.");
+    }
+  };
+
+  return (
+    <BaseDialog
+      open={open}
+      onClose={onClose}
+      size="sm"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+    >
+      {step === "confirm" ? (
+        <>
+          <div className="p-6 pb-0">
+            <h2
+              id={titleId}
+              className="text-base font-semibold text-text-primary"
+            >
+              Generate Activation Link
+            </h2>
+          </div>
+
+          <div className="px-6 pt-2 pb-6">
+            <p id={descId} className="text-sm text-text-muted mb-6">
+              Generate a one-time link for{" "}
+              <span className="font-medium text-text-primary">{email}</span> to
+              set a password and activate their account. Share it directly with
+              them; it expires after a while and can only be used once.
+            </p>
+            {error && (
+              <p role="alert" className="text-2xs text-accent-red mb-4">
+                {error}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 px-6 py-4 border-t border-border">
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => void handleGenerate()}
+              disabled={createToken.isPending}
+              loading={createToken.isPending}
+            >
+              Generate
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="p-6 pb-0">
+            <h2
+              id={titleId}
+              className="text-base font-semibold text-text-primary"
+            >
+              Activation Link
+            </h2>
+          </div>
+
+          <div className="px-6 pt-2 pb-6">
+            <div className="flex items-start gap-2 p-3 bg-accent-yellow/8 border border-accent-yellow/20 rounded-lg mb-4">
+              <ExclamationTriangleIcon
+                className="w-4 h-4 text-accent-yellow shrink-0 mt-0.5"
+                strokeWidth={2}
+              />
+              <p id={descId} className="text-2xs text-accent-yellow">
+                Copy this link now and share it with the user. It will not be
+                shown again.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="flex-1">
+                <InputField
+                  id={`${autoId}-activation-link`}
+                  label="Activation link"
+                  hideLabel
+                  readOnly
+                  value={link}
+                  onChange={() => {}}
+                  variant="mono"
+                />
+              </div>
+              <CopyButton text={link} size="md" showLabel />
+            </div>
+          </div>
+
+          <div className="flex justify-end px-6 py-4 border-t border-border">
+            <Button variant="primary" onClick={onClose}>
+              Close
+            </Button>
+          </div>
+        </>
+      )}
+    </BaseDialog>
+  );
+}

--- a/ui/apps/console/src/pages/team/AddMemberDrawer.tsx
+++ b/ui/apps/console/src/pages/team/AddMemberDrawer.tsx
@@ -1,12 +1,16 @@
 import { useState, FormEvent } from "react";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
-import { PlusIcon } from "@heroicons/react/24/outline";
-import { useAddMember } from "@/hooks/useMemberMutations";
+import { PlusIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import {
+  useAddMember,
+  useCreateActivationToken,
+} from "@/hooks/useMemberMutations";
 import Drawer from "@/components/common/Drawer";
 import InputField from "@/components/common/fields/InputField";
+import CopyButton from "@/components/common/CopyButton";
 import { EMAIL_REGEX } from "@/utils/validation";
 import { RoleSelector } from "./constants";
-import { type AssignableRole } from "./helpers";
+import { type AssignableRole, buildActivationLink } from "./helpers";
 import { Button } from "@shellhub/design-system/primitives";
 
 /* --- Add Member Drawer --- */
@@ -21,17 +25,31 @@ function AddMemberDrawer({
   tenantId: string;
 }) {
   const addMember = useAddMember();
+  const createToken = useCreateActivationToken();
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<AssignableRole>("operator");
+  const [name, setName] = useState("");
+  const [username, setUsername] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [emailError, setEmailError] = useState("");
   const [error, setError] = useState("");
+  // When we provision a brand-new account, we surface its activation link here
+  // instead of closing, so the admin can copy it in one step.
+  const [activationLink, setActivationLink] = useState("");
+  // Enterprise: a namespace admin who isn't a system admin can't provision an
+  // account directly — the add is enqueued for a system admin to approve. We
+  // confirm that here instead of closing silently.
+  const [requestSubmitted, setRequestSubmitted] = useState(false);
 
   useResetOnOpen(open, () => {
     setEmail("");
     setRole("operator");
+    setName("");
+    setUsername("");
     setEmailError("");
     setError("");
+    setActivationLink("");
+    setRequestSubmitted(false);
   });
 
   const trimmedEmail = email.trim();
@@ -47,17 +65,138 @@ function AddMemberDrawer({
     setEmailError("");
     setError("");
     try {
-      await addMember.mutateAsync({
+      const trimmedName = name.trim();
+      const trimmedUsername = username.trim();
+      const namespace = await addMember.mutateAsync({
         path: { tenant: tenantId },
-        body: { email: trimmedEmail, role },
+        body: {
+          email: trimmedEmail,
+          role,
+          // Only sent when provisioning a brand-new account; ignored by the
+          // server when the email already resolves to an existing user.
+          ...(trimmedName ? { name: trimmedName } : {}),
+          ...(trimmedUsername ? { username: trimmedUsername } : {}),
+        },
       });
+
+      const memberRow = namespace?.members?.find(
+        (m) => m.email?.toLowerCase() === trimmedEmail.toLowerCase(),
+      );
+
+      // A non-admin provisioned the account: it exists but is inert until a system
+      // admin approves it, and only an admin can mint its link. Confirm and stop.
+      if (memberRow?.awaiting_approval) {
+        setRequestSubmitted(true);
+        return;
+      }
+
+      // An admin-provisioned account comes back not-confirmed and auto-approved;
+      // mint its activation link right away so there's no second step.
+      if (memberRow?.account_status === "not-confirmed" && memberRow.id) {
+        try {
+          const data = await createToken.mutateAsync({
+            path: { id: memberRow.id },
+          });
+          setActivationLink(
+            buildActivationLink(memberRow.id, data?.token ?? ""),
+          );
+          return;
+        } catch {
+          // The member exists; a link can still be copied from the members list.
+          onClose();
+          return;
+        }
+      }
+
+      // Existing account added directly, or nothing more to do.
       onClose();
     } catch {
-      setError("Failed to add member. Check the email and try again.");
+      setError(
+        "Failed to add member. If the person has no account yet, fill in the name and username to create one.",
+      );
     } finally {
       setSubmitting(false);
     }
   };
+
+  if (requestSubmitted) {
+    return (
+      <Drawer
+        open={open}
+        onClose={onClose}
+        title="Request Submitted"
+        footer={
+          <Button variant="primary" onClick={onClose}>
+            Done
+          </Button>
+        }
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-text-muted">
+            The account for{" "}
+            <span className="font-medium text-text-primary">
+              {trimmedEmail}
+            </span>{" "}
+            was created and is awaiting a system administrator's approval. It
+            shows as "Awaiting approval" in the members list.
+          </p>
+          <p className="text-2xs text-text-muted">
+            Once approved, you'll be able to copy the activation link from the
+            members list and share it with them.
+          </p>
+        </div>
+      </Drawer>
+    );
+  }
+
+  if (activationLink) {
+    return (
+      <Drawer
+        open={open}
+        onClose={onClose}
+        title="Member Provisioned"
+        footer={
+          <Button variant="primary" onClick={onClose}>
+            Done
+          </Button>
+        }
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-text-muted">
+            The account was created. Share this one-time activation link with{" "}
+            <span className="font-medium text-text-primary">
+              {trimmedEmail}
+            </span>{" "}
+            so they can set a password.
+          </p>
+          <div className="flex items-start gap-2 p-3 bg-accent-yellow/8 border border-accent-yellow/20 rounded-lg">
+            <ExclamationTriangleIcon
+              className="w-4 h-4 text-accent-yellow shrink-0 mt-0.5"
+              strokeWidth={2}
+            />
+            <p className="text-2xs text-accent-yellow">
+              Copy it now — it will not be shown again. You can generate a new
+              one later from the members list.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex-1">
+              <InputField
+                id="add-member-activation-link"
+                label="Activation link"
+                hideLabel
+                readOnly
+                value={activationLink}
+                onChange={() => {}}
+                variant="mono"
+              />
+            </div>
+            <CopyButton text={activationLink} size="md" showLabel />
+          </div>
+        </div>
+      </Drawer>
+    );
+  }
 
   return (
     <Drawer
@@ -92,11 +231,33 @@ function AddMemberDrawer({
             if (emailError) setEmailError("");
           }}
           placeholder="user@example.com"
-          hint="Must have an existing ShellHub account"
-
+          hint="An existing account is added directly; a new email is provisioned below"
           error={emailError}
         />
         <RoleSelector value={role} onChange={setRole} />
+
+        <div className="space-y-5 border-t border-border pt-5">
+          <p className="text-2xs text-text-muted">
+            New account (optional) — fill these in to provision an account when
+            the email has none yet. The person sets their password through an
+            activation link.
+          </p>
+          <InputField
+            id="add-member-name"
+            label="Name"
+            value={name}
+            onChange={setName}
+            placeholder="John Doe"
+          />
+          <InputField
+            id="add-member-username"
+            label="Username"
+            value={username}
+            onChange={setUsername}
+            placeholder="john_doe"
+          />
+        </div>
+
         {error && <p className="text-2xs text-accent-red">{error}</p>}
       </form>
     </Drawer>

--- a/ui/apps/console/src/pages/team/MembersTab.tsx
+++ b/ui/apps/console/src/pages/team/MembersTab.tsx
@@ -4,6 +4,7 @@ import {
   UserGroupIcon,
   PencilSquareIcon,
   TrashIcon,
+  LinkIcon,
 } from "@heroicons/react/24/outline";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
 import { useAuthStore } from "@/stores/authStore";
@@ -16,6 +17,7 @@ import { RoleBadge } from "./constants";
 import { initials } from "./helpers";
 import AddMemberDrawer from "./AddMemberDrawer";
 import EditMemberDrawer from "./EditMemberDrawer";
+import ActivationLinkDialog from "./ActivationLinkDialog";
 import RestrictedAction from "@/components/common/RestrictedAction";
 
 // Cloud-only drawer — lazy so its transitive deps (CopyButton, isSdkError,
@@ -40,6 +42,8 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
   const [removeTarget, setRemoveTarget] = useState<NamespaceMember | null>(
     null,
   );
+  const [activationTarget, setActivationTarget] =
+    useState<NamespaceMember | null>(null);
   const [removeError, setRemoveError] = useState<string | null>(null);
 
   const closeRemove = () => {
@@ -90,6 +94,15 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
                   (you)
                 </span>
               )}
+              {m.awaiting_approval ? (
+                <span className="ml-2 inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border bg-accent-blue/10 text-accent-blue border-accent-blue/20">
+                  Awaiting approval
+                </span>
+              ) : m.account_status === "not-confirmed" ? (
+                <span className="ml-2 inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border bg-accent-yellow/10 text-accent-yellow border-accent-yellow/20">
+                  Pending activation
+                </span>
+              ) : null}
             </div>
           </div>
         );
@@ -109,6 +122,18 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
         if (isSelf) return null;
         return (
           <div className="flex items-center justify-end gap-1">
+            {m.account_status === "not-confirmed" && !m.awaiting_approval && (
+              <RestrictedAction action="namespace:addMember">
+                <IconButton
+                  variant="primary"
+                  title="Copy activation link"
+                  aria-label="Copy activation link"
+                  onClick={() => setActivationTarget(m)}
+                >
+                  <LinkIcon className="w-4 h-4" />
+                </IconButton>
+              </RestrictedAction>
+            )}
             <RestrictedAction action="namespace:editMember">
               <IconButton
                 variant="primary"
@@ -193,6 +218,12 @@ function MembersTab({ tenantId, onInvitationSent }: MembersTabProps) {
         onClose={() => setEditTarget(null)}
         tenantId={tenantId}
         member={editTarget}
+      />
+      <ActivationLinkDialog
+        open={!!activationTarget}
+        onClose={() => setActivationTarget(null)}
+        userId={activationTarget?.id ?? ""}
+        email={activationTarget?.email ?? ""}
       />
       <ConfirmDialog
         open={!!removeTarget}

--- a/ui/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
@@ -9,10 +9,15 @@ import AddMemberDrawer from "../AddMemberDrawer";
 /* ------------------------------------------------------------------ */
 
 const mockAddMemberMutateAsync = vi.fn();
+const mockCreateTokenMutateAsync = vi.fn();
 
 vi.mock("@/hooks/useMemberMutations", () => ({
   useAddMember: () => ({
     mutateAsync: mockAddMemberMutateAsync,
+    isPending: false,
+  }),
+  useCreateActivationToken: () => ({
+    mutateAsync: mockCreateTokenMutateAsync,
     isPending: false,
   }),
 }));
@@ -35,7 +40,9 @@ vi.mock("@/components/common/Drawer", () => ({
     return (
       <div role="dialog" aria-label={title}>
         <h2>{title}</h2>
-        <button type="button" onClick={onClose}>Close</button>
+        <button type="button" onClick={onClose}>
+          Close
+        </button>
         {children}
         {footer ?? null}
       </div>
@@ -50,6 +57,7 @@ vi.mock("@/components/common/Drawer", () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   mockAddMemberMutateAsync.mockResolvedValue({});
+  mockCreateTokenMutateAsync.mockResolvedValue({ token: "tok" });
 });
 
 /* ================================================================== */

--- a/ui/apps/console/src/pages/team/helpers.ts
+++ b/ui/apps/console/src/pages/team/helpers.ts
@@ -17,14 +17,20 @@ export type AssignableRole = (typeof ROLES)[number];
  *  role) before feeding them into RoleSelector. */
 export function isAssignableRole(role: unknown): role is AssignableRole {
   return (
-    typeof role === "string" &&
-    (ROLES as readonly string[]).includes(role)
+    typeof role === "string" && (ROLES as readonly string[]).includes(role)
   );
 }
 
 export function isExpired(expiresIn: number): boolean {
   if (expiresIn <= 0) return false;
   return Date.now() > expiresIn * 1000;
+}
+
+/** Builds the public account-activation link an admin hands to a provisioned user. */
+export function buildActivationLink(userId: string, token: string): string {
+  return `${window.location.origin}/activate?id=${encodeURIComponent(
+    userId,
+  )}&token=${encodeURIComponent(token)}`;
 }
 
 export function initials(name: string | undefined) {


### PR DESCRIPTION
Adding a member by an email that has no account used to fail with "user
must already exist", forcing that person to self-register before they
could be added. This adds the missing lane: the member is provisioned on
the spot.

Adding such a member now creates a not-confirmed account and its
namespace membership in a single transaction. The invitee finishes the
account through a one-time activation link (a set-password token in
Redis, 24h TTL, consumed on use), so an admin never sees or handles a
password.

On self-hosted Enterprise a namespace admin who is not a system admin can
provision too, but the account is created awaiting approval and stays
inert until a system admin approves it. Only a system admin can mint the
activation link for an unapproved account; once approved, a namespace
admin who manages the member can mint it as well. Community keeps the
"must already exist" behavior unless the capability is enabled.

Removing a member's last namespace membership on a bound single-namespace
instance now reclaims the orphaned account, since there it can neither
self-register nor own a namespace.

The approval side (the Enterprise capability toggle and the system-admin
approve endpoint) lands in shellhub-io/cloud.
