### PR TITLE
refactor(ui): standardize 404 handling on detail pages

### DIFF
--- a/ui/apps/console/src/components/common/ResourceNotFound.tsx
+++ b/ui/apps/console/src/components/common/ResourceNotFound.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router-dom";
+
+interface ResourceNotFoundProps {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  resource: string;
+  backTo: string;
+}
+
+export default function ResourceNotFound({
+  icon: Icon,
+  resource,
+  backTo,
+}: ResourceNotFoundProps) {
+  return (
+    <div className="text-center py-24" role="status">
+      <Icon
+        className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
+        strokeWidth={1}
+        aria-hidden="true"
+      />
+      <p className="text-sm text-text-muted mb-2">{resource} not found</p>
+      <Link to={backTo} className="text-sm text-primary hover:underline">
+        Back to {resource.toLowerCase()}s
+      </Link>
+    </div>
+  );
+}

--- a/ui/apps/console/src/components/common/__tests__/ResourceNotFound.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/ResourceNotFound.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { CpuChipIcon, ShieldExclamationIcon } from "@heroicons/react/24/outline";
+import ResourceNotFound from "../ResourceNotFound";
+
+function renderNotFound(props: {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  resource: string;
+  backTo: string;
+} = {
+  icon: CpuChipIcon,
+  resource: "Device",
+  backTo: "/devices",
+}) {
+  return render(
+    <MemoryRouter>
+      <ResourceNotFound {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ResourceNotFound", () => {
+  it("announces itself as a status region for screen readers", () => {
+    renderNotFound();
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it('renders "{resource} not found" heading and "Back to {resource}s" link', () => {
+    renderNotFound();
+
+    expect(screen.getByText("Device not found")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "Back to devices" });
+    expect(link).toHaveAttribute("href", "/devices");
+  });
+
+  it("handles multi-word resource names", () => {
+    renderNotFound({
+      icon: ShieldExclamationIcon,
+      resource: "Firewall rule",
+      backTo: "/admin/firewall-rules",
+    });
+
+    expect(screen.getByText("Firewall rule not found")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Back to firewall rules" }),
+    ).toHaveAttribute("href", "/admin/firewall-rules");
+  });
+});

--- a/ui/apps/console/src/pages/ContainerDetails.tsx
+++ b/ui/apps/console/src/pages/ContainerDetails.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  useParams,
-  useNavigate,
-  useSearchParams,
-  Navigate,
-} from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import RenameSection from "@/components/common/RenameSection";
 import {
@@ -37,6 +32,7 @@ import TimelineCard from "@/components/common/TimelineCard";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
 import { LABEL_BASE } from "@/utils/styles";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 
 export default function ContainerDetails() {
   const { uid } = useParams<{ uid: string }>();
@@ -88,14 +84,18 @@ export default function ContainerDetails() {
     }
   }, [searchParams, container, existingSession, restoreTerminal]);
 
-  if (!uid) return <Navigate to="/containers" replace />;
-
   if (isLoading) {
     return <PageLoader label="Loading container details" />;
   }
 
   if (error || !container) {
-    return <Navigate to="/containers" replace />;
+    return (
+      <ResourceNotFound
+        icon={CubeIcon}
+        resource="Container"
+        backTo="/containers"
+      />
+    );
   }
 
   const nsName = currentNamespace?.name ?? "";

--- a/ui/apps/console/src/pages/DeviceDetails.tsx
+++ b/ui/apps/console/src/pages/DeviceDetails.tsx
@@ -37,12 +37,13 @@ import { useHasPermission } from "@/hooks/useHasPermission";
 import CustomFieldsSection from "./devices/CustomFieldsSection";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 
 export default function DeviceDetails() {
   const { uid } = useParams<{ uid: string }>();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { device, isLoading } = useDevice(uid ?? "");
+  const { device, isLoading, error } = useDevice(uid ?? "");
   const tenantId = useAuthStore((s) => s.tenant) ?? "";
   const { namespace: currentNamespace } = useNamespace(tenantId);
   const { installKeys } = useInstallKeys({ perPage: 100 });
@@ -87,8 +88,18 @@ export default function DeviceDetails() {
     }
   }, [searchParams, device, existingSession, restoreTerminal]);
 
