### PR TITLE
refactor(api): extract acting-member and admit-member seams

### DIFF
--- a/api/services/api-key.go
+++ b/api/services/api-key.go
@@ -109,22 +109,10 @@ func (s *service) ListAPIKeys(ctx context.Context, req *requests.ListAPIKey) ([]
 }
 
 func (s *service) UpdateAPIKey(ctx context.Context, req *requests.UpdateAPIKey) error {
-	ns, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
-	if err != nil {
-		return NewErrNamespaceNotFound(req.TenantID, err)
-	}
-
-	// If req.Role is not empty, the requesting user must be a namespace member
-	// with sufficient authority to assign that role.
-	if req.Role != "" {
-		m, ok := ns.FindMember(req.UserID)
-		if !ok {
-			return NewErrNamespaceMemberNotFound(req.UserID, nil)
-		}
-
-		if !m.Role.HasAuthority(req.Role) {
-			return NewErrRoleForbidden()
-		}
+	// The acting member must outrank the role being assigned. A RoleInvalid (empty) req.Role means
+	// no role change, so the seam resolves membership without an authority assertion.
+	if _, _, err := s.resolveActingMember(ctx, req.TenantID, req.UserID, req.Role); err != nil {
+		return err
 	}
 
 	apiKey, err := s.store.APIKeyResolve(ctx, store.APIKeyNameResolver, req.CurrentName, s.store.Options().InNamespace(req.TenantID))

--- a/api/services/api-key_test.go
+++ b/api/services/api-key_test.go
@@ -765,6 +765,70 @@ func TestUpdateAPIKey(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			description: "fails when the role is empty and the actor is not a member",
+			req: &requests.UpdateAPIKey{
+				UserID:      "000000000000000000000000",
+				TenantID:    "00000000-0000-4000-0000-000000000000",
+				CurrentName: "dev",
+				Name:        "newName",
+				Role:        "",
+			},
+			requiredMocks: func(ctx context.Context) {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{Members: []models.Member{}}, nil).
+					Once()
+			},
+			expected: NewErrNamespaceMemberNotFound("000000000000000000000000", nil),
+		},
+		{
+			description: "succeeds updating only the name when the role is empty",
+			req: &requests.UpdateAPIKey{
+				UserID:      "000000000000000000000000",
+				TenantID:    "00000000-0000-4000-0000-000000000000",
+				CurrentName: "dev",
+				Name:        "newName",
+				Role:        "",
+			},
+			requiredMocks: func(ctx context.Context) {
+				existingAPIKey := &models.APIKey{
+					ID:       "existing-id",
+					Name:     "dev",
+					TenantID: "00000000-0000-4000-0000-000000000000",
+					Role:     "operator",
+				}
+
+				updatedAPIKey := &models.APIKey{
+					ID:       "existing-id",
+					Name:     "newName",
+					TenantID: "00000000-0000-4000-0000-000000000000",
+					Role:     "operator",
+				}
+
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
+					Return(&models.Namespace{Members: []models.Member{{ID: "000000000000000000000000", Role: "observer"}}}, nil).
+					Once()
+				queryOptionsMock.
+					On("InNamespace", "00000000-0000-4000-0000-000000000000").
+					Return(nil).
+					Once()
+				storeMock.
+					On("APIKeyResolve", ctx, store.APIKeyNameResolver, "dev", mock.AnythingOfType("[]store.QueryOption")).
+					Return(existingAPIKey, nil).
+					Once()
+				storeMock.
+					On("APIKeyConflicts", ctx, "00000000-0000-4000-0000-000000000000", &models.APIKeyConflicts{Name: "newName"}).
+					Return([]string{}, false, nil).
+					Once()
+				storeMock.
+					On("APIKeyUpdate", ctx, updatedAPIKey).
+					Return(nil).
+					Once()
+			},
+			expected: nil,
+		},
 	}
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/api/services/invitation.go
+++ b/api/services/invitation.go
@@ -95,15 +95,10 @@ func (s *service) AcceptInvite(ctx context.Context, req *requests.AcceptInvite) 
 		return NewErrNamespaceMemberNotFound(req.UserID, err)
 	}
 
