### PR TITLE
fix(store): backfill registration events for keyed devices missing one

### DIFF
--- a/api/store/pg/migration_backfill_test.go
+++ b/api/store/pg/migration_backfill_test.go
@@ -1,0 +1,123 @@
+package pg_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/api/store/storetest/pgprovider"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/clock"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// backfillSQL reads migration 014's up statement from disk so the test exercises the exact SQL that
+// ships, not a copy that could drift from it.
+func backfillSQL(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	path := filepath.Join(filepath.Dir(self), "migrations", "014_backfill_install_key_events.tx.up.sql")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return string(data)
+}
+
+// TestInstallKeyEventBackfillMigration covers migration 014: it writes exactly one registration event
+// for every device attributed to a key but missing one, freezing the decision for already accepted or
+// rejected devices while leaving pending ones open (NULL decided_status, which is what surfaces the
+// accept control), and it never touches a device that already has an event or one with no key.
+func TestInstallKeyEventBackfillMigration(t *testing.T) {
+	ctx := context.Background()
+
+	provider, err := pgprovider.NewProvider(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { provider.Close(t) })
+
+	st := provider.Store()
+
+	owner, err := st.UserCreate(ctx, &models.User{
+		Origin:        models.UserOriginLocal,
+		Status:        models.UserStatusConfirmed,
+		MaxNamespaces: -1,
+		UserData:      models.UserData{Name: "owner", Email: "owner@example.com", Username: "owner"},
+		Password:      models.UserPassword{Hash: "hash"},
+	})
+	require.NoError(t, err)
+
+	// NamespaceCreate seeds the namespace's legacy (system) key; the test devices enroll against it.
+	tenant, err := st.NamespaceCreate(ctx, &models.Namespace{
+		Name:       "ns",
+		Owner:      owner,
+		MaxDevices: -1,
+		Members:    []models.Member{{ID: owner, Role: authorizer.RoleOwner}},
+		Settings:   &models.NamespaceSettings{},
+	})
+	require.NoError(t, err)
+
+	legacy, err := st.InstallKeyResolveSystem(ctx, tenant)
+	require.NoError(t, err)
+
+	now := clock.Now()
+	mkDevice := func(uidSeed, mac string, status models.DeviceStatus, keyID string) string {
+		t.Helper()
+		uid := uidSeed + strings.Repeat("0", 64-len(uidSeed))
+		_, err := st.DeviceCreate(ctx, &models.Device{
+			UID:             uid,
+			TenantID:        tenant,
+			Name:            uidSeed,
+			Identity:        &models.DeviceIdentity{MAC: mac},
+			PublicKey:       "pk-" + uidSeed,
+			Status:          status,
+			StatusUpdatedAt: now,
+			InstallKeyID:    keyID,
+		})
+		require.NoError(t, err)
+
+		return uid
+	}
+
+	pendingUID := mkDevice("aa", "aa:bb:cc:dd:ee:01", models.DeviceStatusPending, legacy.ID)
+	acceptedUID := mkDevice("bb", "aa:bb:cc:dd:ee:02", models.DeviceStatusAccepted, legacy.ID)
+	withEventUID := mkDevice("cc", "aa:bb:cc:dd:ee:03", models.DeviceStatusAccepted, legacy.ID)
+	keylessUID := mkDevice("dd", "aa:bb:cc:dd:ee:04", models.DeviceStatusPending, "")
+
+	// The device that already has an event must be left untouched by the backfill.
+	require.NoError(t, st.InstallKeyEventCreate(ctx, &models.InstallKeyEvent{
+		InstallKeyID: legacy.ID,
+		TenantID:     tenant,
+		DeviceUID:    withEventUID,
+		Hostname:     "cc",
+	}))
+
+	_, err = provider.DB().ExecContext(ctx, backfillSQL(t))
+	require.NoError(t, err)
+
+	type row struct {
+		DeviceUID string `bun:"device_uid"`
+		Decided   string `bun:"decided_status"`
+	}
+	events := make(map[string][]row)
+	var rows []row
+	require.NoError(t, provider.DB().NewRaw("SELECT device_uid, coalesce(decided_status, '') AS decided_status FROM install_key_events").Scan(ctx, &rows))
+	for _, r := range rows {
+		events[r.DeviceUID] = append(events[r.DeviceUID], r)
+	}
+
+	require.Len(t, events[pendingUID], 1, "a pending device without an event gets one")
+	assert.Empty(t, events[pendingUID][0].Decided, "a pending device's backfilled event stays open so the accept control shows")
+
+	require.Len(t, events[acceptedUID], 1, "an accepted device without an event gets one")
+	assert.Equal(t, "accepted", events[acceptedUID][0].Decided, "an accepted device's decision is frozen on the event")
+
+	require.Len(t, events[withEventUID], 1, "a device that already had an event is not given a second one")
+
+	assert.Empty(t, events[keylessUID], "a device with no key is skipped")
+}

