### PR TITLE
docs: update docs for device pairing model

### DIFF
--- a/ui/apps/docs/src/pages/agent/docker.mdx
+++ b/ui/apps/docs/src/pages/agent/docker.mdx
@@ -10,27 +10,27 @@ The default and recommended way to install the ShellHub agent. Requires Docker (
 
 ## Installation
 
-### From the dashboard
+### From the console
 
-The easiest method. In the ShellHub dashboard, click **Add Device** and copy the install script command:
+The easiest method. On the **Devices** page, click **Add Device** and copy the install command:
 
 ```bash
-$ curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | sh
 ```
 
 > **Note:** For self-hosted instances, replace `cloud.shellhub.io` with your server address.
 
-This downloads and runs the agent as a Docker container with automatic restart on reboot.
+This downloads and runs the agent as a Docker container with automatic restart on reboot. The agent prints a pairing code and a link — open the link in your browser to accept the device into your namespace.
 
-The script accepts optional URL parameters to override agent defaults:
+The script accepts optional environment variables to override agent defaults. Pass them before `sh`:
 
-- `keepalive_interval` — interval, in seconds, between keepalive messages
-- `preferred_hostname` — hostname to report instead of the value derived from the network interface MAC address
+- `PREFERRED_HOSTNAME` — hostname to report instead of the value derived from the network interface MAC address
+- `KEEPALIVE_INTERVAL` — interval, in seconds, between keepalive messages
 
 For example:
 
 ```bash
-$ curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID&preferred_hostname=my-device" | sh
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | PREFERRED_HOSTNAME=my-device sh
 ```
 
 ### Manual Docker run
@@ -84,7 +84,7 @@ Check agent logs:
 $ docker logs shellhub-agent
 ```
 
-The device should appear in the ShellHub dashboard with **Pending** status. Click **Accept** to approve it.
+If you used the codeless install, the agent prints a pairing link — open it to accept the device. If you used the manual Docker run with a `TENANT_ID`, the device is registered under the namespace's legacy install key and needs to be accepted from **Install Keys**.
 
 ## Supported architectures
 

--- a/ui/apps/docs/src/pages/agent/install-script.mdx
+++ b/ui/apps/docs/src/pages/agent/install-script.mdx
@@ -11,27 +11,27 @@ The ShellHub server provides an install script at `/install.sh` that auto-detect
 ## Usage
 
 ```bash
-$ curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | sh
 ```
 
 For self-hosted instances, replace the URL with your server address:
 
 ```bash
-$ curl -sSf "https://your-server.example.com/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://your-server.example.com/install.sh" | sh
 ```
 
-The `TENANT_ID` and `SERVER_ADDRESS` are passed as inline environment variables to `sh`. The server serves the script as a static file — it does not inject values into the script content.
+The server injects `SERVER_ADDRESS` into the script from the request host, so the command is the same for every user on an instance. Optional variables like `TENANT_ID` or `PREFERRED_HOSTNAME` are passed as inline environment variables before `sh`.
 
 ## What happens when you run it
 
 The script follows this sequence:
 
 1. **Checks for FreeBSD** — exits early with a link to the [FreeBSD guide](/agent/freebsd) (not supported by the script)
-2. **Validates** that `TENANT_ID` is set (exits if missing)
-3. **Detects architecture** from `uname -m`
-4. **Queries the server** at `/info` to determine the agent version to install
-5. **Probes for install methods** in priority order (see below)
-6. **Installs and starts** the agent using the selected method
+2. **Detects architecture** from `uname -m`
+3. **Queries the server** at `/info` to determine the agent version to install
+4. **Probes for install methods** in priority order (see below)
+5. **Installs and starts** the agent using the selected method
+6. **Runs the enrollment flow** — for Docker, Podman, and Standalone without a `TENANT_ID`, the agent boots tenant-less and prints a pairing code and link; open the link to accept the device into a namespace. Snap requires `TENANT_ID`.
 
 ## Detection order
 
@@ -51,7 +51,7 @@ If neither Docker nor Podman is found, the script prints a warning recommending 
 You can skip auto-detection by setting `INSTALL_METHOD` explicitly:
 
 ```bash
-$ INSTALL_METHOD=standalone curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | INSTALL_METHOD=standalone sh
 ```
 
 ## What each method does
@@ -143,7 +143,9 @@ Override any of these before running the script:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TENANT_ID` | *(required)* | Namespace tenant ID |
+| `TENANT_ID` | *(none)* | Namespace tenant ID. Required for Snap; optional for Docker, Podman, and Standalone (omit for codeless pairing) |
+| `CODE` | *(none)* | Pre-authorized pairing code (Docker/Podman only). The device is accepted automatically when it connects |
+| `INSTALL_KEY` | *(none)* | Reusable install key for fleet provisioning (Docker/Podman only). The key's mode determines whether the device is auto-accepted or left pending |
 | `SERVER_ADDRESS` | `https://cloud.shellhub.io` | ShellHub server URL |
 | `INSTALL_METHOD` | auto-detected | Force a method: `docker`, `podman`, `snap`, `wsl`, `standalone` |
 | `AGENT_VERSION` | from server `/info` | Pin a specific agent version |
@@ -158,8 +160,8 @@ Override any of these before running the script:
 Example — force standalone install with a custom hostname:
 
 ```bash
-$ INSTALL_METHOD=standalone PREFERRED_HOSTNAME=edge-gateway-01 \
-    curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | \
+    INSTALL_METHOD=standalone PREFERRED_HOSTNAME=edge-gateway-01 sh
 ```
 
 ## Supported architectures
@@ -178,7 +180,7 @@ The script auto-detects the CPU architecture from `uname -m`:
 The script can install the agent in connector mode, which registers Docker containers running on the host as individual ShellHub devices:
 
 ```bash
-$ curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh -s -- connector
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | TENANT_ID=YOUR_TENANT_ID sh -s -- connector
 ```
 
 In connector mode:
@@ -192,8 +194,8 @@ In connector mode:
 You can filter which containers are managed with `CONNECTOR_LABEL`:
 
 ```bash
-$ CONNECTOR_LABEL=shellhub.io/managed \
-    curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh -s -- connector
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | \
+    TENANT_ID=YOUR_TENANT_ID CONNECTOR_LABEL=shellhub.io/managed sh -s -- connector
 ```
 
 Only containers with that Docker label are registered as devices.
@@ -202,11 +204,16 @@ Only containers with that Docker label are registered as devices.
 
 ## After installation
 
-Once the agent starts, the device registers with the server but is **not** connectable yet — it appears in the dashboard with a **Pending** status. You must accept it before it can be used: open the [Devices](/guides/devices) view and accept the pending device. After it is accepted, the device shows as **Online** and is ready for SSH sessions.
+What happens next depends on how the agent was installed:
+
+- **Codeless (no `TENANT_ID`)** — the agent prints a pairing code and an accept link. Open the link in your browser to accept the device into your namespace. Once accepted, the device shows as **Online** and is ready for SSH sessions.
+- **With `CODE`** — the device is accepted automatically when it connects. No manual step needed.
+- **With `INSTALL_KEY`** — the outcome depends on the key's mode (automatic, manual, webhook, or allowlist). See [Install Keys](/guides/devices) for details.
+- **With `TENANT_ID` only** — the device is registered under the namespace's legacy install key with **Pending** status. Go to **Install Keys**, open the key's activity, and accept it there.
 
 ## Next steps
 
 - [Agent Overview](/agent/overview) — How the agent works and full configuration reference
-- [Devices](/guides/devices) — Accept the pending device and manage your fleet
+- [Devices](/guides/devices) — Manage your fleet
 - [Docker](/agent/docker) — Manual Docker installation and advanced options
 - [Connecting](/guides/connecting) — Connect to your device after installation

--- a/ui/apps/docs/src/pages/agent/wsl.mdx
+++ b/ui/apps/docs/src/pages/agent/wsl.mdx
@@ -49,23 +49,17 @@ wsl --shutdown
 
 ## Installation
 
-Once systemd and mirrored networking are configured, install the agent using the standard Docker method:
+Once systemd and mirrored networking are configured, install the agent:
 
 ```bash
-$ curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | sh
 ```
 
-> **Note:** For self-hosted instances, replace `cloud.shellhub.io` with your server address.
-
-This requires Docker installed inside WSL. If you don't have Docker in WSL, install it first:
-
-```bash
-$ curl -fsSL https://get.docker.com | sh
-```
+> **Note:** For self-hosted instances, replace `cloud.shellhub.io` with your server address. The WSL install method uses a standalone systemd service, even if Docker is available inside WSL.
 
 ## Verifying
 
-After installation, the device appears in the ShellHub dashboard with **Pending** status. Click **Accept** to approve it.
+After installation, the agent prints a pairing code and an accept link. Open the link in your browser to accept the device into your namespace.
 
 The device hostname in the dashboard matches your WSL distribution's hostname.
 
@@ -73,7 +67,7 @@ The device hostname in the dashboard matches your WSL distribution's hostname.
 
 - **Agent fails to connect** — Confirm mirrored networking is active: run `wsl --version` and check that `networkingMode` is set. If you're on Windows 10 or an older Windows 11 build, mirrored mode is not available.
 - **systemd not working** — After editing `/etc/wsl.conf`, you must fully restart WSL with `wsl --shutdown`. Verify with `systemctl --no-pager` inside WSL — if it errors, systemd is not active.
-- **Docker not starting** — If using Docker CE inside WSL (not Docker Desktop), make sure the Docker daemon is running: `sudo service docker start`. Docker Desktop's WSL integration works differently and may conflict with the agent's `--net host` flag.
+- **Service not starting** — Check the agent service status with `systemctl status shellhub-agent` and logs with `journalctl -u shellhub-agent -f`.
 
 ## Next steps
 

--- a/ui/apps/docs/src/pages/embedded-linux/raspberry-pi.mdx
+++ b/ui/apps/docs/src/pages/embedded-linux/raspberry-pi.mdx
@@ -19,22 +19,20 @@ Install the ShellHub agent on a Raspberry Pi running Raspberry Pi OS (Debian-bas
 SSH into your Pi (or open a terminal) and run:
 
 ```bash
-$ curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | sh
 ```
 
-Replace `YOUR_TENANT_ID` with your namespace's tenant ID. You can also copy this command with the tenant ID already filled in from **Add Device** in the dashboard.
-
-The script auto-detects your Pi's architecture (`armv7l`/`aarch64`) and the best install method available. On a stock Raspberry Pi OS it installs the agent as a systemd service (`shellhub-agent`) that starts on boot and restarts on failure; if Docker or Podman is already present, it uses that instead. You don't need to pick a method or write a `docker run` command by hand.
+The script auto-detects your Pi's architecture (`armv7l`/`aarch64`) and the best install method available. If Docker or Podman is present, it runs the agent as a container; otherwise it installs a native binary as a systemd service (`shellhub-agent`) that starts on boot and restarts on failure.
 
 For self-hosted ShellHub, replace the URL with your server address:
 
 ```bash
-$ curl -sSf "https://your-server.example.com/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://your-server.example.com/install.sh" | sh
 ```
 
 ## Accept the device
 
-Once the agent is running, the Pi appears as **Pending** on the Devices page in the dashboard. Accept it to start connecting.
+After starting, the agent prints a pairing code and an accept link. Open the link in your browser to accept the Pi into your namespace.
 
 ## Connecting to your Pi
 

--- a/ui/apps/docs/src/pages/getting-started/quick-start.mdx
+++ b/ui/apps/docs/src/pages/getting-started/quick-start.mdx
@@ -11,7 +11,7 @@ This guide gets you from zero to your first SSH session through ShellHub. Pick y
 - **[ShellHub Cloud](#shellhub-cloud)** — Fastest way. No server setup, start in 2 minutes.
 - **[Self-Hosted](#self-hosted)** — Run ShellHub on your own infrastructure with Docker Compose.
 
-Both paths end the same way: installing the agent on a device, accepting it, and connecting via SSH.
+Both paths end the same way: installing the agent on a device, accepting it into your namespace, and connecting via SSH.
 
 ---
 
@@ -29,29 +29,39 @@ Once your namespace is ready, you land on the **dashboard**: an overview of your
 
 ### 2. Install the agent
 
-In the dashboard, click **Add Device**. You'll get the install script command:
+When your namespace has no devices yet, a **welcome dialog** appears with the install command and a copy button. You can also find it on the **Devices** page by clicking **Add Device**.
+
+For Docker or Podman (the default), run this on the device you want to manage:
 
 ```bash
-$ curl -sSf "https://cloud.shellhub.io/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ curl -sSf "https://cloud.shellhub.io/install.sh" | sh
 ```
 
-Run this on any Linux device you want to manage. The agent installs as a Docker container and connects to ShellHub automatically.
+The agent installs as a Docker container, connects to ShellHub, and prints a pairing code you'll use in the next step.
 
-> **Tip:** The agent needs Docker or Podman on the device. For other installation methods (Snap, FreeBSD, Buildroot, Yocto), see [Agent](/agent/overview).
-
-![ShellHub Add Device page showing the installation method chooser and the one-line install command](/img/devices/device-add.gif)
+> **Tip:** This command works with Docker, Podman, or Standalone. Snap requires a Tenant ID — pass `TENANT_ID=YOUR_TENANT_ID` before `sh`. For all installation methods, see [Agent](/agent/overview).
 
 ### 3. Accept the device
 
-Open the **Devices** page from the left nav. Your new device appears with **Pending** status, listed with its hostname, SSHID, and operating system. Click **Accept** to approve it — its status moves to **Online** and it's ready to connect.
+After starting, the agent prints a pairing code and an accept link in the terminal:
 
-![ShellHub Devices page on the Pending tab where new devices await acceptance](/img/devices/device-pending.gif)
+```
+To accept this device, open the ShellHub console and enter this code:
+
+      WXYZ-2K7Q
+
+Enter it at https://cloud.shellhub.io/accept-device, or open the link:
+
+  https://cloud.shellhub.io/accept-device?code=WXYZ2K7Q
+```
+
+Open the link in your browser (or enter the code at the URL above) to accept the device into your namespace. Once accepted, the device shows **Online** on the **Devices** page and is ready to connect.
 
 For everything you can do from here — searching, tagging, renaming, and removing devices — see [Devices](/guides/devices).
 
 ### 4. Connect
 
-Click the terminal icon next to the device to open a web SSH session. Enter the device username and password — you're in.
+Click the green **Connect** button next to any online device on the **Devices** page to open a web SSH session. Enter the device username and password — you're in.
 
 ![Device connecting](/img/devices/device-connect.gif)
 
@@ -61,9 +71,9 @@ To connect with your own SSH client:
 $ ssh username@namespace.hostname@cloud.shellhub.io
 ```
 
-Replace `username` with the device user, `hostname` with the device name shown in the dashboard, and `namespace` with your namespace name.
+Replace `username` with the device user, `hostname` with the device name shown in the **Devices** page, and `namespace` with your namespace name.
 
-You should see the device's shell prompt. If you get a connection error, check that the device status shows **Online** in the dashboard.
+You should see the device's shell prompt. If you get a connection error, check that the device status shows **Online** on the **Devices** page.
 
 **Done.** You now have remote SSH access to your device through ShellHub. For web terminal, SSH client, and GUI tool options, see [Connecting to Devices](/guides/connecting).
 
@@ -111,29 +121,38 @@ $ ./bin/setup
 
 Open the generated URL in your browser. Create your admin account and choose a namespace name.
 
-### 5. Install the agent
-
-In the dashboard, click **Add Device** and copy the install command:
+Alternatively, create the account and namespace from the command line:
 
 ```bash
-$ curl -sSf "http://YOUR_SERVER/install.sh?tenant_id=YOUR_TENANT_ID" | sh
+$ ./bin/cli user create <username> <password> <email>
+$ ./bin/cli namespace create <namespace> <username>
 ```
 
-Run this on the Linux device you want to manage. Replace `YOUR_SERVER` with your ShellHub server's address.
+The first user is automatically an admin. See [Administration](/self-hosted/administration) for the full CLI reference.
+
+### 5. Install the agent
+
+On the **Devices** page, click **Add Device** to get the install command. For Docker or Podman (the default):
+
+```bash
+$ curl -sSf "http://YOUR_SERVER/install.sh" | sh
+```
+
+Replace `YOUR_SERVER` with your ShellHub server's address. The agent installs as a Docker container, connects to your server, and prints a pairing code.
 
 ### 6. Accept the device
 
-The device appears with **Pending** status in the dashboard. Click **Accept**.
+The agent prints a pairing code and an accept link in the terminal. Open the link in your browser to accept the device into your namespace.
 
 ### 7. Connect
 
-Click the terminal icon to open a web session, or use your SSH client:
+Click the green **Connect** button next to the device on the **Devices** page to open a web session, or use your SSH client:
 
 ```bash
 $ ssh username@namespace.hostname@your-server.com
 ```
 
-You should see the device's shell prompt. If you get a connection error, check that the device status shows **Online** in the dashboard.
+You should see the device's shell prompt. If you get a connection error, check that the device status shows **Online** on the **Devices** page.
 
 **Done.** Your self-hosted ShellHub instance is running and your first device is connected.
 


### PR DESCRIPTION
## What

Updated the Getting Started chapter and related agent docs to match the browser-based device enrollment model that landed in #6482.

## Why

Several docs pages still described the pre-enrollment flow: a `?tenant_id=` install command, the Pending tab for manual device acceptance, and a "terminal icon" to connect. Since #6482 the default path for container methods is a codeless install where the agent boots tenant-less, prints a pairing code and link, and the user accepts via the browser — no Pending tab involved.

Part of shellhub-io/team#168 — GS-5, GS-6, GS-7, GS-8, GS-10, GS-11

## Changes

### Quick Start (`quick-start.mdx`)

- **Install command (Cloud + Self-Hosted)**: `curl … /install.sh?tenant_id=YOUR_TENANT_ID` → `curl … /install.sh` (codeless). Snap is called out as the exception that still requires `TENANT_ID=`.
- **Accept flow (Cloud + Self-Hosted)**: replaced the Pending→Accept description with the pairing flow — the agent prints a code and an `/accept-device?code=…` link, the user opens it to accept. Included the exact terminal output so the reader knows what to expect.
- **Welcome Wizard (GS-8)**: mentioned the dialog that auto-appears for new namespaces with the install command and copy button.
- **CLI setup alternative (GS-10)**: added `./bin/cli user create` + `namespace create` as a headless alternative to the browser setup in Self-Hosted step 4, with a note that the first user is auto-admin.
- **Connect step**: "Click the terminal icon" → "Click the green **Connect** button" in both sections.
- **Add Device location**: "In the dashboard" → "On the **Devices** page" throughout.
- Removed outdated `device-add.gif` and `device-pending.gif` references.

### Docker agent (`docker.mdx`)

- Install command switched to codeless format.
- Optional parameters changed from `?query_param=` URL format to `PREFERRED_HOSTNAME=` env-var format.
- "From the dashboard" heading → "From the console".
- Verifying section updated: pairing-based acceptance instead of Pending→Accept.

### Raspberry Pi (`raspberry-pi.mdx`)

- Install command switched to codeless format (both Cloud and self-hosted examples).
- Accept section rewritten for pairing flow instead of Pending tab.
- Dropped the `YOUR_TENANT_ID` placeholder and the "copy from Add Device in the dashboard" reference.