-	// Adding the member and consuming the invitation must be atomic: a failure between them would
-	// add the member but leave the invitation stuck pending.
 	err = s.store.WithTransaction(ctx, func(ctx context.Context) error {
 		member := &models.Member{ID: req.UserID, AddedAt: clock.Now(), Role: invitation.Role}
-		if err := s.store.NamespaceCreateMembership(ctx, req.TenantID, member); err != nil {
-			return err
-		}
 
-		return s.store.MembershipInvitationDelete(ctx, invitation)
+		return s.admitMember(ctx, req.TenantID, member, invitation)
 	})
 	if err != nil {
 		log.WithError(err).WithField("tenant-id", req.TenantID).WithField("user-id", req.UserID).
@@ -116,18 +111,9 @@ func (s *service) AcceptInvite(ctx context.Context, req *requests.AcceptInvite) 
 }
 
 func (s *service) GenerateInvitationLink(ctx context.Context, req *requests.GenerateInvitationLink) (string, error) {
-	namespace, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+	namespace, activeUser, err := s.resolveActingMember(ctx, req.TenantID, req.UserID, req.MemberRole)
 	if err != nil {
-		return "", NewErrNamespaceNotFound(req.TenantID, err)
-	}
-
-	activeUser, ok := namespace.FindMember(req.UserID)
-	if !ok {
-		return "", NewErrNamespaceMemberNotFound(req.UserID, err)
-	}
-
-	if !activeUser.Role.HasAuthority(req.MemberRole) {
-		return "", NewErrRoleForbidden()
+		return "", err
 	}
 
 	invitation, err := s.intakeMembership(ctx, namespace, activeUser.ID, req.MemberEmail, req.MemberRole, req.ForwardedHost, req.ForwardedProto)
@@ -181,18 +167,8 @@ func (s *service) UserMembershipInvitationList(ctx context.Context, req *request
 }
 
 func (s *service) NamespaceMembershipInvitationList(ctx context.Context, req *requests.NamespaceMembershipInvitationList) ([]responses.MembershipInvitation, int64, error) {
-	n, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
-	if err != nil {
-		return nil, 0, NewErrNamespaceNotFound(req.TenantID, err)
-	}
-
-	m, ok := n.FindMember(req.UserID)
-	if !ok {
-		return nil, 0, NewErrNamespaceMemberNotFound(req.UserID, nil)
-	}
-
-	if !m.Role.HasAuthority(authorizer.RoleAdministrator) {
-		return nil, 0, NewErrRoleForbidden()
+	if _, _, err := s.resolveActingMember(ctx, req.TenantID, req.UserID, authorizer.RoleAdministrator); err != nil {
+		return nil, 0, err
 	}
 
 	invitations, count, err := s.store.NamespaceMembershipInvitationList(
@@ -218,14 +194,9 @@ func (s *service) NamespaceMembershipInvitationList(ctx context.Context, req *re
 }
 
 func (s *service) CancelMembershipInvitation(ctx context.Context, req *requests.CancelMembershipInvitation) error {
-	n, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+	_, activeMember, err := s.resolveActingMember(ctx, req.TenantID, req.UserID, authorizer.RoleInvalid)
 	if err != nil {
-		return NewErrNamespaceNotFound(req.TenantID, err)
-	}
-
-	activeMember, ok := n.FindMember(req.UserID)
-	if !ok {
-		return NewErrNamespaceMemberNotFound(req.UserID, nil)
+		return err
 	}
 
 	invitation, err := s.store.MembershipInvitationResolve(ctx, req.TenantID, req.InvitedUserID)

--- a/api/services/member.go
+++ b/api/services/member.go
@@ -53,25 +53,57 @@ type MemberService interface {
 	LeaveNamespace(ctx context.Context, req *requests.LeaveNamespace) (*models.UserAuthResponse, error)
 }
 
-func (s *service) AddNamespaceMember(ctx context.Context, req *requests.NamespaceAddMember) (*models.Namespace, error) {
-	namespace, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+// resolveActingMember resolves the namespace and the acting member — the authenticated member
+// identified by actorID performing an operation on it. The store is not consulted for the actor's
+// user record: a resolved membership already proves the account exists, so FindMember alone
+// suffices.
+//
+// When requireAuthorityOver is not [authorizer.RoleInvalid], it additionally asserts that the acting
+// member outranks that role, returning [NewErrRoleForbidden] otherwise. Passing RoleInvalid resolves
+// without any authority assertion.
+//
+// It returns [NewErrNamespaceNotFound] when the namespace does not exist and
+// [NewErrNamespaceMemberNotFound] when the actor is not a member of it.
+func (s *service) resolveActingMember(ctx context.Context, tenantID, actorID string, requireAuthorityOver authorizer.Role) (*models.Namespace, *models.Member, error) {
+	namespace, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, tenantID)
 	if err != nil || namespace == nil {
-		return nil, NewErrNamespaceNotFound(req.TenantID, err)
+		return nil, nil, NewErrNamespaceNotFound(tenantID, err)
 	}
 
-	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
-	if err != nil || user == nil {
-		return nil, NewErrUserNotFound(req.UserID, err)
-	}
-
-	// checks if the active member is in the namespace. user is the active member.
-	active, ok := namespace.FindMember(user.ID)
+	member, ok := namespace.FindMember(actorID)
 	if !ok {
-		return nil, NewErrNamespaceMemberNotFound(user.ID, err)
+		return nil, nil, NewErrNamespaceMemberNotFound(actorID, nil)
 	}
 
-	if !active.Role.HasAuthority(req.MemberRole) {
-		return nil, NewErrRoleForbidden()
+	if requireAuthorityOver != authorizer.RoleInvalid && !member.Role.HasAuthority(requireAuthorityOver) {
+		return nil, nil, NewErrRoleForbidden()
+	}
+
+	return namespace, member, nil
+}
+
+// admitMember places a user into a namespace as a member and, when an invitation is supplied,
+// consumes it — the single "add-and-consume" write shared by every intake path.
+//
+// It opens no transaction of its own: the store's WithTransaction is not reentrant, so a caller that
+// needs the create and the delete to be atomic must wrap the call in its own transaction. admitMember
+// then joins that ambient transaction through the context.
+func (s *service) admitMember(ctx context.Context, tenantID string, member *models.Member, invitation *models.MembershipInvitation) error {
+	if err := s.store.NamespaceCreateMembership(ctx, tenantID, member); err != nil {
+		return err
+	}
+
+	if invitation != nil {
+		return s.store.MembershipInvitationDelete(ctx, invitation)
+	}
+
+	return nil
+}
+
+func (s *service) AddNamespaceMember(ctx context.Context, req *requests.NamespaceAddMember) (*models.Namespace, error) {
+	namespace, active, err := s.resolveActingMember(ctx, req.TenantID, req.UserID, req.MemberRole)
+	if err != nil {
+		return nil, err
 	}
 
 	if _, err := s.intakeMembership(ctx, namespace, active.ID, req.MemberEmail, req.MemberRole, req.ForwardedHost, req.ForwardedProto); err != nil {
@@ -124,7 +156,7 @@ func (s *service) intakeMembership(ctx context.Context, namespace *models.Namesp
 		if userExists && directMembershipAllowed() {
 			member := &models.Member{ID: passiveUser.ID, AddedAt: clock.Now(), Role: role}
 
-			return s.store.NamespaceCreateMembership(ctx, namespace.TenantID, member)
+			return s.admitMember(ctx, namespace.TenantID, member, nil)
 		}
 
 		existing, err := s.store.MembershipInvitationResolve(ctx, namespace.TenantID, passiveUser.ID)
@@ -229,24 +261,14 @@ func (s *service) resendMembershipInvitation(ctx context.Context, invitation *mo
 }
 
 func (s *service) UpdateNamespaceMember(ctx context.Context, req *requests.NamespaceUpdateMember) error {
-	namespace, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+	namespace, active, err := s.resolveActingMember(ctx, req.TenantID, req.UserID, authorizer.RoleInvalid)
 	if err != nil {
-		return NewErrNamespaceNotFound(req.TenantID, err)
-	}
-
-	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
-	if err != nil {
-		return NewErrUserNotFound(req.UserID, err)
-	}
-
-	active, ok := namespace.FindMember(user.ID)
-	if !ok {
-		return NewErrNamespaceMemberNotFound(user.ID, err)
+		return err
 	}
 
 	member, ok := namespace.FindMember(req.MemberID)
 	if !ok {
-		return NewErrNamespaceMemberNotFound(req.MemberID, err)
+		return NewErrNamespaceMemberNotFound(req.MemberID, nil)
 	}
 
 	// A member cannot change their own role through this endpoint. The dangerous case
@@ -291,24 +313,14 @@ func (s *service) UpdateNamespaceMember(ctx context.Context, req *requests.Names
 }
 
 func (s *service) RemoveNamespaceMember(ctx context.Context, req *requests.NamespaceRemoveMember) (*models.Namespace, error) {
-	namespace, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+	namespace, active, err := s.resolveActingMember(ctx, req.TenantID, req.UserID, authorizer.RoleInvalid)
 	if err != nil {
-		return nil, NewErrNamespaceNotFound(req.TenantID, err)
-	}
-
-	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
-	if err != nil {
-		return nil, NewErrUserNotFound(req.UserID, err)
-	}
-
-	active, ok := namespace.FindMember(user.ID)
-	if !ok {
-		return nil, NewErrNamespaceMemberNotFound(user.ID, err)
+		return nil, err
 	}
 
 	passive, ok := namespace.FindMember(req.MemberID)
 	if !ok {
-		return nil, NewErrNamespaceMemberNotFound(req.MemberID, err)
+		return nil, NewErrNamespaceMemberNotFound(req.MemberID, nil)
 	}
 
 	// A member cannot remove themselves through this endpoint; doing so bypasses the
@@ -344,13 +356,12 @@ func (s *service) RemoveNamespaceMember(ctx context.Context, req *requests.Names
 }
 
 func (s *service) LeaveNamespace(ctx context.Context, req *requests.LeaveNamespace) (*models.UserAuthResponse, error) {
-	ns, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+	ns, member, err := s.resolveActingMember(ctx, req.TenantID, req.UserID, authorizer.RoleInvalid)
 	if err != nil {
-		return nil, NewErrNamespaceNotFound(req.TenantID, err)
+		return nil, err
 	}
 
-	member, ok := ns.FindMember(req.UserID)
-	if !ok || member.Role == authorizer.RoleOwner {
+	if member.Role == authorizer.RoleOwner {
 		return nil, NewErrAuthForbidden()
 	}
 

--- a/api/services/member_test.go
+++ b/api/services/member_test.go
@@ -57,35 +57,6 @@ func TestService_AddNamespaceMember(t *testing.T) {
 			},
 		},
 		{
-			description: "fails when the active member was not found",
-			req: &requests.NamespaceAddMember{
-				ForwardedHost: "localhost",
-				UserID:        "000000000000000000000000",
-				TenantID:      "00000000-0000-4000-0000-000000000000",
-				MemberEmail:   "john.doe@test.com",
-				MemberRole:    authorizer.RoleObserver,
-			},
-			requiredMocks: func(ctx context.Context) {
-				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{
-						TenantID: "00000000-0000-4000-0000-000000000000",
-						Name:     "namespace",
-						Owner:    "000000000000000000000000",
-						Members:  []models.Member{},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(nil, ErrUserNotFound).
-					Once()
-			},
-			expected: Expected{
-				namespace: nil,
-				err:       NewErrUserNotFound("000000000000000000000000", ErrUserNotFound),
-			},
-		},
-		{
 			description: "fails when the active member is not on the namespace",
 			req: &requests.NamespaceAddMember{
 				ForwardedHost: "localhost",
@@ -102,13 +73,6 @@ func TestService_AddNamespaceMember(t *testing.T) {
 						Name:     "namespace",
 						Owner:    "000000000000000000000000",
 						Members:  []models.Member{},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 			},
@@ -141,13 +105,6 @@ func TestService_AddNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 			},
 			expected: Expected{
 				namespace: nil,
@@ -178,13 +135,6 @@ func TestService_AddNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 			},
 			expected: Expected{
 				namespace: nil,
@@ -212,10 +162,6 @@ func TestService_AddNamespaceMember(t *testing.T) {
 					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
 					Return(ns, nil).
 					Twice()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{ID: "000000000000000000000000", UserData: models.UserData{Username: "owner"}}, nil).
-					Once()
 				// The transaction body runs so the invitation write is exercised.
 				storeMock.
 					On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
@@ -298,31 +244,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 			expected: NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", ErrNamespaceNotFound),
 		},
 		{
-			description: "[community|enterprise|cloud] fails when the active member was not found",
-			req: &requests.NamespaceUpdateMember{
-				UserID:     "000000000000000000000000",
-				TenantID:   "00000000-0000-4000-0000-000000000000",
-				MemberID:   "000000000000000000000001",
-				MemberRole: authorizer.RoleObserver,
-			},
-			requiredMocks: func(ctx context.Context) {
-				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{
-						TenantID: "00000000-0000-4000-0000-000000000000",
-						Name:     "namespace",
-						Owner:    "000000000000000000000000",
-						Members:  []models.Member{},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(nil, ErrUserNotFound).
-					Once()
-			},
-			expected: NewErrUserNotFound("000000000000000000000000", ErrUserNotFound),
-		},
-		{
 			description: "[community|enterprise|cloud] fails when the active member is not on the namespace",
 			req: &requests.NamespaceUpdateMember{
 				UserID:     "000000000000000000000000",
@@ -338,13 +259,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 						Name:     "namespace",
 						Owner:    "000000000000000000000000",
 						Members:  []models.Member{},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 			},
@@ -371,13 +285,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleOwner,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 			},
@@ -408,13 +315,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleOwner,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 			},
@@ -457,13 +357,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 			},
 			expected: NewErrRoleForbidden(),
 		},
@@ -492,13 +385,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleAdministrator,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 				storeMock.
@@ -533,13 +419,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleAdministrator,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 				storeMock.
@@ -584,13 +463,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 			},
 			expected: NewErrRoleForbidden(),
 		},
@@ -631,13 +503,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
-				storeMock.
 					On("NamespaceUpdateMembership", ctx, "00000000-0000-4000-0000-000000000000", &models.Member{ID: "000000000000000000000001", Role: authorizer.RoleObserver}).
 					Return(nil).
 					Once()
@@ -672,13 +537,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleOwner,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 			},
@@ -718,13 +576,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 			},
 			expected: NewErrRoleForbidden(),
 		},
@@ -760,13 +611,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleInvalid, // corrupted/legacy record
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 				storeMock.
@@ -816,13 +660,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 			},
 			expected: NewErrRoleForbidden(),
 		},
@@ -854,13 +691,6 @@ func TestService_UpdateNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleOwner,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 				// NO NamespaceUpdateMembership call — guard returns early
@@ -923,10 +753,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 							{ID: "000000000000000000000001", Role: authorizer.RoleAdministrator},
 						},
 					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{ID: "000000000000000000000000", UserData: models.UserData{Username: "jane_doe"}}, nil).
 					Once()
 				storeMock.
 					On("NamespaceDeleteMembership", ctx, "00000000-0000-4000-0000-000000000000", &models.Member{ID: "000000000000000000000001", Role: authorizer.RoleAdministrator}).
@@ -994,10 +820,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 					}, nil).
 					Once()
 				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{ID: "000000000000000000000000", UserData: models.UserData{Username: "jane_doe"}}, nil).
