### PR TITLE
fix(ui): search existing tags in device details tag input

### DIFF
--- a/ui/apps/console/src/pages/devices/TagsSection.tsx
+++ b/ui/apps/console/src/pages/devices/TagsSection.tsx
@@ -1,10 +1,13 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { TagIcon, XMarkIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
 import {
   useAddDeviceTag,
   useRemoveDeviceTag,
 } from "@/hooks/useDeviceMutations";
+import { useTags } from "@/hooks/useTags";
+import { useClickOutside } from "@/hooks/useClickOutside";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useHasPermission } from "@/hooks/useHasPermission";
 
 const LABEL =
@@ -19,37 +22,43 @@ export default function TagsSection({ uid, tags }: TagsSectionProps) {
   const addTagMutation = useAddDeviceTag();
   const removeTagMutation = useRemoveDeviceTag();
   const canEditTags = useHasPermission("tag:edit");
+  const { tags: tagObjects } = useTags();
+  const allTags = tagObjects.map((t) => t.name);
   const [input, setInput] = useState("");
   const [adding, setAdding] = useState(false);
+  const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleAdd = async () => {
-    const tag = input.trim();
+  useClickOutside(containerRef, () => setOpen(false));
+  useEscapeKey(() => setOpen(false), open);
+
+  const validate = (tag: string): string | null => {
+    if (tags.includes(tag)) return "This tag is already added.";
+    if (tag.length < 3) return "Tag must be at least 3 characters.";
+    if (tag.length > 255) return "Tag must be at most 255 characters.";
+    if (!/^[a-zA-Z0-9]+$/.test(tag))
+      return "Tag must contain only letters and numbers.";
+    return null;
+  };
+
+  const handleAdd = async (value: string) => {
+    const tag = value.trim();
     if (!tag) return;
-    setError(null);
+    if (tags.length >= 3) return;
 
-    if (tags && tags.includes(tag)) {
-      setError("This tag is already added.");
+    const validationError = validate(tag);
+    if (validationError) {
+      setError(validationError);
       return;
     }
-    if (tags && tags.length >= 3) return;
-    if (tag.length < 3) {
-      setError("Tag must be at least 3 characters.");
-      return;
-    }
-    if (tag.length > 255) {
-      setError("Tag must be at most 255 characters.");
-      return;
-    }
-    if (!/^[a-zA-Z0-9]+$/.test(tag)) {
-      setError("Tag must contain only letters and numbers.");
-      return;
-    }
+    setError(null);
 
     setAdding(true);
     try {
       await addTagMutation.mutateAsync({ path: { uid, name: tag } });
       setInput("");
+      setOpen(false);
     } catch {
       setError("Failed to add tag.");
     }
@@ -64,62 +73,108 @@ export default function TagsSection({ uid, tags }: TagsSectionProps) {
     }
   };
 
+  const trimmed = input.trim();
+  const suggestions = allTags.filter(
+    (t) => !tags.includes(t) && t.toLowerCase().includes(trimmed.toLowerCase()),
+  );
+  const isNew = validate(trimmed) === null && !allTags.includes(trimmed);
+
   return (
     <div>
       <h3 className={LABEL + " mb-2"}>Tags</h3>
       <div className="flex flex-wrap items-center gap-2">
-        {tags &&
-          tags.map((tag) => (
-            <span
-              key={tag}
-              className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 text-primary text-xs rounded-md font-medium"
-            >
-              <TagIcon className="w-3 h-3" strokeWidth={2} />
-              {tag}
-              {canEditTags && (
-                <button
-                  type="button"
-                  onClick={() => void handleRemove(tag)}
-                  aria-label={`Remove tag ${tag}`}
-                  className="hover:text-white transition-colors"
-                >
-                  <XMarkIcon className="w-3 h-3" strokeWidth={2} />
-                </button>
-              )}
-            </span>
-          ))}
-        {canEditTags && (!tags || tags.length < 3) && (
-          <div className="flex items-center gap-1.5">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 text-primary text-xs rounded-md font-medium"
+          >
+            <TagIcon className="w-3 h-3" strokeWidth={2} />
+            {tag}
+            {canEditTags && (
+              <button
+                type="button"
+                onClick={() => void handleRemove(tag)}
+                aria-label={`Remove tag ${tag}`}
+                className="hover:text-white transition-colors"
+              >
+                <XMarkIcon className="w-3 h-3" strokeWidth={2} />
+              </button>
+            )}
+          </span>
+        ))}
+        {canEditTags && tags.length < 3 && (
+          <div
+            ref={containerRef}
+            className="relative flex items-center gap-1.5"
+          >
             <input
               type="text"
               value={input}
               onChange={(e) => {
                 setInput(e.target.value);
                 setError(null);
+                setOpen(true);
               }}
+              onFocus={() => setOpen(true)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
                   e.preventDefault();
-                  void handleAdd();
+                  void handleAdd(input);
                 }
               }}
-              placeholder="Add tag..."
+              placeholder="Search or create tag..."
               aria-label="New tag"
-              className="w-28 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
+              className="w-44 px-2.5 py-1 bg-card border border-border rounded-md text-xs text-text-primary placeholder:text-text-secondary focus:outline-none focus:border-primary/40 transition-all"
             />
             <IconButton
               variant="primary"
               size="sm"
-              disabled={adding || !input.trim()}
+              disabled={adding || !trimmed}
               aria-label="Add tag"
-              onClick={() => void handleAdd()}
+              onClick={() => void handleAdd(input)}
             >
               <PlusIcon className="w-4 h-4" strokeWidth={2} />
             </IconButton>
+
+            {open && trimmed && (suggestions.length > 0 || isNew) && (
+              <div className="absolute top-full left-0 mt-1.5 z-10 w-44 max-h-[140px] overflow-y-auto bg-surface border border-border rounded-lg shadow-2xl divide-y divide-border/60">
+                {suggestions.map((tag) => (
+                  <button
+                    type="button"
+                    key={tag}
+                    onClick={() => void handleAdd(tag)}
+                    disabled={adding}
+                    className="w-full text-left px-2.5 py-1.5 text-2xs text-text-primary hover:bg-hover-medium transition-colors disabled:opacity-dim flex items-center gap-1.5"
+                  >
+                    <TagIcon
+                      className="w-2.5 h-2.5 text-primary shrink-0"
+                      strokeWidth={2}
+                    />
+                    {tag}
+                  </button>
+                ))}
+                {isNew && (
+                  <button
+                    type="button"
+                    onClick={() => void handleAdd(input)}
+                    disabled={adding}
+                    className="w-full text-left px-2.5 py-1.5 text-2xs text-accent-green hover:bg-hover-medium transition-colors disabled:opacity-dim flex items-center gap-1.5"
+                  >
+                    <PlusIcon
+                      className="w-2.5 h-2.5 shrink-0"
+                      strokeWidth={2}
+                    />
+                    Create &ldquo;
+                    {trimmed}
+                    &rdquo;
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>
-      {tags && tags.length >= 3 && (
+      {tags.length >= 3 && (
         <p className="text-2xs text-text-muted mt-1.5">
           Maximum of 3 tags reached.
         </p>

--- a/ui/apps/console/src/pages/devices/__tests__/DeviceDetails.test.tsx
+++ b/ui/apps/console/src/pages/devices/__tests__/DeviceDetails.test.tsx
@@ -33,12 +33,17 @@ vi.mock("@/stores/authStore", () => ({
 }));
 
 vi.mock("@/stores/terminalStore", () => ({
-  useTerminalStore: (sel: (s: { sessions: []; restore: () => void }) => unknown) =>
-    sel({ sessions: [], restore: vi.fn() }),
+  useTerminalStore: (
+    sel: (s: { sessions: []; restore: () => void }) => unknown,
+  ) => sel({ sessions: [], restore: vi.fn() }),
 }));
 
 vi.mock("@/hooks/useHasPermission", () => ({
   useHasPermission: () => true,
+}));
+
+vi.mock("@/hooks/useTags", () => ({
+  useTags: () => ({ tags: [], totalCount: 0, isLoading: false, error: null }),
 }));
 
 vi.mock("@/components/common/CopyButton", () => ({
@@ -106,7 +111,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import { useDevice } from "@/hooks/useDevice";
-import DeviceDetails from "../../DeviceDetails";
+import DeviceDetails from "@/pages/DeviceDetails";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -183,7 +188,9 @@ describe("DeviceDetails", () => {
 
     it("renders the device name as a heading", () => {
       renderPage();
-      expect(screen.getByRole("heading", { name: "my-device" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "my-device" }),
+      ).toBeInTheDocument();
     });
 
     it("renders the MAC address", () => {
@@ -205,7 +212,9 @@ describe("DeviceDetails", () => {
   describe("custom fields section", () => {
     it("renders key-value pairs when custom fields are present", () => {
       vi.mocked(useDevice).mockReturnValue({
-        device: makeDevice({ custom_fields: { env: "production", owner: "team-a" } }),
+        device: makeDevice({
+          custom_fields: { env: "production", owner: "team-a" },
+        }),
         isLoading: false,
         error: null,
         refetch: vi.fn(),
@@ -272,7 +281,9 @@ describe("DeviceDetails", () => {
     it("calls mutation without the deleted key when 'Yes' is clicked", async () => {
       const user = userEvent.setup();
       vi.mocked(useDevice).mockReturnValue({
-        device: makeDevice({ custom_fields: { env: "production", owner: "team-a" } }),
+        device: makeDevice({
+          custom_fields: { env: "production", owner: "team-a" },
+        }),
         isLoading: false,
         error: null,
         refetch: vi.fn(),


### PR DESCRIPTION
## What

The TAGS input on the device details page now searches existing tags as you
type, matching the behavior already present in the device list. Previously it
could only create brand-new tags.

## Why

On the device list, clicking a device's tag control opens a searchable dropdown
of existing tags (with a create-new fallback). On device details, the "Add
tag..." field had no such search — it only ever created a new tag, so there was
no way to discover and reuse tags that already existed in the namespace. The two
views behaved inconsistently for the same action.

## Changes

- **ui/devices**: `TagsSection` (device details) now consumes `useTags()` and
  renders a filtered suggestions dropdown of existing tags, plus a "Create ..."
  option for a genuinely new value — the same pattern the device-list
  `TagsPopover` already uses. Placeholder changed from "Add tag..." to
  "Search or create tag...".
- Dropdown dismisses on click-outside (`useClickOutside`) and Escape
  (`useEscapeKey`), consistent with the other tag editors.
- Tag validation lives in a single `validate()` helper; `isNew` is derived from
  it rather than re-encoding the length/charset rules, so the two can't drift.

The suggestions/validation logic is duplicated (by hand) with `TagsPopover` and
`ContainerTagsPopover` today. This PR deliberately follows that established
pattern rather than introducing an abstraction mid-fix; extracting a shared
`useTagInput` hook + dropdown component across all tag editors is worth a
separate cleanup. Note that container details still uses the old create-only
input — a follow-up could bring it to parity the same way.

## Testing

Drove the running dev app end-to-end:

1. Open a device's details page, focus the TAGS input, type a prefix (e.g.
   `pr`) → dropdown lists matching existing tags.
2. Click a suggestion → tag is added as a chip.
3. Type a value that isn't an existing tag → green "Create ..." option appears
   and creates it.

Edge cases to probe: the 3-tag maximum still hides the input and shows the
"Maximum of 3 tags reached." note; invalid input (< 3 chars, > 255, non
alphanumeric) still surfaces the inline error and offers no Create option.

## Screenshots

Searchable dropdown of existing tags (typing `pr` surfaces `prometheus` /
`production`):

![Device details tag input showing a searchable dropdown of existing tags](https://raw.githubusercontent.com/shellhub-io/shellhub/pr-assets/device-tag-search/11-suggestions.png)

"Create ..." option for a value that isn't an existing tag:

![Device details tag input showing the Create option for a new tag](https://raw.githubusercontent.com/shellhub-io/shellhub/pr-assets/device-tag-search/13-create.png)
