### PR TITLE
refactor(ui): wire footer links and drop dead ones

### DIFF
--- a/ui/apps/docs/src/pages/index.astro
+++ b/ui/apps/docs/src/pages/index.astro
@@ -125,8 +125,7 @@ const allItems = sidebar.flatMap(section =>
       </div>
     </section>
 
-    <!-- Footer -->
-    <Footer />
+    <Footer app="docs" />
 
     <!-- Command Palette -->
     <div class="cmd-palette" id="cmd-palette">

--- a/ui/apps/website/src/components/SiteLayout.tsx
+++ b/ui/apps/website/src/components/SiteLayout.tsx
@@ -1,6 +1,23 @@
+import { Link } from "react-router-dom";
 import { cn } from "@shellhub/design-system/cn";
 import { SiteHeader } from "@/components/SiteHeader";
 import { Footer } from "@shellhub/design-system/components";
+
+function RouterLink({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link to={href} className={className}>
+      {children}
+    </Link>
+  );
+}
 
 export function SiteLayout({
   children,
@@ -18,7 +35,7 @@ export function SiteLayout({
     >
       <SiteHeader />
       {children}
-      <Footer />
+      <Footer linkComponent={RouterLink} />
     </div>
   );
 }

--- a/ui/packages/design-system/__tests__/Footer.test.tsx
+++ b/ui/packages/design-system/__tests__/Footer.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Footer } from "../components/Footer";
+
+describe("Footer", () => {
+  describe("app=website (default)", () => {
+    it("renders website links via linkComponent", () => {
+      render(<Footer />);
+      const link = screen.getByRole("link", { name: "Features" });
+      expect(link).not.toHaveAttribute("target");
+    });
+
+    it("renders docs link as external", () => {
+      render(<Footer />);
+      const link = screen.getByRole("link", { name: "Documentation" });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  });
+
+  describe("app=docs", () => {
+    it("renders website links as external", () => {
+      render(<Footer app="docs" />);
+      const link = screen.getByRole("link", { name: "Features" });
+      expect(link).toHaveAttribute("target", "_blank");
+    });
+
+    it("renders docs link via linkComponent", () => {
+      render(<Footer app="docs" />);
+      const link = screen.getByRole("link", { name: "Documentation" });
+      expect(link).not.toHaveAttribute("target");
+    });
+  });
+
+  it("renders the GitHub social link as external", () => {
+    render(<Footer />);
+    const link = screen.getByRole("link", { name: "GitHub" });
+    expect(link).toHaveAttribute("href", "https://github.com/shellhub-io/shellhub");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("uses linkComponent for same-app links", () => {
+    function CustomLink({
+      href,
+      className,
+      children,
+    }: {
+      href: string;
+      className?: string;
+      children: React.ReactNode;
+    }) {
+      return (
+        <a href={href} className={className} data-router="true">
+          {children}
+        </a>
+      );
+    }
+
+    render(<Footer linkComponent={CustomLink} />);
+
+    expect(screen.getByRole("link", { name: "Features" })).toHaveAttribute(
+      "data-router",
+      "true",
+    );
+    expect(screen.getByRole("link", { name: "Documentation" })).not.toHaveAttribute(
+      "data-router",
+    );
+  });
+
+  it("renders the copyright text with the current year", () => {
+    render(<Footer />);
+    const year = new Date().getFullYear();
+    expect(
+      screen.getByText(new RegExp(`${year}.*ShellHub.*All rights reserved`)),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/packages/design-system/components/Footer.tsx
+++ b/ui/packages/design-system/components/Footer.tsx
@@ -1,66 +1,85 @@
-import {
-  DiscordIcon,
-  GithubIcon,
-  ShellHubLogo,
-  TwitterXIcon,
-} from "../primitives/icons";
+import { GithubIcon, ShellHubLogo } from "../primitives/icons";
 
-export function Footer() {
+const GITHUB_URL = "https://github.com/shellhub-io/shellhub";
+const WEBSITE_URL = "http://website.localhost";
+const DOCS_URL = "http://docs.localhost";
+const CURRENT_YEAR = new Date().getFullYear();
+
+type FooterApp = "website" | "docs";
+
+const APP_ORIGINS: Record<FooterApp, string> = {
+  website: WEBSITE_URL,
+  docs: DOCS_URL,
+};
+
+const COLUMNS = [
+  {
+    title: "Product",
+    links: [
+      { label: "Features", href: `${WEBSITE_URL}/features` },
+      { label: "Pricing", href: `${WEBSITE_URL}/pricing` },
+      { label: "Enterprise", href: `${WEBSITE_URL}/enterprise` },
+    ],
+  },
+  {
+    title: "Resources",
+    links: [
+      { label: "Documentation", href: DOCS_URL },
+      { label: "Getting Started", href: `${WEBSITE_URL}/getting-started` },
+    ],
+  },
+];
+
+interface FooterProps {
+  app?: FooterApp;
+  linkComponent?: React.ElementType;
+}
+
+function isSameApp(href: string, origin: string) {
+  return href.startsWith(origin);
+}
+
+export function Footer({
+  app = "website",
+  linkComponent: Link = "a",
+}: FooterProps) {
+  const origin = APP_ORIGINS[app];
+  const linkCls = "text-text-secondary hover:text-text-primary transition-colors";
+
   return (
     <footer className="border-t border-border pt-14 pb-8">
       <div className="max-w-7xl mx-auto px-8">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[2fr_1fr_1fr_1fr_1fr] gap-10 mb-10">
-          <div>
-            <a href="#" className="inline-block mb-4">
+        <div className="flex flex-wrap gap-10 mb-10">
+          <div className="w-full md:flex-[2]">
+            <Link href={WEBSITE_URL} className="inline-block mb-4">
               <ShellHubLogo className="h-8" />
-            </a>
+            </Link>
             <p className="text-xs text-text-secondary max-w-[220px] leading-relaxed">
               The open source SSH gateway for remote access to Linux devices.
             </p>
           </div>
-          {[
-            {
-              title: "Product",
-              links: [
-                "Features",
-                "Pricing",
-                "Cloud",
-                "Self-Hosted",
-                "Enterprise",
-              ],
-            },
-            {
-              title: "Resources",
-              links: [
-                "Documentation",
-                "Getting Started",
-                "API Reference",
-                "Blog",
-                "Changelog",
-              ],
-            },
-            {
-              title: "Company",
-              links: ["About", "Careers", "Contact", "Partners"],
-            },
-            {
-              title: "Legal",
-              links: ["Privacy Policy", "Terms of Service", "Security"],
-            },
-          ].map((col) => (
-            <div key={col.title}>
+          {COLUMNS.map((col) => (
+            <div key={col.title} className="flex-1 min-w-[140px] text-xs">
               <h5 className="text-2xs font-mono font-semibold uppercase tracking-[0.15em] text-text-secondary mb-3">
                 {col.title}
               </h5>
               <ul className="space-y-1.5">
                 {col.links.map((l) => (
-                  <li key={l}>
-                    <a
-                      href="#"
-                      className="text-xs text-text-secondary hover:text-text-primary transition-colors"
-                    >
-                      {l}
-                    </a>
+                  <li key={l.label}>
+                    {isSameApp(l.href, origin) ? (
+                      <Link href={l.href} className={linkCls}>
+                        {l.label}
+                      </Link>
+                    ) : (
+                      <a
+                        href={l.href}
+                        className={linkCls}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {l.label}
+                      </a>
+                    )}
                   </li>
                 ))}
               </ul>
@@ -70,18 +89,18 @@ export function Footer() {
 
         <div className="flex flex-col sm:flex-row justify-between items-center pt-6 border-t border-border gap-4">
           <span className="text-2xs font-mono text-text-secondary">
-            &copy; 2026 ShellHub. All rights reserved.
+            &copy; {CURRENT_YEAR} ShellHub. All rights reserved.
           </span>
           <div className="flex gap-3">
-            {[GithubIcon, TwitterXIcon, DiscordIcon].map((Icon, i) => (
-              <a
-                key={i}
-                href="#"
-                className="text-text-secondary hover:text-text-primary transition-colors"
-              >
-                <Icon className="w-4 h-4" />
-              </a>
-            ))}
+            <a
+              href={GITHUB_URL}
+              className={linkCls}
+              aria-label="GitHub"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <GithubIcon className="w-4 h-4" />
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What

Footer links now point to real destinations instead of `#`. Links to pages that don't exist yet are removed entirely rather than kept as dead anchors.

## Why

Every link in the Footer component was hardcoded to `href="#"` — 22 dead links across Product, Resources, Company, Legal, and Social sections. Only 7 have real destinations today.

Closes shellhub-io/team#183

## Changes

- **`Footer.tsx`**: link data moved from inline JSX to module-level constants (`WEBSITE_URL`, `DOCS_URL`, `GITHUB_URL`, `COLUMNS`). An `app` prop (`"website"` | `"docs"`) drives `isSameApp` to decide whether each link uses `linkComponent` (same-app, client-side nav) or `<a target="_blank">` (cross-app). Company, Legal, Cloud, Self-Hosted, API Reference, Blog, Changelog, Twitter/X, and Discord links removed — no target pages exist. GitHub is the sole social link. Grid layout replaced with flexbox so the column count adapts to the data. Copyright year is now dynamic.
- **`SiteLayout.tsx`**: passes a `RouterLink` adapter (maps `href` to React Router's `to`) as `linkComponent`. No URL props — Footer owns the data.
- **`docs/index.astro`**: passes `app="docs"` so cross-app links open in a new tab. No `linkComponent` needed (Astro renders static HTML).
- **`Footer.test.tsx`** (new): 7 tests covering same-app vs cross-app behavior for both `app` values, `linkComponent` passthrough, GitHub external link, and dynamic copyright year.

## Testing

- Run `cd packages/design-system && npm run test` — 7 new Footer tests
- Build all three apps (`website`, `docs`, `console`) — all pass
- On the website, verify footer product links use client-side navigation (no full reload), and the Documentation link opens in a new tab
- On docs, verify product links open in a new tab and Documentation stays in the same tab