### PR TITLE
docs: expand CVD policy and add incident response runbook

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,35 +1,90 @@
 # Security Policy
 
-Security is a serious matter for us. We want to ensure and maintain a
-secure environment for our customers and the open-source community.
+ShellHub takes security seriously. We are committed to coordinated vulnerability disclosure (CVD) as required by the [EU Cyber Resilience Act (CRA)][cra] and aligned with [ISO/IEC 29147][iso-29147].
+
+## Scope
+
+This policy covers all components of ShellHub, including but not limited to:
+
+- ShellHub Server (API, SSH gateway, WebSocket proxy)
+- ShellHub Agent
+- ShellHub CLI
+- ShellHub UI
+- Official container images published under `shellhubio/`
+- ShellHub Cloud (the hosted offering)
+
+Out of scope: third-party dependencies (report those upstream), social engineering, denial-of-service against production infrastructure, and findings from automated scanners without a demonstrated impact.
 
 ## Reporting a Vulnerability
 
-We are eager to work with the community to resolve security vulnerabilities
-within our tech stack in a timely manner and to properly acknowledge the
-contributor(s). Please do not publicly disclose a vulnerability until we have
-an opportunity to review and address the issue. Follow these steps to report a
-vulneratbility:
+Do not publicly disclose a vulnerability until we have released a fix and published an advisory. To report:
 
-1. [Open a security advisory][help-security-advisory], which is visible to
-   project maintainers only. Please do *not* submit a normal issue or pull
-   request in our public repositories.
-2. We will confirm the receipt of the report within two business days. (It make
-   take additional time time to resolve the issue.)
-3. If you already have a patch, we will review it and approve it privately;
-   once merged it will be publicly disclosed. We will acknowledge you in our
-   changelog.
-4. In case we need additional information during the investigation, we will be
-   actively reaching out.
+1. **Preferred:** [open a GitHub Security Advisory][new-advisory], visible to project maintainers only. Do *not* submit a normal issue or pull request.
+2. **Alternative:** email [security@shellhub.io][security-mail] with a description of the vulnerability, steps to reproduce, and any supporting material (PoC, logs, screenshots).
+We will confirm receipt within **2 business days**.
 
-Please do not publicly mention the security issue until after we have updated
-the public repository so that other downstream users have an opportunity to
-patch their software.
+## Response Timelines
+
+After triage and severity assessment (using [CVSS v3.1][cvss] or later), we target the following timelines from confirmation to patch release:
+
+| Severity | CVSS Score | Patch Target |
+|----------|------------|--------------|
+| Critical | 9.0–10.0   | 48 hours     |
+| High     | 7.0–8.9    | 30 days      |
+| Medium   | 4.0–6.9    | 90 days      |
+| Low      | 0.1–3.9    | Next release |
+
+These are targets, not guarantees. Complex issues may take longer; if so, we will communicate an updated timeline to the reporter.
+
+## CVE Assignment
+
+We assign a CVE identifier for every confirmed vulnerability. CVEs are requested through [GitHub as a CNA][github-cna], which issues them as part of the Security Advisory workflow. The CVE will be included in the published advisory.
+
+## Security Advisories
+
+All confirmed vulnerabilities are published as [GitHub Security Advisories][advisories] once a fix is available. Each advisory includes:
+
+- A description of the vulnerability and its impact
+- Affected versions
+- The CVE identifier
+- Remediation steps (fixed version, workarounds if any)
+
+Users can subscribe to advisory notifications via GitHub's *Watch* menu on the repository.
+
+## ENISA Notification
+
+For actively exploited vulnerabilities, we will notify the designated [ENISA][enisa] single reporting platform within **24 hours** of becoming aware of active exploitation, provide a full vulnerability notification within **72 hours**, and submit a final report within **14 days**, as required by CRA Article 14.
+
+Our internal incident response process is documented in [SECURITY_INCIDENT_RESPONSE.md][incident-response].
+
+## Researcher Acknowledgment
+
+We value the work of security researchers. Unless the reporter requests anonymity, we will:
+
+- Credit the reporter by name (or handle) in the published advisory
+- Acknowledge the contribution in the release changelog
+
+## Safe Harbor
+
+We consider security research conducted in accordance with this policy to be authorized and will not pursue legal action against researchers who:
+
+- Act in good faith and follow this disclosure policy
+- Avoid privacy violations, data destruction, and service disruption
+- Do not access or modify data belonging to other users
+- Report findings promptly and do not exploit them beyond what is necessary to demonstrate the issue
 
 ## Contact
 
-If you have any questions, please contact us directly at
-[contato@ossystems.com.br][security-mail].
+- **Security reports:** [security@shellhub.io][security-mail]
+- **General questions:** [contact@shellhub.io][general-mail]
 
