### PR TITLE
fix(openapi): resolve validator initialization errors

### DIFF
--- a/openapi/spec/components/schemas/announcementShort.yaml
+++ b/openapi/spec/components/schemas/announcementShort.yaml
@@ -12,5 +12,6 @@ required:
   - title
   - date
 example:
+  uuid: 3dd0d1f8-8246-4519-b11a-a3dd33717f65
   title: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   date: 2017-07-21T17:32:28Z

--- a/openapi/spec/components/schemas/device.yaml
+++ b/openapi/spec/components/schemas/device.yaml
@@ -13,7 +13,6 @@ properties:
   identity:
     $ref: deviceIdentity.yaml
   info:
-    description: Device's info
     $ref: deviceInfo.yaml
   public_key:
     description: Device's public key.
@@ -31,7 +30,6 @@ properties:
     type: boolean
     example: true
   namespace:
-    description: Device's namespace
     $ref: namespaceName.yaml
   status:
     $ref: deviceStatus.yaml

--- a/openapi/spec/components/schemas/deviceTags.yaml
+++ b/openapi/spec/components/schemas/deviceTags.yaml
@@ -5,5 +5,14 @@ items:
 maxItems: 3
 example:
   - name: tag1
+    tenant_id: 00000000-0000-4000-0000-000000000000
+    created_at: '2026-01-01T12:00:00Z'
+    updated_at: '2026-01-02T12:00:00Z'
   - name: tag2
+    tenant_id: 00000000-0000-4000-0000-000000000000
+    created_at: '2026-01-01T12:00:00Z'
+    updated_at: '2026-01-02T12:00:00Z'
   - name: tag3
+    tenant_id: 00000000-0000-4000-0000-000000000000
+    created_at: '2026-01-01T12:00:00Z'
+    updated_at: '2026-01-02T12:00:00Z'

--- a/openapi/spec/components/schemas/namespace.yaml
+++ b/openapi/spec/components/schemas/namespace.yaml
@@ -20,7 +20,8 @@ properties:
           description: The time when the member was added.
           example: 2024-09-03T23:17:50.51Z
         role:
-          $ref: namespaceMemberRole.yaml
+          allOf:
+            - $ref: namespaceMemberRole.yaml
           default: owner
         email:
           type: string
@@ -51,7 +52,7 @@ properties:
   max_devices:
     description: Namespace's max device numbers
     type: integer
-    minimum: 3
+    minimum: -1
     default: 3
   created_at:
     description: Namespace's creation date

--- a/openapi/spec/components/schemas/namespaceName.yaml
+++ b/openapi/spec/components/schemas/namespaceName.yaml
@@ -2,5 +2,5 @@ description: Namespace's name
 type: string
 minLength: 1
 maxLength: 30
-pattern: /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
+pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
 example: examplespace

--- a/openapi/spec/components/schemas/userID.yaml
+++ b/openapi/spec/components/schemas/userID.yaml
@@ -1,4 +1,4 @@
 description: User's ID.
 type: string
-pattern: ^[0-9a-f]{24}$
-example: 507f1f77bcf86cd799439011
+format: uuid
+example: 1857f8cd-94c2-4b2a-930a-0bb608a33457


### PR DESCRIPTION
## What

Fixed several OpenAPI schema violations that prevented the validator from initializing in dev mode, causing it to log `ERRO Failed to initialize OpenAPI validator` and skip all runtime response validation.

## Why

The OpenAPI response validator runs only in development mode and catches spec-vs-reality drift early. These schema errors accumulated as the spec evolved (tag schema gained required fields, user IDs migrated from MongoDB ObjectIDs to UUIDs, `max_devices` started using `-1` for unlimited) without the examples and patterns being updated to match.

## Changes

- **`announcementShort`**: added missing required `uuid` field to the example
- **`device`**: removed `description` siblings from `$ref` properties (`info`, `namespace`) — in OpenAPI 3.0 siblings to `$ref` are ignored, and the validator rejects them; the referenced schemas already carry their own descriptions
- **`deviceTags`**: added `tenant_id`, `created_at`, and `updated_at` to example items to satisfy the tag schema's `required` constraint
- **`namespace`**: wrapped `role`'s `$ref` in `allOf` so `default: owner` is a valid sibling; lowered `max_devices` minimum from `3` to `-1` to reflect that `-1` means unlimited
- **`namespaceName`**: stripped JavaScript-style `/` delimiters from the regex `pattern` — OpenAPI patterns are bare ECMA 262 expressions, not JS literals
- **`userID`**: replaced the MongoDB ObjectID pattern with `format: uuid` to match the PostgreSQL migration