### PR TITLE
fix(ui): fix ShimmerCard children not filling parent height

### DIFF
--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -400,7 +400,7 @@ export default function Integrations() {
           <Reveal delay={0}>
             <ShimmerCard className="h-full">
               <HighlightCard color="accent-blue" className="h-full">
-                <div className="relative">
+                <div className="flex flex-col h-full">
                   {/* VS Code title bar */}
                   <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-[#1E1E2E]">
                     <div className="w-3 h-3 rounded-full bg-accent-red/60" />
@@ -416,7 +416,7 @@ export default function Integrations() {
                     </div>
                   </div>
 
-                  <div className="flex min-h-[240px]">
+                  <div className="flex flex-1">
                     {/* Sidebar */}
                     <div className="w-44 shrink-0 border-r border-border bg-surface/40 p-3">
                       <p className="text-2xs font-mono text-text-muted uppercase tracking-wider mb-2">

--- a/ui/packages/design-system/components/ShimmerCard.tsx
+++ b/ui/packages/design-system/components/ShimmerCard.tsx
@@ -1,10 +1,16 @@
 import { cn } from "../primitives/cn";
 
-export function ShimmerCard({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+export function ShimmerCard({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
   return (
     <div className={cn("group relative", className)}>
       <div className="shimmer absolute inset-0 rounded-xl overflow-hidden opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none" />
-      <div className="relative">{children}</div>
+      <div className="relative size-full">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## What

`ShimmerCard`'s inner wrapper only had `relative` positioning, so children didn't stretch to match the card's height in equal-height grid layouts. This caused visible size mismatches — the shimmer overlay covered the full card, but the content stopped short.

## Why

In side-by-side grid cards (e.g. "Without ShellHub" vs "With ShellHub" comparisons), both `ShimmerCard` containers get the same height from the grid, but the children rendered at their intrinsic height, leaving a gap at the bottom of the shorter card.

## Changes

- **`ShimmerCard`**: added `size-full` to the children wrapper div so it stretches to fill the outer container. Safe across all ~50 usages — when the parent has no explicit height, `size-full` resolves to content height (no visual change); when it does (equal-height grids), the children now properly fill the space.
- **Integrations page**: the VS Code Remote SSH mockup used a fixed `min-h-[240px]` on the editor area and `relative` on the card wrapper, so it didn't fill its `h-full` `ShimmerCard`. Switched to `flex flex-col h-full` on the wrapper and `flex-1` on the editor area.