### PR TITLE
fix(gateway): point the openapi mock and proxy routes at prism

### DIFF
--- a/gateway/nginx/conf.d/shellhub.conf
+++ b/gateway/nginx/conf.d/shellhub.conf
@@ -221,15 +221,18 @@ server {
         proxy_pass http://$upstream;
     }
 
+    # Prism, on the ports openapi/scripts/mock and openapi/scripts/proxy start
+    # it on. Neither is published to the host, so this is the only way in; and
+    # neither runs on its own, so expect 502 here until someone starts one.
     location /openapi/mock {
-        set $upstream openapi:8080;
+        set $upstream openapi:4010;
 
         rewrite ^/openapi/mock/?(.*)$ /$1 break;
         proxy_pass http://$upstream;
     }
 
     location /openapi/proxy {
-        set $upstream openapi:8080;
+        set $upstream openapi:4020;
 
         rewrite ^/openapi/proxy/?(.*)$ /$1 break;
         proxy_pass http://$upstream;


### PR DESCRIPTION
## What

`/openapi/mock` and `/openapi/proxy` reach Prism now. Both answered 404 before, for every request, on every edition.

## Why

They proxy to `openapi:8080`, which is the Go file server in `openapi/main.go` — it registers `/openapi/` and serves the bundled spec and the Redoc UI, nothing else. The locations rewrite the prefix away first, so what arrives is `/api/devices`, which matches no handler.

Prism listens on 4010 (`openapi/scripts/mock`) and 4020 (`openapi/scripts/proxy`). Neither port is published to the host, so the gateway is the only way in — which is why these locations exist at all, and why `openapi/README.md` sends people to `http://localhost/openapi/mock`.

Worth knowing what they are, since they have never worked: `prism mock` serves responses generated from the OpenAPI spec, so a client can be developed against the contract without the API behind it. `prism proxy` forwards to the real stack and validates the request and the response against the spec, reporting anything that violates it — contract testing against a live instance. Both take `community`, `cloud` or `enterprise`, so each edition can be checked against its own spec.

## Changes

- `/openapi/mock` → `openapi:4010`, `/openapi/proxy` → `openapi:4020`.
- A comment on why the ports differ from the neighbouring location, and that Prism is started by hand.

Prism is not a service; it runs while a developer keeps the script in the foreground. So these routes answer 502 when nothing is running, rather than 404 always. `/openapi` itself is untouched.

Verified with the mock running: `GET /openapi/mock/api/devices` returns the example response from the community spec, and 401 with the spec's error body when the request carries no credential.