-					Once()
-				storeMock.
 					On("NamespaceDeleteMembership", ctx, "00000000-0000-4000-0000-000000000000", &models.Member{ID: "000000000000000000000001", Role: authorizer.RoleAdministrator}).
 					Return(nil).
 					Once()
@@ -1057,33 +879,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 			},
 		},
 		{
-			description: "[community|enterprise|cloud] fails when the active member was not found",
-			req: &requests.NamespaceRemoveMember{
-				UserID:   "000000000000000000000000",
-				TenantID: "00000000-0000-4000-0000-000000000000",
-				MemberID: "000000000000000000000001",
-			},
-			requiredMocks: func(ctx context.Context) {
-				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{
-						TenantID: "00000000-0000-4000-0000-000000000000",
-						Name:     "namespace",
-						Owner:    "000000000000000000000000",
-						Members:  []models.Member{},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(nil, ErrUserNotFound).
-					Once()
-			},
-			expected: Expected{
-				namespace: nil,
-				err:       NewErrUserNotFound("000000000000000000000000", ErrUserNotFound),
-			},
-		},
-		{
 			description: "[community|enterprise|cloud] fails when the active member is not on the namespace",
 			req: &requests.NamespaceRemoveMember{
 				UserID:   "000000000000000000000000",
@@ -1098,13 +893,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 						Name:     "namespace",
 						Owner:    "000000000000000000000000",
 						Members:  []models.Member{},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 			},
@@ -1133,13 +921,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleOwner,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 			},
@@ -1174,13 +955,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 			},
 			expected: Expected{
 				namespace: nil,
@@ -1213,13 +987,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 			},
 			expected: Expected{
 				namespace: nil,
@@ -1250,13 +1017,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleAdministrator,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 				storeMock.
@@ -1293,13 +1053,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleAdministrator,
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 				storeMock.
@@ -1370,13 +1123,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 						},
 					}, nil).
 					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
