### PR TITLE
fix(agent): inherit the system locale in session environments

### DIFF
--- a/agent/server/modes/host/env.go
+++ b/agent/server/modes/host/env.go
@@ -1,8 +1,118 @@
 package host
 
 import (
+	"bufio"
+	"os"
+	"slices"
 	"strings"
 )
+
+// localeFiles are the system wide files a locale may be configured in, in the order they are
+// consulted. The first file to define a variable wins, so a systemd locale.conf takes precedence
+// over the Debian defaults. Under the docker build tag these point into the mounted host root.
+var localeFiles = []string{
+	"/etc/locale.conf",
+	"/etc/default/locale",
+	"/etc/environment",
+}
+
+// defaultLocale is used when the host configures no character locale at all, which is the common
+// state on embedded targets. Without it those sessions run under the C locale, where tools writing
+// to a TTY escape every byte >= 0x80 instead of printing the character.
+//
+// C.UTF-8 needs no generated locale data, unlike a language specific locale that glibc would fall
+// back to C for when absent.
+const defaultLocale = "LANG=C.UTF-8"
+
+// sessionEnv builds the locale environment a session starts with.
+//
+// The agent assembles the session environment from scratch, so nothing of the host's own
+// configuration reaches the shell unless it is read here. A regular login gets it through
+// pam_env; a ShellHub session would otherwise run under the C locale even on a host that
+// configures a locale.
+//
+// The client's own variables come last: os/exec keeps the last value of a repeated key, so a
+// client forwarding LANG still overrides the host.
+func sessionEnv(clientEnv []string) []string {
+	envs := systemLocaleEnv()
+	if !hasCharacterLocale(envs) {
+		envs = append([]string{defaultLocale}, envs...)
+	}
+
+	return append(envs, acceptClientEnv(clientEnv)...)
+}
+
+func systemLocaleEnv() []string {
+	locale := make(map[string]string)
+
+	for _, path := range localeFiles {
+		readLocaleFile(path, locale)
+	}
+
+	envs := make([]string, 0, len(locale))
+	for name, value := range locale {
+		envs = append(envs, name+"="+value)
+	}
+
+	slices.Sort(envs)
+
+	return envs
+}
+
+func readLocaleFile(path string, locale map[string]string) {
+	file, err := os.Open(path) //nolint:gosec // the path is one of localeFiles, never input.
+	if err != nil {
+		return
+	}
+
+	defer file.Close() //nolint:errcheck
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		name, value, ok := parseLocaleLine(scanner.Text())
+		if !ok {
+			continue
+		}
+
+		if _, defined := locale[name]; !defined {
+			locale[name] = value
+		}
+	}
+}
+
+func parseLocaleLine(line string) (string, string, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+
+	name, value, ok := strings.Cut(line, "=")
+	if !ok {
+		return "", "", false
+	}
+
+	name = strings.TrimSpace(name)
+	if name != "LANG" && !strings.HasPrefix(name, "LC_") {
+		return "", "", false
+	}
+
+	// pam_env accepts a quoted value, so /etc/environment may hold LANG="pt_BR.UTF-8".
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	if value == "" || strings.ContainsRune(value, 0) {
+		return "", "", false
+	}
+
+	return name, value, true
+}
+
+func hasCharacterLocale(envs []string) bool {
+	return slices.ContainsFunc(envs, func(env string) bool {
+		name, _, _ := strings.Cut(env, "=")
+
+		return name == "LANG" || name == "LC_ALL" || name == "LC_CTYPE"
+	})
+}
 
 // acceptClientEnv filters the environment variables forwarded by an SSH client, keeping only those
 // that are safe to pass into a session. It mirrors the OpenSSH default AcceptEnv behaviour of

--- a/agent/server/modes/host/env_docker.go
+++ b/agent/server/modes/host/env_docker.go
@@ -1,0 +1,12 @@
+//go:build docker
+// +build docker
+
+package host
+
+// The agent image runs from scratch and reaches the host's filesystem through /host, the same
+// mount osauth reads passwd and shadow from.
+func init() {
+	for i, path := range localeFiles {
+		localeFiles[i] = "/host" + path
+	}
+}

