### PR TITLE
fix(ui): remove unnecessary fetchUser from admin route guard

### DIFF
--- a/ui/apps/console/src/components/common/AdminRoute.tsx
+++ b/ui/apps/console/src/components/common/AdminRoute.tsx
@@ -1,25 +1,9 @@
-import { useEffect, useState } from "react";
 import { Outlet, Navigate } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
-import { Spinner } from "@shellhub/design-system/primitives";
 import ErrorBoundary from "./ErrorBoundary";
 
 export default function AdminRoute() {
-  const fetchUser = useAuthStore((s) => s.fetchUser);
   const isAdmin = useAuthStore((s) => s.isAdmin);
-  const [verified, setVerified] = useState(false);
-
-  useEffect(() => {
-    void fetchUser().finally(() => setVerified(true));
-  }, [fetchUser]);
-
-  if (!verified) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
 
   if (!isAdmin) {
     return <Navigate to="/admin/unauthorized" replace />;

--- a/ui/apps/console/src/components/common/__tests__/AdminRoute.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/AdminRoute.test.tsx
@@ -1,44 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
 import AdminRoute from "../AdminRoute";
 
-// Mock the API client so fetchUser never makes a real HTTP request.
-// authStore.fetchUser calls getUserInfo from @/client (re-exported from ../client).
-vi.mock("@/client", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@/client")>();
-  return {
-    ...original,
-    getUserInfo: vi.fn(),
-  };
-});
-
-import { getUserInfo } from "@/client";
-
-const mockGetUserInfo = vi.mocked(getUserInfo);
-
-const baseState = {
-  token: null,
-  user: null,
-  userId: null,
-  email: null,
-  username: null,
-  recoveryEmail: null,
-  tenant: null,
-  role: null,
-  isAdmin: false,
-  name: null,
-  loading: false,
-  error: null,
-  mfaEnabled: false,
-  mfaToken: null,
-  mfaRecoveryExpiry: null,
-};
-
 beforeEach(() => {
-  useAuthStore.setState(baseState);
-  vi.clearAllMocks();
+  useAuthStore.setState({ isAdmin: false });
 });
 
 function renderAdminRoute() {
@@ -48,91 +15,28 @@ function renderAdminRoute() {
         <Route element={<AdminRoute />}>
           <Route path="/admin/dashboard" element={<div>admin content</div>} />
         </Route>
-        <Route path="/admin/unauthorized" element={<div>unauthorized page</div>} />
+        <Route
+          path="/admin/unauthorized"
+          element={<div>unauthorized page</div>}
+        />
       </Routes>
     </MemoryRouter>,
   );
 }
 
 describe("AdminRoute", () => {
-  describe("loading state", () => {
-    it("renders a spinner while verifying admin status", async () => {
-      // fetchUser never settles during this assertion window
-      let resolveFetch!: () => void;
-      mockGetUserInfo.mockReturnValue(
-        new Promise((resolve) => {
-          resolveFetch = () => resolve({ data: { admin: true } });
-        }) as never,
-      );
+  it("renders the Outlet when isAdmin is true", () => {
+    useAuthStore.setState({ isAdmin: true });
+    renderAdminRoute();
 
-      renderAdminRoute();
-
-      // The spinner is the only element in the loading branch; confirm admin
-      // content is not yet visible.
-      expect(screen.queryByText("admin content")).not.toBeInTheDocument();
-      expect(screen.queryByText("unauthorized page")).not.toBeInTheDocument();
-
-      // Unblock so the component can finish, avoiding act() warnings.
-      resolveFetch();
-      await waitFor(() =>
-        expect(screen.queryByText("admin content")).toBeInTheDocument(),
-      );
-    });
+    expect(screen.getByText("admin content")).toBeInTheDocument();
+    expect(screen.queryByText("unauthorized page")).not.toBeInTheDocument();
   });
 
-  describe("admin user", () => {
-    it("renders the Outlet when fetchUser resolves and isAdmin is true", async () => {
-      mockGetUserInfo.mockResolvedValue({
-        data: { admin: true, user: "root", id: "1", email: "a@b.com", tenant: "t", name: "Root" },
-      } as never);
+  it("redirects to /admin/unauthorized when isAdmin is false", () => {
+    renderAdminRoute();
 
-      renderAdminRoute();
-
-      await waitFor(() =>
-        expect(screen.getByText("admin content")).toBeInTheDocument(),
-      );
-      expect(screen.queryByText("unauthorized page")).not.toBeInTheDocument();
-    });
-
-    it("does not redirect to /admin/unauthorized when the user is admin", async () => {
-      mockGetUserInfo.mockResolvedValue({
-        data: { admin: true, user: "root", id: "1", email: "a@b.com", tenant: "t", name: "Root" },
-      } as never);
-
-      renderAdminRoute();
-
-      await waitFor(() =>
-        expect(screen.getByText("admin content")).toBeInTheDocument(),
-      );
-    });
-  });
-
-  describe("non-admin user", () => {
-    it("redirects to /admin/unauthorized when fetchUser resolves and isAdmin is false", async () => {
-      mockGetUserInfo.mockResolvedValue({
-        data: { admin: false, user: "user1", id: "2", email: "u@b.com", tenant: "t", name: "User" },
-      } as never);
-
-      renderAdminRoute();
-
-      await waitFor(() =>
-        expect(screen.getByText("unauthorized page")).toBeInTheDocument(),
-      );
-      expect(screen.queryByText("admin content")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("fetchUser failure", () => {
-    it("redirects to /admin/unauthorized when fetchUser rejects", async () => {
-      // authStore.fetchUser catches the error and sets isAdmin: false
-      mockGetUserInfo.mockRejectedValue(new Error("network error"));
-
-      renderAdminRoute();
-
-      await waitFor(() =>
-        expect(screen.getByText("unauthorized page")).toBeInTheDocument(),
-      );
-      expect(screen.queryByText("admin content")).not.toBeInTheDocument();
-    });
+    expect(screen.getByText("unauthorized page")).toBeInTheDocument();
+    expect(screen.queryByText("admin content")).not.toBeInTheDocument();
   });
 });

--- a/ui/apps/console/src/pages/admin/users/EditUserDrawer.tsx
+++ b/ui/apps/console/src/pages/admin/users/EditUserDrawer.tsx
@@ -25,7 +25,7 @@ export default function EditUserDrawer({
   user,
 }: EditUserDrawerProps) {
   const updateUser = useUpdateUser();
-  const currentUsername = useAuthStore((s) => s.username);
+  const currentUserId = useAuthStore((s) => s.userId);
 
   const schema = useMemo(() => userSchema("edit"), []);
   const defaults = useMemo(() => buildUserDefaults(user), [user]);
@@ -33,7 +33,7 @@ export default function EditUserDrawer({
   const form = useDrawerForm(open, schema, defaults);
   const { control, setError, clearErrors } = form;
 
-  const isSelf = user?.username === currentUsername;
+  const isSelf = user?.id === currentUserId;
   const canChangeConfirmed = user?.status !== "confirmed";
   const disableAdmin = !!user?.admin && isSelf;
 
@@ -47,9 +47,10 @@ export default function EditUserDrawer({
       });
       onClose();
     } catch (err) {
-      const message = isSdkError(err) && err.status === 409
-        ? "A user with this email or username already exists."
-        : "Failed to update user. Please try again.";
+      const message =
+        isSdkError(err) && err.status === 409
+          ? "A user with this email or username already exists."
+          : "Failed to update user. Please try again.";
 
       setError("root", { message });
     }

--- a/ui/apps/console/src/pages/admin/users/__tests__/EditUserDrawer.test.tsx
+++ b/ui/apps/console/src/pages/admin/users/__tests__/EditUserDrawer.test.tsx
@@ -49,7 +49,7 @@ describe("EditUserDrawer", () => {
     vi.mocked(useUpdateUser).mockReturnValue({
       mutateAsync: mockMutateAsync,
     } as never);
-    useAuthStore.setState({ username: "admin" } as never);
+    useAuthStore.setState({ userId: "u2" } as never);
   });
 
   describe("rendering — closed", () => {
@@ -193,25 +193,21 @@ describe("EditUserDrawer", () => {
 
   describe("admin checkbox — self-demotion constraint", () => {
     it("admin checkbox is disabled when editing your own admin account", () => {
-      useAuthStore.setState({ username: "alice" } as never);
+      useAuthStore.setState({ userId: "u1" } as never);
       const selfAdmin: UserAdminResponse = { ...mockUser, admin: true };
       renderDrawer({ user: selfAdmin });
       expect(screen.getByLabelText(/^admin user$/i)).toBeDisabled();
     });
 
     it("admin checkbox is enabled when editing another admin", () => {
-      useAuthStore.setState({ username: "admin" } as never);
-      const otherAdmin: UserAdminResponse = {
-        ...mockUser,
-        username: "bob",
-        admin: true,
-      };
+      useAuthStore.setState({ userId: "u2" } as never);
+      const otherAdmin: UserAdminResponse = { ...mockUser, admin: true };
       renderDrawer({ user: otherAdmin });
       expect(screen.getByLabelText(/^admin user$/i)).not.toBeDisabled();
     });
 
     it("admin checkbox is enabled for a non-admin self user", () => {
-      useAuthStore.setState({ username: "alice" } as never);
+      useAuthStore.setState({ userId: "u1" } as never);
       const selfNonAdmin: UserAdminResponse = { ...mockUser, admin: false };
       renderDrawer({ user: selfNonAdmin });
       expect(screen.getByLabelText(/^admin user$/i)).not.toBeDisabled();


### PR DESCRIPTION
## What

Eliminated the per-navigation flash on admin pages and fixed a broken self-detection check in the admin user editor.

## Why

`AdminRoute` called `fetchUser` on every mount, which rendered a full-screen spinner while the API responded. On first visit to each admin page this produced a visible flash before content appeared. The `isAdmin` field is already persisted in the Zustand store via `partialize` and is available synchronously from `localStorage` — the API round-trip was redundant.

Separately, `EditUserDrawer` compared `user.username` against `authStore.username` to detect whether an admin is editing themselves (to disable the admin checkbox and prevent self-demotion). `username` is explicitly excluded from store persistence, so after a page reload `isSelf` was always `false` and the guard silently stopped working.

## Changes

- **`AdminRoute`**: removed `fetchUser` effect, loading state, and spinner — reads `isAdmin` directly from the persisted store. Tests rewritten from async/mocked to synchronous store-driven assertions.
- **`EditUserDrawer`**: switched `isSelf` from `username` comparison to `userId` (persisted, immutable). Tests updated to set `userId` in the store and match against `mockUser.id`.

## Note

Complementary to #6774, which fixes the backend side: the authn middleware now re-fetches admin status from the database on every request, so a demoted admin's JWT no longer grants API access. Together, both the frontend gate and the backend gate respond immediately to admin status changes.