### PR TITLE
ci: replace `cosign attach sbom` with signed SBOM attestation

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -167,10 +167,10 @@ jobs:
           cosign sign --yes "shellhubio/agent:${{ env.RELEASE_VERSION }}"
           cosign sign --yes "shellhubio/agent:latest"
 
-      - name: Attach SBOM to agent image
+      - name: Attest SBOM for agent image
         run: |
-          cosign attach sbom \
-            --sbom sbom-agent-${{ env.RELEASE_VERSION }}.cdx.json \
+          cosign attest --yes \
+            --predicate sbom-agent-${{ env.RELEASE_VERSION }}.cdx.json \
             --type cyclonedx \
             shellhubio/agent:${{ env.RELEASE_VERSION }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -170,10 +170,10 @@ jobs:
           cosign sign --yes "${{ steps.image.outputs.name }}:${{ env.RELEASE_VERSION }}"
           cosign sign --yes "${{ steps.image.outputs.name }}:latest"
 
-      - name: Attach SBOM to '${{ matrix.project }}' image
+      - name: Attest SBOM for '${{ matrix.project }}' image
         run: |
-          cosign attach sbom \
-            --sbom "sbom-${{ matrix.project }}-${{ env.RELEASE_VERSION }}.cdx.json" \
+          cosign attest --yes \
+            --predicate "sbom-${{ matrix.project }}-${{ env.RELEASE_VERSION }}.cdx.json" \
             --type cyclonedx \
             "${{ steps.image.outputs.name }}:${{ env.RELEASE_VERSION }}"
 

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -31,3 +31,35 @@ A successful verification prints the signature payload and confirms that:
 - The image has not been modified since it was published
 - The image was built by a GitHub Actions workflow in the `shellhub-io/shellhub` repository
 - The signing event is recorded in a public transparency log
+
+## Verifying SBOM attestations
+
+Each image also carries a signed [CycloneDX](https://cyclonedx.org/) SBOM wrapped in an [in-toto](https://in-toto.io/) attestation. The attestation is signed with the same keyless flow as the image itself, so verifying it proves the SBOM has not been tampered with since it was generated during the release build.
+
+```bash
+cosign verify-attestation \
+  --certificate-identity-regexp="https://github.com/shellhub-io/shellhub/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  --type cyclonedx \
+  shellhubio/<image>:<tag>
+```
+
+### Example
+
+```bash
+cosign verify-attestation \
+  --certificate-identity-regexp="https://github.com/shellhub-io/shellhub/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  --type cyclonedx \
+  shellhubio/api:v0.18.0
+```
+
+To extract the SBOM payload from the verified attestation:
+
+```bash
+cosign verify-attestation \
+  --certificate-identity-regexp="https://github.com/shellhub-io/shellhub/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  --type cyclonedx \
+  shellhubio/<image>:<tag> | jq -r '.payload' | base64 -d | jq '.predicate'
+```


### PR DESCRIPTION
## What

SBOMs are now wrapped in signed in-toto attestations instead of being uploaded as unsigned OCI artifacts. Users verify SBOM integrity with `cosign verify-attestation --type cyclonedx`.

## Why

`cosign attach sbom` uploads the SBOM as a separate artifact not covered by the image signature — a tampered SBOM would pass undetected. `cosign attach sbom` is also deprecated upstream in favor of `cosign attest` since cosign v2.0. For CRA compliance, integrity verification must cover delivered software artifacts including their dependency metadata.

Closes #6729

## Changes

- **`docker-publish.yml`**: replaced `cosign attach sbom --sbom` with `cosign attest --yes --predicate` for all matrix images (versioned tag only, matching existing behavior)
- **`build-agent.yml`**: same replacement for the agent image
- **`VERIFICATION.md`**: added "Verifying SBOM attestations" section with `cosign verify-attestation` commands and a payload extraction example

No workflow permission changes needed — both workflows already grant `id-token: write`. The `--yes` flag enables non-interactive keyless signing, same as the existing `cosign sign` steps.

## Testing

Push a release tag and confirm:
1. `cosign verify-attestation --type cyclonedx` succeeds against the published image
2. The attestation payload contains valid CycloneDX JSON
3. The old `cosign attach sbom` tag convention artifact (`sha256-<digest>.sbom`) is no longer present