### PR TITLE
chore(ui): bump react-router-dom from 7.17.0 to 7.18.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,7 +18,7 @@
         "qrcode": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.17.0"
+        "react-router-dom": "^7.18.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -12801,9 +12801,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -12823,12 +12823,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,6 +49,6 @@
     "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.17.0"
+    "react-router-dom": "^7.18.0"
   }
 }


### PR DESCRIPTION
## What
Bumps `react-router-dom` (and its `react-router` peer) to 7.18.x, resolving 5 open Dependabot security advisories.

## Why
Dependabot flagged 5 CVEs against `react-router` 7.17.0. None are exploitable in ShellHub (the console is a client-side SPA with no RSC or SSR, and no `<Link>` targets come from user input), but the fix is a trivial minor bump with no breaking changes.

Resolved advisories:
- GHSA-qwww-vcr4-c8h2 (high) — RSC mode CSRF bypass
- GHSA-chx6-hx7r-mcp5 (high) — DoS via inefficient route matching
- GHSA-wrjc-x8rr-h8h6 (medium) — open redirect via backslash in `<Link>`
- GHSA-h8fp-f39c-q6mh (medium) — `RSCErrorHandler` missing protocol validation (XSS)
- GHSA-337j-9hxr-rhxg (medium) — constructor injection via SSR hydration