### PR TITLE
fix(api): return 403 when current password does not match

### DIFF
--- a/api/routes/user_test.go
+++ b/api/routes/user_test.go
@@ -235,6 +235,21 @@ func TestUpdateUserPassword(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
+			title: "fails when current password does not match",
+			uid:   "123",
+			updatePayloadMock: requests.UserPasswordUpdate{
+				UserParam: requests.UserParam{
+					ID: "123",
+				},
+				CurrentPassword: "wrong_password",
+				NewPassword:     "new_password",
+			},
+			requiredMocks: func(updatePayloadMock requests.UserPasswordUpdate) {
+				mock.On("UpdatePasswordUser", gomock.Anything, "123", updatePayloadMock.CurrentPassword, updatePayloadMock.NewPassword).Return(svc.ErrUserPasswordNotMatch).Once()
+			},
+			expectedStatus: http.StatusForbidden,
+		},
+		{
 			title: "fails when try to updating a password an existing user",
 			uid:   "123",
 			updatePayloadMock: requests.UserPasswordUpdate{

--- a/api/services/errors.go
+++ b/api/services/errors.go
@@ -85,7 +85,7 @@ var (
 	ErrUserUnhandledDuplicate          = errors.New("unhandled duplicated field for the user", ErrLayer, ErrCodeDuplicated)
 	ErrUserPasswordInvalid             = errors.New("user password invalid", ErrLayer, ErrCodeInvalid)
 	ErrUserPasswordDuplicated          = errors.New("user password is equal to new password", ErrLayer, ErrCodeDuplicated)
-	ErrUserPasswordNotMatch            = errors.New("user password does not match to the current password", ErrLayer, ErrCodeInvalid)
+	ErrUserPasswordNotMatch            = errors.New("user password does not match to the current password", ErrLayer, ErrCodeForbidden)
 	ErrUserNotConfirmed                = errors.New("user not confirmed", ErrLayer, ErrCodeForbidden)
 	ErrUserAwaitingApproval            = errors.New("user awaiting approval", ErrLayer, ErrCodeLocked)
 	ErrUserUpdate                      = errors.New("user update", ErrLayer, ErrCodeStore)
@@ -292,7 +292,7 @@ func NewErrUserPasswordDuplicated(next error) error {
 
 // NewErrUserPasswordNotMatch returns an error when the user's password doesn't match with the current password.
 func NewErrUserPasswordNotMatch(next error) error {
-	return NewErrInvalid(ErrUserPasswordNotMatch, nil, next)
+	return NewErrForbidden(ErrUserPasswordNotMatch, next)
 }
 
 // NewErrPublicKeyNotFound returns an error when the public key is not found.


### PR DESCRIPTION
## What

The `UpdateUser` service returned 400 when the user provided an incorrect current password. Changed to 403, which is semantically correct — the request is well-formed; it's the authorization check that fails.

## Why

Caught while testing #6619. The `ChangePasswordDrawer` in `ui/apps/console/src/pages/Profile.tsx` already expected a 403 for this case (line 451), but the API was returning 400 via `ErrCodeInvalid`, so the UI branch for "Current password is incorrect" was unreachable.

## Changes

- **`api/services/errors.go`**: changed `ErrUserPasswordNotMatch` from `ErrCodeInvalid` (→ 400) to `ErrCodeForbidden` (→ 403), and updated `NewErrUserPasswordNotMatch` to use `NewErrForbidden`
- **`api/routes/user_test.go`**: added a test case asserting 403 when the service returns `ErrUserPasswordNotMatch` — no prior test covered this path

Both code paths that raise `ErrUserPasswordNotMatch` are affected: the deprecated `UpdateUserPassword` handler and the newer `UpdateUser` flow via `applyUserChanges`. In both cases the error now resolves to 403. The only UI consumer (`ChangePasswordDrawer`, which calls `PATCH /api/users`) already expects 403.