### PR TITLE
ci: send the pull request head sha to cloud

### DIFF
--- a/.github/workflows/notify-cloud.yml
+++ b/.github/workflows/notify-cloud.yml
@@ -25,12 +25,14 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            // On pull_request_target, context.sha is the base commit, not the head.
             await github.rest.repos.createDispatchEvent({
               owner: 'shellhub-io',
               repo: 'cloud',
               event_type: 'shellhub-pr',
               client_payload: {
                 sha: context.sha,
+                head_sha: context.payload.pull_request.head.sha,
                 head_ref: context.payload.pull_request.head.ref,
                 pr_number: context.payload.pull_request.number,
               },


### PR DESCRIPTION
Cloud compiles against ShellHub's source rather than a published version, so
every ShellHub pull request is validated by an enterprise build in the cloud
repo. `notify-cloud.yml` triggers that build with a `repository_dispatch`.

It fires on `pull_request_target`, where `context.sha` is the base commit, not
the pull request's head. Cloud uses that value both to check out the tree it
validates and as the target of the commit status it reports back, so the check
builds master and posts its result onto master's commit, where the pull request
never displays it. The enterprise validation has effectively been a no-op for
pull requests.

This adds `head_sha` to the dispatch payload. The existing `sha` field stays so
the current cloud workflow keeps working; a companion cloud change switches over
to `head_sha` and can land in either order.