### PR TITLE
refactor(ui): extract ActionButton and ActionButtonGroup from website CTAs

### DIFF
--- a/ui/apps/website/src/components/marketing/ActionButton.tsx
+++ b/ui/apps/website/src/components/marketing/ActionButton.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { Button, type ButtonSize } from "@shellhub/design-system/primitives";
+import { cn } from "@shellhub/design-system/cn";
+import { ArrowRight } from "@/components/ArrowRight";
+
+export type CTAAction =
+  | { label: string; to: string; href?: never; external?: never }
+  | { label: string; href: string; to?: never; external?: boolean };
+
+export interface ActionButtonProps {
+  action: CTAAction;
+  variant?: "primary" | "outline";
+  size?: ButtonSize;
+  glow?: boolean;
+  icon?: ReactNode;
+  iconRight?: ReactNode;
+  fullWidth?: boolean;
+}
+
+export function ActionButton({
+  action,
+  variant = "primary",
+  size = "xl",
+  glow,
+  icon,
+  iconRight,
+  fullWidth = false,
+}: ActionButtonProps) {
+  const isPrimary = variant === "primary";
+  const resolvedGlow = glow ?? (isPrimary ? true : undefined);
+  const resolvedIconRight =
+    iconRight !== undefined ? iconRight : isPrimary ? <ArrowRight /> : undefined;
+
+  const shared = {
+    variant,
+    size,
+    glow: resolvedGlow,
+    icon,
+    iconRight: resolvedIconRight,
+    fullWidth,
+    children: action.label,
+  };
+
+  if (action.to) {
+    return <Button as={Link} to={action.to} {...shared} />;
+  }
+
+  return (
+    <Button
+      as="a"
+      href={action.href}
+      {...shared}
+      {...(action.external && {
+        target: "_blank",
+        rel: "noopener noreferrer",
+      })}
+    />
+  );
+}
+
+export interface ActionButtonGroupProps {
+  primaryAction: CTAAction;
+  secondaryAction: CTAAction;
+  size?: ButtonSize;
+  className?: string;
+}
+
+export function ActionButtonGroup({
+  primaryAction,
+  secondaryAction,
+  size,
+  className,
+}: ActionButtonGroupProps) {
+  return (
+    <div
+      className={cn("flex flex-col sm:flex-row items-center justify-center gap-3", className)}
+    >
+      <ActionButton action={primaryAction} size={size} />
+      <ActionButton action={secondaryAction} variant="outline" size={size} />
+    </div>
+  );
+}

--- a/ui/apps/website/src/components/marketing/CTABanner.tsx
+++ b/ui/apps/website/src/components/marketing/CTABanner.tsx
@@ -1,15 +1,13 @@
-import { Link } from "react-router-dom";
-import { Button } from "@shellhub/design-system/primitives";
 import { Reveal, ConnectionGrid } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
-import { Section, SectionHeader } from "@/components/marketing";
-import type { SectionHeaderProps } from "@/components/marketing";
+import {
+  Section,
+  SectionHeader,
+  ActionButtonGroup,
+  type CTAAction,
+  type SectionHeaderProps,
+} from "@/components/marketing";
 
 type GradientColor = "primary" | "accent-cyan" | "accent-green" | "accent-blue";
