### PR TITLE
fix(ui): scope Drawer escape listener to its panel element

### DIFF
--- a/ui/apps/console/src/components/common/Drawer.tsx
+++ b/ui/apps/console/src/components/common/Drawer.tsx
@@ -35,7 +35,7 @@ export default function Drawer({
 }: DrawerProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const headingId = useId();
-  useEscapeKey(onClose, open);
+  useEscapeKey(onClose, open, panelRef);
   useFocusTrap(panelRef, open);
 
   return (

--- a/ui/apps/console/src/components/common/__tests__/Drawer.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/Drawer.test.tsx
@@ -1,13 +1,18 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import Drawer from "@/components/common/Drawer";
 
-function renderDrawer(open = true) {
-  return render(
-    <Drawer open={open} onClose={vi.fn()} title="Edit device">
-      <p>Body</p>
-    </Drawer>,
-  );
+function renderDrawer(props: { open?: boolean; onClose?: () => void } = {}) {
+  const onClose = props.onClose ?? vi.fn();
+  return {
+    onClose,
+    ...render(
+      <Drawer open={props.open ?? true} onClose={onClose} title="Edit device">
+        <p>Body</p>
+      </Drawer>,
+    ),
+  };
 }
 
 describe("Drawer accessibility", () => {
@@ -26,5 +31,40 @@ describe("Drawer accessibility", () => {
 
     expect(dialog.getAttribute("aria-labelledby")).toBe(heading.id);
     expect(heading.id).not.toBe("");
+  });
+});
+
+describe("Drawer Escape key", () => {
+  it("closes when Escape is pressed and the panel has focus", async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderDrawer();
+
+    screen.getByLabelText("Close").focus();
+    await user.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not close when focus is inside a sibling dialog", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <>
+        <Drawer open onClose={onClose} title="Edit device">
+          <p>Body</p>
+        </Drawer>
+        <dialog ref={(el) => el?.showModal()}>
+          <button type="button">Inside dialog</button>
+        </dialog>
+      </>,
+    );
+
+    const inner = screen.getByText("Inside dialog");
+    inner.focus();
+
+    await user.keyboard("{Escape}");
+
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/ui/apps/console/src/hooks/useEscapeKey.ts
+++ b/ui/apps/console/src/hooks/useEscapeKey.ts
@@ -1,12 +1,19 @@
-import { useEffect } from "react";
+import { RefObject, useEffect } from "react";
 
-export function useEscapeKey(handler: () => void, enabled = true): void {
+export function useEscapeKey(
+  handler: () => void,
+  enabled = true,
+  containerRef?: RefObject<HTMLElement | null>,
+): void {
   useEffect(() => {
     if (!enabled) return;
-    const listener = (e: KeyboardEvent) => {
-      if (e.key === "Escape") handler();
+    const target = containerRef?.current ?? document;
+
+    const listener = (e: Event) => {
+      if ("key" in e && e.key === "Escape") handler();
     };
-    document.addEventListener("keydown", listener);
-    return () => document.removeEventListener("keydown", listener);
-  }, [handler, enabled]);
+
+    target.addEventListener("keydown", listener);
+    return () => target.removeEventListener("keydown", listener);
+  }, [handler, enabled, containerRef]);
 }


### PR DESCRIPTION
## What

Pressing Escape while a dialog was open on top of a Drawer closed both at once. Now only the topmost layer closes.

## Why

`useEscapeKey` listened on `document`, so every Escape keypress reached the Drawer's handler regardless of what had focus. When a sibling `<dialog>` (via `showModal()`) was open — e.g. the delete-tag `ConfirmDialog` inside `ManageTagsDrawer`, or the `VaultUnlockDialog` alongside `ConnectDrawer` — a single Escape fired both the dialog's native `cancel` event and the Drawer's global listener simultaneously.

Closes #6684

## Changes

- **`useEscapeKey`**: added an optional `containerRef` parameter. When provided, the keydown listener attaches to that element instead of `document`. Existing callers (5 dropdown/popover components) are unaffected — they omit the param and keep the global behavior.
- **`Drawer`**: passes `panelRef` as `containerRef`, scoping the listener to the panel. Since sibling dialogs are outside the panel's DOM subtree, keystrokes inside them never reach this listener.

## Testing

- Open the Manage Tags drawer on the Devices page, click the trash icon on a tag, press Escape — the `ConfirmDialog` closes, the drawer stays open.
- Press Escape again — the drawer closes.
- Open the Connect drawer, select private key auth with a locked vault, click Unlock, press Escape — the unlock dialog closes, the connect drawer stays open.