### PR TITLE
fix(agent): reject unsupported transport version at construction

### DIFF
--- a/agent/pkg/agentd/agent.go
+++ b/agent/pkg/agentd/agent.go
@@ -233,9 +233,10 @@ type Agent struct {
 // [NewAgentWithConfig] with a fully populated [Config].
 func NewAgent(address string, tenantID string, privateKey string, mode Mode) (*Agent, error) {
 	return NewAgentWithConfig(&Config{
-		ServerAddress: address,
-		TenantID:      tenantID,
-		PrivateKey:    privateKey,
+		ServerAddress:    address,
+		TenantID:         tenantID,
+		PrivateKey:       privateKey,
+		TransportVersion: TransportV2,
 	}, mode)
 }
 
@@ -245,6 +246,8 @@ var (
 	ErrNewAgentWithConfigEmptyTenant          = errors.New("tenant is empty")
 	ErrNewAgentWithConfigEmptyPrivateKey      = errors.New("private key is empty")
 	ErrNewAgentWithConfigNilMode              = errors.New("agent's mode is nil")
+
+	ErrNewAgentWithConfigUnsupportedTransportVersion = errors.New("transport version is unsupported")
 )
 
 // NewAgentWithConfig creates a new agent instance with all configurations.
@@ -268,6 +271,12 @@ func NewAgentWithConfig(config *Config, mode Mode) (*Agent, error) {
 
 	if mode == nil {
 		return nil, ErrNewAgentWithConfigNilMode
+	}
+
+	switch config.TransportVersion {
+	case TransportV1, TransportV2:
+	default:
+		return nil, ErrNewAgentWithConfigUnsupportedTransportVersion
 	}
 
 	return &Agent{

--- a/agent/pkg/agentd/agent_test.go
+++ b/agent/pkg/agentd/agent_test.go
@@ -147,6 +147,13 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	}
 }
 
+func TestNewAgent(t *testing.T) {
+	agent, err := NewAgent("http://localhost:80", "00000000-0000-4000-0000-000000000000", "./shellhub.key", new(HostMode))
+
+	assert.NoError(t, err)
+	assert.Equal(t, TransportV2, agent.config.TransportVersion)
+}
+
 func TestNewAgentWithConfig(t *testing.T) {
 	type expected struct {
 		agent *Agent
@@ -155,9 +162,10 @@ func TestNewAgentWithConfig(t *testing.T) {
 
 	// NOTICE: configuration structure used by the successfully test.
 	config := &Config{
-		ServerAddress: "http://localhost",
-		TenantID:      "1c462afa-e4b6-41a5-ba54-7236a1770466",
-		PrivateKey:    "/tmp/shellhub.key",
+		ServerAddress:    "http://localhost",
+		TenantID:         "1c462afa-e4b6-41a5-ba54-7236a1770466",
+		PrivateKey:       "/tmp/shellhub.key",
+		TransportVersion: TransportV2,
 	}
 
 	tests := []struct {
@@ -207,14 +215,54 @@ func TestNewAgentWithConfig(t *testing.T) {
 		{
 			description: "fail when mode is nil",
 			config: &Config{
-				ServerAddress: "http://localhost",
-				TenantID:      "1c462afa-e4b6-41a5-ba54-7236a1770466",
-				PrivateKey:    "/tmp/shellhub.key",
+				ServerAddress:    "http://localhost",
+				TenantID:         "1c462afa-e4b6-41a5-ba54-7236a1770466",
+				PrivateKey:       "/tmp/shellhub.key",
+				TransportVersion: TransportV2,
 			},
 			mode: nil,
 			expected: expected{
 				agent: nil,
 				err:   ErrNewAgentWithConfigNilMode,
+			},
+		},
+		{
+			// NOTE: A hand-built Config that bypasses env parsing leaves
+			// TransportVersion at its zero value, which is not a supported
+			// version and would otherwise fail late in Agent.Listen.
+			description: "fail when transport version is unsupported",
+			config: &Config{
+				ServerAddress:    "http://localhost",
+				TenantID:         "1c462afa-e4b6-41a5-ba54-7236a1770466",
+				PrivateKey:       "/tmp/shellhub.key",
+				TransportVersion: 0,
+			},
+			mode: new(HostMode),
+			expected: expected{
+				agent: nil,
+				err:   ErrNewAgentWithConfigUnsupportedTransportVersion,
+			},
+		},
+		{
+			description: "success to create agent with transport version 1",
+			config: &Config{
+				ServerAddress:    "http://localhost",
+				TenantID:         "1c462afa-e4b6-41a5-ba54-7236a1770466",
+				PrivateKey:       "/tmp/shellhub.key",
+				TransportVersion: TransportV1,
+			},
+			mode: new(HostMode),
+			expected: expected{
+				agent: &Agent{
+					config: &Config{
+						ServerAddress:    "http://localhost",
+						TenantID:         "1c462afa-e4b6-41a5-ba54-7236a1770466",
+						PrivateKey:       "/tmp/shellhub.key",
+						TransportVersion: TransportV1,
+					},
+					mode: new(HostMode),
+				},
+				err: nil,
 			},
 		},
 		{


### PR DESCRIPTION
## What
Validate the agent transport protocol version when an `agentd.Agent` is
constructed, so an unsupported value fails immediately and clearly instead
of surfacing much later as a fatal `unsupported transport version: 0` at
listen time.

## Why
`TransportVersion` gets its default (`2`) from the env parser's struct tag
(`env:"TRANSPORT_VERSION,default=2"`). Any code path that builds `agentd.Config`
by hand — the connector, the `NewAgent` convenience constructor, embedders
such as ShellHub Desktop — bypasses that parser, leaving the field at its
zero value. Construction succeeds, then `Agent.Listen` hits the switch's
default branch and dies. The failure is late, opaque, and unreachable by
the existing unit tests, which only exercise the env-parsing path.

Related: shellhub-io/meta-shellhub#88 (the connector's own missing default
is fixed in #6732; this PR guards the whole class so it cannot recur silently).

## Changes
- **agentd**: `NewAgentWithConfig` now rejects a `TransportVersion` outside
  `{1, 2}` with a new `ErrNewAgentWithConfigUnsupportedTransportVersion`,
  turning a late listen-time fatal into an early construction error for
  every caller.
- **agentd**: `NewAgent` (the minimal-config public constructor) now applies
  the `TransportV2` default. Without it, the new guard would reject every
  agent built through that path — its `Example` has no `// Output:` line, so
  no test ran it and the break would have gone unnoticed.
- **tests**: added executed `TestNewAgent` (asserts the default is applied)
  and three `TestNewAgentWithConfig` cases — unsupported version rejected,
  V1 and V2 both accepted.

## Testing
Run in the agent container with the `docker` build tag:
`go test -tags docker ./pkg/agentd/`. All green; `golangci-lint` clean.

Note on ordering: this guard is complementary to #6732, not a replacement.
On its own it moves the connector's zero-value failure from listen time to
construction time — the connector still needs #6732's explicit
`TransportVersion: agentd.TransportV2` to actually connect. Land this
alongside or after #6732.