### PR TITLE
docs(mfa): document the in-app MFA recovery endpoints in the OpenAPI spec

### DIFF
--- a/openapi/spec/components/schemas/mfaDisable.yaml
+++ b/openapi/spec/components/schemas/mfaDisable.yaml
@@ -8,3 +8,15 @@ properties:
     description: User's recovery code.
     type: string
     example: 6UIHAIN3CYUEFY5X
+  main_email_code:
+    description: |
+      The code sent to the main email address by `requestResetMFA`. Must be
+      provided together with `recovery_email_code`.
+    type: string
+    example: JR36Q
+  recovery_email_code:
+    description: |
+      The code sent to the recovery email address by `requestResetMFA`. Must be
+      provided together with `main_email_code`.
+    type: string
+    example: AB2D8

--- a/openapi/spec/paths/api@user@mfa@disable.yaml
+++ b/openapi/spec/paths/api@user@mfa@disable.yaml
@@ -2,8 +2,10 @@ put:
   operationId: disableMFA
   summary: Disable MFA
   description: |
-    Disable MFA for a user. To disable MFA, the user must provide either
-    a recovery code or the current MFA code. If a recovery code is used, it will be invalidated for future use.
+    Disable MFA for a user. To disable MFA, the user must provide one of: the current MFA
+    code, a recovery code, or the two codes emailed by `requestResetMFA`
+    (`main_email_code` and `recovery_email_code`, which must be sent together). If a recovery
+    code is used, it will be invalidated for future use.
 
     The recovery code used to regain access to the account can be used within a 10-minute window on this
     endpoint.

--- a/openapi/spec/paths/api@user@mfa@reset.yaml
+++ b/openapi/spec/paths/api@user@mfa@reset.yaml
@@ -25,6 +25,20 @@ post:
   responses:
     '200':
       description: Success to send the email.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              token:
+                description: |
+                  Opaque token identifying this reset request. Present it in the
+                  `user-id` path segment of `PUT /api/user/mfa/reset/{user-id}`
+                  to complete the reset.
+                type: string
+                example: 4a5f6b3e-1234-4a12-9abc-1234567890ab
+            required:
+              - token
     '400':
       $ref: ../components/responses/400.yaml
     '401':

--- a/openapi/spec/paths/api@user@mfa@reset@{user-id}.yaml
+++ b/openapi/spec/paths/api@user@mfa@reset@{user-id}.yaml
@@ -3,8 +3,9 @@ put:
   summary: Reset MFA
   description: |
     Similar to the `disableMFA` operation, this endpoint uses the two codes sent
-    by `requestResetMFA` instead of a TOTP or recovery code. The user ID must
-    be the same as the one used for `requestResetMFA`.
+    by `requestResetMFA` instead of a TOTP or recovery code. The `user-id` path
+    segment accepts either the opaque token returned by `requestResetMFA` (the
+    in-app flow) or the raw user ID carried by the emailed reset link.
   tags:
     - cloud
     - mfa
@@ -16,8 +17,11 @@ put:
       required: true
       schema:
         type: string
-        description: ID of the user trying to reset MFA.
-        example: 664e02087116dc765ef876a0
+        description: |
+          Either the opaque token returned by `requestResetMFA` (in-app flow) or
+          the raw user ID from the emailed reset link. The server resolves a token
+          to its user; anything else is treated as a raw user ID.
+        example: 4a5f6b3e-1234-4a12-9abc-1234567890ab
   requestBody:
     content:
       application/json:

--- a/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
@@ -98,7 +98,9 @@ describe("mfaResetStore", () => {
 
   describe("requestMfaReset", () => {
     it("sets mfaResetUserId and mfaResetIdentifier on success", async () => {
-      mockedRequestResetMfa.mockResolvedValueOnce(mockSdkResponse(null));
+      mockedRequestResetMfa.mockResolvedValueOnce(
+        mockSdkResponse({ token: "reset-token" }),
+      );
 
       await useMfaResetStore.getState().requestMfaReset("admin");
 
@@ -110,9 +112,9 @@ describe("mfaResetStore", () => {
     });
 
     it("sets loading during request", async () => {
-      let resolve!: (v: SdkResponse<null>) => void;
+      let resolve!: (v: SdkResponse<{ token: string }>) => void;
       mockedRequestResetMfa.mockReturnValueOnce(
-        new Promise<SdkResponse<null>>((r) => {
+        new Promise<SdkResponse<{ token: string }>>((r) => {
           resolve = r;
         }),
       );
@@ -120,7 +122,7 @@ describe("mfaResetStore", () => {
       const promise = useMfaResetStore.getState().requestMfaReset("admin");
       expect(useMfaResetStore.getState().loading).toBe(true);
 
-      resolve(mockSdkResponse(null));
+      resolve(mockSdkResponse({ token: "reset-token" }));
       await promise;
 
       expect(useMfaResetStore.getState().loading).toBe(false);


### PR DESCRIPTION
## What

**Spec + a forced test fix.** Updates the OpenAPI spec to match the cloud
backend changes for in-app MFA recovery, plus one frontend test fix the
spec change forces (the generated SDK is rebuilt from the spec at build
time, so the new `token` field breaks a stale test mock). No runtime
behaviour changes. Commits on this branch:

1. `docs(mfa): document the in-app MFA reset token in the OpenAPI spec` (team#87)
2. `docs(mfa): document the emailed reset codes on disableMFA` (team#88)
3. `test(mfa): update mfaResetStore mocks for the new reset token type`

## Why

The backend gained a new response field and now accepts new request inputs.
Leaving the spec unchanged would let it lie about the API: generated clients
and contract tests would not know about the `token` response or the new
disable inputs.

## Changes

**reset flow**
- `POST /api/user/mfa/reset`: the `200` response now documents the `token`
  body (marked `required`, since a success always returns it).
- `PUT /api/user/mfa/reset/{user-id}`: the `user-id` path param is
  documented as accepting either the opaque token (in-app flow) or the raw
  user ID (emailed-link flow), and the operation description reflects that.
  Also fixed an auto-generated `POST` -> `PUT` in the description.
**Build fix (SDK ripple)**
- The console's generated SDK (`src/client/`, gitignored, rebuilt from the
  spec) now types `requestResetMfa` as returning `{ token }`. Updated the
  `mfaResetStore` test mocks to match, keeping `tsc -b` green. Type-only;
  the store's actual re-wire to use the token stays in the frontend
  follow-up (see below)

**disable flow**
- `PUT /api/user/mfa/disable`: the `mfaDisable` request schema gains optional
  `main_email_code` / `recovery_email_code` fields, mirroring `mfaReset`.
  They are optional, not required: the endpoint takes one of a TOTP code, a
  recovery code, or the two email codes, so marking them required would
  misdescribe the other paths. The operation description lists the three
  options.

## Testing

- Both edited files parse as valid YAML.
- Semantic OpenAPI lint (redocly/openapi toolchain) was not run locally, as
  it runs in a container rather than on the host. Worth running in CI or
  before merge if there is a spec-lint target.

## Companion PR

shellhub-io/cloud#2430

The backend implementation lives in `shellhub-io/cloud` (branch
`feat/mfa-inapp-reset-disable`): the opaque reset token and the emailed-code
`DisableMFA` support this spec documents.

## Follow-up

The frontend re-wire in `shellhub/ui/` (restore the reset-verify page and
the disable-via-email-codes screen) is still required for these flows to be
usable in the product. Tracked with the backend PR.

Refs: shellhub-io/team#87
Refs: shellhub-io/team#88