### PR TITLE
ci: guard latest tag to prevent older releases from clobbering it

### DIFF
--- a/.github/actions/is-latest-tag/action.yml
+++ b/.github/actions/is-latest-tag/action.yml
@@ -1,0 +1,26 @@
+name: Is latest tag
+description: Sets is_latest=true when the tag is the highest stable semver.
+
+inputs:
+  tag:
+    required: true
+
+outputs:
+  is_latest:
+    value: ${{ steps.check.outputs.is_latest }}
+
+runs:
+  using: composite
+  steps:
+    - id: check
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../..
+      env:
+        TAG: ${{ inputs.tag }}
+      run: |
+        git fetch --tags --quiet
+        if bash .github/scripts/is-latest-tag.sh "$TAG"; then
+          echo "is_latest=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "is_latest=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/scripts/is-latest-tag.sh
+++ b/.github/scripts/is-latest-tag.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Exits 0 when the given tag is the highest stable semver among all v* tags
+# in the repository. Exits 1 otherwise. Pre-release tags (containing a hyphen
+# after the version, e.g. v1.0.0-rc.1) are excluded from the candidate set
+# AND are never considered "latest" themselves.
+#
+# Usage: is-latest-tag.sh <tag>
+# Env:   GIT_DIR — override to test against a different repository.
+
+set -euo pipefail
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  echo "Usage: is-latest-tag.sh <tag>" >&2
+  exit 2
+fi
+
+tag="$1"
+
+if [[ "$tag" == *-* ]]; then
+  exit 1
+fi
+
+stable_tags=$(git tag -l 'v*' | grep -v -- '-' || true)
+
+if [[ -z "$stable_tags" ]]; then
+  exit 0
+fi
+
+highest=$(echo "$stable_tags" | sort -V | tail -n1)
+
+if [[ "$tag" == "$highest" ]]; then
+  exit 0
+fi
+
+exit 1

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -36,10 +36,21 @@ jobs:
       - name: Set github reference env
         run: echo RELEASE_VERSION=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
 
+      - name: Check if tag is the latest release
+        id: latest-check
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: ./.github/actions/is-latest-tag
+        with:
+          tag: ${{ env.RELEASE_VERSION }}
+
       - name: Set image tag
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            echo "IMAGE_TAG=${RELEASE_VERSION},latest" >> "$GITHUB_ENV"
+            if [[ "${{ steps.latest-check.outputs.is_latest }}" == "true" ]]; then
+              echo "IMAGE_TAG=${RELEASE_VERSION},latest" >> "$GITHUB_ENV"
+            else
+              echo "IMAGE_TAG=${RELEASE_VERSION}" >> "$GITHUB_ENV"
+            fi
             echo "BUILD_ARGS=--build-arg SHELLHUB_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"
           else
             echo "IMAGE_TAG=${GITHUB_SHA}" >> "$GITHUB_ENV"
@@ -136,8 +147,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
       - name: Set release version
         run: echo RELEASE_VERSION=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
