### PR TITLE
fix: default Postgres to io_method=worker instead of io_uring

### DIFF
--- a/docker-compose.postgres.test.yml
+++ b/docker-compose.postgres.test.yml
@@ -1,11 +1,7 @@
 services:
   postgres:
     image: postgres:18.0
-    command: postgres -c io_method=io_uring
-    security_opt:
-      # Disable seccomp to allow io_uring syscalls (io_uring_setup, io_uring_enter, io_uring_register)
-      # which are blocked by Docker's default seccomp profile for security reasons.
-      - seccomp=unconfined
+    command: postgres -c io_method=worker
     healthcheck:
       start_period: 10s
       interval: 2s

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,12 +1,8 @@
 services:
   postgres:
     image: postgres:18.0
-    command: postgres -c io_method=io_uring
+    command: postgres -c io_method=worker
     restart: unless-stopped
-    security_opt:
-      # Disable seccomp to allow io_uring syscalls (io_uring_setup, io_uring_enter, io_uring_register)
-      # which are blocked by Docker's default seccomp profile for security reasons.
-      - seccomp=unconfined
     healthcheck:
       start_period: 90s
       interval: 5s


### PR DESCRIPTION
## Description

We ship the Postgres service with `io_method=io_uring` forced on, plus `seccomp=unconfined` to allow the io_uring syscalls. On some hosts Postgres fails to start with:

```
could not setup io_uring queue: Cannot allocate memory
```

This `ENOMEM` from `io_uring_setup` is not a lack of RAM. The io_uring rings count against the container's `RLIMIT_MEMLOCK`, and some kernels ship with io_uring disabled via sysctl (`kernel.io_uring_disabled=2`, now a default on several hardened distros). Either condition makes the syscall fail regardless of how much memory the box has. `io_uring` is a fragile default for a self-hosted product that runs on arbitrary kernels and container runtimes.

## Changes

Switch the default to Postgres 18's own default `io_method=worker` (asynchronous I/O via worker processes, no io_uring syscalls) in both `docker-compose.postgres.yml` and `docker-compose.postgres.test.yml`. This also removes the need for the `security_opt: seccomp=unconfined` override, a security downgrade carried only to enable io_uring. The performance difference from io_uring is marginal for our workload and does not justify the support burden.

## Related

Fixes #6629
Reported by a self-hoster upgrading to v0.26.0 (#6627).