-[security-mail]: mailto://contato@ossystems.com.br
-[help-security-advisory]: https://help.github.com/en/articles/creating-a-maintainer-security-advisory
+[cra]: https://eur-lex.europa.eu/eli/reg/2024/2847
+[iso-29147]: https://www.iso.org/standard/72311.html
+[new-advisory]: https://github.com/shellhub-io/shellhub/security/advisories/new
+[security-mail]: mailto:security@shellhub.io
+[general-mail]: mailto:contact@shellhub.io
+[cvss]: https://www.first.org/cvss/v3.1/specification-document
+[github-cna]: https://docs.github.com/en/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database
+[advisories]: https://github.com/shellhub-io/shellhub/security/advisories
+[enisa]: https://www.enisa.europa.eu/
+[incident-response]: SECURITY_INCIDENT_RESPONSE.md

--- a/SECURITY_INCIDENT_RESPONSE.md
+++ b/SECURITY_INCIDENT_RESPONSE.md
@@ -1,0 +1,66 @@
+# Security Incident Response
+
+This document describes ShellHub's internal process for handling security vulnerabilities, aligned with [CRA Article 14][cra] reporting obligations to [ENISA][enisa].
+
+## Workflow
+
+### 1. Report Received
+
+- Acknowledge receipt to the reporter within **2 business days**
+- Open a private GitHub Security Advisory draft
+- Assign a Triage Lead
+
+### 2. Triage and Severity Assessment
+
+- Reproduce the vulnerability
+- Assess severity using [CVSS v3.1][cvss] (or later)
+- Determine whether the vulnerability is actively exploited
+
+If **not** actively exploited, proceed to step 4.
+
+If **actively exploited**, proceed to step 3 immediately.
+
+### 3. ENISA Reporting (Actively Exploited Only)
+
+CRA Article 14 requires three reports to ENISA via the [single reporting platform][enisa-srp]:
+
+| Deadline | Report | Contents |
+|----------|--------|----------|
+| **24 hours** | Early warning | That the vulnerability exists, whether it is actively exploited, and whether it affects other products |
+| **72 hours** | Vulnerability notification | Severity assessment, impact analysis, affected versions, remediation status, and any indicators of compromise |
+| **14 days** | Final report | Root cause analysis, fix details, scope of exploitation (if known), and lessons learned |
+
+All deadlines are counted from the moment the team becomes aware of active exploitation.
+
+### 4. Patch Development
+
+Develop a fix following the patch SLA defined in [SECURITY.md](SECURITY.md):
+
+| Severity | Patch Target |
+|----------|-------------|
+| Critical (9.0–10.0) | 48 hours |
+| High (7.0–8.9) | 30 days |
+| Medium (4.0–6.9) | 90 days |
+| Low (0.1–3.9) | Next release |
+
+- Develop and review the patch in a private fork or branch
+- If the reporter provided a fix, review and integrate it
+
+### 5. Advisory and Release
+
+- Assign a CVE via GitHub's CNA integration
+- Publish the GitHub Security Advisory with: description, affected versions, CVE, fixed version, and workarounds (if any)
+- Release the patched version
+- Credit the reporter (unless they request anonymity)
+- Update the changelog
+
+### 6. Post-Incident
+
+- Notify downstream users and integrators
+- Conduct an internal retrospective for Critical and High severity incidents
+- Update this process if gaps were identified
+
+[cra]: https://eur-lex.europa.eu/eli/reg/2024/2847
+[enisa]: https://www.enisa.europa.eu/
+[enisa-srp]: https://www.enisa.europa.eu/topics/vulnerability-reporting
+[cvss]: https://www.first.org/cvss/v3.1/specification-document


### PR DESCRIPTION
## What

Rewrote `SECURITY.md` to meet CRA coordinated vulnerability disclosure requirements and added `SECURITY_INCIDENT_RESPONSE.md` with the step-by-step workflow for handling actively exploited vulnerabilities.

## Why

The existing `SECURITY.md` covered basic disclosure via GitHub private advisories but lacked patch SLAs, a CVE assignment process, ENISA reporting obligations, safe harbor, and a defined scope — all required by CRA Phase 1 (before September 2026).

Closes shellhub-io/team#101
Closes shellhub-io/team#98

## Changes

- **`SECURITY.md`**: full rewrite — added scope definition, severity-based patch SLAs (Critical 48h through Low next-release), CVE assignment via GitHub CNA, ENISA 24h/72h/14d notification section, researcher acknowledgment, safe harbor clause, and dedicated `security@shellhub.io` contact
- **`SECURITY_INCIDENT_RESPONSE.md`**: new runbook covering report intake → triage → ENISA three-stage reporting → patch development → advisory publication → post-incident retrospective

## Remaining work (outside this PR)

- ~~`security@shellhub.io` mailbox needs to be created~~ — Done
- ENISA single reporting platform registration (when available)