-					}, nil).
-					Once()
 				// Simulate an unexpected store error from NamespaceDeleteMembership (e.g.
 				// TOCTOU: member disappeared after the FindMember precheck). The service
 				// must propagate it unchanged — the default branch must not remap it.
@@ -1418,13 +1164,6 @@ func TestService_RemoveNamespaceMember(t *testing.T) {
 								Role: authorizer.RoleInvalid, // corrupted/legacy record
 							},
 						},
-					}, nil).
-					Once()
-				storeMock.
-					On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-					Return(&models.User{
-						ID:       "000000000000000000000000",
-						UserData: models.UserData{Username: "jane_doe"},
 					}, nil).
 					Once()
 				storeMock.
@@ -1534,7 +1273,7 @@ func TestService_LeaveNamespace(t *testing.T) {
 			},
 			expected: Expected{
 				res: nil,
-				err: NewErrAuthForbidden(),
+				err: NewErrNamespaceMemberNotFound("000000000000000000000000", nil),
 			},
 		},
 		{
@@ -1796,8 +1535,6 @@ func TestService_AddNamespaceMember_LowercasesEmail(t *testing.T) {
 	}
 
 	storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, ns.TenantID).Return(ns, nil).Twice()
-	storeMock.On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-		Return(&models.User{ID: "000000000000000000000000"}, nil).Once()
 	storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
 		Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
 	storeMock.On("UserResolve", ctx, store.UserEmailResolver, "jane@test.com").
