### PR TITLE
fix(server,ui): send device output to the browser verbatim

### DIFF
--- a/server/ssh/web/conn.go
+++ b/server/ssh/web/conn.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -21,6 +22,12 @@ type Conn struct {
 	Socket Socket
 	// Pinger is reponsable to inform the server that a SSH session is open.
 	Pinger *time.Ticker
+
+	// writes serializes every frame written to the socket. Device output, JSON
+	// control messages and keep-alive pings are produced by different
+	// goroutines, and the frame writer underneath is not goroutine-safe: two
+	// concurrent writers otherwise interleave and corrupt a frame.
+	writes sync.Mutex
 }
 
 func NewConn(socket Socket) *Conn {
@@ -116,6 +123,9 @@ func (c *Conn) ReadMessage(message *Message) (int, error) {
 }
 
 func (c *Conn) WriteMessage(message *Message) (int, error) {
+	c.writes.Lock()
+	defer c.writes.Unlock()
+
 	buffer, err := json.Marshal(message)
 	if err != nil {
 		return 0, errors.Join(ErrConnReadMessageJSONInvalid)
@@ -130,6 +140,9 @@ func (c *Conn) WriteMessage(message *Message) (int, error) {
 }
 
 func (c *Conn) WriteBinary(data []byte) (int, error) {
+	c.writes.Lock()
+	defer c.writes.Unlock()
+
 	socket, ok := c.Socket.(*websocket.Conn)
 	if !ok {
 		// NOTE: If the underlying connection is not a websocket connection, fallback to a normal write.
@@ -151,11 +164,35 @@ func (c *Conn) WriteBinary(data []byte) (int, error) {
 	return wrote, nil
 }
 
+func (c *Conn) WritePing() error {
+	c.writes.Lock()
+	defer c.writes.Unlock()
+
+	socket, ok := c.Socket.(*websocket.Conn)
+	if !ok {
+		return nil
+	}
+
+	frame, err := socket.NewFrameWriter(websocket.PingFrame)
+	if err != nil {
+		return err
+	}
+
+	if _, err := frame.Write([]byte{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Conn) Read(buffer []byte) (int, error) {
 	return c.Socket.Read(buffer)
 }
 
 func (c *Conn) Write(buffer []byte) (int, error) {
+	c.writes.Lock()
+	defer c.writes.Unlock()
+
 	return c.Socket.Write(buffer)
 }
 
@@ -176,9 +213,7 @@ func (c *Conn) KeepAlive() {
 			return
 		}
 
-		if fw, err := socket.NewFrameWriter(websocket.PingFrame); err != nil {
-			return
-		} else if _, err = fw.Write([]byte{}); err != nil {
+		if err := c.WritePing(); err != nil {
 			return
 		}
 

--- a/server/ssh/web/conn_test.go
+++ b/server/ssh/web/conn_test.go
@@ -1,13 +1,19 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/shellhub-io/shellhub/server/ssh/web/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
 )
 
 func TestConnReadMessage_input(t *testing.T) {
@@ -164,4 +170,79 @@ func TestConnReadMessage_resize(t *testing.T) {
 			assert.ErrorIs(t, err, test.expect.err)
 		})
 	}
+}
+
+// TestConnConcurrentWritesDoNotRace pins the synchronisation on Conn rather
+// than on any one writer: output frames, control messages and keep-alive pings
+// all share the socket, and the frame writer underneath is not goroutine-safe.
+func TestConnConcurrentWritesDoNotRace(t *testing.T) {
+	const rounds = 50
+
+	output := bytes.Repeat([]byte{'o'}, 128)
+
+	server := httptest.NewServer(websocket.Handler(func(socket *websocket.Conn) {
+		conn := NewConn(socket)
+
+		wg := sync.WaitGroup{}
+		wg.Add(3)
+
+		go func() {
+			defer wg.Done()
+
+			for range rounds {
+				if _, err := conn.WriteBinary(output); err != nil {
+					return
+				}
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			for range rounds {
+				if _, err := conn.WriteMessage(&Message{Kind: messageKindSession, Data: "uid"}); err != nil {
+					return
+				}
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			for range rounds {
+				if err := conn.WritePing(); err != nil {
+					return
+				}
+			}
+		}()
+
+		wg.Wait()
+	}))
+
+	defer server.Close()
+
+	client, err := websocket.Dial("ws"+strings.TrimPrefix(server.URL, "http"), "", server.URL)
+	require.NoError(t, err)
+
+	defer client.Close() //nolint:errcheck
+
+	binary := 0
+
+	for range rounds * 2 {
+		var frame capturedFrame
+
+		if err := frameCapture.Receive(client, &frame); err != nil {
+			break
+		}
+
+		if frame.payloadType == websocket.BinaryFrame {
+			binary++
+
+			// A frame carrying anything other than the whole payload means two
+			// writers interleaved on the shared frame writer.
+			assert.Equal(t, output, frame.data)
+		}
+	}
+
+	assert.Equal(t, rounds, binary)
 }

--- a/server/ssh/web/conn_test.go
+++ b/server/ssh/web/conn_test.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/server/ssh/web/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -180,6 +182,12 @@ func TestConnConcurrentWritesDoNotRace(t *testing.T) {
 
 	output := bytes.Repeat([]byte{'o'}, 128)
 
+	// The client auto-replies a pong to every ping and the handler never reads
+	// them, so closing with that data unread would RST the connection and
+	// truncate what the client has yet to receive. Hold the handler open until
+	// the client has read everything.
+	read := make(chan struct{})
+
 	server := httptest.NewServer(websocket.Handler(func(socket *websocket.Conn) {
 		conn := NewConn(socket)
 
@@ -217,6 +225,7 @@ func TestConnConcurrentWritesDoNotRace(t *testing.T) {
 		}()
 
 		wg.Wait()
+		<-read
 	}))
 
 	defer server.Close()
@@ -226,14 +235,19 @@ func TestConnConcurrentWritesDoNotRace(t *testing.T) {
 
 	defer client.Close() //nolint:errcheck
 
-	binary := 0
+	// Without serialization the frames interleave and the parser desyncs, which
+	// would otherwise block this read until the whole suite times out.
+	require.NoError(t, client.SetDeadline(clock.Now().Add(30*time.Second)))
 
+	binary := 0
+	control := 0
+
+	// Pings are answered and consumed by the client's frame handler, so only the
+	// binary and text frames surface here.
 	for range rounds * 2 {
 		var frame capturedFrame
 
-		if err := frameCapture.Receive(client, &frame); err != nil {
-			break
-		}
+		require.NoError(t, frameCapture.Receive(client, &frame))
 
 		if frame.payloadType == websocket.BinaryFrame {
 			binary++
@@ -241,8 +255,15 @@ func TestConnConcurrentWritesDoNotRace(t *testing.T) {
 			// A frame carrying anything other than the whole payload means two
 			// writers interleaved on the shared frame writer.
 			assert.Equal(t, output, frame.data)
+
+			continue
 		}
+
+		control++
 	}
 
+	close(read)
+
 	assert.Equal(t, rounds, binary)
+	assert.Equal(t, rounds, control)
 }

--- a/server/ssh/web/output.go
+++ b/server/ssh/web/output.go
@@ -1,0 +1,21 @@
+package web
+
+// outputWriter relays a session's output to the web client verbatim: whatever
+// bytes the device wrote, the browser receives. Decoding is the browser's job,
+// so that output in an encoding other than UTF-8 survives the trip.
+//
+// stdout and stderr share one writer so both arrive as binary frames — a text
+// frame must be valid UTF-8 per RFC 6455, which arbitrary device output is not.
+// Serialization is [Conn]'s, since control messages and pings share the socket
+// too.
+type outputWriter struct {
+	conn *Conn
+}
+
+func newOutputWriter(conn *Conn) *outputWriter {
+	return &outputWriter{conn: conn}
+}
+
+func (w *outputWriter) Write(data []byte) (int, error) {
+	return w.conn.WriteBinary(data)
+}

--- a/server/ssh/web/output_test.go
+++ b/server/ssh/web/output_test.go
@@ -1,0 +1,157 @@
+package web
+
+import (
+	"bytes"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
+)
+
+// scriptedReader hands out the stream in the chunk sizes it was scripted with,
+// so a read boundary can be placed on any byte.
+type scriptedReader struct {
+	steps [][]byte
+	i     int
+}
+
+func (r *scriptedReader) Read(p []byte) (int, error) {
+	if r.i >= len(r.steps) {
+		return 0, io.EOF
+	}
+
+	step := r.steps[r.i]
+	if len(step) > len(p) {
+		return 0, io.ErrShortBuffer
+	}
+
+	r.i++
+
+	return copy(p, step), nil
+}
+
+// framingSocket records every write as a distinct frame.
+type framingSocket struct {
+	frames [][]byte
+}
+
+func (s *framingSocket) Write(p []byte) (int, error) {
+	s.frames = append(s.frames, bytes.Clone(p))
+
+	return len(p), nil
+}
+
+func (s *framingSocket) Read(_ []byte) (int, error) { return 0, io.EOF }
+
+func (s *framingSocket) Close() error { return nil }
+
+func (s *framingSocket) joined() []byte {
+	return bytes.Join(s.frames, nil)
+}
+
+func TestOutputWriterPreservesBytes(t *testing.T) {
+	cases := []struct {
+		description string
+		steps       [][]byte
+	}{
+		{
+			description: "utf-8 split mid-character across reads",
+			steps:       [][]byte{{0xe4, 0xb8}, {0xad, 0xe6, 0x96, 0x87}},
+		},
+		{
+			description: "gbk bytes",
+			steps:       [][]byte{{0xd6, 0xd0, 0xce, 0xc4, 0xc4, 0xbf, 0xc2, 0xbc}},
+		},
+		{
+			description: "latin-1 high bytes",
+			steps:       [][]byte{{0x41, 0xe9, 0xe8, 0x42}},
+		},
+		{
+			description: "a chunk of only continuation bytes",
+			steps:       [][]byte{{0x80, 0x81, 0x82}},
+		},
+		{
+			description: "a zero-byte read followed by more data",
+			steps:       [][]byte{{}, {0x41, 0x42, 0x43}},
+		},
+		{
+			description: "every byte on its own read",
+			steps:       [][]byte{{0xe4}, {0xb8}, {0xad}},
+		},
+		{
+			description: "arbitrary binary output",
+			steps:       [][]byte{{0x00, 0x01, 0xff, 0xfe, 0x7f, 0x80}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			socket := &framingSocket{}
+			writer := newOutputWriter(NewConn(socket))
+
+			_, err := io.Copy(writer, &scriptedReader{steps: tc.steps})
+			require.NoError(t, err)
+
+			assert.Equal(t, bytes.Join(tc.steps, nil), socket.joined())
+		})
+	}
+}
+
+// TestOutputWriterSendsBinaryFrames pins the frame type over a real connection.
+// The package's socket mock cannot show it, because WriteBinary falls back to a
+// plain write when the socket is not a websocket.
+func TestOutputWriterSendsBinaryFrames(t *testing.T) {
+	// Invalid UTF-8: a text frame carrying these bytes violates RFC 6455 and the
+	// browser is entitled to fail the connection over it.
+	payload := []byte{0xd6, 0xd0, 0xce, 0xc4}
+
+	server := httptest.NewServer(websocket.Handler(func(socket *websocket.Conn) {
+		writer := newOutputWriter(NewConn(socket))
+
+		if _, err := writer.Write(payload); err != nil {
+			t.Errorf("failed to write the output: %v", err)
+		}
+	}))
+
+	defer server.Close()
+
+	client, err := websocket.Dial("ws"+strings.TrimPrefix(server.URL, "http"), "", server.URL)
+	require.NoError(t, err)
+
+	defer client.Close() //nolint:errcheck
+
+	var frame capturedFrame
+
+	require.NoError(t, frameCapture.Receive(client, &frame))
+
+	assert.Equal(t, byte(websocket.BinaryFrame), frame.payloadType)
+	assert.Equal(t, payload, frame.data)
+}
+
+type capturedFrame struct {
+	payloadType byte
+	data        []byte
+}
+
+// frameCapture exposes the frame's opcode, which the stock Message codec
+// discards when unmarshalling.
+var frameCapture = websocket.Codec{
+	Marshal: func(_ any) ([]byte, byte, error) {
+		return nil, websocket.UnknownFrame, websocket.ErrNotSupported
+	},
+	Unmarshal: func(msg []byte, payloadType byte, v any) error {
+		frame, ok := v.(*capturedFrame)
+		if !ok {
+			return websocket.ErrNotSupported
+		}
+
+		frame.payloadType = payloadType
+		frame.data = msg
+
+		return nil
+	},
+}

--- a/server/ssh/web/session.go
+++ b/server/ssh/web/session.go
@@ -1,13 +1,11 @@
 package web
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
-	"unicode/utf8"
 
 	"github.com/shellhub-io/shellhub/pkg/api/scope"
 	"github.com/shellhub-io/shellhub/pkg/models"
@@ -336,85 +334,14 @@ func newSession(ctx context.Context, service services.Service, handoff *webhando
 		}
 	}()
 
-	go redirToWs(stdout, conn) // nolint:errcheck
-	go io.Copy(conn, stderr)   //nolint:errcheck
+	output := newOutputWriter(conn)
+
+	go io.Copy(output, stdout) //nolint:errcheck
+	go io.Copy(output, stderr) //nolint:errcheck
 
 	if err := agent.Wait(); err != nil {
 		logger.WithError(err).Warning("client remote command returned a error")
 	}
 
 	return nil
-}
-
-func redirToWs(rd io.Reader, ws *Conn) error {
-	// TODO: Evaluate refactoring this function to improve its readability.
-	var buf [32 * 1024]byte
-	var start, end, buflen int
-
-	for {
-		nr, err := rd.Read(buf[start:])
-		if err != nil {
-			return err
-		}
-
-		if nr == 0 {
-			// NOTE: "Callers should treat a return of 0 and nil as indicating that nothing happened; in particular it
-			// does not indicate EOF", in such a case, the caller should not interpret it as EOF, but instead wait for
-			// more data.
-			//
-			// https://pkg.go.dev/io#Reader
-			continue
-		}
-
-		buflen = start + nr
-
-		for end = buflen - 1; end >= 0; end-- {
-			if utf8.RuneStart(buf[end]) {
-				ch, width := utf8.DecodeRune(buf[end:buflen])
-				if ch != utf8.RuneError {
-					end += width
-				}
-
-				break
-			}
-
-			if buflen-end >= 6 {
-				end = nr
-
-				break
-			}
-		}
-
-		if end < 0 {
-			// NOTE: This workround is to avoid a panic in case the end is negative, which would lead to a negative slice.
-			// This situation can happen when the buffer contains only UTF-8 continuation bytes, which are bytes that
-			// cannot start a valid UTF-8 rune. In such cases, the loop above will not find a valid rune start and
-			// will leave `end` as -1.
-			//
-			// https://datatracker.ietf.org/doc/html/rfc3629#section-3
-			log.WithFields(log.Fields{
-				"buf":    buf,
-				"buflen": buflen,
-				"start":  start,
-				"end":    end,
-				"nr":     nr,
-			}).Warn("end is negative, skipping write to avoid panic")
-
-			end = 0
-		}
-
-		if _, err = ws.WriteBinary([]byte(string(bytes.Runes(buf[0:end])))); err != nil {
-			return err
-		}
-
-		start = buflen - end
-
-		if start > 0 {
-			// copy remaning read bytes from the end to the beginning of a buffer
-			// so that we will get normal bytes
-			for i := 0; i < start; i++ {
-				buf[i] = buf[end+i]
-			}
-		}
-	}
 }

--- a/server/ssh/web/session_test.go
+++ b/server/ssh/web/session_test.go
@@ -2,71 +2,15 @@ package web
 
 import (
 	"errors"
-	"io"
 	"net"
 	"testing"
-	"testing/iotest"
 
 	gliderssh "github.com/gliderlabs/ssh"
 	"github.com/shellhub-io/shellhub/server/ssh/pkg/banner"
-	"github.com/shellhub-io/shellhub/server/ssh/web/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
 )
-
-type zeroReadNoEOFReader struct{}
-
-func (r *zeroReadNoEOFReader) Read(p []byte) (int, error) {
-	return 0, nil
-}
-
-// singleRead returns the provided bytes on the first Read call, then EOF.
-type singleRead struct {
-	data []byte
-	read bool
-}
-
-func (r *singleRead) Read(p []byte) (int, error) {
-	if r.read {
-		return 0, io.EOF
-	}
-
-	n := copy(p, r.data)
-	r.read = true
-
-	return n, nil
-}
-
-func TestRedirToWs_Regression_EndNegative(t *testing.T) {
-	mock := mocks.NewMockSocket(t)
-	mock.On("Write", []byte{}).Return(0, nil).Once()
-
-	conn := NewConn(mock)
-
-	// All three bytes are UTF-8 continuation bytes, which will cause the
-	// logic in redirToWs to set end to -1 if not handled properly.
-	// This test ensures that the function does not panic in such a case.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc3629#section-3
-	reader := &singleRead{data: []byte{0x80, 0x81, 0x82}}
-
-	assert.NotPanics(t, func() {
-		_ = redirToWs(reader, conn)
-	}, "redirToWs must not panic when end becomes -1 (all UTF-8 continuation bytes)")
-}
-
-func TestRedirToWs_Regression_ZeroReadThenEOF(t *testing.T) {
-	conn := &Conn{
-		Socket: mocks.NewMockSocket(t),
-	}
-
-	reader := iotest.TimeoutReader(&zeroReadNoEOFReader{})
-
-	assert.NotPanics(t, func() {
-		_ = redirToWs(reader, conn)
-	}, "expected redirToWs to handle zero read without panicking")
-}
 
 // TestBannerNewBannerErrorSetsKind verifies that NewBannerError populates the Kind
 // by calling banner.Classify on the message at construction time.

--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -24,6 +24,7 @@ import SSHApproval from "@/pages/SSHApproval";
 import { cn } from "@shellhub/design-system/cn";
 import { OpfsCastRecorder } from "@/utils/recordings";
 import { useRecordingsStore } from "@/stores/recordingsStore";
+import { createOutputDecoder } from "@/utils/terminalOutputDecoder";
 
 interface TerminalInstanceProps {
   session: TerminalSession;
@@ -64,6 +65,7 @@ export default function TerminalInstance({
       theme: initTheme,
       fontFamilyWithFallback: initFont,
       fontSize: initSize,
+      encoding: initEncoding,
     } = useTerminalThemeStore.getState();
 
     // Finalize the recording exactly once (guarded by nulling the ref before
@@ -142,7 +144,10 @@ export default function TerminalInstance({
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       const wsUrl = `${proto}//${window.location.host}/ws/ssh?token=${token}&cols=${cols}&rows=${rows}`;
       const ws = new WebSocket(wsUrl);
+      ws.binaryType = "arraybuffer";
       wsRef.current = ws;
+
+      const decoder = createOutputDecoder(initEncoding);
       resizeRegisteredRef.current = false;
 
       // Copy key material into local variables so the closure doesn't hold
@@ -191,16 +196,24 @@ export default function TerminalInstance({
         }
       };
 
-      ws.onmessage = async (event) => {
+      // Synchronous by design: awaiting here would decode each frame in
+      // isolation (corrupting a character that spans frames) and would let
+      // frame order follow promise resolution rather than arrival.
+      ws.onmessage = (event) => {
         if (cancelled) return;
-        if (event.data instanceof Blob) {
-          // Binary data = terminal output (password auth or post-signature)
-          const text = await event.data.text();
+        // Control messages are JSON text frames and arrive as strings; anything
+        // else is device output.
+        if (typeof event.data !== "string") {
+          const text = decoder.decode(new Uint8Array(event.data as ArrayBuffer));
           term.write(text);
           recorderRef.current?.recordOutput(text);
           registerResizeHandler();
-        } else {
-          // JSON text message = challenge-response or error
+          return;
+        }
+
+        // Control messages stay async (the signature case signs with WebCrypto),
+        // but the output path above must not await.
+        void (async () => {
           const textData = String(event.data as unknown);
           const msg = parseMessage(textData);
           if (!msg) {
@@ -270,7 +283,7 @@ export default function TerminalInstance({
             default:
               break;
           }
-        }
+        })();
       };
 
       ws.onclose = () => {

--- a/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
@@ -7,6 +7,10 @@ import {
   TERMINAL_FONTS,
   type TerminalTheme,
 } from "@/stores/terminalThemeStore";
+import {
+  TERMINAL_ENCODINGS,
+  type TerminalEncoding,
+} from "@/utils/terminalOutputDecoder";
 import Drawer from "../common/Drawer";
 import { getConfig } from "@/env";
 
@@ -31,9 +35,11 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
     theme,
     fontFamily,
     fontSize,
+    encoding,
     setTheme,
     setFontFamily,
     setFontSize,
+    setEncoding,
     loadThemes,
   } = useTerminalThemeStore();
 
@@ -143,6 +149,28 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
             {fontSize}
           </span>
         </div>
+      </div>
+
+      {/* Character Encoding */}
+      <div className="border-b border-border p-4">
+        <div className="mb-2.5 text-2xs font-mono font-semibold uppercase tracking-label text-text-muted">
+          Character Encoding
+        </div>
+        <select
+          aria-label="Character encoding"
+          value={encoding}
+          onChange={(e) => setEncoding(e.target.value as TerminalEncoding)}
+          className="w-full rounded-md border border-border bg-hover-subtle px-2.5 py-1.5 text-[13px] text-text-secondary"
+        >
+          {TERMINAL_ENCODINGS.map(({ value, label }) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <p className="mt-2 text-2xs text-text-muted">
+          Applies to terminals opened after the change.
+        </p>
       </div>
 
       {/* Preview */}

--- a/ui/apps/console/src/stores/__tests__/terminalThemeStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/terminalThemeStore.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadStore = async () => {
+  const { useTerminalThemeStore } = await import("../terminalThemeStore");
+  return useTerminalThemeStore;
+};
+
+describe("terminalThemeStore encoding", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it("defaults to UTF-8", async () => {
+    const store = await loadStore();
+
+    expect(store.getState().encoding).toBe("utf-8");
+  });
+
+  it("round-trips a selected encoding", async () => {
+    const store = await loadStore();
+
+    store.getState().setEncoding("gbk");
+
+    expect(store.getState().encoding).toBe("gbk");
+  });
+
+  it("restores the selected encoding on reload", async () => {
+    const store = await loadStore();
+    store.getState().setEncoding("gbk");
+
+    vi.resetModules();
+    const reloaded = await loadStore();
+
+    expect(reloaded.getState().encoding).toBe("gbk");
+  });
+
+  it("ignores an encoding it does not offer", async () => {
+    const store = await loadStore();
+
+    store.getState().setEncoding("not-a-real-encoding" as never);
+
+    expect(store.getState().encoding).toBe("utf-8");
+  });
+});

--- a/ui/apps/console/src/stores/terminalThemeStore.ts
+++ b/ui/apps/console/src/stores/terminalThemeStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
 import axios from "axios";
+import {
+  DEFAULT_TERMINAL_ENCODING,
+  isTerminalEncoding,
+  type TerminalEncoding,
+} from "@/utils/terminalOutputDecoder";
 
 export interface TerminalThemeColors {
   background: string;
@@ -57,6 +62,7 @@ const STORAGE_KEYS = {
   theme: "terminalTheme",
   fontFamily: "terminalFontFamily",
   fontSize: "terminalFontSize",
+  encoding: "terminalEncoding",
 };
 
 const FALLBACK_THEME: TerminalTheme = {
@@ -103,21 +109,25 @@ interface TerminalThemeState {
   fontFamily: TerminalFont;
   fontSize: number;
   fontFamilyWithFallback: string;
+  encoding: TerminalEncoding;
   loaded: boolean;
   loadThemes: () => Promise<void>;
   setTheme: (name: string) => void;
   setFontFamily: (font: TerminalFont) => void;
   setFontSize: (size: number) => void;
+  setEncoding: (encoding: TerminalEncoding) => void;
 }
 
 export const useTerminalThemeStore = create<TerminalThemeState>((set, get) => {
   const savedTheme = localStorage.getItem(STORAGE_KEYS.theme);
   const savedFont = localStorage.getItem(STORAGE_KEYS.fontFamily);
   const savedSize = localStorage.getItem(STORAGE_KEYS.fontSize);
+  const savedEncoding = localStorage.getItem(STORAGE_KEYS.encoding);
 
   const initialThemeName = savedTheme || "ShellHub Dark";
   const initialFont = (savedFont as TerminalFont) || "IBM Plex Mono";
   const initialSize = savedSize ? parseInt(savedSize, 10) : 14;
+  const initialEncoding = isTerminalEncoding(savedEncoding) ? savedEncoding : DEFAULT_TERMINAL_ENCODING;
 
   return {
     themes: [FALLBACK_THEME],
@@ -126,6 +136,7 @@ export const useTerminalThemeStore = create<TerminalThemeState>((set, get) => {
     fontFamily: initialFont,
     fontSize: initialSize,
     fontFamilyWithFallback: `'${initialFont}', monospace`,
+    encoding: initialEncoding,
     loaded: false,
 
     loadThemes: async () => {
@@ -175,6 +186,13 @@ export const useTerminalThemeStore = create<TerminalThemeState>((set, get) => {
       const clamped = Math.min(Math.max(size, 8), 24);
       localStorage.setItem(STORAGE_KEYS.fontSize, clamped.toString());
       set({ fontSize: clamped });
+    },
+
+    setEncoding: (encoding) => {
+      if (!isTerminalEncoding(encoding)) return;
+
+      localStorage.setItem(STORAGE_KEYS.encoding, encoding);
+      set({ encoding });
     },
   };
 });

--- a/ui/apps/console/src/utils/__tests__/terminalOutputDecoder.test.ts
+++ b/ui/apps/console/src/utils/__tests__/terminalOutputDecoder.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { createOutputDecoder } from "@/utils/terminalOutputDecoder";
+
+const bytes = (...values: number[]) => new Uint8Array(values);
+
+describe("createOutputDecoder", () => {
+  it("defaults to UTF-8", () => {
+    const decoder = createOutputDecoder();
+
+    expect(decoder.decode(bytes(0xe4, 0xb8, 0xad))).toBe("中");
+  });
+
+  it("holds a multi-byte character split across chunks until it completes", () => {
+    const decoder = createOutputDecoder("utf-8");
+
+    expect(decoder.decode(bytes(0xe4, 0xb8))).toBe("");
+    expect(decoder.decode(bytes(0xad))).toBe("中");
+  });
+
+  it("decodes a character split across chunks for non-UTF-8 encodings too", () => {
+    const decoder = createOutputDecoder("gbk");
+
+    expect(decoder.decode(bytes(0xd6))).toBe("");
+    expect(decoder.decode(bytes(0xd0))).toBe("中");
+  });
+
+  it("decodes GBK bytes that UTF-8 would destroy", () => {
+    const decoder = createOutputDecoder("gbk");
+
+    expect(decoder.decode(bytes(0xd6, 0xd0, 0xce, 0xc4, 0xc4, 0xbf, 0xc2, 0xbc))).toBe("中文目录");
+  });
+
+  it.each([
+    ["an unknown encoding name", "not-a-real-encoding"],
+    ["an empty encoding name", ""],
+  ])("falls back to UTF-8 for %s", (_description, encoding) => {
+    const decoder = createOutputDecoder(encoding);
+
+    expect(decoder.decode(bytes(0xe4, 0xb8, 0xad))).toBe("中");
+  });
+
+  it("yields the replacement character for invalid bytes rather than throwing", () => {
+    const decoder = createOutputDecoder("utf-8");
+
+    expect(decoder.decode(bytes(0x41, 0xff, 0x42))).toBe("A�B");
+  });
+
+  it("keeps decoding across many chunks", () => {
+    const decoder = createOutputDecoder("utf-8");
+    const chunks = [bytes(0x68, 0x69, 0xe6), bytes(0x97, 0xa5), bytes(0x21)];
+
+    expect(chunks.map((chunk) => decoder.decode(chunk)).join("")).toBe("hi日!");
+  });
+});

--- a/ui/apps/console/src/utils/terminalOutputDecoder.ts
+++ b/ui/apps/console/src/utils/terminalOutputDecoder.ts
@@ -1,0 +1,49 @@
+// Encodings a device may emit. The browser decodes them, so the terminal shows
+// what the device wrote rather than the gateway's interpretation of it.
+export const TERMINAL_ENCODINGS = [
+  { value: "utf-8", label: "Unicode (UTF-8)" },
+  { value: "gbk", label: "Chinese Simplified (GBK)" },
+  { value: "gb18030", label: "Chinese Simplified (GB18030)" },
+  { value: "big5", label: "Chinese Traditional (Big5)" },
+  { value: "shift_jis", label: "Japanese (Shift_JIS)" },
+  { value: "euc-jp", label: "Japanese (EUC-JP)" },
+  { value: "euc-kr", label: "Korean (EUC-KR)" },
+  { value: "windows-1251", label: "Cyrillic (Windows-1251)" },
+  { value: "windows-1252", label: "Western (Windows-1252)" },
+  { value: "iso-8859-15", label: "Western (ISO-8859-15)" },
+] as const;
+
+export type TerminalEncoding = (typeof TERMINAL_ENCODINGS)[number]["value"];
+
+export const DEFAULT_TERMINAL_ENCODING: TerminalEncoding = "utf-8";
+
+export const isTerminalEncoding = (value: string | null): value is TerminalEncoding =>
+  TERMINAL_ENCODINGS.some((encoding) => encoding.value === value);
+
+export interface TerminalOutputDecoder {
+  decode(bytes: Uint8Array): string;
+}
+
+/**
+ * Creates a decoder for one terminal session's output.
+ *
+ * The decoder is stateful across calls: a multi-byte character split across
+ * WebSocket frames is held until the bytes completing it arrive, for every
+ * encoding rather than just UTF-8. An encoding the browser does not know falls
+ * back to UTF-8 instead of throwing.
+ */
+export const createOutputDecoder = (
+  encoding: string = DEFAULT_TERMINAL_ENCODING,
+): TerminalOutputDecoder => {
+  let decoder: TextDecoder;
+
+  try {
+    decoder = new TextDecoder(encoding, { fatal: false });
+  } catch {
+    decoder = new TextDecoder(DEFAULT_TERMINAL_ENCODING, { fatal: false });
+  }
+
+  return {
+    decode: (bytes: Uint8Array) => decoder.decode(bytes, { stream: true }),
+  };
+};


### PR DESCRIPTION
## What

The gateway stops rewriting the device's output. Whatever bytes the device wrote, the
browser receives; the terminal decodes them, with a user-selectable character encoding
(UTF-8 by default).

Part 2 of the spec on #6763. Part 1 (announcing `LC_CTYPE=C.UTF-8`, which closes that
issue) ships separately in #6765. The two are independent — this one is the reason a
GBK device can never work today, not what the original reporter hit.

## Why

`redirToWs` decoded the device's bytes to runes and re-encoded them, substituting U+FFFD
for anything that was not valid UTF-8. A device emitting GBK/GB18030 — common on Chinese
systems, and readable by a native client with a matching terminal encoding — could
therefore never be displayed correctly, because the information was destroyed
server-side. Running the old relay against controlled read boundaries:

| input | result |
|---|---|
| UTF-8 split mid-character across reads | preserved |
| GBK `中文目录` (`d6 d0 ce c4 …`) | corrupted → `ef bf bd ef bf bd …` |
| Latin-1 high bytes (`41 e9 e8 42`) | corrupted → `41 ef bf bd ef bf bd 42` |
| a chunk of only continuation bytes | dropped entirely |

Related: #6763

## Changes

- **server/ssh/web**: `redirToWs` deleted. stdout and stderr are copied verbatim into
  binary frames. The hand-rolled scan that kept a multi-byte sequence off a frame
  boundary is no longer needed, because the client's decoder is stateful across writes —
  and with it go two latent bugs it contained: a fallback branch that used the wrong
  length after a partial sequence had been carried over, and a path that silently dropped
  data when a buffer began with continuation bytes. Neither is expressible in a straight
  copy.
- **server/ssh/web**: stderr no longer goes out as a *text* frame. It was relayed with a
  plain copy onto the socket, concurrently with stdout's binary frames; RFC 6455 requires
  text frames to be valid UTF-8, so a sequence split across a stderr read was a protocol
  violation the browser is entitled to fail the connection over. Both streams now share
  one binary-frame writer.
- **server/ssh/web**: write serialization moved onto `Conn`, not onto that writer.
  Keep-alive pings and JSON control messages are produced by other goroutines and write
  to the same `x/net/websocket` frame writer, which is not goroutine-safe; guarding only
  the output path leaves the corruption it set out to prevent. `TestConnConcurrentWritesDoNotRace`
  drives output, control messages and pings concurrently over a real socket and observes
  genuinely corrupted frames without the lock — not merely a race warning.
- **ui (terminal)**: the socket takes `arraybuffer` and the message handler is
  synchronous. It previously awaited `Blob.text()` per frame, which decoded each frame in
  isolation (corrupting anything spanning frames), let frame order follow promise
  resolution rather than arrival, and left the cancellation check stale across the await.
  Control frames stay JSON text and are discriminated by `typeof event.data === "string"`,
  which keeps the existing non-JSON-text fallback intact.
- **ui (`terminalOutputDecoder`)**: a per-session streaming `TextDecoder`. A character
  split across frames is held and completed for *every* encoding, not just UTF-8. An
  unsupported encoding name falls back to UTF-8 rather than throwing. It always yields a
  string: the recorder needs one regardless (asciicast v2 output events are JSON strings
  by specification), so feeding the terminal and the recorder the same string is both
  simpler and what guarantees a recording replays as what the user saw.
- **ui (settings)**: character encoding is a persisted terminal preference alongside the
  existing appearance settings. Changing it applies to sessions opened afterwards — an
  open session's decoder holds stream state, so its scrollback is not retroactively
  re-decoded.

Invalid bytes still render as U+FFFD, but now in the browser, as a rendering decision,
after the bytes have survived the trip. That is what makes selecting GBK able to work.

## Testing

The server tests assert byte-for-byte fidelity through scripted read boundaries rather
than on frame counts or buffer sizes — the implementation details whose removal is the
point. `TestOutputWriterPreservesBytes` places a boundary mid-character and covers GBK,
Latin-1, all-continuation-bytes, a zero-byte read followed by data, and arbitrary binary;
the two pathologies pinned by the deleted `TestRedirToWs_Regression_*` tests are carried
over as explicit cases rather than dropped. `TestOutputWriterSendsBinaryFrames` pins the
frame opcode over a real connection, which the package's socket mock cannot show.

Run the server package with `-race` — `TestConnConcurrentWritesDoNotRace` is the gate on
the locking, and it fails loudly if the lock is narrowed back to the output writer.

Worth probing by hand: a device emitting GBK filenames with the encoding set to GBK, and
a `hexdump`/binary-heavy command to confirm the browser receives exactly what the device
wrote. The terminal component itself stays untested — it is thin wiring (frame-type
branch, decode, write, record), and testing it would mean introducing WebSocket, OPFS and
WebGL shims this app does not have.