### PR TITLE
refactor(ui): extract `HighlightCard` marketing component

### DIFF
--- a/ui/apps/website/src/components/marketing/HighlightCard.tsx
+++ b/ui/apps/website/src/components/marketing/HighlightCard.tsx
@@ -1,0 +1,68 @@
+import { cn } from "@shellhub/design-system/cn";
+
+type HighlightCardColor =
+  | "primary"
+  | "accent-cyan"
+  | "accent-green"
+  | "accent-blue"
+  | "accent-yellow";
+
+interface HighlightCardProps extends React.ComponentPropsWithoutRef<"div"> {
+  color: HighlightCardColor;
+}
+
+const colorStyles: Record<
+  HighlightCardColor,
+  { card: string; gradient: string }
+> = {
+  primary: {
+    card: "border-primary/30 hover:border-primary/50 shadow-[0_0_40px_rgba(102,122,204,0.1)]",
+    gradient: "from-primary/[0.06]",
+  },
+  "accent-cyan": {
+    card: "border-accent-cyan/30 hover:border-accent-cyan/50 shadow-[0_0_40px_rgba(78,154,163,0.08)]",
+    gradient: "from-accent-cyan/[0.06]",
+  },
+  "accent-green": {
+    card: "border-accent-green/30 hover:border-accent-green/50 shadow-[0_0_40px_rgba(130,165,104,0.08)]",
+    gradient: "from-accent-green/[0.06]",
+  },
+  "accent-blue": {
+    card: "border-accent-blue/30 hover:border-accent-blue/50 shadow-[0_0_40px_rgba(86,162,225,0.06)]",
+    gradient: "from-accent-blue/[0.06]",
+  },
+  "accent-yellow": {
+    card: "border-accent-yellow/30 hover:border-accent-yellow/50 shadow-[0_0_40px_rgba(191,140,93,0.06)]",
+    gradient: "from-accent-yellow/[0.06]",
+  },
+};
+
+export function HighlightCard({
+  color,
+  className,
+  children,
+  ...props
+}: HighlightCardProps) {
+  const styles = colorStyles[color];
+
+  return (
+    <div
+      className={cn(
+        "relative bg-card border rounded-xl overflow-hidden transition-all duration-300",
+        styles.card,
+        className,
+      )}
+      {...props}
+    >
+      <div
+        className={cn(
+          "absolute inset-0 bg-gradient-to-br via-transparent to-transparent pointer-events-none",
+          styles.gradient,
+        )}
+      />
+      {children}
+    </div>
+  );
+}
+
+export type { HighlightCardColor, HighlightCardProps };

--- a/ui/apps/website/src/components/marketing/__tests__/HighlightCard.test.tsx
+++ b/ui/apps/website/src/components/marketing/__tests__/HighlightCard.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HighlightCard } from "@/components/marketing/HighlightCard";
+
+describe("HighlightCard", () => {
+  it("renders children inside a card with a gradient overlay", () => {
+    render(
+      <HighlightCard color="primary" data-testid="card">
+        <p>hello</p>
+      </HighlightCard>,
+    );
+    const card = screen.getByTestId("card");
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(card).toHaveClass("relative", "bg-card", "border", "rounded-xl");
+
+    const overlay = card.firstChild as HTMLElement;
+    expect(overlay).toHaveClass("absolute", "inset-0", "pointer-events-none");
+    expect(overlay.className).toContain("bg-gradient-to-br");
+  });
+
+  it.each([
+    ["primary", "border-primary/30", "shadow-[0_0_40px_rgba(102,122,204,0.1)]", "from-primary/[0.06]"],
+    ["accent-cyan", "border-accent-cyan/30", "shadow-[0_0_40px_rgba(78,154,163,0.08)]", "from-accent-cyan/[0.06]"],
+    ["accent-green", "border-accent-green/30", "shadow-[0_0_40px_rgba(130,165,104,0.08)]", "from-accent-green/[0.06]"],
+    ["accent-blue", "border-accent-blue/30", "shadow-[0_0_40px_rgba(86,162,225,0.06)]", "from-accent-blue/[0.06]"],
+    ["accent-yellow", "border-accent-yellow/30", "shadow-[0_0_40px_rgba(191,140,93,0.06)]", "from-accent-yellow/[0.06]"],
+  ] as const)("maps %s to its border, shadow, and gradient", (color, border, shadow, gradient) => {
+    render(
+      <HighlightCard color={color} data-testid="card">
+        content
+      </HighlightCard>,
+    );
+    const card = screen.getByTestId("card");
+    expect(card.className).toContain(border);
+    expect(card.className).toContain(shadow);
+    expect((card.firstChild as HTMLElement).className).toContain(gradient);
+  });
+
+  it("merges className and forwards HTML attributes", () => {
+    render(
+      <HighlightCard
+        color="primary"
+        className="p-8 flex flex-col"
+        aria-label="feature card"
+        data-testid="card"
+      >
+        content
+      </HighlightCard>,
+    );
+    const card = screen.getByTestId("card");
+    expect(card).toHaveClass("p-8", "flex", "flex-col", "bg-card");
+    expect(card).toHaveAttribute("aria-label", "feature card");
+  });
+});