@@ -1839,8 +1576,6 @@ func TestService_AddNamespaceMember_FiresNotification(t *testing.T) {
 	}
 
 	storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, ns.TenantID).Return(ns, nil).Twice()
-	storeMock.On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-		Return(&models.User{ID: "000000000000000000000000"}, nil).Once()
 	storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
 		Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
 	storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").
@@ -1904,8 +1639,6 @@ func TestService_AddNamespaceMember_DirectMembershipFiresNoHook(t *testing.T) {
 	}
 
 	storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, ns.TenantID).Return(ns, nil).Twice()
-	storeMock.On("UserResolve", ctx, store.UserIDResolver, "000000000000000000000000").
-		Return(&models.User{ID: "000000000000000000000000"}, nil).Once()
 	storeMock.On("WithTransaction", ctx, mock.AnythingOfType("store.TransactionCb")).
 		Return(func(ctx context.Context, cb store.TransactionCb) error { return cb(ctx) }).Once()
 	storeMock.On("UserResolve", ctx, store.UserEmailResolver, "invitee@test.com").

--- a/api/services/register.go
+++ b/api/services/register.go
@@ -162,14 +162,10 @@ func (s *service) createInvitedUser(ctx context.Context, req *requests.RegisterU
 
 		// Completing the account through the link joins the namespace now. Login may still be
 		// gated by AwaitingApproval, but the membership is in place so approval alone unblocks
-		// them. The invitation is consumed, so we delete it (atomic with user + membership).
+		// them. admitMember consumes the invitation, atomic with the user + membership write.
 		if membership != nil {
 			member := &models.Member{ID: user.ID, AddedAt: clock.Now(), Role: membership.Role}
-			if err := s.store.NamespaceCreateMembership(ctx, membership.TenantID, member); err != nil {
-				return err
-			}
-
-			if err := s.store.MembershipInvitationDelete(ctx, membership); err != nil {
+			if err := s.admitMember(ctx, membership.TenantID, member, membership); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## What

Introduces two deep, unexported seams in the `api/services` package and routes
the existing membership-intake code through them, with no change to the public
service interfaces or HTTP contracts. Stacked on top of #6646.

Closes #6647

## Why

The membership-intake code had grown two shallow spreads:

- The acting-member prologue — resolve the namespace, find the acting member,
  check their authority — was hand-copied across 8 service methods. A change to
  how the acting member is resolved (or which error a missing member yields) had
  to be made in 8 places and re-asserted in 8 tests.
- "Admit a user into a namespace" (write the membership, consume the invitation,
  atomically) was hand-rolled in 3 intake paths, with the atomicity rule restated
  as a comment in two of them.

The goal is locality (one place to change each concept) and testability, aligned
with the in-flight `refactor/unify-membership-intake` work.

## Changes

- **`resolveActingMember`**: hides the resolve-and-authorize dance behind one
  call returning the namespace and acting member, or the correct typed error.
  Asserts authority only when a non-`RoleInvalid` role is passed — the same
  sentinel convention `UpdateNamespaceMember` already used. Migrated 8 call sites
  (add/update/remove/leave member, generate/list/cancel invitation, update API
  key), passing the role known at each site and keeping the delicate call-site
  guards (BFLA, owner, invitation-role) verbatim.
- **`admitMember`**: owns the single add-and-consume write (create membership,
  then delete the invitation when one is supplied). Opens no transaction of its
  own — the store's `WithTransaction` is not reentrant, so it joins the caller's
  ambient transaction via the context. Wired into all 3 intake paths
  (`AcceptInvite`, `createInvitedUser`, `intakeMembership` direct-add).
- Dropped the redundant acting-user `UserResolve` the three member.go methods did:
  the actor's ID comes from the authenticated token, so a resolved membership
  already proves the account exists.

## Behavior change

A non-member acting user now yields a uniform `NamespaceMemberNotFound` across all
membership endpoints, where the three member.go methods previously returned
`UserNotFound` and `LeaveNamespace` returned `AuthForbidden`. This is stricter and
more consistent, and is guarded upstream by `RequiresPermission`.

## Testing

`go test ./services/...` and `golangci-lint run ./services/...` pass clean. Tests
exercise both seams through the public service methods only. Added two
`UpdateAPIKey` cases covering the empty-role path (an observer renaming a key; a
non-member being rejected) to lock in the now-unconditional membership resolution.