### PR TITLE
fix(ui): decode terminal output as a stream, in arrival order

### DIFF
--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -207,9 +207,12 @@ export default function TerminalInstance({
           // Binary data = terminal output (password auth or post-signature)
           const bytes = new Uint8Array(event.data as ArrayBuffer);
           term.write(bytes);
-          recorderRef.current?.recordOutput(
-            recordingDecoder.decode(bytes, { stream: true }),
-          );
+          // Decode unconditionally: the recorder is null until its async
+          // creation resolves, and feeding the decoder only while it exists
+          // would leave the stream state missing those bytes — so a character
+          // straddling that window would come out corrupted in the recording.
+          const decoded = recordingDecoder.decode(bytes, { stream: true });
+          recorderRef.current?.recordOutput(decoded);
           registerResizeHandler();
           return;
         }

--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -142,8 +142,15 @@ export default function TerminalInstance({
       const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       const wsUrl = `${proto}//${window.location.host}/ws/ssh?token=${token}&cols=${cols}&rows=${rows}`;
       const ws = new WebSocket(wsUrl);
+      ws.binaryType = "arraybuffer";
       wsRef.current = ws;
       resizeRegisteredRef.current = false;
+
+      // xterm.js decodes bytes itself, statefully across writes. The recorder
+      // needs text — asciicast v2 output events are JSON strings — so it gets
+      // its own streaming decoder, which holds a character split across frames
+      // until the bytes completing it arrive.
+      const recordingDecoder = new TextDecoder("utf-8");
 
       // Copy key material into local variables so the closure doesn't hold
       // the original session object (which would keep keys reachable in memory).
@@ -191,15 +198,25 @@ export default function TerminalInstance({
         }
       };
 
-      ws.onmessage = async (event) => {
+      // The output path is synchronous by design: awaiting here decoded each
+      // frame in isolation, corrupting a character that spans frames, and let
+      // frame order follow promise resolution rather than arrival.
+      ws.onmessage = (event) => {
         if (cancelled) return;
-        if (event.data instanceof Blob) {
+        if (typeof event.data !== "string") {
           // Binary data = terminal output (password auth or post-signature)
-          const text = await event.data.text();
-          term.write(text);
-          recorderRef.current?.recordOutput(text);
+          const bytes = new Uint8Array(event.data as ArrayBuffer);
+          term.write(bytes);
+          recorderRef.current?.recordOutput(
+            recordingDecoder.decode(bytes, { stream: true }),
+          );
           registerResizeHandler();
-        } else {
+          return;
+        }
+
+        // Control messages stay async (the signature case signs with WebCrypto),
+        // but the output path above must not await.
+        void (async () => {
           // JSON text message = challenge-response or error
           const textData = String(event.data as unknown);
           const msg = parseMessage(textData);
@@ -270,7 +287,7 @@ export default function TerminalInstance({
             default:
               break;
           }
-        }
+        })();
       };
 
       ws.onclose = () => {


### PR DESCRIPTION
Split out of #6766, as suggested there. Client-side only — the wire format is
untouched, so this needs no server change and no endpoint version.

## What

The web terminal reads binary frames as `arraybuffer` and hands the bytes
straight to xterm.js, on a synchronous handler.

## Why

Output frames were read with `Blob.text()`. That is a one-shot decode per the
File API, so a character whose bytes span two frames was corrupted on both
sides of the split. Awaiting it also let frame order follow promise resolution
rather than arrival, and left the `cancelled` check stale across the await.

`Terminal.write()` accepts a `Uint8Array` and decodes UTF-8 statefully across
calls — one `Utf8ToUtf32` per `Terminal`, with a 3-byte interim buffer that
holds an incomplete sequence until the rest arrives. Passing bytes rather than
a per-frame string fixes the split characters, and dropping the `await` fixes
the ordering.

## Changes

- `binaryType = "arraybuffer"`; the output path is synchronous. Control
  messages keep their async body, since the signature case signs with
  WebCrypto.
- Frames are discriminated on `typeof event.data === "string"` instead of
  `instanceof Blob`, which keeps the existing non-JSON-text fallback intact —
  stderr still arrives as a text frame and still reaches `term.write` when it
  does not parse as a control message.
- The recorder keeps a per-session `TextDecoder({ stream: true })`. asciicast v2
  output events are JSON strings by specification, so it needs text, and
  splitting characters the same way is what makes a recording replay as what
  the user saw.

## Testing

`tsc -b`, `eslint`, and the console suite (2982 tests) pass. The terminal
component itself stays untested — it is thin wiring, and covering it would mean
introducing WebSocket, OPFS and WebGL shims this app does not have.

Worth probing by hand: a command emitting multi-byte output large enough to
span frames (`ls` over a directory of CJK filenames, or `cat` on a large UTF-8
file) and confirming no replacement characters appear at the boundaries.

Reported by @gustavosbarreto in #6766.