--- a/agent/server/modes/host/env_test.go
+++ b/agent/server/modes/host/env_test.go
@@ -1,6 +1,9 @@
 package host
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-playground/assert/v2"
@@ -141,6 +144,132 @@ func TestAcceptClientEnv(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := acceptClientEnv(tt.input)
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// withLocaleFiles points localeFiles at a temporary directory. Each content maps to one entry of
+// localeFiles, in order; an empty content leaves that file absent.
+func withLocaleFiles(t *testing.T, contents ...string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	original := localeFiles
+
+	t.Cleanup(func() { localeFiles = original })
+
+	paths := make([]string, 0, len(contents))
+
+	for i, content := range contents {
+		path := filepath.Join(dir, fmt.Sprintf("locale%d", i))
+
+		if content != "" {
+			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+				t.Fatalf("failed to write the locale file: %v", err)
+			}
+		}
+
+		paths = append(paths, path)
+	}
+
+	localeFiles = paths
+}
+
+func TestSystemLocaleEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    []string
+		expected []string
+	}{
+		{
+			name:     "no locale file on the host",
+			files:    []string{"", "", ""},
+			expected: []string{},
+		},
+		{
+			name:     "reads a configured locale",
+			files:    []string{"LANG=pt_BR.UTF-8\n", "", ""},
+			expected: []string{"LANG=pt_BR.UTF-8"},
+		},
+		{
+			name:     "skips comments and blank lines",
+			files:    []string{"# the system locale\n\nLANG=en_US.UTF-8\n", "", ""},
+			expected: []string{"LANG=en_US.UTF-8"},
+		},
+		{
+			name:     "unquotes a quoted value",
+			files:    []string{"LANG=\"pt_BR.UTF-8\"\n", "", ""},
+			expected: []string{"LANG=pt_BR.UTF-8"},
+		},
+		{
+			name:     "drops variables outside the allowlist",
+			files:    []string{"PATH=/evil\nLD_PRELOAD=/evil.so\nLANG=C.UTF-8\n", "", ""},
+			expected: []string{"LANG=C.UTF-8"},
+		},
+		{
+			name:     "drops a value carrying a NUL byte",
+			files:    []string{"LANG=en\x00evil\n", "", ""},
+			expected: []string{},
+		},
+		{
+			name:     "the first file to define a variable wins",
+			files:    []string{"LANG=pt_BR.UTF-8\n", "LANG=en_US.UTF-8\n", ""},
+			expected: []string{"LANG=pt_BR.UTF-8"},
+		},
+		{
+			name:     "merges variables across files",
+			files:    []string{"LANG=pt_BR.UTF-8\n", "LC_TIME=en_US.UTF-8\n", ""},
+			expected: []string{"LANG=pt_BR.UTF-8", "LC_TIME=en_US.UTF-8"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withLocaleFiles(t, tt.files...)
+
+			assert.Equal(t, tt.expected, systemLocaleEnv())
+		})
+	}
+}
+
+func TestSessionEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		files     []string
+		clientEnv []string
+		expected  []string
+	}{
+		{
+			name:      "falls back when the host configures no locale",
+			files:     []string{"", "", ""},
+			clientEnv: nil,
+			expected:  []string{"LANG=C.UTF-8"},
+		},
+		{
+			name:      "keeps the host locale over the fallback",
+			files:     []string{"LANG=pt_BR.UTF-8\n", "", ""},
+			clientEnv: nil,
+			expected:  []string{"LANG=pt_BR.UTF-8"},
+		},
+		{
+			name:      "falls back when the host sets no character locale",
+			files:     []string{"LC_TIME=pt_BR.UTF-8\n", "", ""},
+			clientEnv: nil,
+			expected:  []string{"LANG=C.UTF-8", "LC_TIME=pt_BR.UTF-8"},
+		},
+		{
+			name:      "the client comes last so it overrides the host",
+			files:     []string{"LANG=pt_BR.UTF-8\n", "", ""},
+			clientEnv: []string{"LANG=ja_JP.UTF-8", "PATH=/evil"},
+			expected:  []string{"LANG=pt_BR.UTF-8", "LANG=ja_JP.UTF-8"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withLocaleFiles(t, tt.files...)
+
+			assert.Equal(t, tt.expected, sessionEnv(tt.clientEnv))
 		})
 	}
 }

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -283,7 +283,7 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 		term = "xterm"
 	}
 
