### PR TITLE
feat: give code-paired devices their own install-key source

### DIFF
--- a/api/services/auth.go
+++ b/api/services/auth.go
@@ -148,19 +148,31 @@ func (s *service) appendInstallKeyEvent(ctx context.Context, key *models.Install
 }
 
 // enrollmentInstallKey resolves the install key for a fresh enrollment. With a presented key it
-// validates it, rejecting an invalid or system key. With no key it resolves the namespace's legacy
-// (system) key, so a keyless enrollment is governed by the legacy key's (manual) mode. It returns the
-// resolved key (nil only when no legacy key exists), the digest to store on the device, and an error
-// only when a presented key is invalid.
-func (s *service) enrollmentInstallKey(ctx context.Context, req requests.DeviceAuth) (*models.InstallKey, string, error) {
+// validates it, rejecting an invalid or system key. With no key it resolves a system key: the pairing
+// key when the enrollment comes from the pairing-code flow (paired), otherwise the namespace's legacy
+// key, so a tenant-only keyless enrollment is governed by the legacy key's (manual) mode. It returns
+// the resolved key (nil only when no matching system key exists), the digest to store on the device,
+// and an error only when a presented key is invalid or a required legacy key is disabled.
+func (s *service) enrollmentInstallKey(ctx context.Context, req requests.DeviceAuth, paired bool) (*models.InstallKey, string, error) {
 	if req.InstallKey != "" {
 		sk, err := s.store.InstallKeyResolve(ctx, store.InstallKeyIDResolver, hashInstallKey(req.InstallKey), s.store.Options().InNamespace(req.TenantID))
-		// The legacy system key is never presentable by an agent; treat it like any invalid key.
-		if err != nil || sk.System || !sk.IsValid() {
+		// A system key (legacy/pairing) is never presentable by an agent; treat it like any invalid key.
+		if err != nil || sk.IsSystem() || !sk.IsValid() {
 			return nil, "", NewErrAuthInvalid(map[string]interface{}{"install_key": "invalid"}, err)
 		}
 
 		return sk, sk.ID, nil
+	}
+
+	// The pairing-code flow attributes to the pairing system key, not the legacy one, so its devices
+	// get their own enrollment source and history. Acceptance is the code itself (automatic mode); the
+	// pairing flow accepts the device explicitly regardless.
+	if paired {
+		if pairing, err := s.store.InstallKeyResolveSystemPairing(ctx, req.TenantID); err == nil {
+			return pairing, pairing.ID, nil
+		}
+
+		return nil, "", nil
 	}
 
 	if legacy, err := s.store.InstallKeyResolveSystem(ctx, req.TenantID); err == nil {
@@ -179,7 +191,16 @@ func (s *service) enrollmentInstallKey(ctx context.Context, req requests.DeviceA
 	return nil, "", nil
 }
 
+// AuthDevice enrolls or resolves a device from an agent's registration request. A keyless enrollment
+// attributes to the namespace's legacy key (see enrollmentInstallKey).
 func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*models.DeviceAuthResponse, error) {
+	return s.authDevice(ctx, req, false)
+}
+
+// authDevice is the shared enrollment path. paired marks the tenant-less pairing-code flow, so a
+// keyless enrollment attributes to the pairing system key instead of the legacy one. The flag is
+// server-only (never read from the wire) so an agent can't claim it to dodge the legacy key.
+func (s *service) authDevice(ctx context.Context, req requests.DeviceAuth, paired bool) (*models.DeviceAuthResponse, error) {
 	namespace, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
 	if err != nil {
 		return nil, NewErrNamespaceNotFound(req.TenantID, err)
@@ -233,7 +254,7 @@ func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*mod
 			return nil, err
 		}
 
-		installKey, installKeyID, err = s.enrollmentInstallKey(ctx, req)
+		installKey, installKeyID, err = s.enrollmentInstallKey(ctx, req, paired)
 		if err != nil {
 			return nil, err
 		}
@@ -304,7 +325,7 @@ func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*mod
 		// pending, exactly as before.
 		// Reflect the decision on the in-memory device so the response carries the resulting status
 		// (the store was already updated through UpdateDeviceStatus by applyEnrollmentDecision).
-		device.Status = s.applyEnrollmentDecision(ctx, s.evaluateEnrollment(ctx, installKey, req, uid, hostname), installKey, req, uid, hostname, false, true)
+		device.Status = s.applyEnrollmentDecision(ctx, s.evaluateEnrollment(ctx, installKey, req, uid, hostname, paired), installKey, req, uid, hostname, false, true)
 	} else {
 		device.LastSeen = clock.Now()
 		device.DisconnectedAt = nil
@@ -318,7 +339,7 @@ func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*mod
 		}
 
 		if device.RemovedAt != nil {
-			installKey, installKeyID, err = s.enrollmentInstallKey(ctx, req)
+			installKey, installKeyID, err = s.enrollmentInstallKey(ctx, req, paired)
 			if err != nil {
 				return nil, err
 			}
@@ -346,7 +367,7 @@ func (s *service) AuthDevice(ctx context.Context, req requests.DeviceAuth) (*mod
 			// A re-registration is a fresh enrollment: the key's mode is re-evaluated (a webhook is
 			// called again, a use is consumed on accept). Keep the in-memory device status consistent
 			// with the decision so the DeviceUpdate below persists it.
-			decision := s.evaluateEnrollment(ctx, installKey, req, uid, hostname)
+			decision := s.evaluateEnrollment(ctx, installKey, req, uid, hostname, paired)
 
 			// An accept/reject runs through UpdateDeviceStatus, which derives the namespace counter delta
 			// from the device's *stored* status. Persist the pending transition first so it reads this

--- a/api/services/auth_install_key_test.go
+++ b/api/services/auth_install_key_test.go
@@ -99,7 +99,7 @@ func TestAuthDevice_InstallKey(t *testing.T) {
 				cacheMock.On("Get", ctx, "auth_device/"+uid, testifymock.Anything).Return(nil).Once()
 				storeMock.On("DeviceResolve", ctx, store.DeviceUIDResolver, uid).Return(nil, store.ErrNoDocuments).Once()
 				queryOptionsMock.On("InNamespace", tenant).Return(nil).Once()
-				storeMock.On("InstallKeyResolve", ctx, store.InstallKeyIDResolver, badDigest, testifymock.AnythingOfType("[]store.QueryOption")).Return(&models.InstallKey{ID: badDigest, TenantID: tenant, System: true, Reusable: true}, nil).Once()
+				storeMock.On("InstallKeyResolve", ctx, store.InstallKeyIDResolver, badDigest, testifymock.AnythingOfType("[]store.QueryOption")).Return(&models.InstallKey{ID: badDigest, TenantID: tenant, Type: models.InstallKeyTypeLegacy, Reusable: true}, nil).Once()
 			},
 			expected: Expected{res: nil, err: NewErrAuthInvalid(map[string]interface{}{"install_key": "invalid"}, nil)},
 		},
@@ -111,7 +111,7 @@ func TestAuthDevice_InstallKey(t *testing.T) {
 				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenant).Return(&models.Namespace{TenantID: tenant, Name: "test"}, nil).Once()
 				cacheMock.On("Get", ctx, "auth_device/"+uid, testifymock.Anything).Return(nil).Once()
 				storeMock.On("DeviceResolve", ctx, store.DeviceUIDResolver, uid).Return(nil, store.ErrNoDocuments).Once()
-				storeMock.On("InstallKeyResolveSystem", ctx, tenant).Return(&models.InstallKey{ID: "legacydigest", TenantID: tenant, System: true, Mode: models.InstallKeyModeManual}, nil).Once()
+				storeMock.On("InstallKeyResolveSystem", ctx, tenant).Return(&models.InstallKey{ID: "legacydigest", TenantID: tenant, Type: models.InstallKeyTypeLegacy, Mode: models.InstallKeyModeManual}, nil).Once()
 				storeMock.On("DeviceCreate", ctx, &models.Device{
 					CreatedAt:       now,
 					UID:             uid,
@@ -162,4 +162,67 @@ func TestAuthDevice_InstallKey(t *testing.T) {
 	}
 
 	storeMock.AssertExpectations(t)
+}
+
+// TestEnrollmentInstallKey covers keyless enrollment-source resolution: the pairing-code flow (paired)
+// attributes to the pairing system key, a plain tenant-only enrollment attributes to the legacy key,
+// and neither resolves the other's key.
+func TestEnrollmentInstallKey(t *testing.T) {
+	const tenant = "00000000-0000-4000-0000-000000000000"
+
+	legacy := &models.InstallKey{ID: "legacydigest", TenantID: tenant, Type: models.InstallKeyTypeLegacy, Mode: models.InstallKeyModeManual}
+	pairing := &models.InstallKey{ID: "pairingdigest", TenantID: tenant, Type: models.InstallKeyTypePairing, Mode: models.InstallKeyModeAutomatic}
+
+	cases := []struct {
+		description   string
+		paired        bool
+		requiredMocks func(context.Context, *mocks.MockStore)
+		expectedKey   *models.InstallKey
+		expectedID    string
+	}{
+		{
+			description: "attributes a tenant-only enrollment to the legacy key",
+			paired:      false,
+			requiredMocks: func(ctx context.Context, s *mocks.MockStore) {
+				s.On("InstallKeyResolveSystem", ctx, tenant).Return(legacy, nil).Once()
+			},
+			expectedKey: legacy,
+			expectedID:  "legacydigest",
+		},
+		{
+			description: "attributes a paired enrollment to the pairing key, not the legacy key",
+			paired:      true,
+			requiredMocks: func(ctx context.Context, s *mocks.MockStore) {
+				s.On("InstallKeyResolveSystemPairing", ctx, tenant).Return(pairing, nil).Once()
+			},
+			expectedKey: pairing,
+			expectedID:  "pairingdigest",
+		},
+		{
+			description: "attributes nothing when the pairing key is missing",
+			paired:      true,
+			requiredMocks: func(ctx context.Context, s *mocks.MockStore) {
+				s.On("InstallKeyResolveSystemPairing", ctx, tenant).Return(nil, store.ErrNoDocuments).Once()
+			},
+			expectedKey: nil,
+			expectedID:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(tt *testing.T) {
+			ctx := context.TODO()
+			storeMock := mocks.NewMockStore(tt)
+			cacheMock := mockcache.NewMockCache(tt)
+			tc.requiredMocks(ctx, storeMock)
+
+			svc := NewService(store.Store(storeMock), privateKey, &privateKey.PublicKey, cacheMock, clientMock)
+			key, id, err := svc.enrollmentInstallKey(ctx, requests.DeviceAuth{TenantID: tenant}, tc.paired)
+
+			require.NoError(tt, err)
+			require.Equal(tt, tc.expectedKey, key)
+			require.Equal(tt, tc.expectedID, id)
+			storeMock.AssertExpectations(tt)
+		})
+	}
 }

--- a/api/services/device-pairing.go
+++ b/api/services/device-pairing.go
@@ -399,7 +399,7 @@ func (s *service) acceptPairingDevice(ctx context.Context, pairing *devicePairin
 		}
 	}
 
-	auth, err := s.AuthDevice(ctx, authReq)
+	auth, err := s.authDevice(ctx, authReq, true)
 	if err != nil {
 		return nil, err
 	}

--- a/api/services/enrollment.go
+++ b/api/services/enrollment.go
@@ -90,9 +90,18 @@ const (
 // evaluateEnrollment runs the install key's mode as a policy and returns the enrollment decision for
 // the device. A nil key (no key presented and no legacy key resolved) defaults to pending for manual
 // review, preserving the historical keyless behavior.
-func (s *service) evaluateEnrollment(ctx context.Context, key *models.InstallKey, req requests.DeviceAuth, uid, hostname string) enrollmentDecision {
+func (s *service) evaluateEnrollment(ctx context.Context, key *models.InstallKey, req requests.DeviceAuth, uid, hostname string, paired bool) enrollmentDecision {
 	if key == nil {
 		return enrollPending
+	}
+
+	// The pairing-code flow is its own acceptance: the user already approved by entering the code, and
+	// the whole stack (the agent's accepted-only waiter, the code-accept UI) assumes pairing == accepted.
+	// So a paired enrollment accepts outright, ignoring the pairing key's mode — never firing the
+	// webhook POST, the allowlist reject, or a manual/pending hold, which would hang the agent or lie in
+	// the UI. The pairing key's mode is meaningless by construction.
+	if paired {
+		return enrollAccept
 	}
 
 	switch key.Mode {
@@ -236,7 +245,9 @@ func (s *service) reconcileEnrollment(ctx context.Context, device *models.Device
 	now := clock.Now()
 	device.LastEnrollmentAttemptAt = &now
 
-	status := s.applyEnrollmentDecision(ctx, s.evaluateEnrollment(ctx, key, req, uid, hostname), key, req, uid, hostname, false, false)
+	// A reconcile re-evaluates a still-pending device (webhook/allowlist); a pairing enrollment never
+	// reaches this path (it accepts outright), so paired is always false here.
+	status := s.applyEnrollmentDecision(ctx, s.evaluateEnrollment(ctx, key, req, uid, hostname, false), key, req, uid, hostname, false, false)
 	if status != models.DeviceStatusPending {
 		device.Status = status
 		device.StatusUpdatedAt = clock.Now()

--- a/api/services/enrollment_e2e_test.go
+++ b/api/services/enrollment_e2e_test.go
@@ -103,15 +103,15 @@ func setupEnrollmentE2E(t *testing.T) *enrollmentE2E {
 	return &enrollmentE2E{svc: svc, st: st, tenantID: tenantID}
 }
 
-// legacyKey inserts the namespace's system (legacy) install key in the given mode.
-func (e *enrollmentE2E) installKey(t *testing.T, digest, name string, mode models.InstallKeyMode, system bool, opts func(*models.InstallKey)) {
+// installKey inserts an install key of the given type in the given mode.
+func (e *enrollmentE2E) installKey(t *testing.T, digest, name string, mode models.InstallKeyMode, keyType models.InstallKeyType, opts func(*models.InstallKey)) {
 	t.Helper()
 	key := &models.InstallKey{
 		ID:        digest,
 		Name:      name,
 		TenantID:  e.tenantID,
 		Mode:      mode,
-		System:    system,
+		Type:      keyType,
 		Reusable:  true,
 		Tags:      []string{},
 		CreatedBy: "00000000-0000-4000-0000-000000000009",
@@ -237,7 +237,7 @@ func TestEnrollmentE2E_Modes(t *testing.T) {
 	e := setupEnrollmentE2E(t)
 
 	t.Run("automatic accepts on enrollment", func(t *testing.T) {
-		e.installKey(t, digest(0x01), "auto", models.InstallKeyModeAutomatic, false, func(k *models.InstallKey) {
+		e.installKey(t, digest(0x01), "auto", models.InstallKeyModeAutomatic, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 			k.KeyEncrypted, k.KeyHint = "", ""
 		})
 		uid := e.enroll(t, "aa:bb:cc:dd:ee:10", plaintextFor(0x01))
@@ -253,7 +253,7 @@ func TestEnrollmentE2E_Modes(t *testing.T) {
 	})
 
 	t.Run("manual key lands pending", func(t *testing.T) {
-		e.installKey(t, digest(0x02), "manual", models.InstallKeyModeManual, false, func(k *models.InstallKey) {
+		e.installKey(t, digest(0x02), "manual", models.InstallKeyModeManual, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 			k.KeyEncrypted, k.KeyHint = "", ""
 		})
 		uid := e.enroll(t, "aa:bb:cc:dd:ee:20", plaintextFor(0x02))
@@ -261,7 +261,7 @@ func TestEnrollmentE2E_Modes(t *testing.T) {
 	})
 
 	t.Run("allowlist accepts a listed MAC and rejects others", func(t *testing.T) {
-		e.installKey(t, digest(0x03), "allow", models.InstallKeyModeAllowlist, false, func(k *models.InstallKey) {
+		e.installKey(t, digest(0x03), "allow", models.InstallKeyModeAllowlist, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 			k.AllowedMACs = []string{"aa:bb:cc:dd:ee:31"}
 			k.KeyEncrypted, k.KeyHint = "", ""
 		})
@@ -283,7 +283,7 @@ func TestEnrollmentE2E_Modes(t *testing.T) {
 	t.Run("the auth response carries the device status", func(t *testing.T) {
 		// The response exposes the enrollment status so an agent can react to its authorization state
 		// instead of connecting blind.
-		e.installKey(t, digest(0x04), "auto-status", models.InstallKeyModeAutomatic, false, clearSecret)
+		e.installKey(t, digest(0x04), "auto-status", models.InstallKeyModeAutomatic, models.InstallKeyTypeUser, clearSecret)
 		res, err := e.svc.AuthDevice(context.Background(), requests.DeviceAuth{
 			TenantID:   e.tenantID,
 			Hostname:   "host-status",
@@ -304,7 +304,7 @@ func TestEnrollmentE2E_ReregisterAndReaccept(t *testing.T) {
 	e := setupEnrollmentE2E(t)
 
 	t.Run("re-registration re-runs the policy and consumes another use", func(t *testing.T) {
-		e.installKey(t, digest(0x40), "auto", models.InstallKeyModeAutomatic, false, clearSecret)
+		e.installKey(t, digest(0x40), "auto", models.InstallKeyModeAutomatic, models.InstallKeyTypeUser, clearSecret)
 
 		uid := e.enroll(t, "aa:bb:cc:dd:ee:40", plaintextFor(0x40))
 		require.Equal(t, models.DeviceStatusAccepted, e.status(t, uid))
@@ -330,7 +330,7 @@ func TestEnrollmentE2E_ReregisterAndReaccept(t *testing.T) {
 	})
 
 	t.Run("a plain reconnect does not re-run the policy", func(t *testing.T) {
-		e.installKey(t, digest(0x41), "auto2", models.InstallKeyModeAutomatic, false, clearSecret)
+		e.installKey(t, digest(0x41), "auto2", models.InstallKeyModeAutomatic, models.InstallKeyTypeUser, clearSecret)
 
 		uid := e.enroll(t, "aa:bb:cc:dd:ee:41", plaintextFor(0x41))
 		require.Equal(t, 1, e.usedTimes(t, digest(0x41)))
@@ -342,7 +342,7 @@ func TestEnrollmentE2E_ReregisterAndReaccept(t *testing.T) {
 	})
 
 	t.Run("an auto-rejected device can be manually re-accepted", func(t *testing.T) {
-		e.installKey(t, digest(0x42), "allow", models.InstallKeyModeAllowlist, false, func(k *models.InstallKey) {
+		e.installKey(t, digest(0x42), "allow", models.InstallKeyModeAllowlist, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 			k.AllowedMACs = []string{"aa:bb:cc:dd:ee:99"}
 			clearSecret(k)
 		})
@@ -374,7 +374,7 @@ func TestEnrollmentE2E_WebhookDeferCallback(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e.installKey(t, digest(0x50), "webhook", models.InstallKeyModeWebhook, false, func(k *models.InstallKey) {
+	e.installKey(t, digest(0x50), "webhook", models.InstallKeyModeWebhook, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 		k.WebhookURL = srv.URL
 		k.WebhookSecret = "s3cr3t"
 		clearSecret(k)
@@ -415,7 +415,7 @@ func TestEnrollmentE2E_CallbackSingleUse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e.installKey(t, digest(0x60), "webhook", models.InstallKeyModeWebhook, false, func(k *models.InstallKey) {
+	e.installKey(t, digest(0x60), "webhook", models.InstallKeyModeWebhook, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 		k.WebhookURL = srv.URL
 		k.WebhookSecret = "s3cr3t"
 		clearSecret(k)
@@ -459,7 +459,7 @@ func TestEnrollmentE2E_CallbackHonorsKeyState(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		e.installKey(t, digest(keyByte), name, models.InstallKeyModeWebhook, false, func(k *models.InstallKey) {
+		e.installKey(t, digest(keyByte), name, models.InstallKeyModeWebhook, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 			k.WebhookURL = srv.URL
 			k.WebhookSecret = "s3cr3t"
 			k.UsageLimit = 1
@@ -518,7 +518,7 @@ func TestEnrollmentE2E_ReconcilePending(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e.installKey(t, digest(0x60), "webhook", models.InstallKeyModeWebhook, false, func(k *models.InstallKey) {
+	e.installKey(t, digest(0x60), "webhook", models.InstallKeyModeWebhook, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 		k.WebhookURL = srv.URL
 		k.WebhookSecret = "s3cr3t"
 		clearSecret(k)
@@ -581,7 +581,7 @@ func TestEnrollmentE2E_ReconcileSkipsInvalidKey(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e.installKey(t, digest(0x61), "webhook-revoked", models.InstallKeyModeWebhook, false, func(k *models.InstallKey) {
+	e.installKey(t, digest(0x61), "webhook-revoked", models.InstallKeyModeWebhook, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 		k.WebhookURL = srv.URL
 		k.WebhookSecret = "s3cr3t"
 		clearSecret(k)
@@ -612,7 +612,7 @@ func TestEnrollmentE2E_ReconcileSkipsInvalidKey(t *testing.T) {
 // check — decides who gets the slot, and it can never land past the limit.
 func TestEnrollmentE2E_UsageLimitUnderConcurrency(t *testing.T) {
 	e := setupEnrollmentE2E(t)
-	e.installKey(t, digest(0x80), "single-use", models.InstallKeyModeAutomatic, false, func(k *models.InstallKey) {
+	e.installKey(t, digest(0x80), "single-use", models.InstallKeyModeAutomatic, models.InstallKeyTypeUser, func(k *models.InstallKey) {
 		k.UsageLimit = 1
 		clearSecret(k)
 	})
@@ -672,7 +672,7 @@ func TestEnrollmentE2E_UsageLimitUnderConcurrency(t *testing.T) {
 // time (device status_updated_at) distinct from the immutable enrollment time.
 func TestEnrollmentE2E_HistoryCredential(t *testing.T) {
 	e := setupEnrollmentE2E(t)
-	e.installKey(t, digest(0x70), "man", models.InstallKeyModeManual, false, clearSecret)
+	e.installKey(t, digest(0x70), "man", models.InstallKeyModeManual, models.InstallKeyTypeUser, clearSecret)
 
 	// A mutable clock so the decision time can advance past the enrollment time deterministically.
 	base := now
@@ -722,7 +722,7 @@ func TestEnrollmentE2E_HistoryCredential(t *testing.T) {
 // current (owns the live status/decision) so the older one doesn't borrow it.
 func TestEnrollmentE2E_HistoryCurrent(t *testing.T) {
 	e := setupEnrollmentE2E(t)
-	e.installKey(t, digest(0x80), "man2", models.InstallKeyModeManual, false, clearSecret)
+	e.installKey(t, digest(0x80), "man2", models.InstallKeyModeManual, models.InstallKeyTypeUser, clearSecret)
 
 	// A mutable clock so the two events get distinct created_at (the "newest per device" window keys on
 	// it); the shared setup clock is fixed, which would tie them.

--- a/api/services/enrollment_test.go
+++ b/api/services/enrollment_test.go
@@ -30,19 +30,24 @@ func TestEvaluateEnrollment(t *testing.T) {
 	cases := []struct {
 		description string
 		key         *models.InstallKey
+		paired      bool
 		expected    enrollmentDecision
 	}{
-		{"a keyless enrollment (nil key) lands pending", nil, enrollPending},
-		{"automatic accepts", &models.InstallKey{Mode: models.InstallKeyModeAutomatic}, enrollAccept},
-		{"manual stays pending", &models.InstallKey{Mode: models.InstallKeyModeManual}, enrollPending},
-		{"allowlist accepts a listed MAC (case-insensitive)", &models.InstallKey{Mode: models.InstallKeyModeAllowlist, AllowedMACs: []string{"aa:bb:cc:dd:ee:ff"}}, enrollAccept},
-		{"allowlist rejects an unlisted MAC", &models.InstallKey{Mode: models.InstallKeyModeAllowlist, AllowedMACs: []string{"11:22:33:44:55:66"}}, enrollReject},
-		{"an unknown mode stays pending", &models.InstallKey{Mode: "bogus"}, enrollPending},
+		{"a keyless enrollment (nil key) lands pending", nil, false, enrollPending},
+		{"automatic accepts", &models.InstallKey{Mode: models.InstallKeyModeAutomatic}, false, enrollAccept},
+		{"manual stays pending", &models.InstallKey{Mode: models.InstallKeyModeManual}, false, enrollPending},
+		{"allowlist accepts a listed MAC (case-insensitive)", &models.InstallKey{Mode: models.InstallKeyModeAllowlist, AllowedMACs: []string{"aa:bb:cc:dd:ee:ff"}}, false, enrollAccept},
+		{"allowlist rejects an unlisted MAC", &models.InstallKey{Mode: models.InstallKeyModeAllowlist, AllowedMACs: []string{"11:22:33:44:55:66"}}, false, enrollReject},
+		{"an unknown mode stays pending", &models.InstallKey{Mode: "bogus"}, false, enrollPending},
+		// The pairing-code flow is its own acceptance: paired accepts regardless of the key's mode, so a
+		// manual/allowlist-miss pairing key still accepts (and never fires the webhook/reject).
+		{"paired accepts despite a manual key", &models.InstallKey{Mode: models.InstallKeyModeManual}, true, enrollAccept},
+		{"paired accepts despite an allowlist miss", &models.InstallKey{Mode: models.InstallKeyModeAllowlist, AllowedMACs: []string{"11:22:33:44:55:66"}}, true, enrollAccept},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			got := svc.evaluateEnrollment(context.Background(), tc.key, req, "uid", "host")
+			got := svc.evaluateEnrollment(context.Background(), tc.key, req, "uid", "host", tc.paired)
 			require.Equal(t, tc.expected, got)
 		})
 	}
@@ -86,7 +91,7 @@ func TestEvaluateEnrollmentWebhook(t *testing.T) {
 				_ = json.NewEncoder(w).Encode(enrollmentWebhookResponse{Decision: string(decision)})
 			}))
 
-			got := svc.evaluateEnrollment(context.Background(), keyFor(srv.URL), req, "uid", "host")
+			got := svc.evaluateEnrollment(context.Background(), keyFor(srv.URL), req, "uid", "host", false)
 			require.Equal(t, decision, got)
 			// The integrator can trust the request: the signature it received matches HMAC(secret, body).
 			require.Equal(t, signEnrollmentWebhook(secret, gotBody), gotSignature)
@@ -101,11 +106,11 @@ func TestEvaluateEnrollmentWebhook(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		require.Equal(t, enrollPending, svc.evaluateEnrollment(context.Background(), keyFor(srv.URL), req, "uid", "host"))
+		require.Equal(t, enrollPending, svc.evaluateEnrollment(context.Background(), keyFor(srv.URL), req, "uid", "host", false))
 	})
 
 	t.Run("fails closed to pending when the integrator is unreachable", func(t *testing.T) {
-		require.Equal(t, enrollPending, svc.evaluateEnrollment(context.Background(), keyFor("http://127.0.0.1:1"), req, "uid", "host"))
+		require.Equal(t, enrollPending, svc.evaluateEnrollment(context.Background(), keyFor("http://127.0.0.1:1"), req, "uid", "host", false))
 	})
 
 	t.Run("fails closed to pending on an unrecognized decision", func(t *testing.T) {
@@ -114,7 +119,7 @@ func TestEvaluateEnrollmentWebhook(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		require.Equal(t, enrollPending, svc.evaluateEnrollment(context.Background(), keyFor(srv.URL), req, "uid", "host"))
+		require.Equal(t, enrollPending, svc.evaluateEnrollment(context.Background(), keyFor(srv.URL), req, "uid", "host", false))
 	})
 
 	t.Run("fails closed to pending on a cancelled context", func(t *testing.T) {
@@ -126,7 +131,7 @@ func TestEvaluateEnrollmentWebhook(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		require.Equal(t, enrollPending, svc.evaluateEnrollment(ctx, keyFor(srv.URL), req, "uid", "host"))
+		require.Equal(t, enrollPending, svc.evaluateEnrollment(ctx, keyFor(srv.URL), req, "uid", "host", false))
 	})
 }
 

--- a/api/services/install-key.go
+++ b/api/services/install-key.go
@@ -300,11 +300,17 @@ func (s *service) UpdateInstallKey(ctx context.Context, req *requests.UpdateInst
 		}
 	}
 
-	// The legacy/system key governs every keyless enrollment in the namespace. Only two fields are
-	// editable: its mode (the default acceptance policy) and disabled (disabling it turns off keyless
-	// enrollment entirely — devices without a key are rejected). Its other fields (name/lifecycle/
-	// limit/tags) are fixed. Revoke never applies: the legacy key is permanent.
-	if installKey.System {
+	// The pairing key force-accepts (its mode is meaningless, see evaluateEnrollment), so nothing about
+	// it is editable.
+	if installKey.IsPairing() {
+		return NewErrInstallKeyForbidden()
+	}
+
+	// The legacy key governs every keyless enrollment in the namespace. Only two fields are editable:
+	// its mode (the default acceptance policy) and disabled (disabling it turns off keyless enrollment
+	// entirely — devices without a key are rejected). Its other fields (name/lifecycle/limit/tags) are
+	// fixed. Revoke never applies: the legacy key is permanent.
+	if installKey.IsSystem() {
 		if req.Name != "" || req.Revoked != nil || req.UsageLimit != nil || req.ExpiresAt.Present || req.Tags != nil || req.Ephemeral != nil || req.EphemeralTimeout != nil {
 			return NewErrInstallKeyForbidden()
 		}
@@ -436,9 +442,9 @@ func (s *service) RevealInstallKey(ctx context.Context, req *requests.RevealInst
 		}
 	}
 
-	// The system key has no presentable secret, and keys created before at-rest encryption have no
+	// A system key has no presentable secret, and keys created before at-rest encryption have no
 	// ciphertext to reveal.
-	if installKey.System || installKey.KeyEncrypted == "" {
+	if installKey.IsSystem() || installKey.KeyEncrypted == "" {
 		return "", NewErrInstallKeyNotFound(req.Name, nil)
 	}
 

--- a/api/services/install-key_test.go
+++ b/api/services/install-key_test.go
@@ -357,8 +357,8 @@ func TestUpdateInstallKey(t *testing.T) {
 				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenant).
 					Return(namespace, nil).Once()
 				storeMock.On("InstallKeyResolve", ctx, store.InstallKeyNameResolver, "legacy", mock.AnythingOfType("[]store.QueryOption")).
-					Return(&models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, System: true, Reusable: true, Mode: models.InstallKeyModeManual}, nil).Once()
-				storeMock.On("InstallKeyUpdate", ctx, &models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, System: true, Reusable: true, Mode: models.InstallKeyModeAutomatic}).
+					Return(&models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, Type: models.InstallKeyTypeLegacy, Reusable: true, Mode: models.InstallKeyModeManual}, nil).Once()
+				storeMock.On("InstallKeyUpdate", ctx, &models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, Type: models.InstallKeyTypeLegacy, Reusable: true, Mode: models.InstallKeyModeAutomatic}).
 					Return(nil).Once()
 			},
 			expectedErr: nil,
@@ -370,8 +370,8 @@ func TestUpdateInstallKey(t *testing.T) {
 				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenant).
 					Return(namespace, nil).Once()
 				storeMock.On("InstallKeyResolve", ctx, store.InstallKeyNameResolver, "legacy", mock.AnythingOfType("[]store.QueryOption")).
-					Return(&models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, System: true, Reusable: true, Mode: models.InstallKeyModeManual}, nil).Once()
-				storeMock.On("InstallKeyUpdate", ctx, &models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, System: true, Reusable: true, Mode: models.InstallKeyModeManual, Disabled: true}).
+					Return(&models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, Type: models.InstallKeyTypeLegacy, Reusable: true, Mode: models.InstallKeyModeManual}, nil).Once()
+				storeMock.On("InstallKeyUpdate", ctx, &models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, Type: models.InstallKeyTypeLegacy, Reusable: true, Mode: models.InstallKeyModeManual, Disabled: true}).
 					Return(nil).Once()
 			},
 			expectedErr: nil,
@@ -383,7 +383,7 @@ func TestUpdateInstallKey(t *testing.T) {
 				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenant).
 					Return(namespace, nil).Once()
 				storeMock.On("InstallKeyResolve", ctx, store.InstallKeyNameResolver, "legacy", mock.AnythingOfType("[]store.QueryOption")).
-					Return(&models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, System: true, Reusable: true, Mode: models.InstallKeyModeManual}, nil).Once()
+					Return(&models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, Type: models.InstallKeyTypeLegacy, Reusable: true, Mode: models.InstallKeyModeManual}, nil).Once()
 			},
 			expectedErr: NewErrInstallKeyForbidden(),
 		},
@@ -476,7 +476,7 @@ func TestUpdateInstallKey(t *testing.T) {
 				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, tenant).
 					Return(namespace, nil).Once()
 				storeMock.On("InstallKeyResolve", ctx, store.InstallKeyNameResolver, "legacy", mock.AnythingOfType("[]store.QueryOption")).
-					Return(&models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, System: true, Reusable: true, Mode: models.InstallKeyModeManual}, nil).Once()
+					Return(&models.InstallKey{ID: "hash", Name: "legacy", TenantID: tenant, Type: models.InstallKeyTypeLegacy, Reusable: true, Mode: models.InstallKeyModeManual}, nil).Once()
 			},
 			expectedErr: NewErrInstallKeyForbidden(),
 		},

--- a/api/store/install_key.go
+++ b/api/store/install_key.go
@@ -27,6 +27,11 @@ type InstallKeyStore interface {
 	// found and an error, if any.
 	InstallKeyResolveSystem(ctx context.Context, tenantID string) (*models.InstallKey, error)
 
+	// InstallKeyResolveSystemPairing fetches the namespace's system-managed pairing key: the source
+	// attributed to devices accepted through the tenant-less pairing-code flow. It returns the key if
+	// found and an error, if any.
+	InstallKeyResolveSystemPairing(ctx context.Context, tenantID string) (*models.InstallKey, error)
+
 	// InstallKeyConflicts reports whether the target contains conflicting attributes with the database. Pass zero
 	// values for attributes you do not wish to match on. It returns an array of conflicting attribute fields and
 	// an error, if any.

--- a/api/store/mocks/mock_store.go
+++ b/api/store/mocks/mock_store.go
@@ -2492,6 +2492,74 @@ func (_c *MockStore_InstallKeyResolveSystem_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// InstallKeyResolveSystemPairing provides a mock function for the type MockStore
+func (_mock *MockStore) InstallKeyResolveSystemPairing(ctx context.Context, tenantID string) (*models.InstallKey, error) {
+	ret := _mock.Called(ctx, tenantID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InstallKeyResolveSystemPairing")
+	}
+
+	var r0 *models.InstallKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*models.InstallKey, error)); ok {
+		return returnFunc(ctx, tenantID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *models.InstallKey); ok {
+		r0 = returnFunc(ctx, tenantID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.InstallKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, tenantID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_InstallKeyResolveSystemPairing_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InstallKeyResolveSystemPairing'
+type MockStore_InstallKeyResolveSystemPairing_Call struct {
+	*mock.Call
+}
+
+// InstallKeyResolveSystemPairing is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tenantID string
+func (_e *MockStore_Expecter) InstallKeyResolveSystemPairing(ctx any, tenantID any) *MockStore_InstallKeyResolveSystemPairing_Call {
+	return &MockStore_InstallKeyResolveSystemPairing_Call{Call: _e.mock.On("InstallKeyResolveSystemPairing", ctx, tenantID)}
+}
+
+func (_c *MockStore_InstallKeyResolveSystemPairing_Call) Run(run func(ctx context.Context, tenantID string)) *MockStore_InstallKeyResolveSystemPairing_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_InstallKeyResolveSystemPairing_Call) Return(installKey *models.InstallKey, err error) *MockStore_InstallKeyResolveSystemPairing_Call {
+	_c.Call.Return(installKey, err)
+	return _c
+}
+
+func (_c *MockStore_InstallKeyResolveSystemPairing_Call) RunAndReturn(run func(ctx context.Context, tenantID string) (*models.InstallKey, error)) *MockStore_InstallKeyResolveSystemPairing_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InstallKeyUpdate provides a mock function for the type MockStore
 func (_mock *MockStore) InstallKeyUpdate(ctx context.Context, installKey *models.InstallKey) error {
 	ret := _mock.Called(ctx, installKey)

--- a/api/store/pg/entity/install-key.go
+++ b/api/store/pg/entity/install-key.go
@@ -28,7 +28,7 @@ type InstallKey struct {
 	Tags               []string   `bun:"tags,array"`
 	Revoked            bool       `bun:"revoked"`
 	Disabled           bool       `bun:"disabled"`
-	System             bool       `bun:"system"`
+	Type               string     `bun:"type"`
 	KeyEncrypted       string     `bun:"key_encrypted,nullzero"`
 	KeyHint            string     `bun:"key_hint,nullzero"`
 	UserID             string     `bun:"user_id"`
@@ -50,6 +50,14 @@ func InstallKeyFromModel(model *models.InstallKey) *InstallKey {
 		tags = []string{}
 	}
 
+	// A zero-valued Type (any user-created key, which never sets it) persists as the explicit "user"
+	// discriminator, so the DB never stores an empty string that the partial unique index would treat
+	// as a system row.
+	keyType := model.Type
+	if keyType == "" {
+		keyType = models.InstallKeyTypeUser
+	}
+
 	return &InstallKey{
 		KeyDigest:          model.ID,
 		NamespaceID:        model.TenantID,
@@ -69,7 +77,7 @@ func InstallKeyFromModel(model *models.InstallKey) *InstallKey {
 		Tags:               tags,
 		Revoked:            model.Revoked,
 		Disabled:           model.Disabled,
-		System:             model.System,
+		Type:               string(keyType),
 		KeyEncrypted:       model.KeyEncrypted,
 		KeyHint:            model.KeyHint,
 		UserID:             model.CreatedBy,
@@ -99,7 +107,7 @@ func InstallKeyToModel(entity *InstallKey) *models.InstallKey {
 		Tags:               entity.Tags,
 		Revoked:            entity.Revoked,
 		Disabled:           entity.Disabled,
-		System:             entity.System,
+		Type:               models.InstallKeyType(entity.Type),
 		KeyEncrypted:       entity.KeyEncrypted,
 		KeyHint:            entity.KeyHint,
 		CreatedBy:          entity.UserID,

--- a/api/store/pg/install-key.go
+++ b/api/store/pg/install-key.go
@@ -73,9 +73,12 @@ func (pg *Pg) InstallKeyList(ctx context.Context, opts ...store.QueryOption) ([]
 
 	entities := make([]entity.InstallKey, 0)
 
-	// The legacy/system key is pinned first (it is the keyless-enrollment queue), then the caller's
-	// sort applies within each group.
-	query := db.NewSelect().Model(&entities).OrderExpr("system DESC")
+	// The system keys are pinned first (they are the keyless/pairing enrollment queues), the legacy
+	// one ahead of the pairing one; the caller's sort applies within each group. Both predicates score
+	// the same for every user key, so their relative order is left to the caller's sort.
+	query := db.NewSelect().
+		Model(&entities).
+		OrderExpr("(type = 'user') ASC, (type = 'pairing') ASC")
 	var err error
 	query, err = applyOptions(ctx, query, opts...)
 	if err != nil {
@@ -118,10 +121,19 @@ func (pg *Pg) InstallKeyResolve(ctx context.Context, resolver store.InstallKeyRe
 }
 
 func (pg *Pg) InstallKeyResolveSystem(ctx context.Context, tenantID string) (*models.InstallKey, error) {
+	return pg.installKeyResolveSystem(ctx, tenantID, models.InstallKeyTypeLegacy)
+}
+
+func (pg *Pg) InstallKeyResolveSystemPairing(ctx context.Context, tenantID string) (*models.InstallKey, error) {
+	return pg.installKeyResolveSystem(ctx, tenantID, models.InstallKeyTypePairing)
+}
+
+// installKeyResolveSystem fetches one of the namespace's system keys by type (legacy or pairing).
+func (pg *Pg) installKeyResolveSystem(ctx context.Context, tenantID string, keyType models.InstallKeyType) (*models.InstallKey, error) {
 	db := pg.GetConnection(ctx)
 
 	installKey := new(entity.InstallKey)
-	if err := db.NewSelect().Model(installKey).Where("namespace_id = ? AND system = true", tenantID).Scan(ctx); err != nil {
+	if err := db.NewSelect().Model(installKey).Where("namespace_id = ? AND type = ?", tenantID, string(keyType)).Scan(ctx); err != nil {
 		return nil, fromSQLError(err)
 	}
 

--- a/api/store/pg/migrations/015_install_key_pairing_system.tx.down.sql
+++ b/api/store/pg/migrations/015_install_key_pairing_system.tx.down.sql
@@ -1,0 +1,11 @@
+-- Reverse the type discriminator: restore the `system` boolean, drop the pairing keys, drop `type`.
+-- The devices FK is ON DELETE SET NULL, so any device attributed to a pairing key has its
+-- install_key_id cleared rather than blocking the drop.
+DROP INDEX IF EXISTS install_keys_namespace_type_unique;
+
+ALTER TABLE install_keys ADD COLUMN system boolean NOT NULL DEFAULT false;
+UPDATE install_keys SET system = true WHERE type <> 'user';
+
+DELETE FROM install_keys WHERE type = 'pairing';
+
+ALTER TABLE install_keys DROP COLUMN type;

--- a/api/store/pg/migrations/015_install_key_pairing_system.tx.up.sql
+++ b/api/store/pg/migrations/015_install_key_pairing_system.tx.up.sql
@@ -1,0 +1,26 @@
+-- Discriminate install keys by a `type` column instead of the `system` boolean + magic `name`. The
+-- two auto-managed system keys per namespace (legacy, pairing) are told apart by `type`; user keys are
+-- `user`. This also adds the pairing key: the source attributed to devices accepted through the
+-- tenant-less pairing-code flow, so they no longer attribute to the legacy key.
+--
+-- Fix-forward only: existing pairing devices already stamped with the legacy key are byte-identical to
+-- keyless-legacy devices and cannot be re-attributed reliably, so they are left as-is.
+
+ALTER TABLE install_keys ADD COLUMN type text NOT NULL DEFAULT 'user';
+
+-- Backfill the existing legacy system key (migration 013 created one per namespace with system = true,
+-- name = 'legacy'). Only system keys are touched; a user key can't be named 'legacy' — it would have
+-- collided with that key on creation.
+UPDATE install_keys SET type = 'legacy' WHERE system = true AND name = 'legacy';
+
+-- One pairing (system) key per existing namespace. Automatic mode (acceptance is the code itself);
+-- agents never present it (resolved by type). Digest is deterministic per namespace.
+INSERT INTO install_keys (key_digest, namespace_id, name, reusable, usage_limit, used_times, ephemeral, tags, revoked, system, type, mode, user_id, created_at, updated_at, expires_at)
+SELECT encode(sha256(('system:pairing:' || id::text)::bytea), 'hex'), id, 'pairing', true, 0, 0, false, '{}', false, true, 'pairing', 'automatic', owner_id, now(), now(), NULL
+FROM namespaces
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE install_keys DROP COLUMN system;
+
+-- Guarantee exactly one legacy and one pairing key per namespace; user keys are unconstrained here.
+CREATE UNIQUE INDEX install_keys_namespace_type_unique ON install_keys (namespace_id, type) WHERE type <> 'user';

--- a/api/store/pg/migrations/015_install_key_pairing_system.tx.up.sql
+++ b/api/store/pg/migrations/015_install_key_pairing_system.tx.up.sql
@@ -3,14 +3,22 @@
 -- `user`. This also adds the pairing key: the source attributed to devices accepted through the
 -- tenant-less pairing-code flow, so they no longer attribute to the legacy key.
 --
--- Fix-forward only: existing pairing devices already stamped with the legacy key are byte-identical to
--- keyless-legacy devices and cannot be re-attributed reliably, so they are left as-is.
+-- Fix-forward only, in two respects:
+--   1. Existing pairing devices already stamped with the legacy key are byte-identical to keyless-legacy
+--      devices and cannot be re-attributed reliably, so they are left as-is.
+--   2. The pairing INSERT below relies on the pre-existing (namespace_id, name) unique index. Unlike
+--      'legacy' (reserved since migration 013), 'pairing' was never a reserved name, so a namespace that
+--      already holds a user key named 'pairing' keeps it and does NOT get a pairing system key (ON
+--      CONFLICT DO NOTHING skips it). Code pairing there still works (acceptPairingDevice accepts the
+--      device explicitly, independent of the resolved key); it just falls back to keyless-legacy
+--      attribution. New namespaces are unaffected: the key is created at NamespaceCreate, before any
+--      user key can claim the name. Accepted as deliberate fix-forward, not worth mutating user data for.
 
 ALTER TABLE install_keys ADD COLUMN type text NOT NULL DEFAULT 'user';
 
 -- Backfill the existing legacy system key (migration 013 created one per namespace with system = true,
--- name = 'legacy'). Only system keys are touched; a user key can't be named 'legacy' — it would have
--- collided with that key on creation.
+-- name = 'legacy'). Only system keys are touched; a user key can't be named 'legacy' (it would have
+-- collided with that key on creation).
 UPDATE install_keys SET type = 'legacy' WHERE system = true AND name = 'legacy';
 
 -- One pairing (system) key per existing namespace. Automatic mode (acceptance is the code itself);

--- a/api/store/pg/namespace.go
+++ b/api/store/pg/namespace.go
@@ -51,19 +51,37 @@ func (pg *Pg) NamespaceCreate(ctx context.Context, namespace *models.Namespace) 
 			}
 		}
 
-		// Every namespace gets its system-managed legacy install key, so a tenant-only enrollment (a
-		// device presenting only the tenant ID) always has a source to attribute to. Created here, at
-		// the single namespace-creation chokepoint every path funnels through — the API, setup, the CLI,
-		// and the cloud/enterprise store that delegates here — so no path can skip it. The digest is
-		// derived from the tenant; agents never present it, it is resolved by the system flag.
-		digest := sha256.Sum256([]byte("system:" + namespace.TenantID))
+		// Every namespace gets its two system-managed install keys, so every keyless enrollment has a
+		// source to attribute to. Created here, at the single namespace-creation chokepoint every path
+		// funnels through — the API, setup, the CLI, and the cloud/enterprise store that delegates here —
+		// so no path can skip them. Digests are derived from the tenant; agents never present them, they
+		// are resolved by type.
+		//
+		// legacy: tenant-only keyless enrollment (a device presenting only the tenant ID). Manual mode,
+		// so such devices land pending.
+		legacyDigest := sha256.Sum256([]byte("system:" + namespace.TenantID))
 		if _, err := pg.InstallKeyCreate(ctx, &models.InstallKey{
-			ID:        hex.EncodeToString(digest[:]),
-			Name:      "legacy",
+			ID:        hex.EncodeToString(legacyDigest[:]),
+			Name:      string(models.InstallKeyTypeLegacy),
 			TenantID:  namespace.TenantID,
 			Mode:      models.InstallKeyModeManual,
 			Reusable:  true,
-			System:    true,
+			Type:      models.InstallKeyTypeLegacy,
+			CreatedBy: namespace.Owner,
+		}); err != nil {
+			return err
+		}
+
+		// pairing: code-pairing enrollment (a tenant-less agent accepted via its printed code). Automatic
+		// mode, since acceptance is the code itself; the pairing flow accepts the device explicitly.
+		pairingDigest := sha256.Sum256([]byte("system:pairing:" + namespace.TenantID))
+		if _, err := pg.InstallKeyCreate(ctx, &models.InstallKey{
+			ID:        hex.EncodeToString(pairingDigest[:]),
+			Name:      string(models.InstallKeyTypePairing),
+			TenantID:  namespace.TenantID,
+			Mode:      models.InstallKeyModeAutomatic,
+			Reusable:  true,
+			Type:      models.InstallKeyTypePairing,
 			CreatedBy: namespace.Owner,
 		}); err != nil {
 			return err

--- a/openapi/spec/components/schemas/installKey.yaml
+++ b/openapi/spec/components/schemas/installKey.yaml
@@ -96,13 +96,20 @@ properties:
       Whether the key is temporarily paused. Unlike `revoked`, this is
       reversible: a disabled key stops registering but can be re-enabled.
     example: false
-  system:
-    type: boolean
+  type:
+    type: string
+    enum:
+      - user
+      - legacy
+      - pairing
     description: |
-      Whether this is the namespace's auto-managed legacy key (the source of
-      devices registered with only a tenant ID). System keys cannot be edited or
-      deleted.
-    example: false
+      The key's origin. `user` is a normal user-created key. `legacy` and
+      `pairing` are the namespace's two auto-managed system keys — the source of
+      devices registered with only a tenant ID, and of devices accepted through
+      the tenant-less pairing-code flow, respectively. System keys are not
+      presentable by an agent; `pairing` is not editable and `legacy` allows only
+      its mode/disabled to change.
+    example: user
   key_hint:
     type: string
     description: |

--- a/pkg/models/install_key.go
+++ b/pkg/models/install_key.go
@@ -22,6 +22,22 @@ const (
 	InstallKeyModeAllowlist InstallKeyMode = "allowlist"
 )
 
+// InstallKeyType discriminates a key's origin: a user-created key, or one of the two auto-managed
+// system keys every namespace has. The system types are told apart by this field (not by name), and
+// neither is presentable by an agent nor freely editable by a user.
+type InstallKeyType string
+
+const (
+	// InstallKeyTypeUser is a normal user-created key.
+	InstallKeyTypeUser InstallKeyType = "user"
+	// InstallKeyTypeLegacy is the tenant-only keyless enrollment source (a device presenting only a
+	// tenant ID, no install key). Manual mode: such devices land pending.
+	InstallKeyTypeLegacy InstallKeyType = "legacy"
+	// InstallKeyTypePairing is the code-pairing enrollment source (a tenant-less agent accepted via its
+	// printed code). Devices accepted through the pairing flow attribute here, not to the legacy key.
+	InstallKeyTypePairing InstallKeyType = "pairing"
+)
+
 // Webhook tuning bounds/defaults (seconds). A stored 0 means "use the default".
 const (
 	// InstallKeyWebhookDefaultTimeout / MaxTimeout bound the synchronous webhook request.
@@ -106,10 +122,10 @@ type InstallKey struct {
 	// Disabled reports whether the key is temporarily paused. Unlike Revoked, it is reversible: a
 	// disabled key stops enrolling but can be re-enabled at any time.
 	Disabled bool `json:"disabled"`
-	// System reports whether this is the namespace's auto-managed legacy key: the source attributed
-	// to devices that enroll with only a tenant ID (no install key). It is always valid, never
-	// auto-accepts, and cannot be edited or deleted.
-	System bool `json:"system"`
+	// Type discriminates the key's origin: a user-created key, or one of the namespace's two
+	// auto-managed system keys (legacy, pairing). System keys are always valid and are not presentable
+	// by an agent; see IsSystem.
+	Type InstallKeyType `json:"type"`
 	// KeyEncrypted holds the plaintext key encrypted at rest (AES-GCM), so an admin can reveal it
 	// later. It is internal-only and never serialized to clients (reveal returns the decrypted value
 	// through its own endpoint).
@@ -144,6 +160,19 @@ func (s *InstallKey) WebhookCallbackTTLOrDefault() int {
 // limit), so only those are retried; automatic/manual have no such recoverable pending state.
 func (s *InstallKey) ReconcilableOnAuth() bool {
 	return s.Mode == InstallKeyModeWebhook || s.Mode == InstallKeyModeAllowlist
+}
+
+// IsSystem reports whether this is one of the namespace's auto-managed system keys (legacy or
+// pairing), as opposed to a user-created key. Checked positively (not `!= user`) so a zero-valued
+// Type — an in-memory key built before persistence defaults it to user — reads as a user key.
+func (s *InstallKey) IsSystem() bool {
+	return s.Type == InstallKeyTypeLegacy || s.Type == InstallKeyTypePairing
+}
+
+// IsPairing reports whether this is the namespace's auto-managed pairing key: the source attributed to
+// devices accepted through the tenant-less pairing-code flow.
+func (s *InstallKey) IsPairing() bool {
+	return s.Type == InstallKeyTypePairing
 }
 
 // IsValid reports whether the install key can still enroll a device: it must not be revoked, disabled,

--- a/ui/apps/console/src/components/common/DataTable.tsx
+++ b/ui/apps/console/src/components/common/DataTable.tsx
@@ -40,6 +40,23 @@ export interface DataTableProps<T> {
   onRowClick?: (row: T) => void;
   rowClassName?: (row: T) => string | undefined;
 
+  /**
+   * Groups rows into labelled sections: a full-width header row is inserted before the first row of
+   * each section (i.e. whenever `sectionOf` changes from the previous row). `data` must already be
+   * ordered so each section's rows are contiguous. `sectionLabel` maps a section key to its heading.
+   */
+  sectionOf?: (row: T) => string;
+  sectionLabel?: (section: string) => string;
+
+  /**
+   * A full-width block appended after the last data row. For a grouped table whose trailing section
+   * is empty — e.g. user-created rows sitting under always-present built-in rows — pass an onboarding
+   * placeholder here; it stands in for the whole section (no section header, since the placeholder
+   * already names it). The caller gates this on the true, unpaginated count (page data alone can't
+   * tell "empty" from "on another page").
+   */
+  trailingEmptyState?: ReactNode;
+
   /** When a row's key matches, an extra full-width row is rendered below it with
    * `renderExpandedRow`. Used for inline accordion panels. */
   expandedRowKey?: string | null;
@@ -124,6 +141,9 @@ export default function DataTable<T>({
   onSort,
   onRowClick,
   rowClassName,
+  sectionOf,
+  sectionLabel,
+  trailingEmptyState,
   expandedRowKey,
   renderExpandedRow,
   hideHeader = false,
@@ -205,50 +225,79 @@ export default function DataTable<T>({
               </td>
             </tr>
           ) : (
-            data.map((row, index) => {
-              const extraClass = rowClassName?.(row) ?? "";
-              const clickHandler = onRowClick;
-              const isClickable = !!clickHandler;
-              const key = rowKey(row, index);
-              const isExpanded = !!renderExpandedRow && expandedRowKey === key;
-              return (
-                <Fragment key={key}>
-                  <tr
-                    onClick={clickHandler ? () => clickHandler(row) : undefined}
-                    onKeyDown={
-                      clickHandler
-                        ? (e) => {
-                            if (e.key === "Enter" || e.key === " ") {
-                              e.preventDefault();
-                              clickHandler(row);
-                            }
-                          }
-                        : undefined
-                    }
-                    tabIndex={isClickable ? 0 : undefined}
-                    className={cn(
-                      "group transition-colors",
-                      isClickable &&
-                        "cursor-pointer hover:bg-hover-subtle focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50 focus-visible:-outline-offset-2",
-                      extraClass,
+            <>
+              {data.map((row, index) => {
+                const extraClass = rowClassName?.(row) ?? "";
+                const clickHandler = onRowClick;
+                const isClickable = !!clickHandler;
+                const key = rowKey(row, index);
+                const isExpanded =
+                  !!renderExpandedRow && expandedRowKey === key;
+                // Insert a section header before the first row of each section (when it changes from the
+                // previous row). `data` is assumed grouped so each section is contiguous.
+                const section = sectionOf?.(row);
+                const showSection =
+                  section !== undefined &&
+                  section !==
+                    (index > 0 ? sectionOf?.(data[index - 1]) : undefined);
+                return (
+                  <Fragment key={key}>
+                    {showSection && (
+                      <tr>
+                        <td
+                          colSpan={columns.length}
+                          className="px-4 pt-2 pb-2 font-mono text-2xs uppercase tracking-label text-text-muted/70"
+                        >
+                          {sectionLabel?.(section) ?? section}
+                        </td>
+                      </tr>
                     )}
-                  >
-                    {columns.map((col) => (
-                      <td key={col.key} className="px-4 py-3.5">
-                        {col.render(row)}
-                      </td>
-                    ))}
-                  </tr>
-                  {isExpanded && (
-                    <tr>
-                      <td colSpan={columns.length} className="p-0">
-                        {renderExpandedRow(row)}
-                      </td>
+                    <tr
+                      onClick={
+                        clickHandler ? () => clickHandler(row) : undefined
+                      }
+                      onKeyDown={
+                        clickHandler
+                          ? (e) => {
+                              if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                clickHandler(row);
+                              }
+                            }
+                          : undefined
+                      }
+                      tabIndex={isClickable ? 0 : undefined}
+                      className={cn(
+                        "group transition-colors",
+                        isClickable &&
+                          "cursor-pointer hover:bg-hover-subtle focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50 focus-visible:-outline-offset-2",
+                        extraClass,
+                      )}
+                    >
+                      {columns.map((col) => (
+                        <td key={col.key} className="px-4 py-3.5">
+                          {col.render(row)}
+                        </td>
+                      ))}
                     </tr>
-                  )}
-                </Fragment>
-              );
-            })
+                    {isExpanded && (
+                      <tr>
+                        <td colSpan={columns.length} className="p-0">
+                          {renderExpandedRow(row)}
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+              {trailingEmptyState && (
+                <tr>
+                  <td colSpan={columns.length} className="p-0">
+                    {trailingEmptyState}
+                  </td>
+                </tr>
+              )}
+            </>
           )}
         </tbody>
       </table>

--- a/ui/apps/console/src/pages/AddDevice.tsx
+++ b/ui/apps/console/src/pages/AddDevice.tsx
@@ -23,6 +23,7 @@ import {
 import CopyButton from "../components/common/CopyButton";
 import PairingCodeDialog from "@/components/common/PairingCodeDialog";
 import CreateInstallKeyDrawer from "@/pages/install-keys/CreateInstallKeyDrawer";
+import { isSystemKey } from "@/pages/install-keys/helpers";
 import { modeInfo } from "@/pages/install-keys/constants";
 import { useInstallKeys } from "@/hooks/useInstallKeys";
 import { useRevealInstallKey } from "@/hooks/useRevealInstallKey";
@@ -214,7 +215,7 @@ export default function AddDevice() {
   // keyless default, not something you bake in) and anything unusable.
   const { installKeys } = useInstallKeys({ perPage: 50 });
   const usableKeys = installKeys.filter(
-    (k) => !k.system && !k.revoked && !k.disabled,
+    (k) => !isSystemKey(k) && !k.revoked && !k.disabled,
   );
   const selectedKey =
     usableKeys.find((k) => k.name === selectedKeyName) ?? usableKeys[0];

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -291,7 +291,9 @@ export default function DeviceDetails() {
                 <DeprecatedBadge />
               ) : (
                 <span className="text-sm font-medium text-text-primary">
-                  {enrollment.name}
+                  {enrollment.kind === "pairing"
+                    ? "Pairing code"
+                    : enrollment.name}
                 </span>
               )
             ) : (

--- a/ui/apps/console/src/pages/install-keys/EditInstallKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/install-keys/EditInstallKeyDrawer.tsx
@@ -5,6 +5,7 @@ import { isSdkError } from "@/api/errors";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import { useUpdateInstallKey } from "@/hooks/useInstallKeyMutations";
 import { type InstallKey, type InstallKeyUpdate } from "@/client";
+import { isSystemKey } from "./helpers";
 import Drawer from "@/components/common/Drawer";
 import InputField from "@/components/common/fields/InputField";
 import TagsSelector from "@/components/common/fields/TagsSelector";
@@ -24,7 +25,7 @@ function EditInstallKeyDrawer({
   const updateKey = useUpdateInstallKey();
   const open = installKey !== null;
   // The legacy/system key is edit-restricted: only its enrollment mode is shown and sent.
-  const isSystem = installKey?.system ?? false;
+  const isSystem = installKey ? isSystemKey(installKey) : false;
   const [name, setName] = useState("");
   const [mode, setMode] = useState<InstallKeyMode>("automatic");
   const [webhookUrl, setWebhookUrl] = useState("");

--- a/ui/apps/console/src/pages/install-keys/InstallKeyActionsMenu.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeyActionsMenu.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
 import {
   EllipsisVerticalIcon,
   NoSymbolIcon,
@@ -8,10 +15,10 @@ import {
 } from "@heroicons/react/24/outline";
 import { IconButton } from "@shellhub/design-system/primitives";
 import { type InstallKey } from "@/client";
-import { useClickOutside } from "@/hooks/useClickOutside";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import { type Action } from "@/utils/permission";
+import { isPairingKey, isSystemKey } from "./helpers";
 
 function MenuItem({
   action,
@@ -47,10 +54,9 @@ function MenuItem({
 }
 
 /**
- * Trailing overflow menu for a install key row. Built on the codebase's
- * click-outside popover pattern (no shared dropdown primitive exists): an
- * ellipsis trigger toggles an absolutely-positioned menu, closed on Escape or
- * an outside click.
+ * Trailing overflow menu for an install key row. An ellipsis trigger toggles a menu closed on Escape
+ * or an outside click. The menu renders in a portal (see the position effect) so it escapes the
+ * table's horizontal-scroll clip; there's no shared dropdown primitive to lean on.
  */
 export default function InstallKeyActionsMenu({
   installKey,
@@ -64,20 +70,49 @@ export default function InstallKeyActionsMenu({
   onRevoke: (key: InstallKey) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  // Right-aligned position, in viewport coordinates. The menu renders in a portal on document.body so
+  // it escapes the table's `overflow-x-auto` clip — otherwise opening it extends the scroll width and
+  // shifts the whole table (and the menu is clipped out of view).
+  const [pos, setPos] = useState({ top: 0, right: 0 });
 
-  useClickOutside(wrapperRef, () => setOpen(false));
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+  }, []);
+
   useEscapeKey(() => setOpen(false), open);
 
-  // Move focus into the menu when it opens so it can be driven from the keyboard.
   useEffect(() => {
-    if (open) {
-      menuRef.current
-        ?.querySelector<HTMLButtonElement>('[role="menuitem"]')
-        ?.focus();
-    }
-  }, [open]);
+    if (!open) return undefined;
+    updatePosition();
+    // Move focus into the menu when it opens so it can be driven from the keyboard.
+    menuRef.current
+      ?.querySelector<HTMLButtonElement>('[role="menuitem"]')
+      ?.focus();
+
+    const reposition = () => updatePosition();
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    const onDown = (e: MouseEvent) => {
+      if (
+        !menuRef.current?.contains(e.target as Node) &&
+        !triggerRef.current?.contains(e.target as Node)
+      )
+        setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+      document.removeEventListener("mousedown", onDown);
+    };
+  }, [open, updatePosition]);
+
+  // The pairing key force-accepts and has no editable fields, so it has no actions at all.
+  if (isPairingKey(installKey)) return null;
 
   // Arrow keys (and Home/End) roam the rendered menu items, wrapping around. Queried live because
   // items are conditionally shown (permissions, the system key hides Revoke).
@@ -117,14 +152,13 @@ export default function InstallKeyActionsMenu({
     fn();
   };
 
-  // A revoked key is terminal — no actions. The legacy/system key is auto-managed but still editable
-  // (its mode governs keyless enrollments), so it keeps Edit; Revoke stays hidden — it's permanent.
+  // A revoked key is terminal, so it has no actions.
   if (installKey.revoked) {
     return null;
   }
 
   return (
-    <div ref={wrapperRef} className="relative shrink-0">
+    <div ref={triggerRef} className="shrink-0">
       <IconButton
         variant="ghost"
         aria-label="Install Key actions"
@@ -135,45 +169,48 @@ export default function InstallKeyActionsMenu({
         <EllipsisVerticalIcon className="w-4 h-4" />
       </IconButton>
 
-      {open && (
-        <div
-          ref={menuRef}
-          role="menu"
-          tabIndex={-1}
-          onKeyDown={onMenuKeyDown}
-          className="absolute right-0 top-full mt-1 z-50 w-40 py-1 bg-surface border border-border rounded-lg shadow-2xl animate-fade-in"
-        >
-          <MenuItem
-            action="installKey:edit"
-            icon={<PencilIcon className="w-4 h-4" />}
-            label="Edit"
-            onSelect={run(() => onEdit(installKey))}
-          />
-          {/* Disable is available for the legacy key too: disabling it turns off keyless enrollment
-              (devices without a key are rejected). Revoke stays hidden — the legacy key is permanent. */}
-          <MenuItem
-            action="installKey:disable"
-            icon={
-              installKey.disabled ? (
-                <PlayIcon className="w-4 h-4" />
-              ) : (
-                <PauseIcon className="w-4 h-4" />
-              )
-            }
-            label={installKey.disabled ? "Enable" : "Disable"}
-            onSelect={run(() => onToggleDisabled(installKey))}
-          />
-          {!installKey.system && (
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            tabIndex={-1}
+            onKeyDown={onMenuKeyDown}
+            style={{ top: pos.top, right: pos.right }}
+            className="fixed z-50 w-40 py-1 bg-surface border border-border rounded-lg shadow-2xl animate-fade-in"
+          >
             <MenuItem
-              action="installKey:revoke"
-              icon={<NoSymbolIcon className="w-4 h-4" />}
-              label="Revoke"
-              danger
-              onSelect={run(() => onRevoke(installKey))}
+              action="installKey:edit"
+              icon={<PencilIcon className="w-4 h-4" />}
+              label="Edit"
+              onSelect={run(() => onEdit(installKey))}
             />
-          )}
-        </div>
-      )}
+            {/* Disable is available for the legacy key too: disabling it turns off keyless enrollment
+                (devices without a key are rejected). Revoke stays hidden — the legacy key is permanent. */}
+            <MenuItem
+              action="installKey:disable"
+              icon={
+                installKey.disabled ? (
+                  <PlayIcon className="w-4 h-4" />
+                ) : (
+                  <PauseIcon className="w-4 h-4" />
+                )
+              }
+              label={installKey.disabled ? "Enable" : "Disable"}
+              onSelect={run(() => onToggleDisabled(installKey))}
+            />
+            {!isSystemKey(installKey) && (
+              <MenuItem
+                action="installKey:revoke"
+                icon={<NoSymbolIcon className="w-4 h-4" />}
+                label="Revoke"
+                danger
+                onSelect={run(() => onRevoke(installKey))}
+              />
+            )}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/ui/apps/console/src/pages/install-keys/InstallKeyHistoryPage.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeyHistoryPage.tsx
@@ -20,7 +20,8 @@ import {
   getExpiryInfo,
   getKeyBlockers,
   getUsageInfo,
-  isSystemKey,
+  installKeyDisplayName,
+  isPairingKey,
 } from "./helpers";
 
 /** One labelled fact in the key summary strip. */
@@ -50,11 +51,7 @@ export default function InstallKeyHistoryPage() {
   // The list caps at 100 keys; past that a deep link degrades to the leaner header.
   const { installKeys } = useInstallKeys({ perPage: 100 });
   const key = installKeys.find((k) => k.id === id) ?? state?.key ?? null;
-  const name = key
-    ? isSystemKey(key)
-      ? "Tenant-only registration"
-      : key.name
-    : (state?.name ?? "");
+  const name = key ? installKeyDisplayName(key) : (state?.name ?? "");
   const [revealOpen, setRevealOpen] = useState(false);
 
   const mode = key ? modeInfo(key.mode) : null;
@@ -149,18 +146,23 @@ export default function InstallKeyHistoryPage() {
                   </span>
                 </Fact>
               )}
-              <Fact label="Install Key">
-                <KeyValueChip
-                  label="Key"
-                  labelTone="primary"
-                  value={
-                    key.key_hint ? `${key.key_hint}••••••` : "••••••••••••••"
-                  }
-                  onClick={() => setRevealOpen(true)}
-                  title="Reveal Install Key"
-                  ariaLabel="Reveal Install Key"
-                />
-              </Fact>
+              {/* The install key chip: user and legacy keys show it (click reveals the key — or, for the
+                  secretless legacy key, its fingerprint). Pairing has nothing to reveal (it accepts on the
+                  printed code), so it's the only one without the chip. */}
+              {!isPairingKey(key) && (
+                <Fact label="Install Key">
+                  <KeyValueChip
+                    label="Key"
+                    labelTone="primary"
+                    value={
+                      key.key_hint ? `${key.key_hint}••••••` : "••••••••••••••"
+                    }
+                    onClick={() => setRevealOpen(true)}
+                    title="Reveal Install Key"
+                    ariaLabel="Reveal Install Key"
+                  />
+                </Fact>
+              )}
             </div>
             <InstallKeyActions installKey={key} />
           </div>

--- a/ui/apps/console/src/pages/install-keys/InstallKeysTable.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeysTable.tsx
@@ -4,13 +4,16 @@ import {
   ClockIcon,
   NoSymbolIcon,
   PauseCircleIcon,
+  PlusIcon,
+  QrCodeIcon,
+  TicketIcon,
 } from "@heroicons/react/24/outline";
 import { ExclamationCircleIcon as ExclamationCircleSolidIcon } from "@heroicons/react/24/solid";
+import { Button } from "@shellhub/design-system/primitives";
 import { type InstallKey } from "@/client";
 import DataTable, { type Column } from "@/components/common/DataTable";
+import RestrictedAction from "@/components/common/RestrictedAction";
 import InstallKeyActionsMenu from "./InstallKeyActionsMenu";
-import InstallKeyEventsTable from "./InstallKeyEventsTable";
-import KeyValueChip from "./KeyValueChip";
 import StatusChip from "./StatusChip";
 import UsageMeter, { usageLabel } from "./UsageMeter";
 import { DeprecatedBadge, modeInfo } from "./constants";
@@ -18,36 +21,10 @@ import {
   getExpiryInfo,
   getKeyBlockers,
   getUsageInfo,
+  installKeyDisplayName,
+  isPairingKey,
   isSystemKey,
 } from "./helpers";
-
-/**
- * The install key's value under its name: the masked secret hint with an inline reveal. This is the
- * artifact the feature is named for — the string you paste into an agent — so it sits in the identity
- * cell, not a separate column. The fingerprint (webhook/route identifier) lives in the reveal dialog.
- */
-function KeyValue({
-  installKey,
-  onReveal,
-}: {
-  installKey: InstallKey;
-  onReveal: (key: InstallKey) => void;
-}) {
-  const hasSecret = !!installKey.key_hint;
-
-  return (
-    <div className="mt-1.5">
-      <KeyValueChip
-        label="Install Key"
-        labelTone="primary"
-        value={hasSecret ? `${installKey.key_hint}••••••` : "••••••••••••••"}
-        onClick={() => onReveal(installKey)}
-        title="Reveal Install Key"
-        ariaLabel="Reveal Install Key"
-      />
-    </div>
-  );
-}
 
 /**
  * The Mode cell: the key's mode identity (icon tile + label). Its secondary line is the mode summary
@@ -56,9 +33,14 @@ function KeyValue({
  * columns instead. The tile dims when the key is inert.
  */
 function EnrollmentCell({ installKey }: { installKey: InstallKey }) {
-  const mode = modeInfo(installKey.mode);
-  const Icon = mode.icon;
   const { revoked, disabled, inert } = getKeyBlockers(installKey);
+
+  // The pairing key has no configurable admission mode — it always accepts via the printed code — so
+  // it reads as a pairing source, not a mode. Every other key shows its actual mode.
+  const info = isPairingKey(installKey)
+    ? { icon: QrCodeIcon, label: "Code pairing", summary: "Accepted by code" }
+    : modeInfo(installKey.mode);
+  const Icon = info.icon;
 
   const state = revoked
     ? { label: "Revoked", glyph: NoSymbolIcon }
@@ -81,7 +63,7 @@ function EnrollmentCell({ installKey }: { installKey: InstallKey }) {
         <div
           className={`text-xs font-semibold whitespace-nowrap ${inert ? "text-text-muted" : "text-text-primary"}`}
         >
-          {mode.label}
+          {info.label}
         </div>
         {state ? (
           <div className="flex items-center gap-1 text-2xs text-text-muted whitespace-nowrap">
@@ -90,9 +72,40 @@ function EnrollmentCell({ installKey }: { installKey: InstallKey }) {
           </div>
         ) : (
           <div className="text-2xs text-text-muted whitespace-nowrap">
-            {mode.summary}
+            {info.summary}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Onboarding placeholder for the "Custom keys" section when the namespace has none yet. The built-in
+ * keys always fill the table, so this replaces the old full-page hero: it lives inside the section it
+ * belongs to, keeping the built-in rows (and their queues) reachable above it.
+ */
+function CustomKeysEmpty({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="px-4 py-6">
+      <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border-light px-5 py-9 text-center">
+        <TicketIcon className="w-8 h-8 text-text-muted" strokeWidth={1.5} />
+        <h3 className="text-sm font-semibold text-text-primary">
+          No custom keys yet
+        </h3>
+        <p className="max-w-xl text-xs text-text-muted">
+          Create a key with its own secret and mode to register devices with
+          your namespace.
+        </p>
+        <RestrictedAction action="installKey:create">
+          <Button
+            size="sm"
+            onClick={onCreate}
+            icon={<PlusIcon className="w-4 h-4" strokeWidth={2} />}
+          >
+            Create Install Key
+          </Button>
+        </RestrictedAction>
       </div>
     </div>
   );
@@ -109,8 +122,9 @@ export default function InstallKeysTable({
   page,
   totalPages,
   totalCount,
+  noCustomKeys,
   onPageChange,
-  onReveal,
+  onCreate,
   onEdit,
   onToggleDisabled,
   onRevoke,
@@ -119,8 +133,12 @@ export default function InstallKeysTable({
   page: number;
   totalPages: number;
   totalCount: number;
+  /** True when the namespace has only built-in keys (no user-created ones), so the Custom keys
+   * section shows its onboarding placeholder instead of rows. Computed by the caller off the true
+   * count — page data alone can't distinguish "none" from "on a later page". */
+  noCustomKeys: boolean;
   onPageChange: (page: number) => void;
-  onReveal: (key: InstallKey) => void;
+  onCreate: () => void;
   onEdit: (key: InstallKey) => void;
   onToggleDisabled: (key: InstallKey) => void;
   onRevoke: (key: InstallKey) => void;
@@ -141,23 +159,21 @@ export default function InstallKeysTable({
           <div>
             <div className="flex items-center gap-2">
               <span className="text-sm font-semibold text-text-primary">
-                Tenant-only registration
+                {installKeyDisplayName(key)}
               </span>
-              <DeprecatedBadge />
+              {!isPairingKey(key) && <DeprecatedBadge />}
             </div>
             <p className="mt-0.5 text-2xs text-text-muted">
-              The legacy path for devices that register without an install key.
-              Kept for compatibility and will be removed in a future release.
-              Its mode controls how those devices are handled.
+              {isPairingKey(key)
+                ? "Devices that pair by the code the agent prints during install — or by opening the link printed with it. Accepted on the code itself."
+                : "The legacy path for devices that register without an install key. Kept for compatibility and will be removed in a future release. Its mode controls how those devices are handled."}
             </p>
-            <KeyValue installKey={key} onReveal={onReveal} />
           </div>
         ) : (
           <div>
             <span className="text-sm font-semibold text-text-primary">
               {key.name}
             </span>
-            <KeyValue installKey={key} onReveal={onReveal} />
             {key.tags && key.tags.length > 0 && (
               <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
                 {key.tags.map((tag) => (
@@ -242,48 +258,29 @@ export default function InstallKeysTable({
     },
   ];
 
-  // The tenant-only (system) row stays permanently expanded, previewing its recent registrations
-  // inline so the legacy path's activity is visible without leaving the list. When it's disabled the
-  // path is off, so the preview collapses.
-  const systemKey = data.find(isSystemKey);
-  const expandSystemKey = systemKey && !systemKey.disabled;
-
   return (
     <DataTable
       label="Install keys"
       columns={columns}
       data={data}
       rowKey={(key) => key.name}
-      expandedRowKey={expandSystemKey ? systemKey.name : null}
-      renderExpandedRow={(key) => (
-        // The key's registration preview, tied to the row above by a shared left rail and a recessed
-        // background so it reads as this row's nested detail.
-        <div className="-ml-px border-l-2 border-l-primary/50 bg-surface/60">
-          <InstallKeyEventsTable
-            id={key.id}
-            perPage={10}
-            compact
-            viewAll={{
-              to: `/install-keys/${encodeURIComponent(key.id)}/activity`,
-              state: { name: "Tenant-only registration", key },
-            }}
-          />
-        </div>
-      )}
-      // Tall, roomy rows; clicking a row opens the key's full enrollment history. The pinned legacy
-      // row gets a faint tint so it reads as the default/system entry.
+      // The auto-managed keys (legacy, pairing) come with the namespace ("Built-in"); the keys an admin
+      // creates are grouped under "Custom keys". `data` is already ordered system-first, so the
+      // sections stay contiguous.
+      sectionOf={(key) => (isSystemKey(key) ? "system" : "user")}
+      sectionLabel={(section) =>
+        section === "system" ? "Built-in" : "Custom keys"
+      }
+      // With only built-in keys, the "Custom keys" section has no rows — render its onboarding
+      // placeholder under the built-in rows instead of the old full-page hero (which never showed,
+      // since the built-in keys keep the table non-empty). The placeholder names the section itself,
+      // so no "Custom keys" header precedes it.
+      trailingEmptyState={
+        noCustomKeys ? <CustomKeysEmpty onCreate={onCreate} /> : undefined
+      }
+      // Tall, roomy rows; clicking a row opens the key's full registration history.
       rowClassName={(key) => {
-        const system = isSystemKey(key);
-        // An expanded tenant-only row shares its preview's recessed background and left rail so the two
-        // read as one block. `[&+tr]:!border-t-transparent` drops the table's divider between the row
-        // and the accordion, so the rail runs unbroken (no grey notch at the seam). Collapsed, the row
-        // keeps only the faint primary tint that marks the system row.
-        const systemClass = system
-          ? expandSystemKey
-            ? " [&>td:first-child]:border-l-2 [&>td:first-child]:border-l-primary/50 [&+tr]:!border-t-transparent"
-            : " bg-primary/[0.03]"
-          : "";
-        const base = `[&>td]:py-5${systemClass}`;
+        const base = "[&>td]:py-5";
         // A revoked key is terminal and archival: fade the whole row so it recedes, while a disabled
         // key (reversible pause) stays at full presence.
         return key.revoked ? `${base} opacity-55` : base;
@@ -291,7 +288,7 @@ export default function InstallKeysTable({
       onRowClick={(key) => {
         void navigate(`/install-keys/${encodeURIComponent(key.id)}/activity`, {
           state: {
-            name: isSystemKey(key) ? "Tenant-only registration" : key.name,
+            name: installKeyDisplayName(key),
             key,
           },
         });

--- a/ui/apps/console/src/pages/install-keys/KeyValueChip.tsx
+++ b/ui/apps/console/src/pages/install-keys/KeyValueChip.tsx
@@ -17,7 +17,8 @@ export default function KeyValueChip({
   ariaLabel,
   labelTone = "muted",
 }: {
-  label: string;
+  /** The prepend label pill. Omit to show just the value (e.g. a bare masked secret). */
+  label?: string;
   value: ReactNode;
   onClick?: () => void;
   /** A trailing affordance (e.g. a reveal eye) shown after the value. */
@@ -34,11 +35,13 @@ export default function KeyValueChip({
 
   const inner = (
     <>
-      <span
-        className={`rounded-full px-1.5 py-px font-mono text-[9px] font-semibold uppercase tracking-wider ${labelCls}`}
-      >
-        {label}
-      </span>
+      {label && (
+        <span
+          className={`rounded-full px-1.5 py-px font-mono text-[9px] font-semibold uppercase tracking-wider ${labelCls}`}
+        >
+          {label}
+        </span>
+      )}
       <span className="min-w-0 font-mono text-2xs text-text-secondary">
         {value}
       </span>

--- a/ui/apps/console/src/pages/install-keys/RevealInstallKeyDialog.tsx
+++ b/ui/apps/console/src/pages/install-keys/RevealInstallKeyDialog.tsx
@@ -8,6 +8,7 @@ import {
 import { Button, Card, Spinner } from "@shellhub/design-system/primitives";
 import { useRevealInstallKey } from "@/hooks/useRevealInstallKey";
 import { type InstallKey } from "@/client";
+import { installKeyDisplayName } from "./helpers";
 import CopyButton from "@/components/common/CopyButton";
 import BaseDialog from "@/components/common/BaseDialog";
 import RestrictedAction from "@/components/common/RestrictedAction";
@@ -32,7 +33,7 @@ export default function RevealInstallKeyDialog({
   const secretLabelId = `reveal-install-key-secret-${autoId}`;
 
   const name = installKey?.name ?? null;
-  const displayName = installKey?.system ? "Tenant-only registration" : name;
+  const displayName = installKey ? installKeyDisplayName(installKey) : name;
   const hasSecret = !!installKey?.key_hint;
   const fingerprint = installKey?.id ?? "";
 
@@ -92,9 +93,8 @@ export default function RevealInstallKeyDialog({
           </p>
         </div>
 
-        {/* The secret, behind a deliberate reveal. Same card as the fingerprint (neutral); the amber
-            warning line below is what marks it sensitive — never a red/error tint. The system key has
-            no secret, so this section is simply absent (the subtitle above already says so). */}
+        {/* The secret, behind a deliberate reveal. The amber warning line below is what marks it
+            sensitive — never a red/error tint. */}
         {hasSecret && (
           <div>
             <span id={secretLabelId} className={LABEL}>

--- a/ui/apps/console/src/pages/install-keys/__tests__/helpers.test.ts
+++ b/ui/apps/console/src/pages/install-keys/__tests__/helpers.test.ts
@@ -5,7 +5,10 @@ import {
   getInstallKeyStatus,
   getKeyBlockers,
   getUsageInfo,
+  installKeyDisplayName,
+  isPairingKey,
   parseAllowedMacs,
+  resolveEnrollmentSource,
   validateModeConfig,
   validateName,
 } from "../helpers";
@@ -218,5 +221,33 @@ describe("parseAllowedMacs", () => {
 
   it("returns an empty list for blank input", () => {
     expect(parseAllowedMacs("\n  \n")).toEqual([]);
+  });
+});
+
+describe("enrollment source", () => {
+  const legacy = key({ id: "leg", name: "legacy", type: "legacy" });
+  const pairing = key({ id: "pair", name: "pairing", type: "pairing" });
+  const real = key({ id: "abc", name: "fleet", type: "user" });
+
+  it("resolves a device to its enrollment source, or null when unmatched", () => {
+    const keys = [legacy, pairing, real];
+    expect(resolveEnrollmentSource(undefined, keys)).toBeNull();
+    expect(resolveEnrollmentSource("nope", keys)).toBeNull();
+    expect(resolveEnrollmentSource("abc", keys)).toEqual({
+      kind: "key",
+      name: "fleet",
+    });
+    expect(resolveEnrollmentSource("leg", keys)).toEqual({ kind: "legacy" });
+    expect(resolveEnrollmentSource("pair", keys)).toEqual({ kind: "pairing" });
+  });
+
+  it("labels the pairing system key apart from the legacy one", () => {
+    expect(isPairingKey(pairing)).toBe(true);
+    expect(isPairingKey(legacy)).toBe(false);
+    expect(isPairingKey(real)).toBe(false);
+
+    expect(installKeyDisplayName(pairing)).toBe("Pairing code");
+    expect(installKeyDisplayName(legacy)).toBe("Tenant-only registration");
+    expect(installKeyDisplayName(real)).toBe("fleet");
   });
 });

--- a/ui/apps/console/src/pages/install-keys/helpers.ts
+++ b/ui/apps/console/src/pages/install-keys/helpers.ts
@@ -12,21 +12,34 @@ export function defaultExpiry(): string {
 }
 
 /**
- * The auto-managed "legacy" key: every namespace has exactly one key with
- * `system === true`, the source attributed to devices enrolled with only a
- * tenant ID. It cannot be edited or deleted (the API returns 403).
+ * The auto-managed system keys: every namespace has two, discriminated by `type` — `legacy` (devices
+ * enrolled with only a tenant ID) and `pairing` (devices accepted through the pairing-code flow). A
+ * user-created key is `user`. System keys are not presentable by an agent.
  */
 export function isSystemKey(key: InstallKey): boolean {
-  return key.system === true;
+  return key.type === "legacy" || key.type === "pairing";
+}
+
+/** The pairing system key specifically. */
+export function isPairingKey(key: InstallKey): boolean {
+  return key.type === "pairing";
+}
+
+/** The display name for a key: a friendly label for either system key, else the key's own name. */
+export function installKeyDisplayName(key: InstallKey): string {
+  if (isPairingKey(key)) return "Pairing code";
+  if (isSystemKey(key)) return "Tenant-only registration";
+  return key.name;
 }
 
 export type EnrollmentSource =
-  { kind: "legacy" } | { kind: "key"; name: string };
+  { kind: "legacy" } | { kind: "pairing" } | { kind: "key"; name: string };
 
 /**
  * Resolve a device's enrollment source by matching its `install_key_id` digest
- * against the namespace's install keys: the system key → legacy/direct, a real
- * key → its name, no digest or no match → null (render as "—").
+ * against the namespace's install keys: the pairing system key → pairing, the
+ * legacy system key → legacy, a real key → its name, no digest or no match →
+ * null (render as "—").
  */
 export function resolveEnrollmentSource(
   installKeyId: string | undefined,
@@ -35,7 +48,9 @@ export function resolveEnrollmentSource(
   if (!installKeyId) return null;
   const match = installKeys.find((k) => k.id === installKeyId);
   if (!match) return null;
-  return match.system ? { kind: "legacy" } : { kind: "key", name: match.name };
+  if (isSystemKey(match))
+    return isPairingKey(match) ? { kind: "pairing" } : { kind: "legacy" };
+  return { kind: "key", name: match.name };
 }
 
 /** Split a MAC-allowlist textarea into a normalized, deduped list (lowercased, blanks dropped). */

--- a/ui/apps/console/src/pages/install-keys/index.tsx
+++ b/ui/apps/console/src/pages/install-keys/index.tsx
@@ -1,10 +1,5 @@
 import { useState } from "react";
-import {
-  ArrowPathIcon,
-  BoltIcon,
-  TagIcon,
-  TicketIcon,
-} from "@heroicons/react/24/outline";
+import { TicketIcon } from "@heroicons/react/24/outline";
 import { Button, Spinner } from "@shellhub/design-system/primitives";
 import { useInstallKeys } from "@/hooks/useInstallKeys";
 import { useUpdateInstallKey } from "@/hooks/useInstallKeyMutations";
@@ -12,12 +7,11 @@ import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { type InstallKey } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
 import RestrictedAction from "@/components/common/RestrictedAction";
-import EmptyState from "@/components/common/EmptyState";
 import InstallKeysTable from "./InstallKeysTable";
 import CreateInstallKeyDrawer from "./CreateInstallKeyDrawer";
 import EditInstallKeyDrawer from "./EditInstallKeyDrawer";
-import RevealInstallKeyDialog from "./RevealInstallKeyDialog";
 import RevokeInstallKeyDialog from "./RevokeInstallKeyDialog";
+import { isSystemKey } from "./helpers";
 
 const PER_PAGE = 10;
 
@@ -35,16 +29,14 @@ export default function InstallKeys() {
   const page = params.page;
   const { installKeys, totalCount, isLoading } = useInstallKeys({ page });
 
-  // The store pins the namespace's auto-managed legacy key first (its keyless-enrollment queue) and
-  // paginates it together with the user's keys, so totalCount already counts it. Drive both the page
-  // count and the item count off that one base, or the "N keys" label and the page controls disagree.
+  // The store pins the namespace's auto-managed built-in keys (legacy, pairing) first and paginates
+  // them together with the user's keys, so totalCount already counts them. Drive both the page count
+  // and the item count off that one base, or the "N keys" label and the page controls disagree.
   const totalPages = Math.ceil(totalCount / PER_PAGE);
-  const cards = installKeys;
 
   const updateKey = useUpdateInstallKey();
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<InstallKey | null>(null);
-  const [revealTarget, setRevealTarget] = useState<InstallKey | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<InstallKey | null>(null);
   const [revokeConfirmText, setRevokeConfirmText] = useState("");
   const [revokeError, setRevokeError] = useState<string | null>(null);
@@ -97,58 +89,12 @@ export default function InstallKeys() {
     }
   };
 
-  // First run only when the namespace has no keys at all. The auto-managed legacy key always exists in
-  // practice, so this hero is effectively a safety net: otherwise the table renders so the pinned legacy
-  // (tenant-only) row — and the pending queue of keyless devices behind it — stays reachable even with
-  // no user-created keys.
-  if (!isLoading && totalCount === 0) {
-    return (
-      <>
-        <EmptyState
-          icon={<TicketIcon className="w-8 h-8" />}
-          overline="Provisioning"
-          title="Install Keys"
-          description="Reusable, revocable credentials that register devices with your namespace. When an agent first connects with a key, the key's mode decides what happens: accept automatically, hold for review, ask your endpoint, or match a MAC allowlist."
-          features={[
-            {
-              icon: <BoltIcon className="w-5 h-5" />,
-              title: "Register on first connect",
-              description:
-                "A device joins your namespace the first time its agent reaches ShellHub, not when it is installed.",
-            },
-            {
-              icon: <ArrowPathIcon className="w-5 h-5" />,
-              title: "Reusable and revocable",
-              description:
-                "Register a single device or a whole fleet, then revoke the key to cut off new ones.",
-            },
-            {
-              icon: <TagIcon className="w-5 h-5" />,
-              title: "Tagged on arrival",
-              description:
-                "Apply namespace tags to every device that registers with the key.",
-            },
-          ]}
-          footnote="Keys can expire, cap their usage, or make their devices ephemeral."
-        >
-          <RestrictedAction action="installKey:create">
-            <Button
-              size="lg"
-              onClick={() => setCreateOpen(true)}
-              icon={<TicketIcon className="w-4 h-4" strokeWidth={2} />}
-            >
-              Create your first key
-            </Button>
-          </RestrictedAction>
-        </EmptyState>
-
-        <CreateInstallKeyDrawer
-          open={createOpen}
-          onClose={() => setCreateOpen(false)}
-        />
-      </>
-    );
-  }
+  // The built-in keys (legacy + pairing) always fill the table, so a namespace with no user-created
+  // keys is not an empty page — it's an empty "Custom keys" section. Detect that (any non-built-in key
+  // on this page, or more than one page, means custom keys exist) so the table can show the onboarding
+  // placeholder in that section instead. Replaces the old full-page hero, which never showed.
+  const noCustomKeys =
+    !installKeys.some((key) => !isSystemKey(key)) && totalPages <= 1;
 
   return (
     <div>
@@ -179,12 +125,13 @@ export default function InstallKeys() {
           )}
 
           <InstallKeysTable
-            data={cards}
+            data={installKeys}
             page={page}
             totalPages={totalPages}
             totalCount={totalCount}
+            noCustomKeys={noCustomKeys}
             onPageChange={setPage}
-            onReveal={setRevealTarget}
+            onCreate={() => setCreateOpen(true)}
             onEdit={setEditTarget}
             onToggleDisabled={(k) => void toggleDisabled(k)}
             onRevoke={openRevoke}
@@ -199,10 +146,6 @@ export default function InstallKeys() {
       <EditInstallKeyDrawer
         installKey={editTarget}
         onClose={() => setEditTarget(null)}
-      />
-      <RevealInstallKeyDialog
-        installKey={revealTarget}
-        onClose={() => setRevealTarget(null)}
       />
       <RevokeInstallKeyDialog
         installKey={revokeTarget}


### PR DESCRIPTION
Devices enrolled through the tenant-less pairing-code flow (the agent
prints a code, the user accepts it in the console) were attributed to the
namespace's legacy install key. They landed in the legacy key's
registration history alongside genuinely keyless devices, so there was no
way to tell a code-paired device from one that enrolled with only a tenant
ID. This gives code pairing its own source.

**Backend**

Install keys are now discriminated by a `type` column (`user`, `legacy`,
`pairing`) instead of the `system` boolean plus name matching. Every
namespace has two auto-managed system keys: `legacy` for tenant-only
keyless enrollment, and `pairing` for code-paired devices. A unique partial
index keeps exactly one of each per namespace. Migration 015 backfills the
pairing key for existing namespaces; new namespaces get it at the same
creation chokepoint as the legacy key.

The pairing flow is its own acceptance, so a paired enrollment accepts
outright and ignores the pairing key's mode. It never fires the webhook,
the allowlist reject, or a manual hold, any of which would hang the agent
or misreport in the UI. The pairing key is not editable and has no
presentable secret.

Existing pairing devices already stamped with the legacy key are
byte-identical to keyless-legacy devices and cannot be re-attributed
reliably, so the migration leaves them as-is (fix-forward).

**UI**

The install keys list splits the two auto-managed keys into a "Built-in"
section, apart from the admin's "Custom keys". Pairing reads as "Code
pairing", not a mode.

The built-in keys always fill the table, so the old full-page onboarding
hero never showed. It is replaced by an in-section placeholder: with no
custom keys, the Custom keys section renders a "Create your first key"
block under the built-in rows. A key's activity page shows its source (the
install key for user and legacy keys, "Pairing code" for paired devices).
