### PR TITLE
refactor(ui): extract IdentityCard and TimelineCard components

### DIFF
--- a/ui/apps/console/src/components/common/IdentityCard.tsx
+++ b/ui/apps/console/src/components/common/IdentityCard.tsx
@@ -1,0 +1,25 @@
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
+import { Card } from "@shellhub/design-system/primitives";
+import InfoItem from "@/components/common/InfoItem";
+
+interface IdentityCardProps {
+  uid: string;
+  mac: string;
+  remoteAddr: string;
+}
+
+export default function IdentityCard({ uid, mac, remoteAddr }: IdentityCardProps) {
+  return (
+    <Card className="p-5 space-y-4">
+      <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
+        <InformationCircleIcon className="w-4 h-4 text-primary" />
+        Identity
+      </h3>
+      <dl className="space-y-3">
+        <InfoItem label="UID" value={uid} mono copyable truncate={8} />
+        <InfoItem label="MAC Address" value={mac} mono copyable />
+        <InfoItem label="Remote Address" value={remoteAddr} mono />
+      </dl>
+    </Card>
+  );
+}

--- a/ui/apps/console/src/components/common/TimelineCard.tsx
+++ b/ui/apps/console/src/components/common/TimelineCard.tsx
@@ -1,0 +1,40 @@
+import { ClockIcon } from "@heroicons/react/24/outline";
+import { Card } from "@shellhub/design-system/primitives";
+import InfoItem from "@/components/common/InfoItem";
+import { formatDateFull, formatRelative } from "@/utils/date";
+
+interface TimelineCardProps {
+  createdAt: string;
+  lastSeen: string;
+  statusUpdatedAt: string;
+}
+
+export default function TimelineCard({
+  createdAt,
+  lastSeen,
+  statusUpdatedAt,
+}: TimelineCardProps) {
+  return (
+    <Card className="p-5 space-y-4">
+      <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
+        <ClockIcon className="w-4 h-4 text-primary" />
+        Timeline
+      </h3>
+      <dl className="space-y-3">
+        <InfoItem label="Created" value={formatDateFull(createdAt)} />
+        <InfoItem label="Last Seen">
+          <span className="text-sm text-text-primary font-medium">
+            {formatRelative(lastSeen)}
+          </span>
+          <span className="text-2xs text-text-muted">
+            {formatDateFull(lastSeen)}
+          </span>
+        </InfoItem>
+        <InfoItem
+          label="Status Updated"
+          value={formatDateFull(statusUpdatedAt)}
+        />
+      </dl>
+    </Card>
+  );
+}