--- a/api/store/pg/migrations/014_backfill_install_key_events.tx.down.sql
+++ b/api/store/pg/migrations/014_backfill_install_key_events.tx.down.sql
@@ -1,0 +1,5 @@
+-- This migration only backfills registration-history rows; it adds no schema. The synthetic events it
+-- writes are indistinguishable from organically recorded ones (append-only, immutable by design), so
+-- there is nothing to safely reverse here. Leaving it as a no-op keeps the down runnable without
+-- deleting real history.
+SELECT 1;

--- a/api/store/pg/migrations/014_backfill_install_key_events.tx.up.sql
+++ b/api/store/pg/migrations/014_backfill_install_key_events.tx.up.sql
@@ -1,0 +1,28 @@
+-- Migration 013 attributed every existing device to its namespace's legacy key (devices.install_key_id)
+-- but created no registration-history row for them. The console routes device acceptance through each
+-- key's registration activity and the devices list shows only accepted devices, so a device that was
+-- pending at upgrade time would be unreachable: absent from the accepted-only list and from every key's
+-- activity, with no way to accept it. One synthetic event per device that has a key but no event closes
+-- that gap. The decision is frozen for devices already accepted/rejected so the history reads correctly;
+-- a pending device gets an open event (decided_status NULL), which is what surfaces the accept control.
+INSERT INTO install_key_events (
+    id, install_key_id, namespace_id, device_uid, hostname, mac, public_key, source_ip,
+    ephemeral, re_registration, decided_status, decided_at, created_at
+)
+SELECT
+    gen_random_uuid(),
+    d.install_key_id,
+    d.namespace_id,
+    d.id,
+    d.name,
+    d.mac,
+    d.public_key,
+    d.remote_addr,
+    d.ephemeral,
+    false,
+    CASE WHEN d.status IN ('accepted', 'rejected') THEN d.status::text END,
+    CASE WHEN d.status IN ('accepted', 'rejected') THEN d.status_updated_at END,
+    d.created_at
+FROM devices d
+WHERE d.install_key_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM install_key_events e WHERE e.device_uid = d.id);


### PR DESCRIPTION
The install-keys feature moved device acceptance into each key's registration activity: the devices list now shows only accepted devices, and a pending device is reviewed from its key's activity instead of a Pending tab.

Migration 013 attributed every existing device to its namespace's legacy install key (`devices.install_key_id`) but did not record a registration event for those devices. On an upgrade with a device that was pending at the time, that device becomes unreachable in the console: it is absent from the accepted-only list and from every key's registration activity, so there is no way to accept it. Devices that were already accepted are unaffected, since they still appear in the list.

Migration 014 closes the gap. It writes one registration event for each device that has a key but no event, so pending devices resurface under their key's activity with the accept control available. The decision is frozen on the event for devices already accepted or rejected, so their history reads correctly; pending devices get an open event.

The event is reconstructed from the device's own facts (hostname, MAC, public key, source IP, ephemeral flag) and its creation time. A device that already has an event, or one with no key, is left untouched.