### PR TITLE
refactor(ui): extract CTABanner marketing component

### DIFF
--- a/ui/apps/website/src/components/marketing/CTABanner.tsx
+++ b/ui/apps/website/src/components/marketing/CTABanner.tsx
@@ -1,0 +1,107 @@
+import { Link } from "react-router-dom";
+import { Button } from "@shellhub/design-system/primitives";
+import { Reveal, ConnectionGrid } from "@shellhub/design-system/components";
+import { ArrowRight } from "@/components/ArrowRight";
+import { Section, SectionHeader } from "@/components/marketing";
+import type { SectionHeaderProps } from "@/components/marketing";
+
+type GradientColor = "primary" | "accent-cyan" | "accent-green" | "accent-blue";
+
+type CTAAction =
+  | { label: string; to: string; href?: never; external?: never }
+  | { label: string; href: string; to?: never; external?: boolean };
+
+const GRADIENT_FROM: Record<GradientColor, string> = {
+  primary: "from-primary/[0.06]",
+  "accent-cyan": "from-accent-cyan/[0.06]",
+  "accent-green": "from-accent-green/[0.06]",
+  "accent-blue": "from-accent-blue/[0.06]",
+};
+
+const GRADIENT_TO: Record<GradientColor, string> = {
+  primary: "to-primary/[0.04]",
+  "accent-cyan": "to-accent-cyan/[0.04]",
+  "accent-green": "to-accent-green/[0.04]",
+  "accent-blue": "to-accent-blue/[0.04]",
+};
+
+export interface CTABannerProps {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  primaryAction: CTAAction;
+  secondaryAction: CTAAction;
+  eyebrowColor?: SectionHeaderProps["eyebrowColor"];
+  gradient?: { from: GradientColor; to: GradientColor };
+}
+
+function ActionButton({
+  action,
+  variant,
+}: {
+  action: CTAAction;
+  variant: "primary" | "outline";
+}) {
+  const isPrimary = variant === "primary";
+  const shared = {
+    variant,
+    size: "xl" as const,
+    glow: isPrimary || undefined,
+    iconRight: isPrimary ? <ArrowRight /> : undefined,
+    children: action.label,
+  };
+
+  if (action.to) {
+    return <Button as={Link} to={action.to} {...shared} />;
+  }
+
+  return (
+    <Button
+      as="a"
+      href={action.href}
+      {...shared}
+      {...(action.external && {
+        target: "_blank",
+        rel: "noopener noreferrer",
+      })}
+    />
+  );
+}
+
+export function CTABanner({
+  eyebrow,
+  title,
+  subtitle,
+  primaryAction,
+  secondaryAction,
+  eyebrowColor,
+  gradient = { from: "primary", to: "accent-cyan" },
+}: CTABannerProps) {
+  return (
+    <Section>
+      <Reveal>
+        <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
+          <ConnectionGrid />
+          <div
+            className={`absolute inset-0 bg-gradient-to-br ${GRADIENT_FROM[gradient.from]} via-transparent ${GRADIENT_TO[gradient.to]} pointer-events-none`}
+          />
+
+          <div className="relative z-10">
+            <SectionHeader
+              variant="cta"
+              eyebrow={eyebrow}
+              eyebrowColor={eyebrowColor}
+              title={title}
+              subtitle={subtitle}
+            />
+
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+              <ActionButton action={primaryAction} variant="primary" />
+              <ActionButton action={secondaryAction} variant="outline" />
+            </div>
+          </div>
+        </div>
+      </Reveal>
+    </Section>
+  );
+}

