### PR TITLE
refactor(ui): extract InfoCard component for website card grids

### DIFF
--- a/ui/apps/website/src/components/marketing/InfoCard.tsx
+++ b/ui/apps/website/src/components/marketing/InfoCard.tsx
@@ -1,0 +1,71 @@
+import type { ComponentType, ReactNode, SVGProps } from "react";
+import { Card } from "@shellhub/design-system/primitives";
+import { Reveal, ShimmerCard } from "@shellhub/design-system/components";
+
+export interface InfoCardProps {
+  color: string;
+  title: string;
+  description: string;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  layout?: "vertical" | "horizontal" | "dot";
+  delay?: number;
+  children?: ReactNode;
+}
+
+export function InfoCard({
+  color,
+  title,
+  description,
+  icon: Icon,
+  layout = "vertical",
+  delay = 0,
+  children,
+}: InfoCardProps) {
+  const marker =
+    layout === "dot" ? (
+      <div
+        className="w-2 h-2 rounded-full mb-4"
+        style={{ background: color }}
+      />
+    ) : (
+      <div
+        className={`w-10 h-10 rounded-lg flex items-center justify-center border ${layout === "horizontal" ? "shrink-0" : "mb-4"}`}
+        style={{
+          background: `${color}15`,
+          borderColor: `${color}25`,
+        }}
+      >
+        {Icon && <Icon className="w-5 h-5" style={{ color }} />}
+      </div>
+    );
+
+  const text = (
+    <>
+      <h4 className="text-sm font-semibold mb-2">{title}</h4>
+      <p className="text-xs text-text-secondary leading-relaxed">
+        {description}
+      </p>
+      {children}
+    </>
+  );
+
+  return (
+    <Reveal delay={delay}>
+      <ShimmerCard className="h-full">
+        <Card hover className="p-6 h-full">
+          {layout === "horizontal" ? (
+            <div className="flex items-start gap-4">
+              {marker}
+              <div>{text}</div>
+            </div>
+          ) : (
+            <>
+              {marker}
+              {text}
+            </>
+          )}
+        </Card>
+      </ShimmerCard>
+    </Reveal>
+  );
+}

