### PR TITLE
agent: set transport version for connector agents

### DIFF
--- a/agent/connector.go
+++ b/agent/connector.go
@@ -274,6 +274,7 @@ func initContainerAgent(ctx context.Context, cli *dockerclient.Client, container
 		PreferredHostname:         container.Name,
 		KeepAliveInterval:         30,
 		MaxRetryConnectionTimeout: 60,
+		TransportVersion:          agentd.TransportV2,
 		Version:                   connector.ConnectorVersion,
 		Platform:                  "connector",
 	}


### PR DESCRIPTION
Connector mode constructs agentd.Config directly, bypassing the environment parser that normally applies the default transport version.

As a result TransportVersion remains zero and every discovered container fails with:

  unsupported transport version: 0

Explicitly use transport protocol version 2, which is the normal default for ShellHub agents.

Fixes : https://github.com/shellhub-io/meta-shellhub/issues/88

When trying to establish the connector connection getting below error-

```
[root@DAB4D ~]# SHELLHUB_SERVER_ADDRESS="http://127.0.0.1:18080/"
SHELLHUB_TENANT_ID="00000000-0000-4000-8000-000000000000"
SHELLHUB_PRIVATE_KEYS="/etc/shellhub/connector/keys"
/usr/bin/shellhub-agent connector
INFO[0000] Starting ShellHub Agent Connector address="http://127.0.0.1:18080/" private_keys=/etc/shellhub/connector/keys tenant_id=00000000-0000-4000-8000-000000000000 version=v0.26.0
INFO[0000] Connector container started hostname=ui_cont id=16f8d11c9301 identity=16f8d11c9301 server_address="http://127.0.0.1:18080/" tenant_id=00000000-0000-4000-8000-000000000000 times0
INFO[0000] Connector container started hostname=cloud_cont id=5e5fe9c6a916 identity=5e5fe9c6a916 server_address="http://127.0.0.1:18080/" tenant_id=00000000-0000-4000-8000-000000000000 ti0
INFO[0000] Connector container started hostname=video_cont id=e3e6eb459bc7 identity=e3e6eb459bc7 server_address="http://127.0.0.1:18080/" tenant_id=00000000-0000-4000-8000-000000000000 timestam0
INFO[0000] Connector container started hostname=m7_cont id=1f42c754f278 identity=1f42c754f278 server_address="http://127.0.0.1:18080/" tenant_id=00000000-0000-4000-8000-000000000000 times0
INFO[0000] Connector container started hostname=lib_cont id=46100cd5314f identity=46100cd5314f server_address="http://127.0.0.1:18080/" tenant_id=00000000-0000-4000-8000-000000000000 timestam0
INFO[0000] Sleeping for 24 hours version=v0.26.0
INFO[0001] Listening for connections hostname=cloud_cont id=5e5fe9c6a916 identity=5e5fe9c6a916 server_address="http://127.0.0.1:18080/" tenant_id=00000000-0000-4000-8000-000000000000 ti0
FATA[0001] Failed to listen for connections error="unsupported transport version: 0" hostname=cloud_cont id=5e5fe9c6a916 identity=5e5fe9c6a916 server_address="http://127.0.0.1:18080/" tenant_i0
```