### PR TITLE
ci: sign container images with cosign keyless signing

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -162,6 +162,11 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      - name: Sign agent image with cosign
+        run: |
+          cosign sign --yes "shellhubio/agent:${{ env.RELEASE_VERSION }}"
+          cosign sign --yes "shellhubio/agent:latest"
+
       - name: Attach SBOM to agent image
         run: |
           cosign attach sbom \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -165,6 +165,11 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      - name: Sign '${{ matrix.project }}' image with cosign
+        run: |
+          cosign sign --yes "${{ steps.image.outputs.name }}:${{ env.RELEASE_VERSION }}"
+          cosign sign --yes "${{ steps.image.outputs.name }}:latest"
+
       - name: Attach SBOM to '${{ matrix.project }}' image
         run: |
           cosign attach sbom \

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -1,0 +1,33 @@
+# Verifying Container Images
+
+All ShellHub container images published to Docker Hub are signed using [cosign](https://docs.sigstore.dev/cosign/overview/) with keyless (OIDC) signing via [Sigstore](https://www.sigstore.dev/). Signatures are generated automatically during CI/CD using GitHub Actions' OIDC identity and recorded in the [Rekor](https://docs.sigstore.dev/logging/overview/) transparency log.
+
+## Prerequisites
+
+Install cosign: https://docs.sigstore.dev/cosign/system_config/installation/
+
+## Verifying an image
+
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/shellhub-io/shellhub/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  shellhubio/<image>:<tag>
+```
+
+Replace `<image>` with the component name (`api`, `ssh`, `gateway`, `ui`, `cli`, `agent`) and `<tag>` with the version (e.g., `v0.26.0`).
+
+### Example
+
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/shellhub-io/shellhub/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  shellhubio/api:v0.18.0
+```
+
+A successful verification prints the signature payload and confirms that:
+
+- The image has not been modified since it was published
+- The image was built by a GitHub Actions workflow in the `shellhub-io/shellhub` repository
+- The signing event is recorded in a public transparency log


### PR DESCRIPTION
## What

All release Docker images are now signed using cosign keyless (OIDC) signing via Sigstore. Users can verify image provenance and integrity using `cosign verify`.

## Why

CRA requires integrity verification of delivered software. ShellHub Docker images published to Docker Hub were not signed — users had no way to verify they hadn't been tampered with.

Closes shellhub-io/team#100

## Changes

- **`docker-publish.yml`**: added `cosign sign --yes` step after the existing cosign install for all matrix projects (`api`, `ssh`, `gateway`, `ui`, `cli`, `api-enterprise`), signing both versioned and `latest` tags
- **`build-agent.yml`**: same in the `sbom` job for the agent image
- **`VERIFICATION.md`**: new file with instructions for verifying image signatures using `cosign verify` with the GitHub Actions OIDC issuer and ShellHub identity