### PR TITLE
ci: make the integration suite pass again

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -31,11 +31,14 @@ jobs:
           - project: cli
             extra_args: ""
             lint_args: ""
-          # Integration tests with PostgreSQL
+          # Integration tests with PostgreSQL. Each of the ~31 SSH cases stands up
+          # its own agent container and runs twice (transport v1 and v2), so the
+          # suite needs well over the 25m the unit-test projects get.
           - project: tests
             extra_args: ""
             lint_args: ""
             database: postgres
+            test_timeout: "45m"
 
     runs-on: ubuntu-latest
 
@@ -115,7 +118,7 @@ jobs:
       - name: Unit test [Go]
         if: steps.filter.outputs.go == 'true' && github.event.pull_request.draft == false
         working-directory: ${{ matrix.project }}
-        run: go test ${{ matrix.extra_args }} -timeout 25m ./...
+        run: go test ${{ matrix.extra_args }} -timeout ${{ matrix.test_timeout || '25m' }} ./...
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
 

--- a/cli/cmd/namespace.go
+++ b/cli/cmd/namespace.go
@@ -49,11 +49,17 @@ The owner must be a valid username within the system. If a tenant ID is provided
 				return err
 			}
 
+			sshAccessMode, err := cmd.Flags().GetString("ssh-access-mode")
+			if err != nil {
+				return err
+			}
+
 			input := inputs.NamespaceCreate{
-				Namespace: strings.ToLower(args[0]),
-				Owner:     strings.ToLower(args[1]),
-				TenantID:  "",
-				Type:      strings.ToLower(namespaceType),
+				Namespace:     strings.ToLower(args[0]),
+				Owner:         strings.ToLower(args[1]),
+				TenantID:      "",
+				Type:          strings.ToLower(namespaceType),
+				SSHAccessMode: strings.ToLower(sshAccessMode),
 			}
 
 			if len(args) == 3 {
@@ -80,6 +86,7 @@ The owner must be a valid username within the system. If a tenant ID is provided
 	}
 
 	cmdNamespace.PersistentFlags().String("type", "team", "type")
+	cmdNamespace.PersistentFlags().String("ssh-access-mode", "", "SSH authorization model: legacy or identity (default identity)")
 
 	return cmdNamespace
 }

--- a/cli/pkg/inputs/namespace.go
+++ b/cli/pkg/inputs/namespace.go
@@ -6,6 +6,9 @@ type NamespaceCreate struct {
 	Owner     string `validate:"required,username"`
 	TenantID  string `validate:"omitempty,uuid"`
 	Type      string `validate:"omitempty,lowercase,oneof=personal team"`
+	// SSHAccessMode selects the namespace's SSH authorization model. Empty leaves
+	// the store's identity-first default in place.
+	SSHAccessMode string `validate:"omitempty,lowercase,oneof=legacy identity"`
 }
 
 // NamespaceDelete defines the structure for inputs when deleting a namespace.

