### PR TITLE
fix(ui): redirect to dashboard on namespace switch

### DIFF
--- a/ui/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -4,9 +4,13 @@ import {
   PlusIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
-import { Dropdown } from "@shellhub/design-system/primitives";
+import { Dropdown, Spinner } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
-import { useNamespaces, useNamespace } from "@/hooks/useNamespaces";
+import {
+  useNamespaces,
+  useNamespace,
+  type Namespace,
+} from "@/hooks/useNamespaces";
 import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
 import { useAuthStore } from "@/stores/authStore";
 import { getInitials } from "@/utils/string";
@@ -27,7 +31,8 @@ export default function NamespaceSelector({
   const { namespaces } = useNamespaces();
   const tenantId = useAuthStore((s) => s.tenant) ?? "";
   const isAdmin = useAuthStore((s) => s.isAdmin);
-  const { namespace: currentNamespace } = useNamespace(tenantId);
+  const { namespace: currentNamespace, isLoading: isNamespaceLoading } =
+    useNamespace(tenantId);
   const switchNs = useSwitchNamespace();
   const navigate = useNavigate();
 
@@ -42,7 +47,6 @@ export default function NamespaceSelector({
     : namespaces.filter((ns) => ns.tenant_id !== currentNamespace?.tenant_id);
 
   const handleSwitch = async (id: string) => {
-    setOpen(false);
     await switchNs.mutateAsync({ tenantId: id });
   };
 
@@ -72,19 +76,12 @@ export default function NamespaceSelector({
                   Admin Console
                 </span>
               </>
-            ) : currentNamespace ? (
-              <>
-                <span className="w-6 h-6 rounded bg-primary/15 border border-primary/20 flex items-center justify-center text-primary text-2xs font-bold font-mono">
-                  {getInitials(currentNamespace.name)}
-                </span>
-                <span className="hidden md:inline text-sm font-medium text-text-primary max-w-[180px] truncate">
-                  {currentNamespace.name}
-                </span>
-              </>
             ) : (
-              <span className="text-sm text-text-muted italic">
-                No namespace
-              </span>
+              <NamespaceTriggerLabel
+                namespace={currentNamespace}
+                isSwitching={switchNs.isPending}
+                isLoading={isNamespaceLoading}
+              />
             )}
             <ChevronDownIcon
               className={cn(
@@ -186,7 +183,6 @@ export default function NamespaceSelector({
               <button
                 type="button"
                 onClick={() => {
-                  setOpen(false);
                   void navigate("/admin");
                 }}
                 className="w-full flex items-center gap-3 px-2 py-2 rounded-md text-left hover:bg-hover-medium transition-colors group"
@@ -234,6 +230,43 @@ export default function NamespaceSelector({
         open={upsellOpen}
         onClose={() => setUpsellOpen(false)}
       />
+    </>
+  );
+}
+
+function NamespaceTriggerLabel({
+  namespace,
+  isSwitching,
+  isLoading,
+}: {
+  namespace: Namespace | null;
+  isSwitching: boolean;
+  isLoading: boolean;
+}) {
+  if (isSwitching || isLoading) {
+    const label = isSwitching ? "Switching..." : "Loading...";
+    return (
+      <>
+        <Spinner size="xs" tone="subtle" />
+        <span className="text-sm text-text-muted italic hidden md:inline">
+          {label}
+        </span>
+      </>
+    );
+  }
+
+  if (!namespace) {
+    return <span className="text-sm text-text-muted italic">No namespace</span>;
+  }
+
+  return (
+    <>
+      <span className="w-6 h-6 rounded bg-primary/15 border border-primary/20 flex items-center justify-center text-primary text-2xs font-bold font-mono">
+        {getInitials(namespace.name)}
+      </span>
+      <span className="hidden md:inline text-sm font-medium text-text-primary max-w-[180px] truncate">
+        {namespace.name}
+      </span>
     </>
   );
 }

--- a/ui/apps/console/src/components/layout/NamespaceSelector.tsx
+++ b/ui/apps/console/src/components/layout/NamespaceSelector.tsx
@@ -43,10 +43,7 @@ export default function NamespaceSelector({
 
   const handleSwitch = async (id: string) => {
     setOpen(false);
-    await switchNs.mutateAsync({
-      tenantId: id,
-      redirectTo: isAdminContext ? "/dashboard" : undefined,
-    });
+    await switchNs.mutateAsync({ tenantId: id });
   };
 
   const handleCreate = () => {
@@ -85,7 +82,9 @@ export default function NamespaceSelector({
                 </span>
               </>
             ) : (
-              <span className="text-sm text-text-muted italic">No namespace</span>
+              <span className="text-sm text-text-muted italic">
+                No namespace
+              </span>
             )}
             <ChevronDownIcon
               className={cn(
@@ -186,7 +185,10 @@ export default function NamespaceSelector({
             <div className="p-2 border-t border-border">
               <button
                 type="button"
-                onClick={() => { setOpen(false); void navigate("/admin"); }}
+                onClick={() => {
+                  setOpen(false);
+                  void navigate("/admin");
+                }}
                 className="w-full flex items-center gap-3 px-2 py-2 rounded-md text-left hover:bg-hover-medium transition-colors group"
               >
                 <span className="w-7 h-7 rounded bg-accent-red/10 border border-accent-red/20 flex items-center justify-center text-accent-red group-hover:bg-accent-red/15 transition-colors shrink-0">

--- a/ui/apps/console/src/hooks/useNamespaceMutations.ts
+++ b/ui/apps/console/src/hooks/useNamespaceMutations.ts
@@ -41,13 +41,12 @@ export function useSwitchNamespace() {
         path: { tenant: tenantId },
         throwOnError: true,
       });
+      window.location.href = redirectTo ?? "/dashboard";
       useAuthStore.getState().setSession({
         token: data.token,
         tenant: tenantId,
         role: data.role,
       });
-      if (redirectTo) window.location.href = redirectTo;
-      else window.location.reload();
     },
   });
 }
@@ -63,12 +62,12 @@ export function useCreateNamespace() {
         path: { tenant: ns.tenant_id },
         throwOnError: true,
       });
+      window.location.href = "/dashboard";
       useAuthStore.getState().setSession({
         token: data.token,
         tenant: ns.tenant_id,
         role: data.role,
       });
-      window.location.reload();
     },
   });
 }

--- a/ui/apps/console/src/pages/SSHApproval.tsx
+++ b/ui/apps/console/src/pages/SSHApproval.tsx
@@ -1,5 +1,10 @@
 import { useState, useEffect, useRef } from "react";
-import { useParams, useNavigate, Navigate } from "react-router-dom";
+import {
+  useParams,
+  useNavigate,
+  useLocation,
+  Navigate,
+} from "react-router-dom";
 import {
   KeyIcon,
   CheckCircleIcon,
@@ -325,15 +330,15 @@ function PendingRequest({
       <Countdown secondsLeft={secondsLeft} totalSeconds={totalSeconds} />
 
       <div className="flex justify-end gap-2">
-          <Button
-            variant="ghost"
-            size="md"
-            disabled={deciding}
-            icon={<NoSymbolIcon className="w-4 h-4" strokeWidth={2} />}
-            onClick={onReject}
-          >
-            Reject
-          </Button>
+        <Button
+          variant="ghost"
+          size="md"
+          disabled={deciding}
+          icon={<NoSymbolIcon className="w-4 h-4" strokeWidth={2} />}
+          onClick={onReject}
+        >
+          Reject
+        </Button>
         {elsewhere ? (
           <Button
             variant="primary"
@@ -610,6 +615,7 @@ function useNamespaceMismatch(namespace: string) {
   const currentTenant = useAuthStore((s) => s.tenant);
   const { namespaces } = useNamespaces();
   const switchNs = useSwitchNamespace();
+  const { pathname } = useLocation();
 
   const target = namespaces.find((ns) => ns.name === namespace);
   const elsewhere =
@@ -620,10 +626,12 @@ function useNamespaceMismatch(namespace: string) {
     currentName:
       namespaces.find((ns) => ns.tenant_id === currentTenant)?.name ?? "",
     switching: switchNs.isPending,
-    // The switch reloads the current URL, so the dialog comes back on the same
-    // code with the console scoped to the right namespace.
     switchToTarget: () => {
-      if (target) void switchNs.mutateAsync({ tenantId: target.tenant_id });
+      if (target)
+        void switchNs.mutateAsync({
+          tenantId: target.tenant_id,
+          redirectTo: pathname,
+        });
     },
   };
 }


### PR DESCRIPTION
## What

Namespace switch navigates to `/dashboard` instead of reloading the current URL, preventing stale data and 404s when switching from a resource-specific page.

## Why

`useSwitchNamespace` called `window.location.reload()` when no `redirectTo` was provided. On pages like `/install-keys/:id/activity`, this preserved both the URL and `history.state` from the previous namespace — the summary card showed stale data (sourced from router state) and the events API returned 404 (resource ID doesn't exist in the new namespace).

Closes shellhub-io/team#189

## Changes

- **`useNamespaceMutations.ts`**: replaced `window.location.reload()` with `window.location.href = redirectTo ?? "/dashboard"` in both `useSwitchNamespace` and `useCreateNamespace`. Navigation fires before `setSession` to avoid a React re-render flash (safe because Zustand's `localStorage` persist is synchronous — the session is written before the browser actually navigates).
- **`SSHApproval.tsx`**: `useNamespaceMismatch` now passes `redirectTo: pathname` (via `useLocation`) so the SSH approval page preserves its intentional stay-on-page behavior when the user switches to the request's namespace.
- **`NamespaceSelector.tsx`**: extracted `NamespaceTriggerLabel` to handle switching/loading/empty states. Uses `switchNs.isPending` (React Query–managed, resets on error) plus `isLoading` from `useNamespace` to show a spinner during the full transition window — prevents the brief "No namespace" flash that appeared between auth store update and namespace data arrival. Removed redundant `setOpen(false)` calls (switch navigates away; admin link unmounts the component).

## Testing

Switch namespace while on a resource detail page (e.g. `/install-keys/:id/activity`, `/devices/:uid`) — should land on `/dashboard`, not reload. Verify the SSH approval flow still works: open `/ssh-identities/new/:code`, trigger a namespace mismatch, and confirm the switch stays on the approval page.