### PR TITLE
refactor(ui): extract shared RenameSection component

### DIFF
--- a/ui/apps/console/src/components/common/RenameSection.tsx
+++ b/ui/apps/console/src/components/common/RenameSection.tsx
@@ -5,26 +5,33 @@ import {
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
-import { useRenameDevice } from "@/hooks/useDeviceMutations";
-import { useHasPermission } from "@/hooks/useHasPermission";
+import { isSdkError } from "@/api/errors";
 
-interface RenameSectionProps {
+export interface RenameSectionProps {
   uid: string;
   currentName: string;
+  rename: (opts: {
+    path: { uid: string };
+    body: { name: string };
+  }) => Promise<unknown>;
+  entityLabel: string;
+  canRename?: boolean;
 }
 
 export default function RenameSection({
   uid,
   currentName,
+  rename,
+  entityLabel,
+  canRename = true,
 }: RenameSectionProps) {
-  const renameMutation = useRenameDevice();
-  const canRename = useHasPermission("device:rename");
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(currentName);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleSave = async () => {
+    if (saving) return;
     if (!name.trim() || name.trim() === currentName) {
       setEditing(false);
       return;
@@ -32,13 +39,18 @@ export default function RenameSection({
     setSaving(true);
     setError(null);
     try {
-      await renameMutation.mutateAsync({
+      await rename({
         path: { uid },
         body: { name: name.trim() },
       });
       setEditing(false);
-    } catch {
-      setError("Failed to rename device.");
+    } catch (e) {
+      const status = isSdkError(e) ? e.status : undefined;
+      const errors: Record<number, string> = {
+        400: `Invalid ${entityLabel} name.`,
+        409: `A ${entityLabel} with that name already exists.`,
+      };
+      setError((status && errors[status]) || `Failed to rename ${entityLabel}.`);
     }
     setSaving(false);
   };
@@ -50,8 +62,8 @@ export default function RenameSection({
         {canRename && (
           <IconButton
             variant="primary"
-            aria-label="Rename device"
-            title="Rename"
+            aria-label={`Rename ${entityLabel}`}
+            title={`Rename ${entityLabel}`}
             onClick={() => {
               setName(currentName);
               setEditing(true);
@@ -65,7 +77,7 @@ export default function RenameSection({
   }
 
   return (
-    <div>
+    <>
       <div className="flex items-center gap-2">
         <input
           type="text"
@@ -75,13 +87,13 @@ export default function RenameSection({
             if (e.key === "Enter") void handleSave();
             if (e.key === "Escape") setEditing(false);
           }}
-          aria-label="Device name"
+          aria-label={`${entityLabel.charAt(0).toUpperCase() + entityLabel.slice(1)} name`}
           className="text-2xl font-bold text-text-primary bg-transparent border-b-2 border-primary/50 focus:outline-none focus:border-primary w-full max-w-md"
         />
         <IconButton
           variant="primary"
           type="button"
-          aria-label="Save device name"
+          aria-label={`Save ${entityLabel} name`}
           disabled={saving}
           onClick={() => void handleSave()}
         >
@@ -95,7 +107,11 @@ export default function RenameSection({
           <XMarkIcon className="w-4 h-4" strokeWidth={2} />
         </IconButton>
       </div>
-      {error && <p className="text-2xs text-accent-red mt-1">{error}</p>}
-    </div>
+      {error && (
+        <p role="alert" className="text-2xs text-accent-red mt-1">
+          {error}
+        </p>
+      )}
+    </>
   );
 }

--- a/ui/apps/console/src/components/common/__tests__/RenameSection.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/RenameSection.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import RenameSection, { type RenameSectionProps } from "../RenameSection";
+
+function makeSdkError(status: number) {
+  return Object.assign(new Error("Request failed"), {
+    status,
+    headers: new Headers(),
+  });
+}
+
+const mockRename = vi
+  .fn<RenameSectionProps["rename"]>()
+  .mockResolvedValue(undefined);
+
+const defaultProps: RenameSectionProps = {
+  uid: "abc-123",
+  currentName: "my-device",
+  rename: mockRename,
+  entityLabel: "device",
+};
+
+function renderAndEdit(overrides: Partial<RenameSectionProps> = {}) {
+  const user = userEvent.setup();
+  render(<RenameSection {...defaultProps} {...overrides} />);
+  return { user };
+}
+
+async function enterEditMode(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: /rename device/i }));
+}
+
+async function typeAndSave(
+  user: ReturnType<typeof userEvent.setup>,
+  name: string,
+) {
+  await enterEditMode(user);
+  const input = screen.getByRole("textbox");
+  await user.clear(input);
+  await user.type(input, name);
+  await user.click(
+    screen.getByRole("button", { name: /save device name/i }),
+  );
+}
+
+beforeEach(() => {
+  mockRename.mockReset().mockResolvedValue(undefined);
+});
+
+describe("RenameSection", () => {
+  describe("display mode", () => {
+    it("renders the current name as a heading", () => {
+      renderAndEdit();
+      expect(
+        screen.getByRole("heading", { name: "my-device" }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the rename button when canRename is true", () => {
+      renderAndEdit();
+      expect(
+        screen.getByRole("button", { name: /rename device/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the rename button when canRename is false", () => {
+      renderAndEdit({ canRename: false });
+      expect(
+        screen.queryByRole("button", { name: /rename device/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("edit mode", () => {
+    it("shows an input pre-filled with the current name", async () => {
+      const { user } = renderAndEdit();
+      await enterEditMode(user);
+
+      expect(screen.getByRole("textbox")).toHaveValue("my-device");
+    });
+
+    it("shows save and cancel buttons", async () => {
+      const { user } = renderAndEdit();
+      await enterEditMode(user);
+
+      expect(
+        screen.getByRole("button", { name: /save device name/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel rename/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("cancels editing when the cancel button is clicked", async () => {
+      const { user } = renderAndEdit();
+      await enterEditMode(user);
+
+      await user.click(screen.getByRole("button", { name: /cancel rename/i }));
+
+      expect(
+        screen.getByRole("heading", { name: "my-device" }),
+      ).toBeInTheDocument();
+    });
+
+    it("cancels editing on Escape", async () => {
+      const { user } = renderAndEdit();
+      await enterEditMode(user);
+
+      await user.click(screen.getByRole("textbox"));
+      await user.keyboard("{Escape}");
+
+      expect(
+        screen.getByRole("heading", { name: "my-device" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("saving", () => {
+    it("calls rename with the trimmed name and exits edit mode", async () => {
+      const { user } = renderAndEdit();
+      await typeAndSave(user, "  new-name  ");
+
+      expect(mockRename).toHaveBeenCalledWith({
+        path: { uid: "abc-123" },
+        body: { name: "new-name" },
+      });
+      expect(
+        screen.getByRole("heading", { name: "my-device" }),
+      ).toBeInTheDocument();
+    });
+
+    it("saves on Enter", async () => {
+      const { user } = renderAndEdit();
+      await enterEditMode(user);
+      const input = screen.getByRole("textbox");
+      await user.clear(input);
+      await user.type(input, "new-name{Enter}");
+
+      expect(mockRename).toHaveBeenCalledWith({
+        path: { uid: "abc-123" },
+        body: { name: "new-name" },
+      });
+    });
+
+    it("exits without calling rename when name is unchanged", async () => {
+      const { user } = renderAndEdit();
+      await enterEditMode(user);
+      await user.click(
+        screen.getByRole("button", { name: /save device name/i }),
+      );
+
+      expect(mockRename).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole("heading", { name: "my-device" }),
+      ).toBeInTheDocument();
+    });
+
+    it("exits without calling rename when name is empty", async () => {
+      const { user } = renderAndEdit();
+      await enterEditMode(user);
+      await user.clear(screen.getByRole("textbox"));
+      await user.click(
+        screen.getByRole("button", { name: /save device name/i }),
+      );
+
+      expect(mockRename).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error handling", () => {
+    it.each([
+      { status: 400, message: /invalid device name/i },
+      { status: 409, message: /already exists/i },
+      { status: 500, message: /failed to rename device/i },
+      { status: undefined, message: /failed to rename device/i },
+    ])(
+      "shows the right error for status $status",
+      async ({ status, message }) => {
+        mockRename.mockRejectedValue(
+          status ? makeSdkError(status) : new Error("network error"),
+        );
+        const { user } = renderAndEdit();
+        await typeAndSave(user, "taken-name");
+
+        expect(screen.getByRole("alert")).toHaveTextContent(message);
+      },
+    );
+
+    it("uses entityLabel in error messages", async () => {
+      mockRename.mockRejectedValue(makeSdkError(409));
+      const user = userEvent.setup();
+      render(
+        <RenameSection {...defaultProps} entityLabel="container" />,
+      );
+      await user.click(
+        screen.getByRole("button", { name: /rename container/i }),
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.clear(input);
+      await user.type(input, "taken-name");
+      await user.click(
+        screen.getByRole("button", { name: /save container name/i }),
+      );
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /a container with that name already exists/i,
+      );
+    });
+  });
+});

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -6,10 +6,8 @@ import {
   Navigate,
 } from "react-router-dom";
 import Breadcrumb from "@/components/common/Breadcrumb";
+import RenameSection from "@/components/common/RenameSection";
 import {
-  XMarkIcon,
-  PencilSquareIcon,
-  CheckIcon,
   TrashIcon,
   InformationCircleIcon,
   ServerIcon,
@@ -17,7 +15,6 @@ import {
   CubeIcon,
   ChevronDoubleRightIcon,
 } from "@heroicons/react/24/outline";
-import { isSdkError } from "../api/errors";
 import { useContainer } from "../hooks/useContainer";
 import {
   useRenameContainer,
@@ -43,7 +40,6 @@ import { LABEL_BASE } from "@/utils/styles";
 
 const VALUE = "text-sm text-text-primary font-medium mt-0.5";
 
-/* ─── Info Row ─── */
 function InfoItem({
   label,
   value,
@@ -64,7 +60,10 @@ function InfoItem({
       <dt className={LABEL_BASE}>{label}</dt>
       <dd className="flex items-center gap-1 mt-0.5">
         <span
-          className={cn("text-sm text-text-primary", mono ? "font-mono text-xs" : "font-medium")}
+          className={cn(
+            "text-sm text-text-primary",
+            mono ? "font-mono text-xs" : "font-medium",
+          )}
         >
           {display || "—"}
         </span>
@@ -74,101 +73,6 @@ function InfoItem({
   );
 }
 
-/* ─── Rename Inline ─── */
-function RenameSection({
-  uid,
-  currentName,
-}: {
-  uid: string;
-  currentName: string;
-}) {
-  const renameMutation = useRenameContainer();
-  const [editing, setEditing] = useState(false);
-  const [name, setName] = useState(currentName);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSave = async () => {
-    if (!name.trim() || name.trim() === currentName) {
-      setEditing(false);
-      return;
-    }
-    setSaving(true);
-    setError(null);
-    try {
-      await renameMutation.mutateAsync({
-        path: { uid },
-        body: { name: name.trim() },
-      });
-      setEditing(false);
-    } catch (e) {
-      const status = isSdkError(e) ? e.status : undefined;
-      if (status === 409)
-        setError("A container with that name already exists.");
-      else if (status === 400) setError("Invalid container name.");
-      else setError("Failed to rename container.");
-    }
-    setSaving(false);
-  };
-
-  if (!editing) {
-    return (
-      <div className="flex items-center gap-2">
-        <h1 className="text-2xl font-bold text-text-primary">{currentName}</h1>
-        <IconButton
-          variant="primary"
-          title="Rename container"
-          aria-label="Rename container"
-          onClick={() => {
-            setName(currentName);
-            setEditing(true);
-          }}
-        >
-          <PencilSquareIcon className="w-4 h-4" />
-        </IconButton>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      <div className="flex items-center gap-2">
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") void handleSave();
-            if (e.key === "Escape") setEditing(false);
-          }}
-          aria-label="Container name"
-          className="text-2xl font-bold text-text-primary bg-transparent border-b-2 border-primary/50 focus:outline-none focus:border-primary w-full max-w-md"
-        />
-        <IconButton
-          variant="primary"
-          aria-label="Save name"
-          disabled={saving}
-          onClick={() => void handleSave()}
-        >
-          <CheckIcon className="w-4 h-4" strokeWidth={2} />
-        </IconButton>
-        <IconButton
-          aria-label="Cancel rename"
-          onClick={() => setEditing(false)}
-        >
-          <XMarkIcon className="w-4 h-4" strokeWidth={2} />
-        </IconButton>
-      </div>
-      {error && (
-        <p role="alert" className="text-2xs text-accent-red mt-1">
-          {error}
-        </p>
-      )}
-    </div>
-  );
-}
-
-/* ─── Page ─── */
 export default function ContainerDetails() {
   const { uid } = useParams<{ uid: string }>();
   const navigate = useNavigate();
@@ -184,6 +88,7 @@ export default function ContainerDetails() {
   const restoreTerminal = useTerminalStore((s) => s.restore);
   const [connectOpen, setConnectOpen] = useState(false);
 
+  const renameMutation = useRenameContainer();
   const addTagMutation = useAddContainerTag();
   const removeTagMutation = useRemoveContainerTag();
   const containerActions = useContainerActions({
@@ -267,7 +172,12 @@ export default function ContainerDetails() {
           </div>
 
           <div>
-            <RenameSection uid={container.uid} currentName={container.name} />
+            <RenameSection
+              uid={container.uid}
+              currentName={container.name}
+              rename={renameMutation.mutateAsync}
+              entityLabel="container"
+            />
             <div className="flex items-center gap-2 mt-1.5">
               <span
                 className={cn(
@@ -278,12 +188,18 @@ export default function ContainerDetails() {
                 )}
               >
                 <span
-                  className={cn("w-1.5 h-1.5 rounded-full", container.online ? "bg-accent-green" : "bg-text-muted/60")}
+                  className={cn(
+                    "w-1.5 h-1.5 rounded-full",
+                    container.online ? "bg-accent-green" : "bg-text-muted/60",
+                  )}
                 />
                 {container.online ? "Online" : "Offline"}
               </span>
               <span
-                className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md", statusColor)}
+                className={cn(
+                  "inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md",
+                  statusColor,
+                )}
               >
                 {container.status
                   ? container.status.charAt(0).toUpperCase() +

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -13,6 +13,7 @@ import {
 import { useDevice } from "../hooks/useDevice";
 import { useDeviceActions } from "../hooks/useDeviceActions";
 import {
+  useRenameDevice,
   useAddDeviceTag,
   useRemoveDeviceTag,
 } from "../hooks/useDeviceMutations";
@@ -29,7 +30,8 @@ import RestrictedAction from "../components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
 import InfoItem from "./devices/InfoItem";
 import TagsSection from "@/components/common/TagsSection";
-import RenameSection from "./devices/RenameSection";
+import RenameSection from "@/components/common/RenameSection";
+import { useHasPermission } from "@/hooks/useHasPermission";
 import CustomFieldsSection from "./devices/CustomFieldsSection";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
@@ -50,6 +52,8 @@ export default function DeviceDetails() {
   );
   const restoreTerminal = useTerminalStore((s) => s.restore);
   const [connectOpen, setConnectOpen] = useState(false);
+  const renameMutation = useRenameDevice();
+  const canRename = useHasPermission("device:rename");
   const addTagMutation = useAddDeviceTag();
   const removeTagMutation = useRemoveDeviceTag();
   const actionsController = useDeviceActions({
@@ -129,7 +133,13 @@ export default function DeviceDetails() {
           </div>
 
           <div>
-            <RenameSection uid={device.uid} currentName={device.name} />
+            <RenameSection
+              uid={device.uid}
+              currentName={device.name}
+              rename={renameMutation.mutateAsync}
+              entityLabel="device"
+              canRename={canRename}
+            />
             <div className="flex items-center gap-2 mt-1.5">
               <span
                 className={cn(
@@ -140,12 +150,18 @@ export default function DeviceDetails() {
                 )}
               >
                 <span
-                  className={cn("w-1.5 h-1.5 rounded-full", device.online ? "bg-accent-green" : "bg-text-muted/60")}
+                  className={cn(
+                    "w-1.5 h-1.5 rounded-full",
+                    device.online ? "bg-accent-green" : "bg-text-muted/60",
+                  )}
                 />
                 {device.online ? "Online" : "Offline"}
               </span>
               <span
-                className={cn("inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md", statusColor)}
+                className={cn(
+                  "inline-flex items-center px-2 py-0.5 text-2xs font-medium rounded-md",
+                  statusColor,
+                )}
               >
                 {device.status.charAt(0).toUpperCase() + device.status.slice(1)}
               </span>
@@ -186,7 +202,9 @@ export default function DeviceDetails() {
                   title="Delete device"
                   aria-label="Delete device"
                   className="border border-border"
-                  onClick={() => actionsController.requestAction(device, "remove")}
+                  onClick={() =>
+                    actionsController.requestAction(device, "remove")
+                  }
                 >
                   <TrashIcon className="w-4 h-4" />
                 </IconButton>
@@ -198,7 +216,9 @@ export default function DeviceDetails() {
               <RestrictedAction action="device:accept">
                 <Button
                   variant="success"
-                  onClick={() => actionsController.requestAction(device, "accept")}
+                  onClick={() =>
+                    actionsController.requestAction(device, "accept")
+                  }
                 >
                   Accept
                 </Button>
@@ -206,7 +226,9 @@ export default function DeviceDetails() {
               <RestrictedAction action="device:reject">
                 <Button
                   variant="warning"
-                  onClick={() => actionsController.requestAction(device, "reject")}
+                  onClick={() =>
+                    actionsController.requestAction(device, "reject")
+                  }
                 >
                   Reject
                 </Button>
@@ -218,7 +240,9 @@ export default function DeviceDetails() {
               <RestrictedAction action="device:accept">
                 <Button
                   variant="success"
-                  onClick={() => actionsController.requestAction(device, "accept")}
+                  onClick={() =>
+                    actionsController.requestAction(device, "accept")
+                  }
                 >
                   Accept
                 </Button>
@@ -226,7 +250,9 @@ export default function DeviceDetails() {
               <RestrictedAction action="device:remove">
                 <Button
                   variant="destructive"
-                  onClick={() => actionsController.requestAction(device, "remove")}
+                  onClick={() =>
+                    actionsController.requestAction(device, "remove")
+                  }
                 >
                   Remove
                 </Button>


### PR DESCRIPTION
## What

Replaced the duplicate inline rename implementations in `DeviceDetails` and `ContainerDetails` with a single shared `RenameSection` component under `components/common/`, following the same pattern as `TagsSection`.

## Why

Both detail pages had near-identical rename logic (~90 lines each) with minor divergences in error handling and permission gating. The device version had a generic catch-all error; the container version had status-specific messages. Neither had a double-submit guard.

## Changes

- **`components/common/RenameSection`**: extracted component accepting `rename` (mutation fn), `entityLabel`, and optional `canRename` props. Error handling uses a status-code map (`isSdkError` with 400/409) instead of the previous if/else chain. Added a double-submit guard (`if (saving) return`). Added `role="alert"` on the error message for accessibility.
- **`pages/DeviceDetails`**: calls the common component with `useRenameDevice().mutateAsync` and `useHasPermission("device:rename")` — permission check was previously buried inside the old wrapper.
- **`pages/ContainerDetails`**: removed the ~90-line inline `RenameSection` function. Calls the common component with `useRenameContainer().mutateAsync` and no `canRename` (containers don't gate rename by permission).
- **Tests**: 16 tests covering display/edit toggle, save (click + Enter), cancel (click + Escape), no-op on unchanged/empty name, error status mapping (400/409/500/unknown), and `entityLabel` parameterization.