--- a/cli/services/namespaces.go
+++ b/cli/services/namespaces.go
@@ -58,6 +58,7 @@ func (s *service) NamespaceCreate(ctx context.Context, input *inputs.NamespaceCr
 		Settings: &models.NamespaceSettings{
 			SessionRecord:          true,
 			ConnectionAnnouncement: models.DefaultAnnouncementMessage,
+			SSHAccessMode:          input.SSHAccessMode,
 		},
 		CreatedAt: clock.Now(),
 		Type:      models.NewDefaultType(),

--- a/tests/environment/configurator.go
+++ b/tests/environment/configurator.go
@@ -126,7 +126,7 @@ func (dcc *DockerComposeConfigurator) Up(ctx context.Context) *DockerCompose {
 	services := []Service{ServiceGateway, ServiceServer}
 	// TODO: Perhaps we could devise a strategy to wait for specific services instead
 	// of blocking until all are running|healthy?
-	if !assert.NoError(dc.t, tcDc.WithEnv(dcc.envs).Up(ctx, compose.Wait(true))) {
+	if err := tcDc.WithEnv(dcc.envs).Up(ctx, compose.Wait(true)); !assert.NoError(dc.t, err) {
 		assert.FailNow(dc.t, err.Error())
 	}
 

--- a/tests/environment/docker_compose.go
+++ b/tests/environment/docker_compose.go
@@ -83,7 +83,7 @@ func (dc *DockerCompose) buildCLICommand(ctx context.Context, cmds []string) (tc
 				Context:       "..",
 				Dockerfile:    "cli/Dockerfile.test",
 				PrintBuildLog: false,
-				KeepImage:     false,
+				KeepImage:     true,
 			},
 		},
 		Logger: log.New(io.Discard, "", log.LstdFlags),

--- a/tests/environment/docker_compose.go
+++ b/tests/environment/docker_compose.go
@@ -119,13 +119,18 @@ func (dc *DockerCompose) NewUser(t *testing.T, username, email, password string)
 // NewNamespace creates a new namespace with the specified values. It is an abstraction around the "namespace
 // create" method of the CLI.
 //
+// sshAccessMode selects the namespace's SSH authorization model ("legacy" or "identity"); an empty value
+// leaves the server's default in place.
+//
 // It is not intended to be a test of the method, but it makes some assertions to guarantee that the following
 // instructions will not fail, calling assert.FailNow if any do.
-func (dc *DockerCompose) NewNamespace(t *testing.T, owner, name, tenant string) {
-	container, err := dc.buildCLICommand(
-		t.Context(),
-		[]string{"./cli", "namespace", "create", name, owner, tenant},
-	)
+func (dc *DockerCompose) NewNamespace(t *testing.T, owner, name, tenant, sshAccessMode string) {
+	cmd := []string{"./cli", "namespace", "create", name, owner, tenant}
+	if sshAccessMode != "" {
+		cmd = append(cmd, "--ssh-access-mode", sshAccessMode)
+	}
+
+	container, err := dc.buildCLICommand(t.Context(), cmd)
 	if !assert.NoError(dc.t, err) {
 		assert.FailNow(dc.t, err.Error())
 	}

--- a/tests/environment/docs.go
+++ b/tests/environment/docs.go
@@ -47,7 +47,7 @@
 //	    t.Cleanup(dockerCompose.Down)
 //
 //	    dockerCompose.NewUser(ctx, "john_doe", "john.doe@test.com", "secret") // Create a new user
-//	    dockerCompose.NewNamespace(ctx, "john_doe", "dev", "00000000-0000-0000-0000-000000000000") // And a namespace
+//	    dockerCompose.NewNamespace(ctx, "john_doe", "dev", "00000000-0000-0000-0000-000000000000", "legacy") // And a namespace
 //	    credentials := dockerCompose.AuthUser("john_doe", "secret")
 //	    // Do something ...
 //	}

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -79,7 +79,7 @@ func NewAgentContainer(ctx context.Context, port string, opts ...NewAgentContain
 				Context:       "..",
 				Dockerfile:    "agent/Dockerfile.test",
 				PrintBuildLog: false,
-				KeepImage:     false,
+				KeepImage:     true,
 				BuildArgs: map[string]*string{
 					"USERNAME": &ShellHubAgentUsername,
 					"PASSWORD": &ShellHubAgentPassword,
@@ -1456,8 +1456,8 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 // newSSHEnvironment brings up a ShellHub stack with a single user and namespace in the given
 // SSH access mode, and authenticates the compose client as that user.
 //
-// The database backend (mongo/postgres) is configured via SHELLHUB_DATABASE in .env; CI runs
-// this suite once per backend.
+// The database backend is configured via SHELLHUB_DATABASE in .env; postgres is the only one
+// supported.
 func newSSHEnvironment(t *testing.T, ctx context.Context, sshAccessMode string) *environment.DockerCompose {
 	t.Helper()
 

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -95,6 +95,72 @@ func NewAgentContainer(ctx context.Context, port string, opts ...NewAgentContain
 	return c, nil
 }
 
+// TestSSHIdentityMode covers the identity authorization model, which namespaces are born
+// into: the presented key IS the identity, so password authentication is not offered at all
+// and only a key enrolled as an SSH identity gets through. The legacy model — passwords and
+// firewall-filtered public keys — is covered by [TestSSH].
+//
+// The access mode is orthogonal to the transport, so this runs on the default version only.
+func TestSSHIdentityMode(t *testing.T) {
+	ctx := context.Background()
+
+	compose := newSSHEnvironment(t, ctx, models.SSHAccessModeIdentity)
+	_, device := startAcceptedAgent(t, ctx, compose)
+
+	sshid := fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name)
+	addr := fmt.Sprintf("localhost:%s", compose.Env("SHELLHUB_SSH_PORT"))
+
+	t.Run("password authentication is not offered", func(t *testing.T) {
+		config := &ssh.ClientConfig{
+			User:            sshid,
+			Auth:            []ssh.AuthMethod{ssh.Password(ShellHubAgentPassword)},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		}
+
+		_, err := ssh.Dial("tcp", addr, config)
+		require.Error(t, err)
+		// The client never gets to try a password: the server advertises publickey only.
+		require.Contains(t, err.Error(), "attempted methods []")
+	})
+
+	t.Run("authenticate with an enrolled identity", func(t *testing.T) {
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+		require.NoError(t, err)
+
+		resp, err := compose.R(ctx).
+			SetBody(&requests.SSHIdentityCreate{
+				Name: "integration",
+				Data: string(ssh.MarshalAuthorizedKey(publicKey)),
+			}).
+			Post("/api/ssh-identities")
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode())
+
+		signer, err := ssh.NewSignerFromKey(privateKey)
+		require.NoError(t, err)
+
+		config := &ssh.ClientConfig{
+			User:            sshid,
+			Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		}
+
+		var conn *ssh.Client
+
+		require.EventuallyWithT(t, func(tt *assert.CollectT) {
+			var err error
+
+			conn, err = ssh.Dial("tcp", addr, config)
+			assert.NoError(tt, err)
+		}, 30*time.Second, 1*time.Second)
+
+		conn.Close()
+	})
+}
+
 func TestSSH(t *testing.T) {
 	// Run all tests with both v1 and v2
 	for _, version := range []int{1, 2} {
@@ -1365,12 +1431,41 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 
 	ctx := context.Background()
 
-	// Database backend (mongo/postgres) is configured via SHELLHUB_DATABASE in .env
-	// The CI runs this test suite twice in parallel - once for each backend
+	// The table below authenticates with a password and with ad-hoc public keys, which is
+	// the legacy authorization model. Namespaces are born identity-first, so the mode has to
+	// be asked for explicitly. Identity mode is covered by [TestSSHIdentityMode].
+	compose := newSSHEnvironment(t, ctx, models.SSHAccessModeLegacy)
+
+	for _, tc := range tests {
+		test := tc
+		t.Run(test.name, func(tt *testing.T) {
+			opts := append([]NewAgentContainerOption{
+				NewAgentContainerWithConnectionVersion(connectionVersion),
+			}, test.options...)
+
+			agent, device := startAcceptedAgent(tt, ctx, compose, opts...)
+
+			test.run(tt, &Environment{
+				services: compose,
+				agent:    agent,
+			}, device)
+		})
+	}
+}
+
+// newSSHEnvironment brings up a ShellHub stack with a single user and namespace in the given
+// SSH access mode, and authenticates the compose client as that user.
+//
+// The database backend (mongo/postgres) is configured via SHELLHUB_DATABASE in .env; CI runs
+// this suite once per backend.
+func newSSHEnvironment(t *testing.T, ctx context.Context, sshAccessMode string) *environment.DockerCompose {
+	t.Helper()
+
 	compose := environment.New(t).Up(ctx)
-	defer compose.Down()
+	t.Cleanup(compose.Down)
+
 	compose.NewUser(t, ShellHubUsername, ShellHubEmail, ShellHubPassword)
-	compose.NewNamespace(t, ShellHubUsername, ShellHubNamespaceName, ShellHubNamespace)
+	compose.NewNamespace(t, ShellHubUsername, ShellHubNamespaceName, ShellHubNamespace, sshAccessMode)
 
 	auth := models.UserAuthResponse{}
 
@@ -1388,67 +1483,54 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 
 	compose.JWT(auth.Token)
 
-	for _, tc := range tests {
-		test := tc
-		t.Run(test.name, func(tt *testing.T) {
-			opts := append([]NewAgentContainerOption{
-				NewAgentContainerWithConnectionVersion(connectionVersion),
-			}, test.options...)
+	return compose
+}
 
-			agent, err := NewAgentContainer(
-				ctx,
-				compose.Env("SHELLHUB_HTTP_PORT"),
-				opts...,
-			)
-			require.NoError(tt, err)
+// startAcceptedAgent starts an agent container, accepts the device it registers, and waits for
+// it to come online, returning the container and the accepted device.
+func startAcceptedAgent(t *testing.T, ctx context.Context, compose *environment.DockerCompose, opts ...NewAgentContainerOption) (testcontainers.Container, *models.Device) {
+	t.Helper()
 
-			agent.Stop(ctx, nil)
+	agent, err := NewAgentContainer(ctx, compose.Env("SHELLHUB_HTTP_PORT"), opts...)
+	require.NoError(t, err)
 
-			err = agent.Start(ctx)
-			require.NoError(tt, err)
+	agent.Stop(ctx, nil)
 
-			tt.Cleanup(func() {
-				agent.Stop(context.Background(), nil)
-			})
+	err = agent.Start(ctx)
+	require.NoError(t, err)
 
-			t.Cleanup(func() {
-				agent.Terminate(context.Background())
-			})
+	t.Cleanup(func() {
+		agent.Stop(context.Background(), nil)
+		agent.Terminate(context.Background())
+	})
 
-			devices := []models.Device{}
+	devices := []models.Device{}
 
-			require.EventuallyWithT(tt, func(tt *assert.CollectT) {
-				resp, err := compose.R(ctx).SetResult(&devices).
-					Get("/api/devices?status=pending")
-				assert.Equal(tt, 200, resp.StatusCode())
-				assert.NoError(tt, err)
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		resp, err := compose.R(ctx).SetResult(&devices).
+			Get("/api/devices?status=pending")
+		assert.Equal(tt, 200, resp.StatusCode())
+		assert.NoError(tt, err)
 
-				assert.Len(tt, devices, 1)
-			}, 30*time.Second, 1*time.Second)
+		assert.Len(tt, devices, 1)
+	}, 30*time.Second, 1*time.Second)
 
-			resp, err := compose.R(ctx).
-				Patch(fmt.Sprintf("/api/devices/%s/accept", devices[0].UID))
-			require.Equal(tt, 200, resp.StatusCode())
-			require.NoError(tt, err)
+	resp, err := compose.R(ctx).
+		Patch(fmt.Sprintf("/api/devices/%s/accept", devices[0].UID))
+	require.Equal(t, 200, resp.StatusCode())
+	require.NoError(t, err)
 
-			device := models.Device{}
+	device := models.Device{}
 
-			require.EventuallyWithT(tt, func(tt *assert.CollectT) {
-				resp, err := compose.R(ctx).
-					SetResult(&device).
-					Get(fmt.Sprintf("/api/devices/%s", devices[0].UID))
-				assert.Equal(tt, 200, resp.StatusCode())
-				assert.NoError(tt, err)
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		resp, err := compose.R(ctx).
+			SetResult(&device).
+			Get(fmt.Sprintf("/api/devices/%s", devices[0].UID))
+		assert.Equal(tt, 200, resp.StatusCode())
+		assert.NoError(tt, err)
 
-				assert.True(tt, device.Online)
-			}, 30*time.Second, 1*time.Second)
+		assert.True(tt, device.Online)
+	}, 30*time.Second, 1*time.Second)
 
-			// --
-
-			test.run(tt, &Environment{
-				services: compose,
-				agent:    agent,
-			}, &device)
-		})
-	}
+	return agent, &device
 }


### PR DESCRIPTION
## What

Makes `validate (tests - postgres)` pass again, and cuts it from ~50 minutes to ~10.

The job had two stacked faults: the suite did not fit its timeout, and the timeout was hiding
the fact that every SSH case was failing outright.

## Why

### The timeout

`TestSSH` runs ~31 cases against both transport versions, each standing up its own agent
container, and did not fit in the 25m the unit-test projects share:

```
panic: test timed out after 25m0s
	running tests:
		TestSSH (25m0s)
		TestSSH/connection_v2 (10m59s)
```

What hid this is the paths filter. The job only reports success when it *skips* the Go tests:
every green run lasts about a minute (e.g. run 30501644237, on a commit touching only
`.github/workflows/notify-cloud.yml`). Every run that actually executed the suite timed out.
The job has been failing whenever it does any work, and passing only when it does none.

### What the timeout was hiding

Given a longer budget the suite completes — and reports **all 56 SSH cases failing**:

```
ssh: handshake failed: ssh: unable to authenticate, attempted methods [], no supported methods remain
```

`77ce019a0 feat(api): persist access policies, identities, approvals and accounts` made
namespaces identity-first by default, both at the store seam
(`server/api/store/pg/namespace.go`) and in the schema
(`ssh_access_mode text not null default 'identity'`).

The suite creates its namespace through `cli namespace create`, which had no way to ask for
another mode, so the namespace was born in identity mode. There,
`newServerConfigCallback` returns a `PartialSuccessError` advertising **publickey only** — so
the suite's password logins never get to try a password, and its ad-hoc keys are not enrolled
identities either.

Confirmed on a live stack, changing nothing but the DB column:

```
ssh_access_mode = identity  →  Authentications that can continue: publickey
ssh_access_mode = legacy    →  Authentications that can continue: password,publickey
```

And by bisect: `77ce019a0` is absent from `4eca6cbcc` (the last green run of this job) and
present in `c7c3cdf4f` (the first failing one). Every green run since has been a skip.

### Why it was so slow

Each of the 62 cases builds an agent container. With `KeepImage: false` testcontainers deletes
the image after every case, so the next build re-exports every layer even though the build
cache is warm — you can see `CACHED` on every Dockerfile step while the case still costs ~47s.
That was ~40s of pure re-export per case, roughly 40 minutes across the run. The same applies
to the `cli` image, built four times per run.

## Changes

- **`.github/workflows/qa.yml`**: `-timeout` comes from an optional `test_timeout` matrix key,
  `45m` for the `tests` project, defaulting to `25m` elsewhere. With the perf fixes below the
  suite lands around 10m, so this is now headroom rather than the fix.
- **`cli`**: `namespace create` grows `--ssh-access-mode legacy|identity`. Namespaces are born
  identity-first and the API refuses a switch back to legacy unless `ssh_legacy_allowed` is
  set, so before this there was no way to provision a legacy namespace. Operators migrating an
  existing fleet need one too, not just the tests.
- **`tests/ssh_test.go`**: `TestSSH` now asks for legacy explicitly, keeping it a test of that
  model. New `TestSSHIdentityMode` covers the identity one: password is never offered, and a
  key enrolled as an SSH identity connects. Access mode is orthogonal to the transport, so it
  runs on the default version rather than doubling the table.
- **`tests/ssh_test.go` / `tests/environment/docker_compose.go`**: `KeepImage: true` for the
  agent and cli images. The image is still rebuilt from the current context on every case, so a
  change to the agent source is picked up exactly as before; only the discard-and-re-export is
  gone.
- **`tests/ssh_test.go`**: agent containers are terminated per case instead of accumulating on
  the parent test for the whole run. Setup is factored into `newSSHEnvironment` and
  `startAcceptedAgent`.
- **`tests/environment/configurator.go`**: on a compose bring-up failure, `assert.FailNow`
  called `err.Error()` on the `err` from `NewDockerComposeWith` — which is `nil` once that call
  succeeded. A bring-up failure therefore died with a SIGSEGV that masked the real cause. It
  now reports the error from `Up`.

## Testing

`validate (tests - postgres)` passes in **10m34s**, against a 48m timeout failure before.

Locally, all 62 cases green at each step, isolating the two perf changes:

| | wall clock |
|---|---|
| before | 3109.9s — 51.8 min |
| + agent `KeepImage` | 621.1s — 10.4 min |
| + cli `KeepImage` | 547.3s — 9.1 min |

Per case, same five cases measured back to back and warm: ~47s → ~6.2s.

## Review notes

`--ssh-access-mode` lets an operator create a legacy namespace without `ssh_legacy_allowed`
being set. That looks right — the flag is on namespace *creation*, the guard is on user-facing
mode *switching*, and the CLI is an admin tool that can already create users and namespaces —
but it is a deliberate escape hatch and worth a second opinion.

`cloud / validate-server-enterprise` fails on this branch, and not because of it: this PR
touches only `qa.yml`, `cli/**` and `tests/**`, none of which cloud imports. It is
shellhub↔cloud drift on master — a `services.Service` interface mismatch from `c496c1026`,
plus unresolved `FirewallConnection` / `WebEndpoint` / `ErrFirewallBlocked` /
`RegisterFirewallEvaluator` symbols. An unrelated `sync-deps` dispatch is failing too. The
check passed on this PR's original base and appeared only when it was rebased onto master, so
it needs fixing in cloud, separately.

## Follow-up, not in this PR

The suite still runs the whole table for both transport versions. Now that a case costs ~6s
rather than ~47s, running the full table under both access modes is affordable in a way it was
not before, if that coverage is wanted.
