### PR TITLE
feat(ui): add Checkbox and Toggle design system primitives

### DIFF
--- a/ui/apps/console/src/components/common/fields/CheckboxField.test.tsx
+++ b/ui/apps/console/src/components/common/fields/CheckboxField.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CheckboxField from "./CheckboxField";
+
+function renderField(
+  overrides: Partial<{
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+    disabled: boolean;
+    label: string;
+    description: string;
+    hint: string;
+    error: string;
+  }> = {},
+) {
+  const props = {
+    id: "test-cb",
+    label: "Accept terms",
+    checked: false,
+    onChange: vi.fn(),
+    ...overrides,
+  };
+  render(<CheckboxField {...props} />);
+  return props;
+}
+
+describe("CheckboxField", () => {
+  it("renders the label as accessible name for the checkbox", () => {
+    renderField();
+    expect(
+      screen.getByRole("checkbox", { name: "Accept terms" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reflects the checked prop", () => {
+    renderField({ checked: true });
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+
+  it("calls onChange when clicked", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderField();
+
+    await user.click(screen.getByRole("checkbox"));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("exposes the disabled state", () => {
+    renderField({ disabled: true });
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+
+  it("renders the description text", () => {
+    renderField({ description: "You must agree to continue" });
+    expect(screen.getByText("You must agree to continue")).toBeInTheDocument();
+  });
+
+  it("shows the error message and marks the input as invalid", () => {
+    renderField({ error: "Required field" });
+
+    expect(screen.getByText("Required field")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("shows the hint when there is no error", () => {
+    renderField({ hint: "Optional" });
+    expect(screen.getByText("Optional")).toBeInTheDocument();
+  });
+});

--- a/ui/apps/console/src/components/common/fields/CheckboxField.tsx
+++ b/ui/apps/console/src/components/common/fields/CheckboxField.tsx
@@ -1,4 +1,6 @@
 import { InputHTMLAttributes, ReactNode } from "react";
+import { Checkbox } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import FieldError from "@/components/common/fields/FieldError";
 import FieldHint from "@/components/common/fields/FieldHint";
 
@@ -40,30 +42,19 @@ export default function CheckboxField({
 
   return (
     <div>
-      <label
-        htmlFor={id}
-        title={title}
-        className={`flex ${alignment} gap-2.5 ${
-          rest.disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"
-        }`}
-      >
-        <input
+      <label htmlFor={id} title={title} className={cn("flex gap-2.5", alignment, rest.disabled ? "cursor-not-allowed" : "cursor-pointer")}>
+        <Checkbox
           {...rest}
           id={id}
-          type="checkbox"
           checked={checked}
-          onChange={(e) => onChange(e.target.checked)}
+          onChange={onChange}
           aria-required={required ? true : undefined}
           aria-invalid={error ? true : undefined}
           aria-describedby={describedBy}
-          className={`${description ? "mt-0.5 " : ""}shrink-0 w-4 h-4 rounded border-border bg-card text-primary focus:ring-1 focus:ring-primary/30 disabled:cursor-not-allowed`}
+          className={cn("shrink-0", description && "mt-0.5")}
         />
-        <span className={hideLabel ? "sr-only" : "min-w-0"}>
-          <span
-            className={`block text-sm ${
-              description ? "font-medium" : ""
-            } text-text-primary`}
-          >
+        <span className={cn(hideLabel ? "sr-only" : "min-w-0", rest.disabled && "opacity-dim")}>
+          <span className={cn("block text-sm text-text-primary", description && "font-medium")}>
             {label}
           </span>
           {description && (

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -38,7 +38,12 @@ import {
 import RestrictedAction from "@/components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
 import Pagination from "@/components/common/Pagination";
-import { Badge, Button, IconButton } from "@shellhub/design-system/primitives";
+import {
+  Badge,
+  Button,
+  IconButton,
+  Toggle,
+} from "@shellhub/design-system/primitives";
 
 /* ─── Constants ─── */
 
@@ -231,8 +236,8 @@ function TimeoutSelector({
   const hasExpiration = value !== "-1";
   const [isEditingCustom, setIsEditingCustom] = useState(false);
 
-  const handleToggle = () => {
-    onChange(hasExpiration ? "-1" : "3600");
+  const handleToggle = (enabled: boolean) => {
+    onChange(enabled ? "3600" : "-1");
     setIsEditingCustom(false);
     onErrorChange(null);
   };
@@ -266,17 +271,11 @@ function TimeoutSelector({
         <span id="endpoint-expiration-label" className={LABEL_BASE}>
           Set expiration
         </span>
-        <button
-          type="button"
-          onClick={handleToggle}
+        <Toggle
+          enabled={hasExpiration}
+          onChange={handleToggle}
           aria-labelledby="endpoint-expiration-label"
-          aria-pressed={hasExpiration}
-          className={`relative w-9 h-5 rounded-full transition-colors ${hasExpiration ? "bg-primary" : "bg-border"}`}
-        >
-          <span
-            className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${hasExpiration ? "translate-x-4" : ""}`}
-          />
-        </button>
+        />
       </div>
 
       {hasExpiration ? (
@@ -623,18 +622,11 @@ function EndpointDrawer({
             >
               Service on the device uses HTTPS
             </span>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={tlsEnabled}
+            <Toggle
+              enabled={tlsEnabled}
+              onChange={setTlsEnabled}
               aria-labelledby="endpoint-tls-https-label"
-              onClick={() => setTlsEnabled(!tlsEnabled)}
-              className={`relative w-9 h-5 rounded-full transition-colors ${tlsEnabled ? "bg-primary" : "bg-border"}`}
-            >
-              <span
-                className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${tlsEnabled ? "translate-x-4" : ""}`}
-              />
-            </button>
+            />
           </div>
           <p className="text-2xs text-text-muted leading-relaxed">
             Enable when the service on the device listens over HTTPS. The proxy

--- a/ui/apps/console/src/pages/__tests__/WebEndpoints.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/WebEndpoints.test.tsx
@@ -5,10 +5,6 @@ import { MemoryRouter } from "react-router-dom";
 import type { Webendpoint } from "@/client/types.gen";
 import WebEndpoints from "../WebEndpoints";
 
-/* ------------------------------------------------------------------ */
-/* Mocks                                                               */
-/* ------------------------------------------------------------------ */
-
 vi.mock("@/hooks/useWebEndpoints");
 vi.mock("@/hooks/useWebEndpointMutations");
 vi.mock("@/hooks/useDevices");
@@ -17,7 +13,10 @@ vi.mock("@/hooks/useHasPermission");
 vi.mock("@/hooks/useDebouncedValue");
 
 import { useWebEndpoints } from "@/hooks/useWebEndpoints";
-import { useDeleteWebEndpoint, useCreateWebEndpoint } from "@/hooks/useWebEndpointMutations";
+import {
+  useDeleteWebEndpoint,
+  useCreateWebEndpoint,
+} from "@/hooks/useWebEndpointMutations";
 import { useDevices } from "@/hooks/useDevices";
 import { useHasPermission } from "@/hooks/useHasPermission";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
@@ -29,8 +28,6 @@ const mockUseDevices = vi.mocked(useDevices);
 const mockUseHasPermission = vi.mocked(useHasPermission);
 const mockUseDebouncedValue = vi.mocked(useDebouncedValue);
 
-// Minimal fixture for the fields WebEndpoints renders; cast to the full
-// generated type so the mocked hook return stays type-compatible.
 function makeEndpoint(address: string): Webendpoint {
   return {
     address,
@@ -78,17 +75,12 @@ function renderPage(initialEntries: string[] = ["/"]) {
   );
 }
 
-/* ------------------------------------------------------------------ */
-/* Tests                                                               */
-/* ------------------------------------------------------------------ */
-
 beforeEach(() => {
   setupDefaultMocks();
 });
 
 describe("WebEndpoints — pagination count / controls decoupling", () => {
   it("shows the endpoint count when totalCount > 0 and only one page exists", () => {
-    // One endpoint fits on a single page — totalPages = Math.ceil(1/10) = 1
     mockUseWebEndpoints.mockReturnValue({
       webEndpoints: [makeEndpoint("ep1.example.com")],
       totalCount: 1,
@@ -98,7 +90,6 @@ describe("WebEndpoints — pagination count / controls decoupling", () => {
 
     renderPage();
 
-    // The count span MUST appear even though there is only 1 page
     expect(screen.getByText(/1 endpoint/i)).toBeInTheDocument();
   });
 
@@ -112,8 +103,6 @@ describe("WebEndpoints — pagination count / controls decoupling", () => {
 
     renderPage();
 
-    // Prev/Next must NOT be present when totalPages === 1.
-    // The buttons expose their accessible name via aria-label ("Previous/Next page").
     expect(
       screen.queryByRole("button", { name: /previous page/i }),
     ).not.toBeInTheDocument();
@@ -123,7 +112,6 @@ describe("WebEndpoints — pagination count / controls decoupling", () => {
   });
 
   it("shows Prev/Next controls and the count when multiple pages exist", () => {
-    // 15 endpoints across 2 pages (perPage = 10)
     const endpoints = Array.from({ length: 10 }, (_, i) =>
       makeEndpoint(`ep${i + 1}.example.com`),
     );
@@ -137,15 +125,15 @@ describe("WebEndpoints — pagination count / controls decoupling", () => {
     renderPage();
 
     expect(screen.getByText(/15 endpoints/i)).toBeInTheDocument();
-    // The buttons expose their accessible name via aria-label ("Previous/Next page").
     expect(
       screen.getByRole("button", { name: /previous page/i }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /next page/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /next page/i }),
+    ).toBeInTheDocument();
   });
 
-  it("does not show the Pagination nav when there are no endpoints (truly empty, no search)", () => {
-    // isTrulyEmpty=true -> EmptyState renders; Pagination component is never mounted.
+  it("does not show the Pagination nav when there are no endpoints", () => {
     mockUseWebEndpoints.mockReturnValue({
       webEndpoints: [],
       totalCount: 0,
@@ -155,7 +143,6 @@ describe("WebEndpoints — pagination count / controls decoupling", () => {
 
     renderPage();
 
-    // The EmptyState branch is taken — no pagination rendered at all.
     expect(screen.queryByText(/0 endpoints/i)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /previous page/i }),
@@ -163,8 +150,6 @@ describe("WebEndpoints — pagination count / controls decoupling", () => {
   });
 
   it("does not flash a '0 endpoints' count while a search request is in-flight", () => {
-    // isSearching=true, isLoading=true -> the Pagination component must be suppressed
-    // so stale zero counts do not appear mid-request.
     mockUseDebouncedValue.mockReturnValue("some-query");
     mockUseWebEndpoints.mockReturnValue({
       webEndpoints: [],
@@ -181,8 +166,6 @@ describe("WebEndpoints — pagination count / controls decoupling", () => {
     ).not.toBeInTheDocument();
   });
 });
-
-// ── URL hydration (usePaginatedListState adoption) ────────────────────────────
 
 describe("WebEndpoints — URL hydration", () => {
   it("reads page=2 and search=myhost from the URL and passes them to useWebEndpoints", () => {
@@ -216,13 +199,10 @@ describe("WebEndpoints — URL hydration", () => {
   });
 });
 
-// ── Search resets page ────────────────────────────────────────────────────────
-
 describe("WebEndpoints — search resets page to 1", () => {
   it("resets to page=1 when a new search term is typed while on page 2", async () => {
     const user = userEvent.setup();
 
-    // Start on page 2 with existing results so the content branch (not EmptyState) renders.
     mockUseWebEndpoints.mockReturnValue({
       webEndpoints: [makeEndpoint("ep1.example.com")],
       totalCount: 25,
@@ -232,29 +212,23 @@ describe("WebEndpoints — search resets page to 1", () => {
 
     renderPage(["/?page=2"]);
 
-    // Confirm initial render passes page=2
     expect(mockUseWebEndpoints).toHaveBeenCalledWith(
       expect.objectContaining({ page: 2 }),
     );
 
-    // Type in the search field
     const searchInput = screen.getByPlaceholderText(/search by address/i);
     await user.type(searchInput, "x");
 
-    // After typing, the hook must now be called with page=1
     expect(mockUseWebEndpoints).toHaveBeenCalledWith(
       expect.objectContaining({ page: 1 }),
     );
   });
 });
 
-// ── Page change writes to URL ─────────────────────────────────────────────────
-
 describe("WebEndpoints — page change writes to URL", () => {
   it("calls useWebEndpoints with page=2 after clicking the Next page button", async () => {
     const user = userEvent.setup();
 
-    // 15 endpoints across 2 pages so Prev/Next controls are present.
     mockUseWebEndpoints.mockReturnValue({
       webEndpoints: Array.from({ length: 10 }, (_, i) =>
         makeEndpoint(`ep${i + 1}.example.com`),
@@ -272,5 +246,60 @@ describe("WebEndpoints — page change writes to URL", () => {
     expect(mockUseWebEndpoints).toHaveBeenCalledWith(
       expect.objectContaining({ page: 2 }),
     );
+  });
+});
+
+async function openEndpointDrawer(user: ReturnType<typeof userEvent.setup>) {
+  mockUseWebEndpoints.mockReturnValue({
+    webEndpoints: [makeEndpoint("ep1.example.com")],
+    totalCount: 1,
+    isLoading: false,
+    error: null,
+  });
+
+  renderPage();
+  await user.click(screen.getByRole("button", { name: /new endpoint/i }));
+}
+
+describe("WebEndpoints — expiration toggle", () => {
+  it("exposes the expiration control as a switch with aria-checked and no aria-pressed", async () => {
+    const user = userEvent.setup();
+    await openEndpointDrawer(user);
+
+    const toggle = screen.getByRole("switch", { name: /set expiration/i });
+
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(toggle).not.toHaveAttribute("aria-pressed");
+  });
+
+  it("flips aria-checked when the expiration switch is clicked", async () => {
+    const user = userEvent.setup();
+    await openEndpointDrawer(user);
+
+    const toggle = screen.getByRole("switch", { name: /set expiration/i });
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+});
+
+describe("WebEndpoints — TLS toggle", () => {
+  it("exposes the TLS control as a switch with aria-checked reflecting state", async () => {
+    const user = userEvent.setup();
+    await openEndpointDrawer(user);
+
+    const toggle = screen.getByRole("switch", { name: /uses https/i });
+
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("calls the TLS handler with the toggled boolean when clicked", async () => {
+    const user = userEvent.setup();
+    await openEndpointDrawer(user);
+
+    const toggle = screen.getByRole("switch", { name: /uses https/i });
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
   });
 });

--- a/ui/apps/console/src/pages/admin/settings/Authentication.tsx
+++ b/ui/apps/console/src/pages/admin/settings/Authentication.tsx
@@ -14,41 +14,14 @@ import PageHeader from "@/components/common/PageHeader";
 import CopyButton from "@/components/common/CopyButton";
 import SamlConfigDrawer from "./SamlConfigDrawer";
 import PageLoader from "@/components/common/PageLoader";
-import { Button, Callout, Card } from "@shellhub/design-system/primitives";
+import {
+  Button,
+  Callout,
+  Card,
+  Toggle,
+} from "@shellhub/design-system/primitives";
 
 type AuthSettings = GetAuthenticationSettingsResponse;
-
-function Toggle({
-  enabled,
-  loading,
-  onToggle,
-  ariaLabel,
-}: {
-  enabled: boolean;
-  loading: boolean;
-  onToggle: () => void;
-  ariaLabel: string;
-}) {
-  return (
-    <button
-      role="switch"
-      type="button"
-      aria-checked={enabled}
-      aria-label={ariaLabel}
-      disabled={loading}
-      onClick={onToggle}
-      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 disabled:opacity-dim disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary/30 focus:ring-offset-2 focus:ring-offset-card ${
-        enabled ? "bg-primary" : "bg-border"
-      }`}
-    >
-      <span
-        className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
-          enabled ? "translate-x-[18px]" : "translate-x-[2px]"
-        }`}
-      />
-    </button>
-  );
-}
 
 export default function AdminAuthentication() {
   const [settings, setSettings] = useState<AuthSettings | null>(null);
@@ -186,9 +159,9 @@ export default function AdminAuthentication() {
             </div>
             <Toggle
               enabled={localEnabled}
-              loading={togglingLocal}
-              onToggle={() => void handleLocalToggle()}
-              ariaLabel="Toggle local authentication"
+              disabled={togglingLocal}
+              onChange={() => void handleLocalToggle()}
+              aria-label="Toggle local authentication"
             />
           </div>
         </Card>
@@ -212,9 +185,9 @@ export default function AdminAuthentication() {
             </div>
             <Toggle
               enabled={samlEnabled}
-              loading={togglingSaml}
-              onToggle={() => void handleSamlToggle()}
-              ariaLabel="Toggle SAML authentication"
+              disabled={togglingSaml}
+              onChange={() => void handleSamlToggle()}
+              aria-label="Toggle SAML authentication"
             />
           </div>
 

--- a/ui/apps/console/src/pages/admin/settings/__tests__/Authentication.test.tsx
+++ b/ui/apps/console/src/pages/admin/settings/__tests__/Authentication.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AdminAuthentication from "../Authentication";
+
+vi.mock("@/client", () => ({
+  getAuthenticationSettings: vi.fn(),
+  configureLocalAuthentication: vi.fn(),
+  configureSamlAuthentication: vi.fn(),
+}));
+
+import {
+  getAuthenticationSettings,
+  configureLocalAuthentication,
+  configureSamlAuthentication,
+} from "@/client";
+
+const mockedGetSettings = vi.mocked(getAuthenticationSettings);
+const mockedConfigureLocal = vi.mocked(configureLocalAuthentication);
+const mockedConfigureSaml = vi.mocked(configureSamlAuthentication);
+
+type SdkResponse<T = unknown> = {
+  data: T;
+  request: Request;
+  response: Response;
+};
+
+function mockSdkResponse<T>(data: T): SdkResponse<T> {
+  return {
+    data,
+    request: new Request("http://localhost"),
+    response: new Response(),
+  };
+}
+
+function mockSettings({
+  localEnabled = true,
+  samlEnabled = false,
+} = {}) {
+  return {
+    local: { enabled: localEnabled },
+    saml: { enabled: samlEnabled },
+  };
+}
+
+function renderPage() {
+  return render(<AdminAuthentication />);
+}
+
+async function settlePendingLoad() {
+  await waitFor(() =>
+    expect(screen.queryByText(/loading settings/i)).not.toBeInTheDocument(),
+  );
+}
+
+beforeEach(() => {
+  mockedGetSettings.mockReset();
+  mockedConfigureLocal.mockReset();
+  mockedConfigureSaml.mockReset();
+  mockedConfigureLocal.mockResolvedValue(mockSdkResponse(undefined));
+  mockedConfigureSaml.mockResolvedValue(mockSdkResponse(undefined));
+});
+
+describe("AdminAuthentication", () => {
+  describe("DS Toggle usage", () => {
+    it("renders the local-auth and SAML rows as role='switch' toggles", async () => {
+      mockedGetSettings.mockResolvedValue(
+        mockSdkResponse(mockSettings()),
+      );
+
+      renderPage();
+      await settlePendingLoad();
+
+      expect(
+        screen.getByRole("switch", { name: "Toggle local authentication" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("switch", { name: "Toggle SAML authentication" }),
+      ).toBeInTheDocument();
+    });
+
+    it("clicking the local-auth toggle fires configureLocalAuthentication with the flipped value", async () => {
+      const user = userEvent.setup();
+      mockedGetSettings.mockResolvedValue(
+        mockSdkResponse(mockSettings()),
+      );
+
+      renderPage();
+      await settlePendingLoad();
+
+      await user.click(
+        screen.getByRole("switch", { name: "Toggle local authentication" }),
+      );
+
+      expect(mockedConfigureLocal).toHaveBeenCalledWith(
+        expect.objectContaining({ body: { enable: false } }),
+      );
+    });
+
+    it("clicking the SAML toggle to turn it off fires configureSamlAuthentication with enable: false", async () => {
+      const user = userEvent.setup();
+      mockedGetSettings.mockResolvedValue(
+        mockSdkResponse(mockSettings({ samlEnabled: true })),
+      );
+
+      renderPage();
+      await settlePendingLoad();
+
+      await user.click(
+        screen.getByRole("switch", { name: "Toggle SAML authentication" }),
+      );
+
+      expect(mockedConfigureSaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.objectContaining({ enable: false }),
+        }),
+      );
+    });
+
+    it("disables the local-auth toggle while togglingLocal is true", async () => {
+      const user = userEvent.setup();
+      mockedGetSettings.mockResolvedValue(
+        mockSdkResponse(mockSettings()),
+      );
+      let resolveConfigure: (() => void) | undefined;
+      mockedConfigureLocal.mockReturnValue(
+        new Promise((resolve) => {
+          resolveConfigure = () => resolve(mockSdkResponse(undefined));
+        }) as never,
+      );
+
+      renderPage();
+      await settlePendingLoad();
+
+      const localToggle = screen.getByRole("switch", {
+        name: "Toggle local authentication",
+      });
+      await user.click(localToggle);
+
+      expect(localToggle).toBeDisabled();
+      expect(
+        screen.getByRole("switch", { name: "Toggle SAML authentication" }),
+      ).not.toBeDisabled();
+
+      resolveConfigure?.();
+      await waitFor(() => expect(localToggle).not.toBeDisabled());
+    });
+
+    it("disables the SAML toggle while togglingSaml is true", async () => {
+      const user = userEvent.setup();
+      mockedGetSettings.mockResolvedValue(
+        mockSdkResponse(mockSettings({ samlEnabled: true })),
+      );
+      let resolveConfigure: (() => void) | undefined;
+      mockedConfigureSaml.mockReturnValue(
+        new Promise((resolve) => {
+          resolveConfigure = () => resolve(mockSdkResponse(undefined));
+        }) as never,
+      );
+
+      renderPage();
+      await settlePendingLoad();
+
+      const samlToggle = screen.getByRole("switch", {
+        name: "Toggle SAML authentication",
+      });
+      await user.click(samlToggle);
+
+      expect(samlToggle).toBeDisabled();
+      expect(
+        screen.getByRole("switch", { name: "Toggle local authentication" }),
+      ).not.toBeDisabled();
+
+      resolveConfigure?.();
+      await waitFor(() => expect(samlToggle).not.toBeDisabled());
+    });
+  });
+});

--- a/ui/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/RuleDrawer.tsx
@@ -25,8 +25,10 @@ import NumericInput from "@/components/common/fields/NumericInput";
 import { LABEL } from "@/utils/styles";
 import {
   Button,
+  Toggle,
   DevicesIcon as DevicesIconComponent,
 } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 /* ─── Icons ─── */
 const UsersIcon = <UserGroupIcon className="w-4 h-4" />;
@@ -203,27 +205,14 @@ export default function RuleDrawer({
           <span id="rule-status-label" className={LABEL}>
             Status
           </span>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={active}
-            aria-labelledby="rule-status-label"
-            onClick={() => setActive(!active)}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              active ? "bg-accent-green" : "bg-border"
-            }`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                active ? "translate-x-6" : "translate-x-1"
-              }`}
+          <div className={cn("flex items-center gap-2.5 text-sm", active ? "text-primary" : "text-text-muted")}>
+            <Toggle
+              enabled={active}
+              onChange={setActive}
+              aria-labelledby="rule-status-label"
             />
-          </button>
-          <span
-            className={`ml-2.5 text-sm ${active ? "text-accent-green" : "text-text-muted"}`}
-          >
             {active ? "Active" : "Inactive"}
-          </span>
+          </div>
         </div>
 
         {/* Priority */}

--- a/ui/apps/console/src/pages/firewall-rules/__tests__/RuleDrawer.test.tsx
+++ b/ui/apps/console/src/pages/firewall-rules/__tests__/RuleDrawer.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RuleDrawer from "../RuleDrawer";
+
+vi.mock("@/hooks/useFirewallRuleMutations", () => ({
+  useCreateFirewallRule: () => ({ mutateAsync: vi.fn() }),
+  useUpdateFirewallRule: () => ({ mutateAsync: vi.fn() }),
+}));
+
+function renderDrawer() {
+  return render(<RuleDrawer open onClose={vi.fn()} editRule={null} />);
+}
+
+describe("RuleDrawer — status toggle", () => {
+  it("renders the status control as a switch defaulting to on", () => {
+    renderDrawer();
+
+    const toggle = screen.getByRole("switch", { name: /status/i });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("toggles the status off on click", async () => {
+    const user = userEvent.setup();
+    renderDrawer();
+
+    const toggle = screen.getByRole("switch", { name: /status/i });
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+});

--- a/ui/packages/design-system/__tests__/Checkbox.test.tsx
+++ b/ui/packages/design-system/__tests__/Checkbox.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Checkbox } from "../primitives/Checkbox";
+
+function renderCheckbox(
+  overrides: Partial<{
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+    disabled: boolean;
+    id: string;
+  }> = {},
+) {
+  const props = {
+    checked: false,
+    onChange: vi.fn(),
+    ...overrides,
+  };
+  render(<Checkbox {...props} />);
+  return props;
+}
+
+describe("Checkbox", () => {
+  it("reflects the checked prop on the input", () => {
+    renderCheckbox({ checked: true });
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+
+  it("reflects unchecked state on the input", () => {
+    renderCheckbox({ checked: false });
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+  });
+
+  it("calls onChange with true when clicking an unchecked checkbox", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderCheckbox({ checked: false });
+
+    await user.click(screen.getByRole("checkbox"));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onChange with false when clicking a checked checkbox", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderCheckbox({ checked: true });
+
+    await user.click(screen.getByRole("checkbox"));
+
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not call onChange when disabled", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderCheckbox({ disabled: true });
+
+    await user.click(screen.getByRole("checkbox"));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("exposes the disabled state to assistive tech", () => {
+    renderCheckbox({ disabled: true });
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+
+  it("forwards the id to the underlying input", () => {
+    renderCheckbox({ id: "agree" });
+    expect(screen.getByRole("checkbox")).toHaveAttribute("id", "agree");
+  });
+
+  it("forwards aria-required to the input", () => {
+    render(
+      <Checkbox checked={false} onChange={() => {}} aria-required={true} />,
+    );
+    expect(screen.getByRole("checkbox")).toHaveAttribute(
+      "aria-required",
+      "true",
+    );
+  });
+});

--- a/ui/packages/design-system/__tests__/Toggle.test.tsx
+++ b/ui/packages/design-system/__tests__/Toggle.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Toggle } from "../primitives/Toggle";
+
+function renderToggle(
+  overrides: Partial<{
+    enabled: boolean;
+    onChange: (enabled: boolean) => void;
+    disabled: boolean;
+  }> = {},
+) {
+  const props = {
+    enabled: false,
+    onChange: vi.fn(),
+    "aria-label": "Test toggle",
+    ...overrides,
+  };
+  render(<Toggle {...props} />);
+  return props;
+}
+
+describe("Toggle", () => {
+  it("renders as a switch with aria-checked reflecting the enabled prop", () => {
+    renderToggle({ enabled: true });
+
+    const toggle = screen.getByRole("switch", { name: "Test toggle" });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("reflects enabled=false as aria-checked=false", () => {
+    renderToggle({ enabled: false });
+
+    const toggle = screen.getByRole("switch", { name: "Test toggle" });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("calls onChange with the negated value on click", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToggle({ enabled: false });
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("does not call onChange when disabled", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToggle({ disabled: true });
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("exposes the disabled state to assistive tech", () => {
+    renderToggle({ disabled: true });
+    expect(screen.getByRole("switch")).toBeDisabled();
+  });
+
+  it("forwards aria-labelledby to the button", () => {
+    render(
+      <Toggle enabled={false} onChange={() => {}} aria-labelledby="my-label" />,
+    );
+    expect(screen.getByRole("switch")).toHaveAttribute(
+      "aria-labelledby",
+      "my-label",
+    );
+  });
+});

--- a/ui/packages/design-system/primitives/Checkbox.tsx
+++ b/ui/packages/design-system/primitives/Checkbox.tsx
@@ -1,0 +1,57 @@
+import type { InputHTMLAttributes } from "react";
+import { CheckIcon } from "@heroicons/react/16/solid";
+import { cn } from "./cn";
+
+export type CheckboxProps = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+} & Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "checked" | "onChange" | "disabled" | "id" | "className" | "type"
+>;
+
+const BOX_BASE =
+  "flex items-center justify-center w-4 h-4 rounded border-2 transition-colors";
+
+export function Checkbox({
+  checked,
+  onChange,
+  disabled,
+  id,
+  className,
+  ...rest
+}: CheckboxProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex focus-within:ring-2 focus-within:ring-primary/40",
+        disabled && "opacity-dim cursor-not-allowed",
+        className,
+      )}
+    >
+      <input
+        {...rest}
+        id={id}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="sr-only"
+      />
+      <span
+        aria-hidden="true"
+        className={cn(
+          BOX_BASE,
+          checked
+            ? "bg-primary border-primary"
+            : "border-border bg-card hover:border-border-light",
+        )}
+      >
+        {checked && <CheckIcon className="w-3 h-3 text-white" />}
+      </span>
+    </span>
+  );
+}

--- a/ui/packages/design-system/primitives/Toggle.tsx
+++ b/ui/packages/design-system/primitives/Toggle.tsx
@@ -1,0 +1,51 @@
+import type { ButtonHTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export type ToggleProps = {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+  disabled?: boolean;
+  className?: string;
+} & Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "onChange" | "disabled" | "className" | "type" | "role"
+>;
+
+const TRACK_BASE =
+  "relative inline-flex h-5 w-9 items-center rounded-full transition-colors " +
+  "focus:ring-2 focus:ring-primary/30 focus:ring-offset-2 focus:ring-offset-card";
+const THUMB_BASE =
+  "inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform";
+
+export function Toggle({
+  enabled,
+  onChange,
+  disabled,
+  className,
+  ...rest
+}: ToggleProps) {
+  return (
+    <button
+      {...rest}
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      disabled={disabled}
+      onClick={() => onChange(!enabled)}
+      className={cn(
+        TRACK_BASE,
+        enabled ? "bg-primary" : "bg-border",
+        disabled && "opacity-dim cursor-not-allowed",
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          THUMB_BASE,
+          enabled ? "translate-x-[18px]" : "translate-x-0.5",
+        )}
+      />
+    </button>
+  );
+}

--- a/ui/packages/design-system/primitives/index.ts
+++ b/ui/packages/design-system/primitives/index.ts
@@ -4,6 +4,10 @@
 
 export { Button } from "./Button";
 export type { ButtonVariant, ButtonSize } from "./Button";
+export { Checkbox } from "./Checkbox";
+export type { CheckboxProps } from "./Checkbox";
+export { Toggle } from "./Toggle";
+export type { ToggleProps } from "./Toggle";
 export { IconButton } from "./IconButton";
 export type { IconButtonVariant, IconButtonSize } from "./IconButton";
 export { Badge } from "./Badge";


### PR DESCRIPTION
## What

Adds accessible `Checkbox` and `Toggle` primitives to the shared design system, then migrates all four ad-hoc implementations in the console app onto them.

## Why

The design system had no form-control primitives for checkboxes or toggle switches. `CheckboxField` rendered a raw native `<input type="checkbox">` that looked inconsistent with the polished radio controls, and toggle/switch markup was duplicated in three files — each with different sizes, ARIA patterns, focus handling, and colors (one used `aria-pressed` instead of `role="switch"`).

Closes #6636

## Changes

- **`Checkbox` primitive**: sr-only `<input type="checkbox">` + styled visual box with `CheckIcon`. Renders as a `<span>` (not `<label>`) so it composes inside consumer `<label>` elements without nesting violations. Props: `checked`, `onChange`, `disabled`, plus passthrough `InputHTMLAttributes`.
- **`Toggle` primitive**: `<button role="switch" aria-checked>` with a sliding thumb. Single standardized size (`h-5 w-9` track, `h-3.5 w-3.5` thumb). Props: `enabled`, `onChange`, `disabled`, plus passthrough `ButtonHTMLAttributes` (for `aria-label`/`aria-labelledby`).
- **`CheckboxField` migration**: swapped raw `<input>` for `<Checkbox>`, dropped `opacity-60` from the outer label (avoids compounding with the primitive's own `opacity-dim`).
- **`Authentication` migration**: deleted the 30-line file-private `Toggle` function, renamed `ariaLabel` → `aria-label`, `onToggle` → `onChange`, `loading` → `disabled`.
- **`RuleDrawer` migration**: replaced inline switch. Intentional visual changes: `bg-accent-green` → `bg-primary`, `h-6 w-11` → `h-5 w-9`.
- **`WebEndpoints` migration**: replaced both inline toggles. Fixed the expiration toggle's incorrect `aria-pressed` → proper `role="switch"` + `aria-checked`. Thumb shrinks from `w-4 h-4` to `h-3.5 w-3.5`.

## Testing

- DS suite: 16 files / 211 tests passing
- Console suite: 181 files / 2620 tests passing
- New test coverage for both primitives (`Checkbox.test.tsx`, `Toggle.test.tsx`) and all four migration sites
- Verify the RuleDrawer status toggle visually — it intentionally switched from green to the standard primary blue