### PR TITLE
chore(ui): remove deprecated `baseUrl` from website's `tsconfig.json`

### DIFF
--- a/ui/apps/website/tsconfig.json
+++ b/ui/apps/website/tsconfig.json
@@ -15,11 +15,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["./src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## What

Removes the deprecated `baseUrl` option from website's `tsconfig.json`.

## Why 

`baseUrl` became deprecated in TS 6.