--- a/ui/apps/website/src/components/marketing/index.ts
+++ b/ui/apps/website/src/components/marketing/index.ts
@@ -10,3 +10,5 @@ export { CTABanner } from "./CTABanner";
 export type { CTABannerProps } from "./CTABanner";
 export { InfoCard } from "./InfoCard";
 export type { InfoCardProps } from "./InfoCard";
+export { HighlightCard } from "./HighlightCard";
+export type { HighlightCardColor, HighlightCardProps } from "./HighlightCard";

--- a/ui/apps/website/src/pages/enterprise/DeploymentOptions.tsx
+++ b/ui/apps/website/src/pages/enterprise/DeploymentOptions.tsx
@@ -1,6 +1,6 @@
 import { CloudIcon, ShoppingCartIcon } from "@heroicons/react/24/outline";
 import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
-import { Section, SectionHeader } from "@/components/marketing";
+import { HighlightCard, Section, SectionHeader } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
 
@@ -16,8 +16,7 @@ export function DeploymentOptions() {
       <div className="grid md:grid-cols-2 gap-6">
         <Reveal delay={0}>
           <ShimmerCard className="h-full">
-            <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+            <HighlightCard color="primary" className="p-8 flex flex-col h-full">
               <div className="relative">
                 <div className="flex items-center gap-3 mb-4">
                   <IconBadge color="primary">
@@ -48,7 +47,7 @@ export function DeploymentOptions() {
                   ))}
                 </ul>
               </div>
-            </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
 

--- a/ui/apps/website/src/pages/enterprise/SupportSection.tsx
+++ b/ui/apps/website/src/pages/enterprise/SupportSection.tsx
@@ -3,7 +3,7 @@ import {
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
 import { Card, IconBadge } from "@shellhub/design-system/primitives";
-import { Section, SectionHeader } from "@/components/marketing";
+import { HighlightCard, Section, SectionHeader } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
 
@@ -48,8 +48,7 @@ export function SupportSection() {
 
         <Reveal delay={0.1}>
           <ShimmerCard className="h-full">
-            <div className="relative bg-card border border-primary/30 rounded-xl p-8 h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+            <HighlightCard color="primary" className="p-8 h-full">
               <div className="relative">
                 <div className="flex items-center gap-3 mb-6">
                   <IconBadge color="primary">
@@ -76,7 +75,7 @@ export function SupportSection() {
                   ))}
                 </ul>
               </div>
