### PR TITLE
chore(ui): enable React Compiler

### DIFF
--- a/ui/apps/console/vite.config.ts
+++ b/ui/apps/console/vite.config.ts
@@ -18,7 +18,11 @@ function healthcheck(): Plugin {
 
 export default defineConfig({
   plugins: [
-    react(),
+    react({
+      babel: {
+        plugins: ["babel-plugin-react-compiler"],
+      },
+    }),
     nodePolyfills({
       // buffer, crypto, stream are needed by node-rsa and sshpk for SSH key parsing/signing.
       // Note: vault-crypto.ts uses browser-native crypto.subtle (Web Crypto API),

--- a/ui/apps/website/vite.config.ts
+++ b/ui/apps/website/vite.config.ts
@@ -4,7 +4,13 @@ import react from "@vitejs/plugin-react";
 import * as path from "node:path";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      babel: {
+        plugins: ["babel-plugin-react-compiler"],
+      },
+    }),
+  ],
   base: "/",
   server: {
     port: 8082,

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -11,7 +11,7 @@ import jsxA11y from "eslint-plugin-jsx-a11y";
 import reactPlugin from "eslint-plugin-react";
 
 export default defineConfig([
-  globalIgnores(["**/dist", "**/node_modules", "**/.astro", "**/.vite", "packages/design-system/**", "**/src/client"]),
+  globalIgnores(["**/dist", "**/node_modules", "**/.astro", "**/.vite", "**/src/client"]),
   js.configs.recommended,
   {
     extends: [...tseslint.configs.recommendedTypeChecked],
@@ -111,6 +111,15 @@ export default defineConfig([
       "@stylistic/operator-linebreak": "off",
       "@stylistic/jsx-wrap-multilines": "off",
       "@stylistic/jsx-curly-newline": "off",
+    },
+  },
+
+  // Design-system is a library — fast refresh doesn't apply, and compound
+  // components intentionally export multiple functions from one file.
+  {
+    files: ["packages/design-system/**/*.{ts,tsx}"],
+    rules: {
+      "react-refresh/only-export-components": "off",
     },
   },
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -36,7 +36,7 @@
         "eslint": "^9.22.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "7.1.0-canary-e0cc7202-20260227",
+        "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-refresh": "^0.5.0",
         "eslint-plugin-unused-imports": "^4.4.1",
         "globals": "^17.4.0",
@@ -8042,7 +8042,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.1.0-canary-e0cc7202-20260227",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -33,6 +33,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/eslint-plugin": "^1.1.44",
         "autoprefixer": "^10.4.20",
+        "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^9.22.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
@@ -6001,6 +6002,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/bail": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,6 +29,7 @@
     "eslint": "^9.22.0",
     "globals": "^17.4.0",
     "eslint-plugin-react-hooks": "7.1.1",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint-plugin-react-refresh": "^0.5.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "dev:console": "npm run dev -w @shellhub/console",
+    "lint": "npm run lint --workspaces --if-present",
     "test": "npm run test --workspaces --if-present"
   },
   "devDependencies": {
@@ -27,7 +28,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9.22.0",
     "globals": "^17.4.0",
-    "eslint-plugin-react-hooks": "7.1.0-canary-e0cc7202-20260227",
+    "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "^0.5.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",

--- a/ui/packages/design-system/__tests__/Dropdown.test.tsx
+++ b/ui/packages/design-system/__tests__/Dropdown.test.tsx
@@ -14,7 +14,7 @@ function MenuDropdown({
   return (
     <Dropdown>
       <Dropdown.Trigger>
-        <button>Actions</button>
+        <button type="button">Actions</button>
       </Dropdown.Trigger>
       <Dropdown.Panel>
         <Dropdown.Item onSelect={onEdit} label="Edit">
@@ -32,7 +32,7 @@ function MenuWithDisabled() {
   return (
     <Dropdown>
       <Dropdown.Trigger>
-        <button>Actions</button>
+        <button type="button">Actions</button>
       </Dropdown.Trigger>
       <Dropdown.Panel>
         <Dropdown.Item label="Edit">Edit</Dropdown.Item>
@@ -137,7 +137,7 @@ function ContentDropdown() {
   return (
     <Dropdown mode="content">
       <Dropdown.Trigger>
-        <button>Open panel</button>
+        <button type="button">Open panel</button>
       </Dropdown.Trigger>
       <Dropdown.Panel aria-label="Info panel">
         <p>Custom content here</p>
@@ -464,7 +464,7 @@ describe("Dropdown", () => {
       render(
         <Dropdown open={true} onOpenChange={onOpenChange} mode="content">
           <Dropdown.Trigger>
-            <button>Trigger</button>
+            <button type="button">Trigger</button>
           </Dropdown.Trigger>
           <Dropdown.Panel aria-label="Controlled">
             <p>Content</p>

--- a/ui/packages/design-system/__tests__/IconButton.test.tsx
+++ b/ui/packages/design-system/__tests__/IconButton.test.tsx
@@ -237,7 +237,7 @@ describe("IconButton — as={Link} (React Router Link-like)", () => {
       children?: React.ReactNode;
       [key: string]: unknown;
     }) => (
-      <a href={to as string} {...rest}>
+      <a href={to} {...rest}>
         {children}
       </a>
     );

--- a/ui/packages/design-system/__tests__/WindowChrome.test.tsx
+++ b/ui/packages/design-system/__tests__/WindowChrome.test.tsx
@@ -38,7 +38,10 @@ describe("WindowChrome — browser variant", () => {
 describe("WindowChrome — titleBarSlot", () => {
   it("renders titleBarSlot content", () => {
     render(
-      <WindowChrome variant="terminal" titleBarSlot={<button>Copy</button>} />,
+      <WindowChrome
+        variant="terminal"
+        titleBarSlot={<button type="button">Copy</button>}
+      />,
     );
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
   });

--- a/ui/packages/design-system/package.json
+++ b/ui/packages/design-system/package.json
@@ -12,6 +12,7 @@
     "./cn": "./primitives/cn.ts"
   },
   "scripts": {
+    "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/ui/packages/design-system/primitives/Button.tsx
+++ b/ui/packages/design-system/primitives/Button.tsx
@@ -103,7 +103,7 @@ export function Button<T extends ElementType = "button">({
   children,
   ...rest
 }: ButtonProps<T>) {
-  const Component = (as ?? "button") as ElementType;
+  const Component: ElementType = as ?? "button";
   const isNativeButton = !as || as === "button";
 
   // Strip `disabled` and `type` from rest before computing interaction props so

--- a/ui/packages/design-system/primitives/Callout.tsx
+++ b/ui/packages/design-system/primitives/Callout.tsx
@@ -16,11 +16,7 @@ import { cn } from "./cn";
 // ---------------------------------------------------------------------------
 
 export type CalloutVariant =
-  | "error"
-  | "success"
-  | "warning"
-  | "info"
-  | "feature";
+  "error" | "success" | "warning" | "info" | "feature";
 
 /** The semantic (non-feature) variants, which render through the SEMANTIC map. */
 type SemanticVariant = Exclude<CalloutVariant, "feature">;
@@ -124,8 +120,7 @@ export function Callout({
     );
   }
 
-  const { bg, border, text, Icon, role, ariaLive } =
-    SEMANTIC[variant as SemanticVariant];
+  const { bg, border, text, Icon, role, ariaLive } = SEMANTIC[variant];
 
   return (
     <div

--- a/ui/packages/design-system/primitives/Card.tsx
+++ b/ui/packages/design-system/primitives/Card.tsx
@@ -15,7 +15,7 @@ export function Card<T extends ElementType = "div">({
   children,
   ...rest
 }: CardProps<T>) {
-  const Component = (as ?? "div") as ElementType;
+  const Component: ElementType = as ?? "div";
 
   return (
     <Component

--- a/ui/packages/design-system/primitives/Dropdown.tsx
+++ b/ui/packages/design-system/primitives/Dropdown.tsx
@@ -187,6 +187,7 @@ function Trigger({ children }: { children: ReactElement }) {
   const childRef = isValidElement(children)
     ? (children as ReactElement & { ref?: React.Ref<HTMLElement> }).ref
     : undefined;
+  // eslint-disable-next-line @typescript-eslint/unbound-method -- Floating UI callback ref setter, does not use `this`
   const mergedRef = useMergeRefs([refs.setReference, childRef].filter(Boolean));
 
   if (!isValidElement(children)) return null;
@@ -206,7 +207,8 @@ function Anchor({
 
   return (
     <div
-      ref={refs.setPositionReference as React.Ref<HTMLDivElement>}
+      // eslint-disable-next-line react-hooks/refs, @typescript-eslint/unbound-method -- Floating UI callback ref setter
+      ref={refs.setPositionReference}
       className={className}
       {...props}
     >
@@ -233,42 +235,40 @@ function Input({ onChange, ...props }: InputProps) {
 
   useEffect(() => () => clearTimeout(blurTimeout.current), []);
 
-  return (
-    <input
-      aria-autocomplete="list"
-      {...getReferenceProps({
-        ref: refs.setReference,
-        ...props,
-        onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-          onChange?.(e.target.value);
-          if (!open) setOpen(true);
-          setActiveIndex(0);
-        },
-        onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
-          clearTimeout(blurTimeout.current);
-          if (!open) setOpen(true);
-          props.onFocus?.(e);
-        },
-        onBlur: (e: React.FocusEvent<HTMLInputElement>) => {
-          const floatingEl = refs.floating.current;
-          if (floatingEl?.contains(e.relatedTarget as Node)) return;
-          blurTimeout.current = setTimeout(() => setOpen(false), 150);
-          props.onBlur?.(e);
-        },
-        onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
-          if (e.key === "Enter" && activeIndex !== null) {
-            const entry = selectCallbacksRef.current.get(activeIndex);
-            if (entry) {
-              e.preventDefault();
-              entry.onSelect();
-              if (entry.closeOnSelect !== false) setOpen(false);
-            }
-          }
-          props.onKeyDown?.(e);
-        },
-      })}
-    />
-  );
+  // eslint-disable-next-line react-hooks/refs -- Floating UI callback ref setter
+  const inputProps = getReferenceProps({
+    ref: refs.setReference, // eslint-disable-line @typescript-eslint/unbound-method
+    ...props,
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange?.(e.target.value);
+      if (!open) setOpen(true);
+      setActiveIndex(0);
+    },
+    onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
+      clearTimeout(blurTimeout.current);
+      if (!open) setOpen(true);
+      props.onFocus?.(e);
+    },
+    onBlur: (e: React.FocusEvent<HTMLInputElement>) => {
+      const floatingEl = refs.floating.current;
+      if (floatingEl?.contains(e.relatedTarget)) return;
+      blurTimeout.current = setTimeout(() => setOpen(false), 150);
+      props.onBlur?.(e);
+    },
+    onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && activeIndex !== null) {
+        const entry = selectCallbacksRef.current.get(activeIndex);
+        if (entry) {
+          e.preventDefault();
+          entry.onSelect();
+          if (entry.closeOnSelect !== false) setOpen(false);
+        }
+      }
+      props.onKeyDown?.(e);
+    },
+  });
+
+  return <input aria-autocomplete="list" {...inputProps} />;
 }
 
 interface PanelProps extends ComponentPropsWithoutRef<"div"> {
@@ -294,6 +294,7 @@ function Panel({ children, className, ...props }: PanelProps) {
 
   const panel = (
     <div
+      // eslint-disable-next-line react-hooks/refs, @typescript-eslint/unbound-method -- Floating UI callback ref setter
       ref={refs.setFloating}
       style={floatingStyles}
       className={cn(
@@ -350,11 +351,12 @@ function Item({
   const itemRole = mode === "combobox" ? "option" : "menuitem";
 
   useEffect(() => {
+    const map = selectCallbacksRef.current;
     if (onSelect && !disabled) {
-      selectCallbacksRef.current.set(index, { onSelect, closeOnSelect });
+      map.set(index, { onSelect, closeOnSelect });
     }
     return () => {
-      selectCallbacksRef.current.delete(index);
+      map.delete(index);
     };
   }, [index, onSelect, disabled, closeOnSelect, selectCallbacksRef]);
 

--- a/ui/packages/design-system/primitives/IconButton.tsx
+++ b/ui/packages/design-system/primitives/IconButton.tsx
@@ -16,14 +16,11 @@ export type IconButtonSize = "sm" | "md" | "lg";
 // Icon-button variants intentionally rest at text-text-muted and accent on hover,
 // so `primary` and `danger` here differ from the always-filled Button variants of the same name.
 const VARIANT: Record<IconButtonVariant, string> = {
-  ghost:
-    "hover:text-text-primary hover:bg-hover-subtle",
-  primary:
-    "hover:text-primary hover:bg-primary/10",
+  ghost: "hover:text-text-primary hover:bg-hover-subtle",
+  primary: "hover:text-primary hover:bg-primary/10",
   danger:
     "hover:text-accent-red hover:bg-accent-red/10 focus-visible:ring-accent-red",
-  filled:
-    "bg-primary text-white hover:bg-primary/90",
+  filled: "bg-primary text-white hover:bg-primary/90",
 };
 
 const SIZE: Record<IconButtonSize, string> = {
@@ -67,7 +64,7 @@ export function IconButton<T extends ElementType = "button">({
   children,
   ...rest
 }: IconButtonProps<T>) {
-  const Component = (as ?? "button") as ElementType;
+  const Component: ElementType = (as ?? "button");
   const isNativeButton = !as || as === "button";
 
   // Strip `disabled` and `type` from rest before computing interaction props so


### PR DESCRIPTION
## What

Enabled React Compiler for the console and website apps by installing `babel-plugin-react-compiler` and wiring it into both Vite configs.

## Why

The codebase already meets all prerequisites — React 19.1, `eslint-plugin-react-hooks` v7.1.1 with all compiler validation rules active, and zero lint violations across console, website, and design-system. The compiler auto-memoizes components, hooks, and expressions, making the ~142 manual `useMemo`/`useCallback` calls in console redundant (removable incrementally, no urgency).

Depends on #6754
Closes #6753

## Changes

- **`ui/package.json`**: added `babel-plugin-react-compiler` `^1.0.0` as a dev dependency
- **`apps/console/vite.config.ts`**, **`apps/website/vite.config.ts`**: passed `"babel-plugin-react-compiler"` to `@vitejs/plugin-react`'s `babel.plugins` option (supported in v5.x; v6+ drops the built-in Babel bridge and requires `@rolldown/plugin-babel` instead)