### PR TITLE
refactor(api): unify namespace membership intake and carry a typed invite payload

### DIFF
--- a/api/services/invitation.go
+++ b/api/services/invitation.go
@@ -2,10 +2,7 @@ package services
 
 import (
 	"context"
-	"errors"
 	"net/url"
-	"strings"
-	"time"
 
 	"github.com/shellhub-io/shellhub/api/pkg/responses"
 	"github.com/shellhub-io/shellhub/api/store"
@@ -133,88 +130,15 @@ func (s *service) GenerateInvitationLink(ctx context.Context, req *requests.Gene
 		return "", NewErrRoleForbidden()
 	}
 
-	passiveUser, err := s.store.UserResolve(ctx, store.UserEmailResolver, strings.ToLower(req.MemberEmail))
-	userExists := err == nil
-	if err != nil {
-		if !errors.Is(err, store.ErrNoDocuments) {
-			return "", err
-		}
-
-		passiveUser = &models.User{}
-		passiveUser.ID, err = s.store.UserInvitationsUpsert(ctx, req.MemberEmail)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	if _, ok := namespace.FindMember(passiveUser.ID); ok {
-		return "", NewErrNamespaceMemberDuplicated(passiveUser.ID, nil)
-	}
-
-	// Direct membership links an existing account to the namespace right away — no cross-tenant
-	// consent step, no link to hand over. Enabled only where it's an internal org (enterprise);
-	// community/cloud keep the invitation/link flow. The empty return signals the caller that the
-	// member was added, not invited.
-	if userExists && directMembershipAllowed() {
-		member := &models.Member{ID: passiveUser.ID, AddedAt: clock.Now(), Role: req.MemberRole}
-
-		return "", s.store.NamespaceCreateMembership(ctx, req.TenantID, member)
-	}
-
-	invitation, err := s.store.MembershipInvitationResolve(ctx, req.TenantID, passiveUser.ID)
-	if err != nil && !errors.Is(err, store.ErrNoDocuments) {
-		return "", err
-	}
-
-	now := clock.Now()
-	expiresAt := now.Add(7 * (24 * time.Hour))
-
-	sig, err := pairingcode.New(pairingcode.InviteCodeLength)
+	invitation, err := s.intakeMembership(ctx, namespace, activeUser.ID, req.MemberEmail, req.MemberRole, req.ForwardedHost, req.ForwardedProto)
 	if err != nil {
 		return "", err
 	}
 
-	if invitation == nil || !invitation.IsPending() {
-		invitation = &models.MembershipInvitation{
-			TenantID:        req.TenantID,
-			UserID:          passiveUser.ID,
-			InvitedBy:       req.UserID,
-			Status:          models.MembershipInvitationStatusPending,
-			Role:            req.MemberRole,
-			ExpiresAt:       &expiresAt,
-			CreatedAt:       now,
-			UpdatedAt:       now,
-			StatusUpdatedAt: now,
-			Invitations:     1,
-			Sig:             sig,
-		}
-
-		if err := s.store.MembershipInvitationCreate(ctx, invitation); err != nil {
-			return "", err
-		}
-	} else {
-		if !invitation.IsExpired() {
-			return "", NewErrNamespaceMemberDuplicated(passiveUser.ID, nil)
-		}
-
-		invitation.Status = models.MembershipInvitationStatusPending
-		invitation.Role = req.MemberRole
-		invitation.ExpiresAt = &expiresAt
-		invitation.UpdatedAt = now
-		invitation.StatusUpdatedAt = now
-		invitation.Invitations++
-		invitation.Sig = sig
-
-		if err := s.store.MembershipInvitationUpdate(ctx, invitation); err != nil {
-			return "", err
-		}
-	}
-
-	// Post-commit: deliver the invitation email (cloud only; a no-op where no delivery hook is
-	// registered). Non-fatal — the admin still gets the link back, so a delivery failure is
-	// logged but doesn't fail the request.
-	if err := fireMembershipInvited(ctx, invitation, req.ForwardedHost, req.ForwardedProto); err != nil {
-		log.WithError(err).WithField("tenant-id", req.TenantID).Warn("failed to deliver membership invitation")
+	// Direct membership added the account right away — no invitation, no link to hand over. The
+	// empty return signals the caller that the member was added, not invited.
+	if invitation == nil {
+		return "", nil
 	}
 
 	return buildInviteURL(req.ForwardedProto, req.ForwardedHost, invitation.Sig), nil

--- a/api/services/invitation_test.go
+++ b/api/services/invitation_test.go
@@ -313,6 +313,8 @@ func TestService_GenerateInvitationLink(t *testing.T) {
 						TenantID: "tenant",
 						Members:  []models.Member{owner, {ID: "invitee", Role: authorizer.RoleObserver}},
 					}, nil).Once()
+				storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
+					Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
 				storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").
 					Return(&models.User{ID: "invitee"}, nil).Once()
 			},
@@ -323,6 +325,8 @@ func TestService_GenerateInvitationLink(t *testing.T) {
 			requiredMocks: func() {
 				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "tenant").
 					Return(namespace, nil).Once()
+				storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
+					Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
 				storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").
 					Return(&models.User{ID: "invitee"}, nil).Once()
 				storeMock.On("MembershipInvitationResolve", ctx, "tenant", "invitee").
@@ -337,6 +341,8 @@ func TestService_GenerateInvitationLink(t *testing.T) {
 			requiredMocks: func() {
 				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "tenant").
 					Return(namespace, nil).Once()
+				storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
+					Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
 				storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").
 					Return(nil, store.ErrNoDocuments).Once()
 				storeMock.On("UserInvitationsUpsert", ctx, "invitee@test.com").
@@ -349,11 +355,35 @@ func TestService_GenerateInvitationLink(t *testing.T) {
 			expected: Expected{true, nil},
 		},
 		{
+			description: "resends an expired invitation and returns a fresh link",
+			requiredMocks: func() {
+				expired := now.Add(-time.Hour)
+				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "tenant").
+					Return(namespace, nil).Once()
+				storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
+					Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
+				storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").
+					Return(&models.User{ID: "invitee"}, nil).Once()
+				storeMock.On("MembershipInvitationResolve", ctx, "tenant", "invitee").
+					Return(&models.MembershipInvitation{
+						TenantID:  "tenant",
+						UserID:    "invitee",
+						Status:    models.MembershipInvitationStatusPending,
+						ExpiresAt: &expired,
+					}, nil).Once()
+				storeMock.On("MembershipInvitationUpdate", ctx, mock.AnythingOfType("*models.MembershipInvitation")).
+					Return(nil).Once()
+			},
+			expected: Expected{true, nil},
+		},
+		{
 			description:      "adds an existing account directly and returns no link when direct membership is on (enterprise)",
 			directMembership: true,
 			requiredMocks: func() {
 				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "tenant").
 					Return(namespace, nil).Once()
+				storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
+					Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
 				storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").
 					Return(&models.User{ID: "invitee"}, nil).Once()
 				storeMock.On("NamespaceCreateMembership", ctx, "tenant", &models.Member{

--- a/api/services/member.go
+++ b/api/services/member.go
@@ -74,14 +74,34 @@ func (s *service) AddNamespaceMember(ctx context.Context, req *requests.Namespac
 		return nil, NewErrRoleForbidden()
 	}
 
-	// Base invitation flow (all editions). An existing account is either added directly
-	// (enterprise, internal org) or invited for consent; a brand-new email gets a placeholder
-	// user_invitation and a pending membership invitation. Email delivery and the approval gate
-	// are edition add-ons applied elsewhere (post-commit hook / registration completion).
-	var invitation *models.MembershipInvitation
+	if _, err := s.intakeMembership(ctx, namespace, active.ID, req.MemberEmail, req.MemberRole, req.ForwardedHost, req.ForwardedProto); err != nil {
+		return nil, err
+	}
+
+	return s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+}
+
+// intakeMembership is the single membership-intake flow shared by AddNamespaceMember and
+// GenerateInvitationLink: given the already-resolved namespace, the acting member's ID, the invited
+// email, the role, and the forwarded host/proto, it resolves-or-upserts the placeholder account,
+// rejects duplicates, short-circuits to direct membership where enabled (enterprise), and creates
+// or resends the pending invitation. The invited email is always lowercased and the whole write runs
+// in one transaction, so both entry points behave identically.
+//
+// It returns the resulting invitation, or nil when direct membership was applied and no invitation
+// is needed. On the invitation path it assembles the typed notification (signature, expiry,
+// recipient email + name, forwarded proto + host) and fires the post-commit delivery hook; delivery
+// is non-fatal — the invite is durable, so a failure is logged but does not fail the call.
+func (s *service) intakeMembership(ctx context.Context, namespace *models.Namespace, invitedBy, email string, role authorizer.Role, forwardedHost, forwardedProto string) (*models.MembershipInvitation, error) {
+	email = strings.ToLower(email)
+
+	var (
+		invitation    *models.MembershipInvitation
+		recipientName string
+	)
 
 	if err := s.store.WithTransaction(ctx, func(ctx context.Context) error {
-		passiveUser, err := s.store.UserResolve(ctx, store.UserEmailResolver, strings.ToLower(req.MemberEmail))
+		passiveUser, err := s.store.UserResolve(ctx, store.UserEmailResolver, email)
 		userExists := err == nil
 		if err != nil {
 			if !errors.Is(err, store.ErrNoDocuments) {
@@ -89,35 +109,37 @@ func (s *service) AddNamespaceMember(ctx context.Context, req *requests.Namespac
 			}
 
 			passiveUser = &models.User{}
-			passiveUser.ID, err = s.store.UserInvitationsUpsert(ctx, strings.ToLower(req.MemberEmail))
+			passiveUser.ID, err = s.store.UserInvitationsUpsert(ctx, email)
 			if err != nil {
 				return err
 			}
 		}
+
+		recipientName = passiveUser.Name
 
 		if _, ok := namespace.FindMember(passiveUser.ID); ok {
 			return NewErrNamespaceMemberDuplicated(passiveUser.ID, nil)
 		}
 
 		if userExists && directMembershipAllowed() {
-			member := &models.Member{ID: passiveUser.ID, AddedAt: clock.Now(), Role: req.MemberRole}
+			member := &models.Member{ID: passiveUser.ID, AddedAt: clock.Now(), Role: role}
 
-			return s.store.NamespaceCreateMembership(ctx, req.TenantID, member)
+			return s.store.NamespaceCreateMembership(ctx, namespace.TenantID, member)
 		}
 
-		existing, err := s.store.MembershipInvitationResolve(ctx, req.TenantID, passiveUser.ID)
+		existing, err := s.store.MembershipInvitationResolve(ctx, namespace.TenantID, passiveUser.ID)
 		if err != nil && !errors.Is(err, store.ErrNoDocuments) {
 			return err
 		}
 
 		switch {
 		case existing == nil, !existing.IsPending():
-			inv, err := s.createMembershipInvitation(ctx, req, passiveUser.ID)
+			inv, err := s.createMembershipInvitation(ctx, namespace.TenantID, invitedBy, passiveUser.ID, role)
 			invitation = inv
 
 			return err
 		case existing.IsExpired():
-			if err := s.resendMembershipInvitation(ctx, existing, req); err != nil {
+			if err := s.resendMembershipInvitation(ctx, existing, role); err != nil {
 				return err
 			}
 			invitation = existing
@@ -130,20 +152,27 @@ func (s *service) AddNamespaceMember(ctx context.Context, req *requests.Namespac
 		return nil, err
 	}
 
-	// Post-commit: deliver the invitation (email on cloud). Non-fatal — the invite is durable,
-	// so a delivery failure is logged but doesn't fail the add.
 	if invitation != nil {
-		if err := fireMembershipInvited(ctx, invitation, req.FowardedHost, req.ForwardedProto); err != nil {
-			log.WithError(err).WithField("tenant-id", req.TenantID).Warn("failed to deliver membership invitation")
+		notification := &models.MembershipInvitationNotification{
+			Signature:      invitation.Sig,
+			ExpiresAt:      *invitation.ExpiresAt,
+			RecipientEmail: email,
+			RecipientName:  recipientName,
+			ForwardedProto: forwardedProto,
+			ForwardedHost:  forwardedHost,
+		}
+
+		if err := fireMembershipInvited(ctx, notification); err != nil {
+			log.WithError(err).WithField("tenant-id", namespace.TenantID).Warn("failed to deliver membership invitation")
 		}
 	}
 
-	return s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+	return invitation, nil
 }
 
 // createMembershipInvitation persists a fresh pending invitation with a one-time signature and a
 // 7-day expiry. The signature is generated here so the link is usable even when no email is sent.
-func (s *service) createMembershipInvitation(ctx context.Context, req *requests.NamespaceAddMember, userID string) (*models.MembershipInvitation, error) {
+func (s *service) createMembershipInvitation(ctx context.Context, tenantID, invitedBy, userID string, role authorizer.Role) (*models.MembershipInvitation, error) {
 	now := clock.Now()
 	expiresAt := now.Add(7 * 24 * time.Hour)
 
@@ -153,10 +182,10 @@ func (s *service) createMembershipInvitation(ctx context.Context, req *requests.
 	}
 
 	invitation := &models.MembershipInvitation{
-		TenantID:        req.TenantID,
+		TenantID:        tenantID,
 		UserID:          userID,
-		InvitedBy:       req.UserID,
-		Role:            req.MemberRole,
+		InvitedBy:       invitedBy,
+		Role:            role,
 		Status:          models.MembershipInvitationStatusPending,
 		ExpiresAt:       &expiresAt,
 		CreatedAt:       now,
@@ -175,7 +204,7 @@ func (s *service) createMembershipInvitation(ctx context.Context, req *requests.
 
 // resendMembershipInvitation refreshes an expired invitation with a new signature and expiry. The
 // previous link stops resolving.
-func (s *service) resendMembershipInvitation(ctx context.Context, invitation *models.MembershipInvitation, req *requests.NamespaceAddMember) error {
+func (s *service) resendMembershipInvitation(ctx context.Context, invitation *models.MembershipInvitation, role authorizer.Role) error {
 	now := clock.Now()
 	expiresAt := now.Add(7 * 24 * time.Hour)
 
@@ -185,7 +214,7 @@ func (s *service) resendMembershipInvitation(ctx context.Context, invitation *mo
 	}
 
 	invitation.Status = models.MembershipInvitationStatusPending
-	invitation.Role = req.MemberRole
+	invitation.Role = role
 	invitation.ExpiresAt = &expiresAt
 	invitation.UpdatedAt = now
 	invitation.StatusUpdatedAt = now

--- a/api/services/member_hooks.go
+++ b/api/services/member_hooks.go
@@ -8,10 +8,11 @@ import (
 )
 
 // MembershipInvitedHookFn is called after a membership invitation is created or refreshed and
-// the transaction has committed. It receives the durable invitation (with its Sig and ExpiresAt).
-// Cloud uses it to deliver the invitation email; the hook runs outside the DB transaction, so a
-// delivery failure never rolls back the (successful) invite.
-type MembershipInvitedHookFn func(ctx context.Context, invitation *models.MembershipInvitation, forwardedHost, forwardedProto string) error
+// the transaction has committed. It receives the fully-populated notification (invitation
+// signature, expiry, recipient email + name, forwarded proto + host) — everything the email
+// needs, assembled by the intake flow. Cloud uses it to deliver the invitation email; the hook
+// runs outside the DB transaction, so a delivery failure never rolls back the (successful) invite.
+type MembershipInvitedHookFn func(ctx context.Context, notification *models.MembershipInvitationNotification) error
 
 var membershipInvitedHooks []MembershipInvitedHookFn
 
@@ -25,12 +26,12 @@ func OnMembershipInvited(fn MembershipInvitedHookFn) {
 	membershipInvitedHooks = append(membershipInvitedHooks, fn)
 }
 
-// fireMembershipInvited dispatches all registered post-invite hooks sequentially. forwardedHost and
-// forwardedProto come from the request and are used to build the emailed link. Errors are returned
-// to the caller, which logs them without failing the request (the invite is durable).
-func fireMembershipInvited(ctx context.Context, invitation *models.MembershipInvitation, forwardedHost, forwardedProto string) error {
+// fireMembershipInvited dispatches all registered post-invite hooks sequentially, passing the typed
+// notification assembled by the intake flow. Errors are returned to the caller, which logs them
+// without failing the request (the invite is durable).
+func fireMembershipInvited(ctx context.Context, notification *models.MembershipInvitationNotification) error {
 	for _, fn := range membershipInvitedHooks {
-		if err := fn(ctx, invitation, forwardedHost, forwardedProto); err != nil {
+		if err := fn(ctx, notification); err != nil {
 			return fmt.Errorf("membership invited hook failed: %w", err)
 		}
 	}

--- a/api/services/member_hooks_test.go
+++ b/api/services/member_hooks_test.go
@@ -23,7 +23,7 @@ func TestOnMembershipInvited(t *testing.T) {
 		membershipInvitedHooks = nil
 
 		called := false
-		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitation, _, _ string) error {
+		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitationNotification) error {
 			called = true
 
 			return nil
@@ -31,7 +31,7 @@ func TestOnMembershipInvited(t *testing.T) {
 
 		require.Len(t, membershipInvitedHooks, 1)
 
-		err := membershipInvitedHooks[0](context.Background(), nil, "", "")
+		err := membershipInvitedHooks[0](context.Background(), nil)
 		assert.NoError(t, err)
 		assert.True(t, called)
 	})
@@ -41,12 +41,15 @@ func TestFireMembershipInvited(t *testing.T) {
 	original := membershipInvitedHooks
 	t.Cleanup(func() { membershipInvitedHooks = original })
 
-	inv := &models.MembershipInvitation{TenantID: "tenant", Sig: "ABCDEF123456"}
+	notification := &models.MembershipInvitationNotification{
+		Signature:      "ABCDEF123456",
+		RecipientEmail: "invitee@test.com",
+	}
 
 	t.Run("no hooks registered", func(t *testing.T) {
 		membershipInvitedHooks = nil
 
-		err := fireMembershipInvited(context.Background(), inv, "", "")
+		err := fireMembershipInvited(context.Background(), notification)
 		assert.NoError(t, err)
 	})
 
@@ -54,14 +57,14 @@ func TestFireMembershipInvited(t *testing.T) {
 		membershipInvitedHooks = nil
 
 		called := false
-		OnMembershipInvited(func(_ context.Context, got *models.MembershipInvitation, _, _ string) error {
+		OnMembershipInvited(func(_ context.Context, got *models.MembershipInvitationNotification) error {
 			called = true
-			assert.Equal(t, inv, got)
+			assert.Equal(t, notification, got)
 
 			return nil
 		})
 
-		err := fireMembershipInvited(context.Background(), inv, "", "")
+		err := fireMembershipInvited(context.Background(), notification)
 		assert.NoError(t, err)
 		assert.True(t, called)
 	})
@@ -70,18 +73,18 @@ func TestFireMembershipInvited(t *testing.T) {
 		membershipInvitedHooks = nil
 
 		errHook := errors.New("hook failed")
-		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitation, _, _ string) error {
+		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitationNotification) error {
 			return errHook
 		})
 
 		secondCalled := false
-		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitation, _, _ string) error {
+		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitationNotification) error {
 			secondCalled = true
 
 			return nil
 		})
 
-		err := fireMembershipInvited(context.Background(), inv, "", "")
+		err := fireMembershipInvited(context.Background(), notification)
 		assert.ErrorIs(t, err, errHook)
 		assert.False(t, secondCalled)
 	})
@@ -90,18 +93,18 @@ func TestFireMembershipInvited(t *testing.T) {
 		membershipInvitedHooks = nil
 
 		var order []int
-		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitation, _, _ string) error {
+		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitationNotification) error {
 			order = append(order, 1)
 
 			return nil
 		})
-		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitation, _, _ string) error {
+		OnMembershipInvited(func(_ context.Context, _ *models.MembershipInvitationNotification) error {
 			order = append(order, 2)
 
 			return nil
 		})
 
-		err := fireMembershipInvited(context.Background(), inv, "", "")
+		err := fireMembershipInvited(context.Background(), notification)
 		assert.NoError(t, err)
 		assert.Equal(t, []int{1, 2}, order)
 	})

--- a/api/services/member_test.go
+++ b/api/services/member_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestService_AddNamespaceMember(t *testing.T) {
@@ -38,11 +39,11 @@ func TestService_AddNamespaceMember(t *testing.T) {
 		{
 			description: "fails when the namespace was not found",
 			req: &requests.NamespaceAddMember{
-				FowardedHost: "localhost",
-				UserID:       "000000000000000000000000",
-				TenantID:     "00000000-0000-4000-0000-000000000000",
-				MemberEmail:  "john.doe@test.com",
-				MemberRole:   authorizer.RoleObserver,
+				ForwardedHost: "localhost",
+				UserID:        "000000000000000000000000",
+				TenantID:      "00000000-0000-4000-0000-000000000000",
+				MemberEmail:   "john.doe@test.com",
+				MemberRole:    authorizer.RoleObserver,
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
@@ -58,11 +59,11 @@ func TestService_AddNamespaceMember(t *testing.T) {
 		{
 			description: "fails when the active member was not found",
 			req: &requests.NamespaceAddMember{
-				FowardedHost: "localhost",
-				UserID:       "000000000000000000000000",
-				TenantID:     "00000000-0000-4000-0000-000000000000",
-				MemberEmail:  "john.doe@test.com",
-				MemberRole:   authorizer.RoleObserver,
+				ForwardedHost: "localhost",
+				UserID:        "000000000000000000000000",
+				TenantID:      "00000000-0000-4000-0000-000000000000",
+				MemberEmail:   "john.doe@test.com",
+				MemberRole:    authorizer.RoleObserver,
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
@@ -87,11 +88,11 @@ func TestService_AddNamespaceMember(t *testing.T) {
 		{
 			description: "fails when the active member is not on the namespace",
 			req: &requests.NamespaceAddMember{
-				FowardedHost: "localhost",
-				UserID:       "000000000000000000000000",
-				TenantID:     "00000000-0000-4000-0000-000000000000",
-				MemberEmail:  "john.doe@test.com",
-				MemberRole:   authorizer.RoleObserver,
+				ForwardedHost: "localhost",
+				UserID:        "000000000000000000000000",
+				TenantID:      "00000000-0000-4000-0000-000000000000",
+				MemberEmail:   "john.doe@test.com",
+				MemberRole:    authorizer.RoleObserver,
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
@@ -119,11 +120,11 @@ func TestService_AddNamespaceMember(t *testing.T) {
 		{
 			description: "fails when the passive role is owner",
 			req: &requests.NamespaceAddMember{
-				FowardedHost: "localhost",
-				UserID:       "000000000000000000000000",
-				TenantID:     "00000000-0000-4000-0000-000000000000",
-				MemberEmail:  "john.doe@test.com",
-				MemberRole:   authorizer.RoleOwner,
+				ForwardedHost: "localhost",
+				UserID:        "000000000000000000000000",
+				TenantID:      "00000000-0000-4000-0000-000000000000",
+				MemberEmail:   "john.doe@test.com",
+				MemberRole:    authorizer.RoleOwner,
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
@@ -156,11 +157,11 @@ func TestService_AddNamespaceMember(t *testing.T) {
 		{
 			description: "fails when the active member's role cannot act over passive member's role",
 			req: &requests.NamespaceAddMember{
-				FowardedHost: "localhost",
-				UserID:       "000000000000000000000000",
-				TenantID:     "00000000-0000-4000-0000-000000000000",
-				MemberEmail:  "john.doe@test.com",
-				MemberRole:   authorizer.RoleAdministrator,
+				ForwardedHost: "localhost",
+				UserID:        "000000000000000000000000",
+				TenantID:      "00000000-0000-4000-0000-000000000000",
+				MemberEmail:   "john.doe@test.com",
+				MemberRole:    authorizer.RoleAdministrator,
 			},
 			requiredMocks: func(ctx context.Context) {
 				storeMock.
@@ -193,11 +194,11 @@ func TestService_AddNamespaceMember(t *testing.T) {
 		{
 			description: "succeeds inviting a brand-new email via the invitation flow",
 			req: &requests.NamespaceAddMember{
-				FowardedHost: "localhost",
-				UserID:       "000000000000000000000000",
-				TenantID:     "00000000-0000-4000-0000-000000000000",
-				MemberEmail:  "john.doe@test.com",
-				MemberRole:   authorizer.RoleObserver,
+				ForwardedHost: "localhost",
+				UserID:        "000000000000000000000000",
+				TenantID:      "00000000-0000-4000-0000-000000000000",
+				MemberEmail:   "john.doe@test.com",
+				MemberRole:    authorizer.RoleObserver,
 			},
 			requiredMocks: func(ctx context.Context) {
 				ns := &models.Namespace{
@@ -1797,5 +1798,160 @@ func TestService_LeaveNamespace(t *testing.T) {
 		})
 	}
 
+	storeMock.AssertExpectations(t)
+}
+
+// TestService_AddNamespaceMember_LowercasesEmail pins that the intake flow lowercases the invited
+// email before both the account lookup and the placeholder upsert, so inviting the same person in
+// different letter-casing never produces a second placeholder account.
+func TestService_AddNamespaceMember_LowercasesEmail(t *testing.T) {
+	storeMock := storemock.NewMockStore(t)
+	ctx := context.TODO()
+	now := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	mockClockNow(t, now)
+
+	ns := &models.Namespace{
+		TenantID: "00000000-0000-4000-0000-000000000000",
+		Owner:    "000000000000000000000000",
+		Members:  []models.Member{{ID: "000000000000000000000000", Role: authorizer.RoleOwner}},
+	}
+
+	storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, ns.TenantID).Return(ns, nil).Twice()
+	storeMock.On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+		Return(&models.User{ID: "000000000000000000000000"}, nil).Once()
+	storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
+		Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
+	storeMock.On("UserResolve", ctx, store.UserEmailResolver, "jane@test.com").
+		Return(nil, store.ErrNoDocuments).Once()
+	storeMock.On("UserInvitationsUpsert", ctx, "jane@test.com").Return("placeholder", nil).Once()
+	storeMock.On("MembershipInvitationResolve", ctx, ns.TenantID, "placeholder").Return(nil, store.ErrNoDocuments).Once()
+	storeMock.On("MembershipInvitationCreate", ctx, mock.AnythingOfType("*models.MembershipInvitation")).Return(nil).Once()
+
+	s := NewService(store.Store(storeMock), privateKey, publicKey, storecache.NewNullCache(), clientMock)
+	_, err := s.AddNamespaceMember(ctx, &requests.NamespaceAddMember{
+		ForwardedHost: "localhost",
+		UserID:        "000000000000000000000000",
+		TenantID:      ns.TenantID,
+		MemberEmail:   "Jane@Test.com",
+		MemberRole:    authorizer.RoleObserver,
+	})
+
+	assert.NoError(t, err)
+	storeMock.AssertExpectations(t)
+}
+
+// TestService_AddNamespaceMember_FiresNotification pins that the post-commit hook receives a
+// fully-populated notification assembled from the resolved invitee, the created invitation, and the
+// request — the whole reason the worker no longer needs to reload anything.
+func TestService_AddNamespaceMember_FiresNotification(t *testing.T) {
+	original := membershipInvitedHooks
+	t.Cleanup(func() { membershipInvitedHooks = original })
+	membershipInvitedHooks = nil
+
+	storeMock := storemock.NewMockStore(t)
+	ctx := context.TODO()
+	now := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	mockClockNow(t, now)
+
+	ns := &models.Namespace{
+		TenantID: "00000000-0000-4000-0000-000000000000",
+		Owner:    "000000000000000000000000",
+		Members:  []models.Member{{ID: "000000000000000000000000", Role: authorizer.RoleOwner}},
+	}
+
+	storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, ns.TenantID).Return(ns, nil).Twice()
+	storeMock.On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+		Return(&models.User{ID: "000000000000000000000000"}, nil).Once()
+	storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
+		Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
+	storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").
+		Return(&models.User{ID: "invitee", UserData: models.UserData{Name: "Invitee Person", Email: "invitee@test.com"}}, nil).Once()
+	storeMock.On("MembershipInvitationResolve", ctx, ns.TenantID, "invitee").Return(nil, store.ErrNoDocuments).Once()
+
+	var created *models.MembershipInvitation
+	storeMock.On("MembershipInvitationCreate", ctx, mock.AnythingOfType("*models.MembershipInvitation")).
+		Run(func(args mock.Arguments) { created = args.Get(1).(*models.MembershipInvitation) }).
+		Return(nil).Once()
+
+	var got *models.MembershipInvitationNotification
+	OnMembershipInvited(func(_ context.Context, n *models.MembershipInvitationNotification) error {
+		got = n
+
+		return nil
+	})
+
+	s := NewService(store.Store(storeMock), privateKey, publicKey, storecache.NewNullCache(), clientMock)
+	_, err := s.AddNamespaceMember(ctx, &requests.NamespaceAddMember{
+		ForwardedHost:  "localhost",
+		ForwardedProto: "https",
+		UserID:         "000000000000000000000000",
+		TenantID:       ns.TenantID,
+		MemberEmail:    "Invitee@Test.com",
+		MemberRole:     authorizer.RoleObserver,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, created)
+	assert.Equal(t, "invitee@test.com", got.RecipientEmail)
+	assert.Equal(t, "Invitee Person", got.RecipientName)
+	assert.Equal(t, "https", got.ForwardedProto)
+	assert.Equal(t, "localhost", got.ForwardedHost)
+	assert.Equal(t, now.Add(7*24*time.Hour), got.ExpiresAt)
+	assert.Equal(t, created.Sig, got.Signature)
+	assert.NotEmpty(t, got.Signature)
+}
+
+// TestService_AddNamespaceMember_DirectMembershipFiresNoHook pins the direct-membership
+// short-circuit: an existing account is added straight to the namespace, no invitation is created,
+// and no delivery hook fires.
+func TestService_AddNamespaceMember_DirectMembershipFiresNoHook(t *testing.T) {
+	original := membershipInvitedHooks
+	t.Cleanup(func() { membershipInvitedHooks = original })
+	membershipInvitedHooks = nil
+
+	directMembershipEnabled = true
+	t.Cleanup(func() { directMembershipEnabled = false })
+
+	storeMock := storemock.NewMockStore(t)
+	ctx := context.TODO()
+	now := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	mockClockNow(t, now)
+
+	ns := &models.Namespace{
+		TenantID: "00000000-0000-4000-0000-000000000000",
+		Owner:    "000000000000000000000000",
+		Members:  []models.Member{{ID: "000000000000000000000000", Role: authorizer.RoleOwner}},
+	}
+
+	storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, ns.TenantID).Return(ns, nil).Twice()
+	storeMock.On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
+		Return(&models.User{ID: "000000000000000000000000"}, nil).Once()
+	storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
+		Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
+	storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").
+		Return(&models.User{ID: "invitee"}, nil).Once()
+	storeMock.On("NamespaceCreateMembership", ctx, ns.TenantID, &models.Member{
+		ID: "invitee", AddedAt: now, Role: authorizer.RoleObserver,
+	}).Return(nil).Once()
+
+	hookCalled := false
+	OnMembershipInvited(func(context.Context, *models.MembershipInvitationNotification) error {
+		hookCalled = true
+
+		return nil
+	})
+
+	s := NewService(store.Store(storeMock), privateKey, publicKey, storecache.NewNullCache(), clientMock)
+	_, err := s.AddNamespaceMember(ctx, &requests.NamespaceAddMember{
+		ForwardedHost: "localhost",
+		UserID:        "000000000000000000000000",
+		TenantID:      ns.TenantID,
+		MemberEmail:   "invitee@test.com",
+		MemberRole:    authorizer.RoleObserver,
+	})
+
+	assert.NoError(t, err)
+	assert.False(t, hookCalled)
 	storeMock.AssertExpectations(t)
 }

--- a/pkg/api/internalclient/mocks/mock_client.go
+++ b/pkg/api/internalclient/mocks/mock_client.go
@@ -825,16 +825,16 @@ func (_c *MockClient_GetPublicKey_Call) RunAndReturn(run func(ctx context.Contex
 }
 
 // InviteMember provides a mock function for the type MockClient
-func (_mock *MockClient) InviteMember(ctx context.Context, tenantID string, userID string, forwardedHost string, forwardedProto string) error {
-	ret := _mock.Called(ctx, tenantID, userID, forwardedHost, forwardedProto)
+func (_mock *MockClient) InviteMember(ctx context.Context, notification *models.MembershipInvitationNotification) error {
+	ret := _mock.Called(ctx, notification)
 
 	if len(ret) == 0 {
 		panic("no return value specified for InviteMember")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
-		r0 = returnFunc(ctx, tenantID, userID, forwardedHost, forwardedProto)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *models.MembershipInvitationNotification) error); ok {
+		r0 = returnFunc(ctx, notification)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -848,42 +848,24 @@ type MockClient_InviteMember_Call struct {
 
 // InviteMember is a helper method to define mock.On call
 //   - ctx context.Context
-//   - tenantID string
-//   - userID string
-//   - forwardedHost string
-//   - forwardedProto string
-func (_e *MockClient_Expecter) InviteMember(ctx any, tenantID any, userID any, forwardedHost any, forwardedProto any) *MockClient_InviteMember_Call {
-	return &MockClient_InviteMember_Call{Call: _e.mock.On("InviteMember", ctx, tenantID, userID, forwardedHost, forwardedProto)}
+//   - notification *models.MembershipInvitationNotification
+func (_e *MockClient_Expecter) InviteMember(ctx any, notification any) *MockClient_InviteMember_Call {
+	return &MockClient_InviteMember_Call{Call: _e.mock.On("InviteMember", ctx, notification)}
 }
 
-func (_c *MockClient_InviteMember_Call) Run(run func(ctx context.Context, tenantID string, userID string, forwardedHost string, forwardedProto string)) *MockClient_InviteMember_Call {
+func (_c *MockClient_InviteMember_Call) Run(run func(ctx context.Context, notification *models.MembershipInvitationNotification)) *MockClient_InviteMember_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 *models.MembershipInvitationNotification
 		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 string
-		if args[3] != nil {
-			arg3 = args[3].(string)
-		}
-		var arg4 string
-		if args[4] != nil {
-			arg4 = args[4].(string)
+			arg1 = args[1].(*models.MembershipInvitationNotification)
 		}
 		run(
 			arg0,
 			arg1,
-			arg2,
-			arg3,
-			arg4,
 		)
 	})
 	return _c
@@ -894,7 +876,7 @@ func (_c *MockClient_InviteMember_Call) Return(err error) *MockClient_InviteMemb
 	return _c
 }
 
-func (_c *MockClient_InviteMember_Call) RunAndReturn(run func(ctx context.Context, tenantID string, userID string, forwardedHost string, forwardedProto string) error) *MockClient_InviteMember_Call {
+func (_c *MockClient_InviteMember_Call) RunAndReturn(run func(ctx context.Context, notification *models.MembershipInvitationNotification) error) *MockClient_InviteMember_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/api/internalclient/namespace.go
+++ b/pkg/api/internalclient/namespace.go
@@ -2,6 +2,7 @@ package internalclient
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/pkg/worker"
@@ -12,10 +13,11 @@ type namespaceAPI interface {
 	// NamespaceLookup retrieves namespace with the specified tenant.
 	// It returns the namespace and any encountered errors.
 	NamespaceLookup(ctx context.Context, tenant string) (*models.Namespace, error)
-	// InviteMember sends an invitation to join the namespace with the specified tenant ID to the
-	// user with the specified id. The job uses the forwarded host and proto to build the invitation
-	// link. It returns an error if any and panics if the Client has no worker available.
-	InviteMember(ctx context.Context, tenantID, userID, forwardedHost, forwardedProto string) error
+	// InviteMember enqueues the invitation-email job carrying the typed notification (signature,
+	// expiry, recipient email + name, forwarded proto + host). The worker renders and sends the
+	// email from this payload alone. It returns an error if any and panics if the Client has no
+	// worker available.
+	InviteMember(ctx context.Context, notification *models.MembershipInvitationNotification) error
 }
 
 func (c *client) NamespaceLookup(ctx context.Context, tenant string) (*models.Namespace, error) {
@@ -34,10 +36,13 @@ func (c *client) NamespaceLookup(ctx context.Context, tenant string) (*models.Na
 	return namespace, nil
 }
 
-func (c *client) InviteMember(ctx context.Context, tenantID, userID, forwardedHost, forwardedProto string) error {
+func (c *client) InviteMember(ctx context.Context, notification *models.MembershipInvitationNotification) error {
 	c.mustWorker()
 
-	// Payload is proto-before-host so the worker can split on ":" without a host:port ambiguity
-	// (tenant/user are UUIDs and proto has no colon, while the host is taken as the remainder).
-	return c.worker.Submit(ctx, worker.TaskPattern("cloud-api:invites"), []byte(tenantID+":"+userID+":"+forwardedProto+":"+forwardedHost))
+	payload, err := json.Marshal(notification)
+	if err != nil {
+		return err
+	}
+
+	return c.worker.Submit(ctx, worker.TaskPattern("cloud-api:invites"), payload)
 }

--- a/pkg/api/requests/invitation.go
+++ b/pkg/api/requests/invitation.go
@@ -14,7 +14,7 @@ type ResolveInvitation struct {
 type GenerateInvitationLink struct {
 	ForwardedHost  string          `header:"X-Forwarded-Host" validate:"required"`
 	ForwardedProto string          `header:"X-Forwarded-Proto"`
-	TenantID       string          `param:"tenant" validate:"required"`
+	TenantID       string          `param:"tenant" validate:"required,uuid"`
 	UserID         string          `header:"X-ID" validate:"required"`
 	MemberEmail    string          `json:"email" validate:"required"`
 	MemberRole     authorizer.Role `json:"role" validate:"required,member_role"`

--- a/pkg/api/requests/namespace.go
+++ b/pkg/api/requests/namespace.go
@@ -66,7 +66,7 @@ type NamespaceEdit struct {
 }
 
 type NamespaceAddMember struct {
-	FowardedHost   string          `header:"X-Forwarded-Host" validate:"required"`
+	ForwardedHost  string          `header:"X-Forwarded-Host" validate:"required"`
 	ForwardedProto string          `header:"X-Forwarded-Proto"`
 	UserID         string          `header:"X-ID" validate:"required"`
 	TenantID       string          `param:"tenant" validate:"required,uuid"`

--- a/pkg/models/membership_invitation.go
+++ b/pkg/models/membership_invitation.go
@@ -45,3 +45,28 @@ func (m MembershipInvitation) IsExpired() bool {
 func (m MembershipInvitation) IsPending() bool {
 	return m.Status == MembershipInvitationStatusPending
 }
+
+// MembershipInvitationNotification is the typed, email-relevant snapshot of a membership
+// invitation event. It is assembled once by the membership-intake flow and carried — via the
+// OnMembershipInvited hook and the internal client — to the worker that renders and sends the
+// invitation email, which reads it without a single store round-trip.
+//
+// It is the single contract across the shellhub↔cloud seam: JSON-encoded over the worker's
+// []byte transport, replacing the former positional colon-delimited string. It deliberately
+// carries only what the email template consumes — not the role or namespace name, which the
+// template uses neither of.
+type MembershipInvitationNotification struct {
+	// Signature is the invitation's one-time signature; the accept-invite link is keyed by it.
+	Signature string `json:"signature"`
+	// ExpiresAt is when the invitation stops resolving, shown to the recipient as the link expiry.
+	ExpiresAt time.Time `json:"expires_at"`
+	// RecipientEmail is the invited address, already lowercased.
+	RecipientEmail string `json:"recipient_email"`
+	// RecipientName is the invitee's display name, empty for a not-yet-registered invitee (exactly
+	// as before).
+	RecipientName string `json:"recipient_name"`
+	// ForwardedProto and ForwardedHost come from the originating request's X-Forwarded-* headers and
+	// build the accept-invite link in the email.
+	ForwardedProto string `json:"forwarded_proto"`
+	ForwardedHost  string `json:"forwarded_host"`
+}


### PR DESCRIPTION
## What
Collapses the two namespace-membership-intake code paths — "Add member" and "Generate invite link" — onto one shared, unexported `intakeMembership` helper, and replaces the hand-rolled positional worker payload with a single typed notification carried end to end.

## Why
The invite flow was written twice and had drifted in user-visible ways: the link path skipped lowercasing the invited email (producing two placeholder accounts for `Jane@x.com` and `jane@x.com`), ran without a store transaction (half-created invitations on partial failure), and validated the tenant differently. Separately, the code firing the "member invited" hook held the fully-populated invitation but threw it away, forwarding only `tenant:user:proto:host` as a colon-delimited string — forcing the worker to re-read the database three times to rebuild what the caller already had, over a contract asserted only in twin prose comments across the shellhub↔cloud boundary.

Closes #6645

## Changes
- **api/services**: both `AddNamespaceMember` and `GenerateInvitationLink` become thin adapters over `intakeMembership`, which owns resolve-or-upsert, the duplicate-member check, the direct-membership short-circuit, and create-or-resend. The email is always lowercased and the whole write always runs inside `store.WithTransaction`, so the two paths behave identically.
- **api/services**: `GenerateInvitationLink`'s inlined signature/expiry copy is deleted in favor of the shared `createMembershipInvitation`/`resendMembershipInvitation` helpers (single source for the 7-day expiry and pairingcode signature).
- **pkg/models**: new `MembershipInvitationNotification` — the typed, email-relevant snapshot (signature, expiry, recipient email + name, forwarded proto + host). Deliberately no role or namespace name; the template uses neither.
- **hook + internal client**: `OnMembershipInvited` and `InviteMember` widen to carry the notification; the internal client JSON-encodes it over the worker's existing `[]byte` transport (task pattern unchanged).
- **requests**: `FowardedHost` renamed to `ForwardedHost` (bound `X-Forwarded-Host` header unchanged, wire-compatible); `GenerateInvitationLink.TenantID` now uuid-validated to match `NamespaceAddMember`.

## Testing
Exercised through the two public methods with mockery: new cases pin email-lowercasing on both paths, `WithTransaction` usage, expired-invitation resend, the direct-membership short-circuit firing no hook, and a fully-populated post-commit notification. The cloud consumer side (worker + hook) moves in lockstep — see the paired PR on shellhub-io/cloud. Deploy both together: the `cloud-api:invites` payload changes from a positional string to JSON, and the shallow invite queue drains rather than carrying a dual-format reader.