### PR TITLE
refactor(ui): fix install-keys lint warnings and simplify UsageMeter

### DIFF
--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -18,7 +18,7 @@ import {
 import { useNamespace } from "../hooks/useNamespaces";
 import { useInstallKeys } from "../hooks/useInstallKeys";
 import { resolveEnrollmentSource } from "@/pages/install-keys/helpers";
-import { DeprecatedBadge } from "@/pages/install-keys/constants";
+import { DeprecatedBadge } from "@/pages/install-keys/StatusChip";
 import { useAuthStore } from "../stores/authStore";
 import { useTerminalStore } from "../stores/terminalStore";
 import DeviceActionsPortal from "./devices/DeviceActionsPortal";

--- a/ui/apps/console/src/pages/install-keys/InstallKeyHistoryPage.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeyHistoryPage.tsx
@@ -14,12 +14,11 @@ import InstallKeyActions from "./InstallKeyActions";
 import RevealInstallKeyDialog from "./RevealInstallKeyDialog";
 import StatusChip from "./StatusChip";
 import KeyValueChip from "./KeyValueChip";
-import UsageMeter, { usageLabel } from "./UsageMeter";
+import UsageMeter from "./UsageMeter";
 import { modeInfo } from "./constants";
 import {
   getExpiryInfo,
   getKeyBlockers,
-  getUsageInfo,
   installKeyDisplayName,
   isPairingKey,
 } from "./helpers";
@@ -97,24 +96,9 @@ export default function InstallKeyHistoryPage() {
                 </Fact>
               )}
               <Fact label="Usage">