--- a/ui/apps/website/src/components/marketing/__tests__/InfoCard.test.tsx
+++ b/ui/apps/website/src/components/marketing/__tests__/InfoCard.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InfoCard, type InfoCardProps } from "@/components/marketing/InfoCard";
+import { C } from "@shellhub/design-system/constants";
+
+const color = C.primary;
+
+function StarIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg data-testid="star-icon" {...props}>
+      <path d="M0 0" />
+    </svg>
+  );
+}
+
+function renderCard(overrides: Partial<InfoCardProps> = {}, children?: React.ReactNode) {
+  return render(
+    <InfoCard
+      icon={StarIcon}
+      color={color}
+      title="Title"
+      description="Description"
+      {...overrides}
+    >
+      {children}
+    </InfoCard>,
+  );
+}
+
+describe("InfoCard", () => {
+  describe("vertical layout (default)", () => {
+    it("renders icon with w-5 h-5 and color, plus title and description", () => {
+      renderCard();
+
+      const icon = screen.getByTestId("star-icon");
+      expect(icon).toHaveClass("w-5", "h-5");
+      expect(icon).toHaveStyle({ color });
+      expect(screen.getByRole("heading", { name: "Title" })).toBeInTheDocument();
+      expect(screen.getByText("Description")).toBeInTheDocument();
+    });
+
+    it("applies color to icon container background and border", () => {
+      const { container } = renderCard();
+
+      const iconContainer = container.querySelector(".w-10.h-10");
+      expect(iconContainer).toHaveStyle({
+        background: `${color}15`,
+        borderColor: `${color}25`,
+      });
+    });
+
+    it("renders icon container with mb-4 (no flex row)", () => {
+      const { container } = renderCard();
+
+      const iconContainer = container.querySelector(".w-10.h-10");
+      expect(iconContainer).toHaveClass("mb-4");
+      expect(iconContainer?.parentElement).not.toHaveClass("flex");
+    });
+
+    it("renders children after description", () => {
+      renderCard({}, <span data-testid="extra">Extra</span>);
+      expect(screen.getByTestId("extra")).toBeInTheDocument();
+    });
+  });
+
+  describe("horizontal layout", () => {
+    it("renders icon and text side by side", () => {
+      const { container } = renderCard({ layout: "horizontal" });
+
+      const flexRow = container.querySelector(".flex.items-start.gap-4");
+      expect(flexRow).not.toBeNull();
+
+      const iconContainer = container.querySelector(".w-10.h-10");
+      expect(iconContainer).toHaveClass("shrink-0");
+      expect(iconContainer).not.toHaveClass("mb-4");
+    });
+  });
+
+  describe("dot layout", () => {
+    it("renders a small dot instead of an icon container", () => {
+      const { container } = renderCard({ layout: "dot" });
+
+      const dot = container.querySelector(".w-2.h-2.rounded-full");
+      expect(dot).not.toBeNull();
+      expect(dot).toHaveStyle({ background: color });
+      expect(container.querySelector(".w-10.h-10")).toBeNull();
+    });
+
+    it("renders children after description", () => {
+      renderCard({ layout: "dot" }, <div data-testid="mockup">Mockup</div>);
+      expect(screen.getByTestId("mockup")).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    it("renders title as an h4 heading", () => {
+      renderCard();
+      expect(screen.getByRole("heading", { name: "Title" }).tagName).toBe("H4");
+    });
+  });
+});

--- a/ui/apps/website/src/components/marketing/index.ts
+++ b/ui/apps/website/src/components/marketing/index.ts
@@ -8,3 +8,5 @@ export { CommandBlock } from "./CommandBlock";
 export type { CommandBlockProps } from "./CommandBlock";
 export { CTABanner } from "./CTABanner";
 export type { CTABannerProps } from "./CTABanner";
+export { InfoCard } from "./InfoCard";
+export type { InfoCardProps } from "./InfoCard";

--- a/ui/apps/website/src/pages/enterprise/SecurityFeatures.tsx
+++ b/ui/apps/website/src/pages/enterprise/SecurityFeatures.tsx
@@ -6,95 +6,16 @@ import {
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
 import { PlayIcon } from "@heroicons/react/24/solid";
-import { Card } from "@shellhub/design-system/primitives";
-import { Section, SectionHeader } from "@/components/marketing";
-import { Reveal, ShimmerCard } from "../landing/components";
+import { Section, SectionHeader, InfoCard } from "@/components/marketing";
 import { C } from "../landing/constants";
 
 const features = [
-  {
-    icon: (
-      <ArrowRightEndOnRectangleIcon
-        width="20"
-        height="20"
-        stroke={C.primary}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
-    color: C.primary,
-    title: "SSO / SAML",
-    desc: "Single sign-on with your identity provider. Support for SAML 2.0 and OpenID Connect.",
-  },
-  {
-    icon: (
-      <UsersIcon
-        width="20"
-        height="20"
-        stroke={C.cyan}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
-    color: C.cyan,
-    title: "LDAP / Active Directory",
-    desc: "Integrate with your existing directory service for centralized user management.",
-  },
-  {
-    icon: (
-      <LockClosedIcon
-        width="20"
-        height="20"
-        stroke={C.yellow}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
-    color: C.yellow,
-    title: "MFA Enforcement",
-    desc: "Require multi-factor authentication for all users or specific roles across the organization.",
-  },
-  {
-    icon: (
-      <PencilIcon
-        width="20"
-        height="20"
-        stroke={C.green}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
-    color: C.green,
-    title: "Audit Logs",
-    desc: "Complete audit trail of every action. User logins, device connections, configuration changes.",
-  },
-  {
-    icon: (
-      <PlayIcon
-        width="20"
-        height="20"
-        style={{ color: C.red }}
-        aria-hidden="true"
-      />
-    ),
-    color: C.red,
-    title: "Session Recording",
-    desc: "Record and replay SSH sessions for compliance, training, and incident investigation.",
-  },
-  {
-    icon: (
-      <ShieldCheckIcon
-        width="20"
-        height="20"
-        stroke={C.blue}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
-    color: C.blue,
-    title: "Firewall Rules",
-    desc: "Define granular connection policies per device, namespace, or user group.",
-  },
+  { icon: ArrowRightEndOnRectangleIcon, color: C.primary, title: "SSO / SAML", desc: "Single sign-on with your identity provider. Support for SAML 2.0 and OpenID Connect." },
+  { icon: UsersIcon, color: C.cyan, title: "LDAP / Active Directory", desc: "Integrate with your existing directory service for centralized user management." },
+  { icon: LockClosedIcon, color: C.yellow, title: "MFA Enforcement", desc: "Require multi-factor authentication for all users or specific roles across the organization." },
+  { icon: PencilIcon, color: C.green, title: "Audit Logs", desc: "Complete audit trail of every action. User logins, device connections, configuration changes." },
+  { icon: PlayIcon, color: C.red, title: "Session Recording", desc: "Record and replay SSH sessions for compliance, training, and incident investigation." },
+  { icon: ShieldCheckIcon, color: C.blue, title: "Firewall Rules", desc: "Define granular connection policies per device, namespace, or user group." },
 ];
 
 export function SecurityFeatures() {
@@ -108,25 +29,14 @@ export function SecurityFeatures() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {features.map((f, i) => (
-          <Reveal key={i} delay={i * 0.04}>
-            <ShimmerCard>
-              <Card hover className="p-6 h-full">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{
-                    background: `${f.color}15`,
-                    borderColor: `${f.color}25`,
-                  }}
-                >
-                  {f.icon}
-                </div>
-                <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                <p className="text-xs text-text-secondary leading-relaxed">
-                  {f.desc}
-                </p>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+          <InfoCard
+            key={i}
+            icon={f.icon}
+            color={f.color}
+            title={f.title}
+            description={f.desc}
+            delay={i * 0.04}
+          />
         ))}
       </div>
     </Section>

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -509,90 +509,39 @@ function WebTerminal() {
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════ */
-/*  SECURITY & ACCESS CONTROL GRID                                */
-/* ═══════════════════════════════════════════════════════════════ */
 const securityFeatures = [
   {
-    icon: (
-      <LockClosedIcon
-        width="20"
-        height="20"
-        stroke={C.yellow}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
+    icon: LockClosedIcon,
     color: C.yellow,
     title: "Multi-Factor Authentication",
     desc: "Add TOTP-based MFA to SSH connections. Works with Google Authenticator, Authy, and any standards-compliant app.",
   },
   {
-    icon: (
-      <ShieldCheckIcon
-        width="20"
-        height="20"
-        stroke={C.red}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
+    icon: ShieldCheckIcon,
     color: C.red,
     title: "Firewall Rules",
     desc: "Control access with flexible rules. Allow or deny connections based on IP address, hostname, or user identity.",
   },
   {
-    icon: (
-      <UsersIcon
-        width="20"
-        height="20"
-        stroke={C.primary}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
+    icon: UsersIcon,
     color: C.primary,
     title: "Role-Based Access Control",
     desc: "Assign roles and permissions at namespace and device level. Owners, operators, and viewers with granular control.",
   },
   {
-    icon: (
-      <PencilSquareIcon
-        width="20"
-        height="20"
-        stroke={C.green}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
+    icon: PencilSquareIcon,
     color: C.green,
     title: "Audit Logging",
     desc: "Complete audit trail of every connection, command, and configuration change. Export logs for compliance reporting.",
   },
   {
-    icon: (
-      <KeyIcon
-        width="20"
-        height="20"
-        stroke={C.cyan}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
+    icon: KeyIcon,
     color: C.cyan,
     title: "Public Key Authentication",
     desc: "Use SSH public keys alongside or instead of passwords. Manage authorized keys centrally through the dashboard.",
   },
   {
-    icon: (
-      <FolderIcon
-        width="20"
-        height="20"
-        stroke={C.blue}
-        strokeWidth="1.5"
-        aria-hidden="true"
-      />
-    ),
+    icon: FolderIcon,
     color: C.blue,
     title: "Namespaces",
     desc: "Isolate devices and teams into separate namespaces. Each with its own members, devices, and security policies.",
@@ -610,25 +559,14 @@ function SecurityGrid() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {securityFeatures.map((f, i) => (
-          <Reveal key={i} delay={i * 0.04}>
-            <ShimmerCard>
-              <Card hover className="p-6 h-full">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{
-                    background: `${f.color}15`,
-                    borderColor: `${f.color}25`,
-                  }}
-                >
-                  {f.icon}
-                </div>
-                <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                <p className="text-xs text-text-secondary leading-relaxed">
-                  {f.desc}
-                </p>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+          <InfoCard
+            key={i}
+            icon={f.icon}
+            color={f.color}
+            title={f.title}
+            description={f.desc}
+            delay={i * 0.04}
+          />
         ))}
       </div>
     </Section>

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -20,50 +20,44 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
 
-/* ------------------------------------------------------------------ */
-/*  Data                                                               */
-/* ------------------------------------------------------------------ */
-
 const techDetails = [
   {
-    icon: <LockClosedIcon className="w-5 h-5" style={{ color: C.primary }} />,
+    icon: LockClosedIcon,
     color: C.primary,
     title: "TLS Encryption",
     desc: "All traffic between agents and the gateway is encrypted with TLS 1.3. No plaintext data ever leaves a device.",
   },
   {
-    icon: <EnvelopeIcon className="w-5 h-5" style={{ color: C.cyan }} />,
+    icon: EnvelopeIcon,
     color: C.cyan,
     title: "WebSocket Tunnels",
     desc: "Persistent WebSocket connections over port 443 ensure reliable communication even through restrictive proxies.",
   },
   {
-    icon: (
-      <ArrowsPointingOutIcon className="w-5 h-5" style={{ color: C.green }} />
-    ),
+    icon: ArrowsPointingOutIcon,
     color: C.green,
     title: "Reverse SSH",
     desc: "The agent initiates the connection outbound, then the gateway multiplexes inbound SSH sessions back through the same tunnel.",
   },
   {
-    icon: <ShieldCheckIcon className="w-5 h-5" style={{ color: C.yellow }} />,
+    icon: ShieldCheckIcon,
     color: C.yellow,
     title: "NAT Traversal",
     desc: "Outbound-only connections mean devices behind any NAT, CGNAT, or carrier-grade firewall are reachable without port forwarding.",
   },
   {
-    icon: <GlobeAltIcon className="w-5 h-5" style={{ color: C.blue }} />,
+    icon: GlobeAltIcon,
     color: C.blue,
     title: "Agent Auto-Update",
     desc: "Agents check for updates automatically and apply them without downtime. Always running the latest secure version.",
   },
   {
-    icon: <BoltIcon className="w-5 h-5" style={{ color: C.red }} />,
+    icon: BoltIcon,
     color: C.red,
     title: "Lightweight Footprint",
     desc: "The agent binary is under 10 MB and uses minimal CPU and memory. Designed for constrained embedded devices.",
@@ -1157,7 +1151,6 @@ export default function HowItWorks() {
         </div>
       </Section>
 
-      {/* ── Technical Details ─────────────────────────────────────── */}
       <Section>
         <SectionHeader
           eyebrow="Under the Hood"
@@ -1167,25 +1160,14 @@ export default function HowItWorks() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {techDetails.map((f, i) => (
-            <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              icon={f.icon}
+              color={f.color}
+              title={f.title}
+              description={f.desc}
+              delay={i * 0.04}
+            />
           ))}
         </div>
       </Section>

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -24,14 +24,11 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
-/* ------------------------------------------------------------------ */
-/*  Syntax-highlighted line helpers                                    */
-/* ------------------------------------------------------------------ */
 function Ln({
   color,
   children,
@@ -60,9 +57,12 @@ function Cyn({ children }: { children: React.ReactNode }) {
   return <span style={{ color: C.cyan }}>{children}</span>;
 }
 
-/* ================================================================== */
-/*  Page                                                               */
-/* ================================================================== */
+const sshFeatures = [
+  { icon: ArrowsRightLeftIcon, color: C.primary, title: "SSH as transport", desc: "Any tool that uses SSH for remote execution works with ShellHub out of the box. Ansible, rsync, scp, Git over SSH." },
+  { icon: ShieldCheckIcon, color: C.cyan, title: "No agent changes", desc: "The ShellHub agent runs independently on your devices. Install once and use it with every tool in your stack." },
+  { icon: CodeBracketIcon, color: C.green, title: "API-first design", desc: "Programmatic access to devices, sessions, and configurations. Build custom integrations with the REST API." },
+];
+
 export default function Integrations() {
   return (
     <SiteLayout>
@@ -980,63 +980,15 @@ export default function Integrations() {
         </Reveal>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {[
-            {
-              color: C.primary,
-              title: "SSH as transport",
-              desc: "Any tool that uses SSH for remote execution works with ShellHub out of the box. Ansible, rsync, scp, Git over SSH.",
-              icon: (
-                <ArrowsRightLeftIcon
-                  className="w-5 h-5"
-                  style={{ color: C.primary }}
-                  aria-hidden="true"
-                />
-              ),
-            },
-            {
-              color: C.cyan,
-              title: "No agent changes",
-              desc: "The ShellHub agent runs independently on your devices. Install once and use it with every tool in your stack.",
-              icon: (
-                <ShieldCheckIcon
-                  className="w-5 h-5"
-                  style={{ color: C.cyan }}
-                  aria-hidden="true"
-                />
-              ),
-            },
-            {
-              color: C.green,
-              title: "API-first design",
-              desc: "Programmatic access to devices, sessions, and configurations. Build custom integrations with the REST API.",
-              icon: (
-                <CodeBracketIcon
-                  className="w-5 h-5"
-                  style={{ color: C.green }}
-                  aria-hidden="true"
-                />
-              ),
-            },
-          ].map((b, i) => (
-            <Reveal key={i} delay={i * 0.06}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${b.color}15`,
-                      borderColor: `${b.color}25`,
-                    }}
-                  >
-                    {b.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{b.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {b.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+          {sshFeatures.map((f, i) => (
+            <InfoCard
+              key={i}
+              icon={f.icon}
+              color={f.color}
+              title={f.title}
+              description={f.desc}
+              delay={i * 0.06}
+            />
           ))}
         </div>
       </Section>

--- a/ui/apps/website/src/pages/landing/FeatureGrid.tsx
+++ b/ui/apps/website/src/pages/landing/FeatureGrid.tsx
@@ -6,9 +6,7 @@ import {
   UsersIcon,
   ServerIcon,
 } from "@heroicons/react/24/outline";
-import { Card } from "@shellhub/design-system/primitives";
-import { Section, SectionHeader } from "@/components/marketing";
-import { Reveal, ShimmerCard } from "./components";
+import { Section, SectionHeader, InfoCard } from "@/components/marketing";
 import { C } from "./constants";
 
 export function FeatureGrid() {
@@ -21,112 +19,21 @@ export function FeatureGrid() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {[
-          {
-            icon: (
-              <CommandLineIcon
-                width="20"
-                height="20"
-                stroke={C.primary}
-                strokeWidth="1.5"
-              />
-            ),
-            color: C.primary,
-            title: "Native SSH Support",
-            desc: "Use your standard SSH client. No proprietary tools or plugins required.",
-            delay: 0,
-          },
-          {
-            icon: (
-              <DocumentTextIcon
-                width="20"
-                height="20"
-                stroke={C.cyan}
-                strokeWidth="1.5"
-              />
-            ),
-            color: C.cyan,
-            title: "SCP/SFTP File Transfer",
-            desc: "Transfer files to and from remote devices with SCP and SFTP.",
-            delay: 0.06,
-          },
-          {
-            icon: (
-              <LockClosedIcon
-                width="20"
-                height="20"
-                stroke={C.yellow}
-                strokeWidth="1.5"
-              />
-            ),
-            color: C.yellow,
-            title: "Multi-Factor Auth",
-            desc: "Require TOTP-based MFA for SSH connections. Works with any authenticator app.",
-            delay: 0.12,
-          },
-          {
-            icon: (
-              <PencilSquareIcon
-                width="20"
-                height="20"
-                stroke={C.green}
-                strokeWidth="1.5"
-              />
-            ),
-            color: C.green,
-            title: "Audit Logging",
-            desc: "Full audit trail of every connection, command, and session. Export logs for compliance.",
-            delay: 0,
-          },
-          {
-            icon: (
-              <UsersIcon
-                width="20"
-                height="20"
-                stroke={C.primary}
-                strokeWidth="1.5"
-              />
-            ),
-            color: C.primary,
-            title: "Team Management & RBAC",
-            desc: "Invite team members, assign roles, and control who can access which devices.",
-            delay: 0.06,
-          },
-          {
-            icon: (
-              <ServerIcon
-                width="20"
-                height="20"
-                stroke={C.blue}
-                strokeWidth="1.5"
-              />
-            ),
-            color: C.blue,
-            title: "Docker Container Access",
-            desc: "SSH directly into Docker containers running on remote hosts. No docker exec needed.",
-            delay: 0.12,
-          },
+          { icon: CommandLineIcon, color: C.primary, title: "Native SSH Support", desc: "Use your standard SSH client. No proprietary tools or plugins required.", delay: 0 },
+          { icon: DocumentTextIcon, color: C.cyan, title: "SCP/SFTP File Transfer", desc: "Transfer files to and from remote devices with SCP and SFTP.", delay: 0.06 },
+          { icon: LockClosedIcon, color: C.yellow, title: "Multi-Factor Auth", desc: "Require TOTP-based MFA for SSH connections. Works with any authenticator app.", delay: 0.12 },
+          { icon: PencilSquareIcon, color: C.green, title: "Audit Logging", desc: "Full audit trail of every connection, command, and session. Export logs for compliance.", delay: 0 },
+          { icon: UsersIcon, color: C.primary, title: "Team Management & RBAC", desc: "Invite team members, assign roles, and control who can access which devices.", delay: 0.06 },
+          { icon: ServerIcon, color: C.blue, title: "Docker Container Access", desc: "SSH directly into Docker containers running on remote hosts. No docker exec needed.", delay: 0.12 },
         ].map((f, i) => (
-          <Reveal key={i} delay={f.delay}>
-            <ShimmerCard>
-              <Card hover className="p-6 h-full">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{
-                    background: `${f.color}15`,
-                    borderColor: `${f.color}25`,
-                  }}
-                >
-                  {f.icon}
-                </div>
-                <h4 className="text-sm font-semibold mb-2 group-hover:text-primary transition-colors">
-                  {f.title}
-                </h4>
-                <p className="text-xs text-text-secondary leading-relaxed">
-                  {f.desc}
-                </p>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+          <InfoCard
+            key={i}
+            icon={f.icon}
+            color={f.color}
+            title={f.title}
+            description={f.desc}
+            delay={f.delay}
+          />
         ))}
       </div>
     </Section>

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -19,7 +19,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
@@ -51,27 +51,25 @@ const painPoints = [
 /* ═══════ Key Features (2x2) ═══════ */
 const smallFeatures = [
   {
-    icon: <PlayCircleIcon className="w-5 h-5" style={{ color: C.red }} />,
+    icon: PlayCircleIcon,
     color: C.red,
     title: "Session Recording",
     desc: "Every container session is captured and replayable for compliance audits, post-incident review, and team training.",
   },
   {
-    icon: (
-      <ComputerDesktopIcon className="w-5 h-5" style={{ color: C.green }} />
-    ),
+    icon: ComputerDesktopIcon,
     color: C.green,
     title: "Web Terminal",
     desc: "Access containers directly from the browser. No SSH client, Docker CLI, or VPN required on your workstation.",
   },
   {
-    icon: <DocumentTextIcon className="w-5 h-5" style={{ color: C.yellow }} />,
+    icon: DocumentTextIcon,
     color: C.yellow,
     title: "SCP / SFTP into Containers",
     desc: "Transfer files in and out of containers with standard SCP and SFTP. No volume mounts or docker cp gymnastics.",
   },
   {
-    icon: <PencilIcon className="w-5 h-5" style={{ color: C.blue }} />,
+    icon: PencilIcon,
     color: C.blue,
     title: "Audit Logging",
     desc: "Full audit trail of every container session. Who connected, when, from where, and what they executed.",
@@ -691,7 +689,6 @@ export default function ContainerManagement() {
         </Reveal>
       </Section>
 
-      {/* ═══════ Pain Points ═══════ */}
       <Section>
         <SectionHeader
           eyebrow="The Problem"
@@ -701,33 +698,15 @@ export default function ContainerManagement() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {painPoints.map((p, i) => (
-            <Reveal key={i} delay={i * 0.06}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div className="flex items-start gap-4">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
-                      style={{
-                        background: `${p.color}15`,
-                        borderColor: `${p.color}25`,
-                      }}
-                    >
-                      <ExclamationTriangleIcon
-                        width={18}
-                        height={18}
-                        style={{ color: p.color }}
-                      />
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {p.desc}
-                      </p>
-                    </div>
-                  </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              icon={ExclamationTriangleIcon}
+              color={p.color}
+              title={p.title}
+              description={p.desc}
+              layout="horizontal"
+              delay={i * 0.06}
+            />
           ))}
         </div>
       </Section>
@@ -833,28 +812,16 @@ export default function ContainerManagement() {
           </ShimmerCard>
         </Reveal>
 
-        {/* 2x2 smaller feature cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {smallFeatures.map((f, i) => (
-            <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              icon={f.icon}
+              color={f.color}
+              title={f.title}
+              description={f.desc}
+              delay={i * 0.04}
+            />
           ))}
         </div>
       </Section>

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -9,16 +9,11 @@ import {
   ShieldCheckIcon,
   TagIcon,
 } from "@heroicons/react/24/outline";
-import {
-  Badge,
-  Button,
-  Card,
-  WindowChrome,
-} from "@shellhub/design-system/primitives";
+import { Badge, Button, WindowChrome } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -52,37 +47,37 @@ const painPoints = [
 
 const features = [
   {
-    icon: <CommandLineIcon className="w-5 h-5" style={{ color: C.primary }} />,
+    icon: CommandLineIcon,
     color: C.primary,
     title: "Standard SSH Transport",
     desc: "Ansible, Terraform, and CI/CD tools connect through ShellHub using standard SSH -- no custom plugins or connectors required.",
   },
   {
-    icon: <DocumentTextIcon className="w-5 h-5" style={{ color: C.cyan }} />,
+    icon: DocumentTextIcon,
     color: C.cyan,
     title: "SCP/SFTP Transfers",
     desc: "Push build artifacts, configuration files, and firmware updates to remote devices as part of your deployment pipeline.",
   },
   {
-    icon: <PencilIcon className="w-5 h-5" style={{ color: C.green }} />,
+    icon: PencilIcon,
     color: C.green,
     title: "Audit Logging",
     desc: "Every automated session is recorded -- see exactly which pipeline ran what command on which device and when.",
   },
   {
-    icon: <TagIcon className="w-5 h-5" style={{ color: C.yellow }} />,
+    icon: TagIcon,
     color: C.yellow,
     title: "Device Tags",
     desc: "Target deployments to specific device groups using tags -- deploy to 'staging' or 'production' fleets with a single inventory.",
   },
   {
-    icon: <ShieldCheckIcon className="w-5 h-5" style={{ color: C.primary }} />,
+    icon: ShieldCheckIcon,
     color: C.primary,
     title: "Firewall Rules",
     desc: "Restrict CI runner access to only the devices they need with IP-based and identity-based firewall policies.",
   },
   {
-    icon: <FolderIcon className="w-5 h-5" style={{ color: C.green }} />,
+    icon: FolderIcon,
     color: C.green,
     title: "Namespaces",
     desc: "Isolate staging and production environments in separate namespaces with independent access policies and device groups.",
@@ -487,20 +482,14 @@ export default function DevopsCiCd() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {painPoints.map((p, i) => (
-            <Reveal key={i} delay={i * 0.06}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-2 h-2 rounded-full mb-4"
-                    style={{ background: p.color }}
-                  />
-                  <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {p.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              color={p.color}
+              title={p.title}
+              description={p.desc}
+              layout="dot"
+              delay={i * 0.06}
+            />
           ))}
         </div>
       </Section>
@@ -515,25 +504,14 @@ export default function DevopsCiCd() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {features.map((f, i) => (
-            <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              icon={f.icon}
+              color={f.color}
+              title={f.title}
+              description={f.desc}
+              delay={i * 0.04}
+            />
           ))}
         </div>
       </Section>

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -14,7 +14,6 @@ import {
 import {
   Badge,
   Button,
-  Card,
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
@@ -22,7 +21,7 @@ import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { C } from "../landing/constants";
 
 /* ═══════ Pain-point data ═══════ */
@@ -31,25 +30,25 @@ const painPoints = [
     color: C.primary,
     title: "Distributed locations",
     desc: "Edge servers scattered across retail stores, warehouses, cell towers, and data centers — each with unique network topology.",
-    icon: <GlobeAltIcon className="w-5 h-5" style={{ color: C.primary }} />,
+    icon: GlobeAltIcon,
   },
   {
     color: C.yellow,
     title: "Unreliable connectivity",
     desc: "Intermittent or low-bandwidth links make traditional VPN tunnels unstable and impossible to maintain reliably.",
-    icon: <SignalSlashIcon className="w-5 h-5" style={{ color: C.yellow }} />,
+    icon: SignalSlashIcon,
   },
   {
     color: C.red,
     title: "On-site visits are expensive",
     desc: "Dispatching a technician to a remote cell tower or warehouse for a configuration change burns time and budget.",
-    icon: <MapPinIcon className="w-5 h-5" style={{ color: C.red }} />,
+    icon: MapPinIcon,
   },
   {
     color: C.cyan,
     title: "Security at scale",
     desc: "Managing SSH keys, firewall rules, and access policies across hundreds of edge locations is operationally complex.",
-    icon: <ShieldCheckIcon className="w-5 h-5" style={{ color: C.cyan }} />,
+    icon: ShieldCheckIcon,
   },
 ];
 
@@ -405,7 +404,6 @@ export default function EdgeComputing() {
         </Reveal>
       </Section>
 
-      {/* ───── Pain Points ───── */}
       <Section>
         <SectionHeader
           eyebrow="Challenges"
@@ -415,29 +413,15 @@ export default function EdgeComputing() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {painPoints.map((p, i) => (
-            <Reveal key={i} delay={i * 0.06}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div className="flex items-start gap-4">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
-                      style={{
-                        background: `${p.color}15`,
-                        borderColor: `${p.color}25`,
-                      }}
-                    >
-                      {p.icon}
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {p.desc}
-                      </p>
-                    </div>
-                  </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              icon={p.icon}
+              color={p.color}
+              title={p.title}
+              description={p.desc}
+              layout="horizontal"
+              delay={i * 0.06}
+            />
           ))}
         </div>
       </Section>
@@ -545,292 +529,218 @@ export default function EdgeComputing() {
 
         {/* 2-column: Web Terminal + SCP/SFTP */}
         <div className="grid md:grid-cols-2 gap-4 mb-4">
-          <Reveal delay={0.05}>
-            <ShimmerCard className="h-full">
-              <Card hover className="p-6 h-full">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{
-                    background: `${C.green}15`,
-                    borderColor: `${C.green}25`,
-                  }}
-                >
-                  <ComputerDesktopIcon
-                    className="w-5 h-5"
-                    style={{ color: C.green }}
-                  />
+          <InfoCard
+            icon={ComputerDesktopIcon}
+            color={C.green}
+            title="Web Terminal"
+            description="Access edge servers from any browser — no SSH client needed. Perfect for field engineers using tablets or shared workstations."
+            delay={0.05}
+          >
+            <div className="mt-4">
+              <WindowChrome
+                variant="browser"
+                size="sm"
+                path="/terminal/edge-chi-03"
+                bodyClassName="space-y-0.5"
+              >
+                <div>
+                  <span style={{ color: C.green }}>admin@edge-chi-03</span>
+                  <span style={{ color: C.textMuted }}>:</span>
+                  <span style={{ color: C.blue }}>~</span>
+                  <span style={{ color: C.textMuted }}>$</span>{" "}
+                  <span style={{ color: C.text }}>df -h /data</span>
                 </div>
-                <h4 className="text-sm font-semibold mb-2">Web Terminal</h4>
-                <p className="text-xs text-text-secondary leading-relaxed mb-4">
-                  Access edge servers from any browser — no SSH client needed.
-                  Perfect for field engineers using tablets or shared
-                  workstations.
-                </p>
-
-                {/* Browser mockup */}
-                <WindowChrome
-                  variant="browser"
-                  size="sm"
-                  path="/terminal/edge-chi-03"
-                  bodyClassName="space-y-0.5"
-                >
-                  <div>
-                    <span style={{ color: C.green }}>admin@edge-chi-03</span>
-                    <span style={{ color: C.textMuted }}>:</span>
-                    <span style={{ color: C.blue }}>~</span>
-                    <span style={{ color: C.textMuted }}>$</span>{" "}
-                    <span style={{ color: C.text }}>df -h /data</span>
-                  </div>
-                  <div style={{ color: C.textSec }}>
-                    Filesystem&nbsp;&nbsp;Size&nbsp;&nbsp;Used&nbsp;&nbsp;Avail&nbsp;&nbsp;Use%
-                  </div>
-                  <div style={{ color: C.textSec }}>
-                    /dev/sda1&nbsp;&nbsp;&nbsp;500G&nbsp;&nbsp;312G&nbsp;&nbsp;188G&nbsp;&nbsp;&nbsp;62%
-                  </div>
-                  <div>
-                    <span style={{ color: C.green }}>admin@edge-chi-03</span>
-                    <span style={{ color: C.textMuted }}>:</span>
-                    <span style={{ color: C.blue }}>~</span>
-                    <span style={{ color: C.textMuted }}>$</span>{" "}
-                    <span
-                      className="animate-pulse"
-                      style={{ color: C.primary }}
-                    >
-                      _
-                    </span>
-                  </div>
-                </WindowChrome>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
-
-          <Reveal delay={0.1}>
-            <ShimmerCard className="h-full">
-              <Card hover className="p-6 h-full">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{
-                    background: `${C.cyan}15`,
-                    borderColor: `${C.cyan}25`,
-                  }}
-                >
-                  <DocumentArrowUpIcon
-                    className="w-5 h-5"
-                    style={{ color: C.cyan }}
-                  />
+                <div style={{ color: C.textSec }}>
+                  Filesystem&nbsp;&nbsp;Size&nbsp;&nbsp;Used&nbsp;&nbsp;Avail&nbsp;&nbsp;Use%
                 </div>
-                <h4 className="text-sm font-semibold mb-2">
-                  SCP / SFTP File Transfer
-                </h4>
-                <p className="text-xs text-text-secondary leading-relaxed mb-4">
-                  Transfer configuration files, firmware updates, and logs to
-                  and from edge servers with progress tracking.
-                </p>
-
-                {/* File transfer mockup */}
-                <div className="bg-surface rounded-lg border border-border p-3 font-mono text-2xs space-y-1.5">
-                  <div style={{ color: C.textMuted }}>
-                    $ scp config.yml admin@edge-den-02:/etc/app/
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span style={{ color: C.text }}>config.yml</span>
-                    <div className="flex-1 h-1.5 bg-background rounded-full overflow-hidden">
-                      <div
-                        className="h-full rounded-full"
-                        style={{ width: "100%", background: C.green }}
-                      />
-                    </div>
-                    <span style={{ color: C.green }}>100%</span>
-                  </div>
-                  <div style={{ color: C.textSec }}>
-                    2.4 KB&nbsp;&nbsp;&nbsp;0:00
-                  </div>
-                  <div
-                    className="pt-1 border-t border-border"
-                    style={{ borderColor: `${C.border}80` }}
+                <div style={{ color: C.textSec }}>
+                  /dev/sda1&nbsp;&nbsp;&nbsp;500G&nbsp;&nbsp;312G&nbsp;&nbsp;188G&nbsp;&nbsp;&nbsp;62%
+                </div>
+                <div>
+                  <span style={{ color: C.green }}>admin@edge-chi-03</span>
+                  <span style={{ color: C.textMuted }}>:</span>
+                  <span style={{ color: C.blue }}>~</span>
+                  <span style={{ color: C.textMuted }}>$</span>{" "}
+                  <span
+                    className="animate-pulse"
+                    style={{ color: C.primary }}
                   >
-                    <div style={{ color: C.textMuted }}>
-                      $ scp admin@edge-den-02:/var/log/app.log ./
-                    </div>
-                    <div className="flex items-center gap-2 mt-1">
-                      <span style={{ color: C.text }}>app.log</span>
-                      <div className="flex-1 h-1.5 bg-background rounded-full overflow-hidden">
-                        <div
-                          className="h-full rounded-full"
-                          style={{ width: "68%", background: C.yellow }}
-                        />
-                      </div>
-                      <span style={{ color: C.yellow }}>68%</span>
-                    </div>
-                    <div style={{ color: C.textSec }}>
-                      45 MB&nbsp;&nbsp;&nbsp;12.3 MB/s&nbsp;&nbsp;&nbsp;ETA 0:02
-                    </div>
-                  </div>
+                    _
+                  </span>
                 </div>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+              </WindowChrome>
+            </div>
+          </InfoCard>
+
+          <InfoCard
+            icon={DocumentArrowUpIcon}
+            color={C.cyan}
+            title="SCP / SFTP File Transfer"
+            description="Transfer configuration files, firmware updates, and logs to and from edge servers with progress tracking."
+            delay={0.1}
+          >
+            <div className="mt-4 bg-surface rounded-lg border border-border p-3 font-mono text-2xs space-y-1.5">
+              <div style={{ color: C.textMuted }}>
+                $ scp config.yml admin@edge-den-02:/etc/app/
+              </div>
+              <div className="flex items-center gap-2">
+                <span style={{ color: C.text }}>config.yml</span>
+                <div className="flex-1 h-1.5 bg-background rounded-full overflow-hidden">
+                  <div
+                    className="h-full rounded-full"
+                    style={{ width: "100%", background: C.green }}
+                  />
+                </div>
+                <span style={{ color: C.green }}>100%</span>
+              </div>
+              <div style={{ color: C.textSec }}>
+                2.4 KB&nbsp;&nbsp;&nbsp;0:00
+              </div>
+              <div
+                className="pt-1 border-t border-border"
+                style={{ borderColor: `${C.border}80` }}
+              >
+                <div style={{ color: C.textMuted }}>
+                  $ scp admin@edge-den-02:/var/log/app.log ./
+                </div>
+                <div className="flex items-center gap-2 mt-1">
+                  <span style={{ color: C.text }}>app.log</span>
+                  <div className="flex-1 h-1.5 bg-background rounded-full overflow-hidden">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ width: "68%", background: C.yellow }}
+                    />
+                  </div>
+                  <span style={{ color: C.yellow }}>68%</span>
+                </div>
+                <div style={{ color: C.textSec }}>
+                  45 MB&nbsp;&nbsp;&nbsp;12.3 MB/s&nbsp;&nbsp;&nbsp;ETA 0:02
+                </div>
+              </div>
+            </div>
+          </InfoCard>
         </div>
 
         {/* 3 smaller cards: Tags, RBAC, Audit */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Reveal delay={0.05}>
-            <ShimmerCard className="h-full">
-              <Card hover className="p-6 h-full">
-                <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
+          <InfoCard
+            icon={TagIcon}
+            color={C.yellow}
+            title="Device Tags"
+            description="Organize edge servers by region, site type, or function for fast filtering and batch operations."
+            delay={0.05}
+          >
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {[
+                { label: "region:northeast", color: C.primary },
+                { label: "type:retail", color: C.green },
+                { label: "env:production", color: C.yellow },
+                { label: "rack:A3", color: C.cyan },
+              ].map((tag) => (
+                <span
+                  key={tag.label}
+                  className="px-2 py-0.5 text-2xs font-mono rounded-full border"
                   style={{
-                    background: `${C.yellow}15`,
-                    borderColor: `${C.yellow}25`,
+                    color: tag.color,
+                    background: `${tag.color}10`,
+                    borderColor: `${tag.color}20`,
                   }}
                 >
-                  <TagIcon className="w-5 h-5" style={{ color: C.yellow }} />
-                </div>
-                <h4 className="text-sm font-semibold mb-2">Device Tags</h4>
-                <p className="text-xs text-text-secondary leading-relaxed mb-3">
-                  Organize edge servers by region, site type, or function for
-                  fast filtering and batch operations.
-                </p>
-                <div className="flex flex-wrap gap-1.5">
-                  {[
-                    { label: "region:northeast", color: C.primary },
-                    { label: "type:retail", color: C.green },
-                    { label: "env:production", color: C.yellow },
-                    { label: "rack:A3", color: C.cyan },
-                  ].map((tag) => (
-                    <span
-                      key={tag.label}
-                      className="px-2 py-0.5 text-2xs font-mono rounded-full border"
-                      style={{
-                        color: tag.color,
-                        background: `${tag.color}10`,
-                        borderColor: `${tag.color}20`,
-                      }}
-                    >
-                      {tag.label}
-                    </span>
-                  ))}
-                </div>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+                  {tag.label}
+                </span>
+              ))}
+            </div>
+          </InfoCard>
 
-          <Reveal delay={0.1}>
-            <ShimmerCard className="h-full">
-              <Card hover className="p-6 h-full">
+          <InfoCard
+            icon={UsersIcon}
+            color={C.primary}
+            title="RBAC"
+            description="Give regional teams access to only their edge servers with role-based controls and namespace isolation."
+            delay={0.1}
+          >
+            <div className="mt-3 space-y-1.5">
+              {[
+                {
+                  role: "NYC Ops Team",
+                  access: "northeast-*",
+                  color: C.primary,
+                },
+                {
+                  role: "Field Engineers",
+                  access: "tower-*",
+                  color: C.yellow,
+                },
+                {
+                  role: "Warehouse Admins",
+                  access: "warehouse-*",
+                  color: C.green,
+                },
+              ].map((r) => (
                 <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{
-                    background: `${C.primary}15`,
-                    borderColor: `${C.primary}25`,
-                  }}
+                  key={r.role}
+                  className="flex items-center justify-between text-2xs font-mono"
                 >
-                  <UsersIcon className="w-5 h-5" style={{ color: C.primary }} />
+                  <span style={{ color: C.textSec }}>{r.role}</span>
+                  <span style={{ color: r.color }}>{r.access}</span>
                 </div>
-                <h4 className="text-sm font-semibold mb-2">RBAC</h4>
-                <p className="text-xs text-text-secondary leading-relaxed mb-3">
-                  Give regional teams access to only their edge servers with
-                  role-based controls and namespace isolation.
-                </p>
-                <div className="space-y-1.5">
-                  {[
-                    {
-                      role: "NYC Ops Team",
-                      access: "northeast-*",
-                      color: C.primary,
-                    },
-                    {
-                      role: "Field Engineers",
-                      access: "tower-*",
-                      color: C.yellow,
-                    },
-                    {
-                      role: "Warehouse Admins",
-                      access: "warehouse-*",
-                      color: C.green,
-                    },
-                  ].map((r) => (
-                    <div
-                      key={r.role}
-                      className="flex items-center justify-between text-2xs font-mono"
-                    >
-                      <span style={{ color: C.textSec }}>{r.role}</span>
-                      <span style={{ color: r.color }}>{r.access}</span>
-                    </div>
-                  ))}
-                </div>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+              ))}
+            </div>
+          </InfoCard>
 
-          <Reveal delay={0.15}>
-            <ShimmerCard className="h-full">
-              <Card hover className="p-6 h-full">
+          <InfoCard
+            icon={PencilSquareIcon}
+            color={C.green}
+            title="Audit Trail"
+            description="Full session recording and command logging across all edge locations for compliance and forensics."
+            delay={0.15}
+          >
+            <div className="mt-3 space-y-1.5">
+              {[
+                {
+                  time: "14:32",
+                  user: "jane",
+                  device: "edge-nyc-01",
+                  action: "SSH session",
+                  color: C.green,
+                },
+                {
+                  time: "14:28",
+                  user: "mike",
+                  device: "tower-aus-03",
+                  action: "File transfer",
+                  color: C.cyan,
+                },
+                {
+                  time: "14:15",
+                  user: "ana",
+                  device: "wh-chi-07",
+                  action: "SSH session",
+                  color: C.green,
+                },
+              ].map((log, i) => (
                 <div
-                  className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                  style={{
-                    background: `${C.green}15`,
-                    borderColor: `${C.green}25`,
-                  }}
+                  key={i}
+                  className="flex items-center gap-2 text-2xs font-mono"
                 >
-                  <PencilSquareIcon
-                    className="w-5 h-5"
-                    style={{ color: C.green }}
-                  />
+                  <span style={{ color: C.textMuted }}>{log.time}</span>
+                  <span style={{ color: C.primary }}>{log.user}</span>
+                  <span style={{ color: C.textMuted }}>&rarr;</span>
+                  <span style={{ color: C.textSec }}>{log.device}</span>
+                  <span
+                    className="ml-auto px-1.5 py-0.5 rounded border"
+                    style={{
+                      color: log.color,
+                      background: `${log.color}10`,
+                      borderColor: `${log.color}20`,
+                    }}
+                  >
+                    {log.action}
+                  </span>
                 </div>
-                <h4 className="text-sm font-semibold mb-2">Audit Trail</h4>
-                <p className="text-xs text-text-secondary leading-relaxed mb-3">
-                  Full session recording and command logging across all edge
-                  locations for compliance and forensics.
-                </p>
-                <div className="space-y-1.5">
-                  {[
-                    {
-                      time: "14:32",
-                      user: "jane",
-                      device: "edge-nyc-01",
-                      action: "SSH session",
-                      color: C.green,
-                    },
-                    {
-                      time: "14:28",
-                      user: "mike",
-                      device: "tower-aus-03",
-                      action: "File transfer",
-                      color: C.cyan,
-                    },
-                    {
-                      time: "14:15",
-                      user: "ana",
-                      device: "wh-chi-07",
-                      action: "SSH session",
-                      color: C.green,
-                    },
-                  ].map((log, i) => (
-                    <div
-                      key={i}
-                      className="flex items-center gap-2 text-2xs font-mono"
-                    >
-                      <span style={{ color: C.textMuted }}>{log.time}</span>
-                      <span style={{ color: C.primary }}>{log.user}</span>
-                      <span style={{ color: C.textMuted }}>&rarr;</span>
-                      <span style={{ color: C.textSec }}>{log.device}</span>
-                      <span
-                        className="ml-auto px-1.5 py-0.5 rounded border"
-                        style={{
-                          color: log.color,
-                          background: `${log.color}10`,
-                          borderColor: `${log.color}20`,
-                        }}
-                      >
-                        {log.action}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </Card>
-            </ShimmerCard>
-          </Reveal>
+              ))}
+            </div>
+          </InfoCard>
         </div>
       </Section>
 
@@ -844,21 +754,16 @@ export default function EdgeComputing() {
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {scenarios.map((s, i) => (
-            <Reveal key={i} delay={i * 0.08}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-2 h-2 rounded-full mb-4"
-                    style={{ background: s.color }}
-                  />
-                  <h4 className="text-sm font-semibold mb-2">{s.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {s.desc}
-                  </p>
-                  {s.mockup}
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              color={s.color}
+              title={s.title}
+              description={s.desc}
+              layout="dot"
+              delay={i * 0.08}
+            >
+              {s.mockup}
+            </InfoCard>
           ))}
         </div>
       </Section>

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -15,49 +15,69 @@ import {
 import {
   Badge,
   Button,
-  Card,
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
-
-/* ═══════ Data ═══════ */
 
 const painPoints = [
   {
     color: C.yellow,
     title: "No public IP",
     desc: "IoT devices behind cellular, CGNAT, or private networks are unreachable with traditional SSH.",
-    icon: <SignalIcon className="w-5 h-5" style={{ color: C.yellow }} />,
+    icon: SignalIcon,
   },
   {
     color: C.primary,
     title: "Fleet scale",
     desc: "Managing SSH keys and firewall rules across hundreds or thousands of devices is unsustainable.",
-    icon: (
-      <ComputerDesktopIcon className="w-5 h-5" style={{ color: C.primary }} />
-    ),
+    icon: ComputerDesktopIcon,
   },
   {
     color: C.red,
     title: "Security gaps",
     desc: "Exposing SSH ports on embedded devices creates a massive attack surface you can't easily monitor.",
-    icon: (
-      <ShieldExclamationIcon className="w-5 h-5" style={{ color: C.red }} />
-    ),
+    icon: ShieldExclamationIcon,
   },
   {
     color: C.cyan,
     title: "No visibility",
     desc: "Without centralized logging, you have no idea who accessed which device or what they did.",
-    icon: <EyeIcon className="w-5 h-5" style={{ color: C.cyan }} />,
+    icon: EyeIcon,
+  },
+];
+
+const features = [
+  {
+    icon: ShieldCheckIcon,
+    color: C.green,
+    title: "Firewall Rules",
+    desc: "Define who can access which devices with granular per-device, per-user, or per-tag firewall policies. Block unauthorized connections before they reach the agent.",
+  },
+  {
+    icon: TagIcon,
+    color: C.yellow,
+    title: "Device Tags",
+    desc: "Organize fleets by location, firmware version, hardware type, or customer. Apply firewall rules and access policies to entire groups at once.",
+  },
+  {
+    icon: PlayCircleIcon,
+    color: C.cyan,
+    title: "Session Recording",
+    desc: "Record every SSH session for compliance, debugging, and knowledge sharing. Replay exactly what happened on a remote device during an incident.",
+  },
+  {
+    icon: PencilIcon,
+    color: C.primary,
+    title: "Audit Logging",
+    desc: "Full audit trail of every connection, command, and configuration change. Know who accessed what, when, and from where for regulatory compliance.",
   },
 ];
 
@@ -294,7 +314,6 @@ export default function IotEmbedded() {
         </div>
       </Section>
 
-      {/* ═══════ Pain Points (2x2) ═══════ */}
       <Section>
         <SectionHeader
           eyebrow="The Challenge"
@@ -304,31 +323,15 @@ export default function IotEmbedded() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {painPoints.map((p, i) => (
-            <Reveal key={i} delay={i * 0.06}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div className="flex items-start gap-4">
-                    <div
-                      className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 border"
-                      style={{
-                        background: `${p.color}15`,
-                        borderColor: `${p.color}25`,
-                      }}
-                    >
-                      {p.icon}
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-semibold mb-1.5">
-                        {p.title}
-                      </h4>
-                      <p className="text-xs text-text-secondary leading-relaxed">
-                        {p.desc}
-                      </p>
-                    </div>
-                  </div>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              icon={p.icon}
+              color={p.color}
+              title={p.title}
+              description={p.desc}
+              layout="horizontal"
+              delay={i * 0.06}
+            />
           ))}
         </div>
       </Section>
@@ -582,62 +585,16 @@ export default function IotEmbedded() {
           </ShimmerCard>
         </Reveal>
 
-        {/* 2x2 grid of feature cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-          {[
-            {
-              icon: (
-                <ShieldCheckIcon
-                  className="w-5 h-5"
-                  style={{ color: C.green }}
-                />
-              ),
-              color: C.green,
-              title: "Firewall Rules",
-              desc: "Define who can access which devices with granular per-device, per-user, or per-tag firewall policies. Block unauthorized connections before they reach the agent.",
-            },
-            {
-              icon: <TagIcon className="w-5 h-5" style={{ color: C.yellow }} />,
-              color: C.yellow,
-              title: "Device Tags",
-              desc: "Organize fleets by location, firmware version, hardware type, or customer. Apply firewall rules and access policies to entire groups at once.",
-            },
-            {
-              icon: (
-                <PlayCircleIcon className="w-5 h-5" style={{ color: C.cyan }} />
-              ),
-              color: C.cyan,
-              title: "Session Recording",
-              desc: "Record every SSH session for compliance, debugging, and knowledge sharing. Replay exactly what happened on a remote device during an incident.",
-            },
-            {
-              icon: (
-                <PencilIcon className="w-5 h-5" style={{ color: C.primary }} />
-              ),
-              color: C.primary,
-              title: "Audit Logging",
-              desc: "Full audit trail of every connection, command, and configuration change. Know who accessed what, when, and from where for regulatory compliance.",
-            },
-          ].map((f, i) => (
-            <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+          {features.map((f, i) => (
+            <InfoCard
+              key={i}
+              icon={f.icon}
+              color={f.color}
+              title={f.title}
+              description={f.desc}
+              delay={i * 0.04}
+            />
           ))}
         </div>
 

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -19,7 +19,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -52,39 +52,37 @@ const painPoints = [
 
 const features = [
   {
-    icon: <PlayCircleIcon className="w-5 h-5" style={{ color: C.cyan }} />,
+    icon: PlayCircleIcon,
     color: C.cyan,
     title: "Session Recording",
     desc: "Every support session is recorded and can be replayed for quality assurance, training, and compliance audits.",
   },
   {
-    icon: <PencilIcon className="w-5 h-5" style={{ color: C.green }} />,
+    icon: PencilIcon,
     color: C.green,
     title: "Audit Logging",
     desc: "Complete audit trail with timestamps, user identity, and session details for every connection made to any device.",
   },
   {
-    icon: <UsersIcon className="w-5 h-5" style={{ color: C.primary }} />,
+    icon: UsersIcon,
     color: C.primary,
     title: "Role-Based Access",
     desc: "Assign support engineers access to specific devices or groups — revoke access instantly when the ticket is closed.",
   },
   {
-    icon: (
-      <ComputerDesktopIcon className="w-5 h-5" style={{ color: C.green }} />
-    ),
+    icon: ComputerDesktopIcon,
     color: C.green,
     title: "Web Terminal",
     desc: "Support engineers access devices straight from the browser — no SSH client setup required on their workstations.",
   },
   {
-    icon: <LockClosedIcon className="w-5 h-5" style={{ color: C.yellow }} />,
+    icon: LockClosedIcon,
     color: C.yellow,
     title: "MFA for SSH",
     desc: "Require multi-factor authentication for support sessions — adding a security layer beyond SSH keys alone.",
   },
   {
-    icon: <ShieldCheckIcon className="w-5 h-5" style={{ color: C.primary }} />,
+    icon: ShieldCheckIcon,
     color: C.primary,
     title: "Firewall Rules",
     desc: "Restrict support access by IP, time window, or device group with granular, time-based firewall policies.",
@@ -490,7 +488,6 @@ export default function RemoteSupport() {
         </div>
       </Section>
 
-      {/* ── Pain Points ──────────────────────────────────────────── */}
       <Section>
         <SectionHeader
           eyebrow="The Problem"
@@ -500,25 +497,18 @@ export default function RemoteSupport() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {painPoints.map((p, i) => (
-            <Reveal key={i} delay={i * 0.06}>
-              <ShimmerCard className="h-full">
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-2 h-2 rounded-full mb-4"
-                    style={{ background: p.color }}
-                  />
-                  <h4 className="text-sm font-semibold mb-2">{p.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {p.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              color={p.color}
+              title={p.title}
+              description={p.desc}
+              layout="dot"
+              delay={i * 0.06}
+            />
           ))}
         </div>
       </Section>
 
-      {/* ── Key Features ─────────────────────────────────────────── */}
       <Section>
         <SectionHeader
           eyebrow="Features"
@@ -528,25 +518,14 @@ export default function RemoteSupport() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {features.map((f, i) => (
-            <Reveal key={i} delay={i * 0.04}>
-              <ShimmerCard>
-                <Card hover className="p-6 h-full">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center mb-4 border"
-                    style={{
-                      background: `${f.color}15`,
-                      borderColor: `${f.color}25`,
-                    }}
-                  >
-                    {f.icon}
-                  </div>
-                  <h4 className="text-sm font-semibold mb-2">{f.title}</h4>
-                  <p className="text-xs text-text-secondary leading-relaxed">
-                    {f.desc}
-                  </p>
-                </Card>
-              </ShimmerCard>
-            </Reveal>
+            <InfoCard
+              key={i}
+              icon={f.icon}
+              color={f.color}
+              title={f.title}
+              description={f.desc}
+              delay={i * 0.04}
+            />
           ))}
         </div>
       </Section>


### PR DESCRIPTION
## What

Extracted a shared `InfoCard` component from ~60 inline icon+title+description card instances scattered across 14 grids in the marketing website.

## Why

The same `Reveal > ShimmerCard > Card` markup with an icon container, title, and description was copy-pasted across every feature grid, pain-point section, and scenario list. Any styling change (spacing, icon size, border treatment) required editing dozens of files in lockstep.

Closes shellhub-io/team#176

## Changes

- **`InfoCard` component** (`components/marketing/InfoCard.tsx`): three layout variants via a `layout` prop — `vertical` (default, icon above text), `horizontal` (icon beside text), and `dot` (small colored circle, no icon). Wraps `Reveal > ShimmerCard > Card` internally. The `icon` prop accepts a component reference (`ComponentType<SVGProps>`); InfoCard renders it at `w-5 h-5` with the card's `color`, eliminating repetitive icon styling at every call site. Optional `children` slot for rich content below the description (terminal mockups, tag pills, audit logs).
- **11 page files migrated**: replaced inline card markup with `<InfoCard>` calls. Data arrays that previously held pre-rendered icon JSX now hold bare component references (e.g., `icon: ShieldCheckIcon` instead of `icon: <ShieldCheckIcon className="w-5 h-5" style={{ color: C.green }} />`). Inline arrays extracted to `const` where they cluttered the JSX (`IotEmbedded`, `integrations`).
- **Net -351 lines** across the migration.

## Testing

- `npm run build` (tsc + vite) passes
- 79/79 vitest tests pass, including 8 new tests for InfoCard covering all three layout variants, icon rendering, children, and heading semantics
- `npm run lint` clean (0 errors, 3 pre-existing warnings in `Navbar.tsx`)