### PR TITLE
fix(api): persist device remote_addr in the postgres store

### DIFF
--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -134,9 +134,13 @@ func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*mod
 
 		// NOTE: The position lookup is best-effort: a pairing accept materializes
 		// the device server-side without a device IP, and a lookup failure should
-		// not block registration.
+		// not block registration. RemoteAddr is only persisted when RealIP parses as
+		// an IP: it comes from the client-controlled X-Real-IP header, and storing an
+		// unbounded value would overflow the remote_addr column and fail registration.
 		position := geoip.Position{}
+		remoteAddr := ""
 		if ip := net.ParseIP(req.RealIP); ip != nil {
+			remoteAddr = req.RealIP
 			if position, err = s.locator.GetPosition(ip); err != nil {
 				log.WithError(err).WithFields(log.Fields{"real_ip": req.RealIP, "tenant_id": req.TenantID}).
 					Warn("failed to resolve the device position")
@@ -156,7 +160,7 @@ func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*mod
 			Name:            strings.ToLower(hostname),
 			Identity:        &models.DeviceIdentity{MAC: req.Identity.MAC},
 			PublicKey:       req.PublicKey,
-			RemoteAddr:      req.RealIP,
+			RemoteAddr:      remoteAddr,
 			Taggable:        models.Taggable{TagIDs: []string{}, Tags: nil},
 			Position:        &models.DevicePosition{Longitude: position.Longitude, Latitude: position.Latitude},
 		}
@@ -196,6 +200,14 @@ func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*mod
 	} else {
 		device.LastSeen = clock.Now()
 		device.DisconnectedAt = nil
+
+		// Refresh RemoteAddr to the current connection's address so it reflects the
+		// latest reconnect, not only first registration. Guarded on a parseable IP for
+		// the same reason as the create branch (client-controlled X-Real-IP, bounded
+		// column); an unparseable value leaves the last known address intact.
+		if ip := net.ParseIP(req.RealIP); ip != nil {
+			device.RemoteAddr = req.RealIP
+		}
 
 		if device.RemovedAt != nil {
 			device.RemovedAt = nil

--- a/api/services/auth_test.go
+++ b/api/services/auth_test.go
@@ -196,6 +196,7 @@ func TestAuthDevice(t *testing.T) {
 					Once()
 
 				expectedDevice := *device
+				expectedDevice.RemoteAddr = "127.0.0.1"
 				expectedDevice.LastSeen = now
 				expectedDevice.DisconnectedAt = nil
 				expectedDevice.Info = &models.DeviceInfo{
@@ -244,6 +245,7 @@ func TestAuthDevice(t *testing.T) {
 					Once()
 
 				expectedDevice := *device
+				expectedDevice.RemoteAddr = "127.0.0.1"
 				expectedDevice.LastSeen = now
 				expectedDevice.DisconnectedAt = nil
 
@@ -286,6 +288,7 @@ func TestAuthDevice(t *testing.T) {
 					Once()
 
 				expectedDevice := *device
+				expectedDevice.RemoteAddr = "127.0.0.1"
 				expectedDevice.LastSeen = now
 				expectedDevice.DisconnectedAt = nil
 
@@ -322,6 +325,7 @@ func TestAuthDevice(t *testing.T) {
 				uid := toUID("00000000-0000-4000-0000-000000000000", "hostname", "", "")
 				device := &models.Device{UID: uid, Name: "hostname"}
 				expectedDevice := *device
+				expectedDevice.RemoteAddr = "127.0.0.1"
 				expectedDevice.LastSeen = clock.Now()
 
 				cacheMock.
@@ -377,6 +381,7 @@ func TestAuthDevice(t *testing.T) {
 				uid := toUID("00000000-0000-4000-0000-000000000000", "hostname", "", "")
 				device := &models.Device{UID: uid, Name: "hostname"}
 				expectedDevice := *device
+				expectedDevice.RemoteAddr = "127.0.0.1"
 				expectedDevice.LastSeen = clock.Now()
 
 				cacheMock.
@@ -477,6 +482,7 @@ func TestAuthDevice(t *testing.T) {
 					Once()
 
 				expectedDevice := *device
+				expectedDevice.RemoteAddr = "127.0.0.1"
 				expectedDevice.LastSeen = now
 				expectedDevice.DisconnectedAt = nil
 				expectedDevice.Info = &models.DeviceInfo{
@@ -543,6 +549,7 @@ func TestAuthDevice(t *testing.T) {
 					Once()
 
 				expectedDevice := *device
+				expectedDevice.RemoteAddr = "127.0.0.1"
 				expectedDevice.LastSeen = now
 				expectedDevice.DisconnectedAt = nil
 				expectedDevice.RemovedAt = nil
@@ -2755,6 +2762,226 @@ func TestAuthDevice_AutoAcceptLicenseLimitNewDevice(t *testing.T) {
 	assert.True(t, found, "expected log entry with message %q at WARN level; got entries: %v", wantMsg, hook.entries)
 
 	storeMock.AssertExpectations(t)
+}
+
+// TestAuthDevice_RemoteAddr verifies that RemoteAddr is persisted from the client-supplied
+// X-Real-IP only when it parses as an IP: an unparseable value (which is attacker-controlled
+// and could overflow the bounded remote_addr column) is stored as empty on create and leaves
+// the previously stored address untouched on reconnect, while a valid IP refreshes it.
+func TestAuthDevice_RemoteAddr(t *testing.T) {
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	prevClock := clock.DefaultBackend
+	prevUUID := uuid.DefaultBackend
+	t.Cleanup(func() {
+		clock.DefaultBackend = prevClock
+		uuid.DefaultBackend = prevUUID
+	})
+
+	clockMock := clockmock.NewMockClock(t)
+	clockMock.On("Now").Return(now)
+	clock.DefaultBackend = clockMock
+
+	uuidMock := uuidmock.NewMockUUID(t)
+	uuidMock.On("Generate").Return("00000000-0000-0000-0000-000000000000")
+	uuid.DefaultBackend = uuidMock
+
+	toUID := func(tenantID, hostname, mac, publicKey string) string {
+		auth := models.DeviceAuth{
+			Hostname:  strings.ToLower(hostname),
+			Identity:  &models.DeviceIdentity{MAC: mac},
+			PublicKey: publicKey,
+			TenantID:  tenantID,
+		}
+
+		uidSHA := sha256.Sum256(structhash.Dump(auth, 1))
+
+		return hex.EncodeToString(uidSHA[:])
+	}
+
+	toToken := func(tenantID, uid string) string {
+		token, err := jwttoken.EncodeDeviceClaims(authorizer.DeviceClaims{UID: uid, TenantID: tenantID}, privateKey)
+		require.NoError(t, err)
+
+		return token
+	}
+
+	const tenantID = "00000000-0000-4000-0000-000000000000"
+
+	oversizedIP := strings.Repeat("a", 200)
+
+	t.Run("[device creation] stores an empty RemoteAddr when RealIP is not a valid IP", func(t *testing.T) {
+		storeMock := mocks.NewMockStore(t)
+		cacheMock := mockcache.NewMockCache(t)
+		ctx := context.TODO()
+		uid := toUID(tenantID, "invalid-ip-device", "aa:bb:cc:dd:ee:ff", "public-key")
+
+		storeMock.
+			On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenantID).
+			Return(&models.Namespace{TenantID: tenantID, Name: "test"}, nil).
+			Once()
+		cacheMock.
+			On("Get", ctx, "auth_device/"+uid, testifymock.Anything).
+			Return(nil).
+			Once()
+		storeMock.
+			On("DeviceResolve", ctx, store.DeviceUIDResolver, uid).
+			Return(nil, store.ErrNoDocuments).
+			Once()
+		storeMock.
+			On(
+				"DeviceCreate",
+				ctx,
+				&models.Device{
+					CreatedAt:       now,
+					UID:             uid,
+					TenantID:        tenantID,
+					LastSeen:        now,
+					DisconnectedAt:  nil,
+					Status:          models.DeviceStatusPending,
+					StatusUpdatedAt: now,
+					Name:            "invalid-ip-device",
+					Identity:        &models.DeviceIdentity{MAC: "aa:bb:cc:dd:ee:ff"},
+					PublicKey:       "public-key",
+					RemoteAddr:      "",
+					Taggable:        models.Taggable{TagIDs: []string{}},
+					Position:        &models.DevicePosition{Longitude: 0., Latitude: 0.},
+				},
+			).
+			Return(uid, nil).
+			Once()
+		storeMock.
+			On("NamespaceIncrementDeviceCount", ctx, tenantID, models.DeviceStatusPending, int64(1)).
+			Return(nil).
+			Once()
+		cacheMock.
+			On("Set", ctx, "auth_device/"+uid, map[string]string{"device_name": "invalid-ip-device", "namespace_name": "test"}, time.Second*30).
+			Return(nil).
+			Once()
+
+		svc := NewService(store.Store(storeMock), privateKey, &privateKey.PublicKey, cacheMock, clientMock)
+
+		res, err := svc.AuthDevice(ctx, requests.DeviceAuth{
+			TenantID:  tenantID,
+			Hostname:  "invalid-ip-device",
+			Identity:  &requests.DeviceIdentity{MAC: "aa:bb:cc:dd:ee:ff"},
+			PublicKey: "public-key",
+			Sessions:  []string{},
+			RealIP:    oversizedIP,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, &models.DeviceAuthResponse{
+			UID:       uid,
+			Token:     toToken(tenantID, uid),
+			Name:      "invalid-ip-device",
+			Namespace: "test",
+		}, res)
+
+		storeMock.AssertExpectations(t)
+	})
+
+	t.Run("[device exists] refreshes RemoteAddr from a valid RealIP on reconnect", func(t *testing.T) {
+		storeMock := mocks.NewMockStore(t)
+		cacheMock := mockcache.NewMockCache(t)
+		ctx := context.TODO()
+		uid := toUID(tenantID, "reconnect-device", "", "")
+		device := &models.Device{UID: uid, Name: "reconnect-device", RemoteAddr: "198.51.100.1"}
+
+		storeMock.
+			On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenantID).
+			Return(&models.Namespace{TenantID: tenantID, Name: "test"}, nil).
+			Once()
+		cacheMock.
+			On("Get", ctx, "auth_device/"+uid, testifymock.Anything).
+			Return(nil).
+			Once()
+		storeMock.
+			On("DeviceResolve", ctx, store.DeviceUIDResolver, uid).
+			Return(device, nil).
+			Once()
+
+		expectedDevice := *device
+		expectedDevice.RemoteAddr = "203.0.113.10"
+		expectedDevice.LastSeen = now
+		expectedDevice.DisconnectedAt = nil
+
+		storeMock.
+			On("DeviceUpdate", ctx, &expectedDevice).
+			Return(nil).
+			Once()
+		cacheMock.
+			On("Set", ctx, "auth_device/"+uid, map[string]string{"device_name": "reconnect-device", "namespace_name": "test"}, time.Second*30).
+			Return(nil).
+			Once()
+
+		svc := NewService(store.Store(storeMock), privateKey, &privateKey.PublicKey, cacheMock, clientMock)
+
+		res, err := svc.AuthDevice(ctx, requests.DeviceAuth{
+			TenantID:  tenantID,
+			Hostname:  "reconnect-device",
+			Identity:  &requests.DeviceIdentity{MAC: ""},
+			PublicKey: "",
+			Sessions:  []string{},
+			RealIP:    "203.0.113.10",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "reconnect-device", res.Name)
+
+		storeMock.AssertExpectations(t)
+	})
+
+	t.Run("[device exists] keeps the previous RemoteAddr when RealIP is invalid on reconnect", func(t *testing.T) {
+		storeMock := mocks.NewMockStore(t)
+		cacheMock := mockcache.NewMockCache(t)
+		ctx := context.TODO()
+		uid := toUID(tenantID, "reconnect-device", "", "")
+		device := &models.Device{UID: uid, Name: "reconnect-device", RemoteAddr: "198.51.100.1"}
+
+		storeMock.
+			On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenantID).
+			Return(&models.Namespace{TenantID: tenantID, Name: "test"}, nil).
+			Once()
+		cacheMock.
+			On("Get", ctx, "auth_device/"+uid, testifymock.Anything).
+			Return(nil).
+			Once()
+		storeMock.
+			On("DeviceResolve", ctx, store.DeviceUIDResolver, uid).
+			Return(device, nil).
+			Once()
+
+		expectedDevice := *device
+		expectedDevice.RemoteAddr = "198.51.100.1"
+		expectedDevice.LastSeen = now
+		expectedDevice.DisconnectedAt = nil
+
+		storeMock.
+			On("DeviceUpdate", ctx, &expectedDevice).
+			Return(nil).
+			Once()
+		cacheMock.
+			On("Set", ctx, "auth_device/"+uid, map[string]string{"device_name": "reconnect-device", "namespace_name": "test"}, time.Second*30).
+			Return(nil).
+			Once()
+
+		svc := NewService(store.Store(storeMock), privateKey, &privateKey.PublicKey, cacheMock, clientMock)
+
+		res, err := svc.AuthDevice(ctx, requests.DeviceAuth{
+			TenantID:  tenantID,
+			Hostname:  "reconnect-device",
+			Identity:  &requests.DeviceIdentity{MAC: ""},
+			PublicKey: "",
+			Sessions:  []string{},
+			RealIP:    oversizedIP,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "reconnect-device", res.Name)
+
+		storeMock.AssertExpectations(t)
+	})
 }
 
 // TestAuthDevice_AutoAcceptLicenseLimitReRegistered verifies that when a previously-removed

--- a/api/store/pg/entity/device.go
+++ b/api/store/pg/entity/device.go
@@ -29,6 +29,7 @@ type Device struct {
 	Version         string            `bun:"version"`
 	Arch            string            `bun:"arch"`
 	Platform        string            `bun:"platform"`
+	RemoteAddr      string            `bun:"remote_addr"`
 	Longitude       float64           `bun:"longitude,type:numeric"`
 	Latitude        float64           `bun:"latitude,type:numeric"`
 	CustomFields    map[string]string `bun:"custom_fields,type:jsonb,nullzero,default:'{}'"`
@@ -55,6 +56,7 @@ func DeviceFromModel(model *models.Device) *Device {
 		StatusUpdatedAt: model.StatusUpdatedAt,
 		Name:            model.Name,
 		PublicKey:       model.PublicKey,
+		RemoteAddr:      model.RemoteAddr,
 		CustomFields:    model.CustomFields,
 		Tags:            []*Tag{},
 	}
@@ -113,7 +115,7 @@ func DeviceToModel(entity *Device) *models.Device {
 		Acceptable:      entity.Acceptable,
 		Namespace:       "",
 		DisconnectedAt:  nil,
-		RemoteAddr:      "",
+		RemoteAddr:      entity.RemoteAddr,
 		CustomFields:    entity.CustomFields,
 		Taggable: models.Taggable{
 			Tags: []models.Tag{},

--- a/api/store/pg/migrations/012_device_remote_addr.tx.down.sql
+++ b/api/store/pg/migrations/012_device_remote_addr.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices DROP COLUMN IF EXISTS remote_addr;

--- a/api/store/pg/migrations/012_device_remote_addr.tx.up.sql
+++ b/api/store/pg/migrations/012_device_remote_addr.tx.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE devices
+    ADD COLUMN IF NOT EXISTS remote_addr character varying(64) NOT NULL DEFAULT '';

--- a/api/store/storetest/device_tests.go
+++ b/api/store/storetest/device_tests.go
@@ -493,6 +493,20 @@ func (s *Suite) TestDeviceCreate(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, statusUpdatedAt.Equal(device.StatusUpdatedAt), "StatusUpdatedAt should match: expected %v, got %v", statusUpdatedAt, device.StatusUpdatedAt)
 	})
+
+	t.Run("succeeds persisting remote_addr on create", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenantID := s.CreateNamespace(t)
+		deviceUID := s.CreateDevice(t,
+			WithTenantID(tenantID),
+			WithDeviceRemoteAddr("203.0.113.7"),
+		)
+
+		created, err := st.DeviceResolve(ctx, store.DeviceUIDResolver, string(deviceUID))
+		require.NoError(t, err)
+		assert.Equal(t, "203.0.113.7", created.RemoteAddr)
+	})
 }
 
 // TestDeviceConflicts tests checking for device conflicts
@@ -700,6 +714,28 @@ func (s *Suite) TestDeviceUpdate(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, newStatusUpdatedAt.Equal(updated.StatusUpdatedAt), "updated StatusUpdatedAt should match: expected %v, got %v", newStatusUpdatedAt, updated.StatusUpdatedAt)
 		assert.Equal(t, models.DeviceStatusAccepted, updated.Status)
+	})
+
+	t.Run("succeeds updating remote_addr", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenantID := s.CreateNamespace(t)
+		deviceUID := s.CreateDevice(t,
+			WithTenantID(tenantID),
+			WithDeviceRemoteAddr("203.0.113.7"),
+		)
+
+		device, err := st.DeviceResolve(ctx, store.DeviceUIDResolver, string(deviceUID))
+		require.NoError(t, err)
+		assert.Equal(t, "203.0.113.7", device.RemoteAddr)
+
+		device.RemoteAddr = "198.51.100.9"
+		err = st.DeviceUpdate(ctx, device)
+		require.NoError(t, err)
+
+		updated, err := st.DeviceResolve(ctx, store.DeviceUIDResolver, string(deviceUID))
+		require.NoError(t, err)
+		assert.Equal(t, "198.51.100.9", updated.RemoteAddr)
 	})
 }
 

--- a/api/store/storetest/helpers.go
+++ b/api/store/storetest/helpers.go
@@ -187,6 +187,13 @@ func WithDeviceStatusUpdatedAt(statusUpdatedAt time.Time) DeviceOption {
 	}
 }
 
+// WithDeviceRemoteAddr sets the device remote address
+func WithDeviceRemoteAddr(addr string) DeviceOption {
+	return func(d *models.Device) {
+		d.RemoteAddr = addr
+	}
+}
+
 // CreateDevice creates a device with default or customized values
 // Returns the generated device UID
 // If tenant is not provided via WithTenantID(), a default namespace will be created


### PR DESCRIPTION
## What

Restores persistence of a device's `remote_addr` (the agent's public IP, from
the `X-Real-IP` header) in the PostgreSQL store, so the web UI and admin device
pages show it again instead of a blank value.

## Why

Closes #6635.

`AuthDevice` sets `device.RemoteAddr = req.RealIP`, but the PG store had nowhere
to keep it: the bun `Device` entity had no `remote_addr` column, `DeviceFromModel`
never copied the field, and `DeviceToModel` hardcoded `RemoteAddr: ""`. Every read
returned `""`. This regressed from the MongoDB store, which marshalled the full
document and round-tripped the field. Only the address string was lost — the
geolocation derived from the same IP already persisted because it maps to real
columns.

## Changes

- **store/entity**: added a `remote_addr` column (migration `012`,
  `varchar(64) NOT NULL DEFAULT ''`) and a `RemoteAddr` field on the bun `Device`
  entity, wired through `DeviceFromModel` (write) and `DeviceToModel` (read).
  `DeviceCreate`/`DeviceUpdate` already write the whole entity, so no store-method
  change was needed.
- **services/auth**: `RemoteAddr` is persisted only when `RealIP` parses as an IP.
  `req.RealIP` is bound straight from the client-controlled `X-Real-IP` header, so
  an unbounded value would overflow the column and fail `DeviceCreate` — turning a
  malformed header into a hard registration failure. A valid IP (<=45 chars) can
  never overflow `varchar(64)`. On reconnect the address is refreshed to the
  current connection when it is a valid IP; an unparseable value leaves the last
  known address intact.
- **tests**: added store round-trip coverage (create + update) — the regression's
  real gap, since prior tests asserted on the service-layer model and never
  round-tripped through the store — and service-level cases covering create and
  reconnect, including a guard that a hostile oversized/non-IP `X-Real-IP` does not
  error auth and does not overwrite a good stored address.

## Testing

- Store round-trip + migration against real Postgres:
  `go test -tags docker ./store/pg/ -run TestPgStore/DeviceStore` (from the `api`
  module).
- Service: `go test ./services/... -run TestAuthDevice`.
- The `remote_addr` column is bounded and the value is IP-validated at the source,
  so oversized headers cannot break device registration — see
  `TestAuthDevice_RemoteAddr`.

## Notes / out of scope

- `remote_addr` refresh on reconnect is best-effort: `AuthDevice` has a 30s
  auth-cache short-circuit (same as `last_seen`), so it is not refreshed on
  reconnects within that window.
- Historical rows keep `''` until their next auth refreshes them.
- `X-Real-IP` spoofability is a pre-existing ingress trust concern; this PR only
  restores durable persistence.