### PR TITLE
fix(ui): expose Drawer as an accessible modal dialog

### DIFF
--- a/ui/apps/console/src/components/common/Drawer.tsx
+++ b/ui/apps/console/src/components/common/Drawer.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useRef } from "react";
+import { ReactNode, useId, useRef } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
@@ -33,6 +33,7 @@ export default function Drawer({
   bodyClassName,
 }: DrawerProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const headingId = useId();
   useEscapeKey(onClose, open);
   useFocusTrap(panelRef, open);
 
@@ -46,6 +47,9 @@ export default function Drawer({
       />
       <div
         ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
         aria-hidden={!open}
         {...(!open ? { inert: true } : {})}
         className={`fixed inset-y-0 right-0 z-[70] w-full ${WIDTH_MAP[width]} bg-surface border-l border-border shadow-2xl flex flex-col transition-transform duration-300 ease-out ${
@@ -60,7 +64,10 @@ export default function Drawer({
               </div>
             )}
             <div>
-              <h2 className="text-base font-semibold text-text-primary">
+              <h2
+                id={headingId}
+                className="text-base font-semibold text-text-primary"
+              >
                 {title}
               </h2>
               {subtitle && (

--- a/ui/apps/console/src/components/common/__tests__/Drawer.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/Drawer.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Drawer from "@/components/common/Drawer";
+
+function renderDrawer(open = true) {
+  return render(
+    <Drawer open={open} onClose={vi.fn()} title="Edit device">
+      <p>Body</p>
+    </Drawer>,
+  );
+}
+
+describe("Drawer accessibility", () => {
+  it("exposes the panel as a modal dialog labelled by its title", () => {
+    renderDrawer();
+
+    const dialog = screen.getByRole("dialog", { name: "Edit device" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("associates aria-labelledby with the heading element via a matching id", () => {
+    renderDrawer();
+
+    const dialog = screen.getByRole("dialog");
+    const heading = screen.getByRole("heading", { name: "Edit device" });
+
+    expect(dialog.getAttribute("aria-labelledby")).toBe(heading.id);
+    expect(heading.id).not.toBe("");
+  });
+});


### PR DESCRIPTION
## What
The base `Drawer` component now exposes its panel as an accessible modal dialog — `role="dialog"`, `aria-modal="true"`, and an accessible name via `aria-labelledby`. This fixes accessibility for all 15+ drawers at once (MFA, connect, firewall rules, SSH keys, namespace edits, …).

## Why
`Drawer.tsx` rendered the panel as a plain `<div>`, so assistive tech saw no dialog role, no modal boundary, and no accessible name tying the panel to its title. Focus trapping and Escape-to-close were already implemented (`useFocusTrap` / `useEscapeKey`) — only the ARIA layer was missing.

Fixes shellhub-io/team#128

## Changes
- **Drawer.tsx**: added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` on the panel; added an `id` on the `<h2>` title. The id comes from React's `useId()` rather than a fixed string — closed drawers stay mounted behind `inert`, so a literal id would produce duplicate-id collisions and an ambiguous `aria-labelledby` when more than one drawer is in the DOM.
- **Drawer.test.tsx** (new): asserts the panel is reachable as `role="dialog"` with the title as its accessible name, and that `aria-labelledby` resolves to the heading's id.

## Testing
`npm run test` (console): 2622 pass, incl. the new Drawer test; `npm run build` (tsc) clean; eslint clean on the changed files. The two remaining eslint warnings are pre-existing, on the backdrop overlay div's click handler — unrelated to this change.
