### PR TITLE
fix(server): serialize every frame written to the web terminal socket

### DIFF
--- a/server/ssh/web/conn.go
+++ b/server/ssh/web/conn.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -21,6 +22,12 @@ type Conn struct {
 	Socket Socket
 	// Pinger is reponsable to inform the server that a SSH session is open.
 	Pinger *time.Ticker
+
+	// writes serializes every frame written to the socket. Device output, JSON
+	// control messages and keep-alive pings are produced by different
+	// goroutines, and the frame writer underneath is not goroutine-safe: two
+	// concurrent writers otherwise interleave and corrupt a frame.
+	writes sync.Mutex
 }
 
 func NewConn(socket Socket) *Conn {
@@ -116,6 +123,9 @@ func (c *Conn) ReadMessage(message *Message) (int, error) {
 }
 
 func (c *Conn) WriteMessage(message *Message) (int, error) {
+	c.writes.Lock()
+	defer c.writes.Unlock()
+
 	buffer, err := json.Marshal(message)
 	if err != nil {
 		return 0, errors.Join(ErrConnReadMessageJSONInvalid)
@@ -130,6 +140,9 @@ func (c *Conn) WriteMessage(message *Message) (int, error) {
 }
 
 func (c *Conn) WriteBinary(data []byte) (int, error) {
+	c.writes.Lock()
+	defer c.writes.Unlock()
+
 	socket, ok := c.Socket.(*websocket.Conn)
 	if !ok {
 		// NOTE: If the underlying connection is not a websocket connection, fallback to a normal write.
@@ -151,11 +164,35 @@ func (c *Conn) WriteBinary(data []byte) (int, error) {
 	return wrote, nil
 }
 
+func (c *Conn) WritePing() error {
+	c.writes.Lock()
+	defer c.writes.Unlock()
+
+	socket, ok := c.Socket.(*websocket.Conn)
+	if !ok {
+		return nil
+	}
+
+	frame, err := socket.NewFrameWriter(websocket.PingFrame)
+	if err != nil {
+		return err
+	}
+
+	if _, err := frame.Write([]byte{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Conn) Read(buffer []byte) (int, error) {
 	return c.Socket.Read(buffer)
 }
 
 func (c *Conn) Write(buffer []byte) (int, error) {
+	c.writes.Lock()
+	defer c.writes.Unlock()
+
 	return c.Socket.Write(buffer)
 }
 
@@ -176,9 +213,7 @@ func (c *Conn) KeepAlive() {
 			return
 		}
 
-		if fw, err := socket.NewFrameWriter(websocket.PingFrame); err != nil {
-			return
-		} else if _, err = fw.Write([]byte{}); err != nil {
+		if err := c.WritePing(); err != nil {
 			return
 		}
 

--- a/server/ssh/web/conn_test.go
+++ b/server/ssh/web/conn_test.go
@@ -1,13 +1,21 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/server/ssh/web/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
 )
 
 func TestConnReadMessage_input(t *testing.T) {
@@ -164,4 +172,122 @@ func TestConnReadMessage_resize(t *testing.T) {
 			assert.ErrorIs(t, err, test.expect.err)
 		})
 	}
+}
+
+// TestConnConcurrentWritesDoNotRace pins the synchronisation on Conn rather
+// than on any one writer: output frames, control messages and keep-alive pings
+// all share the socket, and the frame writer underneath is not goroutine-safe.
+func TestConnConcurrentWritesDoNotRace(t *testing.T) {
+	const rounds = 50
+
+	output := bytes.Repeat([]byte{'o'}, 128)
+
+	// The client auto-replies a pong to every ping and the handler never reads
+	// them, so closing with that data unread would RST the connection and
+	// truncate what the client has yet to receive. Hold the handler open until
+	// the client has read everything.
+	read := make(chan struct{})
+
+	server := httptest.NewServer(websocket.Handler(func(socket *websocket.Conn) {
+		conn := NewConn(socket)
+
+		wg := sync.WaitGroup{}
+		wg.Add(3)
+
+		go func() {
+			defer wg.Done()
+
+			for range rounds {
+				if _, err := conn.WriteBinary(output); err != nil {
+					return
+				}
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			for range rounds {
+				if _, err := conn.WriteMessage(&Message{Kind: messageKindSession, Data: "uid"}); err != nil {
+					return
+				}
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			for range rounds {
+				if err := conn.WritePing(); err != nil {
+					return
+				}
+			}
+		}()
+
+		wg.Wait()
+		<-read
+	}))
+
+	defer server.Close()
+
+	client, err := websocket.Dial("ws"+strings.TrimPrefix(server.URL, "http"), "", server.URL)
+	require.NoError(t, err)
+
+	defer client.Close() //nolint:errcheck
+
+	// Without serialization the frames interleave and the parser desyncs, which
+	// would otherwise block this read until the whole suite times out.
+	require.NoError(t, client.SetDeadline(clock.Now().Add(30*time.Second)))
+
+	binary := 0
+	control := 0
+
+	// Pings are answered and consumed by the client's frame handler, so only the
+	// binary and text frames surface here.
+	for range rounds * 2 {
+		var frame capturedFrame
+
+		require.NoError(t, frameCapture.Receive(client, &frame))
+
+		if frame.payloadType == websocket.BinaryFrame {
+			binary++
+
+			// A frame carrying anything other than the whole payload means two
+			// writers interleaved on the shared frame writer.
+			assert.Equal(t, output, frame.data)
+
+			continue
+		}
+
+		control++
+	}
+
+	close(read)
+
+	assert.Equal(t, rounds, binary)
+	assert.Equal(t, rounds, control)
+}
+
+type capturedFrame struct {
+	payloadType byte
+	data        []byte
+}
+
+// frameCapture exposes the frame's opcode, which the stock Message codec
+// discards when unmarshalling.
+var frameCapture = websocket.Codec{
+	Marshal: func(_ any) ([]byte, byte, error) {
+		return nil, websocket.UnknownFrame, websocket.ErrNotSupported
+	},
+	Unmarshal: func(msg []byte, payloadType byte, v any) error {
+		frame, ok := v.(*capturedFrame)
+		if !ok {
+			return websocket.ErrNotSupported
+		}
+
+		frame.payloadType = payloadType
+		frame.data = msg
+
+		return nil
+	},
 }


### PR DESCRIPTION
Split out of #6766, as suggested there. This is the piece that is unrelated to
locale and changes no frame format.

## What

`Conn` writes are serialized on a mutex that covers every path reaching the
socket.

## Why

Device output, JSON control messages and keep-alive pings are produced by
different goroutines and all write to the same `x/net/websocket` frame writer,
which is not goroutine-safe. Two concurrent writers interleave and corrupt a
frame; the client's parser then desyncs on the stream.

Guarding only one writer would leave exactly the corruption it set out to
prevent, so the lock lives on `Conn`: `WriteBinary`, `WriteMessage` and `Write`,
plus the ping frame, which moves out of `KeepAlive` into `WritePing` for the
same reason.

## Testing

`TestConnConcurrentWritesDoNotRace` drives output, control messages and pings
concurrently over a real socket. Without the lock it reports both a data race
and genuinely corrupted frames — the read fails outright once the frame parser
desyncs — not merely a race warning.

    go test -race ./ssh/web/

Reported by @gustavosbarreto in #6766.