### PR TITLE
fix(storetest): stop CreateDevice generating colliding MAC addresses

### DIFF
--- a/server/api/store/storetest/helpers.go
+++ b/server/api/store/storetest/helpers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -194,6 +195,21 @@ func WithDeviceRemoteAddr(addr string) DeviceOption {
 	}
 }
 
+// deviceSeq backs the default device identifiers. A counter rather than the clock because
+// devices are unique on (namespace_id, mac) while accepted, and clock-derived values collide
+// often enough to fail the suite.
+var deviceSeq atomic.Uint64
+
+func nextDeviceUID() string {
+	return fmt.Sprintf("%064x", deviceSeq.Add(1))
+}
+
+func nextDeviceMAC() string {
+	n := deviceSeq.Add(1)
+
+	return fmt.Sprintf("00:00:%02x:%02x:%02x:%02x", (n>>24)&0xFF, (n>>16)&0xFF, (n>>8)&0xFF, n&0xFF)
+}
+
 // CreateDevice creates a device with default or customized values
 // Returns the generated device UID
 // If tenant is not provided via WithTenantID(), a default namespace will be created
@@ -202,15 +218,11 @@ func (s *Suite) CreateDevice(t *testing.T, opts ...DeviceOption) models.UID {
 	ctx := context.Background()
 	st := s.provider.Store()
 
-	// Generate unique UID (sha256-like format)
-	uid := fmt.Sprintf("%064x", time.Now().UnixNano())
-
-	// Default device
 	device := &models.Device{
-		UID:       uid,
+		UID:       nextDeviceUID(),
 		Name:      fmt.Sprintf("device_%d", time.Now().UnixNano()),
 		TenantID:  "", // Will be set below if not provided via options
-		Identity:  &models.DeviceIdentity{MAC: fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", time.Now().UnixNano()%256, time.Now().UnixNano()%256, time.Now().UnixNano()%256, time.Now().UnixNano()%256, time.Now().UnixNano()%256, time.Now().UnixNano()%256)},
+		Identity:  &models.DeviceIdentity{MAC: nextDeviceMAC()},
 		Info:      &models.DeviceInfo{},
 		PublicKey: "-",
 		Status:    models.DeviceStatusAccepted,

--- a/server/api/store/storetest/helpers_test.go
+++ b/server/api/store/storetest/helpers_test.go
@@ -1,0 +1,40 @@
+package storetest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNextDeviceIdentifiersAreDistinct(t *testing.T) {
+	const calls = 1024
+
+	for _, tc := range []struct {
+		description string
+		next        func() string
+	}{
+		{
+			description: "UID",
+			next:        nextDeviceUID,
+		},
+		{
+			description: "MAC",
+			next:        nextDeviceMAC,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			seen := make(map[string]int, calls)
+
+			for i := range calls {
+				got := tc.next()
+				if first, dup := seen[got]; dup {
+					t.Fatalf("call %d produced %q, already produced by call %d", i, got, first)
+				}
+
+				seen[got] = i
+			}
+
+			assert.Len(t, seen, calls)
+		})
+	}
+}


### PR DESCRIPTION
## What

CreateDevice, the shared test helper used across the store test
suite, generated both the device UID and MAC address from
time.Now().UnixNano(). This change replaces that with a package-level
atomic counter so generated identifiers are guaranteed unique.

## Why

Devices are unique on (namespace_id, mac) while accepted. On machines
with coarse clock resolution, two calls to CreateDevice within the
same test run could land on the same nanosecond value and produce
identical MAC addresses, which then collided against that unique
constraint. This made the store suite intermittently fail with no
code change involved, which is exactly what made it hard to track
down.

Closes shellhub-io/shellhub#6617

## Changes

- Added a package-level atomic.Uint64 counter, deviceSeq, in
  storetest/helpers.go
- Added nextDeviceUID and nextDeviceMAC, both derived from the
  counter instead of the wall clock
- Wired CreateDevice to use these helpers instead of time.Now()
- Added helpers_test.go covering the new helpers directly

## Testing

Flakiness from clock collisions is hard to exercise on demand, since
it depended on timing that isn't reproducible on request. Instead,
this validates that the fix is correct by construction and does not
regress existing behavior:

- go test ./store/storetest/... passes, including the new
  helpers_test.go cases asserting nextDeviceUID and nextDeviceMAC
  never repeat across repeated calls
- go test ./store/pg/... passes, confirming the rest of the store
  suite still works against the new identifiers
- golangci-lint run ./store/... passes, including gosec, since the
  MAC byte extraction uses bit-masking rather than a truncating
  conversion