-                {(() => {
-                  const usage = getUsageInfo(key);
-                  const { inert, overused, revoked, disabled } =
-                    getKeyBlockers(key);
-                  const reached = overused && !revoked && !disabled;
-                  return (
-                    <div className="space-y-1.5">
-                      <span className="font-mono">{usageLabel(usage)}</span>
-                      <div className="w-32">
-                        <UsageMeter
-                          usage={usage}
-                          dimmed={inert}
-                          reached={reached}
-                        />
-                      </div>
-                    </div>
-                  );
-                })()}
+                <div className="w-32">
+                  <UsageMeter installKey={key} />
+                </div>
               </Fact>
               <Fact label="Expires">
                 {(() => {

--- a/ui/apps/console/src/pages/install-keys/InstallKeysTable.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeysTable.tsx
@@ -14,13 +14,12 @@ import { type InstallKey } from "@/client";
 import DataTable, { type Column } from "@/components/common/DataTable";
 import RestrictedAction from "@/components/common/RestrictedAction";
 import InstallKeyActionsMenu from "./InstallKeyActionsMenu";
-import StatusChip from "./StatusChip";
-import UsageMeter, { usageLabel } from "./UsageMeter";
-import { DeprecatedBadge, modeInfo } from "./constants";
+import StatusChip, { DeprecatedBadge } from "./StatusChip";
+import UsageMeter from "./UsageMeter";
+import { modeInfo } from "./constants";
 import {
   getExpiryInfo,
   getKeyBlockers,
-  getUsageInfo,
   installKeyDisplayName,
   isPairingKey,
   isSystemKey,
@@ -187,19 +186,7 @@ export default function InstallKeysTable({
     {
       key: "usage",
       header: "Usage limit",
-      render: (key) => {
-        const usage = getUsageInfo(key);
-        const { inert, overused, revoked, disabled } = getKeyBlockers(key);
-        const reached = overused && !revoked && !disabled;
-        return (
-          <div title={reached ? "Limit reached" : undefined}>
-            <div className="mb-1.5 text-2xs font-mono text-text-secondary">
-              {usageLabel(usage)}
-            </div>
-            <UsageMeter usage={usage} dimmed={inert} reached={reached} />
-          </div>
-        );
-      },
+      render: (key) => <UsageMeter installKey={key} muted />,
     },
     {
       key: "expiry",
@@ -247,6 +234,7 @@ export default function InstallKeysTable({
       headerClassName: "w-12",
       render: (key) => (
         <div
+          role="presentation"
           className="flex justify-end"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}

--- a/ui/apps/console/src/pages/install-keys/StatusChip.tsx
+++ b/ui/apps/console/src/pages/install-keys/StatusChip.tsx
@@ -1,8 +1,8 @@
 import { type ComponentType, type SVGProps } from "react";
+import { cn } from "@shellhub/design-system/cn";
 
 type ChipTone = "green" | "red" | "yellow" | "muted" | "primary";
 
-/** Soft, pill-less chip: a tinted fill in the tone's hue with the label in that hue. */
 const TONE: Record<ChipTone, string> = {
   green: "bg-accent-green/10 text-accent-green",
   red: "bg-accent-red/10 text-accent-red",
@@ -11,12 +11,6 @@ const TONE: Record<ChipTone, string> = {
   primary: "bg-primary/10 text-primary",
 };
 
-/**
- * The install-key feature's chip: an optional icon + label on a soft tinted fill. Quieter than a
- * bordered/uppercase pill, more finished than bare text. One shape for every marker in the feature —
- * the Registration kind, the Review verdict, the Deprecated flag, and tags (`mono`) — so they read as
- * one family. Colour carries the meaning.
- */
 export default function StatusChip({
   icon: Icon,
   label,
@@ -30,12 +24,18 @@ export default function StatusChip({
 }) {
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-2xs ${
-        mono ? "font-mono" : ""
-      } ${TONE[tone]}`}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-2xs",
+        mono && "font-mono",
+        TONE[tone],
+      )}
     >
       {Icon && <Icon className="w-3.5 h-3.5 shrink-0" strokeWidth={1.8} />}
       {label}
     </span>
   );
+}
+
+export function DeprecatedBadge() {
+  return <StatusChip label="Deprecated" tone="yellow" />;
 }

--- a/ui/apps/console/src/pages/install-keys/UsageMeter.tsx
+++ b/ui/apps/console/src/pages/install-keys/UsageMeter.tsx
@@ -1,11 +1,13 @@
-import { type UsageInfo } from "./helpers";
+import { cn } from "@shellhub/design-system/cn";
+import { type InstallKey } from "@/client";
+import { getKeyBlockers, getUsageInfo, type UsageInfo } from "./helpers";
 
-/**
- * The usage bar: how much of a key's allowance is spent. The bar itself carries the state — it turns
- * amber once the key reaches its limit (so "limit reached" reads off the bar, no separate chip); a key
- * that is inert for another reason greys out. Unlimited keys render an infinity track.
- */
-export default function UsageMeter({
+function formatLabel(usage: UsageInfo): string {
+  const cap = usage.kind === "unlimited" ? "∞" : usage.limit;
+  return `${usage.used} / ${cap}`;
+}
+
+function Bar({
   usage,
   dimmed,
   reached,
@@ -15,8 +17,6 @@ export default function UsageMeter({
   reached: boolean;
 }) {
   if (usage.kind === "unlimited") {
-    // The KeyValueChip shell (soft fill + hairline border) with an animated barber-pole hatch, so an
-    // unlimited key reads as a defined, "always-on" bar rather than floating stripes.
     return (
       <div className="h-1.5 overflow-hidden rounded-full border border-border bg-text-muted/[0.08]">
         <div className="usage-infinity h-full" />
@@ -30,22 +30,40 @@ export default function UsageMeter({
       ? "bg-text-muted/40"
       : "bg-primary";
 
+  const width = Math.max(usage.ratio * 100, usage.used > 0 ? 6 : 0) + "%";
+
   return (
     <div className="h-1.5 rounded-full bg-border/60 overflow-hidden">
       <div
-        className={`h-full rounded-full transition-all duration-500 ${fill}`}
-        style={{
-          width: `${Math.max(usage.ratio * 100, usage.used > 0 ? 6 : 0)}%`,
-        }}
+        className={cn("h-full rounded-full transition-all duration-500", fill)}
+        style={{ width }}
       />
     </div>
   );
 }
 
-// Uniform `used / cap`, cap being a number or ∞ for unlimited. State (spent, over limit) is carried by
-// the meter's colour, not a text suffix, so the label stays even.
-export function usageLabel(usage: UsageInfo): string {
-  const cap = usage.kind === "unlimited" ? "∞" : usage.limit;
+export default function UsageMeter({
+  installKey,
+  muted,
+}: {
+  installKey: InstallKey;
+  muted?: boolean;
+}) {
+  const usage = getUsageInfo(installKey);
+  const { inert, overused, revoked, disabled } = getKeyBlockers(installKey);
+  const reached = overused && !revoked && !disabled;
 
-  return `${usage.used} / ${cap}`;
+  return (
+    <div title={reached ? "Limit reached" : undefined}>
+      <div
+        className={cn(
+          "mb-1.5 text-2xs font-mono",
+          muted && "text-text-secondary",
+        )}
+      >
+        {formatLabel(usage)}
+      </div>
+      <Bar usage={usage} dimmed={inert} reached={reached} />
+    </div>
+  );
 }

--- a/ui/apps/console/src/pages/install-keys/constants.tsx
+++ b/ui/apps/console/src/pages/install-keys/constants.tsx
@@ -5,14 +5,9 @@ import {
   HandRaisedIcon,
   ListBulletIcon,
 } from "@heroicons/react/24/outline";
-import StatusChip from "./StatusChip";
 
 type IconType = ComponentType<SVGProps<SVGSVGElement>>;
 
-/**
- * Single source of truth for the enrollment modes: the icon that carries each mode's identity, its
- * label, a one-liner of what it does, and the longer description used in the create/edit selector.
- */
 export const MODE_INFO: Record<
   string,
   { label: string; icon: IconType; summary: string; description: string }
@@ -48,12 +43,4 @@ export const MODE_INFO: Record<
 
 export function modeInfo(mode: string) {
   return MODE_INFO[mode] ?? MODE_INFO.automatic;
-}
-
-/**
- * Marks the namespace's auto-managed tenant-only registration key: a legacy path kept for
- * compatibility and slated for removal, so it carries a caution (deprecated) badge.
- */
-export function DeprecatedBadge() {
-  return <StatusChip label="Deprecated" tone="yellow" />;
 }


### PR DESCRIPTION
## What

Clears all four eslint warnings in the install-keys feature and consolidates `UsageMeter` into a self-contained component that accepts an `InstallKey` directly.

## Why

The console had four lint warnings — three `react-refresh/only-export-components` (files mixing component and non-component exports break fast refresh) and one `jsx-a11y/no-static-element-interactions` (a `<div>` with click handlers but no ARIA role).

## Changes

- **`UsageMeter`**: now accepts `installKey` + optional `muted` instead of raw `usage`/`dimmed`/`reached` props. Absorbs `getUsageInfo`, `getKeyBlockers`, the `reached` derivation, and the label formatting that both `InstallKeysTable` and `InstallKeyHistoryPage` duplicated. The old `usageLabel` export is replaced by a file-private `formatLabel`.
- **`StatusChip`**: `DeprecatedBadge` moved here from `constants.tsx` — both are components, so the file stays fast-refresh compatible. Switched class concatenation to `cn()`.
- **`constants.tsx`**: now exports only `MODE_INFO` and `modeInfo` (no component, no JSX import).
- **`InstallKeysTable`**: added `role="presentation"` to the actions-column wrapper `<div>` that stops row-click propagation.