### PR TITLE
fix(ci): harden GitHub Actions flagged by Semgrep

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -38,12 +38,12 @@ jobs:
 
       - name: Set image tag
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "IMAGE_TAG=${{ env.RELEASE_VERSION }},latest" >> $GITHUB_ENV
-            echo "BUILD_ARGS=--build-arg SHELLHUB_VERSION=${{ env.RELEASE_VERSION }}" >> $GITHUB_ENV
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "IMAGE_TAG=${RELEASE_VERSION},latest" >> "$GITHUB_ENV"
+            echo "BUILD_ARGS=--build-arg SHELLHUB_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"
           else
-            echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
-            echo "BUILD_ARGS=" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${GITHUB_SHA}" >> "$GITHUB_ENV"
+            echo "BUILD_ARGS=" >> "$GITHUB_ENV"
           fi
 
       # Build amd64 only and load it into the local Docker daemon so Trivy can

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -7,10 +7,20 @@ on:
       - '**/go.mod'
       - '**/go.sum'
 
+# pull_request_target runs with repository secrets, and the job below checks out
+# and operates on the PR branch. That is only safe because the job is gated to
+# runs authored by dependabot itself (user.login == 'dependabot[bot]', which a
+# fork PR cannot spoof); the private-module `go mod tidy` needs secrets.PAT in
+# the same context as the branch, so the untrusted-context split does not apply.
+# Do not relax the guard below. GITHUB_TOKEN is read-only here — the push
+# authenticates with secrets.PAT, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   go-mod-tidy:
     name: Update Go modules
-    if: contains(github.head_ref, 'dependabot/go_modules/') && github.event.pull_request.user.login == 'dependabot[bot]'
+    if: startsWith(github.head_ref, 'dependabot/go_modules/') && github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What

Fixes the two ERROR-severity GitHub Actions security findings surfaced by
the new Semgrep workflow's full scan on `master`.

### `build-agent.yml` — shell injection (`run-shell-injection`)

The *Set image tag* step interpolated `${{ github.ref }}` and `${{ github.sha }}`
directly into a `run:` script. Semgrep treats `github` context data in a `run:`
block as an injection sink. Switched to the runner's built-in `$GITHUB_REF` /
`$GITHUB_SHA` environment variables (and the already-exported `$RELEASE_VERSION`),
so no context value is expanded into the script text. **Verified gone** by
re-running the Semgrep scan locally (128 → 127 findings).

### `dependabot_pr.yml` — `pull_request_target` code checkout

This workflow legitimately needs `pull_request_target`: it runs `go mod tidy`
across modules (including the private `cloud` module, which needs `secrets.PAT`)
and pushes the result back to the dependabot branch — so the "untrusted context
split" doesn't apply, since the tidy itself requires the secret alongside the
branch. Its security rests entirely on the actor guard, which a fork PR cannot
spoof. Hardened as defense-in-depth:

- Documented why the pattern is safe so a future edit doesn't weaken the guard.
- Tightened the branch guard `contains(...)` → `startsWith(...)`.
- Added an explicit least-privilege `permissions: contents: read` (the push
  authenticates with `secrets.PAT`, not `GITHUB_TOKEN`).

The Semgrep pattern still matches here because the PR-branch checkout is
required; the finding is an accepted, now-documented true positive.

## Scope

This PR intentionally covers only the two genuinely-exploitable findings. The
remaining Semgrep findings (Dockerfile `missing-user` hardening + audit-level
warnings) are out of scope and will keep the full-scan check red until triaged
separately.