### PR TITLE
fix(store): carry device OS facts into backfilled registration events

### DIFF
--- a/api/store/pg/migration_backfill_test.go
+++ b/api/store/pg/migration_backfill_test.go
@@ -74,6 +74,7 @@ func TestInstallKeyEventBackfillMigration(t *testing.T) {
 			TenantID:        tenant,
 			Name:            uidSeed,
 			Identity:        &models.DeviceIdentity{MAC: mac},
+			Info:            &models.DeviceInfo{ID: "arch", PrettyName: "Arch Linux", Version: "v1.2.3", Arch: "amd64", Platform: "docker"},
 			PublicKey:       "pk-" + uidSeed,
 			Status:          status,
 			StatusUpdatedAt: now,
@@ -101,21 +102,32 @@ func TestInstallKeyEventBackfillMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	type row struct {
-		DeviceUID string `bun:"device_uid"`
-		Decided   string `bun:"decided_status"`
+		DeviceUID  string `bun:"device_uid"`
+		Decided    string `bun:"decided_status"`
+		InfoID     string `bun:"info_id"`
+		InfoPretty string `bun:"info_pretty_name"`
+		InfoArch   string `bun:"info_arch"`
 	}
 	events := make(map[string][]row)
 	var rows []row
-	require.NoError(t, provider.DB().NewRaw("SELECT device_uid, coalesce(decided_status, '') AS decided_status FROM install_key_events").Scan(ctx, &rows))
+	require.NoError(t, provider.DB().
+		NewRaw("SELECT device_uid, coalesce(decided_status, '') AS decided_status, coalesce(info_id, '') AS info_id, coalesce(info_pretty_name, '') AS info_pretty_name, coalesce(info_arch, '') AS info_arch FROM install_key_events").
+		Scan(ctx, &rows))
 	for _, r := range rows {
 		events[r.DeviceUID] = append(events[r.DeviceUID], r)
 	}
 
 	require.Len(t, events[pendingUID], 1, "a pending device without an event gets one")
 	assert.Empty(t, events[pendingUID][0].Decided, "a pending device's backfilled event stays open so the accept control shows")
+	// The device's OS facts must ride along so the registration activity shows the distro icon and name,
+	// not a blank generic row: info_id drives the icon, info_pretty_name/arch the labels.
+	assert.Equal(t, "arch", events[pendingUID][0].InfoID, "the device's distro id (identifier) is copied so the icon renders")
+	assert.Equal(t, "Arch Linux", events[pendingUID][0].InfoPretty)
+	assert.Equal(t, "amd64", events[pendingUID][0].InfoArch)
 
 	require.Len(t, events[acceptedUID], 1, "an accepted device without an event gets one")
 	assert.Equal(t, "accepted", events[acceptedUID][0].Decided, "an accepted device's decision is frozen on the event")
+	assert.Equal(t, "arch", events[acceptedUID][0].InfoID, "OS facts ride along regardless of decision")
 
 	require.Len(t, events[withEventUID], 1, "a device that already had an event is not given a second one")
 

--- a/api/store/pg/migrations/014_backfill_install_key_events.tx.up.sql
+++ b/api/store/pg/migrations/014_backfill_install_key_events.tx.up.sql
@@ -3,11 +3,15 @@
 -- key's registration activity and the devices list shows only accepted devices, so a device that was
 -- pending at upgrade time would be unreachable: absent from the accepted-only list and from every key's
 -- activity, with no way to accept it. One synthetic event per device that has a key but no event closes
--- that gap. The decision is frozen for devices already accepted/rejected so the history reads correctly;
--- a pending device gets an open event (decided_status NULL), which is what surfaces the accept control.
+-- that gap. The device's own facts are copied onto the event (the same fields an enrollment captures):
+-- its OS identity (identifier -> info_id, which drives the distro icon, plus the pretty name, version,
+-- arch, and platform), MAC, public key, and source address. The decision is frozen for devices already
+-- accepted/rejected so the history reads correctly; a pending device gets an open event (decided_status
+-- NULL), which is what surfaces the accept control.
 INSERT INTO install_key_events (
-    id, install_key_id, namespace_id, device_uid, hostname, mac, public_key, source_ip,
-    ephemeral, re_registration, decided_status, decided_at, created_at
+    id, install_key_id, namespace_id, device_uid, hostname, mac,
+    info_id, info_pretty_name, info_version, info_arch, info_platform,
+    public_key, source_ip, ephemeral, re_registration, decided_status, decided_at, created_at
 )
 SELECT
     gen_random_uuid(),
@@ -16,6 +20,11 @@ SELECT
     d.id,
     d.name,
     d.mac,
+    d.identifier,
+    d.pretty_name,
+    d.version,
+    d.arch,
+    d.platform,
     d.public_key,
     d.remote_addr,
     d.ephemeral,


### PR DESCRIPTION
Migration 014 backfills a registration event for each device that has an install key but no event, so devices left pending at upgrade time stay acceptable from their key's registration activity. It copied the device's hostname, MAC, public key, and source address onto the synthetic event but left the OS fields empty.

The registration activity draws the distro icon from the event's `info_id`, and the OS name, architecture, and agent version from the other `info_*` fields. With those empty, a backfilled row rendered as a blank, generic entry, missing everything an organically recorded event shows.

The backfill now copies the device's identity too: `identifier` into `info_id` (the distro icon), plus the pretty name, version, architecture, and platform. This only enriches the rows the migration writes; organic enrollments already capture these fields.