+
+      - name: Check if tag is the latest release
+        id: latest-check
+        uses: ./.github/actions/is-latest-tag
+        with:
+          tag: ${{ env.RELEASE_VERSION }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
@@ -165,7 +185,9 @@ jobs:
       - name: Sign agent image with cosign
         run: |
           cosign sign --yes "shellhubio/agent:${{ env.RELEASE_VERSION }}"
-          cosign sign --yes "shellhubio/agent:latest"
+          if [[ "${{ steps.latest-check.outputs.is_latest }}" == "true" ]]; then
+            cosign sign --yes "shellhubio/agent:latest"
+          fi
 
       - name: Attest SBOM for agent image
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,6 +53,12 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: echo "RELEASE_VERSION=$REF_NAME" >> "$GITHUB_ENV"
 
+      - name: Check if tag is the latest release
+        id: latest-check
+        uses: ./shellhub/.github/actions/is-latest-tag
+        with:
+          tag: ${{ env.RELEASE_VERSION }}
+
       - name: Set image registry and name
         id: image
         run: |
@@ -123,21 +129,19 @@ jobs:
               --ignorefile /work/shellhub/.trivyignore \
               ${{ steps.image.outputs.name }}:${{ env.RELEASE_VERSION }}
 
-      # Push the SAME image that was just scanned — `docker push` re-uses the layers in the local Docker
-      # daemon — no rebuild occurs, so the pushed digest is identical to what
-      # Trivy scanned.
-      #
-      # NOTE: cross-registry push is sequential, not transactional. If the
-      # versioned-tag push succeeds but the `latest` push fails (or vice versa),
-      # the registry will hold a partial set of tags. Re-running the workflow is
-      # safe: buildx GHA cache ensures digest-identical layers on the next run.
+      # Push the SAME image that was just scanned — `docker push` re-uses the
+      # layers in the local daemon, so the pushed digest is identical to what
+      # Trivy scanned. The `latest` tag is only applied when this is the
+      # highest stable semver release.
       - name: Push '${{ matrix.project }}' image (same digest as scanned)
         run: |
-          docker tag \
-            "${{ steps.image.outputs.name }}:${{ env.RELEASE_VERSION }}" \
-            "${{ steps.image.outputs.name }}:latest"
           docker push "${{ steps.image.outputs.name }}:${{ env.RELEASE_VERSION }}"
-          docker push "${{ steps.image.outputs.name }}:latest"
+          if [[ "${{ steps.latest-check.outputs.is_latest }}" == "true" ]]; then
+            docker tag \
+              "${{ steps.image.outputs.name }}:${{ env.RELEASE_VERSION }}" \
+              "${{ steps.image.outputs.name }}:latest"
+            docker push "${{ steps.image.outputs.name }}:latest"
+          fi
 
       - name: Generate SBOM for '${{ matrix.project }}' image
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
@@ -168,7 +172,9 @@ jobs:
       - name: Sign '${{ matrix.project }}' image with cosign
         run: |
           cosign sign --yes "${{ steps.image.outputs.name }}:${{ env.RELEASE_VERSION }}"
-          cosign sign --yes "${{ steps.image.outputs.name }}:latest"
+          if [[ "${{ steps.latest-check.outputs.is_latest }}" == "true" ]]; then
+            cosign sign --yes "${{ steps.image.outputs.name }}:latest"
+          fi
 
       - name: Attest SBOM for '${{ matrix.project }}' image
         run: |

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -1,0 +1,32 @@
+name: Script Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  is-latest-tag:
+    name: is-latest-tag
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        id: filter
+        with:
+          filters: |
+            scripts:
+              - '.github/scripts/is-latest-tag.sh'
+              - '.github/actions/is-latest-tag/**'
+              - 'tests/is-latest-tag_test.sh'
+              - '.github/workflows/script-tests.yml'
+
+      - name: Run is-latest-tag tests
+        if: steps.filter.outputs.scripts == 'true'
+        run: bash tests/is-latest-tag_test.sh

--- a/tests/is-latest-tag_test.sh
+++ b/tests/is-latest-tag_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/.github/scripts/is-latest-tag.sh"
+
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  local tag="$2"
+  local expected_exit="$3"
+  shift 3
+  local tags=("$@")
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" -c user.name=test -c user.email=test@example.com commit --allow-empty -m "init" -q
+
+  for t in "${tags[@]}"; do
+    git -C "$tmpdir" tag "$t"
+  done
+
+  local actual_exit=0
+  GIT_DIR="$tmpdir/.git" bash "$SCRIPT" "$tag" || actual_exit=$?
+
+  if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (expected exit $expected_exit, got $actual_exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== is-latest-tag.sh tests ==="
+
+run_test "newest tag is latest" \
+  "v0.26.0" 0 \
+  "v0.24.0" "v0.25.0" "v0.26.0"
+
+run_test "older patch after newer release" \
+  "v0.25.1" 1 \
+  "v0.24.0" "v0.25.0" "v0.25.1" "v0.26.0"
+
+run_test "pre-release tag is never latest" \
+  "v0.27.0-rc.1" 1 \
+  "v0.24.0" "v0.25.0" "v0.26.0" "v0.27.0-rc.1"
+
+run_test "lone pre-release" \
+  "v0.27.0-rc.1" 1 \
+  "v0.27.0-rc.1"
+
+run_test "first-ever tag is latest" \
+  "v0.1.0" 0 \
+  "v0.1.0"
+
+run_test "equal to current highest" \
+  "v0.26.0" 0 \
+  "v0.26.0"
+
+run_test "pre-releases excluded from candidate set" \
+  "v0.26.0" 0 \
+  "v0.25.0" "v0.26.0" "v0.27.0-beta.1"
+
+run_test "higher major version" \
+  "v1.0.0" 0 \
+  "v0.25.0" "v0.26.0" "v1.0.0"
+
+run_test "lower major version" \
+  "v0.26.0" 1 \
+  "v0.26.0" "v1.0.0"
+
+run_test "no argument prints usage" \
+  "" 2
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

The `latest` Docker tag is now only applied when the published tag is the highest stable semver release. Previously, any `v*` tag push unconditionally overwrote `latest`, so a backport patch (e.g., `v0.25.1` after `v0.26.0`) would silently downgrade it and sign the stale digest.

## Why

Flagged during review of #6712 (cosign image signing). The signing step inherited the pre-existing latest-clobber behavior, meaning `cosign verify ... image:latest` could validate against an outdated image. This fixes the root cause in the push step.

Fixes #6728

## Changes

- **`.github/scripts/is-latest-tag.sh`**: compares a tag against all stable `v*` tags via `git tag -l` + `sort -V`. Exits 0 when the tag is the highest, 1 otherwise. Pre-release tags (containing a hyphen) are excluded from the candidate set and never qualify as latest.
- **`.github/actions/is-latest-tag/action.yml`**: composite action wrapping the script — fetches tags, runs the check, sets `is_latest` output. Inputs are passed via `env:` to avoid expression injection.
- **`docker-publish.yml`**: the `latest` retag, push, and cosign sign are now conditional on `is_latest=true`. Versioned tag is always pushed and signed.
- **`build-agent.yml`**: same guard applied in both the build job (`IMAGE_TAG` no longer unconditionally includes `latest`) and the sbom job (`cosign sign ... latest` is conditional). Added a checkout step to the sbom job so the script is available.
- **`tests/is-latest-tag_test.sh`**: 9 cases covering newest tag, older patch, pre-release, first-ever tag, major version boundaries, and usage error.

## Testing

Run `bash tests/is-latest-tag_test.sh` — all 9 cases should pass. Integration: push a non-latest tag to a fork and confirm `latest` is not retagged on the registry.