-	cmd := command.NewCmd(user, shell, term, *s.deviceName, acceptClientEnv(session.Environ()), shell, "-c", session.RawCommand())
+	cmd := command.NewCmd(user, shell, term, *s.deviceName, sessionEnv(session.Environ()), shell, "-c", session.RawCommand())
 
 	wg := &sync.WaitGroup{}
 	if sIsPty {

--- a/agent/server/modes/host/utils.go
+++ b/agent/server/modes/host/utils.go
@@ -14,7 +14,7 @@ import (
 
 func generateShellCmd(deviceName string, session gliderssh.Session, term string) *exec.Cmd {
 	username := session.User()
-	envs := acceptClientEnv(session.Environ())
+	envs := sessionEnv(session.Environ())
 
 	user, err := osauth.LookupUser(username)
 	if err != nil {

--- a/agent/server/modes/host/utils_freebsd.go
+++ b/agent/server/modes/host/utils_freebsd.go
@@ -13,7 +13,7 @@ import (
 
 func generateShellCmd(deviceName string, session gliderssh.Session, term string) *exec.Cmd {
 	username := session.User()
-	envs := acceptClientEnv(session.Environ())
+	envs := sessionEnv(session.Environ())
 
 	user, err := osauth.LookupUser(username)
 	if err != nil {


### PR DESCRIPTION
Non-ASCII filenames print as octal escapes in a ShellHub session. `ls` shows
`''$'\344\270\255\346\226\207'` where the same command over plain ssh into the same host
shows `中文`. That is #6763.

Those escapes are valid UTF-8 for `中文`, so the device emits UTF-8 and the bytes reach
the browser intact. The session simply runs under the `C` locale, where every byte
`>= 0x80` is non-printable and GNU `ls` writing to a TTY escapes it.

A login shell normally inherits the locale the system configures. The agent builds
`cmd.Env` from a literal slice and reads none of those files, so nothing ever put a
locale there.

## Change

- Read `LANG` and `LC_*` from the files a login reads, in login order.
- Same allowlist as `acceptClientEnv`.
- Fall back to `LANG=C.UTF-8` when the host configures no character locale.
- Precedence: fallback, host, client. Client wins by being appended last, since `os/exec`
  keeps the last value of a repeated key.
- Applies to every session the agent starts: web terminal and native clients alike.

## Verification

Two agents differing only by this commit, same server, same relay, same console.

Before:

<img width="1482" height="668" alt="console-before" src="https://github.com/user-attachments/assets/fb38043e-d89d-4d3c-b745-a4ef97209014" />

After:

<img width="1482" height="668" alt="console-after" src="https://github.com/user-attachments/assets/8c09ccbc-7303-40ef-a163-b5210d5adacd" />

A host that does configure a locale gets that one instead of the fallback.

## #6765 and #6766

Same cause, addressed server side. Findings there worth keeping regardless of this PR:

- `Conn` write race: ping frames, JSON control messages and output share a frame writer
  that is not goroutine safe. Pre-existing and unrelated to locale.
- `redirToWs`: the `bytes.Runes` substitution, and the branch that drops data when a
  buffer starts with continuation bytes.
- `ws.onmessage`: `Blob.text()` is a one shot decode per the File API, so a character
  split across frames is corrupted, and the `await` lets frame order follow promise
  resolution rather than arrival.

#6765 reaches the same cause. The difference is which side declares it: from the gateway
it fixes the web terminal only, since clients that forward nothing keep printing the
escapes. The env request also lands in the channel proxy's generic `default` branch, so
it goes through `sess.Event` and adds one `sessions_events` row per web session.

Two constraints on the server-side approach:

**Frame format.** `/ws/ssh` is absent from the OpenAPI spec and the frame format was
never published. Integrations were written against observed behaviour, which includes
binary frames always being valid UTF-8 and never splitting a character. Per-frame
decoding is the obvious client implementation and would silently yield replacement
characters. No version to bump, no way to notify. Removing that guarantee is an endpoint
version, not a bugfix.

**The client fix needs no server change.** `Terminal.write()` takes `Uint8Array` and
decodes UTF-8 statefully across calls (`_utf8Decoder: Utf8ToUtf32`, 3 byte `interim`, one
per Terminal). `binaryType = "arraybuffer"`, a synchronous handler, and bytes straight to
`term.write` fix split characters and ordering with the wire untouched. The recorder needs
a string and xterm.js exposes no hook for decoded text, so a per session
`TextDecoder({stream: true})` stays for the asciicast.

On selectable encoding: #6763 is not a non-UTF-8 case, and the input path is UTF-8 only
(`ReadMessage` counts runes with `utf8.RuneCountInString`, `CharacterSize` is 4).
Comparable tools land in the same place: the terminal assumes UTF-8 and the locale is
resolved on the device rather than in the transport. Our own terminal states it outright,
xterm.js "does not support any legacy encoding and probably never will".

Suggested split: the `Conn` mutex on its own, the client fixes as a UI PR, the locale
here.
