### PR TITLE
docs(openapi): add spec for session-based MFA disable

### DIFF
--- a/openapi/spec/cloud-openapi.yaml
+++ b/openapi/spec/cloud-openapi.yaml
@@ -122,6 +122,8 @@ paths:
     $ref: paths/api@user@mfa@enable.yaml
   /api/user/mfa/disable:
     $ref: paths/api@user@mfa@disable.yaml
+  /api/user/mfa/recovery/disable:
+    $ref: paths/api@user@mfa@recovery@disable.yaml
   /api/user/mfa/reset/{user-id}:
     $ref: paths/api@user@mfa@reset@{user-id}.yaml
   /api/user:

--- a/openapi/spec/openapi.yaml
+++ b/openapi/spec/openapi.yaml
@@ -267,6 +267,8 @@ paths:
     $ref: paths/api@user@mfa@enable.yaml
   /api/user/mfa/disable:
     $ref: paths/api@user@mfa@disable.yaml
+  /api/user/mfa/recovery/disable:
+    $ref: paths/api@user@mfa@recovery@disable.yaml
   /api/user/mfa/reset/{user-id}:
     $ref: paths/api@user@mfa@reset@{user-id}.yaml
   /api/user:

--- a/openapi/spec/paths/api@user@mfa@disable.yaml
+++ b/openapi/spec/paths/api@user@mfa@disable.yaml
@@ -9,6 +9,10 @@ put:
 
     The recovery code used to regain access to the account can be used within a 10-minute window on this
     endpoint.
+
+    An empty payload is also accepted during the 10-minute recovery window established by
+    `mfaRecover`. In this case, the endpoint checks for a valid recovery session tied to
+    the authenticated user.
   tags:
     - cloud
     - mfa

--- a/openapi/spec/paths/api@user@mfa@recovery@disable.yaml
+++ b/openapi/spec/paths/api@user@mfa@recovery@disable.yaml
@@ -1,0 +1,27 @@
+put:
+  operationId: recoveryDisableMFA
+  summary: Disable MFA via recovery session
+  description: |
+    Disable MFA for the authenticated user during the 10-minute recovery window
+    established by `mfaRecover`. No request body is needed — the endpoint checks for a
+    valid, single-use recovery session tied to the user. If the session has expired or
+    was already consumed, the request is rejected.
+  tags:
+    - cloud
+    - mfa
+    - users
+  security:
+    - jwt: []
+  responses:
+    '200':
+      description: MFA successfully disabled.
+    '400':
+      $ref: ../components/responses/400.yaml
+    '401':
+      $ref: ../components/responses/401.yaml
+    '403':
+      $ref: ../components/responses/403.yaml
+    '404':
+      $ref: ../components/responses/404.yaml
+    '500':
+      $ref: ../components/responses/500.yaml


### PR DESCRIPTION
## What
OpenAPI spec additions for the session-based MFA disable feature implemented in the cloud repo.

## Why
Companion to shellhub-io/cloud#2434.

## Changes
- **New path spec** (`api@user@mfa@recovery@disable.yaml`): `PUT /api/user/mfa/recovery/disable` — `recoveryDisableMFA` operation, JWT-secured, no request body
- **Updated `disableMFA` description**: documents the empty-payload recovery-session bypass
- **Both `openapi.yaml` and `cloud-openapi.yaml`**: reference the new path