### PR TITLE
refactor(ui): promote react-router-dom to root workspace

### DIFF
--- a/ui/apps/console/package.json
+++ b/ui/apps/console/package.json
@@ -38,7 +38,6 @@
     "node-rsa": "^1.1.1",
     "react-day-picker": "^10.0.1",
     "react-hook-form": "^7.81.0",
-    "react-router-dom": "^7.17.0",
     "sshpk": "^1.18.0",
     "zod": "^3.25.76",
     "zustand": "^5.0.14"

--- a/ui/apps/website/package.json
+++ b/ui/apps/website/package.json
@@ -12,7 +12,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@shellhub/design-system": "*",
-    "react-router-dom": "^6.28.0"
+    "@shellhub/design-system": "*"
   }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,7 +17,8 @@
         "date-fns": "^4.1.0",
         "qrcode": "^1.5.4",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.17.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -78,7 +79,6 @@
         "node-rsa": "^1.1.1",
         "react-day-picker": "^10.0.1",
         "react-hook-form": "^7.81.0",
-        "react-router-dom": "^7.17.0",
         "sshpk": "^1.18.0",
         "zod": "^3.25.76",
         "zustand": "^5.0.14"
@@ -196,40 +196,7 @@
       "name": "@shellhub/website",
       "version": "0.0.0",
       "dependencies": {
-        "@shellhub/design-system": "*",
-        "react-router-dom": "^6.28.0"
-      }
-    },
-    "apps/website/node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "apps/website/node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
+        "@shellhub/design-system": "*"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -3067,15 +3034,6 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,6 +47,7 @@
     "date-fns": "^4.1.0",
     "qrcode": "^1.5.4",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.17.0"
   }
 }


### PR DESCRIPTION
## What

Unified `react-router-dom` as a single shared dependency at the workspace root instead of each app declaring its own version.

## Why

Console was on `react-router-dom` v7 and Website on v6, each declared independently. Both apps use the same v6-era routing pattern (`BrowserRouter`, `Routes`, `Route`, `Link`, `useLocation`) — none of which changed in v7 — so there's no reason to carry two separate versions. A single hoisted copy eliminates the nested `node_modules` duplication and keeps both apps on the same upgrade path.

## Changes

- **`ui/package.json`**: added `react-router-dom` ^7.17.0 to root `dependencies`
- **`ui/apps/console/package.json`**: removed per-app `react-router-dom` entry
- **`ui/apps/website/package.json`**: removed per-app `react-router-dom` entry (v6 → v7 upgrade, no code changes required)
- **`ui/package-lock.json`**: removed the nested v6 copy and `@remix-run/router` transitive dependency