### PR TITLE
refactor(ui): remove unnecessary DS re-exports from website

### DIFF
--- a/ui/apps/website/src/pages/enterprise/AdminPanel.tsx
+++ b/ui/apps/website/src/pages/enterprise/AdminPanel.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon } from "@heroicons/react/24/outline";
 import { WindowChrome } from "@shellhub/design-system/primitives";
 import { Section, SectionHeader } from "@/components/marketing";
-import { Reveal, ShimmerCard } from "../landing/components";
+import { Reveal, ShimmerCard } from "@shellhub/design-system/components";
 
 const capabilities = [
   {

--- a/ui/apps/website/src/pages/enterprise/DeploymentOptions.tsx
+++ b/ui/apps/website/src/pages/enterprise/DeploymentOptions.tsx
@@ -2,7 +2,7 @@ import { CloudIcon, ShoppingCartIcon } from "@heroicons/react/24/outline";
 import { Badge, Card, IconBadge } from "@shellhub/design-system/primitives";
 import { HighlightCard, Section, SectionHeader } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
-import { Reveal, ShimmerCard } from "../landing/components";
+import { Reveal, ShimmerCard } from "@shellhub/design-system/components";
 
 export function DeploymentOptions() {
   return (

--- a/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
+++ b/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
@@ -1,7 +1,10 @@
 import { Badge } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+} from "@shellhub/design-system/components";
 import { ActionButtonGroup } from "@/components/marketing";
-import { Reveal, ConnectionGrid } from "../landing/components";
 
 export function HeroEnterprise() {
   return (

--- a/ui/apps/website/src/pages/enterprise/SecurityFeatures.tsx
+++ b/ui/apps/website/src/pages/enterprise/SecurityFeatures.tsx
@@ -7,15 +7,45 @@ import {
 } from "@heroicons/react/24/outline";
 import { PlayIcon } from "@heroicons/react/24/solid";
 import { Section, SectionHeader, InfoCard } from "@/components/marketing";
-import { C } from "../landing/constants";
+import { C } from "@shellhub/design-system/constants";
 
 const features = [
-  { icon: ArrowRightEndOnRectangleIcon, color: C.primary, title: "SSO / SAML", desc: "Single sign-on with your identity provider. Support for SAML 2.0 and OpenID Connect." },
-  { icon: UsersIcon, color: C.cyan, title: "LDAP / Active Directory", desc: "Integrate with your existing directory service for centralized user management." },
-  { icon: LockClosedIcon, color: C.yellow, title: "MFA Enforcement", desc: "Require multi-factor authentication for all users or specific roles across the organization." },
-  { icon: PencilIcon, color: C.green, title: "Audit Logs", desc: "Complete audit trail of every action. User logins, device connections, configuration changes." },
-  { icon: PlayIcon, color: C.red, title: "Session Recording", desc: "Record and replay SSH sessions for compliance, training, and incident investigation." },
-  { icon: ShieldCheckIcon, color: C.blue, title: "Firewall Rules", desc: "Define granular connection policies per device, namespace, or user group." },
+  {
+    icon: ArrowRightEndOnRectangleIcon,
+    color: C.primary,
+    title: "SSO / SAML",
+    desc: "Single sign-on with your identity provider. Support for SAML 2.0 and OpenID Connect.",
+  },
+  {
+    icon: UsersIcon,
+    color: C.cyan,
+    title: "LDAP / Active Directory",
+    desc: "Integrate with your existing directory service for centralized user management.",
+  },
+  {
+    icon: LockClosedIcon,
+    color: C.yellow,
+    title: "MFA Enforcement",
+    desc: "Require multi-factor authentication for all users or specific roles across the organization.",
+  },
+  {
+    icon: PencilIcon,
+    color: C.green,
+    title: "Audit Logs",
+    desc: "Complete audit trail of every action. User logins, device connections, configuration changes.",
+  },
+  {
+    icon: PlayIcon,
+    color: C.red,
+    title: "Session Recording",
+    desc: "Record and replay SSH sessions for compliance, training, and incident investigation.",
+  },
+  {
+    icon: ShieldCheckIcon,
+    color: C.blue,
+    title: "Firewall Rules",
+    desc: "Define granular connection policies per device, namespace, or user group.",
+  },
 ];
 
 export function SecurityFeatures() {

--- a/ui/apps/website/src/pages/enterprise/SupportSection.tsx
+++ b/ui/apps/website/src/pages/enterprise/SupportSection.tsx
@@ -5,7 +5,7 @@ import {
 import { Card, IconBadge } from "@shellhub/design-system/primitives";
 import { HighlightCard, Section, SectionHeader } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
-import { Reveal, ShimmerCard } from "../landing/components";
+import { Reveal, ShimmerCard } from "@shellhub/design-system/components";
 
 export function SupportSection() {
   return (

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -1,5 +1,10 @@
 import { Badge, Card, WindowChrome } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import {
   CheckIcon,
   PlayCircleIcon,
@@ -25,8 +30,7 @@ import {
   SectionHeader,
   type CTAAction,
 } from "@/components/marketing";
-import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C } from "../landing/constants";
+import { C } from "@shellhub/design-system/constants";
 
 const primaryAction: CTAAction = {
   label: "Get Started Free",

--- a/ui/apps/website/src/pages/getting-started/StepPath.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepPath.tsx
@@ -4,7 +4,11 @@ import {
   BuildingOffice2Icon,
   ServerIcon,
 } from "@heroicons/react/24/outline";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import {
   Badge,
   Button,
@@ -15,7 +19,6 @@ import {
 import { HighlightCard } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
 import { signupUrl } from "@/links";
-import { Reveal, ShimmerCard } from "../landing/components";
 
 interface StepPathProps {
   onSelectSelfHosted: () => void;

--- a/ui/apps/website/src/pages/getting-started/StepSetup.tsx
+++ b/ui/apps/website/src/pages/getting-started/StepSetup.tsx
@@ -2,7 +2,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/react/24/outline";
 import { Button } from "@shellhub/design-system/primitives";
 import { CommandBlock } from "@/components/marketing";
 import { docsUrl } from "@/links";
-import { Reveal } from "../landing/components";
+import { Reveal } from "@shellhub/design-system/components";
 
 const DOCKER_CMD = "docker run -d -p 80:80 shellhubio/shellhub";
 

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -15,7 +15,12 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import {
   ActionButtonGroup,
@@ -26,8 +31,7 @@ import {
   SectionHeader,
 } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
-import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
+import { C, FONT_SANS, FONT_MONO } from "@shellhub/design-system/constants";
 
 const techDetails = [
   {

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -19,7 +19,12 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import {
   ActionButtonGroup,
@@ -31,8 +36,7 @@ import {
   type CTAAction,
 } from "@/components/marketing";
 import { docsUrl } from "@/links";
-import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C } from "../landing/constants";
+import { C } from "@shellhub/design-system/constants";
 
 const primaryAction: CTAAction = {
   label: "Get Started Free",

--- a/ui/apps/website/src/pages/landing/Architecture.tsx
+++ b/ui/apps/website/src/pages/landing/Architecture.tsx
@@ -1,7 +1,7 @@
 import { Section, SectionHeader } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
-import { Reveal } from "./components";
-import { C, FONT_SANS, FONT_MONO } from "./constants";
+import { Reveal } from "@shellhub/design-system/components";
+import { C, FONT_SANS, FONT_MONO } from "@shellhub/design-system/constants";
 
 export function Architecture() {
   return (

--- a/ui/apps/website/src/pages/landing/CTA.tsx
+++ b/ui/apps/website/src/pages/landing/CTA.tsx
@@ -1,6 +1,9 @@
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+} from "@shellhub/design-system/components";
 import { ActionButton, Section } from "@/components/marketing";
-import { Reveal, ConnectionGrid } from "./components";
 import { signupUrl } from "@/links";
 
 export function CTA() {

--- a/ui/apps/website/src/pages/landing/FeatureGrid.tsx
+++ b/ui/apps/website/src/pages/landing/FeatureGrid.tsx
@@ -7,7 +7,7 @@ import {
   ServerIcon,
 } from "@heroicons/react/24/outline";
 import { Section, SectionHeader, InfoCard } from "@/components/marketing";
-import { C } from "./constants";
+import { C } from "@shellhub/design-system/constants";
 
 export function FeatureGrid() {
   return (
@@ -19,12 +19,48 @@ export function FeatureGrid() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {[
-          { icon: CommandLineIcon, color: C.primary, title: "Native SSH Support", desc: "Use your standard SSH client. No proprietary tools or plugins required.", delay: 0 },
-          { icon: DocumentTextIcon, color: C.cyan, title: "SCP/SFTP File Transfer", desc: "Transfer files to and from remote devices with SCP and SFTP.", delay: 0.06 },
-          { icon: LockClosedIcon, color: C.yellow, title: "Multi-Factor Auth", desc: "Require TOTP-based MFA for SSH connections. Works with any authenticator app.", delay: 0.12 },
-          { icon: PencilSquareIcon, color: C.green, title: "Audit Logging", desc: "Full audit trail of every connection, command, and session. Export logs for compliance.", delay: 0 },
-          { icon: UsersIcon, color: C.primary, title: "Team Management & RBAC", desc: "Invite team members, assign roles, and control who can access which devices.", delay: 0.06 },
-          { icon: ServerIcon, color: C.blue, title: "Docker Container Access", desc: "SSH directly into Docker containers running on remote hosts. No docker exec needed.", delay: 0.12 },
+          {
+            icon: CommandLineIcon,
+            color: C.primary,
+            title: "Native SSH Support",
+            desc: "Use your standard SSH client. No proprietary tools or plugins required.",
+            delay: 0,
+          },
+          {
+            icon: DocumentTextIcon,
+            color: C.cyan,
+            title: "SCP/SFTP File Transfer",
+            desc: "Transfer files to and from remote devices with SCP and SFTP.",
+            delay: 0.06,
+          },
+          {
+            icon: LockClosedIcon,
+            color: C.yellow,
+            title: "Multi-Factor Auth",
+            desc: "Require TOTP-based MFA for SSH connections. Works with any authenticator app.",
+            delay: 0.12,
+          },
+          {
+            icon: PencilSquareIcon,
+            color: C.green,
+            title: "Audit Logging",
+            desc: "Full audit trail of every connection, command, and session. Export logs for compliance.",
+            delay: 0,
+          },
+          {
+            icon: UsersIcon,
+            color: C.primary,
+            title: "Team Management & RBAC",
+            desc: "Invite team members, assign roles, and control who can access which devices.",
+            delay: 0.06,
+          },
+          {
+            icon: ServerIcon,
+            color: C.blue,
+            title: "Docker Container Access",
+            desc: "SSH directly into Docker containers running on remote hosts. No docker exec needed.",
+            delay: 0.12,
+          },
         ].map((f, i) => (
           <InfoCard
             key={i}

--- a/ui/apps/website/src/pages/landing/Hero.tsx
+++ b/ui/apps/website/src/pages/landing/Hero.tsx
@@ -1,7 +1,6 @@
 import { ShellHubCloudIcon } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import { ConnectionGrid, GlowOrbs } from "@shellhub/design-system/components";
 import { ActionButton } from "@/components/marketing";
-import { ConnectionGrid } from "./components";
 
 export function Hero() {
   return (

--- a/ui/apps/website/src/pages/landing/HowItWorks.tsx
+++ b/ui/apps/website/src/pages/landing/HowItWorks.tsx
@@ -1,8 +1,8 @@
 import { Card } from "@shellhub/design-system/primitives";
 import { Section, SectionHeader } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
-import { Reveal, ShimmerCard } from "./components";
-import { C, FONT_SANS, FONT_MONO } from "./constants";
+import { Reveal, ShimmerCard } from "@shellhub/design-system/components";
+import { C, FONT_SANS, FONT_MONO } from "@shellhub/design-system/constants";
 
 export function HowItWorks() {
   return (

--- a/ui/apps/website/src/pages/landing/Navbar.tsx
+++ b/ui/apps/website/src/pages/landing/Navbar.tsx
@@ -8,7 +8,7 @@ import {
   Bars3Icon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
-import { C } from "./constants";
+import { C } from "@shellhub/design-system/constants";
 import { loginUrl, signupUrl } from "@/links";
 import {
   productCols,

--- a/ui/apps/website/src/pages/landing/OpenSource.tsx
+++ b/ui/apps/website/src/pages/landing/OpenSource.tsx
@@ -1,8 +1,8 @@
 import { StarIcon } from "@heroicons/react/24/solid";
 import { GithubIcon } from "@shellhub/design-system/primitives";
 import { ActionButton, Section, SectionHeader } from "@/components/marketing";
-import { Reveal } from "./components";
-import { C } from "./constants";
+import { Reveal } from "@shellhub/design-system/components";
+import { C } from "@shellhub/design-system/constants";
 import { githubUrl, signupUrl } from "@/links";
 
 export function OpenSource() {

--- a/ui/apps/website/src/pages/landing/QuickStart.tsx
+++ b/ui/apps/website/src/pages/landing/QuickStart.tsx
@@ -1,6 +1,6 @@
 import { ArrowRightIcon } from "@heroicons/react/24/outline";
 import { CommandBlock, Section, SectionHeader } from "@/components/marketing";
-import { Reveal } from "./components";
+import { Reveal } from "@shellhub/design-system/components";
 import { docsUrl } from "@/links";
 
 const DOCKER_CMD = "docker run -d -p 80:80 shellhubio/shellhub";

--- a/ui/apps/website/src/pages/landing/SupportedPlatforms.tsx
+++ b/ui/apps/website/src/pages/landing/SupportedPlatforms.tsx
@@ -11,7 +11,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { DockerIcon } from "@shellhub/design-system/primitives";
 import { Section, SectionHeader } from "@/components/marketing";
-import { Reveal } from "./components";
+import { Reveal } from "@shellhub/design-system/components";
 import { docsUrl } from "@/links";
 
 export function SupportedPlatforms() {

--- a/ui/apps/website/src/pages/landing/components.tsx
+++ b/ui/apps/website/src/pages/landing/components.tsx
@@ -1,5 +1,0 @@
-export {
-  Reveal,
-  ConnectionGrid,
-  ShimmerCard,
-} from "@shellhub/design-system/components";

--- a/ui/apps/website/src/pages/landing/constants.ts
+++ b/ui/apps/website/src/pages/landing/constants.ts
@@ -1,1 +1,0 @@
-export { C, FONT_SANS, FONT_MONO } from "@shellhub/design-system/constants";

--- a/ui/apps/website/src/pages/landing/navData.tsx
+++ b/ui/apps/website/src/pages/landing/navData.tsx
@@ -21,7 +21,7 @@ import {
   VideoCameraIcon,
 } from "@heroicons/react/24/outline";
 import { DiscordIcon, GithubIcon } from "@shellhub/design-system/primitives";
-import { C } from "./constants";
+import { C } from "@shellhub/design-system/constants";
 import { docsUrl, githubUrl } from "@/links";
 
 const ICON_CLASS = "w-4 h-4";
@@ -58,7 +58,9 @@ export const productCols: MenuSection[] = [
         label: "MFA & RBAC",
         href: "/features",
         desc: "Multi-factor auth and role-based access control",
-        icon: <ShieldCheckIcon className={ICON_CLASS} style={{ color: C.blue }} />,
+        icon: (
+          <ShieldCheckIcon className={ICON_CLASS} style={{ color: C.blue }} />
+        ),
       },
       {
         label: "Firewall Rules",
@@ -122,7 +124,9 @@ export const productCols: MenuSection[] = [
         label: "Session Replay",
         href: "/features",
         desc: "Watch and replay recorded SSH sessions",
-        icon: <PlayCircleIcon className={ICON_CLASS} style={{ color: C.blue }} />,
+        icon: (
+          <PlayCircleIcon className={ICON_CLASS} style={{ color: C.blue }} />
+        ),
       },
       {
         label: "Getting Started",
@@ -138,7 +142,10 @@ export const productCols: MenuSection[] = [
         href: "#",
         desc: "Release notes and version history",
         icon: (
-          <PencilSquareIcon className={ICON_CLASS} style={{ color: C.primary }} />
+          <PencilSquareIcon
+            className={ICON_CLASS}
+            style={{ color: C.primary }}
+          />
         ),
       },
     ],
@@ -185,7 +192,10 @@ export const solutionsCols: MenuSection[] = [
         href: "/use-cases/devops-ci-cd",
         desc: "Automate with Ansible, Terraform and CI pipelines",
         icon: (
-          <CodeBracketIcon className={ICON_CLASS} style={{ color: C.primary }} />
+          <CodeBracketIcon
+            className={ICON_CLASS}
+            style={{ color: C.primary }}
+          />
         ),
       },
       {
@@ -230,7 +240,10 @@ export const resourcesCols: MenuSection[] = [
         href: "#",
         desc: "See what shipped in every release",
         icon: (
-          <PencilSquareIcon className={ICON_CLASS} style={{ color: C.primary }} />
+          <PencilSquareIcon
+            className={ICON_CLASS}
+            style={{ color: C.primary }}
+          />
         ),
       },
     ],
@@ -242,13 +255,17 @@ export const resourcesCols: MenuSection[] = [
         label: "API Reference",
         href: docsUrl,
         desc: "REST API endpoints and authentication",
-        icon: <CodeBracketIcon className={ICON_CLASS} style={{ color: C.cyan }} />,
+        icon: (
+          <CodeBracketIcon className={ICON_CLASS} style={{ color: C.cyan }} />
+        ),
       },
       {
         label: "GitHub",
         href: githubUrl,
         desc: "Source code, issues and contributions",
-        icon: <GithubIcon className={ICON_CLASS} style={{ color: C.textSec }} />,
+        icon: (
+          <GithubIcon className={ICON_CLASS} style={{ color: C.textSec }} />
+        ),
       },
       {
         label: "Discord",
@@ -285,7 +302,9 @@ export const resourcesCols: MenuSection[] = [
         label: "Security",
         href: "#",
         desc: "CVEs, responsible disclosure and trust",
-        icon: <ShieldCheckIcon className={ICON_CLASS} style={{ color: C.red }} />,
+        icon: (
+          <ShieldCheckIcon className={ICON_CLASS} style={{ color: C.red }} />
+        ),
       },
     ],
   },

--- a/ui/apps/website/src/pages/pricing/ComparisonTable.tsx
+++ b/ui/apps/website/src/pages/pricing/ComparisonTable.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { CheckIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { Section, SectionHeader } from "@/components/marketing";
-import { Reveal } from "../landing/components";
+import { Reveal } from "@shellhub/design-system/components";
 
 type FeatureValue = boolean | string;
 

--- a/ui/apps/website/src/pages/pricing/HeroPricing.tsx
+++ b/ui/apps/website/src/pages/pricing/HeroPricing.tsx
@@ -1,5 +1,4 @@
-import { GlowOrbs } from "@shellhub/design-system/components";
-import { Reveal } from "../landing/components";
+import { GlowOrbs, Reveal } from "@shellhub/design-system/components";
 
 export function HeroPricing() {
   return (

--- a/ui/apps/website/src/pages/pricing/PricingFAQ.tsx
+++ b/ui/apps/website/src/pages/pricing/PricingFAQ.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { PlusIcon, MinusIcon } from "@heroicons/react/24/outline";
 import { cn } from "@shellhub/design-system/cn";
 import { Section, SectionHeader } from "@/components/marketing";
-import { Reveal } from "../landing/components";
+import { Reveal } from "@shellhub/design-system/components";
 
 const faqs = [
   {

--- a/ui/apps/website/src/pages/pricing/TierCards.tsx
+++ b/ui/apps/website/src/pages/pricing/TierCards.tsx
@@ -1,10 +1,13 @@
 import { Link } from "react-router-dom";
 import { cn } from "@shellhub/design-system/cn";
 import { Button } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import { HighlightCard, Section } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
-import { Reveal, ShimmerCard } from "../landing/components";
 
 const tiers = [
   {
@@ -80,7 +83,10 @@ export function TierCards() {
               <div className="flex items-center gap-3 mb-4">
                 <h3 className="text-lg font-bold">{tier.name}</h3>
                 <span
-                  className={cn("px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] border rounded-full", tier.badgeClass)}
+                  className={cn(
+                    "px-2 py-0.5 text-2xs font-mono font-semibold uppercase tracking-[0.1em] border rounded-full",
+                    tier.badgeClass,
+                  )}
                 >
                   {tier.badge}
                 </span>

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -14,7 +14,12 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import {
   ActionButtonGroup,
@@ -26,8 +31,7 @@ import {
   type CTAAction,
 } from "@/components/marketing";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
-import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C, FONT_SANS, FONT_MONO } from "../landing/constants";
+import { C, FONT_SANS, FONT_MONO } from "@shellhub/design-system/constants";
 
 const primaryAction: CTAAction = {
   label: "Get Started Free",

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -9,7 +9,12 @@ import {
   TagIcon,
 } from "@heroicons/react/24/outline";
 import { Badge, WindowChrome } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import {
   ActionButtonGroup,
@@ -20,8 +25,7 @@ import {
   type CTAAction,
 } from "@/components/marketing";
 import { docsUrl } from "@/links";
-import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C } from "../landing/constants";
+import { C } from "@shellhub/design-system/constants";
 
 const primaryAction: CTAAction = {
   label: "Get Started Free",

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -15,8 +15,12 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
-import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import {
   ActionButtonGroup,
@@ -27,7 +31,7 @@ import {
   SectionHeader,
   type CTAAction,
 } from "@/components/marketing";
-import { C } from "../landing/constants";
+import { C } from "@shellhub/design-system/constants";
 
 const primaryAction: CTAAction = {
   label: "Get Started Free",

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -16,7 +16,12 @@ import {
   IconBadge,
   WindowChrome,
 } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import {
   ActionButtonGroup,
@@ -28,8 +33,7 @@ import {
 } from "@/components/marketing";
 import { ArrowMarker } from "@/components/marketing/ArrowMarker";
 import { FeatureListItem } from "@/components/marketing/FeatureListItem";
-import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C } from "../landing/constants";
+import { C } from "@shellhub/design-system/constants";
 
 const painPoints = [
   {

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -10,7 +10,12 @@ import {
 } from "@heroicons/react/24/outline";
 import { PlayIcon } from "@heroicons/react/24/solid";
 import { Badge, Card, WindowChrome } from "@shellhub/design-system/primitives";
-import { GlowOrbs } from "@shellhub/design-system/components";
+import {
+  ConnectionGrid,
+  GlowOrbs,
+  Reveal,
+  ShimmerCard,
+} from "@shellhub/design-system/components";
 import { SiteLayout } from "@/components/SiteLayout";
 import {
   ActionButtonGroup,
@@ -20,8 +25,7 @@ import {
   SectionHeader,
   type CTAAction,
 } from "@/components/marketing";
-import { Reveal, ShimmerCard, ConnectionGrid } from "../landing/components";
-import { C } from "../landing/constants";
+import { C } from "@shellhub/design-system/constants";
 
 const primaryAction: CTAAction = {
   label: "Get Started Free",


### PR DESCRIPTION
## What

All website consumers now import `Reveal`, `ConnectionGrid`, `ShimmerCard`, `C`, `FONT_SANS`, and `FONT_MONO` directly from `@shellhub/design-system` instead of through two landing-page proxy files that were pure re-exports with zero added value. Both proxy files are deleted.

## Why

`pages/landing/constants.ts` and `pages/landing/components.tsx` re-exported design-system symbols verbatim — no aliases, no transformations, no local additions. This made it look like these were landing-page-specific symbols when they're shared DS primitives, and added a layer of indirection that obscured the true dependency origin.

Closes shellhub-io/team#184

## Changes

- **30 consumer files**: rewired imports from `./constants`, `./components`, `../landing/constants`, `../landing/components` to the canonical `@shellhub/design-system/{constants,components}` paths. Files that already had a partial DS import (e.g. `GlowOrbs`) got the new symbols merged into the existing import statement.
- **`pages/landing/constants.ts`**: deleted
- **`pages/landing/components.tsx`**: deleted