### PR TITLE
feat(ui): complete email-code disable in MfaDisableDialog

### DIFF
--- a/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
+++ b/ui/apps/console/src/components/mfa/MfaDisableDialog.tsx
@@ -72,6 +72,15 @@ export default function MfaDisableDialog({
           body: { recovery_code: recoveryCode },
           throwOnError: true,
         });
+      } else if (mode === "email-reset") {
+        if (!otpMainEmail.isComplete || !otpRecoveryEmail.isComplete) return;
+        await disableMfa({
+          body: {
+            main_email_code: otpMainEmail.getValue(),
+            recovery_email_code: otpRecoveryEmail.getValue(),
+          },
+          throwOnError: true,
+        });
       }
 
       onSuccess();
@@ -157,7 +166,7 @@ export default function MfaDisableDialog({
                     <input
                       key={index}
                       ref={(el) => {
-                        (otp.inputRefs.current[index] = el);
+                        otp.inputRefs.current[index] = el;
                       }}
                       type="text"
                       inputMode="numeric"
@@ -253,46 +262,98 @@ export default function MfaDisableDialog({
                   </div>
                 </div>
               ) : (
-                <div className="space-y-4 text-center">
-                  <div className="flex justify-center">
-                    <div className="w-14 h-14 rounded-full bg-accent-green/15 border border-accent-green/25 flex items-center justify-center">
-                      <CheckCircleIcon
-                        className="w-7 h-7 text-accent-green"
-                        strokeWidth={2}
-                      />
+                <div className="space-y-4">
+                  <div className="flex items-center gap-2 justify-center">
+                    <CheckCircleIcon
+                      className="w-5 h-5 text-accent-green"
+                      strokeWidth={2}
+                    />
+                    <p className="text-xs font-semibold text-text-primary">
+                      Emails Sent!
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5 text-center">
+                      Main Email Code
+                    </p>
+                    <div
+                      className="flex justify-center gap-2 mb-2"
+                      role="group"
+                      aria-label="Main Email Code"
+                      onPaste={otpMainEmail.handlePaste}
+                    >
+                      {otpMainEmail.code.map((char, index) => (
+                        <input
+                          key={index}
+                          ref={(el) => {
+                            otpMainEmail.inputRefs.current[index] = el;
+                          }}
+                          type="text"
+                          maxLength={1}
+                          value={char}
+                          aria-label={`Main email code character ${index + 1} of 5`}
+                          onChange={(e) =>
+                            otpMainEmail.handleChange(index, e.target.value)
+                          }
+                          onKeyDown={(e) =>
+                            otpMainEmail.handleKeyDown(index, e)
+                          }
+                          className="w-10 h-10 text-center text-lg font-mono bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:border-accent-red/50 focus:ring-1 focus:ring-accent-red/20 transition-all uppercase"
+                        />
+                      ))}
                     </div>
                   </div>
 
                   <div>
-                    <h4 className="text-sm font-semibold text-text-primary mb-2">
-                      Emails Sent!
-                    </h4>
-                    <p className="text-xs text-text-muted leading-relaxed">
-                      Verification codes have been sent to both your main and
-                      recovery email addresses.
+                    <p className="block text-2xs font-mono font-semibold uppercase tracking-label text-text-muted mb-2.5 text-center">
+                      Recovery Email Code
                     </p>
+                    <div
+                      className="flex justify-center gap-2 mb-2"
+                      role="group"
+                      aria-label="Recovery Email Code"
+                      onPaste={otpRecoveryEmail.handlePaste}
+                    >
+                      {otpRecoveryEmail.code.map((char, index) => (
+                        <input
+                          key={index}
+                          ref={(el) => {
+                            otpRecoveryEmail.inputRefs.current[index] = el;
+                          }}
+                          type="text"
+                          maxLength={1}
+                          value={char}
+                          aria-label={`Recovery email code character ${index + 1} of 5`}
+                          onChange={(e) =>
+                            otpRecoveryEmail.handleChange(index, e.target.value)
+                          }
+                          onKeyDown={(e) =>
+                            otpRecoveryEmail.handleKeyDown(index, e)
+                          }
+                          className="w-10 h-10 text-center text-lg font-mono bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:border-accent-red/50 focus:ring-1 focus:ring-accent-red/20 transition-all uppercase"
+                        />
+                      ))}
+                    </div>
                   </div>
 
-                  <div className="p-3 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg">
-                    <p className="text-2xs text-text-muted leading-relaxed">
-                      <span className="font-semibold text-accent-yellow">
-                        Next step:
-                      </span>{" "}
-                      Check both email inboxes and click the link in either
-                      email to continue.
-                    </p>
+                  <div className="text-center">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void handleRequestEmailReset()}
+                      loading={requestingEmail}
+                    >
+                      Resend codes
+                    </Button>
                   </div>
-
-                  <Button fullWidth onClick={onClose}>
-                    Close
-                  </Button>
                 </div>
               )}
             </>
           )}
 
           {/* Actions */}