-            </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
       </div>

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
@@ -1084,107 +1084,108 @@ function DeviceOrganization() {
         {/* Tags card */}
         <Reveal delay={0}>
           <ShimmerCard className="h-full">
-            <Card hover className="p-8 h-full">
-              <div className="flex items-center gap-3 mb-6">
-                <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
-                  <TagIcon
-                    className="w-5 h-5 text-primary"
-                    strokeWidth={1.5}
-                    aria-hidden="true"
-                  />
-                </div>
-                <div>
-                  <h3 className="text-sm font-bold">Device Tags</h3>
-                  <p className="text-2xs text-text-muted">
-                    Flexible grouping & filtering
-                  </p>
-                </div>
-              </div>
-
-              {/* Tag mockup */}
-              <div className="space-y-2.5 mb-6">
-                {[
-                  {
-                    name: "rpi-gateway-01",
-                    tags: [
-                      { label: "production", color: C.green },
-                      { label: "gateway", color: C.primary },
-                      { label: "eu-west", color: C.blue },
-                    ],
-                  },
-                  {
-                    name: "sensor-node-04",
-                    tags: [
-                      { label: "staging", color: C.yellow },
-                      { label: "sensor", color: C.cyan },
-                    ],
-                  },
-                  {
-                    name: "edge-server-12",
-                    tags: [
-                      { label: "production", color: C.green },
-                      { label: "compute", color: C.primary },
-                      { label: "us-east", color: C.blue },
-                    ],
-                  },
-                ].map((device) => (
-                  <div
-                    key={device.name}
-                    className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border"
-                  >
-                    <div className="flex items-center gap-2.5">
-                      <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                      <span className="text-xs font-mono font-medium">
-                        {device.name}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-1.5">
-                      {device.tags.map((tag) => (
-                        <span
-                          key={tag.label}
-                          className="px-2 py-0.5 text-2xs font-mono rounded-full border"
-                          style={{
-                            background: `${tag.color}12`,
-                            color: tag.color,
-                            borderColor: `${tag.color}25`,
-                          }}
-                        >
-                          {tag.label}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <ul className="space-y-2">
-                {[
-                  "Filter and group devices by custom tags",
-                  "Apply firewall rules based on tags",
-                  "Bulk operations on tagged groups",
-                ].map((item) => (
-                  <li
-                    key={item}
-                    className="flex items-center gap-2.5 text-xs text-text-secondary"
-                  >
-                    <CheckIcon
-                      strokeWidth={2}
-                      className="w-3.5 h-3.5 text-accent-green shrink-0"
+            <HighlightCard color="primary" className="p-8 h-full">
+              <div className="relative">
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="w-10 h-10 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                    <TagIcon
+                      className="w-5 h-5 text-primary"
+                      strokeWidth={1.5}
                       aria-hidden="true"
                     />
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </Card>
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-bold">Device Tags</h3>
+                    <p className="text-2xs text-primary">
+                      Flexible grouping & filtering
+                    </p>
+                  </div>
+                </div>
+
+                {/* Tag mockup */}
+                <div className="space-y-2.5 mb-6">
+                  {[
+                    {
+                      name: "rpi-gateway-01",
+                      tags: [
+                        { label: "production", color: C.green },
+                        { label: "gateway", color: C.primary },
+                        { label: "eu-west", color: C.blue },
+                      ],
+                    },
+                    {
+                      name: "sensor-node-04",
+                      tags: [
+                        { label: "staging", color: C.yellow },
+                        { label: "sensor", color: C.cyan },
+                      ],
+                    },
+                    {
+                      name: "edge-server-12",
+                      tags: [
+                        { label: "production", color: C.green },
+                        { label: "compute", color: C.primary },
+                        { label: "us-east", color: C.blue },
+                      ],
+                    },
+                  ].map((device) => (
+                    <div
+                      key={device.name}
+                      className="flex items-center justify-between p-3 bg-surface rounded-lg border border-border"
+                    >
+                      <div className="flex items-center gap-2.5">
+                        <div className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                        <span className="text-xs font-mono font-medium">
+                          {device.name}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        {device.tags.map((tag) => (
+                          <span
+                            key={tag.label}
+                            className="px-2 py-0.5 text-2xs font-mono rounded-full border"
+                            style={{
+                              background: `${tag.color}12`,
+                              color: tag.color,
+                              borderColor: `${tag.color}25`,
+                            }}
+                          >
+                            {tag.label}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                <ul className="space-y-2">
+                  {[
+                    "Filter and group devices by custom tags",
+                    "Apply firewall rules based on tags",
+                    "Bulk operations on tagged groups",
+                  ].map((item) => (
+                    <li
+                      key={item}
+                      className="flex items-center gap-2.5 text-xs text-text-secondary"
+                    >
+                      <CheckIcon
+                        strokeWidth={2}
+                        className="w-3.5 h-3.5 text-accent-green shrink-0"
+                        aria-hidden="true"
+                      />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
 
         {/* Namespaces card */}
         <Reveal delay={0.1}>
           <ShimmerCard className="h-full">
-            <div className="relative bg-card border border-accent-cyan/30 rounded-xl p-8 h-full hover:border-accent-cyan/50 transition-all duration-300 shadow-[0_0_40px_rgba(78,154,163,0.08)] overflow-hidden">
-              <div className="absolute inset-0 bg-gradient-to-br from-accent-cyan/[0.04] via-transparent to-transparent pointer-events-none" />
+            <HighlightCard color="accent-cyan" className="p-8 h-full">
               <div className="relative">
                 <div className="flex items-center gap-3 mb-6">
                   <div className="w-10 h-10 rounded-lg bg-accent-cyan/10 border border-accent-cyan/20 flex items-center justify-center">
@@ -1271,7 +1272,7 @@ function DeviceOrganization() {
                   ))}
                 </ul>
               </div>
-            </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
       </div>

--- a/ui/apps/website/src/pages/getting-started/StepPath.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepPath.tsx
@@ -12,6 +12,7 @@ import {
   IconBadge,
   ShellHubCloudIcon,
 } from "@shellhub/design-system/primitives";
+import { HighlightCard } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
 
@@ -27,7 +28,7 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
         {/* Cloud card */}
         <Reveal delay={0}>
           <ShimmerCard className="h-full">
-            <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.15)] overflow-hidden">
+            <HighlightCard color="primary" className="p-8 flex flex-col h-full">
               <GlowOrbs preset="corner" tone="primary" />
               <div className="relative flex items-center gap-3 mb-4">
                 <IconBadge
@@ -67,7 +68,7 @@ export function StepPath({ onSelectCloud, onSelectSelfHosted }: StepPathProps) {
               >
                 Sign Up Free
               </Button>
-            </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
 

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -20,7 +20,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
@@ -1078,8 +1078,7 @@ export default function HowItWorks() {
           {/* ShellHub Side (highlighted) */}
           <Reveal delay={0}>
             <ShimmerCard className="h-full">
-              <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+              <HighlightCard color="primary" className="p-8 flex flex-col h-full">
                 <div className="relative">
                   <div className="flex items-center gap-3 mb-6">
                     <IconBadge color="primary">
@@ -1111,7 +1110,7 @@ export default function HowItWorks() {
                     ))}
                   </ul>
                 </div>
-              </div>
+              </HighlightCard>
             </ShimmerCard>
           </Reveal>
 

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -24,7 +24,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
@@ -399,8 +399,7 @@ export default function Integrations() {
           {/* VS Code Remote SSH */}
           <Reveal delay={0}>
             <ShimmerCard className="h-full">
-              <div className="relative bg-card border border-accent-blue/25 rounded-xl overflow-hidden h-full hover:border-accent-blue/40 transition-all duration-300 shadow-[0_0_40px_rgba(86,162,225,0.06)]">
-                <div className="absolute inset-0 bg-gradient-to-br from-accent-blue/[0.04] via-transparent to-transparent pointer-events-none" />
+              <HighlightCard color="accent-blue" className="h-full">
                 <div className="relative">
                   {/* VS Code title bar */}
                   <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-[#1E1E2E]">
@@ -552,15 +551,14 @@ export default function Integrations() {
                     <span className="text-text-muted">Ln 7, Col 12</span>
                   </div>
                 </div>
-              </div>
+              </HighlightCard>
             </ShimmerCard>
           </Reveal>
 
           {/* Embedded Linux */}
           <Reveal delay={0.1}>
             <ShimmerCard className="h-full">
-              <div className="relative bg-card border border-accent-yellow/25 rounded-xl overflow-hidden h-full hover:border-accent-yellow/40 transition-all duration-300 shadow-[0_0_40px_rgba(191,140,93,0.06)]">
-                <div className="absolute inset-0 bg-gradient-to-br from-accent-yellow/[0.04] via-transparent to-transparent pointer-events-none" />
+              <HighlightCard color="accent-yellow" className="h-full">
                 <div className="relative">
                   {/* Header */}
                   <div className="px-6 pt-6 pb-4">
@@ -648,7 +646,7 @@ export default function Integrations() {
                     </div>
                   </div>
                 </div>
-              </div>
+              </HighlightCard>
             </ShimmerCard>
           </Reveal>
         </div>

--- a/ui/apps/website/src/pages/pricing/TierCards.tsx
+++ b/ui/apps/website/src/pages/pricing/TierCards.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { cn } from "@shellhub/design-system/cn";
 import { Button } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { Section } from "@/components/marketing";
+import { HighlightCard, Section } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard } from "../landing/components";
 
@@ -74,72 +74,77 @@ export function TierCards() {
   return (
     <Section bordered={false} padding="md">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {tiers.map((tier, i) => (
-          <Reveal key={tier.name} delay={i * 0.08}>
-            <ShimmerCard className="h-full">
-              <div
-                className={cn(
-                  "relative rounded-xl p-8 flex flex-col h-full transition-all duration-300 overflow-hidden",
-                  tier.highlighted
-                    ? "bg-card border border-primary/30 hover:border-primary/50 shadow-[0_0_40px_rgba(102,122,204,0.15)]"
-                    : "bg-card border border-border hover:border-border-light",
-                )}
-              >
-                {tier.highlighted && (
-                  <GlowOrbs preset="corner" tone="primary" />
-                )}
-
-                <div className="relative">
-                  <div className="flex items-center gap-3 mb-4">
-                    <h3 className="text-lg font-bold">{tier.name}</h3>
-                    <span
-                      className={cn("px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] border rounded-full", tier.badgeClass)}
-                    >
-                      {tier.badge}
-                    </span>
-                  </div>
-
-                  <div className="mb-2">
-                    <span className="text-3xl font-bold">{tier.price}</span>
-                  </div>
-                  <p className="text-2xs text-text-muted mb-4">
-                    {tier.priceSuffix}
-                  </p>
-                  <p className="text-sm text-text-secondary leading-relaxed mb-6">
-                    {tier.desc}
-                  </p>
-
-                  <ul className="space-y-2.5 mb-8 flex-1">
-                    {tier.features.map((feature) => (
-                      <FeatureListItem
-                        key={feature}
-                        color={tier.highlighted ? "green" : "muted"}
-                      >
-                        {feature}
-                      </FeatureListItem>
-                    ))}
-                  </ul>
-
-                  <Button
-                    as={Link}
-                    to={tier.ctaHref}
-                    variant={tier.highlighted ? "primary" : "surface"}
-                    size="lg"
-                    glow={tier.highlighted}
-                    fullWidth
-                    className={
-                      tier.highlighted
-                        ? undefined
-                        : "hover:scale-[1.02] active:scale-[0.98]"
-                    }
-                  >
-                    {tier.cta}
-                  </Button>
-                </div>
+        {tiers.map((tier, i) => {
+          const content = (
+            <div className="relative">
+              <div className="flex items-center gap-3 mb-4">
+                <h3 className="text-lg font-bold">{tier.name}</h3>
+                <span
+                  className={cn("px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] border rounded-full", tier.badgeClass)}
+                >
+                  {tier.badge}
+                </span>
               </div>
-            </ShimmerCard>
-          </Reveal>
-        ))}
+
+              <div className="mb-2">
+                <span className="text-3xl font-bold">{tier.price}</span>
+              </div>
+              <p className="text-2xs text-text-muted mb-4">
+                {tier.priceSuffix}
+              </p>
+              <p className="text-sm text-text-secondary leading-relaxed mb-6">
+                {tier.desc}
+              </p>
+
+              <ul className="space-y-2.5 mb-8 flex-1">
+                {tier.features.map((feature) => (
+                  <FeatureListItem
+                    key={feature}
+                    color={tier.highlighted ? "green" : "muted"}
+                  >
+                    {feature}
+                  </FeatureListItem>
+                ))}
+              </ul>
+
+              <Button
+                as={Link}
+                to={tier.ctaHref}
+                variant={tier.highlighted ? "primary" : "surface"}
+                size="lg"
+                glow={tier.highlighted}
+                fullWidth
+                className={
+                  tier.highlighted
+                    ? undefined
+                    : "hover:scale-[1.02] active:scale-[0.98]"
+                }
+              >
+                {tier.cta}
+              </Button>
+            </div>
+          );
+
+          return (
+            <Reveal key={tier.name} delay={i * 0.08}>
+              <ShimmerCard className="h-full">
+                {tier.highlighted ? (
+                  <HighlightCard
+                    color="primary"
+                    className="p-8 flex flex-col h-full"
+                  >
+                    <GlowOrbs preset="corner" tone="primary" />
+                    {content}
+                  </HighlightCard>
+                ) : (
+                  <div className="relative rounded-xl p-8 flex flex-col h-full transition-all duration-300 overflow-hidden bg-card border border-border hover:border-border-light">
+                    {content}
+                  </div>
+                )}
+              </ShimmerCard>
+            </Reveal>
+          );
+        })}
       </div>
     </Section>
   );

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -19,7 +19,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
@@ -590,8 +590,7 @@ export default function ContainerManagement() {
           {/* With ShellHub */}
           <Reveal delay={0.1}>
             <ShimmerCard className="h-full">
-              <div className="relative bg-card border border-primary/30 rounded-xl p-8 flex flex-col h-full hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)] overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+              <HighlightCard color="primary" className="p-8 flex flex-col h-full">
                 <div className="relative flex-1 flex flex-col">
                   <div className="flex items-center gap-3 mb-6">
                     <IconBadge color="primary">
@@ -666,7 +665,7 @@ export default function ContainerManagement() {
                     ))}
                   </div>
                 </div>
-              </div>
+              </HighlightCard>
             </ShimmerCard>
           </Reveal>
         </div>
@@ -722,8 +721,7 @@ export default function ContainerManagement() {
         {/* Big feature card: Per-Container Access Control */}
         <Reveal className="mb-6">
           <ShimmerCard>
-            <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)]">
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+            <HighlightCard color="primary">
               <div className="relative grid lg:grid-cols-2 gap-8 p-8">
                 {/* Left: description */}
                 <div className="flex flex-col justify-center">
@@ -808,7 +806,7 @@ export default function ContainerManagement() {
                   </div>
                 </WindowChrome>
               </div>
-            </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
 

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -21,7 +21,7 @@ import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { C } from "../landing/constants";
 
 /* ═══════ Pain-point data ═══════ */
@@ -437,8 +437,7 @@ export default function EdgeComputing() {
         {/* Big highlighted card: Instant Remote Access */}
         <Reveal>
           <ShimmerCard className="mb-4">
-            <div className="relative bg-card border border-primary/30 rounded-xl p-8 overflow-hidden hover:border-primary/50 transition-all duration-300 shadow-[0_0_40px_rgba(102,122,204,0.1)]">
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+            <HighlightCard color="primary" className="p-8">
               <div className="relative grid lg:grid-cols-2 gap-8 items-center">
                 <div>
                   <div className="flex items-center gap-2 mb-4">
@@ -523,7 +522,7 @@ export default function EdgeComputing() {
                   </div>
                 </WindowChrome>
               </div>
-            </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
 

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -21,7 +21,7 @@ import {
 import { GlowOrbs } from "@shellhub/design-system/components";
 import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
@@ -348,8 +348,7 @@ export default function IotEmbedded() {
         {/* Big card: NAT Traversal with SVG diagram */}
         <Reveal>
           <ShimmerCard className="mb-4">
-            <div className="relative bg-card border border-primary/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(102,122,204,0.1)] hover:border-primary/50 transition-all duration-300">
-              <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-transparent pointer-events-none" />
+            <HighlightCard color="primary">
               <div className="relative grid lg:grid-cols-2 gap-8 p-8">
                 {/* Left: text */}
                 <div className="flex flex-col justify-center">
@@ -581,7 +580,7 @@ export default function IotEmbedded() {
                   </div>
                 </div>
               </div>
-            </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
 
@@ -601,8 +600,7 @@ export default function IotEmbedded() {
         {/* Highlighted card: Lightweight Agent */}
         <Reveal>
           <ShimmerCard className="">
-            <div className="relative bg-card border border-accent-green/30 rounded-xl overflow-hidden shadow-[0_0_40px_rgba(130,165,104,0.08)] hover:border-accent-green/50 transition-all duration-300">
-              <div className="absolute inset-0 bg-gradient-to-br from-accent-green/[0.05] via-transparent to-transparent pointer-events-none" />
+            <HighlightCard color="accent-green">
               <div className="relative p-8">
                 <div className="grid lg:grid-cols-[1fr_auto] gap-8 items-center">
                   <div>
@@ -676,7 +674,7 @@ export default function IotEmbedded() {
                   </div>
                 </div>
               </div>
-            </div>
+            </HighlightCard>
           </ShimmerCard>
         </Reveal>
       </Section>


### PR DESCRIPTION
## What

Extracted the repeated "highlight card" shell — colored border, hover glow, shadow, and gradient overlay — into a shared `HighlightCard` component. Replaced all 13 inline instances across 8 website page files with `<HighlightCard color="..." className="...">`.

## Why

The same ~4-line card shell (border, hover border, shadow with color-matched rgba, absolute gradient overlay) was copy-pasted 13 times with only the accent color varying. A color change or visual tweak required editing every site. Centralizing it into one component makes the pattern maintainable and consistent.

Closes shellhub-io/team#175

## Changes

- **`HighlightCard` component** (`components/marketing/HighlightCard.tsx`): accepts a `color` prop (`primary`, `accent-cyan`, `accent-green`, `accent-blue`, `accent-yellow`) and maps it to the matching border, hover, shadow rgba, and gradient classes via a static lookup. Forwards `className` and all HTML div attributes. Renders the gradient overlay internally.
- **13 call-site replacements**: each inline card shell replaced with `<HighlightCard color="..." className="...">`. Layout classes (`p-8`, `flex flex-col`, `h-full`) moved to `className`; the inner `<div className="relative">` wrapper stays in the caller.
- **`StepPath.tsx` and `TierCards.tsx`**: these two sites originally used `<GlowOrbs preset="corner">` instead of the gradient overlay. Both are preserved — `GlowOrbs` now composes alongside the `HighlightCard` gradient rather than replacing it.
- **Device Tags card** (`features/index.tsx`): intentionally promoted from a plain `<Card hover>` to `<HighlightCard color="primary">`. The original created a false visual hierarchy where Device Tags looked like the "lesser" option next to the highlighted Namespaces card, but both are co-equal ShellHub features for organizing devices (same pattern as the integrations page where VS Code and Embedded Linux are both highlighted with different accent colors).
- **Opacity normalization**: minor drifted values across sites (border `/25` vs `/30`, gradient `0.04` vs `0.06`, shadow `0.15` vs `0.1`) were normalized to the dominant values. The visual delta is subtle.
- **Barrel export**: `HighlightCard` and its types exported from `components/marketing/index.ts`.
- **Tests**: 7 tests covering structure, all 5 color mappings, `className` merge, and HTML attribute forwarding.