### PR TITLE
feat(ui): support SSO users in the console

### DIFF
--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -1014,6 +1014,22 @@ server {
         proxy_set_header Connection $connection_upgrade;
     }
 }
+
+# Test SAML IdP (SimpleSAMLphp) for local SSO development. Served at idp.<domain>
+# so it advertises a browser-reachable entity id and SSO URL under the same apex.
+server {
+    listen 80;
+    server_name idp.{{ $cfg.Domain }};
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
+    location / {
+        set $upstream saml-idp:8080;
+
+        proxy_pass http://$upstream;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+    }
+}
 {{ end }}
 
 {{ if and (ne $cfg.Database "migrate") $cfg.EnableEnterprise $cfg.WebEndpoints -}}

--- a/openapi/spec/components/schemas/userOrigin.yaml
+++ b/openapi/spec/components/schemas/userOrigin.yaml
@@ -1,3 +1,3 @@
 description: Specifies the method the user employed to register with ShellHub.
 type: string
-enum: [local]
+enum: [local, saml]

--- a/ui/apps/console/src/components/layout/UserMenu.tsx
+++ b/ui/apps/console/src/components/layout/UserMenu.tsx
@@ -16,7 +16,7 @@ import { useThemeStore } from "@/stores/themeStore";
 import { getInitials } from "@/utils/string";
 
 export default function UserMenu() {
-  const { user, logout } = useAuthStore();
+  const { user, name, email, logout } = useAuthStore();
   const navigate = useNavigate();
   const { namespaces } = useNamespaces();
   const theme = useThemeStore((s) => s.theme);
@@ -33,26 +33,33 @@ export default function UserMenu() {
     void navigate("/login");
   };
 
-  if (!user) return null;
+  // SAML users have no username, so fall back to name/email — the account menu
+  // (its only way to log out) must always render in the authenticated layout.
+  const display = user || name || email || "Account";
+
+  if (!user && !name && !email) return null;
 
   return (
     <div ref={containerRef} className="relative">
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        aria-label={`Account menu for ${user}`}
+        aria-label={`Account menu for ${display}`}
         aria-haspopup="true"
         aria-expanded={open}
         className="flex items-center gap-2 h-8 pl-1 pr-2.5 rounded-lg border border-transparent hover:border-border hover:bg-hover-subtle transition-all duration-150"
       >
         <span className="w-6 h-6 rounded-md bg-primary/15 border border-primary/20 flex items-center justify-center text-primary text-2xs font-bold font-mono">
-          {getInitials(user)}
+          {getInitials(display)}
         </span>
         <span className="hidden sm:inline text-xs font-medium text-text-secondary max-w-[120px] truncate">
-          {user}
+          {display}
         </span>
         <ChevronDownIcon
-          className={cn("w-3 h-3 text-text-muted transition-transform duration-200", open && "rotate-180")}
+          className={cn(
+            "w-3 h-3 text-text-muted transition-transform duration-200",
+            open && "rotate-180",
+          )}
           strokeWidth={2.5}
         />
       </button>
@@ -63,11 +70,11 @@ export default function UserMenu() {
           <div className="p-3.5 border-b border-border">
             <div className="flex items-center gap-3">
               <span className="w-9 h-9 rounded-lg bg-primary/15 border border-primary/20 flex items-center justify-center text-primary text-xs font-bold font-mono shrink-0">
-                {getInitials(user)}
+                {getInitials(display)}
               </span>
               <div className="min-w-0">
                 <p className="text-sm font-semibold text-text-primary truncate">
-                  {user}
+                  {display}
                 </p>
                 <p className="text-2xs text-text-muted mt-0.5">Logged in</p>
               </div>

--- a/ui/apps/console/src/components/layout/__tests__/UserMenu.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/UserMenu.test.tsx
@@ -5,7 +5,14 @@ import { MemoryRouter } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
 import UserMenu from "../UserMenu";
 
-const mockUseNamespaces = vi.fn<() => { namespaces: Array<{ tenant_id: string; name: string }>; isLoading: boolean; error: Error | null; refetch: () => void }>();
+const mockUseNamespaces = vi.fn<
+  () => {
+    namespaces: Array<{ tenant_id: string; name: string }>;
+    isLoading: boolean;
+    error: Error | null;
+    refetch: () => void;
+  }
+>();
 
 vi.mock("@/hooks/useNamespaces", () => ({
   useNamespaces: () => mockUseNamespaces(),
@@ -53,13 +60,29 @@ describe("UserMenu", () => {
   describe("trigger button", () => {
     it("displays the username", () => {
       renderMenu();
-      expect(screen.getByRole("button", { name: /alice/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /alice/i }),
+      ).toBeInTheDocument();
     });
 
     it("returns nothing when there is no logged-in user", () => {
-      useAuthStore.setState({ user: null });
+      useAuthStore.setState({ user: null, name: null, email: null });
       const { container } = renderMenu();
       expect(container).toBeEmptyDOMElement();
+    });
+
+    it("falls back to the name, not the email, when an SSO user has no username", () => {
+      useAuthStore.setState({
+        user: null,
+        name: "Alice",
+        email: "alice@corp.example",
+      });
+      renderMenu();
+      // Exact accessible name proves precedence: the email fallback would read
+      // "Account menu for alice@corp.example".
+      expect(
+        screen.getByRole("button", { name: "Account menu for Alice" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -67,19 +90,25 @@ describe("UserMenu", () => {
     it("shows Profile", async () => {
       renderMenu();
       await openDropdown();
-      expect(screen.getByRole("button", { name: /profile/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /profile/i }),
+      ).toBeInTheDocument();
     });
 
     it("shows Settings", async () => {
       renderMenu();
       await openDropdown();
-      expect(screen.getByRole("button", { name: /settings/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /settings/i }),
+      ).toBeInTheDocument();
     });
 
     it("shows Logout", async () => {
       renderMenu();
       await openDropdown();
-      expect(screen.getByRole("button", { name: /logout/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /logout/i }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -96,19 +125,25 @@ describe("UserMenu", () => {
     it("still shows Profile", async () => {
       renderMenu();
       await openDropdown();
-      expect(screen.getByRole("button", { name: /profile/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /profile/i }),
+      ).toBeInTheDocument();
     });
 
     it("hides Settings", async () => {
       renderMenu();
       await openDropdown();
-      expect(screen.queryByRole("button", { name: /settings/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /settings/i }),
+      ).not.toBeInTheDocument();
     });
 
     it("still shows Logout", async () => {
       renderMenu();
       await openDropdown();
-      expect(screen.getByRole("button", { name: /logout/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /logout/i }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/ui/apps/console/src/pages/Profile.tsx
+++ b/ui/apps/console/src/pages/Profile.tsx
@@ -450,8 +450,19 @@ function ChangePasswordDrawer({
 /* ─── Page ─── */
 
 export default function Profile() {
-  const { name, username, email, recoveryEmail, mfaEnabled, fetchUser } =
-    useAuthStore();
+  const {
+    name,
+    username,
+    email,
+    recoveryEmail,
+    origin,
+    mfaEnabled,
+    fetchUser,
+  } = useAuthStore();
+
+  // SSO users authenticate at their identity provider, so their password and MFA
+  // live there, not in ShellHub — don't offer local password/MFA controls to them.
+  const isSsoUser = origin === "saml";
 
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
   const [pwDrawerOpen, setPwDrawerOpen] = useState(false);
@@ -544,67 +555,84 @@ export default function Profile() {
 
         {/* ── Security ── */}
         <SettingsCard title="Security">
-          <SettingsRow
-            icon={<LockClosedIcon className="w-4 h-4" />}
-            title="Password"
-            description="Credentials used to authenticate into your account"
-          >
-            <Button variant="secondary" onClick={() => setPwDrawerOpen(true)}>
-              Change Password
-            </Button>
-          </SettingsRow>
-
-          {isEnterpriseOrCloud() ? (
+          {isSsoUser ? (
             <SettingsRow
               icon={<ShieldCheckIcon className="w-4 h-4" />}
-              title="Multi-Factor Authentication"
-              description="Add an extra layer of security with TOTP-based 2FA. Recovery codes are shown once during setup."
-              badge={
-                mfaEnabled ? (
-                  <span className="px-1.5 py-0.5 text-2xs font-mono font-semibold uppercase tracking-wider rounded bg-accent-green/10 text-accent-green border border-accent-green/20">
-                    Enabled
-                  </span>
-                ) : null
-              }
+              title="Managed by your identity provider"
+              description="You sign in through SSO, so your password and multi-factor authentication are configured with your identity provider, not in ShellHub."
             >
-              {mfaEnabled ? (
-                <Button
-                  variant="secondary"
-                  onClick={() => setMfaDisableOpen(true)}
-                >
-                  Disable
-                </Button>
-              ) : (
-                <Button
-                  variant="secondary"
-                  onClick={() => setMfaEnableOpen(true)}
-                >
-                  Enable MFA
-                </Button>
-              )}
+              <span className="px-1.5 py-0.5 text-2xs font-mono font-semibold uppercase tracking-wider rounded bg-primary/10 text-primary border border-primary/20">
+                SSO
+              </span>
             </SettingsRow>
           ) : (
-            <SettingsRow
-              icon={<ShieldCheckIcon className="w-4 h-4" />}
-              title="Multi-Factor Authentication"
-              description="Enhance your account security with TOTP-based 2FA"
-              badge={
-                <span className="px-1.5 py-0.5 text-2xs font-mono font-semibold uppercase tracking-wider rounded bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20">
-                  Pro
-                </span>
-              }
-            >
-              <Button
-                as="a"
-                size="sm"
-                variant="secondary"
-                href="https://www.shellhub.io/pricing"
-                target="_blank"
-                rel="noopener noreferrer"
+            <>
+              <SettingsRow
+                icon={<LockClosedIcon className="w-4 h-4" />}
+                title="Password"
+                description="Credentials used to authenticate into your account"
               >
-                Upgrade
-              </Button>
-            </SettingsRow>
+                <Button
+                  variant="secondary"
+                  onClick={() => setPwDrawerOpen(true)}
+                >
+                  Change Password
+                </Button>
+              </SettingsRow>
+
+              {isEnterpriseOrCloud() ? (
+                <SettingsRow
+                  icon={<ShieldCheckIcon className="w-4 h-4" />}
+                  title="Multi-Factor Authentication"
+                  description="Add an extra layer of security with TOTP-based 2FA. Recovery codes are shown once during setup."
+                  badge={
+                    mfaEnabled ? (
+                      <span className="px-1.5 py-0.5 text-2xs font-mono font-semibold uppercase tracking-wider rounded bg-accent-green/10 text-accent-green border border-accent-green/20">
+                        Enabled
+                      </span>
+                    ) : null
+                  }
+                >
+                  {mfaEnabled ? (
+                    <Button
+                      variant="secondary"
+                      onClick={() => setMfaDisableOpen(true)}
+                    >
+                      Disable
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="secondary"
+                      onClick={() => setMfaEnableOpen(true)}
+                    >
+                      Enable MFA
+                    </Button>
+                  )}
+                </SettingsRow>
+              ) : (
+                <SettingsRow
+                  icon={<ShieldCheckIcon className="w-4 h-4" />}
+                  title="Multi-Factor Authentication"
+                  description="Enhance your account security with TOTP-based 2FA"
+                  badge={
+                    <span className="px-1.5 py-0.5 text-2xs font-mono font-semibold uppercase tracking-wider rounded bg-accent-yellow/10 text-accent-yellow border border-accent-yellow/20">
+                      Pro
+                    </span>
+                  }
+                >
+                  <Button
+                    as="a"
+                    size="sm"
+                    variant="secondary"
+                    href="https://www.shellhub.io/pricing"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Upgrade
+                  </Button>
+                </SettingsRow>
+              )}
+            </>
           )}
         </SettingsCard>
 

--- a/ui/apps/console/src/pages/__tests__/Profile.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Profile.test.tsx
@@ -45,6 +45,7 @@ function seedAuthStore(
     email: string;
     recoveryEmail: string;
     mfaEnabled: boolean;
+    origin: "local" | "saml";
   }> = {},
 ) {
   useAuthStore.setState({
@@ -54,6 +55,7 @@ function seedAuthStore(
     email: "test@example.com",
     recoveryEmail: "recovery@example.com",
     mfaEnabled: false,
+    origin: "local",
     loading: false,
     token: "tok",
     userId: "uid-1",
@@ -131,6 +133,32 @@ describe("Profile", () => {
       seedAuthStore({ recoveryEmail: "" });
       renderProfile();
       expect(screen.getByText(/not set/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("SSO users", () => {
+    it("hides password and MFA controls, showing the managed-by-IdP notice", () => {
+      seedAuthStore({ origin: "saml" });
+      renderProfile();
+
+      expect(
+        screen.getByText(/managed by your identity provider/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /^change password$/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the password control for local users", () => {
+      seedAuthStore({ origin: "local" });
+      renderProfile();
+
+      expect(
+        screen.getByRole("button", { name: /^change password$/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/managed by your identity provider/i),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/stores/__tests__/authStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/authStore.test.ts
@@ -60,6 +60,7 @@ beforeEach(() => {
     userId: null,
     email: null,
     username: null,
+    origin: null,
     recoveryEmail: null,
     tenant: null,
     role: null,
@@ -293,11 +294,33 @@ describe("authStore", () => {
       expect(state.name).toBe("Admin User");
     });
 
+    it("maps the SSO origin into the store", async () => {
+      mockedGetUserInfo.mockResolvedValue(
+        mockSdkResponse(mockUserAuth({ origin: "saml" })),
+      );
+
+      await useAuthStore.getState().fetchUser();
+
+      expect(useAuthStore.getState().origin).toBe("saml");
+    });
+
     it("silently ignores errors (interceptor handles redirect)", async () => {
       mockedGetUserInfo.mockRejectedValue(new Error("401"));
 
       // Should not throw
       await useAuthStore.getState().fetchUser();
+    });
+  });
+
+  describe("loginWithToken", () => {
+    it("maps the SSO origin into the store", async () => {
+      mockedGetUserInfo.mockResolvedValue(
+        mockSdkResponse(mockUserAuth({ origin: "saml" })),
+      );
+
+      await useAuthStore.getState().loginWithToken("jwt-token");
+
+      expect(useAuthStore.getState().origin).toBe("saml");
     });
   });
 
@@ -313,6 +336,7 @@ describe("authStore", () => {
         user: "admin",
         userId: "123",
         email: "a@b.com",
+        origin: "saml",
         tenant: "t",
         role: "owner",
         name: "Admin",
@@ -332,6 +356,7 @@ describe("authStore", () => {
         user: "admin",
         userId: "123",
         email: "a@b.com",
+        origin: "saml", // SSO-awareness must survive a reload
         tenant: "t",
         role: "owner",
         name: "Admin",

--- a/ui/apps/console/src/stores/authStore.ts
+++ b/ui/apps/console/src/stores/authStore.ts
@@ -8,6 +8,7 @@ import {
   deleteUser as deleteUserSdk,
   authMfa,
   mfaRecover,
+  type UserOrigin,
 } from "../client";
 import { queryClient } from "../api/queryClient";
 import { tearDownChatwoot } from "../hooks/chatwootRuntime";
@@ -21,6 +22,9 @@ interface AuthState {
   userId: string | null;
   email: string | null;
   username: string | null;
+  // How the user authenticates: "local" (username + password) or "saml" (SSO).
+  // SSO users have no local password/MFA — those live at the identity provider.
+  origin: UserOrigin | null;
   recoveryEmail: string | null;
   tenant: string | null;
   role: Role | null;
@@ -59,6 +63,7 @@ const initialState = {
   userId: null,
   email: null,
   username: null,
+  origin: null,
   recoveryEmail: null,
   tenant: null,
   role: null,
@@ -132,6 +137,7 @@ export const useAuthStore = create<AuthState>()(
             user: data.user,
             userId: data.id,
             email: data.email,
+            origin: data.origin ?? null,
             tenant: data.tenant,
             name: data.name,
             isAdmin: data.admin ?? false,
@@ -177,6 +183,7 @@ export const useAuthStore = create<AuthState>()(
             username: user.user,
             userId: user.id,
             email: user.email,
+            origin: user.origin ?? null,
             recoveryEmail: user.recovery_email,
             name: user.name,
             tenant: user.tenant,
@@ -301,6 +308,7 @@ export const useAuthStore = create<AuthState>()(
         user: state.user,
         userId: state.userId,
         email: state.email,
+        origin: state.origin,
         tenant: state.tenant,
         role: state.role,
         isAdmin: state.isAdmin,


### PR DESCRIPTION
When a user signs in through SAML SSO, the console assumed a local account and broke in two places. This makes the console aware of the auth origin and adjusts what it shows.

## What changes

- The account menu no longer vanishes for SSO users. They have no username, and the menu keyed off it, so the only way to log out or reach the profile disappeared. It now falls back to the display name or email.
- The profile hides the password and MFA controls for SSO users. Those live at the identity provider, not in ShellHub, so offering them just produced errors. SSO users see a short "managed by your identity provider" notice instead.
- The user origin enum accepts `saml`, so the console can tell SSO and local accounts apart.

## Dev environment

Adds a test SAML IdP (SimpleSAMLphp) served at `idp.<domain>` for local SSO development. It is dev-only and inert outside the enterprise dev stack; the matching `saml-idp` service lives in the cloud repo.