### PR TITLE
fix(server): re-verify admin status from store on every request

### DIFF
--- a/server/api/routes/middleware/authn.go
+++ b/server/api/routes/middleware/authn.go
@@ -18,6 +18,7 @@ import (
 type AuthnService interface {
 	AuthAPIKey(ctx context.Context, key string) (*models.APIKey, error)
 	GetUserRole(ctx context.Context, tenantID, userID string) (string, error)
+	GetUserAdmin(ctx context.Context, userID string) (bool, error)
 	PublicKey() *rsa.PublicKey
 }
 
@@ -184,8 +185,8 @@ func (a *Authenticator) Resolve(c echo.Context) (*gateway.Identity, error) {
 			TenantID:  claims.TenantID,
 		}, nil
 	case *authorizer.UserClaims:
-		// The role is a dynamic attribute and the token is stateless, so it has
-		// to be read back (generally from cache) on every request.
+		// Role and admin are dynamic attributes that can change while a JWT is
+		// still valid, so we re-fetch them from the store on every request.
 		if claims.TenantID != "" {
 			role, err := a.service.GetUserRole(c.Request().Context(), claims.TenantID, claims.ID)
 			if err != nil {
@@ -195,12 +196,17 @@ func (a *Authenticator) Resolve(c echo.Context) (*gateway.Identity, error) {
 			claims.Role = authorizer.RoleFromString(role)
 		}
 
+		admin, err := a.service.GetUserAdmin(c.Request().Context(), claims.ID)
+		if err != nil {
+			return nil, err
+		}
+
 		return &gateway.Identity{
 			ID:       claims.ID,
 			Username: claims.Username,
 			TenantID: claims.TenantID,
 			Role:     claims.Role,
-			Admin:    claims.Admin,
+			Admin:    admin,
 		}, nil
 	}
 

--- a/server/api/services/auth.go
+++ b/server/api/services/auth.go
@@ -59,6 +59,9 @@ type AuthService interface {
 	CreateUserToken(ctx context.Context, req *requests.CreateUserToken) (res *models.UserAuthResponse, err error)
 	// GetUserRole get the user's role. It returns the user's role and an error, if any.
 	GetUserRole(ctx context.Context, tenantID, userID string) (role string, err error)
+	// GetUserAdmin checks whether the user currently has admin privileges.
+	// Unlike the JWT claim, this queries the store so changes take effect immediately.
+	GetUserAdmin(ctx context.Context, userID string) (admin bool, err error)
 	// AuthAPIKey authenticates the given key, returning its API key document. An API key can be used
 	// in place of a JWT token to authenticate requests. The key is only related to a namespace and not to a user,
 	// which means that some routes are blocked from authentication within this method. An API key can be expired,
@@ -791,6 +794,15 @@ func (s *service) GetUserRole(ctx context.Context, tenantID, userID string) (str
 	}
 
 	return member.Role.String(), nil
+}
+
+func (s *service) GetUserAdmin(ctx context.Context, userID string) (bool, error) {
+	user, err := s.store.UserResolve(ctx, store.UserIDResolver, userID)
+	if err != nil {
+		return false, err
+	}
+
+	return user.Admin, nil
 }
 
 func (s *service) PublicKey() *rsa.PublicKey {

--- a/server/api/services/mocks/mock_service.go
+++ b/server/api/services/mocks/mock_service.go
@@ -3898,6 +3898,72 @@ func (_c *MockService_GetSystemInfo_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// GetUserAdmin provides a mock function for the type MockService
+func (_mock *MockService) GetUserAdmin(ctx context.Context, userID string) (bool, error) {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserAdmin")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockService_GetUserAdmin_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserAdmin'
+type MockService_GetUserAdmin_Call struct {
+	*mock.Call
+}
+
+// GetUserAdmin is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *MockService_Expecter) GetUserAdmin(ctx any, userID any) *MockService_GetUserAdmin_Call {
+	return &MockService_GetUserAdmin_Call{Call: _e.mock.On("GetUserAdmin", ctx, userID)}
+}
+
+func (_c *MockService_GetUserAdmin_Call) Run(run func(ctx context.Context, userID string)) *MockService_GetUserAdmin_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_GetUserAdmin_Call) Return(admin bool, err error) *MockService_GetUserAdmin_Call {
+	_c.Call.Return(admin, err)
+	return _c
+}
+
+func (_c *MockService_GetUserAdmin_Call) RunAndReturn(run func(ctx context.Context, userID string) (bool, error)) *MockService_GetUserAdmin_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUserRole provides a mock function for the type MockService
 func (_mock *MockService) GetUserRole(ctx context.Context, tenantID string, userID string) (string, error) {
 	ret := _mock.Called(ctx, tenantID, userID)


### PR DESCRIPTION
## What

The authn middleware now re-fetches admin status from the database on every request, matching the existing pattern for `Role`. A demoted admin is rejected immediately instead of retaining access until the JWT expires.

## Why

`Role` was already treated as a dynamic attribute — excluded from the JWT and re-fetched per request via `GetUserRole`. `Admin` was not: it was baked into the JWT at login and trusted verbatim for the token's 72-hour lifetime. A user demoted from admin kept full admin API access (`/admin/api/*` returning 200) until their token expired or they re-logged.

Reproduced: promote user, login, save token, demote in DB, replay token against admin endpoints — all returned 200. After this fix, the same sequence returns 403.

Fixes: shellhub-io/team#193

## Changes

- **`AuthService` interface**: added `GetUserAdmin(ctx, userID)` — queries `UserResolve` by ID and returns the current `Admin` field, same delegation pattern as `GetUserRole`
- **`AuthnService` interface**: added `GetUserAdmin` so the `Authenticator` can call it during `Resolve`
- **`Resolve` in `authn.go`**: calls `GetUserAdmin` after `GetUserRole` and uses the store value instead of trusting `claims.Admin` from the JWT

## Testing

```bash
# Promote a user, login, save the token
UPDATE users SET admin = true WHERE username = 'testuser';
TOKEN=$(curl -s localhost/api/login -H 'Content-Type: application/json' \
  -d '{"username":"testuser","password":"..."}' | jq -r .token)

# Verify admin API works
curl -w '%{http_code}' localhost/admin/api/devices -H "Authorization: Bearer $TOKEN"
# → 200

# Demote, replay the same token
UPDATE users SET admin = false WHERE username = 'testuser';
curl -w '%{http_code}' localhost/admin/api/devices -H "Authorization: Bearer $TOKEN"
# → 403
```