### PR TITLE
refactor(ui): use design-system `cn` for all conditional classNames

### DIFF
--- a/ui/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui/apps/console/src/components/ConnectDrawer.tsx
@@ -26,6 +26,7 @@ import RadioCard from "@/components/common/fields/RadioCard";
 import RadioGroupField from "@/components/common/fields/RadioGroupField";
 import RadioSegment from "@/components/common/fields/RadioSegment";
 import { INPUT, LABEL } from "../utils/styles";
+import { cn } from "@shellhub/design-system/cn";
 import { Card, Button } from "@shellhub/design-system/primitives";
 import type { VaultKeyEntry } from "../types/vault";
 
@@ -446,7 +447,7 @@ export default function ConnectDrawer({
                       onChange={(e) => handleManualKeyChange(e.target.value)}
                       placeholder={"-----BEGIN OPENSSH PRIVATE KEY-----\n..."}
                       rows={5}
-                      className={`${INPUT} font-mono text-xs resize-none`}
+                      className={cn(INPUT, "font-mono text-xs resize-none")}
                     />
                   </div>
                   {state.manualKeyEncrypted && (
@@ -503,11 +504,7 @@ export default function ConnectDrawer({
 
           {!namespaceRecords && recordingSupported && (
             <label
-              className={`flex items-start gap-3 w-full px-3.5 py-3 rounded-lg border text-left transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40 ${
-                state.recordSession
-                  ? "bg-primary/[0.06] border-primary/30 ring-1 ring-primary/10"
-                  : "bg-card border-border hover:border-border-light hover:bg-hover-subtle"
-              }`}
+              className={cn("flex items-start gap-3 w-full px-3.5 py-3 rounded-lg border text-left transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40", state.recordSession ? "bg-primary/[0.06] border-primary/30 ring-1 ring-primary/10" : "bg-card border-border hover:border-border-light hover:bg-hover-subtle")}
             >
               <input
                 type="checkbox"
@@ -522,9 +519,7 @@ export default function ConnectDrawer({
               />
               <span
                 aria-hidden="true"
-                className={`mt-0.5 shrink-0 transition-colors ${
-                  state.recordSession ? "text-primary" : "text-text-muted"
-                }`}
+                className={cn("mt-0.5 shrink-0 transition-colors", state.recordSession ? "text-primary" : "text-text-muted")}
               >
                 <VideoCameraIcon className="w-4 h-4" />
               </span>
@@ -538,11 +533,7 @@ export default function ConnectDrawer({
               </div>
               <span
                 aria-hidden="true"
-                className={`mt-0.5 shrink-0 w-4 h-4 rounded border flex items-center justify-center transition-all ${
-                  state.recordSession
-                    ? "bg-primary border-primary text-white"
-                    : "border-text-muted/40"
-                }`}
+                className={cn("mt-0.5 shrink-0 w-4 h-4 rounded border flex items-center justify-center transition-all", state.recordSession ? "bg-primary border-primary text-white" : "border-text-muted/40")}
               >
                 {state.recordSession && (
                   <CheckIcon className="w-3 h-3" strokeWidth={3} />

--- a/ui/apps/console/src/components/ManageTagsDrawer.tsx
+++ b/ui/apps/console/src/components/ManageTagsDrawer.tsx
@@ -17,6 +17,7 @@ import {
   TrashIcon,
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
 import PageLoader from "@/components/common/PageLoader";
 
@@ -245,11 +246,7 @@ export default function ManageTagsDrawer({
                           void handleRename(tag.name, true);
                         }}
 
-                        className={`w-full px-2.5 py-1 bg-card border rounded-md text-sm text-text-primary focus:outline-none focus:ring-1 transition-all ${
-                          editNameChanged && !editNameValid
-                            ? "border-accent-red/50 focus:ring-accent-red/20"
-                            : "border-primary/50 focus:ring-primary/20"
-                        }`}
+                        className={cn("w-full px-2.5 py-1 bg-card border rounded-md text-sm text-text-primary focus:outline-none focus:ring-1 transition-all", editNameChanged && !editNameValid ? "border-accent-red/50 focus:ring-accent-red/20" : "border-primary/50 focus:ring-primary/20")}
                       />
                       {editNameChanged && !editNameValid && (
                         <p className="mt-1 text-2xs text-accent-red">

--- a/ui/apps/console/src/components/billing/BillingDialog.tsx
+++ b/ui/apps/console/src/components/billing/BillingDialog.tsx
@@ -11,6 +11,7 @@ import BillingLetter from "./BillingLetter";
 import BillingPayment from "./BillingPayment";
 import BillingCheckout from "./BillingCheckout";
 import BillingSuccessful from "./BillingSuccessful";
+import { cn } from "@shellhub/design-system/cn";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const STEPS = ["Overview", "Payment method", "Review", "Success"] as const;
@@ -102,13 +103,14 @@ export default function BillingDialog({
           {Array.from({ length: TOTAL_STEPS }, (_, i) => i + 1).map((s) => (
             <div
               key={s}
-              className={`rounded-full transition-all duration-300 ${
+              className={cn(
+                "rounded-full transition-all duration-300",
                 s < step
                   ? "w-2 h-2 bg-primary"
                   : s === step
                     ? "w-2.5 h-2.5 bg-primary shadow-[0_0_6px_rgba(102,122,204,0.5)]"
-                    : "w-2 h-2 bg-border"
-              }`}
+                    : "w-2 h-2 bg-border",
+              )}
             />
           ))}
         </div>

--- a/ui/apps/console/src/components/billing/BillingSection.tsx
+++ b/ui/apps/console/src/components/billing/BillingSection.tsx
@@ -15,6 +15,7 @@ import { useOpenBillingPortal, useSubscription } from "@/hooks/useBilling";
 import { useInvalidateByIds } from "@/hooks/useInvalidateQueries";
 import { formatExpiry } from "@/utils/date";
 import type { BillingStatus } from "@/client/types.gen";
+import { cn } from "@shellhub/design-system/cn";
 import { Button } from "@shellhub/design-system/primitives";
 
 const BillingDialog = lazy(() => import("./BillingDialog"));
@@ -156,7 +157,7 @@ function SectionRow({
 function StatusBadge({ status }: { status: BillingStatus }) {
   return (
     <span
-      className={`inline-flex items-center px-2.5 py-1 text-2xs font-mono font-semibold rounded border ${STATUS_CHIP[status]}`}
+      className={cn("inline-flex items-center px-2.5 py-1 text-2xs font-mono font-semibold rounded border", STATUS_CHIP[status])}
     >
       {STATUS_LABEL[status]}
     </span>
@@ -276,7 +277,7 @@ export default function BillingSection({ sectionId }: BillingSectionProps) {
           <div
             role="status"
             aria-live="polite"
-            className={`flex items-start gap-3 px-5 py-3 border-b ${BANNER_CLASSES[banner.tone]}`}
+            className={cn("flex items-start gap-3 px-5 py-3 border-b", BANNER_CLASSES[banner.tone])}
           >
             <banner.Icon
               aria-hidden="true"

--- a/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
+++ b/ui/apps/console/src/components/billing/DeviceChooserDialog.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/hooks/useDeviceChooser";
 import { isSdkError } from "@/api/errors";
 import { FREE_TIER_DEVICE_LIMIT } from "./DeviceChooserTrigger";
+import { cn } from "@shellhub/design-system/cn";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
 
 const PER_PAGE = 5;
@@ -407,9 +408,11 @@ const TabButton = forwardRef<HTMLButtonElement, TabButtonProps>(
         disabled={disabled}
         onClick={onSelect}
         onKeyDown={onKeyDown}
-        className={`relative px-4 py-2.5 text-xs font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/50 rounded-t-md
-          ${selected ? "text-text-primary" : "text-text-muted hover:text-text-secondary"}
-          ${disabled ? "opacity-40 cursor-not-allowed hover:text-text-muted" : ""}`}
+        className={cn(
+          "relative px-4 py-2.5 text-xs font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/50 rounded-t-md",
+          selected ? "text-text-primary" : "text-text-muted hover:text-text-secondary",
+          disabled && "opacity-40 cursor-not-allowed hover:text-text-muted",
+        )}
       >
         {children}
         {selected && (
@@ -624,7 +627,7 @@ function SelectionStatus({ count, max }: { count: number; max: number }) {
     <p
       role="status"
       aria-live="polite"
-      className={`text-2xs font-mono tabular-nums ${tone}`}
+      className={cn("text-2xs font-mono tabular-nums", tone)}
     >
       {count} of {max} selected
     </p>

--- a/ui/apps/console/src/components/commandPalette/CommandRow.tsx
+++ b/ui/apps/console/src/components/commandPalette/CommandRow.tsx
@@ -1,5 +1,6 @@
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import { optionId, type BadgeVariant, type CommandItem } from "./items";
 
 const badgeStyles: Record<BadgeVariant, string> = {
@@ -34,25 +35,24 @@ export default function CommandRow({
       data-active={isActive}
       onClick={item.disabled ? undefined : item.onSelect}
       onMouseEnter={onActivate}
-      className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors duration-75 ${
+      className={cn(
+        "w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors duration-75",
         isActive
           ? "bg-primary/10"
-          : item.disabled
-            ? ""
-            : "hover:bg-hover-subtle"
-      } ${item.disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"} ${
-        shaking ? "motion-safe:animate-shake" : ""
-      }`}
+          : !item.disabled && "hover:bg-hover-subtle",
+        item.disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+        shaking && "motion-safe:animate-shake",
+      )}
     >
       <span
-        className={`shrink-0 ${isActive ? "text-primary" : "text-text-muted"} transition-colors duration-75`}
+        className={cn("shrink-0 transition-colors duration-75", isActive ? "text-primary" : "text-text-muted")}
         aria-hidden="true"
       >
         {item.icon}
       </span>
       <div className="flex-1 min-w-0 truncate">
         <span
-          className={`text-sm ${isActive ? "text-text-primary" : "text-text-secondary"} transition-colors duration-75`}
+          className={cn("text-sm transition-colors duration-75", isActive ? "text-text-primary" : "text-text-secondary")}
         >
           {item.label}
         </span>
@@ -64,7 +64,7 @@ export default function CommandRow({
       </div>
       {item.badge && (
         <span
-          className={`shrink-0 text-2xs font-mono font-semibold px-1.5 py-0.5 rounded border ${badgeStyles[item.badge.variant]}`}
+          className={cn("shrink-0 text-2xs font-mono font-semibold px-1.5 py-0.5 rounded border", badgeStyles[item.badge.variant])}
         >
           {item.badge.text}
         </span>

--- a/ui/apps/console/src/components/commandPalette/FeedbackBanner.tsx
+++ b/ui/apps/console/src/components/commandPalette/FeedbackBanner.tsx
@@ -2,6 +2,7 @@ import {
   ExclamationTriangleIcon,
   CheckIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import type { Feedback } from "./items";
 
 interface FeedbackBannerProps {
@@ -17,11 +18,12 @@ export default function FeedbackBanner({ feedback }: FeedbackBannerProps) {
   return (
     <div
       role={feedback.kind === "error" ? "alert" : "status"}
-      className={`flex items-center gap-2 px-4 py-2 text-xs border-b shrink-0 ${
+      className={cn(
+        "flex items-center gap-2 px-4 py-2 text-xs border-b shrink-0",
         feedback.kind === "error"
           ? "text-accent-yellow bg-accent-yellow/10 border-accent-yellow/20"
-          : "text-accent-green bg-accent-green/10 border-accent-green/20"
-      }`}
+          : "text-accent-green bg-accent-green/10 border-accent-green/20",
+      )}
     >
       {feedback.kind === "error" ? (
         <ExclamationTriangleIcon

--- a/ui/apps/console/src/components/commandPalette/PaletteHeader.tsx
+++ b/ui/apps/console/src/components/commandPalette/PaletteHeader.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import type { NormalizedDevice } from "@/hooks/useDevices";
 import { LISTBOX_ID, icons } from "./items";
 
@@ -52,7 +53,7 @@ export default function PaletteHeader({
       ) : (
         <>
           <span
-            className={`shrink-0 ${commandMode ? "text-primary" : "text-text-muted"}`}
+            className={cn("shrink-0", commandMode ? "text-primary" : "text-text-muted")}
             aria-hidden="true"
           >
             {commandMode ? icons.command : icons.search}

--- a/ui/apps/console/src/components/common/BaseDialog.tsx
+++ b/ui/apps/console/src/components/common/BaseDialog.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, RefObject, useCallback, useEffect, useRef } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { useBackdropClose } from "@/hooks/useBackdropClose";
 
@@ -123,20 +124,18 @@ export default function BaseDialog({
   // - At sm and above: auto-height, border, rounded corners, max-width per size.
   // - "full" size omits the max-width class, staying full-screen at all sizes.
   const isFull = size === "full";
-  const panelClasses = [
+  const panelClasses = cn(
     "fixed inset-0 m-auto",
     "w-full h-full",
-    isFull ? "" : "sm:h-fit",
+    !isFull && "sm:h-fit",
     "bg-surface",
-    isFull ? "" : "sm:border sm:border-border sm:rounded-2xl",
+    !isFull && "sm:border sm:border-border sm:rounded-2xl",
     "shadow-2xl shadow-black/40",
     "animate-slide-up",
     "flex flex-col",
     SIZE_CLASSES[size],
-    className ?? "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+    className,
+  );
 
   return (
     <dialog

--- a/ui/apps/console/src/components/common/Breadcrumb.tsx
+++ b/ui/apps/console/src/components/common/Breadcrumb.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 
 export interface BreadcrumbItem {
   label: ReactNode;
@@ -16,7 +17,7 @@ interface BreadcrumbProps {
 
 export default function Breadcrumb({ items, className = "" }: BreadcrumbProps) {
   return (
-    <nav aria-label="Breadcrumb" className={`mb-5 ${className}`}>
+    <nav aria-label="Breadcrumb" className={cn("mb-5", className)}>
       <ol className="flex items-center gap-1.5 min-w-0">
         {items.map((item, i) => {
           const isLast = i === items.length - 1;

--- a/ui/apps/console/src/components/common/ConfirmDialog.tsx
+++ b/ui/apps/console/src/components/common/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useId, useState } from "react";
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 import { Button, type ButtonVariant } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import BaseDialog from "./BaseDialog";
 
@@ -117,7 +118,7 @@ export default function ConfirmDialog({
         {description != null && (
           <div
             id={descriptionId}
-            className={`text-sm text-text-muted ${children || errorMessage ? "mb-4" : "mb-6"}`}
+            className={cn("text-sm text-text-muted", children || errorMessage ? "mb-4" : "mb-6")}
           >
             {description}
           </div>
@@ -126,7 +127,7 @@ export default function ConfirmDialog({
         {errorMessage && (
           <div
             role="alert"
-            className={`${children ? "mt-4" : ""} flex items-start gap-2 bg-accent-red/[0.06] border border-accent-red/20 rounded-lg px-3 py-2.5 text-xs text-accent-red`}
+            className={cn("flex items-start gap-2 bg-accent-red/[0.06] border border-accent-red/20 rounded-lg px-3 py-2.5 text-xs text-accent-red", children && "mt-4")}
           >
             <ExclamationCircleIcon
               className="w-4 h-4 shrink-0 mt-px"

--- a/ui/apps/console/src/components/common/DataTable.tsx
+++ b/ui/apps/console/src/components/common/DataTable.tsx
@@ -5,7 +5,7 @@ import {
   ChevronUpDownIcon,
 } from "@heroicons/react/24/outline";
 import { Card } from "@shellhub/design-system/primitives";
-import { cn } from "@/utils/cn";
+import { cn } from "@shellhub/design-system/cn";
 import Pagination from "./Pagination";
 import PageLoader from "@/components/common/PageLoader";
 

--- a/ui/apps/console/src/components/common/DeviceChip.tsx
+++ b/ui/apps/console/src/components/common/DeviceChip.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { CpuChipIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import DistroIcon from "./DistroIcon";
 
 interface DeviceChipBaseProps {
@@ -48,11 +49,12 @@ export default function DeviceChip(props: DeviceChipProps) {
 
       {online !== undefined && (
         <span
-          className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+          className={cn(
+            "w-1.5 h-1.5 rounded-full shrink-0",
             online
               ? "bg-accent-green shadow-[0_0_4px_rgba(130,165,104,0.6)]"
-              : "bg-text-muted/40"
-          }`}
+              : "bg-text-muted/40",
+          )}
         />
       )}
     </>
@@ -66,7 +68,7 @@ export default function DeviceChip(props: DeviceChipProps) {
     <Link
       to={`/devices/${props.uid}`}
       onClick={props.onClick}
-      className={`${BASE} hover:text-text-primary hover:border-primary/40 hover:bg-primary/5 transition-all duration-150 group/chip`}
+      className={cn(BASE, "hover:text-text-primary hover:border-primary/40 hover:bg-primary/5 transition-all duration-150 group/chip")}
     >
       {inner}
     </Link>

--- a/ui/apps/console/src/components/common/DistroIcon.tsx
+++ b/ui/apps/console/src/components/common/DistroIcon.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@shellhub/design-system/cn";
+
 const distroMap: Record<string, string> = {
   alpine: "fl-alpine",
   arch: "fl-archlinux",
@@ -33,5 +35,5 @@ interface DistroIconProps {
 
 export default function DistroIcon({ id, className = "" }: DistroIconProps) {
   const icon = distroMap[id?.toLowerCase()] ?? "fl-tux";
-  return <i className={`${icon} ${className}`} aria-hidden="true" />;
+  return <i className={cn(icon, className)} aria-hidden="true" />;
 }

--- a/ui/apps/console/src/components/common/Drawer.tsx
+++ b/ui/apps/console/src/components/common/Drawer.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useRef } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 
@@ -39,18 +40,22 @@ export default function Drawer({
   return (
     <>
       <div
-        className={`fixed inset-0 z-[60] bg-black/40 backdrop-blur-[2px] transition-opacity duration-300 ${
-          open ? "opacity-100" : "opacity-0 pointer-events-none"
-        }`}
+        className={cn(
+          "fixed inset-0 z-[60] bg-black/40 backdrop-blur-[2px] transition-opacity duration-300",
+          open ? "opacity-100" : "opacity-0 pointer-events-none",
+        )}
         onClick={onClose}
       />
       <div
         ref={panelRef}
         aria-hidden={!open}
         {...(!open ? { inert: true } : {})}
-        className={`fixed inset-y-0 right-0 z-[70] w-full ${WIDTH_MAP[width]} bg-surface border-l border-border shadow-2xl flex flex-col transition-transform duration-300 ease-out ${
-          open ? "translate-x-0" : "translate-x-full"
-        }`}
+        className={cn(
+          "fixed inset-y-0 right-0 z-[70] w-full",
+          WIDTH_MAP[width],
+          "bg-surface border-l border-border shadow-2xl flex flex-col transition-transform duration-300 ease-out",
+          open ? "translate-x-0" : "translate-x-full",
+        )}
       >
         <div className="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
           <div className="flex items-center gap-2.5">

--- a/ui/apps/console/src/components/common/EmptyState.tsx
+++ b/ui/apps/console/src/components/common/EmptyState.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useId } from "react";
 import { IconBadge } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
+import { cn } from "@shellhub/design-system/cn";
 
 export type EmptyStateAccent = "primary" | "yellow";
 
@@ -94,12 +95,12 @@ export default function EmptyState({
         <div className="text-center mb-10">
           <div
             aria-hidden="true"
-            className={`w-16 h-16 rounded-2xl border flex items-center justify-center mx-auto mb-6 shadow-lg ${styles.badge} ${styles.icon}`}
+            className={cn("w-16 h-16 rounded-2xl border flex items-center justify-center mx-auto mb-6 shadow-lg", styles.badge, styles.icon)}
           >
             {icon}
           </div>
           <span
-            className={`inline-block text-2xs font-mono font-semibold uppercase tracking-wide mb-2 ${styles.overline}`}
+            className={cn("inline-block text-2xs font-mono font-semibold uppercase tracking-wide mb-2", styles.overline)}
           >
             {overline}
           </span>

--- a/ui/apps/console/src/components/common/NoticeBanner.tsx
+++ b/ui/apps/console/src/components/common/NoticeBanner.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { cn } from "@shellhub/design-system/cn";
 
 export interface NoticeBannerProps {
   visible: boolean;
@@ -45,9 +46,10 @@ export default function NoticeBanner({
     <div
       aria-hidden={!visible ? true : undefined}
       {...(!visible ? { inert: true } : {})}
-      className={`grid transition-[grid-template-rows] duration-300 ease-out ${
-        visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
-      }`}
+      className={cn(
+        "grid transition-[grid-template-rows] duration-300 ease-out",
+        visible ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+      )}
     >
       <div className="overflow-hidden">
         {/*
@@ -70,12 +72,12 @@ export default function NoticeBanner({
         <div
           role={role}
           aria-live={ariaLive}
-          className={`${surface} ${text} ${justifyClass} px-5 py-1.5 flex items-center gap-2 border-b`}
+          className={cn(surface, text, justifyClass, "px-5 py-1.5 flex items-center gap-2 border-b")}
         >
           {visible && (
             <>
               <span
-                className={`inline-flex rounded-full h-1.5 w-1.5 shrink-0 ${dot}`}
+                className={cn("inline-flex rounded-full h-1.5 w-1.5 shrink-0", dot)}
               />
               <p className="text-xs font-mono">{children}</p>
             </>

--- a/ui/apps/console/src/components/common/PageHeader.tsx
+++ b/ui/apps/console/src/components/common/PageHeader.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import { IconBadge, type Palette } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
+import { cn } from "@shellhub/design-system/cn";
 
 interface PageHeaderProps {
   icon: ReactNode;
@@ -23,16 +24,17 @@ export default function PageHeader({
 }: PageHeaderProps) {
   return (
     <div
-      className={`relative -mx-8 -mt-8 px-8 py-6 mb-8 border-b border-border ${
+      className={cn(
+        "relative -mx-8 -mt-8 px-8 py-6 mb-8 border-b border-border",
         variant === "decorated"
           ? "animate-fade-in overflow-hidden"
-          : "bg-surface page-header-band"
-      }`}
+          : "bg-surface page-header-band",
+      )}
     >
       {variant === "decorated" && <GlowOrbs preset="corner" tone="primary" />}
 
       <div
-        className={`${variant === "decorated" ? "relative " : ""}flex flex-col sm:flex-row sm:items-center justify-between gap-4`}
+        className={cn(variant === "decorated" && "relative", "flex flex-col sm:flex-row sm:items-center justify-between gap-4")}
       >
         <div className="flex items-start gap-4">
           <IconBadge size="lg" color={iconColor}>

--- a/ui/apps/console/src/components/common/PageLoader.tsx
+++ b/ui/apps/console/src/components/common/PageLoader.tsx
@@ -1,4 +1,5 @@
 import { Spinner, type SpinnerSize } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 type Padding = "none" | "sm" | "md" | "lg" | "fill";
 
@@ -34,15 +35,13 @@ export default function PageLoader({
   padding = "md",
 }: PageLoaderProps) {
   const resolvedSize = size ?? (showLabel ? "md" : "lg");
-  const wrapper = ["flex h-full items-center justify-center", PADDING[padding]]
-    .filter(Boolean)
-    .join(" ");
+  const wrapper = cn("flex h-full items-center justify-center", PADDING[padding]);
 
   if (showLabel) {
     // role="status" is `nameFrom: author` — the visible text doesn't become
     // the accessible name, so set it explicitly via aria-label.
     return (
-      <div role="status" aria-label={label} className={`${wrapper} gap-3`}>
+      <div role="status" aria-label={label} className={cn(wrapper, "gap-3")}>
         <Spinner size={resolvedSize} />
         <span className="text-xs font-mono text-text-muted">{label}</span>
       </div>

--- a/ui/apps/console/src/components/common/SettingsCard.tsx
+++ b/ui/apps/console/src/components/common/SettingsCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "@shellhub/design-system/cn";
 
 type SettingsCardProps = {
   title: string;
@@ -9,13 +10,13 @@ type SettingsCardProps = {
 export default function SettingsCard({ title, children, danger }: SettingsCardProps) {
   return (
     <div
-      className={`bg-card border rounded-xl overflow-hidden ${danger ? "border-accent-red/20 border-l-2 border-l-accent-red/40" : "border-border"}`}
+      className={cn("bg-card border rounded-xl overflow-hidden", danger ? "border-accent-red/20 border-l-2 border-l-accent-red/40" : "border-border")}
     >
       <div
-        className={`px-5 py-3.5 border-b ${danger ? "border-accent-red/10" : "border-border"}`}
+        className={cn("px-5 py-3.5 border-b", danger ? "border-accent-red/10" : "border-border")}
       >
         <h3
-          className={`text-sm font-semibold ${danger ? "text-accent-red" : "text-text-primary"}`}
+          className={cn("text-sm font-semibold", danger ? "text-accent-red" : "text-text-primary")}
         >
           {title}
         </h3>

--- a/ui/apps/console/src/components/common/StatCard.tsx
+++ b/ui/apps/console/src/components/common/StatCard.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { Button, Card } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 interface StatCardBaseProps {
   icon: ReactNode;
@@ -39,7 +40,7 @@ export default function StatCard(props: StatCardProps) {
       </p>
 
       <p
-        className={`text-4xl font-mono font-bold mb-5 tabular-nums ${accent ?? "text-text-primary"}`}
+        className={cn("text-4xl font-mono font-bold mb-5 tabular-nums", accent ?? "text-text-primary")}
       >
         {value}
       </p>

--- a/ui/apps/console/src/components/common/TagFilterDropdown.tsx
+++ b/ui/apps/console/src/components/common/TagFilterDropdown.tsx
@@ -6,6 +6,7 @@ import {
   CheckIcon,
   Cog6ToothIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useTags } from "@/hooks/useTags";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 
@@ -88,11 +89,12 @@ function TagFilterDropdown({
         type="button"
         ref={triggerRef}
         onClick={() => setOpen(!open)}
-        className={`flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-md border transition-all duration-150 ${
+        className={cn(
+          "flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-md border transition-all duration-150",
           hasActive
             ? "bg-primary/15 text-primary border-primary/25"
-            : "bg-card text-text-muted border-border hover:text-text-secondary hover:border-border"
-        }`}
+            : "bg-card text-text-muted border-border hover:text-text-secondary hover:border-border",
+        )}
       >
         <TagIcon className="w-3 h-3" strokeWidth={2} />
         Tags
@@ -102,7 +104,7 @@ function TagFilterDropdown({
           </span>
         )}
         <ChevronDownIcon
-          className={`w-3 h-3 transition-transform ${open ? "rotate-180" : ""}`}
+          className={cn("w-3 h-3 transition-transform", open && "rotate-180")}
           strokeWidth={2}
         />
       </button>
@@ -145,11 +147,12 @@ function TagFilterDropdown({
                       className="w-full flex items-center gap-2 px-2.5 py-1.5 text-xs rounded-md hover:bg-hover-medium transition-colors"
                     >
                       <span
-                        className={`w-3.5 h-3.5 rounded border flex items-center justify-center shrink-0 transition-all ${
+                        className={cn(
+                          "w-3.5 h-3.5 rounded border flex items-center justify-center shrink-0 transition-all",
                           active
                             ? "bg-primary border-primary"
-                            : "border-text-muted/30"
-                        }`}
+                            : "border-text-muted/30",
+                        )}
                       >
                         {active && (
                           <CheckIcon
@@ -159,7 +162,7 @@ function TagFilterDropdown({
                         )}
                       </span>
                       <span
-                        className={`truncate ${active ? "text-primary font-medium" : "text-text-secondary"}`}
+                        className={cn("truncate", active ? "text-primary font-medium" : "text-text-secondary")}
                       >
                         {tag}
                       </span>

--- a/ui/apps/console/src/components/common/fields/InputField.tsx
+++ b/ui/apps/console/src/components/common/fields/InputField.tsx
@@ -1,4 +1,5 @@
 import { InputHTMLAttributes, ReactNode } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import {
   INPUT,
   INPUT_ERROR,
@@ -56,15 +57,13 @@ export default function InputField({
     default: error ? INPUT_ERROR : INPUT,
     mono: error ? INPUT_MONO_ERROR : INPUT_MONO,
   };
-  const inputClassNames = [
+  const inputClassNames = cn(
     baseByVariant[variant],
     appendIcon && "pr-10",
     prependIcon && "pl-10",
     rest.readOnly && INPUT_READONLY,
     className,
-  ]
-    .filter(Boolean)
-    .join(" ");
+  );
 
   return (
     <div>

--- a/ui/apps/console/src/components/common/fields/KeyFileInput.tsx
+++ b/ui/apps/console/src/components/common/fields/KeyFileInput.tsx
@@ -3,6 +3,7 @@ import {
   ArrowUpTrayIcon,
   ExclamationCircleIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useKeyFileInput } from "@/hooks/useKeyFileInput";
 import { INPUT_MONO } from "@/utils/styles";
 import FieldLabel from "@/components/common/fields/FieldLabel";
@@ -78,14 +79,14 @@ export default function KeyFileInput({
               <button
                 type="button"
                 onClick={() => setInputMode("file")}
-                className={`px-2 py-0.5 rounded text-2xs font-medium transition-all ${inputMode === "file" ? "bg-primary/10 text-primary" : "text-text-muted hover:text-text-secondary"}`}
+                className={cn("px-2 py-0.5 rounded text-2xs font-medium transition-all", inputMode === "file" ? "bg-primary/10 text-primary" : "text-text-muted hover:text-text-secondary")}
               >
                 File
               </button>
               <button
                 type="button"
                 onClick={() => setInputMode("text")}
-                className={`px-2 py-0.5 rounded text-2xs font-medium transition-all ${inputMode === "text" ? "bg-primary/10 text-primary" : "text-text-muted hover:text-text-secondary"}`}
+                className={cn("px-2 py-0.5 rounded text-2xs font-medium transition-all", inputMode === "text" ? "bg-primary/10 text-primary" : "text-text-muted hover:text-text-secondary")}
               >
                 Text
               </button>
@@ -105,13 +106,15 @@ export default function KeyFileInput({
           onDragLeave={() => setDragging(false)}
           onDrop={handleDrop}
           onClick={() => fileInputRef.current?.click()}
-          className={`flex flex-col items-center justify-center gap-2 px-4 py-6 border-2 border-dashed rounded-lg cursor-pointer transition-all ${
+          className={cn(
+            "flex flex-col items-center justify-center gap-2 px-4 py-6 border-2 border-dashed rounded-lg cursor-pointer transition-all",
             dragging
               ? "border-primary bg-primary/5"
               : value
                 ? "border-accent-green/30 bg-accent-green/5"
-                : `border-border hover:border-primary/30 ${error ? "border-accent-red/30" : ""}`
-          }`}
+                : "border-border hover:border-primary/30",
+            !dragging && !value && error && "border-accent-red/30",
+          )}
         >
           <input
             ref={fileInputRef}
@@ -154,7 +157,7 @@ export default function KeyFileInput({
           disabled={disabled}
           aria-invalid={error ? true : undefined}
           aria-describedby={describedBy}
-          className={`${INPUT_MONO} resize-none ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+          className={cn(INPUT_MONO, "resize-none", disabled && "opacity-50 cursor-not-allowed")}
         />
       )}
 

--- a/ui/apps/console/src/components/common/fields/RadioCard.tsx
+++ b/ui/apps/console/src/components/common/fields/RadioCard.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import { useRadioGroupContext } from "@/components/common/fields/radioGroupContext";
 
 export default function RadioCard<T extends string>({
@@ -19,11 +20,12 @@ export default function RadioCard<T extends string>({
 
   return (
     <label
-      className={`flex items-start gap-3 w-full px-3.5 py-3 rounded-lg border text-left transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40 ${
+      className={cn(
+        "flex items-start gap-3 w-full px-3.5 py-3 rounded-lg border text-left transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40",
         selected
           ? "bg-primary/[0.06] border-primary/30 ring-1 ring-primary/10"
-          : "bg-card border-border hover:border-border-light hover:bg-hover-subtle"
-      }`}
+          : "bg-card border-border hover:border-border-light hover:bg-hover-subtle",
+      )}
     >
       <input
         type="radio"
@@ -35,22 +37,23 @@ export default function RadioCard<T extends string>({
       />
       <div
         aria-hidden="true"
-        className={`mt-0.5 shrink-0 w-4 h-4 rounded-full border-2 flex items-center justify-center transition-all ${
-          selected ? "border-primary" : "border-text-muted/40"
-        }`}
+        className={cn(
+          "mt-0.5 shrink-0 w-4 h-4 rounded-full border-2 flex items-center justify-center transition-all",
+          selected ? "border-primary" : "border-text-muted/40",
+        )}
       >
         {selected && <div className="w-2 h-2 rounded-full bg-primary" />}
       </div>
       <div className="flex items-start gap-2.5 min-w-0">
         <span
-          className={`mt-0.5 shrink-0 transition-colors ${selected ? "text-primary" : "text-text-muted"}`}
+          className={cn("mt-0.5 shrink-0 transition-colors", selected ? "text-primary" : "text-text-muted")}
         >
           {icon}
         </span>
         <div className="min-w-0">
           <span className={adornment ? "flex items-center gap-2" : "block"}>
             <span
-              className={`block min-w-0 truncate text-sm font-medium transition-colors ${selected ? "text-text-primary" : "text-text-secondary"}`}
+              className={cn("block min-w-0 truncate text-sm font-medium transition-colors", selected ? "text-text-primary" : "text-text-secondary")}
             >
               {label}
             </span>

--- a/ui/apps/console/src/components/common/fields/RadioPill.tsx
+++ b/ui/apps/console/src/components/common/fields/RadioPill.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import { useRadioGroupContext } from "@/components/common/fields/radioGroupContext";
 
 export default function RadioPill<T extends string>({
@@ -15,11 +16,12 @@ export default function RadioPill<T extends string>({
 
   return (
     <label
-      className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border cursor-pointer transition-all focus-within:ring-2 focus-within:ring-primary/40 ${
+      className={cn(
+        "inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border cursor-pointer transition-all focus-within:ring-2 focus-within:ring-primary/40",
         selected
           ? "bg-primary/[0.08] border-primary/30 text-primary ring-1 ring-primary/10"
-          : "bg-card border-border text-text-secondary hover:border-border-light"
-      }`}
+          : "bg-card border-border text-text-secondary hover:border-border-light",
+      )}
     >
       <input
         type="radio"

--- a/ui/apps/console/src/components/common/fields/RadioSegment.tsx
+++ b/ui/apps/console/src/components/common/fields/RadioSegment.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import { useRadioGroupContext } from "@/components/common/fields/radioGroupContext";
 
 export default function RadioSegment<T extends string>({
@@ -15,11 +16,12 @@ export default function RadioSegment<T extends string>({
 
   return (
     <label
-      className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium cursor-pointer transition-all focus-within:ring-2 focus-within:ring-primary/40 ${
+      className={cn(
+        "flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium cursor-pointer transition-all focus-within:ring-2 focus-within:ring-primary/40",
         selected
           ? "bg-primary/10 text-primary border border-primary/20"
-          : "text-text-secondary hover:text-text-primary border border-transparent"
-      }`}
+          : "text-text-secondary hover:text-text-primary border border-transparent",
+      )}
     >
       <input
         type="radio"

--- a/ui/apps/console/src/components/common/fields/SearchField.tsx
+++ b/ui/apps/console/src/components/common/fields/SearchField.tsx
@@ -1,5 +1,6 @@
 import { useId } from "react";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import InputField from "@/components/common/fields/InputField";
 
 interface SearchFieldProps {
@@ -27,9 +28,7 @@ export default function SearchField({
   const generatedId = useId();
   const inputId = id ?? generatedId;
 
-  const wrapperClasses = [full ? null : "max-w-sm w-full", className]
-    .filter(Boolean)
-    .join(" ");
+  const wrapperClasses = cn(!full && "max-w-sm w-full", className);
 
   return (
     <div className={wrapperClasses || undefined}>

--- a/ui/apps/console/src/components/common/fields/TagsSelector.tsx
+++ b/ui/apps/console/src/components/common/fields/TagsSelector.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import { useTags } from "@/hooks/useTags";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import FieldLabel from "@/components/common/fields/FieldLabel";
@@ -51,9 +52,11 @@ export default function TagsSelector({
       </FieldLabel>
       <div ref={wrapperRef} className="relative">
         <div
-          className={`flex flex-wrap gap-1.5 min-h-[42px] px-3 py-2 bg-card border rounded-lg cursor-text transition-all ${
-            open ? "border-primary/50 ring-1 ring-primary/20" : "border-border"
-          } ${error ? "border-accent-red/50" : ""}`}
+          className={cn(
+            "flex flex-wrap gap-1.5 min-h-[42px] px-3 py-2 bg-card border rounded-lg cursor-text transition-all",
+            open ? "border-primary/50 ring-1 ring-primary/20" : "border-border",
+            error && "border-accent-red/50",
+          )}
           onClick={() => setOpen(true)}
         >
           {selected.map((tag) => (

--- a/ui/apps/console/src/components/devices/AcceptDeviceFlow.tsx
+++ b/ui/apps/console/src/components/devices/AcceptDeviceFlow.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRightIcon,
   CommandLineIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { resolveDeviceLoginCode, acceptDevicePairing } from "@/client";
 import { isSdkError } from "@/api/errors";
 import { useAuthStore } from "@/stores/authStore";
@@ -638,7 +639,7 @@ function ResultMessage({
   return (
     <div className="text-center animate-slide-up">
       <div
-        className={`inline-flex items-center justify-center w-14 h-14 rounded-2xl border mb-5 ${TONES[tone].ring}`}
+        className={cn("inline-flex items-center justify-center w-14 h-14 rounded-2xl border mb-5", TONES[tone].ring)}
       >
         <span className={TONES[tone].icon}>{icon}</span>
       </div>

--- a/ui/apps/console/src/components/layout/AdminSidebar.tsx
+++ b/ui/apps/console/src/components/layout/AdminSidebar.tsx
@@ -14,6 +14,7 @@ import {
   ChevronDownIcon,
 } from "@heroicons/react/24/outline";
 import type { ReactNode } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import { getConfig } from "@/env";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
 import { useAuthStore } from "@/stores/authStore";
@@ -167,13 +168,17 @@ function NavGroupItem({
         title={expanded ? undefined : group.label}
         aria-expanded={disabled ? undefined : isOpen}
         aria-disabled={disabled || undefined}
-        className={`w-full ${navBase} transition-all duration-150 ${
+        className={cn(
+          "w-full",
+          navBase,
+          "transition-all duration-150",
           disabled
             ? navDisabled
             : isChildActive
               ? "text-primary"
-              : "text-text-secondary hover:text-text-primary hover:bg-hover-subtle"
-        } ${align}`}
+              : "text-text-secondary hover:text-text-primary hover:bg-hover-subtle",
+          align,
+        )}
       >
         {group.icon}
         {expanded ? (
@@ -181,9 +186,7 @@ function NavGroupItem({
             <span className="flex-1 text-left truncate">{group.label}</span>
             {!disabled && (
               <ChevronDownIcon
-                className={`w-3.5 h-3.5 transition-transform duration-200 ${
-                  isOpen ? "rotate-180" : ""
-                }`}
+                className={cn("w-3.5 h-3.5 transition-transform duration-200", isOpen && "rotate-180")}
                 strokeWidth={2}
               />
             )}
@@ -198,11 +201,7 @@ function NavGroupItem({
               to={child.to}
               onClick={onNavClick}
               className={({ isActive }) =>
-                `flex items-center gap-2 px-2 py-1.5 rounded-md text-[12px] font-medium transition-all duration-150 ${
-                  isActive
-                    ? "text-primary bg-primary/5"
-                    : "text-text-secondary hover:text-text-primary hover:bg-hover-subtle"
-                }`
+                cn("flex items-center gap-2 px-2 py-1.5 rounded-md text-[12px] font-medium transition-all duration-150", isActive ? "text-primary bg-primary/5" : "text-text-secondary hover:text-text-primary hover:bg-hover-subtle")
               }
             >
               <span className="truncate">{child.label}</span>

--- a/ui/apps/console/src/components/layout/AppBar.tsx
+++ b/ui/apps/console/src/components/layout/AppBar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useReducer, useRef } from "react";
 import { useTerminalStore, type TerminalSession } from "@/stores/terminalStore";
 import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
 import { Bars3Icon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { IconButton } from "@shellhub/design-system/primitives";
 import NamespaceSelector from "./NamespaceSelector";
 
@@ -115,9 +116,7 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
 
   return (
     <header
-      className={`theme-dark relative z-50 h-14 border-b px-3 sm:px-5 flex items-center justify-between shrink-0 transition-colors duration-300 ${
-        displayed ? "border-transparent" : "bg-surface border-border"
-      }`}
+      className={cn("theme-dark relative z-50 h-14 border-b px-3 sm:px-5 flex items-center justify-between shrink-0 transition-colors duration-300", displayed ? "border-transparent" : "bg-surface border-border")}
       style={displayed ? { backgroundColor: themeBg } : undefined}
     >
       {/* Left: menu toggle + crossfade with vertical slide */}
@@ -133,7 +132,7 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
         )}
         <div
           onTransitionEnd={handleTransitionEnd}
-          className={`min-w-0 transition-all duration-150 ease-out ${visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"}`}
+          className={cn("min-w-0 transition-all duration-150 ease-out", visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2")}
         >
           {displayed ? (
             <TerminalInfo session={displayed} />
@@ -146,11 +145,7 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
       <div className="flex items-center gap-1">
         {/* Right: terminal actions fade + slide */}
         <div
-          className={`flex items-center transition-all duration-150 ease-out ${
-            displayed && visible
-              ? "opacity-100 translate-y-0"
-              : "opacity-0 translate-y-2 pointer-events-none"
-          }`}
+          className={cn("flex items-center transition-all duration-150 ease-out", displayed && visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2 pointer-events-none")}
         >
           {displayed && <TerminalActions session={displayed} />}
         </div>

--- a/ui/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui/apps/console/src/components/layout/AppLayout.tsx
@@ -16,6 +16,7 @@ import { useNamespaces } from "@/hooks/useNamespaces";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useSidebarLayout } from "@/hooks/useSidebarLayout";
 import VaultAutoLockBanner from "@/components/vault/VaultAutoLockBanner";
+import { cn } from "@shellhub/design-system/cn";
 import { getConfig } from "@/env";
 
 export default function AppLayout() {
@@ -35,7 +36,7 @@ export default function AppLayout() {
   return (
     <ChatwootProvider>
       <div
-        className={`flex flex-col h-screen bg-background ${hasVisibleTerminal ? "overflow-hidden" : ""}`}
+        className={cn("flex flex-col h-screen bg-background", hasVisibleTerminal && "overflow-hidden")}
       >
         <SkipToContentLink />
         <ConnectivityBanner />

--- a/ui/apps/console/src/components/layout/CommandPaletteTrigger.tsx
+++ b/ui/apps/console/src/components/layout/CommandPaletteTrigger.tsx
@@ -1,4 +1,5 @@
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useCommandPaletteStore } from "@/stores/commandPaletteStore";
 import { INPUT } from "@/utils/styles";
 import { navIcon } from "./SidebarShell";
@@ -52,7 +53,7 @@ export default function CommandPaletteTrigger({
     <button
       type="button"
       {...sharedHandlers}
-      className={`${INPUT} group flex items-center gap-2.5 text-left hover:border-primary/40`}
+      className={cn(INPUT, "group flex items-center gap-2.5 text-left hover:border-primary/40")}
     >
       <MagnifyingGlassIcon
         className="w-4 h-4 text-text-muted shrink-0"

--- a/ui/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -4,6 +4,7 @@ import {
   PlusIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useNamespaces, useNamespace } from "@/hooks/useNamespaces";
 import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
 import { useAuthStore } from "@/stores/authStore";
@@ -96,7 +97,7 @@ export default function NamespaceSelector({
           <span className="text-sm text-text-muted italic">No namespace</span>
         )}
         <ChevronDownIcon
-          className={`w-3 h-3 text-text-muted transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          className={cn("w-3 h-3 text-text-muted transition-transform duration-200", open && "rotate-180")}
           strokeWidth={2.5}
         />
       </button>

--- a/ui/apps/console/src/components/layout/PendingDevices.tsx
+++ b/ui/apps/console/src/components/layout/PendingDevices.tsx
@@ -7,6 +7,7 @@ import {
   CpuChipIcon,
   ArrowRightIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useDevices } from "@/hooks/useDevices";
 import { useAcceptDevice, useRejectDevice } from "@/hooks/useDeviceMutations";
 import { useClickOutside } from "@/hooks/useClickOutside";
@@ -142,13 +143,14 @@ export default function PendingDevices() {
                   return (
                     <div
                       key={d.uid}
-                      className={`px-4 py-3 transition-all duration-300 ${
+                      className={cn(
+                        "px-4 py-3 transition-all duration-300",
                         isFlashed
                           ? flash.action === "accepted"
                             ? "bg-accent-green/10"
                             : "bg-accent-red/10"
-                          : "hover:bg-hover-subtle"
-                      }`}
+                          : "hover:bg-hover-subtle",
+                      )}
                     >
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0 flex-1">
@@ -173,11 +175,7 @@ export default function PendingDevices() {
                         {/* Actions */}
                         {isFlashed ? (
                           <span
-                            className={`text-2xs font-mono font-semibold ${
-                              flash.action === "accepted"
-                                ? "text-accent-green"
-                                : "text-accent-red"
-                            }`}
+                            className={cn("text-2xs font-mono font-semibold", flash.action === "accepted" ? "text-accent-green" : "text-accent-red")}
                           >
                             {flash.action === "accepted"
                               ? "Accepted"

--- a/ui/apps/console/src/components/layout/Sidebar.tsx
+++ b/ui/apps/console/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   GlobeAltIcon,
   ShieldExclamationIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import SidebarShell, { NavItemLink, navIcon } from "./SidebarShell";
 import CommandPaletteTrigger from "./CommandPaletteTrigger";
 
@@ -183,11 +184,7 @@ export default function Sidebar({
           className={idx > 0 ? (expanded ? "mt-5" : "mt-1") : ""}
         >
           <p
-            className={`px-3 text-2xs font-mono font-semibold uppercase tracking-label text-text-muted/60 transition-all duration-200 ${
-              expanded
-                ? "opacity-100 mb-1.5"
-                : "opacity-0 h-0 overflow-hidden mb-0"
-            }`}
+            className={cn("px-3 text-2xs font-mono font-semibold uppercase tracking-label text-text-muted/60 transition-all duration-200", expanded ? "opacity-100 mb-1.5" : "opacity-0 h-0 overflow-hidden mb-0")}
           >
             {section.title}
           </p>

--- a/ui/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui/apps/console/src/components/layout/SidebarShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { NavLink } from "react-router-dom";
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import {
   IconButton,
   ShellHubCloudIcon,
@@ -43,7 +44,7 @@ export function NavItemLink({
     return (
       <span
         aria-disabled="true"
-        className={`${navBase} ${navDisabled} ${align}`}
+        className={cn(navBase, navDisabled, align)}
       >
         {item.icon}
         {label}
@@ -57,7 +58,7 @@ export function NavItemLink({
       title={expanded ? undefined : item.label}
       onClick={onClick}
       className={({ isActive }) =>
-        `${navBase} transition-all duration-150 ${isActive ? navActive : navIdle} ${align}`
+        cn(navBase, "transition-all duration-150", isActive ? navActive : navIdle, align)
       }
     >
       {item.icon}
@@ -88,21 +89,17 @@ export function SidebarMobileDrawer({
       role="dialog"
       aria-modal={open}
       aria-label="Navigation menu"
-      className={`fixed inset-0 z-50 ${open ? "" : "pointer-events-none"}`}
+      className={cn("fixed inset-0 z-50", !open && "pointer-events-none")}
       onKeyDown={onKeyDown}
       {...(!open && { inert: true })}
     >
       <div
-        className={`absolute inset-0 bg-black/40 transition-opacity duration-200 ${
-          open ? "opacity-100" : "opacity-0"
-        }`}
+        className={cn("absolute inset-0 bg-black/40 transition-opacity duration-200", open ? "opacity-100" : "opacity-0")}
         onClick={onClose}
         aria-hidden="true"
       />
       <div
-        className={`fixed inset-y-0 left-0 z-50 w-[220px] transition-transform duration-200 ease-in-out ${
-          open ? "translate-x-0" : "-translate-x-full"
-        }`}
+        className={cn("fixed inset-y-0 left-0 z-50 w-[220px] transition-transform duration-200 ease-in-out", open ? "translate-x-0" : "-translate-x-full")}
       >
         {children}
       </div>
@@ -147,9 +144,10 @@ export default function SidebarShell({
 
   return (
     <aside
-      className={`theme-dark bg-surface border-r border-border flex flex-col h-full shrink-0 transition-all duration-200 ease-in-out overflow-hidden ${
-        hidden ? "w-0 opacity-0" : expanded ? "w-[220px]" : "w-[60px]"
-      }`}
+      className={cn(
+        "theme-dark bg-surface border-r border-border flex flex-col h-full shrink-0 transition-all duration-200 ease-in-out overflow-hidden",
+        hidden ? "w-0 opacity-0" : expanded ? "w-[220px]" : "w-[60px]",
+      )}
     >
       {/* Logo */}
       <div className="h-14 flex items-center justify-center border-b border-border px-3">
@@ -161,12 +159,12 @@ export default function SidebarShell({
         >
           <ShellHubLogo
             aria-hidden
-            className={`h-8 transition-opacity duration-200 ${expanded ? "opacity-100" : "opacity-0 absolute"}`}
+            className={cn("h-8 transition-opacity duration-200", expanded ? "opacity-100" : "opacity-0 absolute")}
           />
           <ShellHubCloudIcon
             aria-hidden
             data-testid="sidebar-cloud-icon"
-            className={`h-6 w-6 transition-opacity duration-200 ${expanded ? "opacity-0 absolute" : "opacity-100"}`}
+            className={cn("h-6 w-6 transition-opacity duration-200", expanded ? "opacity-0 absolute" : "opacity-100")}
           />
         </NavLink>
       </div>
@@ -187,10 +185,10 @@ export default function SidebarShell({
 
       {/* Footer with context-specific sidebar toggle */}
       <div
-        className={`h-11 px-3 flex items-center justify-between transition-colors duration-200 ${expanded ? "border-t border-border" : "border-t border-transparent"}`}
+        className={cn("h-11 px-3 flex items-center justify-between transition-colors duration-200", expanded ? "border-t border-border" : "border-t border-transparent")}
       >
         <p
-          className={`text-2xs font-mono text-text-muted/60 whitespace-nowrap transition-opacity duration-200 ${expanded ? "opacity-100" : "opacity-0"}`}
+          className={cn("text-2xs font-mono text-text-muted/60 whitespace-nowrap transition-opacity duration-200", expanded ? "opacity-100" : "opacity-0")}
         >
           {footerLabel}
         </p>
@@ -200,12 +198,10 @@ export default function SidebarShell({
           tabIndex={expanded ? 0 : -1}
           aria-label={toggleLabel}
           title={toggleTitle}
-          className={`duration-200 ${expanded ? "opacity-100" : "opacity-0"} ${pinned ? "text-primary bg-primary/10" : ""}`}
+          className={cn("duration-200", expanded ? "opacity-100" : "opacity-0", pinned && "text-primary bg-primary/10")}
         >
           <ChevronLeftIcon
-            className={`w-3.5 h-3.5 transition-transform duration-200 ${
-              expanded ? "" : "rotate-180"
-            }`}
+            className={cn("w-3.5 h-3.5 transition-transform duration-200", !expanded && "rotate-180")}
             strokeWidth={2}
           />
         </IconButton>

--- a/ui/apps/console/src/components/layout/UserMenu.tsx
+++ b/ui/apps/console/src/components/layout/UserMenu.tsx
@@ -8,6 +8,7 @@ import {
   MoonIcon,
   SunIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useAuthStore } from "@/stores/authStore";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import { useNamespaces } from "@/hooks/useNamespaces";
@@ -51,7 +52,7 @@ export default function UserMenu() {
           {user}
         </span>
         <ChevronDownIcon
-          className={`w-3 h-3 text-text-muted transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          className={cn("w-3 h-3 text-text-muted transition-transform duration-200", open && "rotate-180")}
           strokeWidth={2.5}
         />
       </button>

--- a/ui/apps/console/src/components/terminal/TerminalControls.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalControls.tsx
@@ -7,6 +7,7 @@ import {
   ArrowsPointingOutIcon,
   ArrowsPointingInIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { IconButton } from "@shellhub/design-system/primitives";
 import { useTerminalStore } from "@/stores/terminalStore";
 import type { TerminalSession } from "@/stores/terminalStore";
@@ -26,13 +27,14 @@ export function TerminalInfo({ session }: { session: TerminalSession }) {
   return (
     <div className="flex items-center gap-2.5 min-w-0">
       <span
-        className={`shrink-0 w-2 h-2 rounded-full transition-colors duration-300 ${
+        className={cn(
+          "shrink-0 w-2 h-2 rounded-full transition-colors duration-300",
           status === "connected"
             ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.6)]"
             : status === "connecting"
               ? "bg-accent-yellow animate-pulse"
-              : "bg-accent-red"
-        }`}
+              : "bg-accent-red",
+        )}
       />
       <span className="text-[13px] font-mono text-text-secondary truncate">
         {status === "connected"

--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -19,6 +19,7 @@ import {
   parseMessage,
   resolveError,
 } from "./terminalErrors";
+import { cn } from "@shellhub/design-system/cn";
 import { OpfsCastRecorder } from "@/utils/recordings";
 import { useRecordingsStore } from "@/stores/recordingsStore";
 
@@ -363,7 +364,7 @@ export default function TerminalInstance({
       )}
       <div
         ref={containerRef}
-        className={`flex-1 ${error !== null ? "opacity-30 pointer-events-none" : ""}`}
+        className={cn("flex-1", error !== null && "opacity-30 pointer-events-none")}
       />
     </div>
   );

--- a/ui/apps/console/src/components/terminal/TerminalManager.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalManager.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { cn } from "@shellhub/design-system/cn";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useAuthStore } from "@/stores/authStore";
@@ -72,13 +73,13 @@ export default function TerminalManager({
           <div
             key={s.id}
             style={{ left: isFullscreen ? 0 : sidebarOffset }}
-            className={[
+            className={cn(
               "fixed top-14 bottom-0 right-0 z-40 flex flex-col bg-background",
               "transition-[opacity,transform,left] duration-200 ease-out",
               isVisible
                 ? "opacity-100 translate-y-0"
                 : "opacity-0 translate-y-3 pointer-events-none",
-            ].join(" ")}
+            )}
           >
             <TerminalInstance session={s} visible={isVisible} />
           </div>

--- a/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { CheckIcon, MinusIcon, PlusIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { IconButton } from "@shellhub/design-system/primitives";
 import {
   useTerminalThemeStore,
@@ -87,14 +88,10 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
               type="button"
               key={font}
               onClick={() => setFontFamily(font)}
-              className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 transition-all duration-150 ${
-                font === fontFamily
-                  ? "bg-primary/10 border border-primary/20"
-                  : "hover:bg-hover-subtle border border-transparent"
-              }`}
+              className={cn("flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 transition-all duration-150", font === fontFamily ? "bg-primary/10 border border-primary/20" : "hover:bg-hover-subtle border border-transparent")}
             >
               <span
-                className={`text-[13px] ${font === fontFamily ? "text-primary" : "text-text-secondary"}`}
+                className={cn("text-[13px]", font === fontFamily ? "text-primary" : "text-text-secondary")}
                 style={{ fontFamily: `"${font}", monospace` }}
               >
                 {font}
@@ -219,11 +216,7 @@ function ThemeCard({
     <button
       type="button"
       onClick={onClick}
-      className={`relative rounded-lg border p-2 text-left transition-all duration-150 ${
-        selected
-          ? "border-primary/40 bg-primary/[0.06] ring-1 ring-primary/10"
-          : "border-border hover:border-border-light bg-hover-subtle"
-      }`}
+      className={cn("relative rounded-lg border p-2 text-left transition-all duration-150", selected ? "border-primary/40 bg-primary/[0.06] ring-1 ring-primary/10" : "border-border hover:border-border-light bg-hover-subtle")}
     >
       {/* Color preview */}
       <div
@@ -249,13 +242,14 @@ function ThemeCard({
 
       {/* Name */}
       <div
-        className={`font-mono text-[11px] truncate ${
+        className={cn(
+          "font-mono text-[11px] truncate",
           selected
             ? "text-primary"
             : light
               ? "text-text-muted"
-              : "text-text-secondary"
-        }`}
+              : "text-text-secondary",
+        )}
       >
         {theme.name}
       </div>

--- a/ui/apps/console/src/components/terminal/TerminalTaskbar.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalTaskbar.tsx
@@ -1,4 +1,5 @@
 import { XMarkIcon, CommandLineIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { IconButton } from "@shellhub/design-system/primitives";
 import { useTerminalStore } from "@/stores/terminalStore";
 
@@ -23,35 +24,24 @@ export default function TerminalTaskbar({
         return (
           <div
             key={s.id}
-            className={`flex items-center gap-2 pl-3 pr-1.5 py-1.5 border rounded-lg transition-all duration-150 cursor-pointer group animate-fade-in ${
-              isConnected
-                ? "bg-accent-green/[0.06] border-accent-green/25 hover:border-accent-green/40 hover:bg-accent-green/[0.1]"
-                : "bg-card border-border hover:border-primary/30 hover:bg-primary/[0.04]"
-            }`}
+            className={cn("flex items-center gap-2 pl-3 pr-1.5 py-1.5 border rounded-lg transition-all duration-150 cursor-pointer group animate-fade-in", isConnected ? "bg-accent-green/[0.06] border-accent-green/25 hover:border-accent-green/40 hover:bg-accent-green/[0.1]" : "bg-card border-border hover:border-primary/30 hover:bg-primary/[0.04]")}
             onClick={() => restore(s.id)}
           >
             <span
-              className={`shrink-0 w-1.5 h-1.5 rounded-full transition-colors duration-300 ${
+              className={cn(
+                "shrink-0 w-1.5 h-1.5 rounded-full transition-colors duration-300",
                 isConnected
                   ? "bg-accent-green shadow-[0_0_4px_rgba(130,165,104,0.6)]"
                   : s.connectionStatus === "connecting"
                     ? "bg-accent-yellow animate-pulse"
-                    : "bg-accent-red"
-              }`}
+                    : "bg-accent-red",
+              )}
             />
             <CommandLineIcon
-              className={`w-3.5 h-3.5 transition-colors duration-150 ${
-                isConnected
-                  ? "text-accent-green group-hover:text-accent-green"
-                  : "text-text-muted group-hover:text-primary"
-              }`}
+              className={cn("w-3.5 h-3.5 transition-colors duration-150", isConnected ? "text-accent-green group-hover:text-accent-green" : "text-text-muted group-hover:text-primary")}
             />
             <span
-              className={`text-xs font-medium transition-colors duration-150 max-w-[160px] truncate ${
-                isConnected
-                  ? "text-accent-green"
-                  : "text-text-secondary group-hover:text-text-primary"
-              }`}
+              className={cn("text-xs font-medium transition-colors duration-150 max-w-[160px] truncate", isConnected ? "text-accent-green" : "text-text-secondary group-hover:text-text-primary")}
             >
               {s.deviceName}
             </span>

--- a/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -8,6 +8,7 @@ import {
   ChevronDownIcon,
   ServerStackIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useVaultStore } from "@/stores/vaultStore";
 import { isVaultServerEnabled } from "@/utils/vault-backend-factory";
 import VaultSyncDialog from "@/components/vault/VaultSyncDialog";
@@ -167,7 +168,7 @@ function AutoLockTimeoutSelect({
       >
         {currentLabel}
         <ChevronDownIcon
-          className={`w-3.5 h-3.5 text-text-muted transition-transform duration-150 ${open ? "rotate-180" : ""}`}
+          className={cn("w-3.5 h-3.5 text-text-muted transition-transform duration-150", open && "rotate-180")}
           strokeWidth={2.5}
         />
       </button>
@@ -187,11 +188,7 @@ function AutoLockTimeoutSelect({
                 onChange(minutes);
                 setOpen(false);
               }}
-              className={`px-3 py-2 text-sm cursor-pointer transition-colors ${
-                value === minutes
-                  ? "text-primary bg-primary/10"
-                  : "text-text-secondary hover:text-text-primary hover:bg-hover-medium"
-              }`}
+              className={cn("px-3 py-2 text-sm cursor-pointer transition-colors", value === minutes ? "text-primary bg-primary/10" : "text-text-secondary hover:text-text-primary hover:bg-hover-medium")}
             >
               {TIMEOUT_LABELS[minutes]}
             </li>

--- a/ui/apps/console/src/components/vault/VaultSetupDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultSetupDialog.tsx
@@ -6,6 +6,7 @@ import {
   ServerStackIcon,
   CheckCircleIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useVaultStore } from "@/stores/vaultStore";
 import { loadLegacyKeysFromStorage } from "@/utils/vault-backend-local";
 import {
@@ -133,11 +134,7 @@ function SetupForm({ open, onClose, instanceId }: FormProps) {
               return (
                 <label
                   key={option.mode}
-                  className={`flex items-start gap-3 px-3.5 py-3 rounded-lg border cursor-pointer transition-colors ${
-                    selected
-                      ? "border-primary bg-primary/[0.06]"
-                      : "border-border hover:border-border-light hover:bg-hover-subtle"
-                  }`}
+                  className={cn("flex items-start gap-3 px-3.5 py-3 rounded-lg border cursor-pointer transition-colors", selected ? "border-primary bg-primary/[0.06]" : "border-border hover:border-border-light hover:bg-hover-subtle")}
                 >
                   <input
                     type="radio"
@@ -148,9 +145,7 @@ function SetupForm({ open, onClose, instanceId }: FormProps) {
                     className="sr-only"
                   />
                   <Icon
-                    className={`w-5 h-5 shrink-0 mt-0.5 ${
-                      selected ? "text-primary" : "text-text-muted"
-                    }`}
+                    className={cn("w-5 h-5 shrink-0 mt-0.5", selected ? "text-primary" : "text-text-muted")}
                     strokeWidth={2}
                   />
                   <div className="min-w-0 flex-1">

--- a/ui/apps/console/src/components/wizard/WelcomeWizard.tsx
+++ b/ui/apps/console/src/components/wizard/WelcomeWizard.tsx
@@ -4,6 +4,7 @@ import {
   ArrowRightIcon,
   BookOpenIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import BaseDialog from "@/components/common/BaseDialog";
@@ -50,13 +51,14 @@ export default function WelcomeWizard({ open, onClose }: WelcomeWizardProps) {
           {Array.from({ length: TOTAL_STEPS }, (_, i) => i + 1).map((s) => (
             <div
               key={s}
-              className={`rounded-full transition-all duration-300 ${
+              className={cn(
+                "rounded-full transition-all duration-300",
                 s < step
                   ? "w-2 h-2 bg-primary"
                   : s === step
                     ? "w-2.5 h-2.5 bg-primary shadow-[0_0_6px_rgba(102,122,204,0.5)]"
-                    : "w-2 h-2 bg-border"
-              }`}
+                    : "w-2 h-2 bg-border",
+              )}
             />
           ))}
         </div>

--- a/ui/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui/apps/console/src/pages/AcceptInvite.tsx
@@ -21,6 +21,7 @@ import {
   FormPasswordField,
 } from "@/components/common/fields/rhf";
 import { Button, Spinner, Callout } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import { inviteResolver, type InviteFormValues } from "./setup/inviteResolver";
 
 type Branch =
@@ -516,7 +517,7 @@ function InvitationMessage({
   return (
     <div className="text-center">
       <div
-        className={`inline-flex items-center justify-center w-14 h-14 rounded-full border mb-5 ${ringClass}`}
+        className={cn("inline-flex items-center justify-center w-14 h-14 rounded-full border mb-5", ringClass)}
       >
         {icon}
       </div>

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -37,6 +37,7 @@ import {
   DockerIcon,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 /* ─── Types ─── */
 type Method =
@@ -208,6 +209,13 @@ export default function AddDevice() {
     Boolean(enrollment.device) &&
     enrollment.device?.uid !== dismissedUid;
 
+  const enrollmentBorderColor =
+    enrollment.phase === "connected"
+      ? "border-accent-green/35 bg-accent-green/[0.06]"
+      : enrollment.phase === "expired"
+        ? "border-border-light bg-card"
+        : "border-primary/30 bg-primary/[0.04]";
+
   return (
     <div className="max-w-2xl animate-fade-in">
       <Breadcrumb
@@ -258,11 +266,12 @@ export default function AddDevice() {
               aria-label={opt.title}
               aria-checked={active}
               onClick={() => setMode(opt.id)}
-              className={`flex-1 flex items-center gap-3 px-3.5 h-14 rounded-lg border text-left transition-colors ${
+              className={cn(
+                "flex-1 flex items-center gap-3 px-3.5 h-14 rounded-lg border text-left transition-colors",
                 active
                   ? "bg-primary/15 border-primary/30 text-primary"
-                  : "border-transparent text-text-muted hover:text-text-secondary"
-              }`}
+                  : "border-transparent text-text-muted hover:text-text-secondary",
+              )}
             >
               <opt.icon className="w-5 h-5 shrink-0" strokeWidth={1.8} />
               <span className="flex flex-col min-w-0">
@@ -270,7 +279,7 @@ export default function AddDevice() {
                   {opt.title}
                 </span>
                 <span
-                  className={`text-2xs ${active ? "text-primary/75" : "text-text-muted"}`}
+                  className={cn("text-2xs", active ? "text-primary/75" : "text-text-muted")}
                 >
                   {opt.sub}
                 </span>
@@ -320,11 +329,12 @@ export default function AddDevice() {
                 adornment={
                   m.tag && (
                     <span
-                      className={`px-1.5 py-0.5 text-3xs font-bold uppercase tracking-wider rounded border ${
+                      className={cn(
+                        "px-1.5 py-0.5 text-3xs font-bold uppercase tracking-wider rounded border",
                         m.tag === "Manual"
                           ? "bg-accent-yellow/10 text-accent-yellow border-accent-yellow/20"
-                          : "bg-accent-green/15 text-accent-green border-accent-green/20"
-                      }`}
+                          : "bg-accent-green/15 text-accent-green border-accent-green/20",
+                      )}
                     >
                       {m.tag}
                     </span>
@@ -441,7 +451,7 @@ export default function AddDevice() {
             className="flex items-center gap-1.5 text-2xs font-mono text-text-muted hover:text-text-secondary transition-colors"
           >
             <ChevronRightIcon
-              className={`w-3 h-3 transition-transform ${showAdvanced ? "rotate-90" : ""}`}
+              className={cn("w-3 h-3 transition-transform", showAdvanced && "rotate-90")}
               strokeWidth={2}
             />
             Advanced options
@@ -498,13 +508,7 @@ export default function AddDevice() {
           device the moment it connects — no trip through the pending list. */}
       {usePairingCode ? (
         <div
-          className={`flex items-center gap-3 rounded-xl px-4 py-3.5 mb-6 border ${
-            enrollment.phase === "connected"
-              ? "border-accent-green/35 bg-accent-green/[0.06]"
-              : enrollment.phase === "expired"
-                ? "border-border-light bg-card"
-                : "border-primary/30 bg-primary/[0.04]"
-          }`}
+          className={cn("flex items-center gap-3 rounded-xl px-4 py-3.5 mb-6 border", enrollmentBorderColor)}
         >
           {enrollment.phase === "connected" ? (
             <CheckCircleIcon className="w-5 h-5 text-accent-green shrink-0" />

--- a/ui/apps/console/src/pages/BannerEdit.tsx
+++ b/ui/apps/console/src/pages/BannerEdit.tsx
@@ -8,6 +8,7 @@ import { useEditNamespace } from "../hooks/useNamespaceMutations";
 import { useAuthStore } from "../stores/authStore";
 import { useHasPermission } from "../hooks/useHasPermission";
 import { Button } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import PageLoader from "@/components/common/PageLoader";
 
 const MAX_LENGTH = 4096;
@@ -48,17 +49,17 @@ function BannerEditor({ ns, canEdit }: { ns: Namespace; canEdit: boolean }) {
     }
   };
 
+  const borderColor = overLimit
+    ? "border-accent-red/30"
+    : changed
+      ? "border-primary/30"
+      : "border-border";
+
   return (
     <div className="flex flex-col flex-1 min-h-0 animate-fade-in">
       {/* Textarea wrapper -- grows to fill */}
       <div
-        className={`flex flex-col flex-1 min-h-0 rounded-xl border overflow-hidden transition-colors ${
-          overLimit
-            ? "border-accent-red/30"
-            : changed
-              ? "border-primary/30"
-              : "border-border"
-        }`}
+        className={cn("flex flex-col flex-1 min-h-0 rounded-xl border overflow-hidden transition-colors", borderColor)}
       >
         <textarea
           value={text}
@@ -73,7 +74,7 @@ function BannerEditor({ ns, canEdit }: { ns: Namespace; canEdit: boolean }) {
         />
         <div className="flex items-center justify-between px-4 py-2.5 border-t border-border bg-surface/50 shrink-0">
           <span
-            className={`text-2xs font-mono ${overLimit ? "text-accent-red font-semibold" : "text-text-muted/50"}`}
+            className={cn("text-2xs font-mono", overLimit ? "text-accent-red font-semibold" : "text-text-muted/50")}
           >
             {text.length.toLocaleString()}/{MAX_LENGTH.toLocaleString()}
           </span>

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -40,6 +40,7 @@ import { useHasPermission } from "../hooks/useHasPermission";
 import RestrictedAction from "../components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 /* ─── Shared styles ─── */
 const LABEL =
@@ -67,7 +68,7 @@ function InfoItem({
       <dt className={LABEL}>{label}</dt>
       <dd className="flex items-center gap-1 mt-0.5">
         <span
-          className={`text-sm text-text-primary ${mono ? "font-mono text-xs" : "font-medium"}`}
+          className={cn("text-sm text-text-primary", mono ? "font-mono text-xs" : "font-medium")}
         >
           {display || "—"}
         </span>
@@ -358,6 +359,13 @@ export default function ContainerDetails() {
 
   const tags = normalizeContainer(container).tags;
 
+  const statusColor =
+    container.status === "accepted"
+      ? "bg-accent-green/10 text-accent-green"
+      : container.status === "pending"
+        ? "bg-accent-yellow/10 text-accent-yellow"
+        : "bg-accent-red/10 text-accent-red";
+
   return (
     <div className="animate-fade-in">
       <Breadcrumb
@@ -375,11 +383,12 @@ export default function ContainerDetails() {
               <CubeIcon className="w-7 h-7 text-primary" />
             </div>
             <span
-              className={`absolute -bottom-1 -right-1 w-4 h-4 rounded-full border-2 border-background ${
+              className={cn(
+                "absolute -bottom-1 -right-1 w-4 h-4 rounded-full border-2 border-background",
                 container.online
                   ? "bg-accent-green shadow-[0_0_8px_rgba(130,165,104,0.5)]"
-                  : "bg-text-muted/40"
-              }`}
+                  : "bg-text-muted/40",
+              )}
             />
           </div>
 
@@ -387,25 +396,20 @@ export default function ContainerDetails() {
             <RenameSection uid={container.uid} currentName={container.name} />
             <div className="flex items-center gap-2 mt-1.5">
               <span
-                className={`inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md ${
+                className={cn(
+                  "inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md",
                   container.online
                     ? "bg-accent-green/10 text-accent-green border border-accent-green/20"
-                    : "bg-text-muted/10 text-text-muted border border-border"
-                }`}
+                    : "bg-text-muted/10 text-text-muted border border-border",
+                )}
               >
                 <span
-                  className={`w-1.5 h-1.5 rounded-full ${container.online ? "bg-accent-green" : "bg-text-muted/60"}`}
+                  className={cn("w-1.5 h-1.5 rounded-full", container.online ? "bg-accent-green" : "bg-text-muted/60")}
                 />
                 {container.online ? "Online" : "Offline"}
               </span>
               <span
-                className={`inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md ${
-                  container.status === "accepted"
-                    ? "bg-accent-green/10 text-accent-green"
-                    : container.status === "pending"
-                      ? "bg-accent-yellow/10 text-accent-yellow"
-                      : "bg-accent-red/10 text-accent-red"
-                }`}
+                className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md", statusColor)}
               >
                 {container.status
                   ? container.status.charAt(0).toUpperCase() +

--- a/ui/apps/console/src/pages/Dashboard.tsx
+++ b/ui/apps/console/src/pages/Dashboard.tsx
@@ -22,6 +22,7 @@ import DataTable, { type Column } from "@/components/common/DataTable";
 import { sessionType } from "@/utils/session";
 import type { Session } from "@/client";
 import { Card } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 export default function Dashboard() {
   const tenantId = useAuthStore((s) => s.tenant) ?? "";
@@ -47,11 +48,12 @@ export default function Dashboard() {
       headerClassName: "w-14",
       render: (s) => (
         <span
-          className={`w-2 h-2 rounded-full inline-block ${
+          className={cn(
+            "w-2 h-2 rounded-full inline-block",
             s.active
               ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
-              : "bg-text-muted/40"
-          }`}
+              : "bg-text-muted/40",
+          )}
         />
       ),
     },
@@ -88,7 +90,7 @@ export default function Dashboard() {
               />
             )}
             <code
-              className={`text-xs font-mono ${suspicious ? "text-accent-red/60" : "text-text-secondary"}`}
+              className={cn("text-xs font-mono", suspicious ? "text-accent-red/60" : "text-text-secondary")}
             >
               {s.username}
             </code>
@@ -103,7 +105,7 @@ export default function Dashboard() {
         const type = sessionType(s);
         return type ? (
           <span
-            className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}
+            className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border", type.color)}
           >
             {type.label}
           </span>

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -28,6 +28,7 @@ import TagsSection from "./devices/TagsSection";
 import RenameSection from "./devices/RenameSection";
 import CustomFieldsSection from "./devices/CustomFieldsSection";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 /* ─── Shared styles ─── */
 const VALUE = "text-sm text-text-primary font-medium mt-0.5";
@@ -90,6 +91,13 @@ export default function DeviceDetails() {
       )
     : [];
 
+  const statusColor =
+    device.status === "accepted"
+      ? "bg-accent-green/10 text-accent-green"
+      : device.status === "pending"
+        ? "bg-accent-yellow/10 text-accent-yellow"
+        : "bg-accent-red/10 text-accent-red";
+
   return (
     <div className="animate-fade-in">
       <Breadcrumb
@@ -105,11 +113,12 @@ export default function DeviceDetails() {
               <CpuChipIcon className="w-7 h-7 text-primary" />
             </div>
             <span
-              className={`absolute -bottom-1 -right-1 w-4 h-4 rounded-full border-2 border-background ${
+              className={cn(
+                "absolute -bottom-1 -right-1 w-4 h-4 rounded-full border-2 border-background",
                 device.online
                   ? "bg-accent-green shadow-[0_0_8px_rgba(130,165,104,0.5)]"
-                  : "bg-text-muted/40"
-              }`}
+                  : "bg-text-muted/40",
+              )}
             />
           </div>
 
@@ -117,25 +126,20 @@ export default function DeviceDetails() {
             <RenameSection uid={device.uid} currentName={device.name} />
             <div className="flex items-center gap-2 mt-1.5">
               <span
-                className={`inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md ${
+                className={cn(
+                  "inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md",
                   device.online
                     ? "bg-accent-green/10 text-accent-green border border-accent-green/20"
-                    : "bg-text-muted/10 text-text-muted border border-border"
-                }`}
+                    : "bg-text-muted/10 text-text-muted border border-border",
+                )}
               >
                 <span
-                  className={`w-1.5 h-1.5 rounded-full ${device.online ? "bg-accent-green" : "bg-text-muted/60"}`}
+                  className={cn("w-1.5 h-1.5 rounded-full", device.online ? "bg-accent-green" : "bg-text-muted/60")}
                 />
                 {device.online ? "Online" : "Offline"}
               </span>
               <span
-                className={`inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md ${
-                  device.status === "accepted"
-                    ? "bg-accent-green/10 text-accent-green"
-                    : device.status === "pending"
-                      ? "bg-accent-yellow/10 text-accent-yellow"
-                      : "bg-accent-red/10 text-accent-red"
-                }`}
+                className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md", statusColor)}
               >
                 {device.status.charAt(0).toUpperCase() + device.status.slice(1)}
               </span>

--- a/ui/apps/console/src/pages/MigrationPage.tsx
+++ b/ui/apps/console/src/pages/MigrationPage.tsx
@@ -6,6 +6,7 @@ import {
 } from "@heroicons/react/24/outline";
 import AmbientBackground from "../components/common/AmbientBackground";
 import { ShellHubLogo, Spinner } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 type MigrationStatus = "running" | "completed" | "failed" | "unknown";
 
@@ -43,6 +44,20 @@ export default function MigrationPage() {
     };
   }, []);
 
+  const iconContainerColor =
+    status === "completed"
+      ? "bg-accent-green/10 border-accent-green/20 shadow-accent-green/5"
+      : status === "failed"
+        ? "bg-accent-red/10 border-accent-red/20 shadow-accent-red/5"
+        : "bg-primary/10 border-primary/20 shadow-primary/5";
+
+  const subtitleColor =
+    status === "completed"
+      ? "text-accent-green/60"
+      : status === "failed"
+        ? "text-accent-red/60"
+        : "text-primary/60";
+
   return (
     <div className="relative min-h-screen flex flex-col items-center justify-center bg-background overflow-hidden">
       <AmbientBackground variant={status === "failed" ? "error" : "default"} />
@@ -52,13 +67,7 @@ export default function MigrationPage() {
 
         <div className="animate-float mb-6">
           <div
-            className={`w-20 h-20 rounded-2xl border flex items-center justify-center shadow-lg ${
-              status === "completed"
-                ? "bg-accent-green/10 border-accent-green/20 shadow-accent-green/5"
-                : status === "failed"
-                  ? "bg-accent-red/10 border-accent-red/20 shadow-accent-red/5"
-                  : "bg-primary/10 border-primary/20 shadow-primary/5"
-            }`}
+            className={cn("w-20 h-20 rounded-2xl border flex items-center justify-center shadow-lg", iconContainerColor)}
           >
             {status === "completed" ? (
               <CheckCircleIcon
@@ -80,13 +89,7 @@ export default function MigrationPage() {
         </div>
 
         <p
-          className={`text-2xs font-mono font-semibold uppercase tracking-wide mb-2 ${
-            status === "completed"
-              ? "text-accent-green/60"
-              : status === "failed"
-                ? "text-accent-red/60"
-                : "text-primary/60"
-          }`}
+          className={cn("text-2xs font-mono font-semibold uppercase tracking-wide mb-2", subtitleColor)}
         >
           Database Migration
         </p>

--- a/ui/apps/console/src/pages/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/SessionDetails.tsx
@@ -42,6 +42,7 @@ import {
   Card,
   IconButton,
 } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import SessionTypeBadge from "./sessions/SessionTypeBadge";
 
 /* ── timeline builder ────────────────────────────── */
@@ -200,7 +201,7 @@ function InfoItem({
       <dt className={LABEL}>{label}</dt>
       <dd className="flex items-center gap-1 mt-0.5">
         <span
-          className={`text-sm text-text-primary ${mono ? "font-mono text-xs" : "font-medium"}`}
+          className={cn("text-sm text-text-primary", mono ? "font-mono text-xs" : "font-medium")}
         >
           {display || "—"}
         </span>
@@ -213,12 +214,21 @@ function InfoItem({
 /* ── sub-components ──────────────────────────────── */
 
 function TimelineNode({ event, isLast }: { event: TLEvent; isLast: boolean }) {
+  const titleColor =
+    event.status === "error"
+      ? "text-accent-red"
+      : event.status === "active"
+        ? "text-accent-green"
+        : event.status === "muted"
+          ? "text-text-muted"
+          : "text-text-primary";
+
   return (
     <div className="flex gap-3.5">
       {/* Spine */}
       <div className="flex flex-col items-center shrink-0">
         <div
-          className={`w-6 h-6 rounded-full border flex items-center justify-center ${NODE_COLORS[event.status]}`}
+          className={cn("w-6 h-6 rounded-full border flex items-center justify-center", NODE_COLORS[event.status])}
         >
           {event.status === "active" && event.icon === null ? (
             <span className="relative flex w-2 h-2">
@@ -235,17 +245,9 @@ function TimelineNode({ event, isLast }: { event: TLEvent; isLast: boolean }) {
       </div>
 
       {/* Content */}
-      <div className={`${isLast ? "pb-0" : "pb-4"} min-w-0`}>
+      <div className={cn(isLast ? "pb-0" : "pb-4", "min-w-0")}>
         <p
-          className={`text-sm font-mono font-medium leading-6 ${
-            event.status === "error"
-              ? "text-accent-red"
-              : event.status === "active"
-                ? "text-accent-green"
-                : event.status === "muted"
-                  ? "text-text-muted"
-                  : "text-text-primary"
-          }`}
+          className={cn("text-sm font-mono font-medium leading-6", titleColor)}
         >
           {event.title}
         </p>
@@ -369,11 +371,12 @@ export default function SessionDetails() {
               <CommandLineIcon className="w-7 h-7 text-primary" />
             </div>
             <span
-              className={`absolute -bottom-1 -right-1 w-4 h-4 rounded-full border-2 border-background ${
+              className={cn(
+                "absolute -bottom-1 -right-1 w-4 h-4 rounded-full border-2 border-background",
                 session.active
                   ? "bg-accent-green shadow-[0_0_8px_rgba(130,165,104,0.5)]"
-                  : "bg-text-muted/40"
-              }`}
+                  : "bg-text-muted/40",
+              )}
             />
           </div>
 
@@ -386,14 +389,15 @@ export default function SessionDetails() {
             </div>
             <div className="flex items-center gap-2 mt-1.5 flex-wrap">
               <span
-                className={`inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md ${
+                className={cn(
+                  "inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md",
                   session.active
                     ? "bg-accent-green/10 text-accent-green border border-accent-green/20"
-                    : "bg-text-muted/10 text-text-muted border border-border"
-                }`}
+                    : "bg-text-muted/10 text-text-muted border border-border",
+                )}
               >
                 <span
-                  className={`w-1.5 h-1.5 rounded-full ${session.active ? "bg-accent-green" : "bg-text-muted/60"}`}
+                  className={cn("w-1.5 h-1.5 rounded-full", session.active ? "bg-accent-green" : "bg-text-muted/60")}
                 />
                 {session.active ? "Active" : "Closed"}
               </span>

--- a/ui/apps/console/src/pages/Settings.tsx
+++ b/ui/apps/console/src/pages/Settings.tsx
@@ -35,6 +35,7 @@ import NamespaceNameField from "@/components/common/fields/NamespaceNameField";
 import { validateNamespaceName } from "@/utils/validation";
 import { getConfig } from "../env";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import PageLoader from "@/components/common/PageLoader";
 import SettingsCard from "@/components/common/SettingsCard";
 import SettingsRow from "@/components/common/SettingsRow";
@@ -284,7 +285,7 @@ function BannerPreview({
             className="inline-flex p-1.5 rounded-md text-text-muted hover:text-text-primary hover:bg-hover-medium transition-colors"
           >
             <ChevronDownIcon
-              className={`w-4 h-4 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+              className={cn("w-4 h-4 transition-transform duration-200", open && "rotate-180")}
             />
           </button>
         </div>
@@ -293,7 +294,7 @@ function BannerPreview({
       {/* Collapsible content */}
       <div className="ml-11 mt-3">
         <div
-          className={`relative overflow-hidden rounded-lg border border-border bg-card transition-all duration-200 ease-out ${open ? "max-h-[500px]" : "max-h-[120px]"}`}
+          className={cn("relative overflow-hidden rounded-lg border border-border bg-card transition-all duration-200 ease-out", open ? "max-h-[500px]" : "max-h-[120px]")}
         >
           <pre className="px-3 py-2.5 text-xs font-mono text-text-secondary leading-relaxed whitespace-pre-wrap break-words">
             {banner}
@@ -431,11 +432,12 @@ export default function Settings() {
             description="Defines whether this namespace belongs to one user or a team"
           >
             <span
-              className={`inline-flex items-center px-2.5 py-1 text-2xs font-mono font-semibold rounded border ${
+              className={cn(
+                "inline-flex items-center px-2.5 py-1 text-2xs font-mono font-semibold rounded border",
                 ns.type === "team"
                   ? "bg-primary/10 text-primary border-primary/20"
-                  : "bg-accent-yellow/10 text-accent-yellow border-accent-yellow/20"
-              }`}
+                  : "bg-accent-yellow/10 text-accent-yellow border-accent-yellow/20",
+              )}
             >
               {ns.type ?? "personal"}
             </span>
@@ -465,18 +467,19 @@ export default function Settings() {
               description="Record SSH sessions for audit and playback"
             >
               <div
-                className={`inline-flex items-center h-7 bg-card border border-border rounded-md p-0.5 ${!canUpdateRecording || togglingRecord ? "opacity-40 pointer-events-none" : ""}`}
+                className={cn("inline-flex items-center h-7 bg-card border border-border rounded-md p-0.5", (!canUpdateRecording || togglingRecord) && "opacity-40 pointer-events-none")}
               >
                 <button
                   type="button"
                   onClick={() => {
                     if (sessionRecord) void handleToggleRecord();
                   }}
-                  className={`h-full px-2.5 text-2xs font-medium rounded transition-all duration-150 ${
+                  className={cn(
+                    "h-full px-2.5 text-2xs font-medium rounded transition-all duration-150",
                     !sessionRecord
                       ? "bg-hover-strong text-text-secondary border border-border-light"
-                      : "text-text-muted hover:text-text-secondary border border-transparent"
-                  }`}
+                      : "text-text-muted hover:text-text-secondary border border-transparent",
+                  )}
                 >
                   Off
                 </button>
@@ -485,11 +488,12 @@ export default function Settings() {
                   onClick={() => {
                     if (!sessionRecord) void handleToggleRecord();
                   }}
-                  className={`h-full px-2.5 text-2xs font-medium rounded transition-all duration-150 ${
+                  className={cn(
+                    "h-full px-2.5 text-2xs font-medium rounded transition-all duration-150",
                     sessionRecord
                       ? "bg-primary/15 text-primary border border-primary/25"
-                      : "text-text-muted hover:text-text-secondary border border-transparent"
-                  }`}
+                      : "text-text-muted hover:text-text-secondary border border-transparent",
+                  )}
                 >
                   On
                 </button>
@@ -509,18 +513,19 @@ export default function Settings() {
             description="Automatically accept new devices when they connect for the first time"
           >
             <div
-              className={`inline-flex items-center h-7 bg-card border border-border rounded-md p-0.5 ${!canUpdateAutoAccept || togglingAutoAccept ? "opacity-40 pointer-events-none" : ""}`}
+              className={cn("inline-flex items-center h-7 bg-card border border-border rounded-md p-0.5", (!canUpdateAutoAccept || togglingAutoAccept) && "opacity-40 pointer-events-none")}
             >
               <button
                 type="button"
                 onClick={() => {
                   if (deviceAutoAccept) void handleToggleAutoAccept();
                 }}
-                className={`h-full px-2.5 text-2xs font-medium rounded transition-all duration-150 ${
+                className={cn(
+                  "h-full px-2.5 text-2xs font-medium rounded transition-all duration-150",
                   !deviceAutoAccept
                     ? "bg-hover-strong text-text-secondary border border-border-light"
-                    : "text-text-muted hover:text-text-secondary border border-transparent"
-                }`}
+                    : "text-text-muted hover:text-text-secondary border border-transparent",
+                )}
               >
                 Off
               </button>
@@ -529,11 +534,12 @@ export default function Settings() {
                 onClick={() => {
                   if (!deviceAutoAccept) void handleToggleAutoAccept();
                 }}
-                className={`h-full px-2.5 text-2xs font-medium rounded transition-all duration-150 ${
+                className={cn(
+                  "h-full px-2.5 text-2xs font-medium rounded transition-all duration-150",
                   deviceAutoAccept
                     ? "bg-primary/15 text-primary border border-primary/25"
-                    : "text-text-muted hover:text-text-secondary border border-transparent"
-                }`}
+                    : "text-text-muted hover:text-text-secondary border border-transparent",
+                )}
               >
                 On
               </button>

--- a/ui/apps/console/src/pages/Setup.tsx
+++ b/ui/apps/console/src/pages/Setup.tsx
@@ -17,6 +17,7 @@ import {
   FormPasswordField,
 } from "@/components/common/fields/rhf";
 import { Button, ShellHubLogo } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 const STEP_ONBOARDING = 1;
 const STEP_ACCOUNT = 2;
@@ -202,7 +203,7 @@ export default function Setup() {
 
   return (
     <div
-      className={`w-full mx-auto animate-fade-in ${step === STEP_ONBOARDING ? "max-w-lg" : "max-w-sm"}`}
+      className={cn("w-full mx-auto animate-fade-in", step === STEP_ONBOARDING ? "max-w-lg" : "max-w-sm")}
     >
       <div className="bg-surface border border-border rounded-lg overflow-hidden">
         <div className="px-8 pt-8 pb-6 border-b border-border bg-card/50">
@@ -394,9 +395,10 @@ function StepIndicator({ index, current }: { index: number; current: number }) {
 function StepDot({ active, label }: { active: boolean; label: string }) {
   return (
     <div
-      className={`w-5 h-5 rounded-full flex items-center justify-center text-3xs font-mono font-bold transition-colors ${
-        active ? "bg-primary text-white" : "bg-border text-text-muted"
-      }`}
+      className={cn(
+        "w-5 h-5 rounded-full flex items-center justify-center text-3xs font-mono font-bold transition-colors",
+        active ? "bg-primary text-white" : "bg-border text-text-muted",
+      )}
     >
       {label}
     </div>

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -44,6 +44,7 @@ import {
   IconButton,
   Toggle,
 } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 /* ─── Constants ─── */
 
@@ -136,14 +137,16 @@ function DeviceSelector({
   return (
     <div ref={wrapperRef} className="relative">
       <div
-        className={`flex items-center min-h-[42px] px-3.5 py-2 bg-card border rounded-lg cursor-text transition-all ${
-          open ? "border-primary/50 ring-1 ring-primary/20" : "border-border"
-        } ${error ? "border-accent-red/50" : ""}`}
+        className={cn(
+          "flex items-center min-h-[42px] px-3.5 py-2 bg-card border rounded-lg cursor-text transition-all",
+          open ? "border-primary/50 ring-1 ring-primary/20" : "border-border",
+          error && "border-accent-red/50",
+        )}
       >
         {selected ? (
           <div className="flex items-center gap-2 flex-1 min-w-0">
             <span
-              className={`w-2 h-2 rounded-full shrink-0 ${selected.online ? "bg-accent-green" : "bg-text-muted/40"}`}
+              className={cn("w-2 h-2 rounded-full shrink-0", selected.online ? "bg-accent-green" : "bg-text-muted/40")}
             />
             <span className="text-sm text-text-primary truncate">
               {selected.name}
@@ -196,7 +199,7 @@ function DeviceSelector({
                 className="w-full text-left px-3 py-2 text-sm text-text-primary hover:bg-hover-medium transition-colors flex items-center gap-2"
               >
                 <span
-                  className={`w-2 h-2 rounded-full shrink-0 ${dev.online ? "bg-accent-green" : "bg-text-muted/40"}`}
+                  className={cn("w-2 h-2 rounded-full shrink-0", dev.online ? "bg-accent-green" : "bg-text-muted/40")}
                 />
                 <span className="truncate">{dev.name}</span>
                 <span className="text-2xs text-text-muted font-mono ml-auto shrink-0">
@@ -462,11 +465,12 @@ function EndpointDrawer({
           >
             {/* Localhost card */}
             <label
-              className={`relative block p-4 rounded-lg border transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40 ${
+              className={cn(
+                "relative block p-4 rounded-lg border transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40",
                 hostMode === "localhost"
                   ? "bg-primary/[0.06] border-primary/30"
-                  : "bg-card/50 border-border hover:border-border-light"
-              }`}
+                  : "bg-card/50 border-border hover:border-border-light",
+              )}
             >
               <input
                 type="radio"
@@ -482,19 +486,20 @@ function EndpointDrawer({
               <div className="flex gap-3.5">
                 <div
                   aria-hidden="true"
-                  className={`shrink-0 w-10 h-10 rounded-lg flex items-center justify-center transition-colors ${
+                  className={cn(
+                    "shrink-0 w-10 h-10 rounded-lg flex items-center justify-center transition-colors",
                     hostMode === "localhost"
                       ? "bg-primary/15"
-                      : "bg-hover-medium"
-                  }`}
+                      : "bg-hover-medium",
+                  )}
                 >
                   <ServerStackIcon
-                    className={`w-5 h-5 transition-colors ${hostMode === "localhost" ? "text-primary" : "text-text-muted"}`}
+                    className={cn("w-5 h-5 transition-colors", hostMode === "localhost" ? "text-primary" : "text-text-muted")}
                   />
                 </div>
                 <div className="min-w-0 flex-1">
                   <span
-                    className={`text-sm font-semibold transition-colors ${hostMode === "localhost" ? "text-primary" : "text-text-primary"}`}
+                    className={cn("text-sm font-semibold transition-colors", hostMode === "localhost" ? "text-primary" : "text-text-primary")}
                   >
                     Localhost
                   </span>
@@ -531,11 +536,12 @@ function EndpointDrawer({
 
             {/* Local network card */}
             <label
-              className={`relative block p-4 rounded-lg border transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40 ${
+              className={cn(
+                "relative block p-4 rounded-lg border transition-all cursor-pointer focus-within:ring-2 focus-within:ring-primary/40",
                 hostMode === "custom"
                   ? "bg-primary/[0.06] border-primary/30"
-                  : "bg-card/50 border-border hover:border-border-light"
-              }`}
+                  : "bg-card/50 border-border hover:border-border-light",
+              )}
             >
               <input
                 type="radio"
@@ -551,17 +557,18 @@ function EndpointDrawer({
               <div className="flex gap-3.5">
                 <div
                   aria-hidden="true"
-                  className={`shrink-0 w-10 h-10 rounded-lg flex items-center justify-center transition-colors ${
-                    hostMode === "custom" ? "bg-primary/15" : "bg-hover-medium"
-                  }`}
+                  className={cn(
+                    "shrink-0 w-10 h-10 rounded-lg flex items-center justify-center transition-colors",
+                    hostMode === "custom" ? "bg-primary/15" : "bg-hover-medium",
+                  )}
                 >
                   <ArrowsRightLeftIcon
-                    className={`w-5 h-5 transition-colors ${hostMode === "custom" ? "text-primary" : "text-text-muted"}`}
+                    className={cn("w-5 h-5 transition-colors", hostMode === "custom" ? "text-primary" : "text-text-muted")}
                   />
                 </div>
                 <div className="min-w-0 flex-1">
                   <span
-                    className={`text-sm font-semibold transition-colors ${hostMode === "custom" ? "text-primary" : "text-text-primary"}`}
+                    className={cn("text-sm font-semibold transition-colors", hostMode === "custom" ? "text-primary" : "text-text-primary")}
                   >
                     Local network
                   </span>
@@ -698,22 +705,24 @@ function EndpointCard({
 
   return (
     <div
-      className={`group bg-card border rounded-xl p-4 hover:bg-hover-subtle transition-all ${
+      className={cn(
+        "group bg-card border rounded-xl p-4 hover:bg-hover-subtle transition-all",
         expired
           ? "border-accent-yellow/30"
-          : "border-border hover:border-border-light"
-      }`}
+          : "border-border hover:border-border-light",
+      )}
     >
       <div className="flex items-start justify-between gap-3">
         {/* Left: icon + info */}
         <div className="flex items-start gap-3.5 min-w-0 flex-1">
           <div
-            className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center mt-0.5 ${
-              expired ? "bg-accent-yellow/10" : "bg-primary/10"
-            }`}
+            className={cn(
+              "shrink-0 w-9 h-9 rounded-lg flex items-center justify-center mt-0.5",
+              expired ? "bg-accent-yellow/10" : "bg-primary/10",
+            )}
           >
             <GlobeAltIcon
-              className={`w-4.5 h-4.5 ${expired ? "text-accent-yellow" : "text-primary"}`}
+              className={cn("w-4.5 h-4.5", expired ? "text-accent-yellow" : "text-primary")}
             />
           </div>
           <div className="min-w-0 flex-1">

--- a/ui/apps/console/src/pages/admin/Dashboard.tsx
+++ b/ui/apps/console/src/pages/admin/Dashboard.tsx
@@ -11,6 +11,7 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import PageHeader from "@/components/common/PageHeader";
 import StatCard from "@/components/common/StatCard";
 import DeviceChip from "@/components/common/DeviceChip";
@@ -120,11 +121,7 @@ export default function AdminDashboard() {
       headerClassName: "w-14",
       render: (s) => (
         <span
-          className={`w-2 h-2 rounded-full inline-block ${
-            s.active
-              ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
-              : "bg-text-muted/40"
-          }`}
+          className={cn("w-2 h-2 rounded-full inline-block", s.active ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]" : "bg-text-muted/40")}
         />
       ),
     },
@@ -160,9 +157,7 @@ export default function AdminDashboard() {
               />
             )}
             <code
-              className={`text-xs font-mono ${
-                suspicious ? "text-accent-red/60" : "text-text-secondary"
-              }`}
+              className={cn("text-xs font-mono", suspicious ? "text-accent-red/60" : "text-text-secondary")}
             >
               {s.username}
             </code>
@@ -177,7 +172,7 @@ export default function AdminDashboard() {
         const type = sessionType(s);
         return type ? (
           <span
-            className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}
+            className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border", type.color)}
           >
             {type.label}
           </span>

--- a/ui/apps/console/src/pages/admin/License.tsx
+++ b/ui/apps/console/src/pages/admin/License.tsx
@@ -12,6 +12,7 @@ import {
   DocumentIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import PageHeader from "@/components/common/PageHeader";
 import CopyButton from "@/components/common/CopyButton";
 import { useAdminLicense } from "@/hooks/useAdminLicense";
@@ -81,10 +82,10 @@ function LicenseStatusAlert({
     <div
       role={isUrgent ? "alert" : "status"}
       aria-live={isUrgent ? "assertive" : "polite"}
-      className={`flex items-center gap-3 px-4 py-3 rounded-lg border ${s.container}`}
+      className={cn("flex items-center gap-3 px-4 py-3 rounded-lg border", s.container)}
     >
-      <s.Icon className={`w-5 h-5 ${s.text} shrink-0`} />
-      <p className={`text-sm font-medium ${s.text}`}>{config.message}</p>
+      <s.Icon className={cn("w-5 h-5 shrink-0", s.text)} />
+      <p className={cn("text-sm font-medium", s.text)}>{config.message}</p>
     </div>
   );
 }
@@ -322,16 +323,16 @@ function LicenseUpload() {
               onDragLeave={() => {
                 if (--dragCounter.current === 0) setIsDragging(false);
               }}
-              className={[
+              className={cn(
                 "flex items-center gap-3 w-full px-3.5 py-2.5 rounded-lg border border-dashed cursor-pointer select-none transition-all duration-150",
                 "focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-1 focus-visible:ring-offset-card focus-visible:outline-none",
-                file ? "pr-9" : "",
+                file && "pr-9",
                 isDragging
                   ? "border-primary/50 bg-primary/[0.07]"
                   : file
                     ? "border-border-light bg-hover-subtle hover:bg-hover-medium"
                     : "border-border hover:border-border-light hover:bg-hover-subtle",
-              ].join(" ")}
+              )}
             >
               {file ? (
                 <>
@@ -411,11 +412,12 @@ function LicenseUpload() {
           {feedback && (
             <p
               role={feedback.type === "error" ? "alert" : "status"}
-              className={`text-sm font-medium ${
+              className={cn(
+                "text-sm font-medium",
                 feedback.type === "success"
                   ? "text-accent-green"
-                  : "text-accent-red"
-              }`}
+                  : "text-accent-red",
+              )}
             >
               {feedback.message}
             </p>

--- a/ui/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/admin/SessionDetails.tsx
@@ -5,6 +5,7 @@ import {
   CheckCircleIcon,
   MinusCircleIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useAdminSessionDetail } from "@/hooks/useAdminSessionDetail";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import { formatDateFull } from "@/utils/date";
@@ -38,7 +39,7 @@ function BoolField({
 }) {
   return (
     <span
-      className={`flex items-center gap-1.5 text-sm ${value ? "text-accent-green" : falseColor}`}
+      className={cn("flex items-center gap-1.5 text-sm", value ? "text-accent-green" : falseColor)}
     >
       {value ? (
         <CheckCircleIcon className="w-4 h-4" strokeWidth={2} />
@@ -102,11 +103,7 @@ export default function AdminSessionDetails() {
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <span
-            className={`w-2 h-2 rounded-full inline-block shrink-0 ${
-              session.active
-                ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
-                : "bg-text-muted/40"
-            }`}
+            className={cn("w-2 h-2 rounded-full inline-block shrink-0", session.active ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]" : "bg-text-muted/40")}
             aria-label={session.active ? "Active" : "Inactive"}
           />
           <code className="text-xs font-mono text-text-muted break-all">
@@ -148,7 +145,7 @@ export default function AdminSessionDetails() {
             <Field label="Type">
               {type ? (
                 <span
-                  className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}
+                  className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border", type.color)}
                 >
                   {type.label}
                 </span>

--- a/ui/apps/console/src/pages/admin/Sessions.tsx
+++ b/ui/apps/console/src/pages/admin/Sessions.tsx
@@ -6,6 +6,7 @@ import {
   ShieldExclamationIcon,
 } from "@heroicons/react/24/outline";
 import { Callout } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import { useAdminSessionsList } from "@/hooks/useAdminSessionsList";
 import type { Session } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
@@ -41,11 +42,7 @@ export default function AdminSessions() {
       headerClassName: "w-14",
       render: (s) => (
         <span
-          className={`w-2 h-2 rounded-full inline-block ${
-            s.active
-              ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
-              : "bg-text-muted/40"
-          }`}
+          className={cn("w-2 h-2 rounded-full inline-block", s.active ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]" : "bg-text-muted/40")}
         />
       ),
     },
@@ -93,9 +90,7 @@ export default function AdminSessions() {
               />
             )}
             <code
-              className={`text-xs font-mono ${
-                suspicious ? "text-accent-red/60" : "text-text-secondary"
-              }`}
+              className={cn("text-xs font-mono", suspicious ? "text-accent-red/60" : "text-text-secondary")}
             >
               {s.username}
             </code>

--- a/ui/apps/console/src/pages/admin/announcements/AnnouncementEditor.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/AnnouncementEditor.tsx
@@ -4,6 +4,7 @@ import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
 import Image from "@tiptap/extension-image";
 import { Markdown } from "@tiptap/markdown";
+import { cn } from "@shellhub/design-system/cn";
 import { isAllowedUrl } from "@/utils/url";
 import "./AnnouncementEditor.css";
 
@@ -34,11 +35,7 @@ function ToolbarButton({
       title={title}
       aria-label={title}
       aria-pressed={active}
-      className={`p-1.5 rounded text-xs transition-colors ${
-        active
-          ? "bg-primary/15 text-primary"
-          : "text-text-muted hover:text-text-primary hover:bg-surface"
-      } disabled:opacity-30 disabled:cursor-not-allowed`}
+      className={cn("p-1.5 rounded text-xs transition-colors", active ? "bg-primary/15 text-primary" : "text-text-muted hover:text-text-primary hover:bg-surface", "disabled:opacity-30 disabled:cursor-not-allowed")}
     >
       {children}
     </button>

--- a/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -7,6 +7,7 @@ import {
   TagIcon,
   KeyIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useAdminDevice } from "@/hooks/useAdminDevices";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
@@ -64,9 +65,7 @@ export default function AdminDeviceDetails() {
           <CpuChipIcon className="w-7 h-7 text-primary" />
           {/* Online indicator dot */}
           <span
-            className={`absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full border-2 border-surface ${
-              device.online ? "bg-accent-green" : "bg-text-muted/30"
-            }`}
+            className={cn("absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full border-2 border-surface", device.online ? "bg-accent-green" : "bg-text-muted/30")}
             title={device.online ? "Online" : "Offline"}
             aria-label={device.online ? "Online" : "Offline"}
           />
@@ -77,11 +76,7 @@ export default function AdminDeviceDetails() {
           </h1>
           <div className="flex items-center gap-2 mt-1.5">
             <span
-              className={`inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md ${
-                device.online
-                  ? "bg-accent-green/10 text-accent-green border border-accent-green/20"
-                  : "bg-text-muted/10 text-text-muted border border-text-muted/20"
-              }`}
+              className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md", device.online ? "bg-accent-green/10 text-accent-green border border-accent-green/20" : "bg-text-muted/10 text-text-muted border border-text-muted/20")}
             >
               {device.online ? "Online" : "Offline"}
             </span>

--- a/ui/apps/console/src/pages/admin/devices/DeviceStatusChip.tsx
+++ b/ui/apps/console/src/pages/admin/devices/DeviceStatusChip.tsx
@@ -4,6 +4,7 @@ import {
   XCircleIcon,
   MinusCircleIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import type { DeviceStatus } from "@/client";
 
 const STATUS_CONFIG: Record<
@@ -53,7 +54,7 @@ export default function DeviceStatusChip({ status }: DeviceStatusChipProps) {
 
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md ${className}`}
+      className={cn("inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md", className)}
     >
       <Icon className="w-3 h-3" />
       {label}

--- a/ui/apps/console/src/pages/admin/devices/index.tsx
+++ b/ui/apps/console/src/pages/admin/devices/index.tsx
@@ -3,6 +3,7 @@ import {
   CpuChipIcon,
 } from "@heroicons/react/24/outline";
 import { Callout } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import {
   useAdminDevices,
   type NormalizedDevice,
@@ -215,11 +216,7 @@ export default function AdminDevices() {
               role="tab"
               aria-selected={params.status === tab.value}
               onClick={() => setFilter("status", tab.value)}
-              className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${
-                params.status === tab.value
-                  ? "bg-primary/15 text-primary border border-primary/25"
-                  : "text-text-muted hover:text-text-secondary border border-transparent"
-              }`}
+              className={cn("h-full px-3.5 text-xs font-medium rounded transition-all duration-150", params.status === tab.value ? "bg-primary/15 text-primary border border-primary/25" : "text-text-muted hover:text-text-secondary border border-transparent")}
             >
               {tab.label}
             </button>

--- a/ui/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircleIcon,
   NoSymbolIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useAdminFirewallRule } from "@/hooks/useAdminFirewallRules";
 import ActiveBadge from "@/components/common/ActiveBadge";
 import Breadcrumb from "@/components/common/Breadcrumb";
@@ -58,11 +59,7 @@ export default function AdminFirewallRuleDetails() {
       {/* Header */}
       <div className="flex items-start gap-4 mb-8">
         <div
-          className={`w-14 h-14 rounded-xl flex items-center justify-center shrink-0 border ${
-            isAllow
-              ? "bg-accent-green/10 border-accent-green/20"
-              : "bg-accent-red/10 border-accent-red/20"
-          }`}
+          className={cn("w-14 h-14 rounded-xl flex items-center justify-center shrink-0 border", isAllow ? "bg-accent-green/10 border-accent-green/20" : "bg-accent-red/10 border-accent-red/20")}
         >
           {isAllow ? (
             <CheckCircleIcon className="w-7 h-7 text-accent-green" />

--- a/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -7,6 +7,7 @@ import {
   InformationCircleIcon,
   Cog6ToothIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useAdminNamespace } from "@/hooks/useAdminNamespaces";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import CopyButton from "@/components/common/CopyButton";
@@ -209,11 +210,7 @@ export default function NamespaceDetails() {
               <dt className={LABEL}>Session Recording</dt>
               <dd className="mt-1">
                 <span
-                  className={`inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md ${
-                    namespace.settings?.session_record
-                      ? "bg-accent-green/10 text-accent-green border border-accent-green/20"
-                      : "bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20"
-                  }`}
+                  className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md", namespace.settings?.session_record ? "bg-accent-green/10 text-accent-green border border-accent-green/20" : "bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20")}
                 >
                   {namespace.settings?.session_record ? "Enabled" : "Disabled"}
                 </span>
@@ -223,11 +220,7 @@ export default function NamespaceDetails() {
               <dt className={LABEL}>Auto-Accept Devices</dt>
               <dd className="mt-1">
                 <span
-                  className={`inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md ${
-                    namespace.settings?.device_auto_accept
-                      ? "bg-accent-green/10 text-accent-green border border-accent-green/20"
-                      : "bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20"
-                  }`}
+                  className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md", namespace.settings?.device_auto_accept ? "bg-accent-green/10 text-accent-green border border-accent-green/20" : "bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20")}
                 >
                   {namespace.settings?.device_auto_accept
                     ? "Enabled"

--- a/ui/apps/console/src/pages/admin/settings/SamlConfigDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/settings/SamlConfigDrawer.tsx
@@ -6,6 +6,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { configureSamlAuthentication } from "@/client";
 import type { GetAuthenticationSettingsResponse } from "@/client";
+import { cn } from "@shellhub/design-system/cn";
 import Drawer from "@/components/common/Drawer";
 import InputField from "@/components/common/fields/InputField";
 import CheckboxField from "@/components/common/fields/CheckboxField";
@@ -325,7 +326,7 @@ export default function SamlConfigDrawer({
                 }
                 aria-invalid={certInvalid || undefined}
                 aria-describedby={certInvalid ? "certificate-error" : undefined}
-                className={`${INPUT} resize-none font-mono text-2xs leading-relaxed ${certInvalid ? "border-accent-red/50" : ""}`}
+                className={cn(INPUT, "resize-none font-mono text-2xs leading-relaxed", certInvalid && "border-accent-red/50")}
               />
               {certInvalid && (
                 <p
@@ -348,7 +349,7 @@ export default function SamlConfigDrawer({
           >
             <span>Advanced Settings</span>
             <ChevronDownIcon
-              className={`w-4 h-4 transition-transform duration-200 ${showAdvanced ? "rotate-180" : ""}`}
+              className={cn("w-4 h-4 transition-transform duration-200", showAdvanced && "rotate-180")}
               strokeWidth={2}
             />
           </button>

--- a/ui/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -9,6 +9,7 @@ import {
   ClockIcon,
   KeyIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useAdminUser } from "@/hooks/useAdminUsers";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import { useLoginAsUser } from "@/hooks/useLoginAsUser";
@@ -47,7 +48,7 @@ function InfoItem({
       <dt className={LABEL}>{label}</dt>
       <dd className="flex items-center gap-1 mt-0.5">
         <span
-          className={`text-sm text-text-primary ${mono ? "font-mono text-xs" : "font-medium"}`}
+          className={cn("text-sm text-text-primary", mono ? "font-mono text-xs" : "font-medium")}
         >
           {value || "\u2014"}
         </span>
@@ -230,11 +231,7 @@ export default function UserDetails() {
               <dt className={LABEL}>MFA</dt>
               <dd className="mt-1">
                 <span
-                  className={`inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md ${
-                    user.mfa.enabled
-                      ? "bg-accent-green/10 text-accent-green border border-accent-green/20"
-                      : "bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20"
-                  }`}
+                  className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-semibold rounded-md", user.mfa.enabled ? "bg-accent-green/10 text-accent-green border border-accent-green/20" : "bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20")}
                 >
                   {user.mfa.enabled ? "Enabled" : "Disabled"}
                 </span>

--- a/ui/apps/console/src/pages/admin/users/UserStatusChip.tsx
+++ b/ui/apps/console/src/pages/admin/users/UserStatusChip.tsx
@@ -3,6 +3,7 @@ import {
   ExclamationCircleIcon,
   ClockIcon,
 } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 
 export type UserStatus = "confirmed" | "not-confirmed" | "awaiting_approval";
 
@@ -43,7 +44,7 @@ export default function UserStatusChip({ status }: UserStatusChipProps) {
 
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md ${className}`}
+      className={cn("inline-flex items-center gap-1 px-2 py-0.5 text-2xs font-semibold rounded-md", className)}
     >
       <Icon className="w-3 h-3" />
       {label}

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -32,6 +32,7 @@ import {
   Callout,
   IconButton,
 } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import RestrictedAction from "@/components/common/RestrictedAction";
 
 const PER_PAGE = 10;
@@ -367,11 +368,7 @@ export default function Containers() {
               role="tab"
               aria-selected={params.status === tab.value}
               onClick={() => handleStatusChange(tab.value)}
-              className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${
-                params.status === tab.value
-                  ? "bg-primary/15 text-primary border border-primary/25"
-                  : "text-text-muted hover:text-text-secondary border border-transparent"
-              }`}
+              className={cn("h-full px-3.5 text-xs font-medium rounded transition-all duration-150", params.status === tab.value ? "bg-primary/15 text-primary border border-primary/25" : "text-text-muted hover:text-text-secondary border border-transparent")}
             >
               {tab.label}
             </button>

--- a/ui/apps/console/src/pages/devices/InfoItem.tsx
+++ b/ui/apps/console/src/pages/devices/InfoItem.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@shellhub/design-system/cn";
 import CopyButton from "@/components/common/CopyButton";
 
 const LABEL =
@@ -25,7 +26,7 @@ export default function InfoItem({
       <dt className={LABEL}>{label}</dt>
       <dd className="flex items-center gap-1 mt-0.5">
         <span
-          className={`text-sm text-text-primary ${mono ? "font-mono text-xs" : "font-medium"}`}
+          className={cn("text-sm text-text-primary", mono ? "font-mono text-xs" : "font-medium")}
         >
           {display || "—"}
         </span>

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -33,6 +33,7 @@ import {
   Callout,
   IconButton,
 } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import RestrictedAction from "@/components/common/RestrictedAction";
 
 const PER_PAGE = 10;
@@ -354,11 +355,7 @@ export default function Devices() {
               type="button"
               key={tab.value}
               onClick={() => handleStatusChange(tab.value)}
-              className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${
-                params.status === tab.value
-                  ? "bg-primary/15 text-primary border border-primary/25"
-                  : "text-text-muted hover:text-text-secondary border border-transparent"
-              }`}
+              className={cn("h-full px-3.5 text-xs font-medium rounded transition-all duration-150", params.status === tab.value ? "bg-primary/15 text-primary border border-primary/25" : "text-text-muted hover:text-text-secondary border border-transparent")}
             >
               {tab.label}
             </button>

--- a/ui/apps/console/src/pages/public-keys/index.tsx
+++ b/ui/apps/console/src/pages/public-keys/index.tsx
@@ -26,6 +26,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { PublicKeyResponse as PublicKey } from "@/client";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 const PER_PAGE = 10;
 
@@ -73,7 +74,7 @@ function ScopeCell({ pk }: { pk: PublicKey }) {
   return (
     <div className="flex items-center gap-2 flex-wrap">
       <span
-        className={`inline-flex items-center gap-1 text-xs font-mono ${isAllUsers ? "text-text-muted" : "text-text-secondary"}`}
+        className={cn("inline-flex items-center gap-1 text-xs font-mono", isAllUsers ? "text-text-muted" : "text-text-secondary")}
       >
         {isAllUsers ? (
           <UsersIcon className="w-3 h-3 shrink-0" strokeWidth={2} />

--- a/ui/apps/console/src/pages/sessions/index.tsx
+++ b/ui/apps/console/src/pages/sessions/index.tsx
@@ -28,6 +28,7 @@ import {
   IconButton,
   Spinner,
 } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 
 const PER_PAGE = 10;
 
@@ -140,11 +141,7 @@ export default function Sessions() {
       headerClassName: "w-14",
       render: (s) => (
         <span
-          className={`w-2 h-2 rounded-full inline-block ${
-            s.active
-              ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]"
-              : "bg-text-muted/40"
-          }`}
+          className={cn("w-2 h-2 rounded-full inline-block", s.active ? "bg-accent-green shadow-[0_0_6px_rgba(130,165,104,0.4)]" : "bg-text-muted/40")}
         />
       ),
     },
@@ -203,7 +200,7 @@ export default function Sessions() {
               />
             )}
             <code
-              className={`text-xs font-mono ${suspicious ? "text-accent-red/60" : "text-text-secondary"}`}
+              className={cn("text-xs font-mono", suspicious ? "text-accent-red/60" : "text-text-secondary")}
             >
               {s.username}
             </code>
@@ -227,7 +224,7 @@ export default function Sessions() {
         const type = sessionType(s);
         return type ? (
           <span
-            className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${type.color}`}
+            className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border", type.color)}
           >
             {type.label}
           </span>

--- a/ui/apps/console/src/pages/team/ApiKeysTab.tsx
+++ b/ui/apps/console/src/pages/team/ApiKeysTab.tsx
@@ -5,6 +5,7 @@ import {
   TrashIcon,
 } from "@heroicons/react/24/outline";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import { useApiKeys } from "@/hooks/useApiKeys";
 import { useDeleteApiKey } from "@/hooks/useApiKeyMutations";
 import { useTableSort } from "@/hooks/useTableSort";
@@ -112,7 +113,7 @@ function ApiKeysTab() {
         const expired = isExpired(key.expires_in);
         return (
           <span
-            className={`text-xs ${expired ? "text-accent-red" : "text-text-secondary"}`}
+            className={cn("text-xs", expired ? "text-accent-red" : "text-text-secondary")}
           >
             {formatExpiry(key.expires_in)}
           </span>

--- a/ui/apps/console/src/pages/team/MembersTab.tsx
+++ b/ui/apps/console/src/pages/team/MembersTab.tsx
@@ -8,6 +8,7 @@ import {
   ArrowPathIcon,
 } from "@heroicons/react/24/outline";
 import { Button, IconButton } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
 import type { MemberView, MembershipInvitation } from "@/client";
 import { useAuthStore } from "@/stores/authStore";
 import {
@@ -57,7 +58,7 @@ function Badge({
   }[tone];
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border ${styles}`}
+      className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-mono font-semibold rounded border", styles)}
     >
       {children}
     </span>
@@ -220,7 +221,7 @@ function MembersTab({ tenantId }: { tenantId: string }) {
               <Badge tone="yellow">Pending invite</Badge>
               {row.invite.expires_at && (
                 <span
-                  className={`text-2xs ${expired ? "text-accent-red" : "text-text-muted"}`}
+                  className={cn("text-2xs", expired ? "text-accent-red" : "text-text-muted")}
                 >
                   {expired
                     ? "expired"

--- a/ui/apps/console/src/pages/team/index.tsx
+++ b/ui/apps/console/src/pages/team/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { UserGroupIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { useAuthStore } from "@/stores/authStore";
 import PageHeader from "@/components/common/PageHeader";
 import MembersTab from "./MembersTab";
@@ -32,11 +33,7 @@ export default function Team() {
             type="button"
             key={t.value}
             onClick={() => setTab(t.value)}
-            className={`h-full px-3.5 text-xs font-medium rounded transition-all duration-150 ${
-              tab === t.value
-                ? "bg-primary/15 text-primary border border-primary/25"
-                : "text-text-muted hover:text-text-secondary border border-transparent"
-            }`}
+            className={cn("h-full px-3.5 text-xs font-medium rounded transition-all duration-150", tab === t.value ? "bg-primary/15 text-primary border border-primary/25" : "text-text-muted hover:text-text-secondary border border-transparent")}
           >
             {t.label}
           </button>

--- a/ui/apps/console/src/utils/cn.ts
+++ b/ui/apps/console/src/utils/cn.ts
@@ -1,3 +1,0 @@
-export function cn(...classes: (string | false | undefined | null)[]) {
-  return classes.filter(Boolean).join(" ");
-}

--- a/ui/apps/website/src/components/SiteLayout.tsx
+++ b/ui/apps/website/src/components/SiteLayout.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import { Navbar } from "@/pages/landing/Navbar";
 import { Footer } from "@shellhub/design-system/components";
 
@@ -23,7 +24,7 @@ export function SiteLayout({
 
   return (
     <div
-      className={`min-h-screen bg-background text-text-primary font-sans antialiased overflow-x-hidden${className ? " " + className : ""}`}
+      className={cn("min-h-screen bg-background text-text-primary font-sans antialiased overflow-x-hidden", className)}
     >
       <Navbar
         navSolid={navSolid}

--- a/ui/apps/website/src/pages/getting-started/StepSignup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSignup.tsx
@@ -1,4 +1,5 @@
 import { useState, FormEvent } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import {
   UserIcon,
   EnvelopeIcon,
@@ -265,7 +266,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
                     }));
                   }}
                   placeholder="Min. 5 chars"
-                  className={`${INPUT_BASE} pr-9`}
+                  className={cn(INPUT_BASE, "pr-9")}
                 />
                 <button
                   type="button"
@@ -331,7 +332,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
                 className="flex items-start gap-3 w-full text-left group"
               >
                 <span
-                  className={`mt-px w-4 h-4 rounded flex items-center justify-center shrink-0 border transition-all duration-200 ${acceptPrivacy ? "bg-primary border-primary" : "bg-surface border-border group-hover:border-border-light"}`}
+                  className={cn("mt-px w-4 h-4 rounded flex items-center justify-center shrink-0 border transition-all duration-200", acceptPrivacy ? "bg-primary border-primary" : "bg-surface border-border group-hover:border-border-light")}
                 >
                   {acceptPrivacy && (
                     <CheckIcon
@@ -364,7 +365,7 @@ export function StepSignup({ onBack }: StepSignupProps) {
                 className="flex items-start gap-3 w-full text-left group"
               >
                 <span
-                  className={`mt-px w-4 h-4 rounded flex items-center justify-center shrink-0 border transition-all duration-200 ${acceptMarketing ? "bg-primary border-primary" : "bg-surface border-border group-hover:border-border-light"}`}
+                  className={cn("mt-px w-4 h-4 rounded flex items-center justify-center shrink-0 border transition-all duration-200", acceptMarketing ? "bg-primary border-primary" : "bg-surface border-border group-hover:border-border-light")}
                 >
                   {acceptMarketing && (
                     <CheckIcon

--- a/ui/apps/website/src/pages/getting-started/index.tsx
+++ b/ui/apps/website/src/pages/getting-started/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { cn } from "@shellhub/design-system/cn";
 import { ConnectionGrid, GlowOrbs } from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import { StepPath } from "./StepPath";
@@ -30,27 +31,19 @@ export default function GettingStarted() {
               <div key={step.label} className="flex items-center gap-3">
                 <div className="flex items-center gap-2">
                   <div
-                    className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold transition-colors duration-300 ${
-                      i <= currentStep
-                        ? "bg-primary text-white"
-                        : "bg-border text-text-muted"
-                    }`}
+                    className={cn("w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold transition-colors duration-300", i <= currentStep ? "bg-primary text-white" : "bg-border text-text-muted")}
                   >
                     {i + 1}
                   </div>
                   <span
-                    className={`text-xs font-medium transition-colors duration-300 hidden sm:inline ${
-                      i <= currentStep ? "text-text-primary" : "text-text-muted"
-                    }`}
+                    className={cn("text-xs font-medium transition-colors duration-300 hidden sm:inline", i <= currentStep ? "text-text-primary" : "text-text-muted")}
                   >
                     {step.label}
                   </span>
                 </div>
                 {i < steps.length - 1 && (
                   <div
-                    className={`w-12 h-px transition-colors duration-300 ${
-                      i < currentStep ? "bg-primary" : "bg-border"
-                    }`}
+                    className={cn("w-12 h-px transition-colors duration-300", i < currentStep ? "bg-primary" : "bg-border")}
                   />
                 )}
               </div>

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { cn } from "@shellhub/design-system/cn";
 import {
   ArrowDownIcon,
   ArrowsRightLeftIcon,
@@ -471,7 +472,7 @@ export default function Integrations() {
                         ).map((f, i) => (
                           <div
                             key={i}
-                            className={`flex items-center gap-1.5 px-1.5 py-0.5 rounded text-2xs font-mono ${f.active ? "bg-accent-blue/10 text-accent-blue" : "text-text-secondary hover:bg-white/[0.03]"}`}
+                            className={cn("flex items-center gap-1.5 px-1.5 py-0.5 rounded text-2xs font-mono", f.active ? "bg-accent-blue/10 text-accent-blue" : "text-text-secondary hover:bg-white/[0.03]")}
                             style={{ paddingLeft: `${f.indent * 12 + 6}px` }}
                           >
                             {f.isDir ? (

--- a/ui/apps/website/src/pages/landing/Navbar.tsx
+++ b/ui/apps/website/src/pages/landing/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { cn } from "@shellhub/design-system/cn";
 import { Button, ShellHubLogo } from "@shellhub/design-system/primitives";
 import {
   ChevronDownIcon,
@@ -121,7 +122,7 @@ function MegaMenuItem({ item }: { item: MenuItem }) {
   }
   return (
     <span
-      className={`${sharedClass} cursor-default`}
+      className={cn(sharedClass, "cursor-default")}
       aria-disabled="true"
       {...hoverHandlers}
     >
@@ -146,11 +147,12 @@ function FullWidthMenu({
 
   return (
     <div
-      className={`absolute top-full left-0 right-0 transition-all duration-[170ms] ease-out z-50 ${
+      className={cn(
+        "absolute top-full left-0 right-0 transition-all duration-[170ms] ease-out z-50",
         isOpen
           ? "opacity-100 translate-y-0 pointer-events-auto"
-          : "opacity-0 -translate-y-1 pointer-events-none"
-      }`}
+          : "opacity-0 -translate-y-1 pointer-events-none",
+      )}
       style={{
         background: C.bg,
         borderBottom: `1px solid ${C.border}`,
@@ -199,7 +201,7 @@ function MobileDropdown({
       >
         {label}
         <ChevronDownIcon
-          className={`w-3 h-3 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          className={cn("w-3 h-3 transition-transform duration-200", open && "rotate-180")}
           aria-hidden="true"
         />
       </button>
@@ -273,7 +275,7 @@ function MobileDropdown({
             return (
               <span
                 key={item.label}
-                className={`${itemClass} cursor-default`}
+                className={cn(itemClass, "cursor-default")}
                 aria-disabled="true"
                 {...itemHover}
               >
@@ -329,11 +331,12 @@ export function Navbar({
     <>
       {/* Backdrop */}
       <div
-        className={`fixed inset-0 top-14 z-40 transition-all duration-200 ${
+        className={cn(
+          "fixed inset-0 top-14 z-40 transition-all duration-200",
           activeMenu
             ? "opacity-100 pointer-events-auto"
-            : "opacity-0 pointer-events-none"
-        }`}
+            : "opacity-0 pointer-events-none",
+        )}
         style={{ background: "rgba(0,0,0,0.3)", backdropFilter: "blur(2px)" }}
         onClick={() => setActiveMenu(null)}
       />
@@ -394,7 +397,7 @@ export function Navbar({
               >
                 {label}
                 <ChevronDownIcon
-                  className={`w-3 h-3 transition-transform duration-200 ${activeMenu === id ? "rotate-180" : ""}`}
+                  className={cn("w-3 h-3 transition-transform duration-200", activeMenu === id && "rotate-180")}
                   aria-hidden="true"
                 />
               </button>
@@ -455,7 +458,7 @@ export function Navbar({
         {/* Mobile nav */}
         <div
           data-testid="mobile-nav"
-          className={`${mobileMenu ? "flex" : "hidden"} lg:hidden absolute top-14 left-0 right-0 flex-col gap-0.5 items-stretch p-3 border-b shadow-xl`}
+          className={cn(mobileMenu ? "flex" : "hidden", "lg:hidden absolute top-14 left-0 right-0 flex-col gap-0.5 items-stretch p-3 border-b shadow-xl")}
           style={{
             background: `${C.surface}f8`,
             backdropFilter: "blur(20px)",

--- a/ui/apps/website/src/pages/pricing/PricingFAQ.tsx
+++ b/ui/apps/website/src/pages/pricing/PricingFAQ.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { PlusIcon, MinusIcon } from "@heroicons/react/24/outline";
+import { cn } from "@shellhub/design-system/cn";
 import { Section, SectionHeader } from "@/components/marketing";
 import { Reveal } from "../landing/components";
 
@@ -59,9 +60,10 @@ function FAQItem({ q, a, index }: { q: string; a: string; index: number }) {
           )}
         </div>
         <div
-          className={`overflow-hidden transition-all duration-300 ${
-            open ? "max-h-40 opacity-100 mt-3" : "max-h-0 opacity-0"
-          }`}
+          className={cn(
+            "overflow-hidden transition-all duration-300",
+            open ? "max-h-40 opacity-100 mt-3" : "max-h-0 opacity-0",
+          )}
         >
           <p className="text-sm text-text-secondary leading-relaxed pr-8">
             {a}

--- a/ui/apps/website/src/pages/pricing/TierCards.tsx
+++ b/ui/apps/website/src/pages/pricing/TierCards.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { cn } from "@shellhub/design-system/cn";
 import { Button } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { Section } from "@/components/marketing";
@@ -77,11 +78,12 @@ export function TierCards() {
           <Reveal key={tier.name} delay={i * 0.08}>
             <ShimmerCard className="h-full">
               <div
-                className={`relative rounded-xl p-8 flex flex-col h-full transition-all duration-300 overflow-hidden ${
+                className={cn(
+                  "relative rounded-xl p-8 flex flex-col h-full transition-all duration-300 overflow-hidden",
                   tier.highlighted
                     ? "bg-card border border-primary/30 hover:border-primary/50 shadow-[0_0_40px_rgba(102,122,204,0.15)]"
-                    : "bg-card border border-border hover:border-border-light"
-                }`}
+                    : "bg-card border border-border hover:border-border-light",
+                )}
               >
                 {tier.highlighted && (
                   <GlowOrbs preset="corner" tone="primary" />
@@ -91,7 +93,7 @@ export function TierCards() {
                   <div className="flex items-center gap-3 mb-4">
                     <h3 className="text-lg font-bold">{tier.name}</h3>
                     <span
-                      className={`px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] border rounded-full ${tier.badgeClass}`}
+                      className={cn("px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] border rounded-full", tier.badgeClass)}
                     >
                       {tier.badge}
                     </span>

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { cn } from "@shellhub/design-system/cn";
 import {
   CheckIcon,
   ComputerDesktopIcon,
@@ -388,9 +389,10 @@ export default function RemoteSupport() {
                   {auditRows.map((row, i) => (
                     <div
                       key={i}
-                      className={`grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2.5 rounded-lg items-center ${
-                        i % 2 === 0 ? "bg-surface" : "bg-transparent"
-                      }`}
+                      className={cn(
+                        "grid grid-cols-[60px_1fr_1fr_1fr_70px] gap-2 px-3 py-2.5 rounded-lg items-center",
+                        i % 2 === 0 ? "bg-surface" : "bg-transparent",
+                      )}
                     >
                       <span className="text-2xs font-mono text-text-muted">
                         {row.time}

--- a/ui/packages/design-system/components/Reveal.tsx
+++ b/ui/packages/design-system/components/Reveal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { cn } from "../primitives/cn";
 
 function useReveal() {
   const ref = useRef<HTMLDivElement>(null);
@@ -18,7 +19,7 @@ function useReveal() {
 export function Reveal({ children, className = "", delay = 0 }: { children: React.ReactNode; className?: string; delay?: number }) {
   const ref = useReveal();
   return (
-    <div ref={ref} className={`landing-reveal ${className}`} style={delay ? { transitionDelay: `${delay}s` } : undefined}>
+    <div ref={ref} className={cn("landing-reveal", className)} style={delay ? { transitionDelay: `${delay}s` } : undefined}>
       {children}
     </div>
   );

--- a/ui/packages/design-system/components/ShimmerCard.tsx
+++ b/ui/packages/design-system/components/ShimmerCard.tsx
@@ -1,6 +1,8 @@
+import { cn } from "../primitives/cn";
+
 export function ShimmerCard({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (
-    <div className={`group relative ${className}`}>
+    <div className={cn("group relative", className)}>
       <div className="shimmer absolute inset-0 rounded-xl overflow-hidden opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none" />
       <div className="relative">{children}</div>
     </div>


### PR DESCRIPTION
## What

Consolidated all conditional `className` construction across console, website, and the design-system package to use the shared `cn()` utility (`clsx` + `tailwind-merge`), replacing ad-hoc patterns that lacked Tailwind class conflict resolution.

## Why

The codebase had four competing patterns for conditional classes: template literal ternaries, `[...].filter(Boolean).join(" ")`, bare `.join(" ")`, and a local naive `cn` in `utils/cn.ts` that only concatenated strings without `tailwind-merge`. Conflicting Tailwind classes (e.g. `text-sm` overridden by `text-xs`) were resolved by CSS source order rather than deterministically. The design-system already exported a proper `cn()` backed by `clsx` + `tailwind-merge` — it just wasn't used outside the DS primitives.

## Changes

- **`apps/console/src/utils/cn.ts`**: deleted. Its sole consumer (`DataTable.tsx`) now imports from `@shellhub/design-system/cn`
- **`packages/design-system/components/Reveal.tsx`, `ShimmerCard.tsx`**: migrated from template literal class concatenation to their own package's `cn`
- **93 files across console + website**: every `className={\`...\`}` with interpolation converted to `cn()`. Empty-string ternary branches (`cond ? "x" : ""`) simplified to `cond && "x"`. Complex multi-condition expressions extracted into named variables for readability
- **`SupportedPlatforms.tsx`** intentionally skipped — uses dynamic class construction (`bg-${p.color}/10`) which is a separate issue

## Testing

- `tsc --noEmit` passes for console, website, and design-system
- `npm run build` (console) passes clean
- `npm run lint` passes with 0 errors on both apps (pre-existing warnings only)
- No remaining `filter(Boolean).join`, `@/utils/cn` imports, or template literal `className` patterns (except `SupportedPlatforms.tsx`)