### PR TITLE
fix(server): declare a utf-8 character locale on web terminal sessions

### DIFF
--- a/server/ssh/web/session.go
+++ b/server/ssh/web/session.go
@@ -283,20 +283,8 @@ func newSession(ctx context.Context, service services.Service, handoff *webhando
 		return err
 	}
 
-	if err := agent.RequestPty("xterm", int(dim.Rows), int(dim.Cols), ssh.TerminalModes{
-		ssh.ECHO:          1,
-		ssh.TTY_OP_ISPEED: 14400,
-		ssh.TTY_OP_OSPEED: 14400,
-	}); err != nil {
-		logger.WithError(err).Debug("failed to request the pty on session")
-
-		return ErrPty
-	}
-
-	if err := agent.Shell(); err != nil {
-		logger.WithError(err).Debug("failed to request the shell on session")
-
-		return ErrShell
+	if err := prepareShell(logger, agent, dim); err != nil {
+		return err
 	}
 
 	go func() {

--- a/server/ssh/web/session.go
+++ b/server/ssh/web/session.go
@@ -315,7 +315,7 @@ func newSession(ctx context.Context, service services.Service, handoff *webhando
 			case messageKindResize:
 				dim := message.Data.(Dimensions)
 
-				if err := agent.WindowChange(int(dim.Rows), int(dim.Cols)); err != nil {
+				if err := agent.WindowChange(dim.rows(), dim.cols()); err != nil {
 					logger.WithError(err).Error("failed to change the size of window for terminal session")
 
 					return

--- a/server/ssh/web/shell.go
+++ b/server/ssh/web/shell.go
@@ -1,0 +1,55 @@
+package web
+
+import (
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+)
+
+// The web terminal can only render UTF-8, so it declares a UTF-8 character
+// locale to the device. LC_CTYPE covers character classification only and
+// outranks LANG, so a device profile setting LANG=C cannot undo it. C.UTF-8
+// needs no generated locale data, unlike a language-specific locale that glibc
+// would fall back to C for when absent.
+const (
+	localeEnvName  = "LC_CTYPE"
+	localeEnvValue = "C.UTF-8"
+)
+
+const terminalType = "xterm"
+
+// shellSession is the narrow view of an SSH session that shell bring-up needs.
+type shellSession interface {
+	Setenv(name, value string) error
+	RequestPty(term string, height, width int, modes ssh.TerminalModes) error
+	Shell() error
+}
+
+// prepareShell brings a session up for interactive use.
+//
+// The locale must be announced before the shell request because the agent only
+// records environment variables received before it. A rejected env request is
+// not fatal — the session continues with the device's own locale.
+func prepareShell(logger *log.Entry, session shellSession, dim Dimensions) error {
+	if err := session.Setenv(localeEnvName, localeEnvValue); err != nil {
+		logger.WithError(err).WithField("name", localeEnvName).
+			Debug("failed to set the character locale on session")
+	}
+
+	if err := session.RequestPty(terminalType, int(dim.Rows), int(dim.Cols), ssh.TerminalModes{
+		ssh.ECHO:          1,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}); err != nil {
+		logger.WithError(err).Debug("failed to request the pty on session")
+
+		return ErrPty
+	}
+
+	if err := session.Shell(); err != nil {
+		logger.WithError(err).Debug("failed to request the shell on session")
+
+		return ErrShell
+	}
+
+	return nil
+}

--- a/server/ssh/web/shell.go
+++ b/server/ssh/web/shell.go
@@ -35,7 +35,7 @@ func prepareShell(logger *log.Entry, session shellSession, dim Dimensions) error
 			Debug("failed to set the character locale on session")
 	}
 
-	if err := session.RequestPty(terminalType, int(dim.Rows), int(dim.Cols), ssh.TerminalModes{
+	if err := session.RequestPty(terminalType, dim.rows(), dim.cols(), ssh.TerminalModes{
 		ssh.ECHO:          1,
 		ssh.TTY_OP_ISPEED: 14400,
 		ssh.TTY_OP_OSPEED: 14400,

--- a/server/ssh/web/shell_test.go
+++ b/server/ssh/web/shell_test.go
@@ -1,0 +1,122 @@
+package web
+
+import (
+	"errors"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+type recordingSession struct {
+	calls []string
+	env   map[string]string
+	term  string
+	rows  int
+	cols  int
+
+	setenvErr     error
+	requestPtyErr error
+	shellErr      error
+}
+
+func newRecordingSession() *recordingSession {
+	return &recordingSession{env: make(map[string]string)}
+}
+
+func (r *recordingSession) Setenv(name, value string) error {
+	r.calls = append(r.calls, "setenv")
+	r.env[name] = value
+
+	return r.setenvErr
+}
+
+func (r *recordingSession) RequestPty(term string, height, width int, _ ssh.TerminalModes) error {
+	r.calls = append(r.calls, "pty")
+	r.term = term
+	r.rows = height
+	r.cols = width
+
+	return r.requestPtyErr
+}
+
+func (r *recordingSession) Shell() error {
+	r.calls = append(r.calls, "shell")
+
+	return r.shellErr
+}
+
+func TestPrepareShell(t *testing.T) {
+	dim := Dimensions{Rows: 24, Cols: 80}
+
+	cases := []struct {
+		description   string
+		session       func() *recordingSession
+		expectedCalls []string
+		expectedErr   error
+	}{
+		{
+			description:   "announces the character locale before starting the shell",
+			session:       newRecordingSession,
+			expectedCalls: []string{"setenv", "pty", "shell"},
+			expectedErr:   nil,
+		},
+		{
+			description: "continues the bring-up when the env request is rejected",
+			session: func() *recordingSession {
+				session := newRecordingSession()
+				session.setenvErr = errors.New("env request rejected")
+
+				return session
+			},
+			expectedCalls: []string{"setenv", "pty", "shell"},
+			expectedErr:   nil,
+		},
+		{
+			description: "fails when the pty request fails",
+			session: func() *recordingSession {
+				session := newRecordingSession()
+				session.requestPtyErr = errors.New("pty request failed")
+
+				return session
+			},
+			expectedCalls: []string{"setenv", "pty"},
+			expectedErr:   ErrPty,
+		},
+		{
+			description: "fails when the shell request fails",
+			session: func() *recordingSession {
+				session := newRecordingSession()
+				session.shellErr = errors.New("shell request failed")
+
+				return session
+			},
+			expectedCalls: []string{"setenv", "pty", "shell"},
+			expectedErr:   ErrShell,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			session := tc.session()
+
+			err := prepareShell(log.WithField("test", tc.description), session, dim)
+
+			require.ErrorIs(t, err, tc.expectedErr)
+			assert.Equal(t, tc.expectedCalls, session.calls)
+			assert.Equal(t, map[string]string{"LC_CTYPE": "C.UTF-8"}, session.env)
+		})
+	}
+}
+
+func TestPrepareShellRequestsThePtyWithTheClientDimensions(t *testing.T) {
+	session := newRecordingSession()
+
+	require.NoError(t, prepareShell(log.WithField("test", t.Name()), session, Dimensions{Rows: 40, Cols: 132}))
+
+	assert.Equal(t, "xterm", session.term)
+	assert.Equal(t, 40, session.rows)
+	assert.Equal(t, 132, session.cols)
+}

--- a/server/ssh/web/utils.go
+++ b/server/ssh/web/utils.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"math"
 )
 
 type Credentials struct {
@@ -78,6 +79,24 @@ func (c *Credentials) isPassword() bool {
 type Dimensions struct {
 	Cols uint32 `json:"cols"`
 	Rows uint32 `json:"rows"`
+}
+
+// maxDimension bounds a terminal's width and height. The client sends them as
+// uint32, but they reach the kernel as a winsize, whose fields are unsigned
+// shorts — and narrowing an unbounded uint32 to int wraps negative where int is
+// 32 bits wide.
+const maxDimension = math.MaxUint16
+
+func (d Dimensions) rows() int { return boundDimension(d.Rows) }
+
+func (d Dimensions) cols() int { return boundDimension(d.Cols) }
+
+func boundDimension(value uint32) int {
+	if value > maxDimension {
+		return maxDimension
+	}
+
+	return int(value)
 }
 
 type Info struct {

--- a/server/ssh/web/utils_test.go
+++ b/server/ssh/web/utils_test.go
@@ -1,0 +1,43 @@
+package web
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDimensionsBounds(t *testing.T) {
+	cases := []struct {
+		description  string
+		dim          Dimensions
+		expectedRows int
+		expectedCols int
+	}{
+		{
+			description:  "keeps an ordinary terminal size",
+			dim:          Dimensions{Rows: 24, Cols: 80},
+			expectedRows: 24,
+			expectedCols: 80,
+		},
+		{
+			description:  "keeps the largest size a winsize can hold",
+			dim:          Dimensions{Rows: math.MaxUint16, Cols: math.MaxUint16},
+			expectedRows: math.MaxUint16,
+			expectedCols: math.MaxUint16,
+		},
+		{
+			description:  "bounds a size the kernel could not represent",
+			dim:          Dimensions{Rows: math.MaxUint32, Cols: math.MaxUint32},
+			expectedRows: math.MaxUint16,
+			expectedCols: math.MaxUint16,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.expectedRows, tc.dim.rows())
+			assert.Equal(t, tc.expectedCols, tc.dim.cols())
+		})
+	}
+}


### PR DESCRIPTION
## What

The web terminal now declares `LC_CTYPE=C.UTF-8` to the device before starting the
shell, so tools that adapt their output to the locale (`ls`, `find`, `tree`, `busybox`)
print non-ASCII filenames as characters instead of octal escapes.

## Why

The web terminal was the only ShellHub client that sent no locale at session setup. The
device's shell therefore ran in the `C`/POSIX locale, where every byte >= 0x80 is
non-printable; GNU `ls` writing to a TTY escapes those bytes, producing output like
`''$'\344\270\255\346\226\207\347\233\256\345\275\225'` for `中文目录`. Connecting to
the same device with a native `ssh` client renders the names correctly, because native
clients already forward `LANG`/`LC_*`.

This only shows on devices whose own shell profile does not already set a UTF-8 locale —
the normal state for the embedded and IoT targets ShellHub is built for, which is why it
looked intermittent.

Closes #6763

## Changes

- **server/ssh/web**: send `LC_CTYPE=C.UTF-8` as an SSH `env` request before the shell
  request. `LC_CTYPE` governs character classification only and outranks `LANG`, so a
  device profile setting `LANG=C` cannot silently undo it; setting `LANG` instead would
  overreach and be overridable. `C.UTF-8` requires no generated locale data (present on
  glibc >= 2.35, always available on musl, satisfies BusyBox's UTF-8 check) — a
  language-specific locale such as `zh_CN.UTF-8` may be absent, and glibc then falls
  back to `C`, reintroducing the bug on exactly the devices this fixes. The value is
  hardcoded: the web terminal can only render UTF-8, so there is no coherent alternative
  to offer.
- **server/ssh/web**: session bring-up moved out of `newSession` into `prepareShell`
  over a narrow three-method interface (`Setenv`, `RequestPty`, `Shell`). `newSession`
  cannot be tested — it dials a fixed address and needs the cache and internal API
  client — and the property worth enforcing is an ordering one: the agent only records
  env received *before* the shell request, so "env then shell" is the contract, not
  merely "env was sent".
- **Failure handling**: a device or intermediary rejecting the `env` request logs at
  debug level and continues; the user simply gets today's behaviour rather than a broken
  session. A failing PTY or shell request still surfaces as `ErrPty`/`ErrShell`.

No agent or gateway change was needed. The gateway already proxies client channel
requests through generically, and the agent already accepts `LANG` and any `LC_*`
(`agent/server/modes/host/env.go`), mirroring OpenSSH's default `AcceptEnv`. Native
clients are unaffected.

## Testing

`TestPrepareShell` drives a fake that records bring-up calls in order, covering the
ordering contract and the non-fatal env failure. Verify by hand on a device with GNU
coreutils and no locale of its own — on a dev agent whose profile sets `LANG`, prefix
with `env -u LANG -u LC_ALL -u LC_CTYPE` to put the shell in the state a bare embedded
device is already in, then run `ls` over a directory holding non-ASCII names.

A device that emits a non-UTF-8 encoding (GBK/GB18030) still cannot render, because the
output relay replaces invalid UTF-8 with U+FFFD server-side. That is a second,
independent defect and ships separately as Part 2 of the spec on #6763.