--- a/ui/apps/console/src/components/common/__tests__/IdentityCard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/IdentityCard.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ClipboardProvider } from "../ClipboardProvider";
+import IdentityCard from "../IdentityCard";
+
+function renderCard(props: Partial<Parameters<typeof IdentityCard>[0]> = {}) {
+  return render(
+    <ClipboardProvider>
+      <IdentityCard uid="abc-def-123" mac="aa:bb:cc:dd" remoteAddr="192.168.1.1" {...props} />
+    </ClipboardProvider>,
+  );
+}
+
+describe("IdentityCard", () => {
+  it("renders the Identity heading", () => {
+    renderCard();
+
+    expect(
+      screen.getByRole("heading", { name: /identity/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders UID truncated to 8 characters", () => {
+    renderCard();
+
+    expect(screen.getByText("abc-def-")).toBeInTheDocument();
+  });
+
+  it("renders MAC Address", () => {
+    renderCard();
+
+    expect(screen.getByText("aa:bb:cc:dd")).toBeInTheDocument();
+  });
+
+  it("renders Remote Address", () => {
+    renderCard();
+
+    expect(screen.getByText("192.168.1.1")).toBeInTheDocument();
+  });
+
+  it("shows copy buttons for UID and MAC", () => {
+    renderCard();
+
+    const copyButtons = screen.getAllByRole("button", { name: /copy/i });
+    expect(copyButtons).toHaveLength(2);
+  });
+
+  it("shows em-dash for empty MAC and Remote Address", () => {
+    renderCard({ mac: "", remoteAddr: "" });
+
+    const dashes = screen.getAllByText("—");
+    expect(dashes).toHaveLength(2);
+  });
+});

--- a/ui/apps/console/src/components/common/__tests__/TimelineCard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/TimelineCard.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TimelineCard from "../TimelineCard";
+
+describe("TimelineCard", () => {
+  const defaultProps = {
+    createdAt: "2026-01-15T10:30:00Z",
+    lastSeen: "2026-06-20T14:00:00Z",
+    statusUpdatedAt: "2026-03-01T08:00:00Z",
+  };
+
+  it("renders the Timeline heading", () => {
+    render(<TimelineCard {...defaultProps} />);
+
+    expect(
+      screen.getByRole("heading", { name: /timeline/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Created date", () => {
+    render(<TimelineCard {...defaultProps} />);
+
+    const terms = screen.getAllByRole("term");
+    expect(terms.some((t) => t.textContent === "Created")).toBe(true);
+  });
+
+  it("renders Last Seen with both relative and absolute display", () => {
+    render(<TimelineCard {...defaultProps} />);
+
+    const terms = screen.getAllByRole("term");
+    expect(terms.some((t) => t.textContent === "Last Seen")).toBe(true);
+
+    const definitions = screen.getAllByRole("definition");
+    const lastSeenDd = definitions[1];
+    const spans = lastSeenDd.querySelectorAll("span");
+    expect(spans.length).toBe(2);
+  });
+
+  it("renders Status Updated date", () => {
+    render(<TimelineCard {...defaultProps} />);
+
+    const terms = screen.getAllByRole("term");
+    expect(terms.some((t) => t.textContent === "Status Updated")).toBe(true);
+  });
+
+  it("shows em-dash for empty dates", () => {
+    render(
+      <TimelineCard createdAt="" lastSeen="" statusUpdatedAt="" />,
+    );
+
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -9,9 +9,7 @@ import Breadcrumb from "@/components/common/Breadcrumb";
 import RenameSection from "@/components/common/RenameSection";
 import {
   TrashIcon,
-  InformationCircleIcon,
   ServerIcon,
-  ClockIcon,
   CubeIcon,
   ChevronDoubleRightIcon,
 } from "@heroicons/react/24/outline";
@@ -29,12 +27,13 @@ import { useContainerActions } from "../hooks/useContainerActions";
 import ContainerActionsPortal from "./containers/ContainerActionsPortal";
 import ConnectDrawer from "../components/ConnectDrawer";
 import CopyButton from "../components/common/CopyButton";
-import { formatDateFull, formatRelative } from "../utils/date";
 import { buildSshid } from "../utils/sshid";
 import RestrictedAction from "../components/common/RestrictedAction";
 import TagsSection from "@/components/common/TagsSection";
 import PageLoader from "@/components/common/PageLoader";
+import IdentityCard from "@/components/common/IdentityCard";
 import InfoItem from "@/components/common/InfoItem";
+import TimelineCard from "@/components/common/TimelineCard";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
 import { LABEL_BASE } from "@/utils/styles";
@@ -283,32 +282,11 @@ export default function ContainerDetails() {
 
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        <Card className="p-5 space-y-4">
-          <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
-            <InformationCircleIcon className="w-4 h-4 text-primary" />
-            Identity
-          </h3>
-          <dl className="space-y-3">
-            <InfoItem
-              label="UID"
-              value={container.uid}
-              mono
-              copyable
-              truncate={8}
-            />
-            <InfoItem
-              label="MAC Address"
-              value={container.identity?.mac ?? ""}
-              mono
-              copyable
-            />
-            <InfoItem
-              label="Remote Address"
-              value={container.remote_addr ?? ""}
-              mono
-            />
-          </dl>
-        </Card>
+        <IdentityCard
+          uid={container.uid}
+          mac={container.identity?.mac ?? ""}
+          remoteAddr={container.remote_addr ?? ""}
+        />
 
         <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
@@ -334,30 +312,11 @@ export default function ContainerDetails() {
           </dl>
         </Card>
 
-        <Card className="p-5 space-y-4">
-          <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
-            <ClockIcon className="w-4 h-4 text-primary" />
-            Timeline
-          </h3>
-          <dl className="space-y-3">
-            <InfoItem
-              label="Created"
-              value={formatDateFull(container.created_at)}
-            />
-            <InfoItem label="Last Seen">
-              <span className="text-sm text-text-primary font-medium">
-                {formatRelative(container.last_seen)}
-              </span>
-              <span className="text-2xs text-text-muted">
-                {formatDateFull(container.last_seen)}
-              </span>
-            </InfoItem>
-            <InfoItem
-              label="Status Updated"
-              value={formatDateFull(container.status_updated_at ?? "")}
-            />
-          </dl>
-        </Card>
+        <TimelineCard
+          createdAt={container.created_at}
+          lastSeen={container.last_seen}
+          statusUpdatedAt={container.status_updated_at ?? ""}
+        />
       </div>
 
       {/* Tags */}

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -4,9 +4,7 @@ import Breadcrumb from "@/components/common/Breadcrumb";
 import { LABEL_BASE } from "@/utils/styles";
 import {
   TrashIcon,
-  InformationCircleIcon,
   ComputerDesktopIcon,
-  ClockIcon,
   CpuChipIcon,
   ChevronDoubleRightIcon,
 } from "@heroicons/react/24/outline";
@@ -24,11 +22,12 @@ import DeviceActionsPortal from "./devices/DeviceActionsPortal";
 import ConnectDrawer from "../components/ConnectDrawer";
 import CopyButton from "../components/common/CopyButton";
 import PlatformBadge from "../components/common/PlatformBadge";
-import { formatDateFull, formatRelative } from "../utils/date";
 import { buildSshid } from "../utils/sshid";
 import RestrictedAction from "../components/common/RestrictedAction";
 import PageLoader from "@/components/common/PageLoader";
+import IdentityCard from "@/components/common/IdentityCard";
 import InfoItem from "@/components/common/InfoItem";
+import TimelineCard from "@/components/common/TimelineCard";
 import TagsSection from "@/components/common/TagsSection";
 import RenameSection from "@/components/common/RenameSection";
 import { useHasPermission } from "@/hooks/useHasPermission";
@@ -273,32 +272,11 @@ export default function DeviceDetails() {
 
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        <Card className="p-5 space-y-4">
-          <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
-            <InformationCircleIcon className="w-4 h-4 text-primary" />
-            Identity
-          </h3>
-          <dl className="space-y-3">
-            <InfoItem
-              label="UID"
-              value={device.uid}
-              mono
-              copyable
-              truncate={8}
-            />
-            <InfoItem
-              label="MAC Address"
-              value={device.identity?.mac ?? ""}
-              mono
-              copyable
-            />
-            <InfoItem
-              label="Remote Address"
-              value={device.remote_addr ?? ""}
-              mono
-            />
-          </dl>
-        </Card>
+        <IdentityCard
+          uid={device.uid}
+          mac={device.identity?.mac ?? ""}
+          remoteAddr={device.remote_addr ?? ""}
+        />
 
         <Card className="p-5 space-y-4">
           <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
@@ -330,30 +308,11 @@ export default function DeviceDetails() {
           </dl>
         </Card>
 
-        <Card className="p-5 space-y-4">
-          <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
-            <ClockIcon className="w-4 h-4 text-primary" />
-            Timeline
-          </h3>
-          <dl className="space-y-3">
-            <InfoItem
-              label="Created"
-              value={formatDateFull(device.created_at)}
-            />
-            <InfoItem label="Last Seen">
-              <span className="text-sm text-text-primary font-medium">
-                {formatRelative(device.last_seen)}
-              </span>
-              <span className="text-2xs text-text-muted">
-                {formatDateFull(device.last_seen)}
-              </span>
-            </InfoItem>
-            <InfoItem
-              label="Status Updated"
-              value={formatDateFull(device.status_updated_at ?? "")}
-            />
-          </dl>
-        </Card>
+        <TimelineCard
+          createdAt={device.created_at}
+          lastSeen={device.last_seen}
+          statusUpdatedAt={device.status_updated_at ?? ""}
+        />
       </div>
 
       {/* Tags + Custom Fields */}

--- a/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -1,7 +1,6 @@
 import { useParams, Link } from "react-router-dom";
 import {
   CpuChipIcon,
-  InformationCircleIcon,
   ComputerDesktopIcon,
   ClockIcon,
   TagIcon,
@@ -14,6 +13,7 @@ import DistroIcon from "@/components/common/DistroIcon";
 import PlatformBadge from "@/components/common/PlatformBadge";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatDateFull, formatRelative } from "@/utils/date";
+import IdentityCard from "@/components/common/IdentityCard";
 import InfoItem from "@/components/common/InfoItem";
 import PageLoader from "@/components/common/PageLoader";
 import { Card } from "@shellhub/design-system/primitives";
@@ -91,33 +91,11 @@ export default function AdminDeviceDetails() {
 
       {/* Info Grid */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        {/* Identity Card */}
-        <Card className="p-5 space-y-4">
-          <h3 className="text-xs font-semibold text-text-primary flex items-center gap-2">
-            <InformationCircleIcon className="w-4 h-4 text-primary" />
-            Identity
-          </h3>
-          <dl className="space-y-3">
-            <InfoItem
-              label="UID"
-              value={device.uid}
-              mono
-              copyable
-              truncate={8}
-            />
-            <InfoItem
-              label="MAC Address"
-              value={device.identity?.mac ?? ""}
-              mono
-              copyable
-            />
-            <InfoItem
-              label="Remote Address"
-              value={device.remote_addr ?? ""}
-              mono
-            />
-          </dl>
-        </Card>
+        <IdentityCard
+          uid={device.uid}
+          mac={device.identity?.mac ?? ""}
+          remoteAddr={device.remote_addr ?? ""}
+        />
 
         {/* System Card */}
         <Card className="p-5 space-y-4">


### PR DESCRIPTION
## What

Extracted two shared card components from detail pages: `IdentityCard` (UID, MAC Address, Remote Address) and `TimelineCard` (Created, Last Seen, Status Updated).

## Why

Follow-up to #6673 (`InfoItem` extraction). Three pages had identical Identity sections and two had identical Timeline sections — copy-pasted markup that should be a single component.

## Changes

- **`IdentityCard`**: replaces the Identity card in DeviceDetails, ContainerDetails, and AdminDeviceDetails. Props: `uid`, `mac`, `remoteAddr`.
- **`TimelineCard`**: replaces the Timeline card in DeviceDetails and ContainerDetails. Props: `createdAt`, `lastSeen`, `statusUpdatedAt`. Last Seen renders both relative and absolute timestamps.
- **Scoped deliberately**: UserDetails' Identity section (different fields) and AdminDeviceDetails' "Namespace & Timeline" section (mixed concerns, different Last Seen rendering) stay inline.

## Testing

6 tests for `IdentityCard`, 5 for `TimelineCard` — heading, field rendering, copy buttons, em-dash fallback.