### PR TITLE
ci: skip enterprise validation for fork pull requests

### DIFF
--- a/.github/workflows/notify-cloud.yml
+++ b/.github/workflows/notify-cloud.yml
@@ -8,6 +8,9 @@ jobs:
   dispatch:
     name: Dispatch enterprise validation to cloud
 
+    # A repository_dispatch run is not covered by the fork-approval gate.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Follow-up to #6761, which started sending the pull request head to cloud so the
enterprise validation builds the code under review instead of the base commit.

Cloud checks that head out and runs `go test -tags enterprise` over it, with the
private enterprise source checked out on the same runner. For a pull request
from a fork, the head is attacker-controlled and `go test` executes whatever it
contains, so the private source and the tokens on that runner are reachable.

GitHub's approval gate for workflows from forks does not apply here. It covers
runs triggered by the pull request; this one is triggered by a
`repository_dispatch` sent from a `pull_request_target` workflow, which is a
different path.

Skipping the dispatch for forks closes it. Fork pull requests lose the
enterprise check, which is what they effectively had before #6761 while the
workflow validated the base commit, and the check is still meaningful for
everything that can require a paired cloud change.