### PR TITLE
fix(ssh): set explicit USE policy on proxyproto listener

### DIFF
--- a/ssh/server/server.go
+++ b/ssh/server/server.go
@@ -148,6 +148,15 @@ func NewServer(dialer *dialer.Dialer, cache cache.Cache, opts *Options) *Server 
 	return server
 }
 
+func newProxyListener(lis net.Listener) *proxyproto.Listener {
+	return &proxyproto.Listener{ // nolint: exhaustruct
+		Listener: lis,
+		ConnPolicy: func(_ proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+			return proxyproto.USE, nil
+		},
+	}
+}
+
 func (s *Server) ListenAndServe() error {
 	log.WithFields(log.Fields{
 		"addr": s.sshd.Addr,
@@ -160,8 +169,8 @@ func (s *Server) ListenAndServe() error {
 		return err
 	}
 
-	proxy := &proxyproto.Listener{Listener: list} // nolint: exhaustruct
-	defer proxy.Close()                           //nolint:errcheck
+	proxy := newProxyListener(list)
+	defer proxy.Close() //nolint:errcheck
 
 	return s.sshd.Serve(proxy)
 }

--- a/ssh/server/server_test.go
+++ b/ssh/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/pkg/cache"
@@ -15,6 +16,7 @@ import (
 	"github.com/shellhub-io/shellhub/ssh/pkg/dialer"
 	"github.com/shellhub-io/shellhub/ssh/session"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // stubContext is a minimal gliderssh.Context implementation for tests.
@@ -118,4 +120,55 @@ func TestBannerHandlerSuccess(t *testing.T) {
 
 	assert.Empty(t, result,
 		"BannerHandler must return an empty string on the success path")
+}
+
+func TestProxyListenerAcceptsWithoutProxyHeader(t *testing.T) {
+	raw, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	proxy := newProxyListener(raw)
+	defer proxy.Close() //nolint:errcheck
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	done := make(chan error, 1)
+	go func() {
+		conn, err := proxy.Accept()
+		if err != nil {
+			done <- err
+
+			return
+		}
+		defer conn.Close() //nolint:errcheck
+
+		conn.SetDeadline(deadline) //nolint:errcheck
+
+		buf := make([]byte, 5)
+		n, err := conn.Read(buf)
+		if err != nil {
+			done <- err
+
+			return
+		}
+
+		_, err = conn.Write(buf[:n])
+		done <- err
+	}()
+
+	conn, err := net.Dial("tcp", proxy.Addr().String())
+	require.NoError(t, err)
+
+	defer conn.Close() //nolint:errcheck
+
+	conn.SetDeadline(deadline) //nolint:errcheck
+
+	_, err = conn.Write([]byte("hello"))
+	assert.NoError(t, err)
+
+	buf := make([]byte, 5)
+	n, err := conn.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", string(buf[:n]))
+
+	assert.NoError(t, <-done)
 }


### PR DESCRIPTION
## What

Explicitly set `ConnPolicy` to `USE` on the `proxyproto.Listener` in the SSH server, restoring pre-v0.15 behavior where connections without a PROXY protocol header are accepted.

## Why

The `go-proxyproto` [bump from v0.14 to v0.15](https://github.com/pires/go-proxyproto/releases/tag/v0.15.0) (commit `5b6a30c7a`) changed the library's default `ConnPolicy` from `USE` to `REQUIRE`. Since the SSH listener never set an explicit policy, all direct connections (no PROXY header) started being rejected with `ErrNoProxyProtocol` — manifesting as `ssh: handshake failed: EOF` or `kex_exchange_identification: Connection closed by remote host`.

Closes #6667

## Changes

- **`ssh/server/server.go`**: extracted `newProxyListener` that wraps a `net.Listener` with `proxyproto.Listener` and sets `ConnPolicy` to unconditionally return `proxyproto.USE`. `ListenAndServe` now calls this instead of constructing the struct inline. PROXY headers are still parsed when present (deployments behind an L4 load balancer continue to work), just no longer required.

- **`ssh/server/server_test.go`**: added `TestProxyListenerAcceptsWithoutProxyHeader` — creates a real TCP listener wrapped with `newProxyListener`, dials without a PROXY header, and asserts a successful read/write round-trip. This test fails against the previous code (`REQUIRE` default rejects the connection) and passes with the fix.

## Testing

Unit test and `golangci-lint` pass in the `ssh` container. The `TestSSH/connection_v1/*` integration suite (31 subtests — the same ones failing in CI) passes end-to-end with testcontainers.