### PR TITLE
refactor(ui): replace raw z-index values with semantic tokens

### DIFF
--- a/ui/apps/console/src/components/common/Drawer.tsx
+++ b/ui/apps/console/src/components/common/Drawer.tsx
@@ -43,7 +43,7 @@ export default function Drawer({
       <div
         role="presentation"
         className={cn(
-          "fixed inset-0 z-[60] bg-black/40 backdrop-blur-[2px] transition-opacity duration-300",
+          "fixed inset-0 z-drawer-backdrop bg-black/40 backdrop-blur-[2px] transition-opacity duration-300",
           open ? "opacity-100" : "opacity-0 pointer-events-none",
         )}
         onClick={onClose}
@@ -56,7 +56,7 @@ export default function Drawer({
         aria-hidden={!open}
         {...(!open ? { inert: true } : {})}
         className={cn(
-          "fixed inset-y-0 right-0 z-[70] w-full",
+          "fixed inset-y-0 right-0 z-drawer w-full",
           WIDTH_MAP[width],
           "bg-surface border-l border-border shadow-2xl flex flex-col transition-transform duration-300 ease-out",
           open ? "translate-x-0" : "translate-x-full",

--- a/ui/apps/console/src/components/common/TagFilterDropdown.tsx
+++ b/ui/apps/console/src/components/common/TagFilterDropdown.tsx
@@ -113,7 +113,7 @@ function TagFilterDropdown({
         createPortal(
           <div
             ref={popoverRef}
-            className="fixed z-50 w-[240px] bg-surface border border-border rounded-xl shadow-2xl animate-fade-in"
+            className="fixed z-dropdown w-[240px] bg-surface border border-border rounded-xl shadow-2xl animate-fade-in"
             style={{ top: pos.top, left: pos.left }}
           >
             {/* Search */}

--- a/ui/apps/console/src/components/common/TagsPopover.tsx
+++ b/ui/apps/console/src/components/common/TagsPopover.tsx
@@ -189,7 +189,7 @@ export default function TagsPopover({
             ref={popoverRef}
             role="dialog"
             aria-label="Manage tags"
-            className="fixed z-50 w-[300px] bg-surface border border-border rounded-xl shadow-2xl animate-fade-in"
+            className="fixed z-dropdown w-[300px] bg-surface border border-border rounded-xl shadow-2xl animate-fade-in"
             style={{ top: pos.top, left: pos.left }}
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}

--- a/ui/apps/console/src/components/common/TagsSection.tsx
+++ b/ui/apps/console/src/components/common/TagsSection.tsx
@@ -193,7 +193,7 @@ export default function TagsSection({
               <ul
                 id="tag-suggestions"
                 role="listbox"
-                className="absolute top-full left-0 mt-1.5 z-10 w-44 max-h-[140px] overflow-y-auto bg-surface border border-border rounded-lg shadow-2xl divide-y divide-border/60"
+                className="absolute top-full left-0 mt-1.5 z-raised w-44 max-h-[140px] overflow-y-auto bg-surface border border-border rounded-lg shadow-2xl divide-y divide-border/60"
               >
                 {options.map((opt, i) => (
                   <li

--- a/ui/apps/console/src/components/common/fields/TagsSelector.tsx
+++ b/ui/apps/console/src/components/common/fields/TagsSelector.tsx
@@ -90,7 +90,7 @@ export default function TagsSelector({
           />
         </div>
         {open && (
-          <div className="absolute z-10 mt-1 w-full max-h-48 overflow-y-auto bg-surface border border-border rounded-lg shadow-xl">
+          <div className="absolute z-raised mt-1 w-full max-h-48 overflow-y-auto bg-surface border border-border rounded-lg shadow-xl">
             {loading ? (
               <div className="px-3 py-2 text-xs text-text-muted">
                 Loading tags...

--- a/ui/apps/console/src/components/layout/AdminLayout.tsx
+++ b/ui/apps/console/src/components/layout/AdminLayout.tsx
@@ -47,7 +47,7 @@ export default function AdminLayout() {
             onMenuToggle={isDesktop ? undefined : handlers.toggleDrawer}
           />
           <div className="relative size-full">
-            <div className="grid-bg scanline absolute inset-0 -z-10" />
+            <div className="grid-bg scanline absolute inset-0 z-bg" />
             <main
               id="main-content"
               tabIndex={-1}

--- a/ui/apps/console/src/components/layout/AppBar.tsx
+++ b/ui/apps/console/src/components/layout/AppBar.tsx
@@ -116,7 +116,10 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
 
   return (
     <header
-      className={cn("theme-dark relative z-50 h-14 border-b px-3 sm:px-5 flex items-center justify-between shrink-0 transition-colors duration-300", displayed ? "border-transparent" : "bg-surface border-border")}
+      className={cn(
+        "theme-dark relative z-appbar h-14 border-b px-3 sm:px-5 flex items-center justify-between shrink-0 transition-colors duration-300",
+        displayed ? "border-transparent" : "bg-surface border-border",
+      )}
       style={displayed ? { backgroundColor: themeBg } : undefined}
     >
       {/* Left: menu toggle + crossfade with vertical slide */}
@@ -132,7 +135,10 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
         )}
         <div
           onTransitionEnd={handleTransitionEnd}
-          className={cn("min-w-0 transition-all duration-150 ease-out", visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2")}
+          className={cn(
+            "min-w-0 transition-all duration-150 ease-out",
+            visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
+          )}
         >
           {displayed ? (
             <TerminalInfo session={displayed} />
@@ -145,7 +151,12 @@ export default function AppBar({ onMenuToggle }: AppBarProps) {
       <div className="flex items-center gap-1">
         {/* Right: terminal actions fade + slide */}
         <div
-          className={cn("flex items-center transition-all duration-150 ease-out", displayed && visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2 pointer-events-none")}
+          className={cn(
+            "flex items-center transition-all duration-150 ease-out",
+            displayed && visible
+              ? "opacity-100 translate-y-0"
+              : "opacity-0 translate-y-2 pointer-events-none",
+          )}
         >
           {displayed && <TerminalActions session={displayed} />}
         </div>

--- a/ui/apps/console/src/components/layout/AppLayout.tsx
+++ b/ui/apps/console/src/components/layout/AppLayout.tsx
@@ -84,7 +84,7 @@ export default function AppLayout() {
               }
             />
             <div className="relative size-full">
-              <div className="grid-bg scanline absolute inset-0 -z-10" />
+              <div className="grid-bg scanline absolute inset-0 z-bg" />
               <main
                 id="main-content"
                 tabIndex={-1}
@@ -93,7 +93,7 @@ export default function AppLayout() {
               >
                 <Outlet />
               </main>
-              <div className="content-seam pointer-events-none absolute inset-0 z-10" />
+              <div className="content-seam pointer-events-none absolute inset-0 z-raised" />
             </div>
           </div>
         </div>

--- a/ui/apps/console/src/components/layout/LoginLayout.tsx
+++ b/ui/apps/console/src/components/layout/LoginLayout.tsx
@@ -5,7 +5,7 @@ export default function LoginLayout() {
   return (
     <div className="relative min-h-screen flex items-center justify-center bg-background overflow-hidden">
       <AmbientBackground />
-      <div className="relative z-10 w-full">
+      <div className="relative z-raised w-full">
         <Outlet />
       </div>
     </div>

--- a/ui/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -106,7 +106,7 @@ export default function NamespaceSelector({
       </button>
 
       {open && (
-        <div className="absolute top-full left-0 mt-1.5 w-80 max-w-[calc(100vw-2rem)] bg-surface border border-border rounded-lg shadow-2xl shadow-black/40 z-50 overflow-hidden animate-slide-down">
+        <div className="absolute top-full left-0 mt-1.5 w-80 max-w-[calc(100vw-2rem)] bg-surface border border-border rounded-lg shadow-2xl shadow-black/40 z-dropdown overflow-hidden animate-slide-down">
           {/* Active namespace header (non-admin only) */}
           {!isAdminContext && currentNamespace && (
             <div className="p-4 border-b border-border">

--- a/ui/apps/console/src/components/layout/SidebarShell.tsx
+++ b/ui/apps/console/src/components/layout/SidebarShell.tsx
@@ -42,10 +42,7 @@ export function NavItemLink({
 
   if (disabled) {
     return (
-      <span
-        aria-disabled="true"
-        className={cn(navBase, navDisabled, align)}
-      >
+      <span aria-disabled="true" className={cn(navBase, navDisabled, align)}>
         {item.icon}
         {label}
       </span>
@@ -58,7 +55,12 @@ export function NavItemLink({
       title={expanded ? undefined : item.label}
       onClick={onClick}
       className={({ isActive }) =>
-        cn(navBase, "transition-all duration-150", isActive ? navActive : navIdle, align)
+        cn(
+          navBase,
+          "transition-all duration-150",
+          isActive ? navActive : navIdle,
+          align,
+        )
       }
     >
       {item.icon}
@@ -89,17 +91,26 @@ export function SidebarMobileDrawer({
       role="dialog"
       aria-modal={open}
       aria-label="Navigation menu"
-      className={cn("fixed inset-0 z-50", !open && "pointer-events-none")}
+      className={cn(
+        "fixed inset-0 z-drawer-backdrop",
+        !open && "pointer-events-none",
+      )}
       onKeyDown={onKeyDown}
       {...(!open && { inert: true })}
     >
       <div
-        className={cn("absolute inset-0 bg-black/40 transition-opacity duration-200", open ? "opacity-100" : "opacity-0")}
+        className={cn(
+          "absolute inset-0 bg-black/40 transition-opacity duration-200",
+          open ? "opacity-100" : "opacity-0",
+        )}
         onClick={onClose}
         aria-hidden="true"
       />
       <div
-        className={cn("fixed inset-y-0 left-0 z-50 w-[220px] transition-transform duration-200 ease-in-out", open ? "translate-x-0" : "-translate-x-full")}
+        className={cn(
+          "fixed inset-y-0 left-0 z-drawer w-[220px] transition-transform duration-200 ease-in-out",
+          open ? "translate-x-0" : "-translate-x-full",
+        )}
       >
         {children}
       </div>
@@ -159,12 +170,18 @@ export default function SidebarShell({
         >
           <ShellHubLogo
             aria-hidden
-            className={cn("h-8 transition-opacity duration-200", expanded ? "opacity-100" : "opacity-0 absolute")}
+            className={cn(
+              "h-8 transition-opacity duration-200",
+              expanded ? "opacity-100" : "opacity-0 absolute",
+            )}
           />
           <ShellHubCloudIcon
             aria-hidden
             data-testid="sidebar-cloud-icon"
-            className={cn("h-6 w-6 transition-opacity duration-200", expanded ? "opacity-0 absolute" : "opacity-100")}
+            className={cn(
+              "h-6 w-6 transition-opacity duration-200",
+              expanded ? "opacity-0 absolute" : "opacity-100",
+            )}
           />
         </NavLink>
       </div>
@@ -185,10 +202,16 @@ export default function SidebarShell({
 
       {/* Footer with context-specific sidebar toggle */}
       <div
-        className={cn("h-11 px-3 flex items-center justify-between transition-colors duration-200", expanded ? "border-t border-border" : "border-t border-transparent")}
+        className={cn(
+          "h-11 px-3 flex items-center justify-between transition-colors duration-200",
+          expanded ? "border-t border-border" : "border-t border-transparent",
+        )}
       >
         <p
-          className={cn("text-2xs font-mono text-text-muted/60 whitespace-nowrap transition-opacity duration-200", expanded ? "opacity-100" : "opacity-0")}
+          className={cn(
+            "text-2xs font-mono text-text-muted/60 whitespace-nowrap transition-opacity duration-200",
+            expanded ? "opacity-100" : "opacity-0",
+          )}
         >
           {footerLabel}
         </p>
@@ -198,10 +221,17 @@ export default function SidebarShell({
           tabIndex={expanded ? 0 : -1}
           aria-label={toggleLabel}
           title={toggleTitle}
-          className={cn("duration-200", expanded ? "opacity-100" : "opacity-0", pinned && "text-primary bg-primary/10")}
+          className={cn(
+            "duration-200",
+            expanded ? "opacity-100" : "opacity-0",
+            pinned && "text-primary bg-primary/10",
+          )}
         >
           <ChevronLeftIcon
-            className={cn("w-3.5 h-3.5 transition-transform duration-200", !expanded && "rotate-180")}
+            className={cn(
+              "w-3.5 h-3.5 transition-transform duration-200",
+              !expanded && "rotate-180",
+            )}
             strokeWidth={2}
           />
         </IconButton>

--- a/ui/apps/console/src/components/layout/SkipToContentLink.tsx
+++ b/ui/apps/console/src/components/layout/SkipToContentLink.tsx
@@ -13,7 +13,7 @@ export default function SkipToContentLink() {
   return (
     <a
       href="#main-content"
-      className="fixed left-4 top-4 z-[200] -translate-y-20 rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-text-primary transition-transform focus:translate-y-0"
+      className="fixed left-4 top-4 z-skip-link -translate-y-20 rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-text-primary transition-transform focus:translate-y-0"
     >
       Skip to main content
     </a>

--- a/ui/apps/console/src/components/layout/UserMenu.tsx
+++ b/ui/apps/console/src/components/layout/UserMenu.tsx
@@ -58,7 +58,7 @@ export default function UserMenu() {
       </button>
 
       {open && (
-        <div className="absolute top-full right-0 mt-1.5 w-56 bg-surface border border-border rounded-lg shadow-2xl shadow-black/40 z-50 overflow-hidden animate-slide-down">
+        <div className="absolute top-full right-0 mt-1.5 w-56 bg-surface border border-border rounded-lg shadow-2xl shadow-black/40 z-dropdown overflow-hidden animate-slide-down">
           {/* User info */}
           <div className="p-3.5 border-b border-border">
             <div className="flex items-center gap-3">

--- a/ui/apps/console/src/components/terminal/RecordingSnackbar.tsx
+++ b/ui/apps/console/src/components/terminal/RecordingSnackbar.tsx
@@ -23,7 +23,7 @@ export default function RecordingSnackbar() {
     <div
       role="status"
       aria-live="polite"
-      className="fixed bottom-16 right-4 z-50 w-80 max-w-[calc(100vw-2rem)] bg-card border border-accent-green/30 rounded-lg shadow-lg shadow-black/30 px-4 py-3 flex items-start gap-3 animate-slide-up"
+      className="fixed bottom-16 right-4 z-toast w-80 max-w-[calc(100vw-2rem)] bg-card border border-accent-green/30 rounded-lg shadow-lg shadow-black/30 px-4 py-3 flex items-start gap-3 animate-slide-up"
     >
       <CheckCircleIcon
         className="w-4 h-4 text-accent-green shrink-0 mt-0.5"

--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -355,7 +355,7 @@ export default function TerminalInstance({
         <TerminalErrorBanner error={error} sessionId={session.id} />
       )}
       {session.record && session.connectionStatus === "connected" && (
-        <div className="absolute top-2 right-3 z-10 flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-black/40 backdrop-blur-sm pointer-events-none select-none">
+        <div className="absolute top-2 right-3 z-raised flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-black/40 backdrop-blur-sm pointer-events-none select-none">
           <span className="w-1.5 h-1.5 rounded-full bg-accent-red animate-pulse shadow-[0_0_4px_rgba(220,80,80,0.7)]" />
           <span className="text-2xs font-semibold tracking-wide text-accent-red">
             REC
@@ -364,7 +364,10 @@ export default function TerminalInstance({
       )}
       <div
         ref={containerRef}
-        className={cn("flex-1", error !== null && "opacity-30 pointer-events-none")}
+        className={cn(
+          "flex-1",
+          error !== null && "opacity-30 pointer-events-none",
+        )}
       />
     </div>
   );

--- a/ui/apps/console/src/components/terminal/TerminalManager.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalManager.tsx
@@ -74,7 +74,7 @@ export default function TerminalManager({
             key={s.id}
             style={{ left: isFullscreen ? 0 : sidebarOffset }}
             className={cn(
-              "fixed top-14 bottom-0 right-0 z-40 flex flex-col bg-background",
+              "fixed top-14 bottom-0 right-0 z-terminal flex flex-col bg-background",
               "transition-[opacity,transform,left] duration-200 ease-out",
               isVisible
                 ? "opacity-100 translate-y-0"

--- a/ui/apps/console/src/components/terminal/TerminalTaskbar.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalTaskbar.tsx
@@ -16,7 +16,7 @@ export default function TerminalTaskbar({
   return (
     <div
       style={{ left: sidebarOffset }}
-      className="fixed bottom-0 right-0 z-30 h-11 flex items-center gap-1.5 px-3 bg-surface border-t border-border animate-slide-up transition-[left] duration-200 ease-out"
+      className="fixed bottom-0 right-0 z-terminal-bar h-11 flex items-center gap-1.5 px-3 bg-surface border-t border-border animate-slide-up transition-[left] duration-200 ease-out"
     >
       {minimized.map((s) => {
         const isConnected = s.connectionStatus === "connected";

--- a/ui/apps/console/src/components/vault/VaultAutoLockBanner.tsx
+++ b/ui/apps/console/src/components/vault/VaultAutoLockBanner.tsx
@@ -52,7 +52,7 @@ export default function VaultAutoLockBanner() {
   if (!visible) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-[75] w-80">
+    <div className="fixed bottom-4 right-4 z-toast w-80">
       <Callout
         variant="warning"
         onDismiss={() => {

--- a/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
+++ b/ui/apps/console/src/components/vault/VaultSettingsSection.tsx
@@ -180,7 +180,7 @@ function AutoLockTimeoutSelect({
         <ul
           role="listbox"
           aria-label="Auto-lock timeout options"
-          className="absolute right-0 top-full mt-1 w-36 bg-surface border border-border rounded-lg shadow-2xl shadow-black/40 z-50 overflow-hidden animate-slide-down"
+          className="absolute right-0 top-full mt-1 w-36 bg-surface border border-border rounded-lg shadow-2xl shadow-black/40 z-dropdown overflow-hidden animate-slide-down"
         >
           {ALLOWED_TIMEOUT_MINUTES.map((minutes) => (
             <li

--- a/ui/apps/console/src/components/vault/VaultSyncPromoDialog.tsx
+++ b/ui/apps/console/src/components/vault/VaultSyncPromoDialog.tsx
@@ -52,7 +52,7 @@ export default function VaultSyncPromoDialog({ open, onClose, onSync }: Props) {
       <div className="p-6">
         <div className="flex flex-col items-center text-center mb-5">
           <div className="relative w-14 h-14 rounded-2xl bg-primary/10 flex items-center justify-center mb-4">
-            <div className="absolute inset-0 rounded-2xl bg-primary/20 blur-xl -z-10" />
+            <div className="absolute inset-0 rounded-2xl bg-primary/20 blur-xl z-bg" />
             <ServerStackIcon className="w-7 h-7 text-primary" />
           </div>
           <h2

--- a/ui/apps/console/src/components/vault/__tests__/VaultAutoLockBanner.test.tsx
+++ b/ui/apps/console/src/components/vault/__tests__/VaultAutoLockBanner.test.tsx
@@ -236,10 +236,10 @@ describe("VaultAutoLockBanner", () => {
       });
 
       const wrapper = container.firstChild as HTMLElement;
-      expect(wrapper.className).toContain("fixed");
-      expect(wrapper.className).toContain("bottom-4");
-      expect(wrapper.className).toContain("right-4");
-      expect(wrapper.className).toContain("z-[75]");
+      expect(wrapper).toHaveClass("fixed");
+      expect(wrapper).toHaveClass("bottom-4");
+      expect(wrapper).toHaveClass("right-4");
+      expect(wrapper).toHaveClass("z-toast");
     });
   });
 });

--- a/ui/apps/console/src/pages/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/SessionDetails.tsx
@@ -576,9 +576,8 @@ export default function SessionDetails() {
         errorMessage={closeError}
       />
 
-      {/* Recording error banner */}
       {logsError && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[90] px-4 py-2.5 bg-accent-red/10 border border-accent-red/30 text-accent-red text-sm font-mono rounded-lg shadow-lg">
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-banner px-4 py-2.5 bg-accent-red/10 border border-accent-red/30 text-accent-red text-sm font-mono rounded-lg shadow-lg">
           {logsError}
         </div>
       )}

--- a/ui/apps/console/src/pages/WebEndpoints.tsx
+++ b/ui/apps/console/src/pages/WebEndpoints.tsx
@@ -177,7 +177,7 @@ function DeviceSelector({
       </div>
       {error && <p className="mt-1 text-2xs text-accent-red">{error}</p>}
       {open && !selected && (
-        <div className="absolute z-10 mt-1 w-full max-h-48 overflow-y-auto bg-surface border border-border rounded-lg shadow-xl">
+        <div className="absolute z-raised mt-1 w-full max-h-48 overflow-y-auto bg-surface border border-border rounded-lg shadow-xl">
           {loading ? (
             <div className="px-3 py-2 text-xs text-text-muted">
               Loading devices...

--- a/ui/apps/console/src/pages/install-keys/ExpirationField.tsx
+++ b/ui/apps/console/src/pages/install-keys/ExpirationField.tsx
@@ -30,7 +30,7 @@ const PRESETS = [
 const CALENDAR_CLASSNAMES = {
   months: "relative flex flex-col",
   month: "flex flex-col",
-  nav: "absolute top-0 inset-x-0 flex items-center justify-between h-9 z-10",
+  nav: "absolute top-0 inset-x-0 flex items-center justify-between h-9 z-raised",
   button_previous:
     "inline-flex items-center justify-center w-7 h-7 rounded-md text-text-secondary hover:bg-hover-subtle hover:text-text-primary transition-colors disabled:opacity-30 disabled:pointer-events-none",
   button_next:
@@ -110,7 +110,7 @@ export default function ExpirationField({
           <div
             role="dialog"
             aria-label="Choose an expiration date"
-            className="absolute left-0 top-full mt-1 z-50 w-[19rem] p-3 bg-surface border border-border rounded-xl shadow-2xl animate-fade-in"
+            className="absolute left-0 top-full mt-1 z-dropdown w-[19rem] p-3 bg-surface border border-border rounded-xl shadow-2xl animate-fade-in"
           >
             <div className="flex flex-wrap gap-1.5 mb-3">
               {PRESETS.map((preset) => {

--- a/ui/apps/console/src/pages/install-keys/InstallKeyActionsMenu.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeyActionsMenu.tsx
@@ -177,7 +177,7 @@ export default function InstallKeyActionsMenu({
             tabIndex={-1}
             onKeyDown={onMenuKeyDown}
             style={{ top: pos.top, right: pos.right }}
-            className="fixed z-50 w-40 py-1 bg-surface border border-border rounded-lg shadow-2xl animate-fade-in"
+            className="fixed z-dropdown w-40 py-1 bg-surface border border-border rounded-lg shadow-2xl animate-fade-in"
           >
             <MenuItem
               action="installKey:edit"

--- a/ui/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
+++ b/ui/apps/console/src/pages/sessions/SessionPlayerDialog.tsx
@@ -16,12 +16,12 @@ export default function SessionPlayerDialog({
   if (!open) return null;
 
   return (
-    <div className="absolute inset-0 z-[80] flex flex-col bg-[#121314]">
+    <div className="absolute inset-0 z-overlay flex flex-col bg-[#121314]">
       {/* Close button overlay */}
       <IconButton
         onClick={onClose}
         aria-label="Close"
-        className="absolute top-2 right-2 z-10 bg-black/40 hover:bg-black/60"
+        className="absolute top-2 right-2 z-raised bg-black/40 hover:bg-black/60"
       >
         <XMarkIcon className="w-4 h-4" strokeWidth={2} />
       </IconButton>

--- a/ui/apps/docs/src/layouts/DocsLayout.astro
+++ b/ui/apps/docs/src/layouts/DocsLayout.astro
@@ -47,8 +47,7 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   </head>
   <body class="bg-background text-text-primary font-sans antialiased">
-    <!-- Header -->
-    <header class="sticky top-0 z-50 h-14 bg-background/40 backdrop-blur-xl border-b border-border shadow-lg shadow-black/10">
+    <header class="sticky top-0 z-appbar h-14 bg-background/40 backdrop-blur-xl border-b border-border shadow-lg shadow-black/10">
       <div class="flex items-center justify-between h-full max-w-7xl mx-auto px-8">
         <div class="flex items-center gap-3">
           <a href={websiteUrl} class="flex items-center shrink-0">
@@ -91,8 +90,7 @@ const sidebarForScript = sidebar.map(({ icon: _icon, ...rest }) => rest);
     <div class="relative max-w-7xl mx-auto grid grid-cols-12 gap-8 px-8">
       <div class="grid-bg grid-bg-fade absolute inset-0 pointer-events-none"></div>
 
-      <!-- Left Sidebar (off-canvas drawer on mobile, static column on md+) -->
-      <aside id="docs-sidebar" class="fixed top-14 left-0 h-[calc(100vh-56px)] w-72 z-40 bg-background overflow-y-auto pt-8 pb-12 border-r border-border -translate-x-full md:translate-x-0 md:static md:col-span-3 md:w-auto md:h-[calc(100vh-56px)] md:z-auto md:bg-transparent md:border-r-0 md:sticky md:top-14">
+      <aside id="docs-sidebar" class="fixed top-14 left-0 h-[calc(100vh-56px)] w-72 z-drawer bg-background overflow-y-auto pt-8 pb-12 border-r border-border -translate-x-full md:translate-x-0 md:static md:col-span-3 md:w-auto md:h-[calc(100vh-56px)] md:z-auto md:bg-transparent md:border-r-0 md:sticky md:top-14">
         <nav class="flex flex-col gap-4">
           {sidebar.map((section) => {
             const sectionId = section.label.toLowerCase().replace(/\s+/g, "-");

--- a/ui/apps/docs/src/pages/index.astro
+++ b/ui/apps/docs/src/pages/index.astro
@@ -33,8 +33,7 @@ const allItems = sidebar.flatMap(section =>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   </head>
   <body class="bg-background text-text-primary font-sans antialiased">
-    <!-- Header -->
-    <header class="sticky top-0 z-50 h-14 bg-background/40 backdrop-blur-xl border-b border-border shadow-lg shadow-black/10">
+    <header class="sticky top-0 z-appbar h-14 bg-background/40 backdrop-blur-xl border-b border-border shadow-lg shadow-black/10">
       <div class="flex items-center justify-between h-full max-w-7xl mx-auto px-8">
         <div class="flex items-center gap-3">
           <a href={websiteUrl} class="flex items-center shrink-0">

--- a/ui/apps/docs/src/styles/global.css
+++ b/ui/apps/docs/src/styles/global.css
@@ -70,7 +70,7 @@ html {
 .cmd-palette {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: theme(zIndex.overlay);
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -221,7 +221,7 @@ html {
 .docs-drawer-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 39;
+  z-index: theme(zIndex.drawer-backdrop);
   background: rgba(0, 0, 0, 0.6);
   opacity: 0;
   pointer-events: none;

--- a/ui/apps/website/src/components/CTABanner.tsx
+++ b/ui/apps/website/src/components/CTABanner.tsx
@@ -51,7 +51,7 @@ export function CTABanner({
             className={`absolute inset-0 bg-gradient-to-br ${GRADIENT_FROM[gradient.from]} via-transparent ${GRADIENT_TO[gradient.to]} pointer-events-none`}
           />
 
-          <div className="relative z-10">
+          <div className="relative z-raised">
             <SectionHeader
               variant="cta"
               eyebrow={eyebrow}

--- a/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
+++ b/ui/apps/website/src/pages/enterprise/HeroEnterprise.tsx
@@ -12,7 +12,7 @@ export function HeroEnterprise() {
       <ConnectionGrid />
       <GlowOrbs preset="section" tone="primary" />
 
-      <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+      <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
         <Reveal>
           <Badge shape="pill" color="yellow" className="mb-6">
             Enterprise

--- a/ui/apps/website/src/pages/features/index.tsx
+++ b/ui/apps/website/src/pages/features/index.tsx
@@ -78,7 +78,7 @@ function Hero() {
       <ConnectionGrid />
       <GlowOrbs preset="section" tone="cyan" />
 
-      <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+      <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
         <Reveal>
           <Badge shape="pill" color="primary" className="mb-6 tracking-label">
             Features

--- a/ui/apps/website/src/pages/getting-started/index.tsx
+++ b/ui/apps/website/src/pages/getting-started/index.tsx
@@ -20,7 +20,7 @@ export default function GettingStarted() {
         <ConnectionGrid />
         <GlowOrbs preset="section" tone="primary" />
 
-        <div className="relative z-10 w-full max-w-4xl flex flex-col items-center">
+        <div className="relative z-raised w-full max-w-4xl flex flex-col items-center">
           {/* Progress indicator */}
           <div className="flex items-center gap-3 mb-12 animate-fade-in">
             {steps.map((step, i) => (

--- a/ui/apps/website/src/pages/how-it-works/index.tsx
+++ b/ui/apps/website/src/pages/how-it-works/index.tsx
@@ -106,7 +106,7 @@ export default function HowItWorks() {
         <ConnectionGrid />
         <GlowOrbs preset="section" tone="cyan" />
 
-        <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+        <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
           <Reveal>
             <Badge shape="pill" color="primary" className="mb-6 tracking-label">
               How It Works
@@ -643,7 +643,7 @@ export default function HowItWorks() {
           <Reveal>
             <div className="relative grid md:grid-cols-2 gap-8 mb-16">
               {/* Timeline dot */}
-              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-primary border-2 border-background z-10 hidden md:block" />
+              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-primary border-2 border-background z-raised hidden md:block" />
 
               <div className="md:pr-12 md:text-right">
                 <div className="flex items-center gap-3 mb-4 md:justify-end">
@@ -718,7 +718,7 @@ export default function HowItWorks() {
           {/* Step 2: Agent Connects */}
           <Reveal>
             <div className="relative grid md:grid-cols-2 gap-8 mb-16">
-              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-cyan border-2 border-background z-10 hidden md:block" />
+              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-cyan border-2 border-background z-raised hidden md:block" />
 
               <div className="md:order-last md:text-left md:pl-12">
                 <div className="flex items-center gap-3 mb-4">
@@ -983,7 +983,7 @@ export default function HowItWorks() {
           {/* Step 3: SSH from Anywhere */}
           <Reveal>
             <div className="relative grid md:grid-cols-2 gap-8">
-              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-green border-2 border-background z-10 hidden md:block" />
+              <div className="absolute left-8 lg:left-1/2 top-8 w-3 h-3 -ml-1.5 rounded-full bg-accent-green border-2 border-background z-raised hidden md:block" />
 
               <div className="md:pr-12 md:text-right">
                 <div className="flex items-center gap-3 mb-4 md:justify-end">

--- a/ui/apps/website/src/pages/integrations/index.tsx
+++ b/ui/apps/website/src/pages/integrations/index.tsx
@@ -105,7 +105,7 @@ export default function Integrations() {
         <ConnectionGrid />
         <GlowOrbs preset="section" tone="cyan" />
 
-        <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+        <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
           <Reveal>
             <Badge shape="pill" color="cyan" className="mb-6 tracking-label">
               Integrations

--- a/ui/apps/website/src/pages/landing/CTA.tsx
+++ b/ui/apps/website/src/pages/landing/CTA.tsx
@@ -15,7 +15,7 @@ export function CTA() {
     >
       <ConnectionGrid />
       <GlowOrbs preset="duo" tone="primary" />
-      <div className="max-w-7xl mx-auto px-8 relative z-10">
+      <div className="max-w-7xl mx-auto px-8 relative z-raised">
         <Reveal>
           <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-bold tracking-[-0.03em] leading-tight mb-4">
             Ready to connect to your devices?

--- a/ui/apps/website/src/pages/landing/Hero.tsx
+++ b/ui/apps/website/src/pages/landing/Hero.tsx
@@ -8,7 +8,7 @@ export function Hero() {
       <ConnectionGrid />
       <GlowOrbs preset="hero" />
 
-      <div className="relative z-10 max-w-4xl flex flex-col items-center">
+      <div className="relative z-raised max-w-4xl flex flex-col items-center">
         {/* Floating ShellHub cloud */}
         <div className="animate-float mb-8 inline-block">
           <ShellHubCloudIcon className="h-16 drop-shadow-[0_0_24px_rgba(102,122,204,0.35)]" />

--- a/ui/apps/website/src/pages/landing/Navbar.tsx
+++ b/ui/apps/website/src/pages/landing/Navbar.tsx
@@ -136,7 +136,7 @@ function FullWidthMenu({
   return (
     <div
       className={cn(
-        "absolute top-full left-0 right-0 transition-all duration-[170ms] ease-out z-50",
+        "absolute top-full left-0 right-0 transition-all duration-[170ms] ease-out z-dropdown",
         isOpen
           ? "opacity-100 translate-y-0 pointer-events-auto"
           : "opacity-0 -translate-y-1 pointer-events-none",
@@ -323,7 +323,7 @@ export function Navbar({
       {/* Backdrop */}
       <div
         className={cn(
-          "fixed inset-0 top-14 z-40 transition-all duration-200",
+          "fixed inset-0 top-14 z-drawer-backdrop transition-all duration-200",
           activeMenu
             ? "opacity-100 pointer-events-auto"
             : "opacity-0 pointer-events-none",
@@ -335,7 +335,7 @@ export function Navbar({
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- nav onClick delegates to child links only */}
       <nav
         id="shellhub-nav"
-        className="fixed top-0 left-0 right-0 z-50 h-14 transition-all duration-300"
+        className="fixed top-0 left-0 right-0 z-appbar h-14 transition-all duration-300"
         onClick={(e) => {
           if ((e.target as HTMLElement).closest("a")) closeMenus();
         }}

--- a/ui/apps/website/src/pages/landing/SupportedPlatforms.tsx
+++ b/ui/apps/website/src/pages/landing/SupportedPlatforms.tsx
@@ -18,7 +18,7 @@ export function SupportedPlatforms() {
   return (
     <Section className="relative overflow-hidden" container={false}>
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[700px] bg-primary/[0.03] rounded-full blur-3xl pointer-events-none" />
-      <div className="max-w-7xl mx-auto px-8 relative z-10">
+      <div className="max-w-7xl mx-auto px-8 relative z-raised">
         <SectionHeader
           eyebrow="Supported Platforms"
           title={

--- a/ui/apps/website/src/pages/pricing/HeroPricing.tsx
+++ b/ui/apps/website/src/pages/pricing/HeroPricing.tsx
@@ -5,7 +5,7 @@ export function HeroPricing() {
     <section className="relative pt-32 pb-16 overflow-hidden">
       <GlowOrbs preset="section" tone="primary" />
 
-      <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+      <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
         <Reveal>
           <h1 className="text-[clamp(2rem,5vw,3.5rem)] font-bold tracking-[-0.03em] leading-[1.1] mb-4">
             Simple, transparent pricing

--- a/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
+++ b/ui/apps/website/src/pages/use-cases/ContainerManagement.tsx
@@ -480,7 +480,7 @@ export default function ContainerManagement() {
         <ConnectionGrid />
         <GlowOrbs preset="section" tone="cyan" />
 
-        <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+        <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
           <Reveal>
             <Badge shape="pill" color="cyan" className="mb-6 tracking-label">
               Use Case
@@ -840,7 +840,7 @@ export default function ContainerManagement() {
 
         <div className="relative grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* Connecting line (visible on md+) */}
-          <div className="hidden md:block absolute top-[52px] left-[16.66%] right-[16.66%] h-[1px] z-0">
+          <div className="hidden md:block absolute top-[52px] left-[16.66%] right-[16.66%] h-[1px] z-base">
             <div
               className="w-full h-full"
               style={{
@@ -854,7 +854,7 @@ export default function ContainerManagement() {
               <div className="relative text-center">
                 {/* Step number circle */}
                 <div
-                  className="relative z-10 w-[60px] h-[60px] rounded-full mx-auto mb-6 flex items-center justify-center border text-lg font-bold font-mono"
+                  className="relative z-raised w-[60px] h-[60px] rounded-full mx-auto mb-6 flex items-center justify-center border text-lg font-bold font-mono"
                   style={{
                     background: `${s.color}12`,
                     borderColor: `${s.color}30`,

--- a/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
+++ b/ui/apps/website/src/pages/use-cases/DevopsCiCd.tsx
@@ -245,7 +245,7 @@ export default function DevopsCiCd() {
         <ConnectionGrid />
         <GlowOrbs preset="section" tone="primary" />
 
-        <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+        <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
           <Reveal>
             <Badge shape="pill" color="green" className="mb-6 tracking-label">
               Use Case

--- a/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
+++ b/ui/apps/website/src/pages/use-cases/EdgeComputing.tsx
@@ -185,7 +185,7 @@ export default function EdgeComputing() {
         <ConnectionGrid />
         <GlowOrbs preset="section" tone="blue" />
 
-        <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+        <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
           <Reveal>
             <Badge shape="pill" color="blue" className="mb-6 tracking-label">
               Use Case

--- a/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
+++ b/ui/apps/website/src/pages/use-cases/IotEmbedded.tsx
@@ -146,7 +146,7 @@ export default function IotEmbedded() {
         <ConnectionGrid />
         <GlowOrbs preset="section" tone="green" />
 
-        <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+        <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
           <Reveal>
             <Badge shape="pill" color="green" className="mb-6 tracking-label">
               Use Case

--- a/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
+++ b/ui/apps/website/src/pages/use-cases/RemoteSupport.tsx
@@ -173,7 +173,7 @@ export default function RemoteSupport() {
         <ConnectionGrid />
         <GlowOrbs preset="section" tone="yellow" />
 
-        <div className="max-w-7xl mx-auto px-8 relative z-10 text-center">
+        <div className="max-w-7xl mx-auto px-8 relative z-raised text-center">
           <Reveal>
             <Badge shape="pill" color="yellow" className="mb-6">
               Use Case
@@ -539,7 +539,7 @@ export default function RemoteSupport() {
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 relative">
           {/* Connecting arrows (desktop only) */}
-          <div className="hidden md:block absolute top-1/2 left-[calc(33.33%-12px)] w-[calc(33.33%+24px)] -translate-y-1/2 pointer-events-none z-0">
+          <div className="hidden md:block absolute top-1/2 left-[calc(33.33%-12px)] w-[calc(33.33%+24px)] -translate-y-1/2 pointer-events-none z-base">
             <svg
               className="w-full h-8"
               viewBox="0 0 400 32"

--- a/ui/packages/design-system/tailwind.preset.js
+++ b/ui/packages/design-system/tailwind.preset.js
@@ -1,6 +1,22 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   theme: {
+    zIndex: {
+      base: "0",
+      auto: "auto",
+      bg: "-10",
+      raised: "10",
+      "terminal-bar": "30",
+      terminal: "40",
+      appbar: "50",
+      dropdown: "55",
+      "drawer-backdrop": "60",
+      drawer: "70",
+      toast: "75",
+      overlay: "80",
+      banner: "90",
+      "skip-link": "200",
+    },
     extend: {
       colors: {
         primary: {


### PR DESCRIPTION
## What

Adds a named z-index scale to the design-system Tailwind preset and replaces every raw `z-10`, `z-50`, `z-[75]`, etc. across console, docs, and website with a semantic token (`z-raised`, `z-appbar`, `z-toast`, ...).

Partial implementation of #6716 — this covers the z-index scale (pillar 1). The shared `Dropdown` primitive (pillar 2) and dropdown migrations (pillar 3) will follow in a separate PR.

## Why

z-index values were hardcoded ad hoc per component across 40+ call sites with no shared contract for which layer sits above which. Adding a new overlay meant guessing a number higher than whatever it renders under and discovering the ordering by trial and error.

## Changes

- **`tailwind.preset.js`**: added a `zIndex` key at `theme` level (replacement, not `extend`) with named tokens: `bg`, `base`, `raised`, `terminal-bar`, `terminal`, `appbar`, `dropdown`, `drawer-backdrop`, `drawer`, `toast`, `overlay`, `banner`, `skip-link`, plus `auto`. The replacement strategy means any new raw `z-[N]` usage fails to resolve — the broken class name is the enforcement mechanism.
- **console (26 files)**: mechanical swap of every raw z-index class to the matching token. No behavioral changes — each token maps to the same value the component already used, except where the old value was semantically wrong (e.g. `RecordingSnackbar` was `z-50` but is a toast, now `z-toast` at 75).
- **docs (3 files)**: header `z-appbar`, sidebar `z-drawer`, raw CSS values in `global.css` reference `theme(zIndex.overlay)` and `theme(zIndex.drawer-backdrop)`.
- **website (15 files)**: all `z-10` → `z-raised`, navbar `z-appbar`/`z-dropdown`/`z-drawer-backdrop`.
- **`VaultAutoLockBanner.test.tsx`**: assertion updated from `z-[75]` to `z-toast`, switched from `className.toContain` to `toHaveClass`.