### PR TITLE
fix(ui): repair AcceptInvite race, profile bug, and consolidate branches

### DIFF
--- a/ui/apps/console/src/hooks/__tests__/useInvitations.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useInvitations.test.ts
@@ -2,13 +2,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useNamespaceInvitations } from "../useInvitations";
+import {
+  useNamespaceInvitations,
+  useResolveInvitation,
+} from "../useInvitations";
 import type { MembershipInvitation } from "../../client";
 
 vi.mock("../../client", () => ({
   getMembershipInvitationList: vi.fn(),
   getNamespaceMembershipInvitationList: vi.fn(),
 }));
+
+const mockResolveFn = vi.fn();
 
 vi.mock("../../client/@tanstack/react-query.gen", () => ({
   getMembershipInvitationListQueryKey: vi.fn((opts: unknown) => [
@@ -19,6 +24,10 @@ vi.mock("../../client/@tanstack/react-query.gen", () => ({
     { _id: "getNamespaceMembershipInvitationList" },
     opts,
   ]),
+  resolveInvitationOptions: vi.fn((opts: unknown) => ({
+    queryKey: [{ _id: "resolveInvitation" }, opts],
+    queryFn: () => mockResolveFn() as unknown,
+  })),
 }));
 
 vi.mock("../../api/pagination", () => ({
@@ -154,5 +163,75 @@ describe("useNamespaceInvitations", () => {
       expect(opts.query.page).toBe(1);
       expect(opts.query.per_page).toBe(10);
     });
+  });
+});
+
+describe("useResolveInvitation", () => {
+  it("normalizes wire fields to camelCase", async () => {
+    mockResolveFn.mockResolvedValue({
+      tenant_id: "t1",
+      user_id: "u1",
+      email: "alice@example.com",
+      status: "confirmed",
+    });
+
+    const { result } = renderHook(() => useResolveInvitation("CODE"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.resolved).toEqual({
+      tenantId: "t1",
+      userId: "u1",
+      email: "alice@example.com",
+      status: "confirmed",
+    });
+  });
+
+  it.each(["tenant_id", "user_id", "status"])(
+    "returns null when %s is missing",
+    async (field) => {
+      const data = {
+        tenant_id: "t1",
+        user_id: "u1",
+        email: "a@b.com",
+        status: "confirmed",
+        [field]: null,
+      };
+      mockResolveFn.mockResolvedValue(data);
+
+      const { result } = renderHook(() => useResolveInvitation("CODE"), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.resolved).toBeNull();
+    },
+  );
+
+  it("falls back to empty string when email is null", async () => {
+    mockResolveFn.mockResolvedValue({
+      tenant_id: "t1",
+      user_id: "u1",
+      email: null,
+      status: "invited",
+    });
+
+    const { result } = renderHook(() => useResolveInvitation("CODE"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.resolved?.email).toBe("");
+  });
+
+  it("does not fetch when invite is empty", () => {
+    const { result } = renderHook(() => useResolveInvitation(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.resolved).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(mockResolveFn).not.toHaveBeenCalled();
   });
 });

--- a/ui/apps/console/src/hooks/useInvitations.ts
+++ b/ui/apps/console/src/hooks/useInvitations.ts
@@ -4,7 +4,10 @@ import {
   type GetNamespaceMembershipInvitationListData,
   type MembershipInvitation,
 } from "@/client";
-import { getNamespaceMembershipInvitationListQueryKey } from "@/client/@tanstack/react-query.gen";
+import {
+  getNamespaceMembershipInvitationListQueryKey,
+  resolveInvitationOptions,
+} from "@/client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "@/api/pagination";
 import {
   invitationStatusFilter,
@@ -17,6 +20,27 @@ interface UseNamespaceInvitationsParams {
   page?: number;
   perPage?: number;
   enabled?: boolean;
+}
+
+export function useResolveInvitation(invite: string) {
+  const { data, isLoading, isError } = useQuery({
+    ...resolveInvitationOptions({ query: { invite } }),
+    enabled: !!invite,
+    retry: false,
+    staleTime: Infinity,
+  });
+
+  const resolved =
+    data?.tenant_id && data.user_id && data.status
+      ? {
+          tenantId: data.tenant_id,
+          userId: data.user_id,
+          email: data.email ?? "",
+          status: data.status,
+        }
+      : null;
+
+  return { resolved, isLoading, isError };
 }
 
 export function useNamespaceInvitations({

--- a/ui/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui/apps/console/src/pages/AcceptInvite.tsx
@@ -274,7 +274,10 @@ export default function AcceptInvite() {
               <h2 className="text-lg font-semibold text-text-primary mb-2">
                 You&apos;ve been invited
               </h2>
-              <p className="text-sm text-text-secondary leading-relaxed">
+              <p
+                id="invite-email-hint"
+                className="text-sm text-text-secondary leading-relaxed"
+              >
                 Set up your account to join. You&apos;re joining as{" "}
                 <span className="font-medium text-text-primary font-mono">
                   {inviteEmail || "your email"}
@@ -290,6 +293,7 @@ export default function AcceptInvite() {
               onSubmit={(e) => void handleSubmit(handleSignUp)(e)}
               className="space-y-4"
               aria-label="Complete your account"
+              aria-describedby="invite-email-hint"
             >
               <FormInputField<InviteFormValues>
                 id="invite-name"
@@ -389,6 +393,11 @@ export default function AcceptInvite() {
                 Go to Dashboard
               </Button>
             </div>
+            {switchNamespace.isPending && (
+              <p className="sr-only" role="status">
+                Switching to namespace…
+              </p>
+            )}
           </div>
         )}
 

--- a/ui/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui/apps/console/src/pages/AcceptInvite.tsx
@@ -44,7 +44,7 @@ export default function AcceptInvite() {
   const authUserId = useAuthStore((s) => s.userId);
   const authEmail = useAuthStore((s) => s.email);
   const logout = useAuthStore((s) => s.logout);
-  const setSession = useAuthStore((s) => s.setSession);
+  const loginWithToken = useAuthStore((s) => s.loginWithToken);
 
   const invite = searchParams.get("invite") ?? "";
 
@@ -147,7 +147,7 @@ export default function AcceptInvite() {
     setError("");
     try {
       if (postAction?.kind === "joined" && postAction.token) {
-        setSession({ token: postAction.token, tenant });
+        await loginWithToken(postAction.token);
       }
 
       await switchNamespace.mutateAsync({

--- a/ui/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui/apps/console/src/pages/AcceptInvite.tsx
@@ -10,10 +10,10 @@ import {
   UserCircleIcon,
   ClockIcon,
 } from "@heroicons/react/24/outline";
-import { resolveInvitation } from "@/client";
 import { useAuthStore } from "@/stores/authStore";
 import { useSignUpStore } from "@/stores/signUpStore";
 import { useAcceptInvite } from "@/hooks/useInvitationMutations";
+import { useResolveInvitation } from "@/hooks/useInvitations";
 import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import {
@@ -25,14 +25,17 @@ import { cn } from "@shellhub/design-system/cn";
 import { inviteResolver, type InviteFormValues } from "./setup/inviteResolver";
 
 type Branch =
-  | { kind: "loading" }
-  | { kind: "missing-params" }
-  | { kind: "error"; message: string }
-  | { kind: "wrong-user" }
-  | { kind: "complete" } // account doesn't exist yet: the invitee sets it up here
-  | { kind: "submitted" } // completed, waiting for a superadmin's approval
-  | { kind: "joined"; token?: string } // accepted/completed and live: confirm before entering
-  | { kind: "ready" }; // account exists and is signed in: accept
+  | "loading"
+  | "missing-params"
+  | "error"
+  | "wrong-user"
+  | "sign-up"
+  | "pending-approval"
+  | "joined"
+  | "accept";
+
+type PostAction =
+  { kind: "pending-approval" } | { kind: "joined"; token?: string };
 
 export default function AcceptInvite() {
   const [searchParams] = useSearchParams();
@@ -52,14 +55,14 @@ export default function AcceptInvite() {
   const signUpLoading = useSignUpStore((s) => s.signUpLoading);
   const signUpError = useSignUpStore((s) => s.signUpError);
 
-  // Resolved from the invite code (the link no longer carries these). tenant is
-  // needed to accept/decline; email is shown as context while completing.
-  const [tenant, setTenant] = useState("");
-  const [inviteEmail, setInviteEmail] = useState("");
-  const [branch, setBranch] = useState<Branch>({ kind: "loading" });
-  const [confirmKind, setConfirmKind] = useState<"accept" | null>(null);
-  const [actionError, setActionError] = useState("");
-  const [completeError, setCompleteError] = useState("");
+  const { resolved, isLoading, isError } = useResolveInvitation(invite);
+
+  const tenant = resolved?.tenantId ?? "";
+  const inviteEmail = resolved?.email ?? "";
+
+  const [postAction, setPostAction] = useState<PostAction | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [error, setError] = useState("");
 
   const { control, handleSubmit } = useForm<InviteFormValues>({
     resolver: inviteResolver,
@@ -72,76 +75,36 @@ export default function AcceptInvite() {
     },
   });
 
+  const needsLogin =
+    !authToken &&
+    !postAction &&
+    !!resolved &&
+    (resolved.status === "not-confirmed" || resolved.status === "confirmed");
+
   useEffect(() => {
-    let cancelled = false;
+    if (!needsLogin) return;
+    const redirectTarget = `/accept-invite?invite=${encodeURIComponent(invite)}`;
+    void navigate(`/login?redirect=${encodeURIComponent(redirectTarget)}`);
+  }, [needsLogin, invite, navigate]);
 
-    async function resolve() {
-      if (!invite) {
-        if (!cancelled) setBranch({ kind: "missing-params" });
-        return;
-      }
+  const branch: Branch = (() => {
+    if (postAction) return postAction.kind;
+    if (!invite) return "missing-params";
+    if (isLoading || needsLogin) return "loading";
+    if (isError || !resolved) return "error";
 
-      try {
-        const { data } = await resolveInvitation({
-          query: { invite },
-          throwOnError: true,
-        });
-        if (cancelled) return;
-
-        if (data.tenant_id) setTenant(data.tenant_id);
-        if (data.email) setInviteEmail(data.email);
-
-        // Logged in: only the invited account may accept. Compare against the
-        // account the code resolves to.
-        if (authToken) {
-          if (authUserId === data.user_id) setBranch({ kind: "ready" });
-          else setBranch({ kind: "wrong-user" });
-          return;
-        }
-
-        // No account yet — the invitee sets it up right here, no generic sign-up.
-        if (data.status === "invited") {
-          setBranch({ kind: "complete" });
-          return;
-        }
-
-        // Account exists but they aren't signed in: send them to log in, then
-        // back here to accept.
-        if (data.status === "not-confirmed" || data.status === "confirmed") {
-          const redirectTarget = `/accept-invite?invite=${encodeURIComponent(invite)}`;
-          void navigate(
-            `/login?redirect=${encodeURIComponent(redirectTarget)}`,
-          );
-          return;
-        }
-
-        if (!cancelled) {
-          setBranch({
-            kind: "error",
-            message: "We couldn't verify this invitation. Please try again.",
-          });
-        }
-      } catch {
-        if (!cancelled) {
-          setBranch({
-            kind: "error",
-            message:
-              "This invitation is invalid or has expired. Please ask the sender for a new one.",
-          });
-        }
-      }
+    if (authToken) {
+      return authUserId === resolved.userId ? "accept" : "wrong-user";
     }
 
-    void resolve();
-    return () => {
-      cancelled = true;
-    };
-  }, [invite, authToken, authUserId, navigate]);
+    if (resolved.status === "invited") return "sign-up";
 
-  const onComplete = async (values: InviteFormValues) => {
-    setCompleteError("");
+    return "error";
+  })();
 
-    // email comes from the invite; no ToS/marketing (that's Cloud's open sign-up).
+  const handleSignUp = async (values: InviteFormValues) => {
+    setError("");
+
     const token = await signUp({
       name: values.name,
       username: values.username,
@@ -151,60 +114,48 @@ export default function AcceptInvite() {
       sig: invite,
     });
 
-    const { signUpError: err, signUpServerFields: fields } =
-      useSignUpStore.getState();
-
-    if (err) return; // shown via the signUpError Callout
-    if (fields.length > 0) {
-      setCompleteError(
+    const { signUpError: err, signUpServerFields } = useSignUpStore.getState();
+    if (err) return;
+    if (signUpServerFields.length > 0) {
+      setError(
         "That username or email is already in use. Try a different username.",
       );
       return;
     }
 
     if (token) {
-      // Confirmed account (superadmin invite / Cloud). Carry the token so entering the namespace
-      // can establish the session. Calling setSession here would flip authToken and re-run the
-      // resolve effect, clobbering this screen; defer it to handleEnterNamespace instead.
-      setBranch({ kind: "joined", token });
+      setPostAction({ kind: "joined", token });
       return;
     }
 
-    // No token: the account was created but needs a superadmin's approval
-    // before it can sign in (Enterprise, non-superadmin inviter).
-    setBranch({ kind: "submitted" });
+    setPostAction({ kind: "pending-approval" });
   };
 
   const handleAccept = async () => {
     if (!tenant || !authToken) return;
-    setActionError("");
+    setError("");
     try {
       await acceptInvite.mutateAsync({ path: { tenant } });
-      setConfirmKind(null);
-      setBranch({ kind: "joined" });
+      setShowConfirm(false);
+      setPostAction({ kind: "joined" });
     } catch {
-      setActionError("Failed to accept the invitation. Please try again.");
+      setError("Failed to accept the invitation. Please try again.");
     }
   };
 
   const handleEnterNamespace = async () => {
-    setActionError("");
+    setError("");
     try {
-      // A freshly-completed account isn't signed in yet: establish the session from the completion
-      // token so getNamespaceToken is authenticated. (The accept flow of an existing account is
-      // already signed in and carries no token.)
-      if (branch.kind === "joined" && branch.token) {
-        setSession({ token: branch.token, tenant });
+      if (postAction?.kind === "joined" && postAction.token) {
+        setSession({ token: postAction.token, tenant });
       }
 
-      // switchNamespace mints a fresh namespace-scoped token, stores { token, tenant, role }
-      // via setSession, and hard-navigates so NamespaceGuard re-initializes cleanly.
       await switchNamespace.mutateAsync({
         tenantId: tenant,
         redirectTo: "/dashboard",
       });
     } catch {
-      setActionError("Couldn't open the namespace. Please try again.");
+      setError("Couldn't open the namespace. Please try again.");
     }
   };
 
@@ -218,7 +169,7 @@ export default function AcceptInvite() {
   return (
     <div className="w-full max-w-md mx-auto animate-fade-in">
       <div className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm">
-        {branch.kind === "loading" && (
+        {branch === "loading" && (
           <div
             className="flex flex-col items-center gap-3 py-6"
             role="status"
@@ -229,7 +180,7 @@ export default function AcceptInvite() {
           </div>
         )}
 
-        {branch.kind === "missing-params" && (
+        {branch === "missing-params" && (
           <InvitationMessage
             tone="error"
             icon={
@@ -254,7 +205,7 @@ export default function AcceptInvite() {
           />
         )}
 
-        {branch.kind === "error" && (
+        {branch === "error" && (
           <InvitationMessage
             tone="error"
             icon={
@@ -264,7 +215,7 @@ export default function AcceptInvite() {
               />
             }
             title="Invitation Unavailable"
-            description={branch.message}
+            description="This invitation is invalid or has expired. Please ask the sender for a new one."
             action={
               <Button
                 as={Link}
@@ -279,7 +230,7 @@ export default function AcceptInvite() {
           />
         )}
 
-        {branch.kind === "wrong-user" && (
+        {branch === "wrong-user" && (
           <InvitationMessage
             tone="warning"
             icon={
@@ -311,7 +262,7 @@ export default function AcceptInvite() {
           />
         )}
 
-        {branch.kind === "complete" && (
+        {branch === "sign-up" && (
           <div>
             <div className="text-center mb-6">
               <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 border border-primary/20 mb-5">
@@ -332,19 +283,11 @@ export default function AcceptInvite() {
               </p>
             </div>
 
-            {signUpError && (
-              <Callout variant="error" className="mb-4">
-                {signUpError}
-              </Callout>
-            )}
-            {completeError && (
-              <Callout variant="error" className="mb-4">
-                {completeError}
-              </Callout>
-            )}
+            <ErrorCallout message={signUpError} />
+            <ErrorCallout message={error} />
 
             <form
-              onSubmit={(e) => void handleSubmit(onComplete)(e)}
+              onSubmit={(e) => void handleSubmit(handleSignUp)(e)}
               className="space-y-4"
               aria-label="Complete your account"
             >
@@ -385,7 +328,7 @@ export default function AcceptInvite() {
           </div>
         )}
 
-        {branch.kind === "submitted" && (
+        {branch === "pending-approval" && (
           <InvitationMessage
             tone="warning"
             icon={
@@ -410,7 +353,7 @@ export default function AcceptInvite() {
           />
         )}
 
-        {branch.kind === "joined" && (
+        {branch === "joined" && (
           <div className="text-center">
             <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-green/10 border border-accent-green/20 mb-5">
               <CheckCircleIcon
@@ -434,11 +377,7 @@ export default function AcceptInvite() {
               ) : null}
               .
             </p>
-            {actionError && (
-              <Callout variant="error" className="mb-4">
-                {actionError}
-              </Callout>
-            )}
+            <ErrorCallout message={error} />
             <div className="flex items-center justify-center">
               <Button
                 onClick={() => void handleEnterNamespace()}
@@ -453,7 +392,7 @@ export default function AcceptInvite() {
           </div>
         )}
 
-        {branch.kind === "ready" && (
+        {branch === "accept" && (
           <div className="text-center">
             <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 border border-primary/20 mb-5">
               <EnvelopeOpenIcon
@@ -471,7 +410,7 @@ export default function AcceptInvite() {
             <div className="flex items-center justify-center">
               <Button
                 icon={<CheckCircleIcon className="w-4 h-4" strokeWidth={2} />}
-                onClick={() => setConfirmKind("accept")}
+                onClick={() => setShowConfirm(true)}
               >
                 Accept
               </Button>
@@ -481,19 +420,28 @@ export default function AcceptInvite() {
       </div>
 
       <ConfirmDialog
-        open={confirmKind === "accept"}
+        open={showConfirm}
         onClose={() => {
-          setConfirmKind(null);
-          setActionError("");
+          setShowConfirm(false);
+          setError("");
         }}
         onConfirm={handleAccept}
         title="Accept Invitation"
         description="You will be added to the namespace and switched to it immediately."
         confirmLabel="Accept"
         variant="primary"
-        errorMessage={confirmKind === "accept" ? actionError || null : null}
+        errorMessage={error || null}
       />
     </div>
+  );
+}
+
+function ErrorCallout({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <Callout variant="error" className="mb-4">
+      {message}
+    </Callout>
   );
 }
 
@@ -517,7 +465,10 @@ function InvitationMessage({
   return (
     <div className="text-center">
       <div
-        className={cn("inline-flex items-center justify-center w-14 h-14 rounded-full border mb-5", ringClass)}
+        className={cn(
+          "inline-flex items-center justify-center w-14 h-14 rounded-full border mb-5",
+          ringClass,
+        )}
       >
         {icon}
       </div>

--- a/ui/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui/apps/console/src/pages/AcceptInvite.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { ComponentType, SVGProps, useEffect, useState } from "react";
 import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import {
@@ -166,6 +166,159 @@ export default function AcceptInvite() {
     );
   };
 
+  const messages: Partial<Record<Branch, InvitationMessageProps>> = {
+    "missing-params": {
+      tone: "error",
+      icon: XCircleIcon,
+      title: "Invalid Invitation",
+      description:
+        "This invitation link is missing its code. Please use the link from the original email.",
+      action: { label: "Back to Login", to: "/login" },
+    },
+    error: {
+      tone: "error",
+      icon: ExclamationTriangleIcon,
+      title: "Invitation Unavailable",
+      description:
+        "This invitation is invalid or has expired. Please ask the sender for a new one.",
+      action: { label: "Back to Login", to: "/login" },
+    },
+    "wrong-user": {
+      tone: "warning",
+      icon: UserCircleIcon,
+      title: "Different Account Signed In",
+      description: (
+        <>
+          You're signed in as{" "}
+          <span className="font-medium text-text-primary font-mono">
+            {authEmail ?? "another account"}
+          </span>
+          . Sign out and use the account this invitation was sent to.
+        </>
+      ),
+      action: { label: "Sign Out", onClick: handleSignOut },
+    },
+    "sign-up": {
+      tone: "primary",
+      icon: EnvelopeOpenIcon,
+      title: "You've been invited",
+      descriptionId: "invite-email-hint",
+      description: (
+        <>
+          Set up your account to join. You're joining as{" "}
+          <span className="font-medium text-text-primary font-mono">
+            {inviteEmail || "your email"}
+          </span>
+          .
+        </>
+      ),
+      children: (
+        <>
+          <ErrorCallout message={signUpError} />
+          <ErrorCallout message={error} />
+
+          <form
+            onSubmit={(e) => void handleSubmit(handleSignUp)(e)}
+            className="space-y-4"
+            aria-label="Complete your account"
+            aria-describedby="invite-email-hint"
+          >
+            <FormInputField<InviteFormValues>
+              id="invite-name"
+              label="Name"
+              name="name"
+              control={control}
+              placeholder="Your name"
+              autoComplete="name"
+            />
+            <FormInputField<InviteFormValues>
+              id="invite-username"
+              label="Username"
+              name="username"
+              control={control}
+              placeholder="username"
+              autoComplete="username"
+            />
+            <FormPasswordField<InviteFormValues>
+              id="invite-password"
+              label="Password"
+              name="password"
+              control={control}
+              autoComplete="new-password"
+            />
+            <FormPasswordField<InviteFormValues>
+              id="invite-confirm-password"
+              label="Confirm password"
+              name="confirmPassword"
+              control={control}
+              autoComplete="new-password"
+            />
+            <Button type="submit" className="w-full" loading={signUpLoading}>
+              Join Namespace
+            </Button>
+          </form>
+        </>
+      ),
+    },
+    "pending-approval": {
+      tone: "warning",
+      icon: ClockIcon,
+      title: "Waiting for Approval",
+      description:
+        "Your account was created and is waiting for an administrator to approve it. You'll be able to sign in once it's approved.",
+      action: { label: "Back to Login", to: "/login" },
+    },
+    joined: {
+      tone: "success",
+      icon: CheckCircleIcon,
+      title: "You're in",
+      description: (
+        <>
+          Your account is now a member of the namespace
+          {inviteEmail ? (
+            <>
+              {" "}
+              as{" "}
+              <span className="font-medium text-text-primary font-mono">
+                {inviteEmail}
+              </span>
+            </>
+          ) : null}
+          .
+        </>
+      ),
+      action: {
+        label: "Go to Dashboard",
+        onClick: () => void handleEnterNamespace(),
+        loading: switchNamespace.isPending,
+      },
+      children: (
+        <>
+          <ErrorCallout message={error} />
+          {switchNamespace.isPending && (
+            <p className="sr-only" role="status">
+              Switching to namespace…
+            </p>
+          )}
+        </>
+      ),
+    },
+    accept: {
+      tone: "primary",
+      icon: EnvelopeOpenIcon,
+      title: "Namespace Invitation",
+      description:
+        "Accepting this invitation will add you to the namespace. You will be automatically switched to it after accepting.",
+      action: {
+        label: "Accept",
+        onClick: () => setShowConfirm(true),
+        icon: CheckCircleIcon,
+      },
+    },
+  };
+
+  const message = messages[branch];
+
   return (
     <div className="w-full max-w-md mx-auto animate-fade-in">
       <div className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm">
@@ -180,252 +333,7 @@ export default function AcceptInvite() {
           </div>
         )}
 
-        {branch === "missing-params" && (
-          <InvitationMessage
-            tone="error"
-            icon={
-              <XCircleIcon
-                className="w-7 h-7 text-accent-red"
-                strokeWidth={1.5}
-              />
-            }
-            title="Invalid Invitation"
-            description="This invitation link is missing its code. Please use the link from the original email."
-            action={
-              <Button
-                as={Link}
-                to="/login"
-                iconRight={
-                  <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-                }
-              >
-                Back to Login
-              </Button>
-            }
-          />
-        )}
-
-        {branch === "error" && (
-          <InvitationMessage
-            tone="error"
-            icon={
-              <ExclamationTriangleIcon
-                className="w-7 h-7 text-accent-red"
-                strokeWidth={1.5}
-              />
-            }
-            title="Invitation Unavailable"
-            description="This invitation is invalid or has expired. Please ask the sender for a new one."
-            action={
-              <Button
-                as={Link}
-                to="/login"
-                iconRight={
-                  <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-                }
-              >
-                Back to Login
-              </Button>
-            }
-          />
-        )}
-
-        {branch === "wrong-user" && (
-          <InvitationMessage
-            tone="warning"
-            icon={
-              <UserCircleIcon
-                className="w-7 h-7 text-accent-yellow"
-                strokeWidth={1.5}
-              />
-            }
-            title="Different Account Signed In"
-            description={
-              <>
-                You&apos;re signed in as{" "}
-                <span className="font-medium text-text-primary font-mono">
-                  {authEmail ?? "another account"}
-                </span>
-                . Sign out and use the account this invitation was sent to.
-              </>
-            }
-            action={
-              <Button
-                onClick={handleSignOut}
-                iconRight={
-                  <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-                }
-              >
-                Sign Out
-              </Button>
-            }
-          />
-        )}
-
-        {branch === "sign-up" && (
-          <div>
-            <div className="text-center mb-6">
-              <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 border border-primary/20 mb-5">
-                <EnvelopeOpenIcon
-                  className="w-7 h-7 text-primary"
-                  strokeWidth={1.5}
-                />
-              </div>
-              <h2 className="text-lg font-semibold text-text-primary mb-2">
-                You&apos;ve been invited
-              </h2>
-              <p
-                id="invite-email-hint"
-                className="text-sm text-text-secondary leading-relaxed"
-              >
-                Set up your account to join. You&apos;re joining as{" "}
-                <span className="font-medium text-text-primary font-mono">
-                  {inviteEmail || "your email"}
-                </span>
-                .
-              </p>
-            </div>
-
-            <ErrorCallout message={signUpError} />
-            <ErrorCallout message={error} />
-
-            <form
-              onSubmit={(e) => void handleSubmit(handleSignUp)(e)}
-              className="space-y-4"
-              aria-label="Complete your account"
-              aria-describedby="invite-email-hint"
-            >
-              <FormInputField<InviteFormValues>
-                id="invite-name"
-                label="Name"
-                name="name"
-                control={control}
-                placeholder="Your name"
-                autoComplete="name"
-              />
-              <FormInputField<InviteFormValues>
-                id="invite-username"
-                label="Username"
-                name="username"
-                control={control}
-                placeholder="username"
-                autoComplete="username"
-              />
-              <FormPasswordField<InviteFormValues>
-                id="invite-password"
-                label="Password"
-                name="password"
-                control={control}
-                autoComplete="new-password"
-              />
-              <FormPasswordField<InviteFormValues>
-                id="invite-confirm-password"
-                label="Confirm password"
-                name="confirmPassword"
-                control={control}
-                autoComplete="new-password"
-              />
-              <Button type="submit" className="w-full" loading={signUpLoading}>
-                Join Namespace
-              </Button>
-            </form>
-          </div>
-        )}
-
-        {branch === "pending-approval" && (
-          <InvitationMessage
-            tone="warning"
-            icon={
-              <ClockIcon
-                className="w-7 h-7 text-accent-yellow"
-                strokeWidth={1.5}
-              />
-            }
-            title="Waiting for Approval"
-            description="Your account was created and is waiting for an administrator to approve it. You'll be able to sign in once it's approved."
-            action={
-              <Button
-                as={Link}
-                to="/login"
-                iconRight={
-                  <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-                }
-              >
-                Back to Login
-              </Button>
-            }
-          />
-        )}
-
-        {branch === "joined" && (
-          <div className="text-center">
-            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-green/10 border border-accent-green/20 mb-5">
-              <CheckCircleIcon
-                className="w-7 h-7 text-accent-green"
-                strokeWidth={1.5}
-              />
-            </div>
-            <h2 className="text-lg font-semibold text-text-primary mb-3">
-              You&apos;re in
-            </h2>
-            <p className="text-sm text-text-secondary leading-relaxed mb-6">
-              Your account is now a member of the namespace
-              {inviteEmail ? (
-                <>
-                  {" "}
-                  as{" "}
-                  <span className="font-medium text-text-primary font-mono">
-                    {inviteEmail}
-                  </span>
-                </>
-              ) : null}
-              .
-            </p>
-            <ErrorCallout message={error} />
-            <div className="flex items-center justify-center">
-              <Button
-                onClick={() => void handleEnterNamespace()}
-                loading={switchNamespace.isPending}
-                iconRight={
-                  <ArrowRightIcon className="w-4 h-4" strokeWidth={2} />
-                }
-              >
-                Go to Dashboard
-              </Button>
-            </div>
-            {switchNamespace.isPending && (
-              <p className="sr-only" role="status">
-                Switching to namespace…
-              </p>
-            )}
-          </div>
-        )}
-
-        {branch === "accept" && (
-          <div className="text-center">
-            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 border border-primary/20 mb-5">
-              <EnvelopeOpenIcon
-                className="w-7 h-7 text-primary"
-                strokeWidth={1.5}
-              />
-            </div>
-            <h2 className="text-lg font-semibold text-text-primary mb-3">
-              Namespace Invitation
-            </h2>
-            <p className="text-sm text-text-secondary leading-relaxed mb-6">
-              Accepting this invitation will add you to the namespace. You will
-              be automatically switched to it after accepting.
-            </p>
-            <div className="flex items-center justify-center">
-              <Button
-                icon={<CheckCircleIcon className="w-4 h-4" strokeWidth={2} />}
-                onClick={() => setShowConfirm(true)}
-              >
-                Accept
-              </Button>
-            </div>
-          </div>
-        )}
+        {message && <InvitationMessage {...message} />}
       </div>
 
       <ConfirmDialog
@@ -454,38 +362,102 @@ function ErrorCallout({ message }: { message: string | null }) {
   );
 }
 
-function InvitationMessage({
-  tone,
-  icon,
-  title,
-  description,
-  action,
-}: {
-  tone: "error" | "warning";
-  icon: React.ReactNode;
+type Tone = "error" | "warning" | "primary" | "success";
+
+const toneStyles: Record<Tone, { ring: string; iconColor: string }> = {
+  error: {
+    ring: "bg-accent-red/10 border-accent-red/20",
+    iconColor: "text-accent-red",
+  },
+  warning: {
+    ring: "bg-accent-yellow/10 border-accent-yellow/20",
+    iconColor: "text-accent-yellow",
+  },
+  primary: { ring: "bg-primary/10 border-primary/20", iconColor: "text-primary" },
+  success: {
+    ring: "bg-accent-green/10 border-accent-green/20",
+    iconColor: "text-accent-green",
+  },
+};
+
+interface InvitationActionProps {
+  label: string;
+  to?: string;
+  onClick?: () => void;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  loading?: boolean;
+}
+
+interface InvitationMessageProps {
+  tone: Tone;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
   title: string;
   description: React.ReactNode;
-  action: React.ReactNode;
-}) {
-  const ringClass =
-    tone === "error"
-      ? "bg-accent-red/10 border-accent-red/20"
-      : "bg-accent-yellow/10 border-accent-yellow/20";
+  descriptionId?: string;
+  action?: InvitationActionProps;
+  children?: React.ReactNode;
+}
+
+function InvitationMessage({
+  tone,
+  icon: Icon,
+  title,
+  description,
+  descriptionId,
+  action,
+  children,
+}: InvitationMessageProps) {
+  const { ring, iconColor } = toneStyles[tone];
+
+  return (
+    <div>
+      <div className="text-center">
+        <div
+          className={cn(
+            "inline-flex items-center justify-center w-14 h-14 rounded-full border mb-5",
+            ring,
+          )}
+        >
+          <Icon className={cn("w-7 h-7", iconColor)} strokeWidth={1.5} />
+        </div>
+        <h1 className="text-lg font-semibold text-text-primary mb-3">
+          {title}
+        </h1>
+        <p
+          id={descriptionId}
+          className="text-sm text-text-secondary leading-relaxed mb-6"
+        >
+          {description}
+        </p>
+      </div>
+      {children}
+      {action && <InvitationAction {...action} />}
+    </div>
+  );
+}
+
+function InvitationAction({
+  label,
+  to,
+  onClick,
+  icon: ActionIcon,
+  loading,
+}: InvitationActionProps) {
+  const iconProps = ActionIcon
+    ? { icon: <ActionIcon className="w-4 h-4" strokeWidth={2} /> }
+    : { iconRight: <ArrowRightIcon className="w-4 h-4" strokeWidth={2} /> };
+
   return (
     <div className="text-center">
-      <div
-        className={cn(
-          "inline-flex items-center justify-center w-14 h-14 rounded-full border mb-5",
-          ringClass,
-        )}
-      >
-        {icon}
-      </div>
-      <h2 className="text-lg font-semibold text-text-primary mb-3">{title}</h2>
-      <p className="text-sm text-text-secondary leading-relaxed mb-6">
-        {description}
-      </p>
-      {action}
+      {to ? (
+        <Button as={Link} to={to} loading={loading} {...iconProps}>
+          {label}
+        </Button>
+      ) : (
+        <Button onClick={onClick} loading={loading} {...iconProps}>
+          {label}
+        </Button>
+      )}
     </div>
   );
 }

--- a/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
@@ -154,6 +154,16 @@ beforeEach(() => {
     role: null,
     name: null,
     loading: false,
+    loginWithToken: async (token: string) => {
+      useAuthStore.setState({
+        token,
+        user: "alice",
+        userId: "u1",
+        email: "alice@example.com",
+        name: "Alice",
+        loading: false,
+      });
+    },
   });
   signUpState.signUpLoading = false;
   signUpState.signUpError = null;
@@ -329,9 +339,11 @@ describe("AcceptInvite", () => {
           redirectTo: "/dashboard",
         }),
       );
-      // The completion token must establish the session, otherwise switchNamespace fires
-      // unauthenticated and bounces the invitee to /login.
-      expect(useAuthStore.getState().token).toBe("tok");
+      const session = useAuthStore.getState();
+      expect(session.token).toBe("tok");
+      expect(session.user).toBe("alice");
+      expect(session.name).toBe("Alice");
+      expect(session.email).toBe("alice@example.com");
     });
 
     it("shows the Waiting for Approval screen when no token is returned", async () => {

--- a/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
@@ -88,6 +88,7 @@ vi.mock("@/stores/signUpStore", () => ({
 
 const mockAcceptMutateAsync = vi.fn();
 const mockSwitchNamespaceMutateAsync = vi.fn();
+const switchNamespaceState = vi.hoisted(() => ({ isPending: false }));
 
 vi.mock("@/hooks/useInvitationMutations", () => ({
   useAcceptInvite: () => ({
@@ -99,7 +100,9 @@ vi.mock("@/hooks/useInvitationMutations", () => ({
 vi.mock("@/hooks/useNamespaceMutations", () => ({
   useSwitchNamespace: () => ({
     mutateAsync: mockSwitchNamespaceMutateAsync,
-    isPending: false,
+    get isPending() {
+      return switchNamespaceState.isPending;
+    },
   }),
 }));
 
@@ -168,6 +171,7 @@ beforeEach(() => {
   signUpState.signUpLoading = false;
   signUpState.signUpError = null;
   signUpState.signUpServerFields = [];
+  switchNamespaceState.isPending = false;
   mockAcceptMutateAsync.mockResolvedValue(undefined);
   mockSwitchNamespaceMutateAsync.mockResolvedValue(undefined);
   setResolved("confirmed");
@@ -308,6 +312,17 @@ describe("AcceptInvite", () => {
       expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument();
     });
 
+    it("links the form to the email hint via aria-describedby", () => {
+      renderPage(VALID_PARAMS);
+      const form = screen.getByRole("form", {
+        name: /complete your account/i,
+      });
+      const describedById = form.getAttribute("aria-describedby");
+      expect(describedById).toBeTruthy();
+      const hint = document.getElementById(describedById!);
+      expect(hint).toHaveTextContent(/alice@example.com/);
+    });
+
     it("submits with the invite code as sig, no marketing, and switches namespace on token", async () => {
       mockSignUp.mockResolvedValue("tok");
       const user = userEvent.setup();
@@ -344,6 +359,34 @@ describe("AcceptInvite", () => {
       expect(session.user).toBe("alice");
       expect(session.name).toBe("Alice");
       expect(session.email).toBe("alice@example.com");
+    });
+
+    it("announces the loading state to screen readers when switching namespace", async () => {
+      mockSignUp.mockResolvedValue("tok");
+      const user = userEvent.setup();
+      renderPage(VALID_PARAMS);
+      await fillForm(user);
+      await user.click(screen.getByRole("button", { name: /join namespace/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("heading", { name: /you're in/i }),
+        ).toBeInTheDocument(),
+      );
+
+      switchNamespaceState.isPending = true;
+      mockSwitchNamespaceMutateAsync.mockReturnValue(new Promise(() => {}));
+
+      await user.click(
+        screen.getByRole("button", { name: /go to dashboard/i }),
+      );
+
+      await waitFor(() => {
+        const statuses = screen.getAllByRole("status");
+        expect(statuses.some((el) => el.textContent?.match(/switching/i))).toBe(
+          true,
+        );
+      });
     });
 
     it("shows the Waiting for Approval screen when no token is returned", async () => {

--- a/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
@@ -9,7 +9,6 @@ import {
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAuthStore } from "@/stores/authStore";
 import AcceptInvite from "../AcceptInvite";
 
@@ -59,11 +58,14 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-const mockResolveInvitation = vi.fn();
+const mockResolveResult = vi.hoisted(() => ({
+  resolved: null as Record<string, unknown> | null,
+  isLoading: false,
+  isError: false,
+}));
 
-vi.mock("@/client", () => ({
-  resolveInvitation: (...args: unknown[]): unknown =>
-    mockResolveInvitation(...args),
+vi.mock("@/hooks/useInvitations", () => ({
+  useResolveInvitation: () => mockResolveResult,
 }));
 
 const { mockSignUp, signUpState } = vi.hoisted(() => {
@@ -108,29 +110,25 @@ vi.mock("@/hooks/useNamespaceMutations", () => ({
 const INVITE_CODE = "INVITECODE12";
 const VALID_PARAMS = `invite=${INVITE_CODE}`;
 
-function resolved(status: string) {
-  return {
-    data: {
-      tenant_id: "t1",
-      user_id: "u1",
-      email: "alice@example.com",
-      status,
-    },
-    response: new Response(),
+function setResolved(status: string) {
+  mockResolveResult.resolved = {
+    tenantId: "t1",
+    userId: "u1",
+    email: "alice@example.com",
+    status,
   };
+  mockResolveResult.isLoading = false;
+  mockResolveResult.isError = false;
 }
 
 function createWrapper(initialSearch = "") {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
   return ({ children }: { children: React.ReactNode }) => (
     <MemoryRouter
       initialEntries={[
         `/accept-invite${initialSearch ? "?" + initialSearch : ""}`,
       ]}
     >
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      {children}
     </MemoryRouter>
   );
 }
@@ -162,7 +160,7 @@ beforeEach(() => {
   signUpState.signUpServerFields = [];
   mockAcceptMutateAsync.mockResolvedValue(undefined);
   mockSwitchNamespaceMutateAsync.mockResolvedValue(undefined);
-  mockResolveInvitation.mockResolvedValue(resolved("confirmed"));
+  setResolved("confirmed");
 });
 
 /* ================================================================== */
@@ -182,8 +180,10 @@ describe("AcceptInvite", () => {
   });
 
   describe("initial loading state", () => {
-    it("shows the checking invitation spinner while resolving", async () => {
-      mockResolveInvitation.mockReturnValue(new Promise(() => {}));
+    it("shows the checking invitation spinner while resolving", () => {
+      mockResolveResult.resolved = null;
+      mockResolveResult.isLoading = true;
+      mockResolveResult.isError = false;
       renderPage(VALID_PARAMS);
       expect(screen.getByRole("status")).toBeInTheDocument();
       expect(screen.getByText(/checking invitation/i)).toBeInTheDocument();
@@ -191,18 +191,18 @@ describe("AcceptInvite", () => {
   });
 
   describe("branch: error (resolve rejects)", () => {
-    it("renders the Invitation Unavailable heading", async () => {
-      mockResolveInvitation.mockRejectedValue(new Error("network failure"));
+    it("renders the Invitation Unavailable heading", () => {
+      mockResolveResult.resolved = null;
+      mockResolveResult.isLoading = false;
+      mockResolveResult.isError = true;
       renderPage(VALID_PARAMS);
-      await waitFor(() =>
-        expect(
-          screen.getByRole("heading", { name: /invitation unavailable/i }),
-        ).toBeInTheDocument(),
-      );
+      expect(
+        screen.getByRole("heading", { name: /invitation unavailable/i }),
+      ).toBeInTheDocument();
     });
   });
 
-  describe("branch: ready (authenticated as the invited user)", () => {
+  describe("branch: accept (authenticated as the invited user)", () => {
     beforeEach(() => {
       useAuthStore.setState({
         token: "jwt-token",
@@ -212,13 +212,11 @@ describe("AcceptInvite", () => {
       } as never);
     });
 
-    it("renders the Namespace Invitation heading with Accept", async () => {
+    it("renders the Namespace Invitation heading with Accept", () => {
       renderPage(VALID_PARAMS);
-      await waitFor(() =>
-        expect(
-          screen.getByRole("heading", { name: /namespace invitation/i }),
-        ).toBeInTheDocument(),
-      );
+      expect(
+        screen.getByRole("heading", { name: /namespace invitation/i }),
+      ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /accept/i }),
       ).toBeInTheDocument();
@@ -230,11 +228,6 @@ describe("AcceptInvite", () => {
     it("accepts and switches namespace using the resolved tenant", async () => {
       const user = userEvent.setup();
       renderPage(VALID_PARAMS);
-      await waitFor(() =>
-        expect(
-          screen.getByRole("button", { name: /^accept$/i }),
-        ).toBeInTheDocument(),
-      );
       await user.click(screen.getByRole("button", { name: /^accept$/i }));
       const dialog = screen.getByRole("dialog");
       await user.click(
@@ -268,7 +261,7 @@ describe("AcceptInvite", () => {
   });
 
   describe("branch: wrong-user (authenticated as a different user)", () => {
-    it("renders the Different Account Signed In heading", async () => {
+    it("renders the Different Account Signed In heading", () => {
       useAuthStore.setState({
         token: "jwt-token",
         userId: "other-user-id",
@@ -276,17 +269,15 @@ describe("AcceptInvite", () => {
         loading: false,
       } as never);
       renderPage(VALID_PARAMS);
-      await waitFor(() =>
-        expect(
-          screen.getByRole("heading", { name: /different account signed in/i }),
-        ).toBeInTheDocument(),
-      );
+      expect(
+        screen.getByRole("heading", { name: /different account signed in/i }),
+      ).toBeInTheDocument();
     });
   });
 
-  describe("branch: complete (unauthenticated, status invited)", () => {
+  describe("branch: sign-up (unauthenticated, status invited)", () => {
     beforeEach(() => {
-      mockResolveInvitation.mockResolvedValue(resolved("invited"));
+      setResolved("invited");
     });
 
     async function fillForm(user: ReturnType<typeof userEvent.setup>) {
@@ -296,17 +287,14 @@ describe("AcceptInvite", () => {
       await user.type(screen.getByLabelText(/confirm password/i), "Secret123");
     }
 
-    it("renders the invite completion form with the resolved email", async () => {
+    it("renders the invite completion form with the resolved email", () => {
       renderPage(VALID_PARAMS);
-      await waitFor(() =>
-        expect(
-          screen.getByRole("heading", { name: /you've been invited/i }),
-        ).toBeInTheDocument(),
-      );
+      expect(
+        screen.getByRole("heading", { name: /you've been invited/i }),
+      ).toBeInTheDocument();
       expect(screen.getByText(/alice@example.com/)).toBeInTheDocument();
       expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/^username$/i)).toBeInTheDocument();
-      // Email is NOT an editable field
       expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument();
     });
 
@@ -314,11 +302,6 @@ describe("AcceptInvite", () => {
       mockSignUp.mockResolvedValue("tok");
       const user = userEvent.setup();
       renderPage(VALID_PARAMS);
-      await waitFor(() =>
-        expect(
-          screen.getByRole("button", { name: /join namespace/i }),
-        ).toBeInTheDocument(),
-      );
       await fillForm(user);
       await user.click(screen.getByRole("button", { name: /join namespace/i }));
 
@@ -355,11 +338,6 @@ describe("AcceptInvite", () => {
       mockSignUp.mockResolvedValue(null);
       const user = userEvent.setup();
       renderPage(VALID_PARAMS);
-      await waitFor(() =>
-        expect(
-          screen.getByRole("button", { name: /join namespace/i }),
-        ).toBeInTheDocument(),
-      );
       await fillForm(user);
       await user.click(screen.getByRole("button", { name: /join namespace/i }));
 
@@ -374,7 +352,7 @@ describe("AcceptInvite", () => {
 
   describe("branch: unauthenticated with an existing account → login", () => {
     it("navigates to /login with a redirect back to accept-invite when confirmed", async () => {
-      mockResolveInvitation.mockResolvedValue(resolved("confirmed"));
+      setResolved("confirmed");
       renderPage(VALID_PARAMS);
       await waitFor(() =>
         expect(mockNavigate).toHaveBeenCalledWith(
@@ -386,7 +364,7 @@ describe("AcceptInvite", () => {
     });
 
     it("navigates to /login when not-confirmed", async () => {
-      mockResolveInvitation.mockResolvedValue(resolved("not-confirmed"));
+      setResolved("not-confirmed");
       renderPage(VALID_PARAMS);
       await waitFor(() =>
         expect(mockNavigate).toHaveBeenCalledWith(

--- a/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
@@ -1,22 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  render,
-  screen,
-  cleanup,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import React from "react";
 import { useAuthStore } from "@/stores/authStore";
 import AcceptInvite from "../AcceptInvite";
 
-/* ------------------------------------------------------------------ */
-/* Mocks                                                               */
-/* ------------------------------------------------------------------ */
-
-// Stub ConfirmDialog — jsdom lacks HTMLDialogElement.showModal()
 vi.mock("@/components/common/ConfirmDialog", () => ({
   default: ({
     open,
@@ -59,7 +48,12 @@ vi.mock("react-router-dom", async (importOriginal) => {
 });
 
 const mockResolveResult = vi.hoisted(() => ({
-  resolved: null as Record<string, unknown> | null,
+  resolved: null as {
+    tenantId: string;
+    userId: string;
+    email: string;
+    status: string;
+  } | null,
   isLoading: false,
   isError: false,
 }));
@@ -106,10 +100,6 @@ vi.mock("@/hooks/useNamespaceMutations", () => ({
   }),
 }));
 
-/* ------------------------------------------------------------------ */
-/* Helpers                                                             */
-/* ------------------------------------------------------------------ */
-
 const INVITE_CODE = "INVITECODE12";
 const VALID_PARAMS = `invite=${INVITE_CODE}`;
 
@@ -139,12 +129,6 @@ function createWrapper(initialSearch = "") {
 function renderPage(search = VALID_PARAMS) {
   return render(<AcceptInvite />, { wrapper: createWrapper(search) });
 }
-
-/* ------------------------------------------------------------------ */
-/* Setup / teardown                                                    */
-/* ------------------------------------------------------------------ */
-
-afterEach(cleanup);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -176,10 +160,6 @@ beforeEach(() => {
   mockSwitchNamespaceMutateAsync.mockResolvedValue(undefined);
   setResolved("confirmed");
 });
-
-/* ================================================================== */
-/* Tests                                                               */
-/* ================================================================== */
 
 describe("AcceptInvite", () => {
   describe("branch: missing-params", () => {
@@ -223,7 +203,7 @@ describe("AcceptInvite", () => {
         userId: "u1",
         email: "alice@example.com",
         loading: false,
-      } as never);
+      });
     });
 
     it("renders the Namespace Invitation heading with Accept", () => {
@@ -281,7 +261,7 @@ describe("AcceptInvite", () => {
         userId: "other-user-id",
         email: "other@example.com",
         loading: false,
-      } as never);
+      });
       renderPage(VALID_PARAMS);
       expect(
         screen.getByRole("heading", { name: /different account signed in/i }),


### PR DESCRIPTION
## What

Fixes two bugs in AcceptInvite (re-fetch race and missing profile fields), adds screen-reader hints, and consolidates seven inline branch renders into a data-driven component.

## Changes

- **re-fetch race**: The resolve `useEffect` re-fired when `setSession` updated `authToken`, causing the consumed invite to error and flash a failure screen. Replaced with a `useResolveInvitation` React Query hook (`staleTime: Infinity`, one-shot) and derived branch at render time — auth changes no longer trigger a re-fetch.
- **missing profile**: `handleEnterNamespace` called `setSession` (token + tenant only), leaving `user`/`name`/`email` null. `UserMenu` returned null and the dashboard rendered without an account menu. Replaced with `loginWithToken`, which calls `getUserInfo` and populates all profile fields.
- **a11y**: Linked the sign-up form to the "joining as" paragraph via `aria-describedby`. Added a `role="status"` region for the namespace-switch loading state.
- **refactor**: Consolidated seven inline branch renders into a `messages` record mapping `Branch` to `InvitationMessageProps`. `InvitationMessage` now owns tone-driven icon/ring styling, a structured `action` object, and a `children` slot. All headings upgraded from `<h2>` to `<h1>`.
- **tests**: Removed banner comments, redundant `cleanup`, `as never` casts. Typed the `useResolveInvitation` mock against the hook's return shape.

## Testing

`npm run build`, `npm run test`, and `npm run lint` all pass inside the `ui` container.