### PR TITLE
ci: group Dependabot updates instead of one pull request per module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 
+# Every entry sets open-pull-requests-limit explicitly. The default is 5 per entry,
+# which multiplies by the number of entries here and lets a quiet week turn into
+# dozens of simultaneous pull requests.
+
 updates:
 - package-ecosystem: github-actions
   directory: "/"
@@ -7,10 +11,14 @@ updates:
     interval: weekly
   cooldown:
     default-days: 7
+  open-pull-requests-limit: 5
   groups:
-    codeql:
+    # applies-to keeps this to version updates, so a security fix still arrives on
+    # its own instead of waiting behind an unrelated action in the same pull request.
+    actions:
+      applies-to: version-updates
       patterns:
-        - "github/codeql-action/*"
+        - "*"
 
 - package-ecosystem: docker
   directories:
@@ -24,6 +32,15 @@ updates:
     default-days: 7
   commit-message:
     prefix: "docker"
+  open-pull-requests-limit: 5
+  groups:
+    # These four share the same base image, so without group-by a single bump
+    # arrives as four pull requests that all edit the same version.
+    images:
+      applies-to: version-updates
+      group-by: dependency-name
+      patterns:
+        - "*"
   # The Go image follows the toolchain pinned in go.mod, so it only moves when we
   # bump the toolchain ourselves.
   ignore:
@@ -37,6 +54,7 @@ updates:
     default-days: 7
   commit-message:
     prefix: "docker"
+  open-pull-requests-limit: 5
   ignore:
     - dependency-name: "node"
       update-types: ["version-update:semver-major"]
@@ -51,56 +69,61 @@ updates:
   commit-message:
     prefix: "ui"
   versioning-strategy: lockfile-only
+  open-pull-requests-limit: 5
   groups:
+    # React refuses to run unless react and react-dom are on the exact same version,
+    # so split across two pull requests each half fails CI on its own and neither can
+    # ever go green.
+    react:
+      patterns:
+        - "react"
+        - "react-dom"
+        - "@types/react"
+        - "@types/react-dom"
     tiptap:
       patterns:
         - "@tiptap/*"
+    # A dependency matching more than one group is not placed in the first match, so
+    # the catch-all has to exclude the groups above by hand.
+    ui:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
+      exclude-patterns:
+        - "react"
+        - "react-dom"
+        - "@types/react"
+        - "@types/react-dom"
+        - "@tiptap/*"
 
+# One entry for every Go module rather than one entry each. The modules share a
+# workspace, so `go mod tidy` on any of them rewrites the others' go.sum, and a
+# dependency they have in common used to arrive as one pull request per module —
+# each carrying the same edits, each conflicting with the rest. group-by collapses
+# those into a single pull request per dependency.
+#
+# The commit scope is `deps` because such an update genuinely spans layers; there is
+# no single module to name.
+#
 # Indirect dependencies come along when `devscripts/prepare-release` re-resolves the
 # module, so only direct ones are allowed here: an indirect bump on its own lands
 # ahead of the dependency that pins it and cannot build.
 - package-ecosystem: gomod
-  directory: "/"
+  directories:
+    - "/"
+    - "/agent"
+    - "/gateway"
+    - "/openapi"
+    - "/server"
+    - "/tests"
   schedule:
     interval: weekly
   cooldown:
     default-days: 7
   commit-message:
-    prefix: "pkg"
-  allow:
-    - dependency-type: direct
-- package-ecosystem: gomod
-  directory: "/server"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "server"
-  allow:
-    - dependency-type: direct
-  ignore:
-    - dependency-name: "github.com/shellhub-io/shellhub"
-- package-ecosystem: gomod
-  directory: "/agent"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "agent"
-  allow:
-    - dependency-type: direct
-  ignore:
-    - dependency-name: "github.com/shellhub-io/shellhub"
-- package-ecosystem: gomod
-  directory: "/gateway"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "gateway"
+    prefix: "deps"
+  open-pull-requests-limit: 10
   allow:
     - dependency-type: direct
   groups:
@@ -108,29 +131,13 @@ updates:
       patterns:
         - "github.com/caddyserver/*"
         - "github.com/caddy-dns/*"
-  ignore:
-    - dependency-name: "github.com/shellhub-io/shellhub"
-- package-ecosystem: gomod
-  directory: "/openapi"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "openapi"
-  allow:
-    - dependency-type: direct
-  ignore:
-    - dependency-name: "github.com/shellhub-io/shellhub"
-- package-ecosystem: gomod
-  directory: "/tests"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "tests"
-  allow:
-    - dependency-type: direct
+    go-modules:
+      applies-to: version-updates
+      group-by: dependency-name
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "github.com/caddyserver/*"
+        - "github.com/caddy-dns/*"
   ignore:
     - dependency-name: "github.com/shellhub-io/shellhub"


### PR DESCRIPTION
## What

Collapses `.github/dependabot.yml` from 11 update entries to 5, grouping updates that belong together and putting an explicit ceiling on how many pull requests each entry may open.

## Why

Pointing Dependabot at the modules that actually exist (`e2d091c13`) released a backlog of 24 open pull requests in one day. Draining that batch showed the file's real problems, and all of them are structural rather than one-off.

The six `gomod` entries treated the modules as independent, which they are not. They share a workspace, so `go mod tidy` on any one of them rewrites the others' `go.sum`. A dependency several modules have in common therefore arrived as one pull request per module, each carrying the same edits and each conflicting with the rest once any one merged. `testcontainers` came as four pull requests, `go-envconfig` as two, and four of the batch had to be regenerated through `@dependabot recreate` after unrelated merges.

`react` and `react-dom` arrived separately, and React refuses to run unless the two are on the exact same version. Each half fails CI on its own, so neither could ever go green. The react-only half was closed rather than merged.

No entry set `open-pull-requests-limit`, which defaults to 5 and applies per entry rather than per file.

## Changes

- **gomod**: one entry over all six module directories, with `group-by: dependency-name` so a shared dependency produces a single pull request. The `caddy` group is kept and excluded from the catch-all, since a dependency matching more than one group is not placed in the first one it matches.
- **npm**: a `react` group covering `react`, `react-dom` and their `@types` packages, plus a catch-all for minor and patch updates that excludes the named groups.
- **docker**: the four Go images share a base, so they are grouped by dependency name for the same reason as the Go modules.
- **github-actions**: a single group replaces the `codeql-action`-specific one.
- **limits**: every entry now states `open-pull-requests-limit`.
- Catch-all groups carry `applies-to: version-updates`, so a security fix arrives on its own instead of waiting behind a broken neighbour in the same pull request.

## Notes

Go bumps now carry a `deps` commit scope rather than `server`, `gateway` or `pkg`. An update that spans the workspace has no single module to name.

`group-by: dependency-name` is generally available on github.com (`fpt` and `ghec`, and GHES 3.21 onward) and is documented as creating "a single pull request for each dependency update across all specified directories, rather than separate pull requests per directory". Its documented limitations are satisfied here: both entries keep a single package ecosystem, and the grouping applies to version updates only. Where directories carry incompatible version constraints for the same dependency, Dependabot falls back to separate pull requests rather than stalling.

It has not run against this repository yet, so the first grouped run is worth confirming on the repository's Dependabot page.

