### PR TITLE
refactor(gateway): stop rewriting requests the API can route itself

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,10 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [server, agent, pkg, cli]
+        project: [server, agent, pkg, cli, gateway]
         database: ['']  # Empty by default
         include:
           - project: server
+            extra_args: ""
+            lint_args: ""
+          - project: gateway
             extra_args: ""
             lint_args: ""
           - project: agent
@@ -137,27 +140,3 @@ jobs:
               docker save -o "/tmp/docker-cache/${name}.tar" "$img" 2>/dev/null || true
             done
 
-  gateway-lint:
-    name: lint (gateway)
-    if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
-        id: filter
-        with:
-          filters: |
-            go:
-              - 'gateway/**'
-
-      - name: Code linting [Go]
-        if: steps.filter.outputs.go == 'true'
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
-        with:
-          working-directory: gateway
-          version: v2.11.3
-          args: --timeout 2m ./...
-          skip-cache: true

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -53,28 +53,37 @@ func TestMain_smoke(t *testing.T) {
 
 	t.Logf("gateway container listening at %s", baseURL)
 
-	healthURL := baseURL + "/healthcheck"
-
-	client := http.Client{Timeout: 5 * time.Second}
+	// The one route nginx answers by itself. Everything else proxies to an
+	// upstream that does not exist beside a lone container, so asking for it
+	// would assert on how nginx reports a missing backend rather than on
+	// whether this image boots and serves the configuration it generated.
+	//
+	// Location matters as much as the status: absolute_redirect is off, so the
+	// redirects this gateway emits are relative, and a client that compares the
+	// header would see it change if that ever stopped being true.
+	client := http.Client{
+		Timeout: 5 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 
 	const maxRetries = 10
 
 	var resp *http.Response
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		t.Logf("healthcheck attempt %d/%d: GET %s", attempt, maxRetries, healthURL)
-
 		var err error
 
-		resp, err = client.Get(healthURL)
+		resp, err = client.Get(baseURL + "/v1/")
 		if err == nil {
 			break
 		}
 
-		t.Logf("healthcheck attempt %d/%d failed: %v", attempt, maxRetries, err)
+		t.Logf("attempt %d/%d failed: %v", attempt, maxRetries, err)
 
 		if attempt == maxRetries {
-			t.Fatalf("healthcheck: all %d attempts exhausted, last error: %v", maxRetries, err)
+			t.Fatalf("all %d attempts exhausted, last error: %v", maxRetries, err)
 		}
 
 		delay := time.Duration(attempt) * time.Second
@@ -87,5 +96,6 @@ func TestMain_smoke(t *testing.T) {
 
 	defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusMovedPermanently, resp.StatusCode)
+	assert.Equal(t, "/", resp.Header.Get("Location"))
 }

--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -185,11 +185,14 @@ server {
         proxy_pass http://$upstream;
     }
 
+    # These three are published at the root of the domain and answered under
+    # /api. The API resolves them itself, so they are routed here and nothing
+    # more -- the mapping belongs with the routes, not with whatever happens to
+    # sit in front of them.
     location /healthcheck {
         set $upstream {{ $cfg.APIBackend }};
         limit_req zone=api_limit{{ if $api_burst }} {{ $api_burst }}{{ end }} {{ $api_delay }};
 
-        rewrite ^/(.*)$ /api/healthcheck break;
         proxy_pass http://$upstream;
     }
 
@@ -197,7 +200,6 @@ server {
         set $upstream {{ $cfg.APIBackend }};
         limit_req zone=api_limit{{ if $api_burst }} {{ $api_burst }}{{ end }} {{ $api_delay }};
 
-        rewrite ^/(.*)$ /api/info break;
         proxy_pass http://$upstream;
     }
 
@@ -205,7 +207,6 @@ server {
         set $upstream {{ $cfg.APIBackend }};
         limit_req zone=api_limit{{ if $api_burst }} {{ $api_burst }}{{ end }} {{ $api_delay }};
 
-        rewrite ^/(.*)$ /api/install break;
         # The script embeds request-derived defaults (SERVER_ADDRESS from the
         # forwarded host), so it must never be cached: a shared cache would serve
         # one requester's address to everyone.
@@ -338,23 +339,30 @@ server {
     listen 80;
     {{- end }}
 
-    server_name "~^(?<address>[a-f0-9]{32})\.{{ $DOMAIN }}$";
+    server_name "~^[a-f0-9]{32}\.{{ $DOMAIN }}$";
     resolver 127.0.0.11 valid=10s ipv6=off;
 
-    location ~ ^/(?<path>.*) {
+    # The address is the subdomain, and the API reads it off the Host. Passing
+    # the hostname is the whole contract: it used to be decomposed here into
+    # X-Address and X-Path, which meant this file had to know both the shape of
+    # an address and the route that serves one.
+    #
+    # $request_uri, because the path belongs to the device's own HTTP server and
+    # is not ours to normalize: proxy_pass through a variable would otherwise
+    # rebuild it from $uri, and an escaped separator would reach the device as a
+    # real one, asking it for a resource nobody asked for.
+    location / {
         set $upstream {{ $cfg.APIBackend }};
 
-        rewrite ^/(.*)$ /http/proxy break;
+        proxy_set_header Host $host;
         proxy_set_header X-Request-ID $request_id;
-        proxy_set_header X-Address $address;
-        proxy_set_header X-Path /$path$is_args$args;
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade    $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         proxy_buffering off;
 
-        proxy_pass http://$upstream;
+        proxy_pass http://$upstream$request_uri;
     }
 }
 {{ end }}

--- a/server/api/routes/aliases.go
+++ b/server/api/routes/aliases.go
@@ -23,4 +23,8 @@ var rootAliases = map[string]string{
 	// the query string, so it has to survive the rewrite.
 	"^/install.sh":   "/api" + GetSystemDownloadInstallScriptURL,
 	"^/install.sh?*": "/api" + GetSystemDownloadInstallScriptURL + "?$1",
+	// The name the install script was published under before, kept because the
+	// address is the part that outlives the release that changed it.
+	"^/kickstart.sh":   "/api" + GetSystemDownloadInstallScriptURL,
+	"^/kickstart.sh?*": "/api" + GetSystemDownloadInstallScriptURL + "?$1",
 }

--- a/server/api/routes/aliases_test.go
+++ b/server/api/routes/aliases_test.go
@@ -47,6 +47,16 @@ func TestRootAliasesReachCanonicalRoutes(t *testing.T) {
 			},
 		},
 		{
+			description: "the install script's former name",
+			target:      "/kickstart.sh",
+			mock: func(service *serviceMocks.MockService) {
+				service.
+					On("SystemDownloadInstallScript", mock.Anything, mock.Anything).
+					Return("#!/bin/sh", nil).
+					Once()
+			},
+		},
+		{
 			description: "install script keeps its query string",
 			target:      "/install.sh?tenant_id=00000000-0000-4000-0000-000000000000&preferred_hostname=host",
 			mock: func(service *serviceMocks.MockService) {


### PR DESCRIPTION
## What

The edge stops rewriting requests the API already knows how to route, and the gateway module starts running its tests in CI.

## Why

shellhub-io/shellhub#6776 taught the API the routes that only the edge configuration knew: the root aliases, and the hostname a web endpoint is reached at. Both places have known them since, which is the safe state to make the change from, not the state to stay in — a second place where routes are declared is a second place to keep in step.

The tests come first for a reason. The QA matrix covers `server`, `agent`, `pkg` and `cli`; the gateway only ever had a lint job, so its tests have never run in a pipeline — including the one written to pin the `proxy_set_header` inheritance the whole configuration rests on. Nothing had noticed that the smoke test was broken either: it asserted 200 on `/healthcheck` from a container standing on its own, with no API beside it to answer.

## Changes

- **CI**: `gateway` joins the matrix, which brings tests, build and the `go.mod` completeness check. The standalone lint job goes — the matrix leg runs the same action, version and arguments. The smoke test now asserts on the one route nginx answers by itself, and checks the redirect target as well, since `absolute_redirect` is off and these redirects are relative.
- **Root aliases**: the `rewrite` lines under `/healthcheck`, `/info` and `/install.sh` are gone; the locations stay, because without them the request falls through to `/` and the UI answers 200 with HTML — a failure that looks like a success.
- **`/kickstart.sh`**: now an alias in the API. It had no callers in the tree and was going to be left behind, but with the rewrite gone the edge no longer turns it into anything, and a published address outlives the release that renamed it.
- **Web endpoints**: the block forwards `Host` and lets the API derive the address, instead of taking the hostname apart into `X-Address` and `X-Path`. It also passes `$request_uri`: `proxy_pass` through a variable rebuilds the URI from `$uri`, which is normalized and decoded, so an escaped separator reached the device as a real one and the device answered a request for a resource nobody asked for. That was true before this change; it is fixed here because this is where the path stops being ours to interpret.

## Compatibility

The gateway and the API now have to move together — the same rule agreed in shellhub-io/shellhub#6775, since an older API would no longer receive `X-Address`.

Verified against a real device with an echo service behind a web endpoint: request lines and headers arrive byte-identical through the edge and straight to the API, differing only in the request id, which the API generates when no proxy supplied one.
