### PR TITLE
ci: steer echo-contrib back to the Echo 4 line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -141,3 +141,11 @@ updates:
         - "github.com/caddy-dns/*"
   ignore:
     - dependency-name: "github.com/shellhub-io/shellhub"
+    # echo-contrib's v0.50 line is its Echo 5 support, published by mistake on the
+    # v0 series: upstream says anyone still on Echo 4 pulls it in unintentionally,
+    # and that it will be retracted so v0 goes back to meaning Echo 4. Our line
+    # continues at v0.18. Without this, v0.50.1 is the highest version and the only
+    # one ever offered, so ignoring it is what lets v0.18.x through rather than what
+    # stops updates. Drop this once the retraction lands.
+    - dependency-name: "github.com/labstack/echo-contrib"
+      versions: [">=0.50.0"]


### PR DESCRIPTION
## What

Ignores the `v0.50` line of `github.com/labstack/echo-contrib` so Dependabot offers `v0.18.x` instead.

## Why

`echo-contrib` published its Echo 5 support as `v0.50.0`, on the same `v0` series that until then meant Echo 4. Upstream describes this as a mistake in the `v0.50.1` release notes:

> Echo 5 support was introduced in this repository with the v0.50.0 release. However, this also means that users who are still on Echo 4 and run `go get -u ./...` will inadvertently pull in Echo 5, which they neither want nor need at this time.
>
> `v0.50.0` will be retracted in v0.18.0 series and v0+ will only support Echo 4. For Echo 5 support use `v5` major version of this repository.

The continuation of the line we are on is `v0.18.0`, published two weeks after `v0.50.0`:

```
v0.17.4   2025-05-09   <- current
v0.50.0   2026-01-18   <- Echo 5 line, to be retracted
v0.18.0   2026-01-31   <- the Echo 4 continuation
v0.50.1   2026-02-14
v5.0.0    2026-01-31
```

Dependabot is `go get -u` on a schedule, so it proposed `v0.50.1` in #6787, which was closed. Because it offers the highest version that is not ignored, and `v0.50.1` outranks `v0.18.0`, leaving this alone means the wrong update arrives every week and the right one never does. Ignoring the `v0.50` line is what lets `v0.18.x` through rather than what stops updates.

Worth recording that CI does not catch this. `v0.50.1` still compiles against Echo 4 for `echoprometheus` and `pprof`, the two packages used here, and leaves `echo/v4` untouched in `go.mod`, so the bump passes every check. Only the release note identifies it as the wrong line.

## Changes

- **gomod**: ignore `github.com/labstack/echo-contrib` at `>=0.50.0`, with the reasoning inline.

## Notes

The rule becomes redundant once the retraction lands upstream, since Go stops selecting a retracted version on its own. The comment in the file says so, so it can be removed rather than inherited.
