### PR TITLE
ci: point dependabot at the modules that exist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,36 +11,22 @@ updates:
     codeql:
       patterns:
         - "github/codeql-action/*"
+
 - package-ecosystem: docker
-  directory: "/cli"
+  directories:
+    - "/agent"
+    - "/cli"
+    - "/gateway"
+    - "/openapi"
+    - "/server"
   schedule:
     interval: weekly
   cooldown:
     default-days: 7
   commit-message:
-    prefix: "docker: cli"
-  ignore:
-    - dependency-name: "golang"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-- package-ecosystem: docker
-  directory: "/api"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "docker: api"
-  ignore:
-    - dependency-name: "golang"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-- package-ecosystem: docker
-  directory: "/gateway"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "docker: gateway"
+    prefix: "docker"
+  # The Go image follows the toolchain pinned in go.mod, so it only moves when we
+  # bump the toolchain ourselves.
   ignore:
     - dependency-name: "golang"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -51,33 +37,12 @@ updates:
   cooldown:
     default-days: 7
   commit-message:
-    prefix: "docker: ui"
+    prefix: "docker"
   ignore:
     - dependency-name: "node"
       update-types: ["version-update:semver-major"]
       versions: [">=25"]
-- package-ecosystem: docker
-  directory: "/agent"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "docker: agent"
-  ignore:
-    - dependency-name: "golang"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-- package-ecosystem: docker
-  directory: "/ssh"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "docker: ssh"
-  ignore:
-    - dependency-name: "golang"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
 - package-ecosystem: npm
   directory: "/ui"
   schedule:
@@ -91,6 +56,32 @@ updates:
     tiptap:
       patterns:
         - "@tiptap/*"
+
+# Indirect dependencies come along when `devscripts/prepare-release` re-resolves the
+# module, so only direct ones are allowed here: an indirect bump on its own lands
+# ahead of the dependency that pins it and cannot build.
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7
+  commit-message:
+    prefix: "pkg"
+  allow:
+    - dependency-type: direct
+- package-ecosystem: gomod
+  directory: "/server"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7
+  commit-message:
+    prefix: "server"
+  allow:
+    - dependency-type: direct
+  ignore:
+    - dependency-name: "github.com/shellhub-io/shellhub"
 - package-ecosystem: gomod
   directory: "/agent"
   schedule:
@@ -99,28 +90,10 @@ updates:
     default-days: 7
   commit-message:
     prefix: "agent"
+  allow:
+    - dependency-type: direct
   ignore:
-      - dependency-name: "github.com/shellhub-io/shellhub"
-- package-ecosystem: gomod
-  directory: "/api"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "api"
-  ignore:
-      - dependency-name: "github.com/shellhub-io/shellhub"
-- package-ecosystem: gomod
-  directory: "/ssh"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "ssh"
-  ignore:
-      - dependency-name: "github.com/shellhub-io/shellhub"
+    - dependency-name: "github.com/shellhub-io/shellhub"
 - package-ecosystem: gomod
   directory: "/cli"
   schedule:
@@ -129,5 +102,48 @@ updates:
     default-days: 7
   commit-message:
     prefix: "cli"
+  allow:
+    - dependency-type: direct
   ignore:
-      - dependency-name: "github.com/shellhub-io/shellhub"
+    - dependency-name: "github.com/shellhub-io/shellhub"
+- package-ecosystem: gomod
+  directory: "/gateway"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7
+  commit-message:
+    prefix: "gateway"
+  allow:
+    - dependency-type: direct
+  groups:
+    caddy:
+      patterns:
+        - "github.com/caddyserver/*"
+        - "github.com/caddy-dns/*"
+  ignore:
+    - dependency-name: "github.com/shellhub-io/shellhub"
+- package-ecosystem: gomod
+  directory: "/openapi"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7
+  commit-message:
+    prefix: "openapi"
+  allow:
+    - dependency-type: direct
+  ignore:
+    - dependency-name: "github.com/shellhub-io/shellhub"
+- package-ecosystem: gomod
+  directory: "/tests"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7
+  commit-message:
+    prefix: "tests"
+  allow:
+    - dependency-type: direct
+  ignore:
+    - dependency-name: "github.com/shellhub-io/shellhub"


### PR DESCRIPTION
Dependabot was still updating `api/` and `ssh/`, which were merged into `server/`.
Meanwhile `server/`, `gateway/`, `openapi/`, `tests/` and the root module had no
entry at all, so the modules CI validates were the ones nobody was watching.

The directory list now matches the repository: gomod for `/`, `/agent`, `/cli`,
`/gateway`, `/openapi`, `/server` and `/tests`, docker for every image we build.

Go updates are restricted to direct dependencies. An indirect bump on its own
lands ahead of the dependency that pins it and cannot build, which is what
happened in #6781: cel-go 0.29.0 changed the `interpreter.NewCall` signature and
caddy v2.11.4 does not compile against it. Indirect dependencies already come
along whenever `devscripts/prepare-release` re-resolves the module.

The caddy modules are grouped so the proxy and its DNS providers move together,
and the docker commit prefixes no longer emit a duplicated colon
(`docker: cli: bump ...`).