-
-type CTAAction =
-  | { label: string; to: string; href?: never; external?: never }
-  | { label: string; href: string; to?: never; external?: boolean };
 
 const GRADIENT_FROM: Record<GradientColor, string> = {
   primary: "from-primary/[0.06]",
@@ -33,39 +31,6 @@ export interface CTABannerProps {
   secondaryAction: CTAAction;
   eyebrowColor?: SectionHeaderProps["eyebrowColor"];
   gradient?: { from: GradientColor; to: GradientColor };
-}
-
-function ActionButton({
-  action,
-  variant,
-}: {
-  action: CTAAction;
-  variant: "primary" | "outline";
-}) {
-  const isPrimary = variant === "primary";
-  const shared = {
-    variant,
-    size: "xl" as const,
-    glow: isPrimary || undefined,
-    iconRight: isPrimary ? <ArrowRight /> : undefined,
-    children: action.label,
-  };
-
-  if (action.to) {
-    return <Button as={Link} to={action.to} {...shared} />;
-  }
-
-  return (
-    <Button
-      as="a"
-      href={action.href}
-      {...shared}
-      {...(action.external && {
-        target: "_blank",
-        rel: "noopener noreferrer",
-      })}
-    />
-  );
 }
 
 export function CTABanner({
@@ -95,10 +60,10 @@ export function CTABanner({
               subtitle={subtitle}
             />
 
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <ActionButton action={primaryAction} variant="primary" />
-              <ActionButton action={secondaryAction} variant="outline" />
-            </div>
+            <ActionButtonGroup
+              primaryAction={primaryAction}
+              secondaryAction={secondaryAction}
+            />
           </div>
         </div>
       </Reveal>

--- a/ui/apps/website/src/components/marketing/__tests__/ActionButton.test.tsx
+++ b/ui/apps/website/src/components/marketing/__tests__/ActionButton.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ActionButton, ActionButtonGroup } from "@/components/marketing";
+
+function renderButton(
+  props?: Partial<React.ComponentProps<typeof ActionButton>>,
+) {
+  const defaults: React.ComponentProps<typeof ActionButton> = {
+    action: { label: "Get Started", to: "/getting-started" },
+    ...props,
+  };
+
+  return render(
+    <MemoryRouter>
+      <ActionButton {...defaults} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ActionButton", () => {
+  describe("routing", () => {
+    it("renders an internal link when action.to is set", () => {
+      renderButton({ action: { label: "Go", to: "/go" } });
+      const link = screen.getByRole("link", { name: "Go" });
+      expect(link).toHaveAttribute("href", "/go");
+      expect(link).not.toHaveAttribute("target");
+    });
+
+    it("renders an external link when action.href is set with external", () => {
+      renderButton({
+        action: {
+          label: "Docs",
+          href: "https://docs.shellhub.io",
+          external: true,
+        },
+      });
+      const link = screen.getByRole("link", { name: "Docs" });
+      expect(link).toHaveAttribute("href", "https://docs.shellhub.io");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+
+    it("renders an anchor link without target when href has no external flag", () => {
+      renderButton({
+        action: { label: "Arch", href: "#architecture" },
+      });
+      const link = screen.getByRole("link", { name: "Arch" });
+      expect(link).toHaveAttribute("href", "#architecture");
+      expect(link).not.toHaveAttribute("target");
+    });
+  });
+
+  describe("variant-driven defaults", () => {
+    it("primary variant applies glow and ArrowRight icon by default", () => {
+      const { container } = renderButton();
+      const link = screen.getByRole("link");
+      expect(link.className).toContain("shadow-primary/30");
+      expect(
+        container.querySelector("[aria-hidden='true']"),
+      ).toBeInTheDocument();
+    });
+
+    it("outline variant has no glow and no icon by default", () => {
+      const { container } = renderButton({ variant: "outline" });
+      const link = screen.getByRole("link");
+      expect(link.className).not.toContain("shadow-primary/30");
+      expect(
+        container.querySelector("[aria-hidden='true']"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("prop overrides", () => {
+    it("size defaults to xl", () => {
+      renderButton();
+      const link = screen.getByRole("link");
+      expect(link.className).toContain("py-3.5");
+    });
+
+    it("accepts a size prop", () => {
+      renderButton({ size: "md" });
+      const link = screen.getByRole("link");
+      expect(link.className).toContain("py-2");
+      expect(link.className).not.toContain("py-3.5");
+    });
+
+    it("glow can be explicitly disabled on primary", () => {
+      renderButton({ glow: false });
+      const link = screen.getByRole("link");
+      expect(link.className).not.toContain("shadow-primary/30");
+    });
+
+    it("iconRight can be overridden", () => {
+      renderButton({
+        iconRight: <span data-testid="custom-icon" />,
+      });
+      expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+    });
+
+    it("iconRight={null} suppresses the default arrow", () => {
+      const { container } = renderButton({
+        iconRight: null,
+      });
+      expect(
+        container.querySelector("[aria-hidden='true']"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("accepts a left icon prop", () => {
+      renderButton({
+        variant: "outline",
+        icon: <span data-testid="github-icon" />,
+      });
+      expect(screen.getByTestId("github-icon")).toBeInTheDocument();
+    });
+
+    it("accepts fullWidth prop", () => {
+      renderButton({ fullWidth: true });
+      const link = screen.getByRole("link");
+      expect(link).toHaveClass("w-full");
+    });
+  });
+});
+
+function renderGroup(
+  props?: Partial<React.ComponentProps<typeof ActionButtonGroup>>,
+) {
+  const defaults: React.ComponentProps<typeof ActionButtonGroup> = {
+    primaryAction: { label: "Get Started", to: "/getting-started" },
+    secondaryAction: { label: "View Pricing", to: "/pricing" },
+    ...props,
+  };
+
+  return render(
+    <MemoryRouter>
+      <ActionButtonGroup {...defaults} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ActionButtonGroup", () => {
+  it("renders both primary and secondary actions", () => {
+    renderGroup();
+    expect(
+      screen.getByRole("link", { name: "Get Started" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "View Pricing" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+  });
+
+  it("applies responsive flex layout", () => {
+    const { container } = renderGroup();
+    const wrapper = container.firstElementChild;
+    expect(wrapper).toHaveClass(
+      "flex",
+      "flex-col",
+      "sm:flex-row",
+      "items-center",
+      "justify-center",
+      "gap-3",
+    );
+  });
+
+  it("passes size to both buttons", () => {
+    renderGroup({
+      primaryAction: { label: "Start", to: "/start" },
+      secondaryAction: { label: "Pricing", to: "/pricing" },
+      size: "md",
+    });
+    const links = screen.getAllByRole("link");
+    for (const link of links) {
+      expect(link.className).toContain("py-2");
+    }
+  });
+});

--- a/ui/apps/website/src/components/marketing/index.ts
+++ b/ui/apps/website/src/components/marketing/index.ts
@@ -1,3 +1,9 @@
+export { ActionButton, ActionButtonGroup } from "./ActionButton";
+export type {
+  ActionButtonProps,
+  ActionButtonGroupProps,
+  CTAAction,
+} from "./ActionButton";
 export { Section } from "./Section";
 export type { SectionOwnProps, SectionProps } from "./Section";
 export { SectionHeader } from "./SectionHeader";

--- a/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
+++ b/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
@@ -1,7 +1,6 @@
-import { Link } from "react-router-dom";
-import { Badge, Button } from "@shellhub/design-system/primitives";
+import { Badge } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
+import { ActionButtonGroup } from "@/components/marketing";
 import { Reveal, ConnectionGrid } from "../landing/components";
 
 export function HeroEnterprise() {
@@ -31,21 +30,10 @@ export function HeroEnterprise() {
           </p>
         </Reveal>
         <Reveal>
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-            <Button
-              as={Link}
-              to="/pricing"
-              variant="primary"
-              size="xl"
-              glow
-              iconRight={<ArrowRight />}
-            >
-              Get a Quote
-            </Button>
-            <Button as={Link} to="/pricing" variant="outline" size="xl">
-              Compare Plans
-            </Button>
-          </div>
+          <ActionButtonGroup
+            primaryAction={{ label: "Get a Quote", to: "/pricing" }}
+            secondaryAction={{ label: "Compare Plans", to: "/pricing" }}
+          />
         </Reveal>
       </div>
     </section>

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -1,10 +1,4 @@
-import { Link } from "react-router-dom";
-import {
-  Badge,
-  Button,
-  Card,
-  WindowChrome,
-} from "@shellhub/design-system/primitives";
+import { Badge, Card, WindowChrome } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
 import {
   CheckIcon,
@@ -21,11 +15,24 @@ import {
   TagIcon,
   ChevronRightIcon,
 } from "@heroicons/react/24/outline";
-import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import {
+  ActionButtonGroup,
+  CTABanner,
+  HighlightCard,
+  InfoCard,
+  Section,
+  SectionHeader,
+  type CTAAction,
+} from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
+
+const primaryAction: CTAAction = {
+  label: "Get Started Free",
+  to: "/getting-started",
+};
+const secondaryAction: CTAAction = { label: "View Pricing", to: "/pricing" };
 
 /* ─── Typed line helper ────────────────────────────────────────── */
 function Line({
@@ -89,21 +96,10 @@ function Hero() {
           </p>
         </Reveal>
         <Reveal>
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-            <Button
-              as={Link}
-              to="/getting-started"
-              variant="primary"
-              size="xl"
-              glow
-              iconRight={<ArrowRight />}
-            >
-              Get Started Free
-            </Button>
-            <Button as={Link} to="/pricing" variant="outline" size="xl">
-              View Pricing
-            </Button>
-          </div>
+          <ActionButtonGroup
+            primaryAction={primaryAction}
+            secondaryAction={secondaryAction}
+          />
         </Reveal>
       </div>
     </section>
@@ -1286,8 +1282,8 @@ function FeaturesCTA() {
       eyebrow="Ready to get started?"
       title="Deploy ShellHub in minutes"
       subtitle="Open-source and free to start. Run a single command and manage your first device in under five minutes."
-      primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
-      secondaryAction={{ label: "View Pricing", to: "/pricing" }}
+      primaryAction={primaryAction}
+      secondaryAction={secondaryAction}
     />
   );
 }

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import {
   ArrowsPointingOutIcon,
   BoltIcon,
@@ -12,15 +11,20 @@ import {
 } from "@heroicons/react/24/outline";
 import {
   Badge,
-  Button,
   Card,
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import {
+  ActionButtonGroup,
+  CTABanner,
+  HighlightCard,
+  InfoCard,
+  Section,
+  SectionHeader,
+} from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
@@ -120,21 +124,16 @@ export default function HowItWorks() {
             </p>
           </Reveal>
           <Reveal>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as={Link}
-                to="/getting-started"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Get Started Free
-              </Button>
-              <Button as="a" href="#architecture" variant="outline" size="xl">
-                See the Architecture
-              </Button>
-            </div>
+            <ActionButtonGroup
+              primaryAction={{
+                label: "Get Started Free",
+                to: "/getting-started",
+              }}
+              secondaryAction={{
+                label: "See the Architecture",
+                href: "#architecture",
+              }}
+            />
           </Reveal>
         </div>
       </section>
@@ -1078,7 +1077,10 @@ export default function HowItWorks() {
           {/* ShellHub Side (highlighted) */}
           <Reveal delay={0}>
             <ShimmerCard className="h-full">
-              <HighlightCard color="primary" className="p-8 flex flex-col h-full">
+              <HighlightCard
+                color="primary"
+                className="p-8 flex flex-col h-full"
+              >
                 <div className="relative">
                   <div className="flex items-center gap-3 mb-6">
                     <IconBadge color="primary">

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import { cn } from "@shellhub/design-system/cn";
 import {
   ArrowDownIcon,
@@ -16,18 +15,34 @@ import {
 } from "@heroicons/react/24/outline";
 import {
   Badge,
-  Button,
   Card,
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import {
+  ActionButtonGroup,
+  CTABanner,
+  HighlightCard,
+  InfoCard,
+  Section,
+  SectionHeader,
+  type CTAAction,
+} from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
+
+const primaryAction: CTAAction = {
+  label: "Get Started Free",
+  to: "/getting-started",
+};
+const secondaryAction: CTAAction = {
+  label: "Read the Docs",
+  href: docsUrl,
+  external: true,
+};
 
 function Ln({
   color,
@@ -58,9 +73,24 @@ function Cyn({ children }: { children: React.ReactNode }) {
 }
 
 const sshFeatures = [
-  { icon: ArrowsRightLeftIcon, color: C.primary, title: "SSH as transport", desc: "Any tool that uses SSH for remote execution works with ShellHub out of the box. Ansible, rsync, scp, Git over SSH." },
-  { icon: ShieldCheckIcon, color: C.cyan, title: "No agent changes", desc: "The ShellHub agent runs independently on your devices. Install once and use it with every tool in your stack." },
-  { icon: CodeBracketIcon, color: C.green, title: "API-first design", desc: "Programmatic access to devices, sessions, and configurations. Build custom integrations with the REST API." },
+  {
+    icon: ArrowsRightLeftIcon,
+    color: C.primary,
+    title: "SSH as transport",
+    desc: "Any tool that uses SSH for remote execution works with ShellHub out of the box. Ansible, rsync, scp, Git over SSH.",
+  },
+  {
+    icon: ShieldCheckIcon,
+    color: C.cyan,
+    title: "No agent changes",
+    desc: "The ShellHub agent runs independently on your devices. Install once and use it with every tool in your stack.",
+  },
+  {
+    icon: CodeBracketIcon,
+    color: C.green,
+    title: "API-first design",
+    desc: "Programmatic access to devices, sessions, and configurations. Build custom integrations with the REST API.",
+  },
 ];
 
 export default function Integrations() {
@@ -93,28 +123,10 @@ export default function Integrations() {
             </p>
           </Reveal>
           <Reveal>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as="a"
-                href={docsUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Browse Docs
-              </Button>
-              <Button
-                as={Link}
-                to="/getting-started"
-                variant="outline"
-                size="xl"
-              >
-                Get Started Free
-              </Button>
-            </div>
+            <ActionButtonGroup
+              primaryAction={primaryAction}
+              secondaryAction={secondaryAction}
+            />
           </Reveal>
         </div>
       </section>
@@ -995,12 +1007,8 @@ export default function Integrations() {
         eyebrow="Ready to integrate?"
         title="Start integrating today"
         subtitle="Get ShellHub running and connect it to your existing workflow in minutes. Standard SSH means zero learning curve."
-        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
-        secondaryAction={{
-          label: "Read the Docs",
-          href: docsUrl,
-          external: true,
-        }}
+        primaryAction={primaryAction}
+        secondaryAction={secondaryAction}
         gradient={{ from: "accent-cyan", to: "primary" }}
       />
     </SiteLayout>

--- a/ui/apps/website/src/pages/landing/CTA.tsx
+++ b/ui/apps/website/src/pages/landing/CTA.tsx
@@ -1,7 +1,5 @@
-import { Button } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { Section } from "@/components/marketing";
-import { ArrowRight } from "@/components/ArrowRight";
+import { ActionButton, Section } from "@/components/marketing";
 import { Reveal, ConnectionGrid } from "./components";
 import { signupUrl } from "@/links";
 
@@ -26,18 +24,13 @@ export function CTA() {
           </p>
         </Reveal>
         <Reveal>
-          <Button
-            as="a"
-            href={signupUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            variant="primary"
-            size="xl"
-            glow
-            iconRight={<ArrowRight />}
-          >
-            Get Started Free
-          </Button>
+          <ActionButton
+            action={{
+              label: "Get Started Free",
+              href: signupUrl,
+              external: true,
+            }}
+          />
         </Reveal>
       </div>
     </Section>

--- a/ui/apps/website/src/pages/landing/Hero.tsx
+++ b/ui/apps/website/src/pages/landing/Hero.tsx
@@ -1,7 +1,6 @@
-import { Link } from "react-router-dom";
-import { Button, ShellHubCloudIcon } from "@shellhub/design-system/primitives";
+import { ShellHubCloudIcon } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
+import { ActionButton } from "@/components/marketing";
 import { ConnectionGrid } from "./components";
 
 export function Hero() {
@@ -46,16 +45,9 @@ export function Hero() {
           className="flex gap-3 flex-wrap justify-center animate-fade-in"
           style={{ animationDelay: "300ms" }}
         >
-          <Button
-            as={Link}
-            to="/getting-started"
-            variant="primary"
-            size="xl"
-            glow
-            iconRight={<ArrowRight />}
-          >
-            Get Started
-          </Button>
+          <ActionButton
+            action={{ label: "Get Started", to: "/getting-started" }}
+          />
         </div>
       </div>
     </section>

--- a/ui/apps/website/src/pages/landing/Navbar.tsx
+++ b/ui/apps/website/src/pages/landing/Navbar.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { cn } from "@shellhub/design-system/cn";
-import { Button, ShellHubLogo } from "@shellhub/design-system/primitives";
+import { ShellHubLogo } from "@shellhub/design-system/primitives";
+import { ActionButton } from "@/components/marketing";
 import {
   ChevronDownIcon,
   Bars3Icon,
@@ -410,28 +411,22 @@ export function Navbar({
             ))}
           </div>
 
-          {/* CTA */}
           <div className="hidden lg:flex items-center gap-2">
-            <Button
-              as="a"
-              href={loginUrl}
-              target="_blank"
-              rel="noopener noreferrer"
+            <ActionButton
+              action={{ label: "Log In", href: loginUrl, external: true }}
               variant="outline"
               size="md"
-            >
-              Log In
-            </Button>
-            <Button
-              as="a"
-              href={signupUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="primary"
+            />
+            <ActionButton
+              action={{
+                label: "Sign Up Free",
+                href: signupUrl,
+                external: true,
+              }}
               size="md"
-            >
-              Sign Up Free
-            </Button>
+              glow={false}
+              iconRight={null}
+            />
           </div>
         </div>
 
@@ -490,28 +485,23 @@ export function Navbar({
             className="pt-2 mt-1 flex flex-col gap-2"
             style={{ borderTop: `1px solid ${C.border}` }}
           >
-            <Button
-              as="a"
-              href={loginUrl}
-              target="_blank"
-              rel="noopener noreferrer"
+            <ActionButton
+              action={{ label: "Log In", href: loginUrl, external: true }}
               variant="outline"
               size="md"
               fullWidth
-            >
-              Log In
-            </Button>
-            <Button
-              as="a"
-              href={signupUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="primary"
+            />
+            <ActionButton
+              action={{
+                label: "Sign Up Free",
+                href: signupUrl,
+                external: true,
+              }}
               size="md"
+              glow={false}
               fullWidth
-            >
-              Sign Up Free
-            </Button>
+              iconRight={null}
+            />
           </div>
         </div>
       </nav>

--- a/ui/apps/website/src/pages/landing/OpenSource.tsx
+++ b/ui/apps/website/src/pages/landing/OpenSource.tsx
@@ -1,6 +1,6 @@
 import { StarIcon } from "@heroicons/react/24/solid";
-import { Button, GithubIcon } from "@shellhub/design-system/primitives";
-import { Section, SectionHeader } from "@/components/marketing";
+import { GithubIcon } from "@shellhub/design-system/primitives";
+import { ActionButton, Section, SectionHeader } from "@/components/marketing";
 import { Reveal } from "./components";
 import { C } from "./constants";
 import { githubUrl, signupUrl } from "@/links";
@@ -27,27 +27,26 @@ export function OpenSource() {
       </Reveal>
       <Reveal>
         <div className="flex gap-3 justify-center flex-wrap">
-          <Button
-            as="a"
-            href={githubUrl}
-            target="_blank"
-            rel="noopener noreferrer"
+          <ActionButton
+            action={{
+              label: "View on GitHub",
+              href: githubUrl,
+              external: true,
+            }}
             variant="outline"
             size="lg"
             icon={<GithubIcon width={16} height={16} />}
-          >
-            View on GitHub
-          </Button>
-          <Button
-            as="a"
-            href={signupUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            variant="primary"
+          />
+          <ActionButton
+            action={{
+              label: "Try Cloud Free",
+              href: signupUrl,
+              external: true,
+            }}
             size="lg"
-          >
-            Try Cloud Free
-          </Button>
+            glow={false}
+            iconRight={null}
+          />
         </div>
       </Reveal>
     </Section>

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import {
   CheckIcon,
   ComputerDesktopIcon,
@@ -11,20 +10,31 @@ import {
 } from "@heroicons/react/24/outline";
 import {
   Badge,
-  Button,
   Card,
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import {
+  ActionButtonGroup,
+  CTABanner,
+  HighlightCard,
+  InfoCard,
+  Section,
+  SectionHeader,
+  type CTAAction,
+} from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
 
-/* ═══════ Pain Points ═══════ */
+const primaryAction: CTAAction = {
+  label: "Get Started Free",
+  to: "/getting-started",
+};
+const secondaryAction: CTAAction = { label: "Compare Plans", to: "/pricing" };
+
 const painPoints = [
   {
     title: "docker exec isn't remote",
@@ -492,21 +502,10 @@ export default function ContainerManagement() {
             </p>
           </Reveal>
           <Reveal>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as={Link}
-                to="/getting-started"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Get Started Free
-              </Button>
-              <Button as={Link} to="/pricing" variant="outline" size="xl">
-                Compare Plans
-              </Button>
-            </div>
+            <ActionButtonGroup
+              primaryAction={primaryAction}
+              secondaryAction={secondaryAction}
+            />
           </Reveal>
         </div>
       </section>
@@ -590,7 +589,10 @@ export default function ContainerManagement() {
           {/* With ShellHub */}
           <Reveal delay={0.1}>
             <ShimmerCard className="h-full">
-              <HighlightCard color="primary" className="p-8 flex flex-col h-full">
+              <HighlightCard
+                color="primary"
+                className="p-8 flex flex-col h-full"
+              >
                 <div className="relative flex-1 flex flex-col">
                   <div className="flex items-center gap-3 mb-6">
                     <IconBadge color="primary">
@@ -875,8 +877,8 @@ export default function ContainerManagement() {
         eyebrow="Ready to simplify container access?"
         title="Manage your containers remotely"
         subtitle="Install the ShellHub agent and get instant SSH access to containers on any remote host. Free to start, no credit card required."
-        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
-        secondaryAction={{ label: "Compare Plans", to: "/pricing" }}
+        primaryAction={primaryAction}
+        secondaryAction={secondaryAction}
         eyebrowColor="cyan"
         gradient={{ from: "accent-cyan", to: "primary" }}
       />

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import {
   ArrowRightIcon,
   CheckIcon,
@@ -9,18 +8,30 @@ import {
   ShieldCheckIcon,
   TagIcon,
 } from "@heroicons/react/24/outline";
-import { Badge, Button, WindowChrome } from "@shellhub/design-system/primitives";
+import { Badge, WindowChrome } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import {
+  ActionButtonGroup,
+  CTABanner,
+  InfoCard,
+  Section,
+  SectionHeader,
+  type CTAAction,
+} from "@/components/marketing";
 import { docsUrl } from "@/links";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
 
-/* ------------------------------------------------------------------ */
-/*  Data                                                               */
-/* ------------------------------------------------------------------ */
+const primaryAction: CTAAction = {
+  label: "Get Started Free",
+  to: "/getting-started",
+};
+const secondaryAction: CTAAction = {
+  label: "Read the Docs",
+  href: docsUrl,
+  external: true,
+};
 
 const painPoints = [
   {
@@ -252,28 +263,10 @@ export default function DevopsCiCd() {
             </p>
           </Reveal>
           <Reveal>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as={Link}
-                to="/getting-started"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Get Started Free
-              </Button>
-              <Button
-                as="a"
-                href={docsUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                variant="outline"
-                size="xl"
-              >
-                Read the Docs
-              </Button>
-            </div>
+            <ActionButtonGroup
+              primaryAction={primaryAction}
+              secondaryAction={secondaryAction}
+            />
           </Reveal>
         </div>
       </section>
@@ -520,12 +513,8 @@ export default function DevopsCiCd() {
         eyebrow="Ready to automate?"
         title="Automate your device deployments today"
         subtitle="Connect ShellHub to your CI/CD pipeline and start deploying to remote devices in minutes -- no VPN, no static IPs, no hassle."
-        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
-        secondaryAction={{
-          label: "Read the Docs",
-          href: docsUrl,
-          external: true,
-        }}
+        primaryAction={primaryAction}
+        secondaryAction={secondaryAction}
       />
     </SiteLayout>
   );

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import {
   CommandLineIcon,
   ComputerDesktopIcon,
@@ -13,18 +12,29 @@ import {
 } from "@heroicons/react/24/outline";
 import {
   Badge,
-  Button,
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import {
+  ActionButtonGroup,
+  CTABanner,
+  HighlightCard,
+  InfoCard,
+  Section,
+  SectionHeader,
+  type CTAAction,
+} from "@/components/marketing";
 import { C } from "../landing/constants";
 
-/* ═══════ Pain-point data ═══════ */
+const primaryAction: CTAAction = {
+  label: "Get Started Free",
+  to: "/getting-started",
+};
+const secondaryAction: CTAAction = { label: "Compare Plans", to: "/pricing" };
+
 const painPoints = [
   {
     color: C.primary,
@@ -193,21 +203,10 @@ export default function EdgeComputing() {
             </p>
           </Reveal>
           <Reveal>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as={Link}
-                to="/getting-started"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Get Started Free
-              </Button>
-              <Button as={Link} to="/pricing" variant="outline" size="xl">
-                Compare Plans
-              </Button>
-            </div>
+            <ActionButtonGroup
+              primaryAction={primaryAction}
+              secondaryAction={secondaryAction}
+            />
           </Reveal>
         </div>
       </section>
@@ -560,10 +559,7 @@ export default function EdgeComputing() {
                   <span style={{ color: C.textMuted }}>:</span>
                   <span style={{ color: C.blue }}>~</span>
                   <span style={{ color: C.textMuted }}>$</span>{" "}
-                  <span
-                    className="animate-pulse"
-                    style={{ color: C.primary }}
-                  >
+                  <span className="animate-pulse" style={{ color: C.primary }}>
                     _
                   </span>
                 </div>
@@ -771,8 +767,8 @@ export default function EdgeComputing() {
         eyebrow="Ready to connect your edge?"
         title="Your edge servers, instantly accessible"
         subtitle="Install the lightweight agent on your edge servers and start managing them remotely in minutes — no infrastructure changes needed."
-        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
-        secondaryAction={{ label: "Compare Plans", to: "/pricing" }}
+        primaryAction={primaryAction}
+        secondaryAction={secondaryAction}
         gradient={{ from: "accent-blue", to: "primary" }}
       />
     </SiteLayout>

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import {
   BoltIcon,
   CheckIcon,
@@ -14,14 +13,19 @@ import {
 } from "@heroicons/react/24/outline";
 import {
   Badge,
-  Button,
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, HighlightCard, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import {
+  ActionButtonGroup,
+  CTABanner,
+  HighlightCard,
+  InfoCard,
+  Section,
+  SectionHeader,
+} from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
@@ -160,21 +164,13 @@ export default function IotEmbedded() {
             </p>
           </Reveal>
           <Reveal>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as={Link}
-                to="/getting-started"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Get Started Free
-              </Button>
-              <Button as={Link} to="/pricing" variant="outline" size="xl">
-                View Pricing
-              </Button>
-            </div>
+            <ActionButtonGroup
+              primaryAction={{
+                label: "Get Started Free",
+                to: "/getting-started",
+              }}
+              secondaryAction={{ label: "View Pricing", to: "/pricing" }}
+            />
           </Reveal>
         </div>
       </section>

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import { cn } from "@shellhub/design-system/cn";
 import {
   CheckIcon,
@@ -10,18 +9,25 @@ import {
   UsersIcon,
 } from "@heroicons/react/24/outline";
 import { PlayIcon } from "@heroicons/react/24/solid";
-import {
-  Badge,
-  Button,
-  Card,
-  WindowChrome,
-} from "@shellhub/design-system/primitives";
+import { Badge, Card, WindowChrome } from "@shellhub/design-system/primitives";
 import { GlowOrbs } from "@shellhub/design-system/components";
-import { ArrowRight } from "@/components/ArrowRight";
 import { SiteLayout } from "@/components/SiteLayout";
-import { CTABanner, InfoCard, Section, SectionHeader } from "@/components/marketing";
+import {
+  ActionButtonGroup,
+  CTABanner,
+  InfoCard,
+  Section,
+  SectionHeader,
+  type CTAAction,
+} from "@/components/marketing";
 import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
 import { C } from "../landing/constants";
+
+const primaryAction: CTAAction = {
+  label: "Get Started Free",
+  to: "/getting-started",
+};
+const secondaryAction: CTAAction = { label: "View Pricing", to: "/pricing" };
 
 /* ─── Pain-point cards ─────────────────────────────────────────────── */
 
@@ -185,21 +191,10 @@ export default function RemoteSupport() {
             </p>
           </Reveal>
           <Reveal>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button
-                as={Link}
-                to="/getting-started"
-                variant="primary"
-                size="xl"
-                glow
-                iconRight={<ArrowRight />}
-              >
-                Get Started Free
-              </Button>
-              <Button as={Link} to="/pricing" variant="outline" size="xl">
-                View Pricing
-              </Button>
-            </div>
+            <ActionButtonGroup
+              primaryAction={primaryAction}
+              secondaryAction={secondaryAction}
+            />
           </Reveal>
         </div>
       </section>
@@ -607,8 +602,8 @@ export default function RemoteSupport() {
         eyebrow="Ready to get started?"
         title="Secure support starts here"
         subtitle="Enable audited, accountable remote support for your team in minutes. No VPN required, no SSH keys to manage, no audit gaps."
-        primaryAction={{ label: "Get Started Free", to: "/getting-started" }}
-        secondaryAction={{ label: "View Pricing", to: "/pricing" }}
+        primaryAction={primaryAction}
+        secondaryAction={secondaryAction}
       />
     </SiteLayout>
   );


### PR DESCRIPTION
## What

Extracted `ActionButton` and `ActionButtonGroup` as shared marketing components, eliminating the duplicated CTA button pattern that was copy-pasted across 14 call sites in the website's hero and CTA sections.

## Why

Every hero section manually wired up the same 6-prop `Button` incantation (`as={Link}`, `variant="primary"`, `size="xl"`, `glow`, `iconRight={<ArrowRight />}`, routing logic). `CTABanner` already solved this internally with a private `ActionButton` helper, but it wasn't exported — so every other section duplicated the logic.

Closes shellhub-io/team#177

## Changes

- **`ActionButton`**: new polymorphic component that renders a CTA link with variant-driven defaults — primary gets glow + ArrowRight automatically, outline gets neither. Supports `size`, `glow`, `icon`/`iconRight`, and `fullWidth` overrides. Defaults to `variant="primary"` and `size="xl"`.
- **`ActionButtonGroup`**: renders a primary + secondary `ActionButton` pair in a responsive flex layout (`flex-col` → `flex-row` at `sm:`). Used by hero sections and `CTABanner`.
- **`CTABanner`**: dropped its private `ActionButton` function, now composes `ActionButtonGroup`.
- **14 call sites migrated**: 9 hero pairs, 2 solo primaries (landing Hero/CTA), 1 OpenSource pair (`size="lg"`, left GitHub icon), 2 navbar pairs (`size="md"`).
- **Action dedup**: 6 pages that repeated identical actions in both the hero and bottom `CTABanner` now share a single pair of constants.
- **Integrations hero**: swapped primary/secondary so "Get Started Free" is the primary action (matching the CTA banner), "Read the Docs" is secondary.

## Testing

- 15 new tests in `ActionButton.test.tsx` covering routing (internal link vs external anchor vs in-page anchor), variant-driven defaults (glow, ArrowRight), prop overrides (`size`, `glow={false}`, `iconRight={null}`, left `icon`, `fullWidth`), and `ActionButtonGroup` layout/size passthrough.
- Existing `CTABanner` tests (9) pass unchanged as a regression check.
- Full suite: 110 tests pass, build (`tsc -b` + Vite) clean, lint 0 errors.