-          {mode !== "email-reset" && (
+          {(mode !== "email-reset" || emailRequested) && (
             <div className="flex justify-end gap-2 pt-2">
               <Button variant="secondary" onClick={onClose}>
                 Cancel

--- a/ui/apps/console/src/components/mfa/__tests__/MfaDisableDialog.test.tsx
+++ b/ui/apps/console/src/components/mfa/__tests__/MfaDisableDialog.test.tsx
@@ -5,15 +5,22 @@ import MfaDisableDialog from "../MfaDisableDialog";
 
 vi.mock("@/client", () => ({
   disableMfa: vi.fn(),
+  requestResetMfa: vi.fn(),
 }));
 
 vi.mock("@/hooks/useFocusTrap", () => ({ useFocusTrap: vi.fn() }));
 
-import { disableMfa } from "@/client";
+import { disableMfa, requestResetMfa } from "@/client";
+import { useAuthStore } from "@/stores/authStore";
 
 const mockedDisableMfa = vi.mocked(disableMfa);
+const mockedRequestResetMfa = vi.mocked(requestResetMfa);
 
-type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };
+type SdkResponse<T = unknown> = {
+  data: T;
+  request: Request;
+  response: Response;
+};
 
 function mockSdkResponse<T>(data: T): SdkResponse<T> {
   return {
@@ -27,6 +34,27 @@ describe("MfaDisableDialog", () => {
   const onClose = vi.fn();
   const onSuccess = vi.fn();
 
+  function renderDialog(open = true) {
+    const user = userEvent.setup();
+    render(
+      <MfaDisableDialog open={open} onClose={onClose} onSuccess={onSuccess} />,
+    );
+    return user;
+  }
+
+  async function fillTotpCode(
+    user: ReturnType<typeof userEvent.setup>,
+    code = "123456",
+  ) {
+    const inputs = screen.getAllByRole("textbox");
+    const otpInputs = inputs.filter(
+      (input) => input.getAttribute("maxLength") === "1",
+    );
+    for (let i = 0; i < code.length; i++) {
+      await user.type(otpInputs[i], code[i]);
+    }
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockedDisableMfa.mockResolvedValue(mockSdkResponse(undefined));
@@ -34,41 +62,27 @@ describe("MfaDisableDialog", () => {
 
   describe("Mode Switching", () => {
     it("defaults to TOTP mode", () => {
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      renderDialog();
 
-      // TOTP mode shows "Verification Code" label and OTP inputs
       expect(screen.getByText(/Verification Code/i)).toBeInTheDocument();
-      expect(screen.getByText(/Use recovery code instead/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Use recovery code instead/i),
+      ).toBeInTheDocument();
     });
 
     it("switches to recovery code mode", async () => {
-      const user = userEvent.setup();
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      const user = renderDialog();
 
-      const switchButton = screen.getByText(/use recovery code/i);
-      await user.click(switchButton);
+      await user.click(screen.getByText(/use recovery code/i));
 
-      // Recovery mode shows placeholder input
       expect(screen.getByPlaceholderText(/recovery code/i)).toBeInTheDocument();
     });
 
     it("switches back to TOTP mode from recovery", async () => {
-      const user = userEvent.setup();
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      const user = renderDialog();
 
-      // Switch to recovery mode
-      const switchToRecovery = screen.getByText(/use recovery code/i);
-      await user.click(switchToRecovery);
-
-      // Switch back to TOTP
-      const switchToTotp = screen.getByText(/use authenticator/i);
-      await user.click(switchToTotp);
+      await user.click(screen.getByText(/use recovery code/i));
+      await user.click(screen.getByText(/use authenticator/i));
 
       expect(screen.getByText(/Verification Code/i)).toBeInTheDocument();
     });
@@ -76,129 +90,81 @@ describe("MfaDisableDialog", () => {
 
   describe("TOTP Mode Validation", () => {
     it("requires all 6 digits before enabling submit", async () => {
-      const user = userEvent.setup();
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      const user = renderDialog();
 
-      const disableButton = screen.getByRole("button", { name: /disable mfa/i });
+      const disableButton = screen.getByRole("button", {
+        name: /disable mfa/i,
+      });
       expect(disableButton).toBeDisabled();
 
-      // Type 6 digits
-      const inputs = screen.getAllByRole("textbox");
-      const otpInputs = inputs.filter((input) =>
-        input.getAttribute("maxLength") === "1",
-      );
-
-      await user.type(otpInputs[0], "1");
-      await user.type(otpInputs[1], "2");
-      await user.type(otpInputs[2], "3");
-      await user.type(otpInputs[3], "4");
-      await user.type(otpInputs[4], "5");
-      await user.type(otpInputs[5], "6");
+      await fillTotpCode(user);
 
       expect(disableButton).toBeEnabled();
     });
 
     it("successfully disables MFA with valid TOTP", async () => {
-      const user = userEvent.setup();
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      const user = renderDialog();
 
-      // Enter 6-digit code
-      const inputs = screen.getAllByRole("textbox");
-      const otpInputs = inputs.filter((input) =>
-        input.getAttribute("maxLength") === "1",
-      );
+      await fillTotpCode(user);
 
-      await user.type(otpInputs[0], "1");
-      await user.type(otpInputs[1], "2");
-      await user.type(otpInputs[2], "3");
-      await user.type(otpInputs[3], "4");
-      await user.type(otpInputs[4], "5");
-      await user.type(otpInputs[5], "6");
-
-      const disableButton = screen.getByRole("button", { name: /disable mfa/i });
-      await user.click(disableButton);
+      await user.click(screen.getByRole("button", { name: /disable mfa/i }));
 
       await waitFor(() => {
-        expect(mockedDisableMfa).toHaveBeenCalledWith({ body: { code: "123456" }, throwOnError: true });
+        expect(mockedDisableMfa).toHaveBeenCalledWith({
+          body: { code: "123456" },
+          throwOnError: true,
+        });
         expect(onSuccess).toHaveBeenCalled();
         expect(onClose).toHaveBeenCalled();
       });
     });
 
     it("shows error on invalid TOTP", async () => {
-      const user = userEvent.setup();
       mockedDisableMfa.mockRejectedValue(new Error("Invalid code"));
+      const user = renderDialog();
 
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      await fillTotpCode(user, "999999");
 
-      // Enter 6-digit code
-      const inputs = screen.getAllByRole("textbox");
-      const otpInputs = inputs.filter((input) =>
-        input.getAttribute("maxLength") === "1",
-      );
-
-      await user.type(otpInputs[0], "9");
-      await user.type(otpInputs[1], "9");
-      await user.type(otpInputs[2], "9");
-      await user.type(otpInputs[3], "9");
-      await user.type(otpInputs[4], "9");
-      await user.type(otpInputs[5], "9");
-
-      const disableButton = screen.getByRole("button", { name: /disable mfa/i });
-      await user.click(disableButton);
+      await user.click(screen.getByRole("button", { name: /disable mfa/i }));
 
       await waitFor(() => {
-        expect(screen.getByText(/Invalid verification code/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Invalid verification code/i),
+        ).toBeInTheDocument();
       });
-
-      // Should not call onSuccess
       expect(onSuccess).not.toHaveBeenCalled();
     });
   });
 
   describe("Recovery Code Mode Validation", () => {
     it("requires recovery code before enabling submit", async () => {
-      const user = userEvent.setup();
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      const user = renderDialog();
 
-      // Switch to recovery mode
-      const switchButton = screen.getByText(/use recovery code/i);
-      await user.click(switchButton);
+      await user.click(screen.getByText(/use recovery code/i));
 
-      const disableButton = screen.getByRole("button", { name: /disable mfa/i });
+      const disableButton = screen.getByRole("button", {
+        name: /disable mfa/i,
+      });
       expect(disableButton).toBeDisabled();
 
-      // Type recovery code
-      const recoveryInput = screen.getByPlaceholderText(/recovery code/i);
-      await user.type(recoveryInput, "abc123xyz");
+      await user.type(
+        screen.getByPlaceholderText(/recovery code/i),
+        "abc123xyz",
+      );
 
       expect(disableButton).toBeEnabled();
     });
 
     it("successfully disables MFA with valid recovery code", async () => {
-      const user = userEvent.setup();
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
+      const user = renderDialog();
+
+      await user.click(screen.getByText(/use recovery code/i));
+      await user.type(
+        screen.getByPlaceholderText(/recovery code/i),
+        "valid-recovery-code",
       );
 
-      // Switch to recovery mode
-      const switchButton = screen.getByText(/use recovery code/i);
-      await user.click(switchButton);
-
-      // Enter recovery code
-      const recoveryInput = screen.getByPlaceholderText(/recovery code/i);
-      await user.type(recoveryInput, "valid-recovery-code");
-
-      const disableButton = screen.getByRole("button", { name: /disable mfa/i });
-      await user.click(disableButton);
+      await user.click(screen.getByRole("button", { name: /disable mfa/i }));
 
       await waitFor(() => {
         expect(mockedDisableMfa).toHaveBeenCalledWith({
@@ -211,50 +177,36 @@ describe("MfaDisableDialog", () => {
     });
 
     it("shows error on invalid recovery code", async () => {
-      const user = userEvent.setup();
       mockedDisableMfa.mockRejectedValue(new Error("Invalid recovery code"));
+      const user = renderDialog();
 
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
+      await user.click(screen.getByText(/use recovery code/i));
+      await user.type(
+        screen.getByPlaceholderText(/recovery code/i),
+        "invalid-code",
       );
 
-      // Switch to recovery mode
-      const switchButton = screen.getByText(/use recovery code/i);
-      await user.click(switchButton);
-
-      // Enter recovery code
-      const recoveryInput = screen.getByPlaceholderText(/recovery code/i);
-      await user.type(recoveryInput, "invalid-code");
-
-      const disableButton = screen.getByRole("button", { name: /disable mfa/i });
-      await user.click(disableButton);
+      await user.click(screen.getByRole("button", { name: /disable mfa/i }));
 
       await waitFor(() => {
         expect(screen.getByText(/Invalid recovery code/i)).toBeInTheDocument();
       });
-
       expect(onSuccess).not.toHaveBeenCalled();
     });
   });
 
   describe("Dialog Behavior", () => {
     it("closes when cancel button is clicked", async () => {
-      const user = userEvent.setup();
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      const user = renderDialog();
 
-      const cancelButton = screen.getByText(/cancel/i);
-      await user.click(cancelButton);
+      await user.click(screen.getByText(/cancel/i));
 
       expect(onClose).toHaveBeenCalled();
       expect(onSuccess).not.toHaveBeenCalled();
     });
 
     it("closes when clicking outside (backdrop)", () => {
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      renderDialog();
 
       const dialog = document.querySelector("dialog") as HTMLElement;
       fireEvent.mouseDown(dialog);
@@ -264,7 +216,11 @@ describe("MfaDisableDialog", () => {
 
     it("does not render when open is false", () => {
       const { container } = render(
-        <MfaDisableDialog open={false} onClose={onClose} onSuccess={onSuccess} />,
+        <MfaDisableDialog
+          open={false}
+          onClose={onClose}
+          onSuccess={onSuccess}
+        />,
       );
 
       expect(container.firstChild).toBeNull();
@@ -273,7 +229,6 @@ describe("MfaDisableDialog", () => {
 
   describe("Loading State", () => {
     it("disables submit button while submitting", async () => {
-      const user = userEvent.setup();
       let resolveDisable: (v: SdkResponse) => void;
       mockedDisableMfa.mockReturnValue(
         new Promise<SdkResponse>((resolve) => {
@@ -281,30 +236,17 @@ describe("MfaDisableDialog", () => {
         }),
       );
 
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      const user = renderDialog();
 
-      // Enter code
-      const inputs = screen.getAllByRole("textbox");
-      const otpInputs = inputs.filter((input) =>
-        input.getAttribute("maxLength") === "1",
-      );
+      await fillTotpCode(user);
 
-      await user.type(otpInputs[0], "1");
-      await user.type(otpInputs[1], "2");
-      await user.type(otpInputs[2], "3");
-      await user.type(otpInputs[3], "4");
-      await user.type(otpInputs[4], "5");
-      await user.type(otpInputs[5], "6");
-
-      const disableButton = screen.getByRole("button", { name: /disable mfa/i });
+      const disableButton = screen.getByRole("button", {
+        name: /disable mfa/i,
+      });
       await user.click(disableButton);
 
-      // Button should be disabled during submission
       expect(disableButton).toBeDisabled();
 
-      // Resolve the promise
       resolveDisable!(mockSdkResponse(undefined));
 
       await waitFor(() => {
@@ -315,39 +257,143 @@ describe("MfaDisableDialog", () => {
 
   describe("Error Handling", () => {
     it("shows error after failed TOTP submit and switches to recovery mode", async () => {
-      const user = userEvent.setup();
       mockedDisableMfa.mockRejectedValue(new Error("Invalid code"));
+      const user = renderDialog();
 
-      render(
-        <MfaDisableDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      );
+      await fillTotpCode(user, "999999");
 
-      // Try with invalid TOTP
-      const inputs = screen.getAllByRole("textbox");
-      const otpInputs = inputs.filter((input) =>
-        input.getAttribute("maxLength") === "1",
-      );
-
-      await user.type(otpInputs[0], "9");
-      await user.type(otpInputs[1], "9");
-      await user.type(otpInputs[2], "9");
-      await user.type(otpInputs[3], "9");
-      await user.type(otpInputs[4], "9");
-      await user.type(otpInputs[5], "9");
-
-      const disableButton = screen.getByRole("button", { name: /disable mfa/i });
-      await user.click(disableButton);
+      await user.click(screen.getByRole("button", { name: /disable mfa/i }));
 
       await waitFor(() => {
-        expect(screen.getByText(/Invalid verification code/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Invalid verification code/i),
+        ).toBeInTheDocument();
       });
 
-      // Switch to recovery mode — component does not clear the error on mode switch
-      const switchButton = screen.getByText(/use recovery code instead/i);
-      await user.click(switchButton);
+      await user.click(screen.getByText(/use recovery code instead/i));
 
-      // Recovery mode input is now visible
       expect(screen.getByPlaceholderText(/recovery code/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("Email-Reset Mode", () => {
+    beforeEach(() => {
+      useAuthStore.setState({ user: "admin" });
+      mockedRequestResetMfa.mockResolvedValue(
+        mockSdkResponse({ token: "reset-token" }),
+      );
+    });
+
+    async function navigateToEmailReset(
+      user: ReturnType<typeof userEvent.setup>,
+    ) {
+      await user.click(screen.getByText(/use recovery code/i));
+      await user.click(screen.getByText(/request email reset/i));
+    }
+
+    async function requestCodes(user: ReturnType<typeof userEvent.setup>) {
+      await user.click(
+        screen.getByRole("button", { name: /send verification codes/i }),
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/Emails Sent!/i)).toBeInTheDocument();
+      });
+    }
+
+    async function fillEmailOtpInputs(
+      user: ReturnType<typeof userEvent.setup>,
+    ) {
+      const mainInputs = screen.getAllByLabelText(/main email code character/i);
+      for (let i = 0; i < mainInputs.length; i++) {
+        await user.type(mainInputs[i], String.fromCharCode(65 + i));
+      }
+
+      const recoveryInputs = screen.getAllByLabelText(
+        /recovery email code character/i,
+      );
+      for (let i = 0; i < recoveryInputs.length; i++) {
+        await user.type(recoveryInputs[i], String(i + 1));
+      }
+    }
+
+    it("shows OTP inputs after requesting codes", async () => {
+      const user = renderDialog();
+
+      await navigateToEmailReset(user);
+      await requestCodes(user);
+
+      expect(
+        screen.getAllByLabelText(/main email code character/i),
+      ).toHaveLength(5);
+      expect(
+        screen.getAllByLabelText(/recovery email code character/i),
+      ).toHaveLength(5);
+      expect(
+        screen.getByRole("button", { name: /disable mfa/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("submits email codes and calls onSuccess/onClose", async () => {
+      const user = renderDialog();
+
+      await navigateToEmailReset(user);
+      await requestCodes(user);
+      await fillEmailOtpInputs(user);
+
+      await user.click(screen.getByRole("button", { name: /disable mfa/i }));
+
+      await waitFor(() => {
+        expect(mockedDisableMfa).toHaveBeenCalledWith({
+          body: { main_email_code: "ABCDE", recovery_email_code: "12345" },
+          throwOnError: true,
+        });
+        expect(onSuccess).toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    it("shows error and resets OTP inputs on failure", async () => {
+      mockedDisableMfa.mockRejectedValue(new Error("Invalid codes"));
+      const user = renderDialog();
+
+      await navigateToEmailReset(user);
+      await requestCodes(user);
+      await fillEmailOtpInputs(user);
+
+      await user.click(screen.getByRole("button", { name: /disable mfa/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Invalid email verification codes/i),
+        ).toBeInTheDocument();
+      });
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+
+      const mainInputs = screen.getAllByLabelText(/main email code character/i);
+      const recoveryInputs = screen.getAllByLabelText(
+        /recovery email code character/i,
+      );
+      for (const input of [...mainInputs, ...recoveryInputs]) {
+        expect(input).toHaveValue("");
+      }
+    });
+
+    it("resets email-reset state when switching back to recovery", async () => {
+      const user = renderDialog();
+
+      await navigateToEmailReset(user);
+
+      expect(
+        screen.getByRole("button", { name: /send verification codes/i }),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByText(/use recovery code/i));
+
+      expect(screen.getByPlaceholderText(/recovery code/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /disable mfa/i }),
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## What

Completes the email-reset mode in `MfaDisableDialog` so a logged-in user who lost both their authenticator and recovery codes can disable MFA by entering the codes emailed to them, without leaving the dialog.

## Why

The dialog's email-reset mode was partially wired: it sent verification codes but then showed a dead-end "Emails Sent — click the link" card with a Close button. No OTP inputs were rendered (despite the hooks being initialized), `handleSubmit` had no `email-reset` branch, and the Cancel/Submit buttons were hidden. The backend already accepts `main_email_code` and `recovery_email_code` on `PUT /api/user/mfa/disable`, but the frontend never sent them.

Closes shellhub-io/team#171

## Changes

- **`handleSubmit`**: added `email-reset` branch that calls `disableMfa` with `{ main_email_code, recovery_email_code }`. The existing error handling and OTP reset logic in the catch block already covered this mode — only the try block was missing.
- **post-send UI**: replaced the dead-end card with two 5-char OTP input groups (main + recovery email codes), keeping "Emails Sent!" as a compact inline header. Added a "Resend codes" ghost button below the inputs.
- **action buttons**: changed the visibility condition from `mode !== "email-reset"` to `(mode !== "email-reset" || emailRequested)` so Cancel and Disable MFA appear once the OTP inputs are rendered.
- **tests**: added 5 tests covering the email-reset flow (OTP inputs appear after request, successful submit, error + OTP reset, `onClose` not called on failure, mode switching back to recovery). Extracted `renderDialog` and `fillTotpCode` helpers to eliminate repeated render boilerplate across all 19 tests.

## Testing

**Happy path**: Profile → Disable MFA → recovery mode → Request email reset → Send Verification Codes → enter both 5-char codes → Disable MFA. Should disable MFA and close the dialog.

**Error path**: enter wrong codes → error callout appears, both OTP inputs clear, dialog stays open for retry.

**Regression**: TOTP and recovery modes should work unchanged. Cancel/backdrop close should work in all modes.