--- a/ui/apps/website/src/components/marketing/__tests__/CTABanner.test.tsx
+++ b/ui/apps/website/src/components/marketing/__tests__/CTABanner.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { CTABanner } from "@/components/marketing/CTABanner";
+
+vi.mock("@shellhub/design-system/components", () => ({
+  Reveal: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="reveal" className={className}>
+      {children}
+    </div>
+  ),
+  ConnectionGrid: () => <div data-testid="connection-grid" />,
+}));
+
+function renderBanner(
+  props?: Partial<React.ComponentProps<typeof CTABanner>>,
+) {
+  const defaults: React.ComponentProps<typeof CTABanner> = {
+    eyebrow: "Ready?",
+    title: "Get started today",
+    subtitle: "Deploy in minutes.",
+    primaryAction: { label: "Start", to: "/getting-started" },
+    secondaryAction: { label: "Pricing", to: "/pricing" },
+    ...props,
+  };
+
+  return render(
+    <MemoryRouter>
+      <CTABanner {...defaults} />
+    </MemoryRouter>,
+  );
+}
+
+describe("CTABanner", () => {
+  it("renders heading, eyebrow, subtitle, Reveal, and ConnectionGrid", () => {
+    renderBanner();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Get started today" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ready?")).toBeInTheDocument();
+    expect(screen.getByText("Deploy in minutes.")).toBeInTheDocument();
+    expect(screen.getByTestId("reveal")).toBeInTheDocument();
+    expect(screen.getByTestId("connection-grid")).toBeInTheDocument();
+  });
+
+  it.each([
+    { slot: "primaryAction", label: "Go", to: "/go" },
+    { slot: "secondaryAction", label: "Alt", to: "/alt" },
+  ] as const)("$slot with `to` renders an internal link", ({ slot, label, to }) => {
+    renderBanner({ [slot]: { label, to } });
+    const link = screen.getByRole("link", { name: label });
+    expect(link).toHaveAttribute("href", to);
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  it("href without external omits target and rel", () => {
+    renderBanner({
+      primaryAction: { label: "Email", href: "mailto:sales@shellhub.io" },
+    });
+    const link = screen.getByRole("link", { name: "Email" });
+    expect(link).toHaveAttribute("href", "mailto:sales@shellhub.io");
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  it("href with external sets target and rel", () => {
+    renderBanner({
+      secondaryAction: {
+        label: "Docs",
+        href: "https://docs.shellhub.io",
+        external: true,
+      },
+    });
+    const link = screen.getByRole("link", { name: "Docs" });
+    expect(link).toHaveAttribute("href", "https://docs.shellhub.io");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("uses primary→accent-cyan gradient by default", () => {
+    const { container } = renderBanner();
+    const overlay = container.querySelector("[class*='bg-gradient-to-br']");
+    expect(overlay!.className).toContain("from-primary/[0.06]");
+    expect(overlay!.className).toContain("to-accent-cyan/[0.04]");
+  });
+
+  it("accepts custom gradient colors", () => {
+    const { container } = renderBanner({
+      gradient: { from: "accent-green", to: "primary" },
+    });
+    const overlay = container.querySelector("[class*='bg-gradient-to-br']");
+    expect(overlay!.className).toContain("from-accent-green/[0.06]");
+    expect(overlay!.className).toContain("to-primary/[0.04]");
+  });
+
+  it.each([
+    { color: "green" as const, expected: "text-accent-green" },
+    { color: undefined, expected: "text-primary" },
+  ])("eyebrowColor=$color applies $expected", ({ color, expected }) => {
+    renderBanner({ eyebrowColor: color });
+    expect(screen.getByText("Ready?")).toHaveClass(expected);
+  });
+});

--- a/ui/apps/website/src/components/marketing/index.ts
+++ b/ui/apps/website/src/components/marketing/index.ts
@@ -6,3 +6,5 @@ export { FeatureListItem } from "./FeatureListItem";
 export type { FeatureListItemProps } from "./FeatureListItem";
 export { CommandBlock } from "./CommandBlock";
 export type { CommandBlockProps } from "./CommandBlock";
+export { CTABanner } from "./CTABanner";
+export type { CTABannerProps } from "./CTABanner";

--- a/ui/apps/website/src/pages/enterprise/EnterpriseCTA.tsx
+++ b/ui/apps/website/src/pages/enterprise/EnterpriseCTA.tsx
@@ -1,43 +1,16 @@
-import { Link } from "react-router-dom";
-import { Button } from "@shellhub/design-system/primitives";
-import { ArrowRight } from "@/components/ArrowRight";
-import { Section, SectionHeader } from "@/components/marketing";
-import { Reveal, ConnectionGrid } from "../landing/components";
+import { CTABanner } from "@/components/marketing";
 
 export function EnterpriseCTA() {
   return (
-    <Section>
-      <Reveal>
-        <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-          <ConnectionGrid />
-          <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
-
-          <div className="relative z-10">
-            <SectionHeader
-              variant="cta"
-              eyebrow="Ready to get started?"
-              title="Talk to our team"
-              subtitle="Get a demo, discuss your requirements, and find the right plan for your organization. Our team typically responds within one business day."
-            />
-
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as="a"
-                href="mailto:sales@shellhub.io"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Contact Sales
-              </Button>
-              <Button as={Link} to="/pricing" variant="outline" size="xl">
-                View Pricing
-              </Button>
-            </div>
-          </div>
-        </div>
-      </Reveal>
-    </Section>
+    <CTABanner
+      eyebrow="Ready to get started?"
+      title="Talk to our team"
+      subtitle="Get a demo, discuss your requirements, and find the right plan for your organization. Our team typically responds within one business day."
+      primaryAction={{
+        label: "Contact Sales",
+        href: "mailto:sales@shellhub.io",
+      }}
+      secondaryAction={{ label: "View Pricing", to: "/pricing" }}
+    />
   );
 }

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -1341,50 +1341,18 @@ function DeviceOrganization() {
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════ */
-/*  CTA                                                           */
-/* ═══════════════════════════════════════════════════════════════ */
 function FeaturesCTA() {
   return (
-    <Section>
-      <Reveal>
-        <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-          <ConnectionGrid />
-          <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
-
-          <div className="relative z-10">
-            <SectionHeader
-              variant="cta"
-              eyebrow="Ready to get started?"
-              title="Deploy ShellHub in minutes"
-              subtitle="Open-source and free to start. Run a single command and manage your first device in under five minutes."
-            />
-
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as={Link}
-                to="/getting-started"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Get Started Free
-              </Button>
-              <Button as={Link} to="/pricing" variant="outline" size="xl">
-                View Pricing
-              </Button>
-            </div>
-          </div>
-        </div>
-      </Reveal>
-    </Section>
+    <CTABanner
+      eyebrow="Ready to get started?"
+      title="Deploy ShellHub in minutes"
+      subtitle="Open-source and free to start. Run a single command and manage your first device in under five minutes."
+      primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
+      secondaryAction={{ label: "View Pricing", to: "/pricing" }}
+    />
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════ */
-/*  PAGE                                                          */
-/* ═══════════════════════════════════════════════════════════════ */
 export default function Features() {
   return (
     <SiteLayout>

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -20,7 +20,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, Section, SectionHeader } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
@@ -1190,40 +1190,13 @@ export default function HowItWorks() {
         </div>
       </Section>
 
-      {/* ── CTA ──────────────────────────────────────────────────── */}
-      <Section>
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
-
-            <div className="relative z-10">
-              <SectionHeader
-                variant="cta"
-                eyebrow="Ready to try it?"
-                title="See it in action"
-                subtitle="Deploy ShellHub in under five minutes and connect to your first device. No credit card required."
-              />
-
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as={Link}
-                  to="/getting-started"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Get Started Free
-                </Button>
-                <Button as={Link} to="/pricing" variant="outline" size="xl">
-                  View Pricing
-                </Button>
-              </div>
-            </div>
-          </div>
-        </Reveal>
-      </Section>
+      <CTABanner
+        eyebrow="Ready to try it?"
+        title="See it in action"
+        subtitle="Deploy ShellHub in under five minutes and connect to your first device. No credit card required."
+        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
+        secondaryAction={{ label: "View Pricing", to: "/pricing" }}
+      />
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -24,7 +24,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, Section, SectionHeader } from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -472,7 +472,12 @@ export default function Integrations() {
                         ).map((f, i) => (
                           <div
                             key={i}
-                            className={cn("flex items-center gap-1.5 px-1.5 py-0.5 rounded text-2xs font-mono", f.active ? "bg-accent-blue/10 text-accent-blue" : "text-text-secondary hover:bg-white/[0.03]")}
+                            className={cn(
+                              "flex items-center gap-1.5 px-1.5 py-0.5 rounded text-2xs font-mono",
+                              f.active
+                                ? "bg-accent-blue/10 text-accent-blue"
+                                : "text-text-secondary hover:bg-white/[0.03]",
+                            )}
                             style={{ paddingLeft: `${f.indent * 12 + 6}px` }}
                           >
                             {f.isDir ? (
@@ -1036,47 +1041,18 @@ export default function Integrations() {
         </div>
       </Section>
 
-      {/* ─────────── CTA ─────────── */}
-      <Section>
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
-
-            <div className="relative z-10">
-              <SectionHeader
-                variant="cta"
-                eyebrow="Ready to integrate?"
-                title="Start integrating today"
-                subtitle="Get ShellHub running and connect it to your existing workflow in minutes. Standard SSH means zero learning curve."
-              />
-
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as={Link}
-                  to="/getting-started"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Get Started Free
-                </Button>
-                <Button
-                  as="a"
-                  href={docsUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  variant="outline"
-                  size="xl"
-                >
-                  Read the Docs
-                </Button>
-              </div>
-            </div>
-          </div>
-        </Reveal>
-      </Section>
+      <CTABanner
+        eyebrow="Ready to integrate?"
+        title="Start integrating today"
+        subtitle="Get ShellHub running and connect it to your existing workflow in minutes. Standard SSH means zero learning curve."
+        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
+        secondaryAction={{
+          label: "Read the Docs",
+          href: docsUrl,
+          external: true,
+        }}
+        gradient={{ from: "accent-cyan", to: "primary" }}
+      />
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -19,7 +19,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, Section, SectionHeader } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
@@ -906,41 +906,15 @@ export default function ContainerManagement() {
         </div>
       </Section>
 
-      {/* ═══════ CTA ═══════ */}
-      <Section>
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
-
-            <div className="relative z-10">
-              <SectionHeader
-                variant="cta"
-                eyebrowColor="cyan"
-                eyebrow="Ready to simplify container access?"
-                title="Manage your containers remotely"
-                subtitle="Install the ShellHub agent and get instant SSH access to containers on any remote host. Free to start, no credit card required."
-              />
-
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as={Link}
-                  to="/getting-started"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Get Started Free
-                </Button>
-                <Button as={Link} to="/pricing" variant="outline" size="xl">
-                  Compare Plans
-                </Button>
-              </div>
-            </div>
-          </div>
-        </Reveal>
-      </Section>
+      <CTABanner
+        eyebrow="Ready to simplify container access?"
+        title="Manage your containers remotely"
+        subtitle="Install the ShellHub agent and get instant SSH access to containers on any remote host. Free to start, no credit card required."
+        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
+        secondaryAction={{ label: "Compare Plans", to: "/pricing" }}
+        eyebrowColor="cyan"
+        gradient={{ from: "accent-cyan", to: "primary" }}
+      />
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -18,7 +18,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, Section, SectionHeader } from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -538,47 +538,17 @@ export default function DevopsCiCd() {
         </div>
       </Section>
 
-      {/* ── CTA ──────────────────────────────────────────────────── */}
-      <Section>
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
-
-            <div className="relative z-10">
-              <SectionHeader
-                variant="cta"
-                eyebrow="Ready to automate?"
-                title="Automate your device deployments today"
-                subtitle="Connect ShellHub to your CI/CD pipeline and start deploying to remote devices in minutes -- no VPN, no static IPs, no hassle."
-              />
-
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as={Link}
-                  to="/getting-started"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Get Started Free
-                </Button>
-                <Button
-                  as="a"
-                  href={docsUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  variant="outline"
-                  size="xl"
-                >
-                  Read the Docs
-                </Button>
-              </div>
-            </div>
-          </div>
-        </Reveal>
-      </Section>
+      <CTABanner
+        eyebrow="Ready to automate?"
+        title="Automate your device deployments today"
+        subtitle="Connect ShellHub to your CI/CD pipeline and start deploying to remote devices in minutes -- no VPN, no static IPs, no hassle."
+        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
+        secondaryAction={{
+          label: "Read the Docs",
+          href: docsUrl,
+          external: true,
+        }}
+      />
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -22,7 +22,7 @@ import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { SiteLayout } from "@/components/SiteLayout";
-import { Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, Section, SectionHeader } from "@/components/marketing";
 import { C } from "../landing/constants";
 
 /* ═══════ Pain-point data ═══════ */
@@ -863,40 +863,14 @@ export default function EdgeComputing() {
         </div>
       </Section>
 
-      {/* ───── CTA ───── */}
-      <Section>
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-accent-blue/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
-
-            <div className="relative z-10">
-              <SectionHeader
-                variant="cta"
-                eyebrow="Ready to connect your edge?"
-                title="Your edge servers, instantly accessible"
-                subtitle="Install the lightweight agent on your edge servers and start managing them remotely in minutes — no infrastructure changes needed."
-              />
-
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as={Link}
-                  to="/getting-started"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Get Started Free
-                </Button>
-                <Button as={Link} to="/pricing" variant="outline" size="xl">
-                  Compare Plans
-                </Button>
-              </div>
-            </div>
-          </div>
-        </Reveal>
-      </Section>
+      <CTABanner
+        eyebrow="Ready to connect your edge?"
+        title="Your edge servers, instantly accessible"
+        subtitle="Install the lightweight agent on your edge servers and start managing them remotely in minutes — no infrastructure changes needed."
+        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
+        secondaryAction={{ label: "Compare Plans", to: "/pricing" }}
+        gradient={{ from: "accent-blue", to: "primary" }}
+      />
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -22,7 +22,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, Section, SectionHeader } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
@@ -755,46 +755,18 @@ export default function IotEmbedded() {
         </Reveal>
       </Section>
 
-      {/* ═══════ CTA with ConnectionGrid ═══════ */}
-      <Section>
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.06] via-transparent to-primary/[0.04] pointer-events-none" />
-
-            <div className="relative z-10">
-              <SectionHeader
-                variant="cta"
-                eyebrowColor="green"
-                eyebrow="Ready to get started?"
-                title="Start managing your IoT fleet today"
-                subtitle="Deploy the ShellHub agent on your devices and get instant remote access — no network changes, no VPNs, no exposed ports."
-              />
-
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as={Link}
-                  to="/getting-started"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Get Started Free
-                </Button>
-                <Button
-                  as="a"
-                  href="mailto:sales@shellhub.io"
-                  variant="outline"
-                  size="xl"
-                >
-                  Contact Sales
-                </Button>
-              </div>
-            </div>
-          </div>
-        </Reveal>
-      </Section>
+      <CTABanner
+        eyebrow="Ready to get started?"
+        title="Start managing your IoT fleet today"
+        subtitle="Deploy the ShellHub agent on your devices and get instant remote access — no network changes, no VPNs, no exposed ports."
+        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
+        secondaryAction={{
+          label: "Contact Sales",
+          href: "mailto:sales@shellhub.io",
+        }}
+        eyebrowColor="green"
+        gradient={{ from: "accent-green", to: "primary" }}
+      />
     </SiteLayout>
   );
 }

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -19,7 +19,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -624,40 +624,13 @@ export default function RemoteSupport() {
         </div>
       </Section>
 
-      {/* ── CTA ──────────────────────────────────────────────────── */}
-      <Section>
-        <Reveal>
-          <div className="relative bg-card border border-border rounded-2xl p-12 text-center overflow-hidden">
-            <ConnectionGrid />
-            <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-accent-cyan/[0.04] pointer-events-none" />
-
-            <div className="relative z-10">
-              <SectionHeader
-                variant="cta"
-                eyebrow="Ready to get started?"
-                title="Secure support starts here"
-                subtitle="Enable audited, accountable remote support for your team in minutes. No VPN required, no SSH keys to manage, no audit gaps."
-              />
-
-              <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-                <Button
-                  as={Link}
-                  to="/getting-started"
-                  variant="primary"
-                  size="xl"
-                  glow
-                  iconRight={<ArrowRight />}
-                >
-                  Get Started Free
-                </Button>
-                <Button as={Link} to="/pricing" variant="outline" size="xl">
-                  View Pricing
-                </Button>
-              </div>
-            </div>
-          </div>
-        </Reveal>
-      </Section>
+      <CTABanner
+        eyebrow="Ready to get started?"
+        title="Secure support starts here"
+        subtitle="Enable audited, accountable remote support for your team in minutes. No VPN required, no SSH keys to manage, no audit gaps."
+        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
+        secondaryAction={{ label: "View Pricing", to: "/pricing" }}
+      />
     </SiteLayout>
   );
 }


### PR DESCRIPTION
## Summary

- Extract a shared `CTABanner` component from 9 copy-pasted CTA blocks across the website
- Each page's CTA now uses `<CTABanner>` with props for text, gradient colors, `eyebrowColor`, and action buttons (internal `Link` or external `<a>`)
- Net reduction of ~30 lines; production code shrinks significantly (test file accounts for the additions)

## Usages replaced

| File | Variation |
|------|-----------|
| `enterprise/EnterpriseCTA.tsx` | mailto primary action |
| `features/index.tsx` | default |
| `how-it-works/index.tsx` | default |
| `integrations/index.tsx` | swapped gradient, external docs link |
| `use-cases/IotEmbedded.tsx` | `eyebrowColor="green"`, green gradient, mailto secondary |
| `use-cases/EdgeComputing.tsx` | blue gradient |
| `use-cases/ContainerManagement.tsx` | `eyebrowColor="cyan"`, cyan gradient |
| `use-cases/DevopsCiCd.tsx` | external docs link |
| `use-cases/RemoteSupport.tsx` | default |

## Test plan

- [x] 9 unit tests covering text rendering, internal/external links, gradients, and `eyebrowColor`
- [x] `npm run build` (typecheck) passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (85/85)

Fixes: shellhub-io/team#174