### PR TITLE
feat(ui): wire in-app MFA reset flow to use opaque token

### DIFF
--- a/ui/apps/console/src/pages/MfaResetRequest.tsx
+++ b/ui/apps/console/src/pages/MfaResetRequest.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
-import { EnvelopeIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import { EnvelopeIcon } from "@heroicons/react/24/outline";
 import { Button, Callout } from "@shellhub/design-system/primitives";
 import { useAuthStore } from "../stores/authStore";
 import { useMfaResetStore } from "../stores/mfaResetStore";
@@ -11,7 +11,6 @@ export default function MfaResetRequest() {
   const { user, username, mfaToken } = useAuthStore();
   const { requestMfaReset, loading, error } = useMfaResetStore();
   const navigate = useNavigate();
-  const [emailsSent, setEmailsSent] = useState(false);
 
   const identifier = user || username;
 
@@ -37,7 +36,7 @@ export default function MfaResetRequest() {
   const onSubmit = async () => {
     try {
       await requestMfaReset(identifier);
-      setEmailsSent(true);
+      void navigate("/mfa-reset-verify");
     } catch {
       // Error is set in store
     }
@@ -67,92 +66,48 @@ export default function MfaResetRequest() {
         </p>
       </div>
 
-      {/* Form or Success Card */}
+      {/* Form */}
       <div
         className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
         style={{ animationDelay: "200ms" }}
       >
-        {!emailsSent ? (
-          <form onSubmit={(e) => void handleSubmit(onSubmit)(e)} className="space-y-5">
-            {error && <Callout variant="error">{error}</Callout>}
+        <form
+          onSubmit={(e) => void handleSubmit(onSubmit)(e)}
+          className="space-y-5"
+        >
+          {error && <Callout variant="error">{error}</Callout>}
 
-            <div className="p-4 bg-primary/5 border border-primary/20 rounded-lg">
-              <p className="text-xs text-text-muted text-center">
-                Verification codes will be sent to the email addresses
-                registered for:
-              </p>
-              <p className="text-sm font-mono font-semibold text-primary text-center mt-2">
-                {identifier}
-              </p>
-            </div>
+          <div className="p-4 bg-primary/5 border border-primary/20 rounded-lg">
+            <p className="text-xs text-text-muted text-center">
+              Verification codes will be sent to the email addresses registered
+              for:
+            </p>
+            <p className="text-sm font-mono font-semibold text-primary text-center mt-2">
+              {identifier}
+            </p>
+          </div>
 
-            <Button
-              variant="primary"
-              size="lg"
-              fullWidth
-              type="submit"
-              className="px-4"
-              loading={loading}
-              disabled={loading}
-            >
-              {loading ? "Sending..." : "Send Verification Codes"}
-            </Button>
+          <Button
+            variant="primary"
+            size="lg"
+            fullWidth
+            type="submit"
+            className="px-4"
+            loading={loading}
+            disabled={loading}
+          >
+            {loading ? "Sending..." : "Send Verification Codes"}
+          </Button>
 
-            <div className="text-center pt-2">
-              <Link
-                to="/mfa-recover"
-                className="block text-xs text-text-muted hover:text-text-secondary transition-colors"
-              >
-                ← Back to recovery
-              </Link>
-            </div>
-          </form>
-        ) : (
-          <div className="space-y-5 text-center">
-            <div className="flex justify-center">
-              <div className="w-16 h-16 rounded-full bg-accent-green/15 border border-accent-green/25 flex items-center justify-center">
-                <CheckCircleIcon
-                  className="w-8 h-8 text-accent-green"
-                  strokeWidth={2}
-                />
-              </div>
-            </div>
-
-            <div>
-              <h3 className="text-lg font-semibold text-text-primary mb-2">
-                Emails Sent!
-              </h3>
-              <p className="text-sm text-text-muted leading-relaxed">
-                We've sent verification codes to both your{" "}
-                <span className="font-semibold text-text-primary">
-                  main email
-                </span>{" "}
-                and{" "}
-                <span className="font-semibold text-text-primary">
-                  recovery email
-                </span>{" "}
-                addresses.
-              </p>
-            </div>
-
-            <div className="p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg">
-              <p className="text-xs text-text-muted leading-relaxed">
-                <span className="font-semibold text-accent-yellow">
-                  Next step:
-                </span>{" "}
-                Check both email inboxes and click the link in either email to
-                continue with the reset process.
-              </p>
-            </div>
-
+          <div className="text-center pt-2">
             <Link
-              to="/login"
+              to="/mfa-recover"
               className="block text-xs text-text-muted hover:text-text-secondary transition-colors"
             >
-              ← Back to login
+              ← Back to recovery
             </Link>
           </div>
-        )}
+        </form>
       </div>
 
       {/* Info Note */}

--- a/ui/apps/console/src/pages/MfaResetVerify.tsx
+++ b/ui/apps/console/src/pages/MfaResetVerify.tsx
@@ -9,7 +9,7 @@ import AuthFooterLinks from "../components/common/AuthFooterLinks";
 export default function MfaResetVerify() {
   const {
     completeMfaReset,
-    mfaResetUserId,
+    mfaResetToken,
     mfaResetIdentifier,
     loading,
     error,
@@ -26,12 +26,12 @@ export default function MfaResetVerify() {
 
   // State guard: redirect if no reset session
   useEffect(() => {
-    if (!mfaResetUserId) {
+    if (!mfaResetToken) {
       void navigate("/mfa-recover");
     }
-  }, [mfaResetUserId, navigate]);
+  }, [mfaResetToken, navigate]);
 
-  if (!mfaResetUserId) {
+  if (!mfaResetToken) {
     return null; // Prevent rendering while redirecting
   }
 
@@ -95,7 +95,7 @@ export default function MfaResetVerify() {
                 <input
                   key={index}
                   ref={(el) => {
-                    (otpMain.inputRefs.current[index] = el);
+                    otpMain.inputRefs.current[index] = el;
                   }}
                   type="text"
                   maxLength={1}
@@ -127,7 +127,7 @@ export default function MfaResetVerify() {
                 <input
                   key={index}
                   ref={(el) => {
-                    (otpRecovery.inputRefs.current[index] = el);
+                    otpRecovery.inputRefs.current[index] = el;
                   }}
                   type="text"
                   maxLength={1}

--- a/ui/apps/console/src/pages/__tests__/MfaResetRequest.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/MfaResetRequest.test.tsx
@@ -11,6 +11,7 @@ function renderPage() {
     <MemoryRouter initialEntries={["/mfa-reset-request"]}>
       <Routes>
         <Route path="/mfa-reset-request" element={<MfaResetRequest />} />
+        <Route path="/mfa-reset-verify" element={<div>Verify Page</div>} />
         <Route path="/login" element={<div>Login Page</div>} />
       </Routes>
     </MemoryRouter>,
@@ -34,27 +35,33 @@ describe("MfaResetRequest", () => {
     renderPage();
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: /send verification codes/i }));
+    await user.click(
+      screen.getByRole("button", { name: /send verification codes/i }),
+    );
 
     await waitFor(() => {
       expect(mockRequest).toHaveBeenCalledWith("admin");
     });
   });
 
-  it("shows the email-sent success view after a successful submit", async () => {
+  it("navigates to /mfa-reset-verify after a successful submit", async () => {
     renderPage();
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: /send verification codes/i }));
+    await user.click(
+      screen.getByRole("button", { name: /send verification codes/i }),
+    );
 
     await waitFor(() => {
-      expect(screen.getByText(/Emails Sent!/i)).toBeInTheDocument();
+      expect(screen.getByText("Verify Page")).toBeInTheDocument();
     });
   });
 
   it("shows the store error in a Callout when the request fails", async () => {
     const mockRequest = vi.fn().mockImplementation(async () => {
-      useMfaResetStore.setState({ error: "Unable to send reset emails. Please check your identifier." });
+      useMfaResetStore.setState({
+        error: "Unable to send reset emails. Please check your identifier.",
+      });
       throw new Error("Reset request failed");
     });
     useMfaResetStore.setState({ requestMfaReset: mockRequest, error: null });
@@ -62,10 +69,14 @@ describe("MfaResetRequest", () => {
     renderPage();
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: /send verification codes/i }));
+    await user.click(
+      screen.getByRole("button", { name: /send verification codes/i }),
+    );
 
     await waitFor(() => {
-      expect(screen.getByText(/Unable to send reset emails/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Unable to send reset emails/i),
+      ).toBeInTheDocument();
     });
   });
 
@@ -80,7 +91,11 @@ describe("MfaResetRequest", () => {
   });
 
   it("renders nothing when there is no identifier but an active mfaToken", () => {
-    useAuthStore.setState({ user: null, username: null, mfaToken: "active-tok" });
+    useAuthStore.setState({
+      user: null,
+      username: null,
+      mfaToken: "active-tok",
+    });
 
     const { container } = renderPage();
 

--- a/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
@@ -54,7 +54,7 @@ function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
 
 beforeEach(() => {
   useMfaResetStore.setState({
-    mfaResetUserId: null,
+    mfaResetToken: null,
     mfaResetIdentifier: null,
     loading: false,
     error: null,
@@ -83,7 +83,7 @@ describe("mfaResetStore", () => {
   describe("initial state", () => {
     it("initializes with clean state", () => {
       const state = useMfaResetStore.getState();
-      expect(state.mfaResetUserId).toBeNull();
+      expect(state.mfaResetToken).toBeNull();
       expect(state.mfaResetIdentifier).toBeNull();
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();
@@ -97,7 +97,7 @@ describe("mfaResetStore", () => {
   });
 
   describe("requestMfaReset", () => {
-    it("sets mfaResetUserId and mfaResetIdentifier on success", async () => {
+    it("stores the opaque token from the API response", async () => {
       mockedRequestResetMfa.mockResolvedValueOnce(
         mockSdkResponse({ token: "reset-token" }),
       );
@@ -105,7 +105,7 @@ describe("mfaResetStore", () => {
       await useMfaResetStore.getState().requestMfaReset("admin");
 
       const state = useMfaResetStore.getState();
-      expect(state.mfaResetUserId).toBe("admin");
+      expect(state.mfaResetToken).toBe("reset-token");
       expect(state.mfaResetIdentifier).toBe("admin");
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();
@@ -140,21 +140,21 @@ describe("mfaResetStore", () => {
       expect(state.error).toBe(
         "Unable to send reset emails. Please check your identifier.",
       );
-      expect(state.mfaResetUserId).toBeNull();
+      expect(state.mfaResetToken).toBeNull();
     });
   });
 
   describe("completeMfaReset", () => {
     beforeEach(() => {
-      useMfaResetStore.setState({ mfaResetUserId: "user-123" });
+      useMfaResetStore.setState({ mfaResetToken: "user-123" });
     });
 
-    it("throws when no mfaResetUserId", async () => {
-      useMfaResetStore.setState({ mfaResetUserId: null });
+    it("throws when no mfaResetToken", async () => {
+      useMfaResetStore.setState({ mfaResetToken: null });
 
       await expect(
         useMfaResetStore.getState().completeMfaReset("code1", "code2"),
-      ).rejects.toThrow("No user ID available");
+      ).rejects.toThrow("No reset token available");
 
       expect(useMfaResetStore.getState().error).toBe(
         "Invalid reset session. Please start over.",
@@ -178,9 +178,9 @@ describe("mfaResetStore", () => {
       expect(auth.mfaEnabled).toBe(false);
     });
 
-    it("clears mfaResetUserId and mfaResetIdentifier on success", async () => {
+    it("clears mfaResetToken and mfaResetIdentifier on success", async () => {
       useMfaResetStore.setState({
-        mfaResetUserId: "user-123",
+        mfaResetToken: "user-123",
         mfaResetIdentifier: "admin",
       });
       mockedResetMfa.mockResolvedValueOnce(mockSdkResponse(mockUserAuth()));
@@ -188,7 +188,7 @@ describe("mfaResetStore", () => {
       await useMfaResetStore.getState().completeMfaReset("AAA11", "BBB22");
 
       const state = useMfaResetStore.getState();
-      expect(state.mfaResetUserId).toBeNull();
+      expect(state.mfaResetToken).toBeNull();
       expect(state.mfaResetIdentifier).toBeNull();
       expect(state.loading).toBe(false);
     });
@@ -217,15 +217,14 @@ describe("mfaResetStore", () => {
       expect(state.error).toBe(
         "Invalid verification codes. Please check and try again.",
       );
-      // Reset fields not cleared on failure
-      expect(state.mfaResetUserId).toBe("user-123");
+      expect(state.mfaResetToken).toBe("user-123");
     });
   });
 
   describe("reset", () => {
     it("clears all state to initial values", () => {
       useMfaResetStore.setState({
-        mfaResetUserId: "user-abc",
+        mfaResetToken: "user-abc",
         mfaResetIdentifier: "admin",
         loading: true,
         error: "some error",
@@ -234,7 +233,7 @@ describe("mfaResetStore", () => {
       useMfaResetStore.getState().reset();
 
       const state = useMfaResetStore.getState();
-      expect(state.mfaResetUserId).toBeNull();
+      expect(state.mfaResetToken).toBeNull();
       expect(state.mfaResetIdentifier).toBeNull();
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();

--- a/ui/apps/console/src/stores/mfaResetStore.ts
+++ b/ui/apps/console/src/stores/mfaResetStore.ts
@@ -3,7 +3,7 @@ import { requestResetMfa, resetMfa } from "../client";
 import { useAuthStore } from "./authStore";
 
 interface MfaResetState {
-  mfaResetUserId: string | null;
+  mfaResetToken: string | null;
   mfaResetIdentifier: string | null;
   loading: boolean;
   error: string | null;
@@ -16,7 +16,7 @@ interface MfaResetState {
 }
 
 const initialState = {
-  mfaResetUserId: null,
+  mfaResetToken: null,
   mfaResetIdentifier: null,
   loading: false,
   error: null,
@@ -28,12 +28,12 @@ export const useMfaResetStore = create<MfaResetState>()((set, get) => ({
   requestMfaReset: async (identifier: string) => {
     set({ loading: true, error: null });
     try {
-      await requestResetMfa({
+      const { data } = await requestResetMfa({
         body: { identifier },
         throwOnError: true,
       });
       set({
-        mfaResetUserId: identifier,
+        mfaResetToken: data.token,
         mfaResetIdentifier: identifier,
         loading: false,
       });
@@ -50,16 +50,16 @@ export const useMfaResetStore = create<MfaResetState>()((set, get) => ({
     mainEmailCode: string,
     recoveryEmailCode: string,
   ) => {
-    const { mfaResetUserId } = get();
-    if (!mfaResetUserId) {
+    const { mfaResetToken } = get();
+    if (!mfaResetToken) {
       set({ error: "Invalid reset session. Please start over." });
-      throw new Error("No user ID available");
+      throw new Error("No reset token available");
     }
 
     set({ loading: true, error: null });
     try {
       const { data } = await resetMfa({
-        path: { "user-id": mfaResetUserId },
+        path: { "user-id": mfaResetToken },
         body: {
           main_email_code: mainEmailCode,
           recovery_email_code: recoveryEmailCode,
@@ -67,18 +67,17 @@ export const useMfaResetStore = create<MfaResetState>()((set, get) => ({
         throwOnError: true,
       });
 
-      const userData = data;
       useAuthStore.setState({
-        token: userData.token,
-        user: userData.user,
-        userId: userData.id,
-        email: userData.email,
-        tenant: userData.tenant,
-        name: userData.name,
-        isAdmin: userData.admin ?? false,
-        mfaEnabled: userData.mfa || false,
+        token: data.token,
+        user: data.user,
+        userId: data.id,
+        email: data.email,
+        tenant: data.tenant,
+        name: data.name,
+        isAdmin: data.admin ?? false,
+        mfaEnabled: data.mfa ?? false,
       });
-      set({ mfaResetUserId: null, mfaResetIdentifier: null, loading: false });
+      set({ mfaResetToken: null, mfaResetIdentifier: null, loading: false });
     } catch {
       set({
         loading: false,


### PR DESCRIPTION
## What

Wired the in-app MFA reset flow so users can enter verification codes immediately after requesting them, without leaving the app to click an emailed link.

## Why

The backend (`POST /api/user/mfa/reset`) returns an opaque `{ token }` that must be passed as the `user-id` path segment to `PUT /api/user/mfa/reset/{user-id}`, but the frontend was ignoring the response entirely. `mfaResetStore.requestMfaReset` stored the raw username/email as `mfaResetUserId`, so `completeMfaReset` sent a username where the API expects a token. On top of that, `MfaResetRequest` showed a dead-end "Emails Sent — click the link" card instead of navigating to the already-implemented `MfaResetVerify` page, making that page unreachable.

Closes shellhub-io/team#170

## Changes

- **`mfaResetStore`**: renamed `mfaResetUserId` to `mfaResetToken`, destructured `data.token` from the `requestResetMfa` response and stored it (was discarding the response), updated `completeMfaReset` to guard on and pass `mfaResetToken`. Removed the `userData` alias and normalized `||` to `??` for the `mfa` boolean default.
- **`MfaResetRequest`**: replaced `setEmailsSent(true)` with `navigate("/mfa-reset-verify")` after a successful request. Removed the `emailsSent` state, the success card UI, and the unused `CheckCircleIcon` import.
- **`MfaResetVerify`**: updated the guard and render check from `mfaResetUserId` to `mfaResetToken`. Display text still uses `mfaResetIdentifier` (unchanged).
- **`MfaResetComplete`** (email-link flow): untouched — it reads the user ID from `?id=` and calls `resetMfa` directly, independent of the store.

## Testing

**Happy path**: log in with MFA-enabled account, navigate to MFA recovery, click Reset MFA via Email, submit — should navigate to `/mfa-reset-verify` (not show an "Emails Sent" card). Enter both codes, verify MFA resets and redirects to dashboard.

**Error paths**: enter wrong codes on the verify page — error callout should appear, OTP inputs should clear. Navigate directly to `/mfa-reset-verify` without requesting codes — should redirect to `/mfa-recover`. Trigger an API failure on the request step — error callout on the request page, stay on `/mfa-reset-request`.

**Regression**: click the emailed reset link instead of using the in-app flow — `/reset-mfa?id=...` should still work unchanged.