-  if (isLoading || !device) {
+  if (isLoading) {
     return <PageLoader label="Loading device details" />;
+  }
+
+  if (error || !device) {
+    return (
+      <ResourceNotFound
+        icon={CpuChipIcon}
+        resource="Device"
+        backTo="/devices"
+      />
+    );
   }
 
   const nsName = currentNamespace?.name ?? "";

--- a/ui/apps/console/src/pages/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/SessionDetails.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import Breadcrumb from "@/components/common/Breadcrumb";
 import {
   ClockIcon,
@@ -44,6 +44,7 @@ import {
 } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
 import InfoItem from "@/components/common/InfoItem";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 import SessionTypeBadge from "./sessions/SessionTypeBadge";
 
 type EventStatus = "success" | "error" | "info" | "active" | "muted";
@@ -244,7 +245,6 @@ function DurationStat({
 
 export default function SessionDetails() {
   const { uid } = useParams<{ uid: string }>();
-  const navigate = useNavigate();
   const { session, isLoading, error } = useSession(uid!);
   const closeSession = useCloseSession();
   const deleteRecording = useDeleteSessionRecording();
@@ -292,23 +292,17 @@ export default function SessionDetails() {
     }
   };
 
-  if (isLoading || !session) {
+  if (isLoading) {
     return <PageLoader label="Loading session" />;
   }
 
-  if (error) {
+  if (error || !session) {
     return (
-      <div className="flex flex-col items-center justify-center py-24 gap-3">
-        <XCircleIcon className="w-8 h-8 text-accent-red/60" />
-        <p className="text-sm font-mono text-text-muted">{error.message}</p>
-        <button
-          type="button"
-          onClick={() => void navigate("/sessions")}
-          className="text-xs font-mono text-primary hover:underline"
-        >
-          ← Back to sessions
-        </button>
-      </div>
+      <ResourceNotFound
+        icon={CommandLineIcon}
+        resource="Session"
+        backTo="/sessions"
+      />
     );
   }
 

--- a/ui/apps/console/src/pages/admin/SessionDetails.tsx
+++ b/ui/apps/console/src/pages/admin/SessionDetails.tsx
@@ -1,7 +1,6 @@
 import { useParams, Link } from "react-router-dom";
 import {
   CommandLineIcon,
-  ExclamationCircleIcon,
   CheckCircleIcon,
   MinusCircleIcon,
 } from "@heroicons/react/24/outline";
@@ -12,6 +11,7 @@ import InfoItem from "@/components/common/InfoItem";
 import { formatDateFull } from "@/utils/date";
 import { sessionType } from "@/utils/session";
 import PageLoader from "@/components/common/PageLoader";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 import { Card } from "@shellhub/design-system/primitives";
 
 function BoolField({
@@ -48,18 +48,11 @@ export default function AdminSessionDetails() {
 
   if (error || !session) {
     return (
-      <div className="h-full flex items-center justify-center">
-        <div className="text-center" role="alert">
-          <ExclamationCircleIcon className="w-10 h-10 text-accent-red mx-auto mb-3" />
-          <p className="text-sm font-medium text-text-primary">
-            Session not found
-          </p>
-          <p className="text-2xs text-text-muted mt-1">
-            {error?.message ??
-              "The session may have been removed or the ID is invalid."}
-          </p>
-        </div>
-      </div>
+      <ResourceNotFound
+        icon={CommandLineIcon}
+        resource="Session"
+        backTo="/admin/sessions"
+      />
     );
   }
 

--- a/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/AnnouncementDetails.tsx
@@ -13,6 +13,7 @@ import DeleteAnnouncementDialog from "./DeleteAnnouncementDialog";
 import AnnouncementContent from "./AnnouncementContent";
 import { formatDateFull } from "@/utils/date";
 import PageLoader from "@/components/common/PageLoader";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 
 const LABEL =
@@ -34,19 +35,11 @@ export default function AnnouncementDetails() {
 
   if (error || !announcement) {
     return (
-      <div className="text-center py-24">
-        <MegaphoneIcon
-          className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
-          strokeWidth={1}
-        />
-        <p className="text-sm text-text-muted mb-2">Announcement not found</p>
-        <Link
-          to="/admin/announcements"
-          className="text-sm text-primary hover:underline"
-        >
-          Back to announcements
-        </Link>
-      </div>
+      <ResourceNotFound
+        icon={MegaphoneIcon}
+        resource="Announcement"
+        backTo="/admin/announcements"
+      />
     );
   }
 

--- a/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/devices/AdminDeviceDetails.tsx
@@ -16,6 +16,7 @@ import { formatDateFull, formatRelative } from "@/utils/date";
 import IdentityCard from "@/components/common/IdentityCard";
 import InfoItem from "@/components/common/InfoItem";
 import PageLoader from "@/components/common/PageLoader";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 import { Card } from "@shellhub/design-system/primitives";
 
 export default function AdminDeviceDetails() {
@@ -28,19 +29,11 @@ export default function AdminDeviceDetails() {
 
   if (error || !device) {
     return (
-      <div className="text-center py-24">
-        <CpuChipIcon
-          className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
-          strokeWidth={1}
-        />
-        <p className="text-sm text-text-muted mb-2">Device not found</p>
-        <Link
-          to="/admin/devices"
-          className="text-sm text-primary hover:underline"
-        >
-          Back to devices
-        </Link>
-      </div>
+      <ResourceNotFound
+        icon={CpuChipIcon}
+        resource="Device"
+        backTo="/admin/devices"
+      />
     );
   }
 

--- a/ui/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/AdminFirewallRuleDetails.tsx
@@ -14,6 +14,7 @@ import CopyButton from "@/components/common/CopyButton";
 import FilterBadge from "@/components/common/FilterBadge";
 import InfoItem from "@/components/common/InfoItem";
 import PageLoader from "@/components/common/PageLoader";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 import { Card } from "@shellhub/design-system/primitives";
 
 export default function AdminFirewallRuleDetails() {
@@ -26,19 +27,11 @@ export default function AdminFirewallRuleDetails() {
 
   if (error || !rule) {
     return (
-      <div className="text-center py-24">
-        <ShieldExclamationIcon
-          className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
-          strokeWidth={1}
-        />
-        <p className="text-sm text-text-muted mb-2">Firewall rule not found</p>
-        <Link
-          to="/admin/firewall-rules"
-          className="text-sm text-primary hover:underline"
-        >
-          Back to firewall rules
-        </Link>
-      </div>
+      <ResourceNotFound
+        icon={ShieldExclamationIcon}
+        resource="Firewall rule"
+        backTo="/admin/firewall-rules"
+      />
     );
   }
 

--- a/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/NamespaceDetails.tsx
@@ -17,6 +17,7 @@ import { formatDateFull } from "@/utils/date";
 import { formatMaxDevices } from "./utils";
 import InfoItem from "@/components/common/InfoItem";
 import PageLoader from "@/components/common/PageLoader";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 import {
   Badge,
   Button,
@@ -44,19 +45,11 @@ export default function NamespaceDetails() {
 
   if (error || !namespace) {
     return (
-      <div className="text-center py-24">
-        <ServerStackIcon
-          className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
-          strokeWidth={1}
-        />
-        <p className="text-sm text-text-muted mb-2">Namespace not found</p>
-        <Link
-          to="/admin/namespaces"
-          className="text-sm text-primary hover:underline"
-        >
-          Back to namespaces
-        </Link>
-      </div>
+      <ResourceNotFound
+        icon={ServerStackIcon}
+        resource="Namespace"
+        backTo="/admin/namespaces"
+      />
     );
   }
 

--- a/ui/apps/console/src/pages/admin/users/UserDetails.tsx
+++ b/ui/apps/console/src/pages/admin/users/UserDetails.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import {
   UsersIcon,
   PencilSquareIcon,
@@ -20,6 +20,7 @@ import DeleteUserDialog from "./DeleteUserDialog";
 import { formatDateFull } from "@/utils/date";
 import InfoItem from "@/components/common/InfoItem";
 import PageLoader from "@/components/common/PageLoader";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 import {
   Badge,
   Button,
@@ -56,19 +57,11 @@ export default function UserDetails() {
 
   if (error || !user) {
     return (
-      <div className="text-center py-24">
-        <UsersIcon
-          className="w-10 h-10 text-text-muted/30 mx-auto mb-3"
-          strokeWidth={1}
-        />
-        <p className="text-sm text-text-muted mb-2">User not found</p>
-        <Link
-          to="/admin/users"
-          className="text-sm text-primary hover:underline"
-        >
-          Back to users
-        </Link>
-      </div>
+      <ResourceNotFound
+        icon={UsersIcon}
+        resource="User"
+        backTo="/admin/users"
+      />
     );
   }
 

--- a/ui/apps/console/src/pages/install-keys/InstallKeyHistoryPage.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeyHistoryPage.tsx
@@ -9,6 +9,8 @@ import { ExclamationCircleIcon as ExclamationCircleSolidIcon } from "@heroicons/
 import { IconBadge } from "@shellhub/design-system/primitives";
 import { type InstallKey } from "@/client";
 import { useInstallKeys } from "@/hooks/useInstallKeys";
+import PageLoader from "@/components/common/PageLoader";
+import ResourceNotFound from "@/components/common/ResourceNotFound";
 import InstallKeyEventsTable from "./InstallKeyEventsTable";
 import InstallKeyActions from "./InstallKeyActions";
 import RevealInstallKeyDialog from "./RevealInstallKeyDialog";
@@ -47,14 +49,28 @@ export default function InstallKeyHistoryPage() {
   // Source the key from the list rather than router state alone: the summary must survive a refresh or
   // a deep link (state is only set when arriving from the list) and stay live after a revoke/disable
   // here (the mutation invalidates the list). Fall back to the router-state copy while the list loads.
-  // The list caps at 100 keys; past that a deep link degrades to the leaner header.
-  const { installKeys } = useInstallKeys({ perPage: 100 });
+  // The list caps at 100 keys; past that a deep link shows "Install key not found"
+  const { installKeys, isLoading } = useInstallKeys({ perPage: 100 });
   const key = installKeys.find((k) => k.id === id) ?? state?.key ?? null;
   const name = key ? installKeyDisplayName(key) : (state?.name ?? "");
   const [revealOpen, setRevealOpen] = useState(false);
 
   const mode = key ? modeInfo(key.mode) : null;
   const ModeIcon = mode?.icon;
+
+  if (isLoading && !key) {
+    return <PageLoader label="Loading install key" />;
+  }
+
+  if (!key) {
+    return (
+      <ResourceNotFound
+        icon={TicketIcon}
+        resource="Install key"
+        backTo="/install-keys"
+      />
+    );
+  }
 
   return (
     <div>


### PR DESCRIPTION
## What

Shared `ResourceNotFound` component replaces every inline not-found block across detail pages, and fixes the loading/error guard anti-pattern that caused some pages to spin forever on a 404.

## Why

Detail pages handled missing resources four different ways: `DeviceDetails` and `SessionDetails` merged `isLoading` with `!data` into a single guard, so a 404 (where `data` is null but `isLoading` is false) trapped the page on a permanent spinner. `ContainerDetails` silently redirected to the list. `InstallKeyHistoryPage` rendered a hollow page with no heading or back link. The admin pages all handled it correctly but each inlined its own copy of the same block.

Closes shellhub-io/team#190

## Changes

- **`ResourceNotFound`** (`components/common/`): new shared component — accepts `icon`, `resource`, and `backTo` props, renders the centered muted-icon / not-found text / back-link pattern the admin pages already used. Uses `role="status"` for screen reader announcement and `aria-hidden` on the decorative icon.
- **`DeviceDetails`**: split `isLoading || !device` into separate `isLoading` and `error || !device` guards; destructure `error` from `useDevice`.
- **`SessionDetails`**: reordered guards so `error || !session` is checked after `isLoading` (the previous error block was dead code); removed the unused `useNavigate` import.
- **`ContainerDetails`**: replaced both `<Navigate to="/containers" replace />` paths with `ResourceNotFound`; removed the `Navigate` import.
- **`InstallKeyHistoryPage`**: added `isLoading` and `!key` guards (previously rendered a degraded page with no error state at all).
- **Admin detail pages** (6 files): replaced inline not-found blocks with `ResourceNotFound`. `AdminSessionDetails` was the only outlier (red icon, `role="alert"`, extra description line, no back link) — now aligned to the standard pattern.

## Testing

`ResourceNotFound` has 3 tests covering `role="status"` announcement, text derivation, and multi-word resource names. Existing admin detail page tests (`AdminDeviceDetails`, `AdminFirewallRuleDetails`) pass unchanged — the refactor is transparent to them. Full suite green (214 files, 3004 tests), build and lint clean.