### PR TITLE
ci: make the Semgrep gate honour suppressions and stop blocking master

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Mark workspace safe for git (semgrep container runs as different user)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # --error is deliberately absent: under --sarif, semgrep counts
+      # nosemgrep-suppressed findings as blocking, so --error would ignore every
+      # inline suppression. The "Evaluate findings" step below is the gate and
+      # reads the suppressions back out of the SARIF.
       - name: Run Semgrep (PR — baseline diff)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -45,7 +49,6 @@ jobs:
             --config p/dockerfile \
             --config p/ci \
             --baseline-commit ${{ github.event.pull_request.base.sha }} \
-            --error \
             --sarif \
             --output semgrep.sarif \
             .
@@ -57,7 +60,6 @@ jobs:
             --config p/golang \
             --config p/dockerfile \
             --config p/ci \
-            --error \
             --sarif \
             --output semgrep.sarif \
             .
@@ -68,6 +70,44 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: semgrep
+
+      # Pull requests block on findings they introduce (the scan above is
+      # already limited to the baseline diff). The full scan on master and the
+      # weekly cron report only: they re-report a pre-existing backlog that no
+      # single change is accountable for, and failing on it just keeps master
+      # permanently red. The backlog stays visible as code scanning alerts.
+      - name: Evaluate findings
+        if: ${{ always() }}
+        env:
+          ENFORCE: ${{ github.event_name == 'pull_request' }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+
+          with open("semgrep.sarif") as fd:
+              sarif = json.load(fd)
+
+          results = [r for run in sarif.get("runs", []) for r in run.get("results", [])]
+          blocking = [r for r in results if not r.get("suppressions")]
+
+          for r in blocking:
+              loc = r["locations"][0]["physicalLocation"]
+              path = loc["artifactLocation"]["uri"]
+              line = loc["region"]["startLine"]
+              print(f"{path}:{line}  {r['ruleId']}")
+
+          suppressed = len(results) - len(blocking)
+          print(f"\n{len(blocking)} blocking, {suppressed} suppressed via nosemgrep")
+
+          if not blocking:
+              sys.exit(0)
+
+          if os.environ["ENFORCE"] != "true":
+              print("Report-only for this event; not failing the build.")
+              sys.exit(0)
+
+          sys.exit(1)
+          PY
 
   # security-gate is the frozen required-check name referenced in branch protection.
   # It aggregates all scan jobs: success or skipped = pass, failure or cancelled = fail.

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -19,3 +19,9 @@
 
 # Generated mock files — not maintained by hand; findings are false positives.
 **/mocks/
+
+# Go test files — never shipped in a runtime image. Test harnesses legitimately
+# dial local fixtures with relaxed settings (e.g. InsecureIgnoreHostKey against
+# the test gateway), which the security rules cannot distinguish from the real
+# thing. Production code under the same rules is NOT excluded.
+**/*_test.go


### PR DESCRIPTION
## What

Splits the Semgrep exit code away from `--error` so inline `nosemgrep`
suppressions actually count, and demotes the full scan on `master` and the
weekly cron to report-only. Excludes Go test files from scanning.

Full-scan findings drop from 54 to 23.

## Why

The `Semgrep` workflow has been failing repeatedly on `master` — runs
`30254805549` (cron), `30229452822` and `30261657585` (dependabot pushes).
None were caused by the change that triggered them: PRs scan
`--baseline-commit`, so only the full scan on `master` saw the accumulated
backlog, and `--error` failed the build on all of it.

Two separate problems were behind it.

**Inline suppressions were silently ineffective.** Under `--sarif`, semgrep
emits a `nosemgrep`-suppressed finding with `suppressions: [{"kind":
"inSource"}]` but still counts it as blocking, so `--error` ignored every
suppression in the repo. Verified against the CI image on the current tree:

| Output | Findings |
|---|---|
| `--json` | 23 |
| `--sarif` | 24 blocking |

That one-finding delta is the `dependabot_pr.yml` exception accepted in
`4e59b0e58`, which has been failing the build since 2026-07-22 despite being
correctly annotated. Rule anchoring was never the issue — a `nosemgrep` on a
Dockerfile `ENTRYPOINT` suppresses correctly under `--json`.

**Test-file noise dominated the backlog.** 29 of 31
`avoid-ssh-insecure-ignore-host-key` findings were in `tests/` (a test-only
module with no non-test `.go` files) and `ssh/web/session_test.go`, where
dialing a local test gateway with `InsecureIgnoreHostKey` is correct. The
existing `.semgrepignore` already encoded this policy for fixtures and mocks;
it had no `*_test.go` entry.

Severity gating was considered and rejected: the 12 `ERROR` findings are
exactly the Dockerfile cluster that is hardest to fix (7 dev-only stages, plus
`agent`/`gateway`/`ui` which are root by design), while the 11 `WARNING`
findings include the host-key and websocket sites that merit actual review.
Gating on severity would block on the wrong half.

## Changes

- **`.semgrepignore`**: excludes `**/*_test.go`. Clears 29 host-key findings
  plus one in `pkg/wsconnadapter`. Production code under the same rules is not
  excluded — the two `InsecureIgnoreHostKey` sites in `ssh/session/session.go`
  and `ssh/web/session.go` are still reported.
- **`semgrep.yml`**: drops `--error` from both scan invocations and adds an
  `Evaluate findings` step that computes the exit code from the SARIF, skipping
  results that carry `suppressions`. Gating on the SARIF rather than running a
  second `--json` scan avoids two command lines whose `--config` sets could
  drift apart — a divergence that would fail open.
- **`semgrep.yml`**: pull requests still block on findings they introduce; the
  `master` and cron full scans report only. The backlog stays visible as code
  scanning alerts.

`security-gate` keeps its name and still runs on pull requests, so branch
protection is unaffected.

## Testing

Verified against `semgrep/semgrep:1.154.0` with the workflow's `--config` set,
running the gate script inside the container:

- `dependabot_pr.yml` is excluded from the blocking set (23 blocking, 1
  suppressed), confirming suppressions are honoured.
- `ENFORCE=true` exits 1; `ENFORCE=false` exits 0 and prints a report-only
  notice.

The report-only path cannot be fully exercised until this lands and a push to
`master` runs it.

Two behaviours worth a reviewer's attention:

- `--error` is gone, but semgrep still exits non-zero on genuine scan errors,
  and `Evaluate findings` fails if `semgrep.sarif` is absent, so a scan that
  dies without output cannot pass silently.
- `if: always()` on the gate does not weaken it. A failed earlier step already
  fails the job; the condition exists so the gate still reports when the SARIF
  upload is skipped on fork PRs.

Out of scope: GitHub is not honouring the SARIF `suppressions` field — alert
204 remains `state: open` despite five days of correctly suppressed uploads —
so suppressed findings stay visible in the Security tab. Clearing them needs
API dismissals with a reason. The 23 remaining findings are likewise left as a
tracked backlog.