### PR TITLE
fix: correctness and liveness defects in the SSH gateway and agent

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -19,21 +19,30 @@ jobs:
         project: [server, agent, pkg, gateway]
         database: ['']  # Empty by default
         include:
+          # race_args applies to `go test` only: a race-instrumented `go build`
+          # would just be discarded, and the detector costs several minutes.
           - project: server
             extra_args: ""
             lint_args: ""
+            race_args: "-race"
+            test_timeout: "40m"
           - project: gateway
             extra_args: ""
             lint_args: ""
+            race_args: "-race"
           - project: agent
             extra_args: "-tags docker"
             lint_args: "--build-tags docker"
+            race_args: "-race"
           - project: pkg
             extra_args: ""
             lint_args: ""
+            race_args: "-race"
           # Integration tests with PostgreSQL. Each of the ~31 SSH cases stands up
           # its own agent container and runs twice (transport v1 and v2), so the
-          # suite needs well over the 25m the unit-test projects get.
+          # suite needs well over the 25m the unit-test projects get. The detector
+          # is left off here: it would instrument the harness, not the services
+          # under test, on an already 45-minute job.
           - project: tests
             extra_args: ""
             lint_args: ""
@@ -117,7 +126,7 @@ jobs:
       - name: Unit test [Go]
         if: steps.filter.outputs.go == 'true' && github.event.pull_request.draft == false
         working-directory: ${{ matrix.project }}
-        run: go test ${{ matrix.extra_args }} -timeout ${{ matrix.test_timeout || '25m' }} ./...
+        run: go test ${{ matrix.extra_args }} ${{ matrix.race_args }} -timeout ${{ matrix.test_timeout || '25m' }} ./...
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
 

--- a/agent/server/modes/host/relay_test.go
+++ b/agent/server/modes/host/relay_test.go
@@ -1,0 +1,123 @@
+package host
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturingSession records what each stream received, so a test can tell stdout
+// from stderr. The embedded fakeSession discards both.
+type capturingSession struct {
+	*fakeSession
+
+	stdout *syncBuffer
+	stderr *syncBuffer
+}
+
+func newCapturingSession() *capturingSession {
+	return &capturingSession{
+		fakeSession: newFakeSession("session-id", "user"),
+		stdout:      new(syncBuffer),
+		stderr:      new(syncBuffer),
+	}
+}
+
+func (c *capturingSession) Write(p []byte) (int, error) { return c.stdout.Write(p) }
+
+func (c *capturingSession) Stderr() io.ReadWriter { return c.stderr }
+
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.Read(p)
+}
+
+func (s *syncBuffer) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.Len()
+}
+
+func TestRelayOutputKeepsStreamsApart(t *testing.T) {
+	session := newCapturingSession()
+
+	stdout := bytes.NewBufferString("to stdout")
+	stderr := bytes.NewBufferString("to stderr")
+
+	wg := new(sync.WaitGroup)
+	relayOutput(wg, session, stdout, stderr)
+	wg.Wait()
+
+	assert.Equal(t, "to stdout", session.stdout.String())
+	assert.Equal(t, "to stderr", session.stderr.String())
+}
+
+// TestRelayOutputDrainsStderrWhileStdoutIsOpen is the regression this exists
+// for. With io.MultiReader the stderr writer blocks once it fills the pipe
+// buffer, because nothing reads it until stdout reaches EOF — and stdout only
+// reaches EOF once the command exits, which it cannot do while blocked.
+func TestRelayOutputDrainsStderrWhileStdoutIsOpen(t *testing.T) {
+	session := newCapturingSession()
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	stderrReader, stderrWriter, err := os.Pipe()
+	require.NoError(t, err)
+
+	wg := new(sync.WaitGroup)
+	relayOutput(wg, session, stdoutReader, stderrReader)
+
+	// Comfortably past the 64 KiB Linux pipe buffer.
+	payload := bytes.Repeat([]byte("e"), 256*1024)
+
+	written := make(chan error, 1)
+
+	go func() {
+		_, err := stderrWriter.Write(payload)
+		written <- err
+	}()
+
+	select {
+	case err := <-written:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("writing to stderr blocked while stdout was still open")
+	}
+
+	require.NoError(t, stderrWriter.Close())
+	require.NoError(t, stdoutWriter.Close())
+
+	wg.Wait()
+
+	assert.Equal(t, len(payload), session.stderr.Len())
+	assert.Zero(t, session.stdout.Len())
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.String()
+}

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"os/user"
 	"strings"
 	"sync"
 	"syscall"
@@ -417,7 +416,11 @@ func (s *Sessioner) SFTP(session gliderssh.Session) error {
 
 	cmd := newSFTPServerCommand()
 
-	looked, err := user.Lookup(session.User())
+	// osauth, not os/user: the agent usually runs in a container with the host's
+	// filesystem mounted, and osauth is the one that reads the host's passwd.
+	// os/user reads the container's, where the account being logged into does
+	// not exist.
+	looked, err := osauth.LookupUser(session.User())
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"user": session.Context().User(),
@@ -427,8 +430,8 @@ func (s *Sessioner) SFTP(session gliderssh.Session) error {
 	}
 
 	home := fmt.Sprintf("HOME=%s", looked.HomeDir)
-	gid := fmt.Sprintf("GID=%s", looked.Gid)
-	uid := fmt.Sprintf("UID=%s", looked.Uid)
+	gid := fmt.Sprintf("GID=%d", looked.GID)
+	uid := fmt.Sprintf("UID=%d", looked.UID)
 
 	cmd.Env = append(cmd.Env, home)
 	cmd.Env = append(cmd.Env, gid)

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -170,6 +170,33 @@ func (s *Sessioner) Shell(session gliderssh.Session) error {
 	return nil
 }
 
+// relayOutput copies a command's output back to the SSH session, keeping stdout
+// and stderr on their own streams, and adds both copies to wg.
+//
+// The two must be copied concurrently. io.MultiReader drains its readers in
+// sequence, so it never touches stderr until stdout reaches EOF: a command
+// writing more than the pipe buffer to stderr blocks in write(2), never exits,
+// and stdout never reaches EOF either.
+func relayOutput(wg *sync.WaitGroup, session gliderssh.Session, stdout, stderr io.Reader) {
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		if _, err := io.Copy(session, stdout); err != nil {
+			fmt.Println(err) //nolint:forbidigo
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		if _, err := io.Copy(session.Stderr(), stderr); err != nil {
+			fmt.Println(err) //nolint:forbidigo
+		}
+	}()
+}
+
 // Heredoc handles the server's SSH heredoc session when server is running in host mode.
 //
 // heredoc is special block of code that contains multi-line strings that will be redirected to a stdin of a shell. It
@@ -225,12 +252,12 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 		stdin.Close()
 	}()
 
-	go func() {
-		combinedOutput := io.MultiReader(stdout, stderr)
-		if _, err := io.Copy(session, combinedOutput); err != nil {
-			fmt.Println(err) //nolint:forbidigo
-		}
-	}()
+	wg := &sync.WaitGroup{}
+	relayOutput(wg, session, stdout, stderr)
+
+	// cmd.Wait closes the parent ends of the pipes, so the copies have to finish
+	// first or they lose whatever the command wrote last.
+	wg.Wait()
 
 	if err := cmd.Wait(); err != nil {
 		log.Warn(err)
@@ -320,16 +347,7 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 			stdin.Close()
 		}()
 
-		wg.Add(1)
-
-		// relay the command's combined output and error streams back to the SSH session.
-		go func() {
-			defer wg.Done()
-			combinedOutput := io.MultiReader(stdout, stderr)
-			if _, err := io.Copy(session, combinedOutput); err != nil {
-				fmt.Println(err) //nolint:forbidigo
-			}
-		}()
+		relayOutput(wg, session, stdout, stderr)
 	}
 
 	log.WithFields(log.Fields{

--- a/server/app/server.go
+++ b/server/app/server.go
@@ -60,6 +60,14 @@ type Env struct {
 
 	// Metrics enables the /metrics endpoint.
 	Metrics bool `env:"METRICS,default=false"`
+
+	// Domain is the instance's base domain, used to build the browser approval
+	// URL shown in the terminal when a namespace requires SSH login approval.
+	Domain string `env:"SHELLHUB_DOMAIN,default=localhost"`
+
+	// AutoSSL reports whether the console is served over HTTPS; it selects the
+	// scheme of that approval URL.
+	AutoSSL bool `env:"SHELLHUB_AUTO_SSL,default=false"`
 }
 
 // sshEnv is parsed with the SSH_ prefix, keeping the names the ssh service used.
@@ -282,6 +290,8 @@ func (s *Server) setupSSH(service services.Service) error {
 		ConnectTimeout:               env.ConnectTimeout,
 		AllowPublickeyAccessBelow060: env.AllowPublickeyAccessBelow060,
 		HostKeyFile:                  env.HostKeyFile,
+		Domain:                       s.env.Domain,
+		AutoSSL:                      s.env.AutoSSL,
 	})
 
 	return err

--- a/server/ssh/server/auth/doc.go
+++ b/server/ssh/server/auth/doc.go
@@ -1,6 +1,12 @@
 // Package auth provides authentication handlers for client connections.
 //
-// This package includes two authentication methods: [PasswordHandler] and [PublicKeyHandler].
-// [PasswordHandler] is the second authentication method tried by the server to connect the client to the agent,
-// while [PublicKeyHandler] is the first authentication method attempted.
+// Public key authentication runs in two phases, because the SSH protocol lets a
+// client ask whether a key would be accepted without signing anything.
+// [PublicKeyOffer] answers that question and only reads; [PublicKeyVerified]
+// runs once the signature checks out and is where the browser approval, the
+// session registration and the connection to the agent happen.
+//
+// [PasswordHandler] is the second authentication method tried by the server to
+// connect the client to the agent. A password has no query form, so it
+// authenticates in one step.
 package auth

--- a/server/ssh/server/auth/publickey.go
+++ b/server/ssh/server/auth/publickey.go
@@ -9,17 +9,28 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// PublicKeyHandler handles ShellHub client's connection using the public key authentication method.
-func PublicKeyHandler(ctx gliderssh.Context, publicKey gliderssh.PublicKey) bool {
-	logger := log.WithFields(
-		log.Fields{
-			"uid":   ctx.SessionID(),
-			"sshid": ctx.User(),
-			"key":   ssh.MarshalAuthorizedKey(publicKey),
-		})
+// resolveKeyAuth builds the [session.Auth] for a presented key. It is a lookup:
+// identity mode resolves the key to an account, legacy mode uses the key as
+// presented, and neither writes anything.
+func resolveKeyAuth(ctx gliderssh.Context, sess *session.Session, publicKey gliderssh.PublicKey) (session.Auth, error) {
+	if !sess.IsIdentityMode() {
+		return session.AuthPublicKey(publicKey), nil
+	}
 
-	logger.Trace("trying to use public key authentication")
+	// In identity mode the presented key IS the identity: resolve its fingerprint
+	// to an account (connect straight through) or hold the login open for a
+	// browser approval that turns the key into one. The ephemeral mint to the
+	// agent is unchanged; the user's key is never forwarded.
+	//
+	// Native and web alike. The web terminal holds its own registered key, so it
+	// is a first-class identity resolved here like any other public key; password
+	// authentication is disabled entirely in identity mode.
+	return sess.ResolveKeyAuth(ctx, publicKey)
+}
 
+// obtain returns the session for a connection that has got far enough to
+// authenticate, dropping the connection otherwise.
+func obtain(ctx gliderssh.Context, logger *log.Entry) (*session.Session, bool) {
 	sess, state := session.ObtainSession(ctx)
 	if state < session.StateEvaluated {
 		logger.Trace("failed to get the session from context on public key handler")
@@ -29,30 +40,84 @@ func PublicKeyHandler(ctx gliderssh.Context, publicKey gliderssh.PublicKey) bool
 			conn.Close()
 		}
 
+		return nil, false
+	}
+
+	return sess, true
+}
+
+// PublicKeyOffer decides whether a public key is acceptable.
+//
+// The SSH protocol lets a client ask about a key without signing anything, and
+// x/crypto runs this for that query, so it stays a read: no approval is parked,
+// no session is registered, and the agent is not contacted. Everything with a
+// cost waits for [PublicKeyVerified].
+//
+// An unenrolled key is acceptable in identity mode — enrolling it is the point
+// of the flow — so a miss is not refused here.
+func PublicKeyOffer(ctx gliderssh.Context, publicKey gliderssh.PublicKey) bool {
+	logger := log.WithFields(
+		log.Fields{
+			"uid":   ctx.SessionID(),
+			"sshid": ctx.User(),
+			"key":   ssh.MarshalAuthorizedKey(publicKey),
+		})
+
+	logger.Trace("trying to use public key authentication")
+
+	sess, ok := obtain(ctx, logger)
+	if !ok {
 		return false
 	}
 
-	// In identity mode the presented key IS the identity: resolve its fingerprint
-	// to an account (connect straight through) or hold the login open for a
-	// browser approval that turns the key into one. The ephemeral mint to the
-	// agent is unchanged; the user's key is never forwarded.
-	auth := session.AuthPublicKey(publicKey)
-	if sess.IsIdentityMode() {
-		// Native and web alike. The web terminal holds its own registered key, so
-		// it is a first-class identity resolved here like any other public key;
-		// password authentication is disabled entirely in identity mode.
-		resolved, err := sess.ResolveKeyAuth(ctx, publicKey)
-		if err != nil {
-			logger.WithError(err).Warn("failed to resolve the identity for the public key")
+	auth, err := resolveKeyAuth(ctx, sess, publicKey)
+	if err != nil {
+		logger.WithError(err).Warn("failed to resolve the identity for the public key")
 
-			return false
-		}
+		return false
+	}
 
-		auth = resolved
+	if err := auth.Offer(sess); err != nil {
+		logger.WithError(err).Warn("refused the offered public key")
+
+		return false
+	}
+
+	return true
+}
+
+// PublicKeyVerified authenticates once the client has proven it holds the key.
+//
+// x/crypto calls it only after the signature checks out and only when the offer
+// was accepted, so this is where the browser approval, the session registration
+// and the connection to the agent belong. Failing here is an ordinary
+// authentication failure and counts against MaxAuthTries.
+func PublicKeyVerified(ctx gliderssh.Context, publicKey gliderssh.PublicKey) bool {
+	logger := log.WithFields(
+		log.Fields{
+			"uid":   ctx.SessionID(),
+			"sshid": ctx.User(),
+			"key":   ssh.MarshalAuthorizedKey(publicKey),
+		})
+
+	sess, ok := obtain(ctx, logger)
+	if !ok {
+		return false
+	}
+
+	// Resolved again rather than carried over from the offer: x/crypto caches one
+	// key at a time, so a client that offers several keys can have the callback
+	// re-run in any order, and a stale carry-over would authenticate the wrong
+	// one. The lookup is a single read.
+	auth, err := resolveKeyAuth(ctx, sess, publicKey)
+	if err != nil {
+		logger.WithError(err).Warn("failed to resolve the identity for the public key")
+
+		return false
 	}
 
 	if err := sess.Auth(ctx, auth); err != nil {
-		logger.Warn("failed to authenticate on device using public key")
+		logger.WithError(err).Warn("failed to authenticate on device using public key")
 
 		return false
 	}

--- a/server/ssh/server/channels/openfailure.go
+++ b/server/ssh/server/channels/openfailure.go
@@ -4,8 +4,21 @@ import (
 	"errors"
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 )
+
+// denyRequest answers a channel request the server will not act on.
+//
+// A client that asked for a reply blocks until it gets one — OpenSSH sends
+// pty-req that way — so dropping a malformed request without answering would
+// hang the session instead of failing it.
+func denyRequest(logger *log.Entry, req *gossh.Request) {
+	// Reply is itself a no-op when the client did not ask for one.
+	if err := req.Reply(false, nil); err != nil {
+		logger.WithError(err).Error("failed to deny the channel request")
+	}
+}
 
 // openFailureReason maps a failure to open the agent's channel onto the
 // rejection the client receives.

--- a/server/ssh/server/channels/openfailure.go
+++ b/server/ssh/server/channels/openfailure.go
@@ -1,0 +1,34 @@
+package channels
+
+import (
+	"errors"
+	"fmt"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// openFailureReason maps a failure to open the agent's channel onto the
+// rejection the client receives.
+//
+// Only an agent that actively refuses produces an *gossh.OpenChannelError; an
+// agent whose connection is gone fails earlier, on the write, with a transport
+// error that carries no reason of its own.
+func openFailureReason(err error) gossh.RejectionReason {
+	var openErr *gossh.OpenChannelError
+	if errors.As(err, &openErr) {
+		return openErr.Reason
+	}
+
+	return gossh.ConnectionFailed
+}
+
+// openFailureMessage is the text the client is shown. The agent's own wording is
+// preferred where there is one, since it knows why it refused.
+func openFailureMessage(err error) string {
+	var openErr *gossh.OpenChannelError
+	if errors.As(err, &openErr) && openErr.Message != "" {
+		return openErr.Message
+	}
+
+	return fmt.Sprintf("failed to open the session channel on the device: %v", err)
+}

--- a/server/ssh/server/channels/openfailure_test.go
+++ b/server/ssh/server/channels/openfailure_test.go
@@ -1,0 +1,56 @@
+package channels
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func TestOpenFailureReason(t *testing.T) {
+	tests := []struct {
+		description string
+		err         error
+		expected    gossh.RejectionReason
+	}{
+		{
+			description: "carries the agent's own reason",
+			err:         &gossh.OpenChannelError{Reason: gossh.Prohibited, Message: "not allowed"},
+			expected:    gossh.Prohibited,
+		},
+		{
+			description: "falls back when the agent's connection is gone",
+			err:         io.EOF,
+			expected:    gossh.ConnectionFailed,
+		},
+		{
+			description: "falls back on any other transport error",
+			err:         errors.New("ssh: unexpected packet in response to channel open"),
+			expected:    gossh.ConnectionFailed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expected, openFailureReason(test.err))
+		})
+	}
+}
+
+func TestOpenFailureMessage(t *testing.T) {
+	t.Run("prefers the agent's wording", func(t *testing.T) {
+		err := &gossh.OpenChannelError{Reason: gossh.Prohibited, Message: "administratively prohibited"}
+		assert.Equal(t, "administratively prohibited", openFailureMessage(err))
+	})
+
+	t.Run("explains itself when the agent said nothing", func(t *testing.T) {
+		assert.Contains(t, openFailureMessage(io.EOF), "EOF")
+	})
+
+	t.Run("does not return an empty message", func(t *testing.T) {
+		err := &gossh.OpenChannelError{Reason: gossh.ConnectionFailed, Message: ""}
+		assert.NotEmpty(t, openFailureMessage(err))
+	})
+}

--- a/server/ssh/server/channels/pipe_test.go
+++ b/server/ssh/server/channels/pipe_test.go
@@ -1,0 +1,267 @@
+package channels
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/envs"
+	"github.com/shellhub-io/shellhub/pkg/envs/envstest"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/ssh/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// stream is one direction of a channel: writes are buffered, reads block until
+// there is something to read or the write side is closed.
+type stream struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	buf    bytes.Buffer
+	closed bool
+}
+
+func newStream() *stream {
+	s := &stream{} //nolint:exhaustruct
+	s.cond = sync.NewCond(&s.mu)
+
+	return s
+}
+
+func (s *stream) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return 0, io.EOF
+	}
+
+	n, err := s.buf.Write(p)
+	s.cond.Broadcast()
+
+	return n, err
+}
+
+func (s *stream) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for s.buf.Len() == 0 && !s.closed {
+		s.cond.Wait()
+	}
+
+	if s.buf.Len() == 0 {
+		return 0, io.EOF
+	}
+
+	return s.buf.Read(p)
+}
+
+func (s *stream) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.closed = true
+	s.cond.Broadcast()
+}
+
+func (s *stream) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.String()
+}
+
+// duplex pairs the two halves of an io.ReadWriter that are independent in the
+// SSH protocol, as gossh.Channel.Stderr is.
+type duplex struct {
+	in  *stream
+	out *stream
+}
+
+func (d duplex) Read(p []byte) (int, error)  { return d.in.Read(p) }
+func (d duplex) Write(p []byte) (int, error) { return d.out.Write(p) }
+
+// fakeChannel is a gossh.Channel with each direction of each stream separate, so
+// a test can feed the peer's output and inspect what was relayed, and can
+// observe when the write side is closed.
+type fakeChannel struct {
+	dataIn    *stream
+	dataOut   *stream
+	stderrIn  *stream
+	stderrOut *stream
+
+	mu           sync.Mutex
+	closeWritten bool
+}
+
+func newFakeChannel() *fakeChannel {
+	return &fakeChannel{ //nolint:exhaustruct
+		dataIn:    newStream(),
+		dataOut:   newStream(),
+		stderrIn:  newStream(),
+		stderrOut: newStream(),
+	}
+}
+
+func (f *fakeChannel) Read(p []byte) (int, error)  { return f.dataIn.Read(p) }
+func (f *fakeChannel) Write(p []byte) (int, error) { return f.dataOut.Write(p) }
+
+func (f *fakeChannel) Stderr() io.ReadWriter { return duplex{in: f.stderrIn, out: f.stderrOut} }
+
+func (f *fakeChannel) Close() error {
+	f.dataIn.close()
+	f.stderrIn.close()
+
+	return nil
+}
+
+func (f *fakeChannel) CloseWrite() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.closeWritten = true
+
+	return nil
+}
+
+func (f *fakeChannel) closeWriteCalled() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.closeWritten
+}
+
+func (*fakeChannel) SendRequest(_ string, _ bool, _ []byte) (bool, error) { return true, nil }
+
+// quiet marks the peer as having nothing left to send.
+func (f *fakeChannel) quiet() {
+	f.dataIn.close()
+	f.stderrIn.close()
+}
+
+func newPipeSession(t *testing.T) *session.Session {
+	t.Helper()
+
+	// Recording is a separate concern from the data path; the community edition
+	// keeps the recorder out of the writer set.
+	envstest.SetEdition(t, envs.Community)
+
+	sess := &session.Session{ //nolint:exhaustruct
+		UID:   "session-uid",
+		Seats: session.NewSeats(),
+		Data: session.Data{ //nolint:exhaustruct
+			SSHID: "user@namespace.device",
+			Device: &models.Device{ //nolint:exhaustruct
+				UID:  "device-uid",
+				Info: &models.DeviceInfo{Version: "latest"}, //nolint:exhaustruct
+			},
+		},
+	}
+
+	_, err := sess.Seats.NewSeat()
+	require.NoError(t, err)
+
+	return sess
+}
+
+func runPipe(t *testing.T, sess *session.Session, client, agent gossh.Channel) chan struct{} {
+	t.Helper()
+
+	done := make(chan bool, 1)
+	finished := make(chan struct{})
+
+	go func() {
+		defer close(finished)
+
+		pipe(sess, client, agent, 0, done)
+	}()
+
+	return finished
+}
+
+func waitFor(t *testing.T, finished chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-finished:
+	case <-time.After(10 * time.Second):
+		t.Fatal("pipe did not return")
+	}
+}
+
+// TestPipeKeepsStreamsApart is the regression: joining the two streams with
+// io.MultiReader meant stderr was only read after stdout reached EOF, so it
+// arrived out of order and tagged as ordinary data.
+func TestPipeKeepsStreamsApart(t *testing.T) {
+	sess := newPipeSession(t)
+	client, agent := newFakeChannel(), newFakeChannel()
+
+	_, err := agent.dataIn.Write([]byte("to stdout"))
+	require.NoError(t, err)
+
+	_, err = agent.stderrIn.Write([]byte("to stderr"))
+	require.NoError(t, err)
+
+	agent.quiet()
+	client.quiet()
+
+	waitFor(t, runPipe(t, sess, client, agent))
+
+	assert.Equal(t, "to stdout", client.dataOut.String())
+	assert.Equal(t, "to stderr", client.stderrOut.String())
+}
+
+// TestPipeDrainsAgentStderrBeforeStdoutEOF covers the hang: extended data sits
+// in x/crypto's buffer and consumes the channel window, so a chatty stderr
+// stalls the whole session if nothing reads it until stdout is done.
+func TestPipeDrainsAgentStderrBeforeStdoutEOF(t *testing.T) {
+	sess := newPipeSession(t)
+	client, agent := newFakeChannel(), newFakeChannel()
+
+	_, err := agent.stderrIn.Write([]byte("early stderr"))
+	require.NoError(t, err)
+
+	client.quiet()
+
+	finished := runPipe(t, sess, client, agent)
+
+	assert.Eventually(t, func() bool {
+		return client.stderrOut.String() == "early stderr"
+	}, 10*time.Second, 10*time.Millisecond, "stderr was not relayed while stdout was still open")
+
+	agent.quiet()
+
+	waitFor(t, finished)
+}
+
+// TestPipeClosesWriteAfterBothStreams pins the ordering: CloseWrite makes every
+// later write return EOF, so firing it when only stdout is drained truncates
+// stderr.
+func TestPipeClosesWriteAfterBothStreams(t *testing.T) {
+	sess := newPipeSession(t)
+	client, agent := newFakeChannel(), newFakeChannel()
+
+	client.quiet()
+	agent.dataIn.close()
+
+	finished := runPipe(t, sess, client, agent)
+
+	// stdout is already at EOF; the agent's stderr is not.
+	assert.Never(t, client.closeWriteCalled, 200*time.Millisecond, 20*time.Millisecond,
+		"client write side was closed while agent stderr was still open")
+
+	_, err := agent.stderrIn.Write([]byte("late stderr"))
+	require.NoError(t, err)
+
+	agent.stderrIn.close()
+
+	waitFor(t, finished)
+
+	assert.True(t, client.closeWriteCalled())
+	assert.Equal(t, "late stderr", client.stderrOut.String())
+}

--- a/server/ssh/server/channels/pipestart_test.go
+++ b/server/ssh/server/channels/pipestart_test.go
@@ -3,6 +3,8 @@ package channels
 import (
 	"testing"
 
+	"github.com/shellhub-io/shellhub/server/ssh/session"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +44,7 @@ func TestStartsDataPipe(t *testing.T) {
 		},
 		{
 			description: "a keepalive does not",
-			requestType: KeepAliveRequestType,
+			requestType: session.KeepAliveRequestType,
 			expected:    false,
 		},
 		{

--- a/server/ssh/server/channels/pipestart_test.go
+++ b/server/ssh/server/channels/pipestart_test.go
@@ -1,0 +1,65 @@
+package channels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartsDataPipe(t *testing.T) {
+	tests := []struct {
+		description string
+		requestType string
+		expected    bool
+	}{
+		{
+			// Regression: a shell with no pty is the only request such a session
+			// sends, so leaving it out left heredocs with no data path and they
+			// hung until the client gave up.
+			description: "a shell starts the pipe, which is all a heredoc sends",
+			requestType: ShellRequestType,
+			expected:    true,
+		},
+		{
+			description: "a pty request starts the pipe",
+			requestType: PtyRequestType,
+			expected:    true,
+		},
+		{
+			description: "an exec starts the pipe",
+			requestType: ExecRequestType,
+			expected:    true,
+		},
+		{
+			description: "a subsystem starts the pipe",
+			requestType: SubsystemRequestType,
+			expected:    true,
+		},
+		{
+			description: "a window change does not, it only resizes",
+			requestType: WindowChangeRequestType,
+			expected:    false,
+		},
+		{
+			description: "a keepalive does not",
+			requestType: KeepAliveRequestType,
+			expected:    false,
+		},
+		{
+			description: "agent forwarding does not, it has its own channel",
+			requestType: AuthRequestOpenSSHRequest,
+			expected:    false,
+		},
+		{
+			description: "an unknown request does not",
+			requestType: "something@example.com",
+			expected:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.expected, startsDataPipe(test.requestType))
+		})
+	}
+}

--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -295,7 +295,10 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 						var pty models.SSHPty
 
 						if err := gossh.Unmarshal(req.Payload, &pty); err != nil {
-							reject(nil, "failed to recover the session dimensions")
+							logger.WithError(err).Error("failed to recover the session dimensions")
+							denyRequest(logger, req)
+
+							continue
 						}
 
 						sess.Seats.SetPty(seat, true)
@@ -305,7 +308,10 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 						var dimensions models.SSHWindowChange
 
 						if err := gossh.Unmarshal(req.Payload, &dimensions); err != nil {
-							reject(nil, "failed to recover the session dimensions")
+							logger.WithError(err).Error("failed to recover the new window dimensions")
+							denyRequest(logger, req)
+
+							continue
 						}
 
 						sess.Event(req.Type, dimensions, seat) //nolint:errcheck
@@ -320,14 +326,14 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 							for {
 								newAgentChannel, ok := <-agentChannels
 								if !ok {
-									reject(nil, "channel for agent forwarding done")
+									logger.Trace("channel for agent forwarding done")
 
 									return
 								}
 
 								agentChannel, agentReqs, err := newAgentChannel.Accept()
 								if err != nil {
-									reject(nil, "failed to accept the chanel request from agent on auth request")
+									logger.WithError(err).Error("failed to accept the chanel request from agent on auth request")
 
 									return
 								}
@@ -337,7 +343,7 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 
 								clientChannel, clientReqs, err := clientConn.OpenChannel(AuthRequestOpenSSHChannel, nil)
 								if err != nil {
-									reject(nil, "failed to open the auth request channel from agent to client")
+									logger.WithError(err).Error("failed to open the auth request channel from agent to client")
 
 									return
 								}

--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -105,10 +105,13 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 				"ip":       sess.IPAddress,
 			})
 
+		// Only usable before the channel is accepted: Reject on a channel that has
+		// already been decided returns an error that nothing can act on, so the
+		// client would be left with no explanation at all.
 		reject := func(err error, msg string) {
 			logger.WithError(err).Error(msg)
 
-			newChan.Reject(gossh.ConnectionFailed, msg) //nolint:errcheck
+			newChan.Reject(openFailureReason(err), msg) //nolint:errcheck
 		}
 
 		logger.Info("session channel started")
@@ -121,23 +124,28 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 			return
 		}
 
-		client, err := sess.NewClientChannel(newChan, seat)
-		if err != nil {
-			reject(err, "failed to accept the channel opening")
-
-			return
-		}
-
-		defer client.Close()
-
+		// The agent channel is opened first so its failure can still be reported:
+		// accepting the client's channel commits to it, and a rejection after that
+		// reaches nobody. The device dropping between the banner-handler dial and
+		// this point is the common case, and it used to close in silence.
 		agent, err := sess.NewAgentChannel(SessionChannel, seat)
 		if err != nil {
-			reject(err, "failed to open the session channel on agent")
+			reject(err, openFailureMessage(err))
 
 			return
 		}
 
 		defer agent.Close()
+
+		client, err := sess.NewClientChannel(newChan, seat)
+		if err != nil {
+			reject(err, "failed to accept the channel opening")
+			sess.DropAgentChannel(seat)
+
+			return
+		}
+
+		defer client.Close()
 
 		var wg sync.WaitGroup
 

--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -282,7 +282,7 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 					case ExecRequestType, SubsystemRequestType:
 						session.Event[models.SSHCommand](sess, req.Type, req.Payload, seat)
 
-						sess.Type = ExecRequestType
+						sess.Seats.SetType(seat, ExecRequestType)
 					case PtyRequestType:
 						var pty models.SSHPty
 

--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -1,7 +1,6 @@
 package channels
 
 import (
-	"strings"
 	"sync"
 
 	gliderssh "github.com/gliderlabs/ssh"
@@ -10,11 +9,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	gossh "golang.org/x/crypto/ssh"
 )
-
-// KeepAliveRequestTypePrefix Through the time, the [KeepAliveRequestType] type sent from agent to server changed its
-// name, but always keeping the prefix "keepalive". So, to maintain the retro compatibility, we check if this prefix
-// exists and perform the necessary operations.
-const KeepAliveRequestTypePrefix string = "keepalive"
 
 const (
 	// Once the session has been set up, a program is started at the remote end.  The program can be a shell, an
@@ -50,8 +44,6 @@ const (
 	//
 	// https://www.rfc-editor.org/rfc/rfc4254#section-6.7
 	WindowChangeRequestType = "window-change"
-	// It is a custom request type that the Agent sends to maintain the session alive, even when no data is sent.
-	KeepAliveRequestType = KeepAliveRequestTypePrefix + "@shellhub.io"
 	//  When the command running at the other end terminates, the following message can be sent to return the exit
 	//  status of the command. Returning the status is RECOMMENDED.
 	//
@@ -185,61 +177,7 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 			go pipe(sess, client.Channel, agent.Channel, seat, done)
 		})
 
-		wg.Add(3)
-
-		go func() {
-			defer wg.Done()
-
-			for {
-				select {
-				case <-ctx.Done():
-					logger.Info("context has done (global requests)")
-
-					return
-				case req, ok := <-sess.Agent.Requests:
-					if !ok {
-						logger.Trace("global requests is closed")
-
-						return
-					}
-
-					logger.Debugf("global request from agent: %s", req.Type)
-
-					switch {
-					// NOTE: The Agent sends "keepalive" requests to the server to avoid the Web Socket being closed due
-					// to inactivity. Through the time, the request type sent from agent to server changed its name, but
-					// always keeping the prefix "keepalive". So, to maintain the retro compatibility, we check if this
-					// prefix exists and perform the necessary operations.
-					case strings.HasPrefix(req.Type, KeepAliveRequestTypePrefix):
-						if req.WantReply {
-							if err := req.Reply(true, nil); err != nil {
-								logger.WithError(err).Error("failed to reply to keepalive request from agent")
-							}
-
-							logger.Info("replied to keepalive request from agent")
-						}
-
-						if _, err := client.Channel.SendRequest(KeepAliveRequestType, req.WantReply, req.Payload); err != nil {
-							logger.Error("failed to send the keepalive request received from agent to client")
-
-							return
-						}
-
-						if err := sess.KeepAlive(ctx); err != nil {
-							logger.WithError(err).Error("failed to send the API request to inform that the session is open")
-
-							return
-						}
-					default:
-						if req.WantReply {
-							if err := req.Reply(false, nil); err != nil {
-								logger.WithError(err).Error(err)
-							}
-						}
-					}
-				}
-			}
-		}()
+		wg.Add(2)
 
 		go func() {
 			defer wg.Done()

--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -78,6 +78,22 @@ const AuthRequestOpenSSHRequest = "auth-agent-req@openssh.com"
 // https://www.ietf.org/archive/id/draft-miller-ssh-agent-11.html#section-4.2
 const AuthRequestOpenSSHChannel = "auth-agent@openssh.com"
 
+// startsDataPipe reports whether a channel request puts the session into
+// service, and so must start the data pipe between client and agent.
+//
+// Piping waits for one of these rather than starting as soon as the channel
+// opens, so a recorded session has its header written before any frame reaches
+// it. A shell counts: without a pty the client sends nothing else, and leaving
+// it out left that session with no data path at all.
+func startsDataPipe(requestType string) bool {
+	switch requestType {
+	case ShellRequestType, PtyRequestType, ExecRequestType, SubsystemRequestType:
+		return true
+	default:
+		return false
+	}
+}
+
 // DefaultSessionHandler is the default handler for session's channel.
 //
 // A session is a remote execution of a program. The program may be a shell, an application, a system command, or some
@@ -387,8 +403,7 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 						}
 					}
 
-					switch req.Type {
-					case PtyRequestType, ExecRequestType, SubsystemRequestType:
+					if startsDataPipe(req.Type) {
 						oncePipe()
 					}
 				}

--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -86,7 +86,19 @@ const AuthRequestOpenSSHChannel = "auth-agent@openssh.com"
 // https://www.rfc-editor.org/rfc/rfc4254#section-6
 func DefaultSessionHandler() gliderssh.ChannelHandler {
 	return func(_ *gliderssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
-		sess, _ := session.ObtainSession(ctx)
+		sess, state := session.ObtainSession(ctx)
+		if sess == nil || state < session.StateFinished {
+			// Unreachable today: a channel only opens once authentication has
+			// completed, and that is what advances the session to StateFinished.
+			// Kept so a change to the auth ordering fails the channel instead of
+			// dereferencing nothing and taking the API down with it.
+			log.WithFields(log.Fields{"session": ctx.SessionID(), "state": state}).
+				Error("session channel opened without an established session")
+
+			newChan.Reject(gossh.ConnectionFailed, "session is not established") //nolint:errcheck
+
+			return
+		}
 
 		go func() {
 			// NOTE: As [gossh.ServerConn] is shared by all channels calls, close it after a channel close block any

--- a/server/ssh/server/channels/tcpip.go
+++ b/server/ssh/server/channels/tcpip.go
@@ -15,7 +15,18 @@ import (
 // DefaultDirectTCPIPHandler is the channel's handler for direct-tcpip channels like "local port forwarding" and "dynamic
 // application-level port forwarding".
 func DefaultDirectTCPIPHandler(server *gliderssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
-	sess, _ := session.ObtainSession(ctx)
+	sess, state := session.ObtainSession(ctx)
+	if sess == nil || state < session.StateFinished {
+		// See the same guard in the session channel handler: unreachable today,
+		// and here the goroutine below sits outside the panic recovery.
+		log.WithFields(log.Fields{"session": ctx.SessionID(), "state": state}).
+			Error("direct-tcpip channel opened without an established session")
+
+		newChan.Reject(gossh.ConnectionFailed, "session is not established") //nolint:errcheck
+
+		return
+	}
+
 	go func() {
 		// NOTICE: As [gossh.ServerConn] is shared by all channels calls, close it after a channel close block any
 		// other channel involkation. To avoid it, we wait for the connection be closed to finish the sesison.

--- a/server/ssh/server/channels/utils.go
+++ b/server/ssh/server/channels/utils.go
@@ -128,8 +128,10 @@ func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, seat
 			// NOTE: When request is [ExecRequestType] and agent's version is less than v0.9.2, we should close the agent
 			// connection to avoid it be hanged after data flow ends.
 			if ver, err := semver.NewVersion(sess.Device.Info.Version); ver != nil && err == nil {
+				item, _ := sess.Seats.Get(seat)
+
 				// NOTE: We indicate here v0.9.3, but it is not included due the assertion `less than`.
-				if ver.LessThan(semver.MustParse("v0.9.3")) && sess.Type == ExecRequestType {
+				if ver.LessThan(semver.MustParse("v0.9.3")) && item.Type == ExecRequestType {
 					agent.Close()
 				} else {
 					agent.CloseWrite() //nolint:errcheck

--- a/server/ssh/server/channels/utils.go
+++ b/server/ssh/server/channels/utils.go
@@ -77,15 +77,17 @@ func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, seat
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
 
-	c := io.MultiReader(client, client.Stderr())
-	a := io.MultiReader(agent, agent.Stderr())
+	// A well-behaved client never sends extended data — it is defined server to
+	// client — but x/crypto buffers whatever arrives without ever replenishing
+	// the window, so an unread stream would eventually stall the channel.
+	go io.Copy(io.Discard, client.Stderr()) //nolint:errcheck
 
 	go func() {
 		defer wg.Done()
-		defer client.CloseWrite()
 		defer func() {
 			done <- true
 		}()
+		defer client.CloseWrite() //nolint:errcheck
 
 		writers := []io.Writer{client}
 		if envs.IsEnterpriseOrCloud() {
@@ -110,14 +112,37 @@ func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, seat
 			}
 		}
 
-		multi := io.MultiWriter(writers...)
-		if _, err := io.Copy(multi, &deadReadGuard{r: a}); err != nil && err != io.EOF {
-			log.WithError(err).Error("failed on coping data from agent to client")
+		// CloseWrite makes every later write return EOF, so it must not run until
+		// both streams are drained, or the tail of stderr is silently dropped.
+		fromAgent := new(sync.WaitGroup)
+		fromAgent.Add(2)
 
-			// Close both ends so the other copy goroutine unblocks and pipe can return.
-			_ = agent.Close()
-			_ = client.Close()
-		}
+		multi := io.MultiWriter(writers...)
+
+		go func() {
+			defer fromAgent.Done()
+
+			if _, err := io.Copy(multi, &deadReadGuard{r: agent}); err != nil && err != io.EOF {
+				log.WithError(err).Error("failed on coping data from agent to client")
+
+				// Close both ends so the other copy goroutine unblocks and pipe can return.
+				_ = agent.Close()
+				_ = client.Close()
+			}
+		}()
+
+		go func() {
+			defer fromAgent.Done()
+
+			if _, err := io.Copy(client.Stderr(), &deadReadGuard{r: agent.Stderr()}); err != nil && err != io.EOF {
+				log.WithError(err).Error("failed on coping stderr from agent to client")
+
+				_ = agent.Close()
+				_ = client.Close()
+			}
+		}()
+
+		fromAgent.Wait()
 
 		log.Trace("agent channel data copy done")
 	}()
@@ -141,7 +166,7 @@ func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, seat
 			}
 		}()
 
-		if _, err := io.Copy(agent, &deadReadGuard{r: c}); err != nil && err != io.EOF {
+		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && err != io.EOF {
 			log.WithError(err).Error("failed on coping data from client to agent")
 
 			// Close both ends so the other copy goroutine unblocks and pipe can return.
@@ -156,6 +181,9 @@ func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, seat
 }
 
 // hose is a generic version of [pipe] function without the record capability.
+//
+// It carries the ssh-agent forwarding channel, which is plain data in both
+// directions: neither side ever sends extended data over it.
 func hose(sess *session.Session, agent gossh.Channel, client gossh.Channel) {
 	defer log.
 		WithFields(log.Fields{"session": sess.UID, "sshid": sess.SSHID}).
@@ -164,14 +192,11 @@ func hose(sess *session.Session, agent gossh.Channel, client gossh.Channel) {
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
 
-	a := io.MultiReader(agent, agent.Stderr())
-	c := io.MultiReader(client, client.Stderr())
-
 	go func() {
 		defer wg.Done()
 		defer agent.CloseWrite() //nolint:errcheck
 
-		if _, err := io.Copy(agent, &deadReadGuard{r: c}); err != nil && err != io.EOF {
+		if _, err := io.Copy(agent, &deadReadGuard{r: client}); err != nil && err != io.EOF {
 			log.WithError(err).Error("failed on coping data from client to agent")
 
 			// Close the agent so the other copy goroutine unblocks.
@@ -185,7 +210,7 @@ func hose(sess *session.Session, agent gossh.Channel, client gossh.Channel) {
 		defer wg.Done()
 		defer client.CloseWrite() //nolint:errcheck
 
-		if _, err := io.Copy(client, &deadReadGuard{r: a}); err != nil && err != io.EOF {
+		if _, err := io.Copy(client, &deadReadGuard{r: agent}); err != nil && err != io.EOF {
 			log.WithError(err).Error("failed on coping data from agent to client")
 
 			// Close the client so the other copy goroutine unblocks.

--- a/server/ssh/server/server.go
+++ b/server/ssh/server/server.go
@@ -182,6 +182,21 @@ var (
 func newServerConfigCallback(ctx gliderssh.Context) *gossh.ServerConfig {
 	return &gossh.ServerConfig{ //nolint:exhaustruct
 		NoClientAuth: true,
+		// Runs only after the client has signed for the key it offered, and only
+		// when the offer was accepted. x/crypto reads it from the top-level config
+		// rather than from the callbacks a PartialSuccessError installs, so it
+		// covers identity and legacy namespaces alike.
+		//
+		// A publickey callback must not return a PartialSuccessError while this is
+		// set — x/crypto rejects that combination by dropping the connection, not
+		// by failing the attempt. Ours return only nil or a denial.
+		VerifiedPublicKeyCallback: func(_ gossh.ConnMetadata, key gossh.PublicKey, _ *gossh.Permissions, _ string) (*gossh.Permissions, error) {
+			if ok := auth.PublicKeyVerified(ctx, key); !ok {
+				return nil, errPermissionDenied
+			}
+
+			return ctx.Permissions().Permissions, nil
+		},
 		// Capture the pre-auth connection so the enrollment/step-up banner can be
 		// sent mid-handshake, after the presented key is resolved, instead of
 		// unconditionally up front.
@@ -197,7 +212,7 @@ func newServerConfigCallback(ctx gliderssh.Context) *gossh.ServerConfig {
 			return nil, &gossh.PartialSuccessError{
 				Next: gossh.ServerAuthCallbacks{ //nolint:exhaustruct
 					PublicKeyCallback: func(_ gossh.ConnMetadata, key gossh.PublicKey) (*gossh.Permissions, error) {
-						if ok := auth.PublicKeyHandler(ctx, key); !ok {
+						if ok := auth.PublicKeyOffer(ctx, key); !ok {
 							return nil, errPermissionDenied
 						}
 
@@ -240,7 +255,7 @@ func NewServer(dialer *dialer.Dialer, service services.Service, handoff *webhand
 		ServerConfigCallback: newServerConfigCallback,
 		BannerHandler:        newBannerHandler(dialer, service, handoff),
 		PasswordHandler:      auth.PasswordHandler,
-		PublicKeyHandler:     auth.PublicKeyHandler,
+		PublicKeyHandler:     auth.PublicKeyOffer,
 		// Channels form the foundation of secure communication between clients and servers in SSH connections. A
 		// channel, in the context of SSH, is a logical conduit through which data travels securely between the client
 		// and the server. SSH channels serve as the infrastructure for executing commands, establishing shell sessions,

--- a/server/ssh/server/server.go
+++ b/server/ssh/server/server.go
@@ -32,6 +32,12 @@ type Options struct {
 	// Agents 0.5.x or earlier do not validate the public key request and may panic.
 	// Please refer to: https://github.com/shellhub-io/shellhub/issues/3453
 	AllowPublickeyAccessBelow060 bool
+	// Domain is the instance's base domain, used to build the browser approval
+	// URL shown in the terminal when a namespace requires SSH login approval.
+	Domain string
+	// AutoSSL reports whether the console is served over HTTPS; it selects the
+	// scheme of that approval URL.
+	AutoSSL bool
 }
 
 type Server struct {
@@ -176,6 +182,13 @@ func newServerConfigCallback(ctx gliderssh.Context) *gossh.ServerConfig {
 }
 
 func NewServer(dialer *dialer.Dialer, service services.Service, handoff *webhandoff.Store, opts *Options) (*Server, error) {
+	session.Configure(session.Config{
+		AllowPublickeyAccessBelow060: opts.AllowPublickeyAccessBelow060,
+		Domain:                       opts.Domain,
+		AutoSSL:                      opts.AutoSSL,
+		ConnectTimeout:               opts.ConnectTimeout,
+	})
+
 	server := &Server{ // nolint: exhaustruct
 		opts:   opts,
 		dialer: dialer,

--- a/server/ssh/server/server.go
+++ b/server/ssh/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"net"
 	"os"
@@ -39,6 +40,33 @@ type Options struct {
 	// scheme of that approval URL.
 	AutoSSL bool
 }
+
+// keepAlive is how a peer that went away without closing its socket gets
+// reclaimed: the kernel probes an idle connection and the read then fails with
+// a net.Error, which is what cancels the connection's context.
+//
+// These are Go's own defaults, set explicitly so the bound stays a decision of
+// ours rather than one a future release could change underneath us. Nine probes
+// fifteen seconds apart after fifteen seconds of silence puts the worst case at
+// about two and a half minutes.
+var keepAlive = net.KeepAliveConfig{
+	Enable:   true,
+	Idle:     15 * time.Second,
+	Interval: 15 * time.Second,
+	Count:    9,
+}
+
+// handshakeBudget bounds an unauthenticated connection.
+//
+// It has to outlast the browser approvals an identity-mode login can wait on:
+// an enrollment and a re-auth are two separate waits in one handshake, and the
+// deadline would otherwise cut off a login the user is about to approve.
+//
+// It bounds the connection, not the time spent inside a callback. The library
+// applies it as a socket deadline, and no I/O is in flight while the gateway
+// waits on an approval, so it fires on the next read rather than interrupting
+// the wait.
+const handshakeBudget = 2*session.ApprovalWaitTimeout + 30*time.Second
 
 type Server struct {
 	sshd   *gliderssh.Server
@@ -196,6 +224,14 @@ func NewServer(dialer *dialer.Dialer, service services.Service, handoff *webhand
 
 	server.sshd = &gliderssh.Server{ // nolint: exhaustruct
 		Addr: ":2222",
+		// Only the handshake is bounded by a deadline. An established connection
+		// is left to TCP keepalive, which reclaims a dead peer without punishing
+		// a live one for being quiet — an idle port forward carries no traffic
+		// for hours and is perfectly healthy.
+		//
+		// MaxTimeout is deliberately left unset too: it is an absolute deadline
+		// that is never cleared, so it would kill established shells at the limit.
+		HandshakeTimeout: handshakeBudget,
 		ConnCallback: func(ctx gliderssh.Context, conn net.Conn) net.Conn {
 			ctx.SetValue("conn", conn)
 
@@ -291,7 +327,9 @@ func (s *Server) ListenAndServe() error {
 		"addr": s.sshd.Addr,
 	}).Info("ssh server listening")
 
-	list, err := net.Listen("tcp", s.sshd.Addr)
+	lc := net.ListenConfig{KeepAliveConfig: keepAlive} //nolint:exhaustruct
+
+	list, err := lc.Listen(context.Background(), "tcp", s.sshd.Addr)
 	if err != nil {
 		log.WithError(err).Error("failed to listen an serve the TCP server")
 

--- a/server/ssh/server/timeout_test.go
+++ b/server/ssh/server/timeout_test.go
@@ -1,0 +1,13 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/shellhub-io/shellhub/server/ssh/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandshakeBudgetOutlastsApproval(t *testing.T) {
+	assert.Greater(t, handshakeBudget, session.ApprovalWaitTimeout,
+		"a login waiting on a browser approval would be cut off mid-handshake")
+}

--- a/server/ssh/session/approval_limit.go
+++ b/server/ssh/session/approval_limit.go
@@ -1,0 +1,100 @@
+package session
+
+import (
+	"errors"
+	"net"
+	"sync"
+)
+
+const (
+	// maxApprovalWaitsPerSource bounds how many logins from one address may sit
+	// waiting on a browser approval at the same time. A person approving a login
+	// needs one; a handful covers someone opening several terminals at once.
+	maxApprovalWaitsPerSource = 3
+
+	// maxApprovalWaitsTotal bounds the whole process, so a botnet spread across
+	// many addresses cannot do what one address cannot.
+	maxApprovalWaitsTotal = 256
+)
+
+// ErrApprovalBusy is returned when too many logins are already parked on an
+// approval decision.
+var ErrApprovalBusy = errors.New("ssh: too many logins waiting for approval")
+
+// approvalLimiter bounds the logins parked on a browser approval.
+//
+// Each wait holds a goroutine and an approval row for up to the approval
+// window, which is the most expensive thing an unauthenticated-but-key-holding
+// client can ask the gateway to do. Counting the waits bounds that directly,
+// rather than proxying for it by counting connections: a connection cap keys on
+// the wrong thing, since a NAT'd office legitimately opens many.
+type approvalLimiter struct {
+	perSource int
+	total     int
+
+	mu       sync.Mutex
+	inFlight map[string]int
+	current  int
+}
+
+func newApprovalLimiter(perSource, total int) *approvalLimiter {
+	return &approvalLimiter{
+		perSource: perSource,
+		total:     total,
+		inFlight:  make(map[string]int),
+		current:   0,
+	}
+}
+
+// acquire takes a slot for addr, returning the release func and whether it was
+// granted.
+//
+// Loopback is exempt: the web terminal bridge dials the gateway over it, so
+// every browser session in the instance would otherwise share one budget.
+func (l *approvalLimiter) acquire(addr string) (func(), bool) {
+	if isLoopback(addr) {
+		return func() {}, true
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.current >= l.total || l.inFlight[addr] >= l.perSource {
+		return nil, false
+	}
+
+	l.inFlight[addr]++
+	l.current++
+
+	return sync.OnceFunc(func() { l.release(addr) }), true
+}
+
+func (l *approvalLimiter) release(addr string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.inFlight[addr]--; l.inFlight[addr] <= 0 {
+		delete(l.inFlight, addr)
+	}
+
+	l.current--
+}
+
+func isLoopback(addr string) bool {
+	ip := net.ParseIP(addr)
+
+	return ip != nil && ip.IsLoopback()
+}
+
+var approvals = newApprovalLimiter(maxApprovalWaitsPerSource, maxApprovalWaitsTotal)
+
+// holdApprovalSlot reserves this session's place among the logins waiting on an
+// approval. The returned func gives it back and is safe to call more than once.
+func (s *Session) holdApprovalSlot() (func(), error) {
+	release, ok := approvals.acquire(s.IPAddress)
+	if !ok {
+		return nil, ErrApprovalBusy
+	}
+
+	return release, nil
+}

--- a/server/ssh/session/approval_limit_test.go
+++ b/server/ssh/session/approval_limit_test.go
@@ -1,0 +1,117 @@
+package session
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApprovalLimiter(t *testing.T) {
+	t.Run("grants up to the per-source limit", func(t *testing.T) {
+		limiter := newApprovalLimiter(2, 10)
+
+		_, ok := limiter.acquire("10.0.0.1")
+		require.True(t, ok)
+
+		_, ok = limiter.acquire("10.0.0.1")
+		require.True(t, ok)
+
+		_, ok = limiter.acquire("10.0.0.1")
+		assert.False(t, ok, "a third wait from the same address should be refused")
+	})
+
+	t.Run("one address does not starve another", func(t *testing.T) {
+		limiter := newApprovalLimiter(1, 10)
+
+		_, ok := limiter.acquire("10.0.0.1")
+		require.True(t, ok)
+
+		_, ok = limiter.acquire("10.0.0.2")
+		assert.True(t, ok)
+	})
+
+	t.Run("releasing frees the slot", func(t *testing.T) {
+		limiter := newApprovalLimiter(1, 10)
+
+		release, ok := limiter.acquire("10.0.0.1")
+		require.True(t, ok)
+
+		_, ok = limiter.acquire("10.0.0.1")
+		require.False(t, ok)
+
+		release()
+
+		_, ok = limiter.acquire("10.0.0.1")
+		assert.True(t, ok)
+	})
+
+	t.Run("releasing twice does not hand out a slot that was never taken", func(t *testing.T) {
+		limiter := newApprovalLimiter(1, 10)
+
+		release, ok := limiter.acquire("10.0.0.1")
+		require.True(t, ok)
+
+		release()
+		release()
+
+		_, ok = limiter.acquire("10.0.0.1")
+		require.True(t, ok)
+
+		_, ok = limiter.acquire("10.0.0.1")
+		assert.False(t, ok)
+	})
+
+	t.Run("the total bounds what many addresses can do", func(t *testing.T) {
+		limiter := newApprovalLimiter(1, 2)
+
+		_, ok := limiter.acquire("10.0.0.1")
+		require.True(t, ok)
+
+		_, ok = limiter.acquire("10.0.0.2")
+		require.True(t, ok)
+
+		_, ok = limiter.acquire("10.0.0.3")
+		assert.False(t, ok)
+	})
+
+	// The web terminal bridge dials the gateway over loopback, so every browser
+	// session in the instance shares that address.
+	t.Run("loopback is exempt", func(t *testing.T) {
+		limiter := newApprovalLimiter(1, 1)
+
+		for range 8 {
+			_, ok := limiter.acquire("127.0.0.1")
+			require.True(t, ok)
+		}
+
+		_, ok := limiter.acquire("::1")
+		assert.True(t, ok)
+	})
+
+	t.Run("stays consistent under contention", func(t *testing.T) {
+		limiter := newApprovalLimiter(4, 64)
+
+		wg := new(sync.WaitGroup)
+		wg.Add(64)
+
+		for range 64 {
+			go func() {
+				defer wg.Done()
+
+				if release, ok := limiter.acquire("10.0.0.1"); ok {
+					release()
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		limiter.mu.Lock()
+		defer limiter.mu.Unlock()
+
+		assert.Zero(t, limiter.current)
+		assert.Empty(t, limiter.inFlight)
+	})
+}

--- a/server/ssh/session/auther.go
+++ b/server/ssh/session/auther.go
@@ -157,6 +157,11 @@ func (*passwordAuth) Evaluate(*Session) error {
 // so this is the only thing that releases an abandoned login.
 const approvalWaitTimeout = 90 * time.Second
 
+// ApprovalWaitTimeout is [approvalWaitTimeout] for callers that have to size a
+// deadline around it — the SSH server's handshake timeout, above all, which
+// would otherwise cut off a login the user is about to approve.
+const ApprovalWaitTimeout = approvalWaitTimeout
+
 // approvalAskInterval is the pause between two asks. The API holds each one open
 // until the decision lands, so this is not what paces the wait — it only keeps a
 // gateway talking to an API too old to honour that from spinning, and bounds how

--- a/server/ssh/session/auther.go
+++ b/server/ssh/session/auther.go
@@ -52,12 +52,22 @@ func mintEphemeralSigner(session *Session, config *gossh.ClientConfig) error {
 // must have an [authFunc] to authenticate the session and an 'Evaluate' method to
 // evaluate the session's context if necessary (e.g. the agent version when
 // authenticating with public keys).
+//
+// The two checks are split by what the client has proven. The SSH protocol lets
+// a client ask whether a key would be acceptable without signing anything, and
+// x/crypto runs the publickey callback for that query, so anything reachable
+// before a signature must stay cheap and free of side effects.
 type Auth interface {
 	// Auth defines the callback that must be called when authenticating the session.
 	Auth() authFunc
 
-	// Evaluate evaluates the session's context, returning an error if there's something
-	// possibly broken. It's not always necessary.
+	// Offer decides whether the credential is acceptable at all. It may run
+	// before the client has proven it holds the key — including for a key it
+	// does not hold — so it must only read.
+	Offer(*Session) error
+
+	// Evaluate runs once the credential is proven, and is where anything with a
+	// cost or a side effect belongs. It's not always necessary.
 	Evaluate(*Session) error
 }
 
@@ -73,7 +83,13 @@ func (*publicKeyAuth) Auth() authFunc {
 	return mintEphemeralSigner
 }
 
-func (p *publicKeyAuth) Evaluate(session *Session) error {
+func (*publicKeyAuth) Evaluate(*Session) error {
+	// Everything legacy mode checks about a key is a read, so it all happens in
+	// Offer and there is nothing left to do once the signature lands.
+	return nil
+}
+
+func (p *publicKeyAuth) Offer(session *Session) error {
 	// Versions earlier than 0.6.0 do not validate the user when receiving a public key
 	// authentication request. This implies that requests with invalid users are
 	// treated as "authenticated" because the connection does not raise any error.
@@ -148,6 +164,11 @@ func (p *passwordAuth) Auth() authFunc {
 
 func (*passwordAuth) Evaluate(*Session) error {
 	// We don't need (yet) to do any evaluation when authenticating with password.
+	return nil
+}
+
+func (*passwordAuth) Offer(*Session) error {
+	// A password is only ever sent proven; the protocol has no query form for it.
 	return nil
 }
 
@@ -234,7 +255,22 @@ func (*approvalAuth) Auth() authFunc {
 	return mintEphemeralSigner
 }
 
+func (*approvalAuth) Offer(*Session) error {
+	// An unenrolled key is acceptable — turning it into an identity is the whole
+	// point of the flow — but nothing may be parked or written until the client
+	// has proven it holds the key.
+	return nil
+}
+
 func (a *approvalAuth) Evaluate(session *Session) error {
+	if err := session.openApproval(a.ctx, models.SSHApprovalIdentity, nil); err != nil {
+		return err
+	}
+
+	// Now that the key is known to be unknown and proven to be theirs, surface
+	// the approval URL and hold here.
+	sendBanner(a.ctx, buildAddKeyBanner(sshconf.Domain, sshconf.AutoSSL, session.ApprovalCode, session.Fingerprint))
+
 	approver, err := session.awaitApproval(a.ctx)
 	if err != nil {
 		return err
@@ -263,6 +299,12 @@ func AuthIdentity(ctx gliderssh.Context) Auth {
 
 func (*identityAuth) Auth() authFunc {
 	return mintEphemeralSigner
+}
+
+func (*identityAuth) Offer(*Session) error {
+	// The key resolved to a live identity, which is all that can be decided
+	// before the client proves it holds it.
+	return nil
 }
 
 func (a *identityAuth) Evaluate(session *Session) error {
@@ -345,9 +387,11 @@ func sendBanner(ctx gliderssh.Context, msg string) {
 
 // ResolveKeyAuth resolves the presented key to a ShellHub identity (identity
 // mode) and returns the auth to run: a hit yields the identity auth (authorize +
-// mint, no browser); a miss arranges a browser approval (attaching the key to
-// the pending code, surfacing its URL to the client, and having the console page
-// bind it) and yields the approval auth (poll + mint).
+// mint, no browser); a miss yields the approval auth, which arranges the browser
+// approval once the client has proven it holds the key.
+//
+// It is a lookup and nothing more. It runs for a key the client has only
+// offered, so it must not write.
 func (s *Session) ResolveKeyAuth(ctx gliderssh.Context, publicKey gliderssh.PublicKey) (Auth, error) {
 	s.Fingerprint = gossh.FingerprintSHA256(publicKey)
 	s.KeyData = gossh.MarshalAuthorizedKey(publicKey)
@@ -379,14 +423,6 @@ func (s *Session) ResolveKeyAuth(ctx gliderssh.Context, publicKey gliderssh.Publ
 	if s.Web {
 		return nil, ErrAccessDenied
 	}
-
-	if err := s.openApproval(ctx, models.SSHApprovalIdentity, nil); err != nil {
-		return nil, err
-	}
-
-	// Now that the key is known to be unknown, surface the approval URL and hold
-	// here. A key that is already an identity returns above and never sees this.
-	sendBanner(ctx, buildAddKeyBanner(sshconf.Domain, sshconf.AutoSSL, s.ApprovalCode, s.Fingerprint))
 
 	return AuthApproval(ctx), nil
 }

--- a/server/ssh/session/auther.go
+++ b/server/ssh/session/auther.go
@@ -263,6 +263,13 @@ func (*approvalAuth) Offer(*Session) error {
 }
 
 func (a *approvalAuth) Evaluate(session *Session) error {
+	release, err := session.holdApprovalSlot()
+	if err != nil {
+		return err
+	}
+
+	defer release()
+
 	if err := session.openApproval(a.ctx, models.SSHApprovalIdentity, nil); err != nil {
 		return err
 	}
@@ -321,6 +328,13 @@ func (a *identityAuth) Evaluate(session *Session) error {
 	}
 
 	if dec.RequireReauth && needsReauth(session.LastReauthAt, dec.ReauthPeriod) {
+		release, err := session.holdApprovalSlot()
+		if err != nil {
+			return err
+		}
+
+		defer release()
+
 		// The identity is already established by the key, so the decision only
 		// refreshes its window. The policy's period rides along so the console can
 		// say how long that lasts.

--- a/server/ssh/session/channel_test.go
+++ b/server/ssh/session/channel_test.go
@@ -1,0 +1,180 @@
+package session
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	servicemocks "github.com/shellhub-io/shellhub/server/api/services/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+type fakeChannel struct{}
+
+func (*fakeChannel) Read([]byte) (int, error)    { return 0, io.EOF }
+func (*fakeChannel) Write(p []byte) (int, error) { return len(p), nil }
+func (*fakeChannel) Close() error                { return nil }
+func (*fakeChannel) CloseWrite() error           { return nil }
+func (*fakeChannel) Stderr() io.ReadWriter       { return nil }
+
+func (*fakeChannel) SendRequest(_ string, _ bool, _ []byte) (bool, error) {
+	return true, nil
+}
+
+type fakeNewChannel struct{}
+
+func (*fakeNewChannel) Accept() (gossh.Channel, <-chan *gossh.Request, error) {
+	requests := make(chan *gossh.Request)
+	close(requests)
+
+	return &fakeChannel{}, requests, nil
+}
+
+func (*fakeNewChannel) Reject(gossh.RejectionReason, string) error { return nil }
+
+func (*fakeNewChannel) ChannelType() string { return "session" }
+func (*fakeNewChannel) ExtraData() []byte   { return nil }
+
+// TestNewClientChannelConcurrent covers the crash a multiplexed connection could
+// trigger: channel handlers run one goroutine per channel open, so unguarded
+// writes to the seat map are a runtime fatal error that recover cannot contain.
+// Without the mutex this fails under -race, and often dies outright.
+func TestNewClientChannelConcurrent(t *testing.T) {
+	const seats = 64
+
+	sess := newTestSession(servicemocks.NewMockService(t))
+
+	wg := new(sync.WaitGroup)
+	wg.Add(seats)
+
+	for seat := range seats {
+		go func() {
+			defer wg.Done()
+
+			channel, err := sess.NewClientChannel(&fakeNewChannel{}, seat)
+			assert.NoError(t, err)
+			assert.NotNil(t, channel)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Len(t, sess.Client.Channels, seats)
+
+	for seat := range seats {
+		assert.NotNil(t, sess.Client.Channels[seat], "seat %d lost its channel", seat)
+	}
+}
+
+func TestNewClientChannelRejectsSeatTwice(t *testing.T) {
+	sess := newTestSession(servicemocks.NewMockService(t))
+
+	_, err := sess.NewClientChannel(&fakeNewChannel{}, 0)
+	require.NoError(t, err)
+
+	_, err = sess.NewClientChannel(&fakeNewChannel{}, 0)
+	assert.ErrorIs(t, err, ErrSeatAlreadySet)
+}
+
+// TestDropAgentChannelConcurrent exercises the removal path against the same map
+// under contention, as the channel handler uses it to roll back a seat whose
+// client side failed to open.
+func TestDropAgentChannelConcurrent(t *testing.T) {
+	const seats = 32
+
+	sess := newTestSession(servicemocks.NewMockService(t))
+
+	for seat := range seats {
+		sess.Agent.Channels[seat] = &AgentChannel{Channel: &fakeChannel{}, Requests: nil}
+	}
+
+	wg := new(sync.WaitGroup)
+	wg.Add(seats)
+
+	for seat := range seats {
+		go func() {
+			defer wg.Done()
+
+			sess.DropAgentChannel(seat)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Empty(t, sess.Agent.Channels)
+}
+
+// TestSeatsConcurrentAccess covers the seat fields themselves: they are written
+// from the client-request goroutine and read from the pipe goroutine, so the
+// setters mutate in place and Get has to hand back a copy.
+func TestSeatsConcurrentAccess(t *testing.T) {
+	const seats = 32
+
+	sess := newTestSession(servicemocks.NewMockService(t))
+
+	ids := make([]int, 0, seats)
+
+	for range seats {
+		id, err := sess.Seats.NewSeat()
+		require.NoError(t, err)
+
+		ids = append(ids, id)
+	}
+
+	wg := new(sync.WaitGroup)
+
+	for _, id := range ids {
+		wg.Add(3)
+
+		go func() {
+			defer wg.Done()
+
+			sess.Seats.SetPty(id, true)
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			sess.Seats.SetType(id, "exec")
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			sess.Seats.Get(id)
+		}()
+	}
+
+	wg.Wait()
+
+	for _, id := range ids {
+		seat, ok := sess.Seats.Get(id)
+		assert.True(t, ok)
+		assert.True(t, seat.HasPty)
+		assert.Equal(t, "exec", seat.Type)
+	}
+}
+
+// TestSeatsGetReturnsCopy pins the reason Get does not hand out the stored
+// pointer: a caller holding it would observe later mutations without any
+// synchronization.
+func TestSeatsGetReturnsCopy(t *testing.T) {
+	sess := newTestSession(servicemocks.NewMockService(t))
+
+	id, err := sess.Seats.NewSeat()
+	require.NoError(t, err)
+
+	seat, ok := sess.Seats.Get(id)
+	require.True(t, ok)
+	require.False(t, seat.HasPty)
+
+	sess.Seats.SetPty(id, true)
+
+	assert.False(t, seat.HasPty)
+
+	seat, ok = sess.Seats.Get(id)
+	require.True(t, ok)
+	assert.True(t, seat.HasPty)
+}

--- a/server/ssh/session/conf.go
+++ b/server/ssh/session/conf.go
@@ -1,34 +1,40 @@
 package session
 
-import (
-	"github.com/shellhub-io/shellhub/pkg/envs"
-	log "github.com/sirupsen/logrus"
-)
+import "time"
 
-type config struct {
-	// Allows SSH to connect with an agent via a public key when the agent version is less than 0.6.0.
-	// Agents 0.5.x or earlier do not validate the public key request and may panic.
+// Config carries the settings the session package needs from the SSH server.
+type Config struct {
+	// AllowPublickeyAccessBelow060 allows SSH to connect with an agent via a public key when the agent version is
+	// less than 0.6.0. Agents 0.5.x or earlier do not validate the public key request and may panic.
 	// Please refer to: https://github.com/shellhub-io/shellhub/issues/3453
-	AllowPublickeyAccessBelow060 bool `env:"ALLOW_PUBLIC_KEY_ACCESS_BELLOW_0_6_0,default=false"`
+	AllowPublickeyAccessBelow060 bool
 
 	// Domain is the instance's base domain, used to build the browser approval URL
 	// shown in the terminal when a namespace requires SSH login approval.
-	Domain string `env:"SHELLHUB_DOMAIN,default=localhost"`
+	Domain string
 
 	// AutoSSL reports whether the instance serves the console over HTTPS; it
 	// selects the scheme of the approval URL.
-	AutoSSL bool `env:"SHELLHUB_AUTO_SSL,default=false"`
+	AutoSSL bool
+
+	// ConnectTimeout bounds the SSH handshake against the agent. Zero leaves it
+	// unbounded.
+	ConnectTimeout time.Duration
 }
 
-// sshconf is a global variable responsible for managing all environment configurations.
-var sshconf *config
+// sshconf holds the settings installed by [Configure].
+//
+// It is never nil: a test that does not configure the package reads these
+// defaults rather than dereferencing nothing.
+var sshconf = &Config{
+	AllowPublickeyAccessBelow060: false,
+	Domain:                       "localhost",
+	AutoSSL:                      false,
+	ConnectTimeout:               0,
+}
 
-func init() {
-	var err error
-
-	sshconf, err = envs.Parse[config]()
-	if err != nil {
-		log.WithError(err).
-			Error("failed to parse the environment variables")
-	}
+// Configure installs the package settings. It is called once from the SSH
+// server's constructor, before any connection is served.
+func Configure(cfg Config) {
+	sshconf = &cfg
 }

--- a/server/ssh/session/connect_test.go
+++ b/server/ssh/session/connect_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// TestConnectBoundsASilentAgent is the reason ConnectTimeout exists.
+//
+// An agent that accepts the stream and then says nothing leaves the SSH
+// handshake with nothing to wait on. The library offers no deadline of its own
+// here — ClientConfig.Timeout only bounds the TCP dial in gossh.Dial, which is
+// not the path this takes — so without the deadline the goroutine parks for the
+// life of the process.
+//
+// Note this covers the handshake specifically. A device that has gone away
+// entirely fails earlier, in the dialer, on its own deadlines.
+func TestConnectBoundsASilentAgent(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	defer listener.Close()
+
+	accepted := make(chan net.Conn, 1)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+
+		// Accept and stay silent: never send the SSH version banner.
+		accepted <- conn
+	}()
+
+	peer, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+
+	defer peer.Close()
+
+	Configure(Config{ //nolint:exhaustruct
+		ConnectTimeout: 2 * time.Second,
+	})
+
+	defer Configure(Config{ConnectTimeout: 0}) //nolint:exhaustruct
+
+	sess := newTestSession(nil)
+	sess.Agent.Conn = peer
+
+	noAuth := func(*Session, *gossh.ClientConfig) error { return nil }
+
+	done := make(chan error, 1)
+
+	start := time.Now()
+
+	go func() { done <- sess.connect(newStubContext(), noAuth) }()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "a silent agent must not authenticate")
+		assert.WithinDuration(t, start.Add(2*time.Second), time.Now(), 3*time.Second,
+			"the handshake should give up at the configured timeout")
+	case <-time.After(30 * time.Second):
+		t.Fatal("the handshake against a silent agent never gave up")
+	}
+
+	if conn := <-accepted; conn != nil {
+		conn.Close()
+	}
+}
+
+// TestConnectWithoutTimeoutNeverGivesUp pins why the deadline is the mechanism:
+// with it unset the same silent agent holds the handshake open indefinitely,
+// which is what the code did before ConnectTimeout was wired up.
+func TestConnectWithoutTimeoutNeverGivesUp(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	defer listener.Close()
+
+	go func() {
+		if conn, err := listener.Accept(); err == nil {
+			defer conn.Close()
+
+			time.Sleep(10 * time.Second)
+		}
+	}()
+
+	peer, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+
+	defer peer.Close()
+
+	Configure(Config{ConnectTimeout: 0}) //nolint:exhaustruct
+
+	sess := newTestSession(nil)
+	sess.Agent.Conn = peer
+
+	noAuth := func(*Session, *gossh.ClientConfig) error { return nil }
+
+	done := make(chan error, 1)
+	go func() { done <- sess.connect(newStubContext(), noAuth) }()
+
+	select {
+	case <-done:
+		t.Fatal("it returned without a deadline; the timeout is not what bounds this")
+	case <-time.After(3 * time.Second):
+		// Still waiting, as expected.
+	}
+}

--- a/server/ssh/session/drain_test.go
+++ b/server/ssh/session/drain_test.go
@@ -1,0 +1,114 @@
+package session
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	servicemocks "github.com/shellhub-io/shellhub/server/api/services/mocks"
+	"github.com/stretchr/testify/mock"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// drained feeds the loop and asserts it keeps consuming until the channel is
+// closed, which is the only thing that may end it.
+func drained(t *testing.T, sess *Session, reqs chan *gossh.Request, send int) {
+	t.Helper()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		sess.drainAgentRequests(newStubContext(), reqs)
+	}()
+
+	for range send {
+		select {
+		case reqs <- &gossh.Request{Type: "keepalive@shellhub.io"}: //nolint:exhaustruct
+		case <-time.After(5 * time.Second):
+			t.Error("the drain stopped consuming requests")
+
+			close(reqs)
+
+			return
+		}
+	}
+
+	close(reqs)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("the drain did not return after the requests channel closed")
+	}
+}
+
+// TestDrainAgentRequestsSurvivesKeepAliveFailure is the regression. The agent's
+// requests are buffered by a handful before its mux blocks on the send, and the
+// agent keeps sending for as long as its connection lives, so a loop that gave
+// up on a transient failure would freeze every channel on the connection.
+func TestDrainAgentRequestsSurvivesKeepAliveFailure(t *testing.T) {
+	serviceMock := servicemocks.NewMockService(t)
+	serviceMock.EXPECT().
+		KeepAliveSession(mock.Anything, models.UID("test-uid")).
+		Return(errors.New("store is down"))
+
+	sess := newTestSession(serviceMock)
+
+	// More than x/crypto buffers, so a loop that stopped early would wedge.
+	drained(t, sess, make(chan *gossh.Request), 32)
+}
+
+func TestDrainAgentRequestsRefusesOtherRequests(t *testing.T) {
+	sess := newTestSession(servicemocks.NewMockService(t))
+
+	reqs := make(chan *gossh.Request)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		sess.drainAgentRequests(newStubContext(), reqs)
+	}()
+
+	for range 32 {
+		reqs <- &gossh.Request{Type: "tcpip-forward"} //nolint:exhaustruct
+	}
+
+	close(reqs)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the drain did not return after the requests channel closed")
+	}
+}
+
+func TestDrainAgentRequestsEndsWithTheAgentConnection(t *testing.T) {
+	serviceMock := servicemocks.NewMockService(t)
+	serviceMock.EXPECT().
+		KeepAliveSession(mock.Anything, models.UID("test-uid")).
+		Return(nil)
+
+	sess := newTestSession(serviceMock)
+
+	reqs := make(chan *gossh.Request)
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		sess.drainAgentRequests(newStubContext(), reqs)
+	}()
+
+	reqs <- &gossh.Request{Type: "keepalive"} //nolint:exhaustruct
+	close(reqs)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the drain outlived the agent connection")
+	}
+}

--- a/server/ssh/session/identity_test.go
+++ b/server/ssh/session/identity_test.go
@@ -118,7 +118,44 @@ func TestResolveKeyAuth(t *testing.T) {
 		assert.Empty(t, sess.UserID)
 	})
 
-	t.Run("unknown key opens an identity approval and yields the approval auth", func(t *testing.T) {
+	t.Run("unknown key yields the approval auth without writing anything", func(t *testing.T) {
+		serviceMock := servicemocks.NewMockService(t)
+		serviceMock.EXPECT().
+			ResolveSSHIdentity(mock.Anything, "tenant-id", fingerprint).
+			Return(nil, false, nil).
+			Once()
+
+		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
+
+		auth, err := sess.ResolveKeyAuth(newStubContext(), pubKey)
+		require.NoError(t, err)
+		assert.IsType(t, &approvalAuth{}, auth)
+		assert.Empty(t, sess.UserID)
+
+		// The approval is only parked once the client proves it holds the key: the
+		// code is untouched, and the mock would fail if CreateSSHApproval ran.
+		assert.Equal(t, "WXYZ2K7Q", sess.ApprovalCode)
+	})
+
+	// Offer is what runs for a key the client has merely offered, so it must not
+	// reach the service at all.
+	t.Run("offering an unknown key writes nothing", func(t *testing.T) {
+		serviceMock := servicemocks.NewMockService(t)
+		serviceMock.EXPECT().
+			ResolveSSHIdentity(mock.Anything, "tenant-id", fingerprint).
+			Return(nil, false, nil).
+			Once()
+
+		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
+
+		auth, err := sess.ResolveKeyAuth(newStubContext(), pubKey)
+		require.NoError(t, err)
+		require.NoError(t, auth.Offer(sess))
+
+		assert.Equal(t, "WXYZ2K7Q", sess.ApprovalCode)
+	})
+
+	t.Run("the approval is parked once the key is proven", func(t *testing.T) {
 		serviceMock := servicemocks.NewMockService(t)
 		serviceMock.EXPECT().
 			ResolveSSHIdentity(mock.Anything, "tenant-id", fingerprint).
@@ -132,13 +169,19 @@ func TestResolveKeyAuth(t *testing.T) {
 			})).
 			Return(&models.SSHApprovalCreated{Code: "AB12CD34"}, nil).
 			Once()
+		serviceMock.EXPECT().
+			GetSSHApprovalStatus(mock.Anything, mock.Anything).
+			Return(&models.SSHApprovalStatus{State: models.SSHApprovalRejected}, nil). //nolint:exhaustruct
+			Once()
 
 		sess := newIdentitySession(serviceMock, models.SSHAccessModeIdentity)
 
 		auth, err := sess.ResolveKeyAuth(newStubContext(), pubKey)
 		require.NoError(t, err)
-		assert.IsType(t, &approvalAuth{}, auth)
+
+		// Rejected rather than approved: the point is that the approval was
+		// created and waited on, not what the person decided.
+		require.ErrorIs(t, auth.Evaluate(sess), ErrApprovalRejected)
 		assert.Equal(t, "AB12CD34", sess.ApprovalCode)
-		assert.Empty(t, sess.UserID)
 	})
 }

--- a/server/ssh/session/session.go
+++ b/server/ssh/session/session.go
@@ -530,9 +530,13 @@ func (s *Session) Recorded(seat int) error {
 
 // connect connects the session's client to the session's agent.
 func (s *Session) connect(ctx gliderssh.Context, authOpt authFunc) error {
+	// NOTE: ClientConfig.Timeout only bounds the TCP dial in gossh.Dial, which is
+	// not the path taken here, so the handshake below is bounded by a deadline on
+	// the connection instead.
 	config := &gossh.ClientConfig{
 		User:            s.Target.Username,
 		HostKeyCallback: gossh.InsecureIgnoreHostKey(), // nolint: gosec
+		Timeout:         sshconf.ConnectTimeout,
 	}
 
 	if err := authOpt(s, config); err != nil {
@@ -549,7 +553,9 @@ func (s *Session) connect(ctx gliderssh.Context, authOpt authFunc) error {
 	}
 
 	if config.Timeout > 0 {
-		if err := s.Agent.Conn.SetReadDeadline(clock.Now().Add(config.Timeout)); err != nil {
+		// Both directions: an agent that accepts the stream and never drains it
+		// blocks the write just as surely as a silent one blocks the read.
+		if err := s.Agent.Conn.SetDeadline(clock.Now().Add(config.Timeout)); err != nil {
 			log.WithError(err).
 				WithFields(log.Fields{"session": s.UID, "sshid": s.SSHID}).
 				Error("Error when trying to set dial deadline")
@@ -572,7 +578,7 @@ func (s *Session) connect(ctx gliderssh.Context, authOpt authFunc) error {
 	}
 
 	if config.Timeout > 0 {
-		if err := s.Agent.Conn.SetReadDeadline(time.Time{}); err != nil {
+		if err := s.Agent.Conn.SetDeadline(time.Time{}); err != nil {
 			log.WithError(err).
 				WithFields(log.Fields{"session": s.UID, "sshid": s.SSHID}).
 				Error("Error when trying to set dial deadline with Time{}")

--- a/server/ssh/session/session.go
+++ b/server/ssh/session/session.go
@@ -789,7 +789,7 @@ func buildReauthBanner(domain string, autoSSL bool, code string) string {
 // As a client may try to create N sessions with the same context, a [snapshot] is used
 // to save/retrieve the current session state. To illustrate a practical use of this
 // pattern you can imagine a client that wants to connect to a specified device. It first
-// calls the `PublicKeyHandler` with a specified context. At this stage, there are no
+// calls the `PublicKeyVerified` handler with a specified context. At this stage, there are no
 // sessions associated with the provided context, and a new one will be created. If it
 // fails, the same client (and consequently the same context) will call the
 // `PasswordHandler`, which also calls `session.New`. Since we have already created a

--- a/server/ssh/session/session.go
+++ b/server/ssh/session/session.go
@@ -36,14 +36,8 @@ type Data struct {
 	// Namespace is the namespace where device is located.
 	Namespace *models.Namespace
 	IPAddress string
-	// Type is the connection type.
-	Type string
-	// Term is the terminal used for the client.
-	Term string
 	// Web reports whether the session originated from the web terminal.
 	Web bool
-	// Handled check if the session is already handling a "shell", "exec" or a "subsystem".
-	Handled bool
 	// UserID is the ShellHub account bound to this session: resolved from the
 	// presented key in identity mode, or set by the enrollment/step-up approval.
 	// Empty in legacy mode.
@@ -90,15 +84,21 @@ type Agent struct {
 	Client *gossh.Client
 	// Requests is the channel to handle SSH global requests.
 	Requests <-chan *gossh.Request
+	// mu guards Channels. Channel handlers run one goroutine per channel open on
+	// a shared connection, so an unguarded map here is a runtime fatal error that
+	// recover cannot contain — and the HTTP API shares this process.
+	mu sync.Mutex
 	// Channels store the channels to agent, and its seat.
 	Channels map[int]*AgentChannel
 }
 
 // Close closes the underlying ssh client connection.
 func (a *Agent) Close() error {
+	a.mu.Lock()
 	for _, channel := range a.Channels {
 		channel.Close() //nolint:errcheck
 	}
+	a.mu.Unlock()
 
 	return a.Client.Close()
 }
@@ -118,12 +118,17 @@ func (c *ClientChannel) Close() error {
 
 // Client represents a connection to a client.
 type Client struct {
+	// mu guards Channels, for the same reason as [Agent.mu].
+	mu sync.Mutex
 	// Channels store the channels to client, and its seat.
 	Channels map[int]*ClientChannel
 }
 
 // Close closes a connection to client and all its channels.
 func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	for _, channel := range c.Channels {
 		if err := channel.Close(); err != nil {
 			return err
@@ -165,6 +170,10 @@ type Session struct {
 type Seat struct {
 	// HasPty is the status of pty on the seat.
 	HasPty bool
+	// Type is the connection type requested on this seat ("exec", "subsystem",
+	// …). It is per-seat and not per-session: one seat may run a shell while
+	// another runs an exec on the same multiplexed connection.
+	Type string
 }
 
 type Seats struct {
@@ -194,13 +203,30 @@ func (s *Seats) NewSeat() (int, error) {
 
 	s.Items.Store(id, &Seat{
 		HasPty: false,
+		Type:   "",
 	})
 
 	return id, nil
 }
 
-// Get gets a seat reference from their id.
-func (s *Seats) Get(seat int) (*Seat, bool) {
+// Get returns a copy of the seat with the given id.
+//
+// It is a copy because the stored value is mutated in place by the setters: a
+// caller holding the pointer would read fields without synchronization, and the
+// pipe goroutine does exactly that.
+func (s *Seats) Get(seat int) (Seat, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	item, ok := s.load(seat)
+	if !ok {
+		return Seat{}, false //nolint:exhaustruct
+	}
+
+	return *item, true
+}
+
+func (s *Seats) load(seat int) (*Seat, bool) {
 	loaded, ok := s.Items.Load(seat)
 	if !ok {
 		return nil, false
@@ -219,7 +245,7 @@ func (s *Seats) SetPty(seat int, status bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	item, ok := s.Get(seat)
+	item, ok := s.load(seat)
 	if !ok {
 		log.Warn("failed to set pty because no seat was created before")
 
@@ -227,6 +253,23 @@ func (s *Seats) SetPty(seat int, status bool) {
 	}
 
 	item.HasPty = status
+
+	s.Items.Store(seat, item)
+}
+
+// SetType sets the connection type on a seat from their id.
+func (s *Seats) SetType(seat int, kind string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	item, ok := s.load(seat)
+	if !ok {
+		log.Warn("failed to set type because no seat was created before")
+
+		return
+	}
+
+	item.Type = kind
 
 	s.Items.Store(seat, item)
 }
@@ -339,6 +382,9 @@ func NewSession(ctx gliderssh.Context, dialer *dialer.Dialer, service services.S
 
 // NewClientChannel accepts a new channel from a client and set a seat for it.
 func (s *Session) NewClientChannel(newChannel gossh.NewChannel, seat int) (*ClientChannel, error) {
+	s.Client.mu.Lock()
+	defer s.Client.mu.Unlock()
+
 	if _, ok := s.Client.Channels[seat]; ok {
 		return nil, ErrSeatAlreadySet
 	}
@@ -360,6 +406,9 @@ func (s *Session) NewClientChannel(newChannel gossh.NewChannel, seat int) (*Clie
 
 // NewAgentChannel opens a new channel to agent and set a seat for it.
 func (s *Session) NewAgentChannel(name string, seat int) (*AgentChannel, error) {
+	s.Agent.mu.Lock()
+	defer s.Agent.mu.Unlock()
+
 	if _, ok := s.Agent.Channels[seat]; ok {
 		return nil, ErrSeatAlreadySet
 	}
@@ -377,6 +426,21 @@ func (s *Session) NewAgentChannel(name string, seat int) (*AgentChannel, error) 
 	s.Agent.Channels[seat] = a
 
 	return a, nil
+}
+
+// DropAgentChannel closes the agent channel on a seat and forgets it, so a seat
+// whose client side failed to open does not keep a live channel behind it.
+func (s *Session) DropAgentChannel(seat int) {
+	s.Agent.mu.Lock()
+	defer s.Agent.mu.Unlock()
+
+	channel, ok := s.Agent.Channels[seat]
+	if !ok {
+		return
+	}
+
+	channel.Close() //nolint:errcheck
+	delete(s.Agent.Channels, seat)
 }
 
 func (s *Session) checkFirewall(ctx context.Context) error {

--- a/server/ssh/session/session.go
+++ b/server/ssh/session/session.go
@@ -82,8 +82,6 @@ type Agent struct {
 	Conn net.Conn
 	// Client is a [gossh.Client] connected and authenticated to the agent, waiting for an open session request.
 	Client *gossh.Client
-	// Requests is the channel to handle SSH global requests.
-	Requests <-chan *gossh.Request
 	// mu guards Channels. Channel handlers run one goroutine per channel open on
 	// a shared connection, so an unguarded map here is a runtime fatal error that
 	// recover cannot contain — and the HTTP API shares this process.
@@ -591,9 +589,68 @@ func (s *Session) connect(ctx gliderssh.Context, authOpt authFunc) error {
 	close(ch)
 
 	s.Agent.Client = gossh.NewClient(conn, chans, ch)
-	s.Agent.Requests = reqs
+
+	go s.drainAgentRequests(ctx, reqs)
 
 	return nil
+}
+
+// keepAliveRequestPrefix matches the agent's keepalive. The name it sends has
+// changed over the years but has always kept this prefix, so old agents are
+// recognised by it rather than by an exact match.
+const keepAliveRequestPrefix = "keepalive"
+
+// KeepAliveRequestType is the keepalive the gateway forwards to the client.
+const KeepAliveRequestType = keepAliveRequestPrefix + "@shellhub.io"
+
+// drainAgentRequests consumes the agent's global requests for as long as the
+// agent connection lives.
+//
+// It has to exist and it has to be the only one. The agent's requests are
+// deliberately kept away from [gossh.NewClient] above, so nothing else reads
+// them, and x/crypto buffers only a handful before the mux blocks on the send —
+// which would freeze every channel on this connection, port forwards included.
+// The agent keeps sending regardless, since its keepalive loop is scoped to its
+// connection and not to any one channel.
+//
+// That is why no error in here ends the loop. Only the channel closing does,
+// which happens when the agent connection goes away.
+func (s *Session) drainAgentRequests(ctx gliderssh.Context, reqs <-chan *gossh.Request) {
+	logger := log.WithFields(log.Fields{"session": s.UID, "sshid": s.SSHID})
+
+	defer logger.Trace("agent global requests drained")
+
+	for req := range reqs {
+		if !strings.HasPrefix(req.Type, keepAliveRequestPrefix) {
+			if req.WantReply {
+				if err := req.Reply(false, nil); err != nil {
+					logger.WithError(err).Warn("failed to refuse a global request from the agent")
+				}
+			}
+
+			continue
+		}
+
+		if req.WantReply {
+			if err := req.Reply(true, nil); err != nil {
+				logger.WithError(err).Warn("failed to reply to the keepalive from the agent")
+			}
+		}
+
+		if err := s.KeepAlive(ctx); err != nil {
+			logger.WithError(err).Warn("failed to record the session as alive")
+		}
+
+		// Forwarded on the connection rather than on a channel, so it also
+		// reaches a client that only has port forwards open. The value is read
+		// per request because the library publishes it once the handshake is
+		// done, and this loop starts during authentication.
+		if conn, ok := ctx.Value(gliderssh.ContextKeyConn).(gossh.Conn); ok && conn != nil {
+			if _, _, err := conn.SendRequest(KeepAliveRequestType, false, req.Payload); err != nil {
+				logger.WithError(err).Warn("failed to forward the keepalive to the client")
+			}
+		}
+	}
 }
 
 var ErrDialUnknown = errors.New("unknown protocol version")

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -360,45 +360,6 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				require.Error(t, err)
 			},
 		},
-		/*{
-			name: "connection keepalive when session is requested",
-			run: func(t *testing.T, environment *Environment, device *models.Device) {
-				config := &ssh.ClientConfig{
-					User: fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name),
-					Auth: []ssh.AuthMethod{
-						ssh.Password(ShellHubAgentPassword),
-					},
-					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
-				}
-
-				var globalConn ssh.Conn
-
-				require.EventuallyWithT(t, func(tt *assert.CollectT) {
-					var err error
-
-					dialed, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config.Timeout)
-					assert.NoError(tt, err)
-
-					conn, _, _, err := ssh.NewClientConn(dialed, fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
-					assert.NoError(tt, err)
-
-					globalConn = conn
-				}, 30*time.Second, 1*time.Second)
-
-				ch, reqs, err := globalConn.OpenChannel("session", nil)
-				assert.NoError(t, err)
-
-				ok, err := ch.SendRequest("shell", true, nil)
-				assert.True(t, ok)
-				assert.NoError(t, err)
-
-				req := <-reqs
-				assert.True(t, strings.HasPrefix(req.Type, "keepalive"))
-
-				ch.Close()
-				globalConn.Close()
-			},
-		}*/
 		{
 			name: "connection SHELL with Pty",
 			run: func(t *testing.T, environment *Environment, device *models.Device) {
@@ -919,6 +880,208 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				assert.Equal(t, 1024*1024, len(output))
 				for _, b := range output {
 					assert.Equal(t, byte('X'), b)
+				}
+			},
+		},
+		{
+			// Regression: stderr used to be merged into stdout, so `2>/dev/null`
+			// filtered nothing and redirects were polluted. CombinedOutput cannot
+			// catch that — it merges the two streams itself — so this reads them
+			// apart.
+			name: "connection EXEC with separate stdout and stderr",
+			run: func(t *testing.T, environment *Environment, device *models.Device) {
+				config := &ssh.ClientConfig{
+					User: fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name),
+					Auth: []ssh.AuthMethod{
+						ssh.Password(ShellHubAgentPassword),
+					},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+				}
+
+				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				require.NoError(t, err)
+				defer conn.Close()
+
+				sess, err := conn.NewSession()
+				require.NoError(t, err)
+				defer sess.Close()
+
+				var stdout, stderr bytes.Buffer
+
+				sess.Stdout = &stdout
+				sess.Stderr = &stderr
+
+				err = sess.Run(`echo -n "to stdout"; echo -n "to stderr" 1>&2; exit 7`)
+
+				var status *ssh.ExitError
+
+				require.ErrorAs(t, err, &status)
+				assert.Equal(t, 7, status.ExitStatus())
+
+				assert.Equal(t, "to stdout", stdout.String())
+				assert.Equal(t, "to stderr", stderr.String())
+			},
+		},
+		{
+			// Regression: io.MultiReader drains its readers in sequence, so nothing
+			// read stderr until stdout reached EOF. A command writing past the pipe
+			// buffer blocked in write(2) and never exited, so stdout never reached
+			// EOF either. The assertion that matters is that this returns at all.
+			name: "connection EXEC with large stderr",
+			run: func(t *testing.T, environment *Environment, device *models.Device) {
+				config := &ssh.ClientConfig{
+					User: fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name),
+					Auth: []ssh.AuthMethod{
+						ssh.Password(ShellHubAgentPassword),
+					},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+				}
+
+				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				require.NoError(t, err)
+				defer conn.Close()
+
+				sess, err := conn.NewSession()
+				require.NoError(t, err)
+				defer sess.Close()
+
+				var stdout, stderr bytes.Buffer
+
+				sess.Stdout = &stdout
+				sess.Stderr = &stderr
+
+				done := make(chan error, 1)
+
+				go func() {
+					// Well past the 64 KiB pipe buffer that used to deadlock.
+					done <- sess.Run("yes E | tr -d '\n' | head -c 1048576 1>&2; echo -n done")
+				}()
+
+				select {
+				case err := <-done:
+					require.NoError(t, err)
+				case <-time.After(60 * time.Second):
+					t.Fatal("writing 1MiB to stderr never completed")
+				}
+
+				assert.Equal(t, 1024*1024, stderr.Len())
+				assert.Equal(t, "done", stdout.String())
+			},
+		},
+		{
+			// Regression: a shell with no pty is all a heredoc sends, and it was
+			// not one of the requests that started the data pipe, so the session
+			// had no data path and hung until the client gave up.
+			name: "connection SHELL without Pty",
+			run: func(t *testing.T, environment *Environment, device *models.Device) {
+				config := &ssh.ClientConfig{
+					User: fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name),
+					Auth: []ssh.AuthMethod{
+						ssh.Password(ShellHubAgentPassword),
+					},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+				}
+
+				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				require.NoError(t, err)
+				defer conn.Close()
+
+				sess, err := conn.NewSession()
+				require.NoError(t, err)
+				defer sess.Close()
+
+				stdin, err := sess.StdinPipe()
+				require.NoError(t, err)
+
+				var stdout, stderr bytes.Buffer
+
+				sess.Stdout = &stdout
+				sess.Stderr = &stderr
+
+				// No RequestPty: this is the heredoc shape.
+				require.NoError(t, sess.Shell())
+
+				_, err = io.WriteString(stdin, "echo -n heredoc_out\necho -n heredoc_err 1>&2\nexit 5\n")
+				require.NoError(t, err)
+				require.NoError(t, stdin.Close())
+
+				done := make(chan error, 1)
+
+				go func() { done <- sess.Wait() }()
+
+				select {
+				case err := <-done:
+					var status *ssh.ExitError
+
+					require.ErrorAs(t, err, &status)
+					assert.Equal(t, 5, status.ExitStatus())
+				case <-time.After(60 * time.Second):
+					t.Fatal("a shell without a pty never produced anything")
+				}
+
+				assert.Equal(t, "heredoc_out", stdout.String())
+				assert.Equal(t, "heredoc_err", stderr.String())
+			},
+		},
+		{
+			// Replaces a case disabled since b32abb41d. It waited for the keepalive
+			// on the channel's request stream; the gateway forwards it on the
+			// connection now, so that a client holding only port forwards gets one
+			// too.
+			name: "connection keepalive reaches the client",
+			run: func(t *testing.T, environment *Environment, device *models.Device) {
+				config := &ssh.ClientConfig{
+					User: fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name),
+					Auth: []ssh.AuthMethod{
+						ssh.Password(ShellHubAgentPassword),
+					},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+				}
+
+				addr := fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT"))
+
+				dialed, err := net.DialTimeout("tcp", addr, 30*time.Second)
+				require.NoError(t, err)
+
+				conn, chans, reqs, err := ssh.NewClientConn(dialed, addr, config)
+				require.NoError(t, err)
+
+				defer conn.Close()
+
+				go func() {
+					for newChan := range chans {
+						newChan.Reject(ssh.UnknownChannelType, "unexpected") //nolint:errcheck
+					}
+				}()
+
+				// The agent only starts its keepalive loop once a session is
+				// requested, so ask for one and leave it open.
+				ch, chReqs, err := conn.OpenChannel("session", nil)
+				require.NoError(t, err)
+
+				defer ch.Close()
+
+				go ssh.DiscardRequests(chReqs)
+
+				_, err = ch.SendRequest("shell", true, nil)
+				require.NoError(t, err)
+
+				// The agent runs with SHELLHUB_KEEPALIVE_INTERVAL=1.
+				for {
+					select {
+					case req, ok := <-reqs:
+						require.True(t, ok, "the connection closed before a keepalive arrived")
+
+						if req.WantReply {
+							req.Reply(false, nil) //nolint:errcheck
+						}
+
+						if strings.HasPrefix(req.Type, "keepalive") {
+							return
+						}
+					case <-time.After(60 * time.Second):
+						t.Fatal("no keepalive reached the client on the connection")
+					}
 				}
 			},
 		},


### PR DESCRIPTION
## What

Fixes a group of defects in the SSH gateway and the agent, found while researching whether to drop `gliderlabs/ssh`. They are independent of that question. The most serious is a crash that takes the HTTP API down with the SSH server; the rest are hangs, silent failures, and work done for peers that have not authenticated.

## Why

The SSH server and the HTTP API share a process, so a fatal error in one kills the other. CI was not running the race detector, which is why the crash was never caught.

Closes #1969

## Changes

**Crash and races**

- **seat maps**: `Client.Channels` and `Agent.Channels` were plain maps written by one goroutine per channel open. Two channels opening at once on a multiplexed connection produced `fatal error: concurrent map writes` — a runtime fatal that `recover` cannot contain, so the API died with it. Reachable by any authenticated user.
- `Session.Type` was one field for the whole session, read from the pipe goroutine and written from the request goroutine. Besides the race, it meant an `exec` on one seat made another seat's teardown hard-close the wrong channel. It moves onto the seat.
- **ci**: the race detector now runs, which is what would have caught the above.

**Hangs**

- **agent, host mode**: `io.MultiReader` does not merge concurrently — it drains stdout to EOF before touching stderr. Nothing drained stderr, so a command writing past the 64 KiB pipe buffer blocked forever. Below that threshold stderr still arrived tagged as stdout, so `2>/dev/null` filtered nothing and SCP was corrupted by anything `.bashrc` wrote.
- **gateway**: the same mistake one hop further along, where the ceiling is the 2 MiB channel window rather than a pipe buffer. Extended data is server-to-client only, so just one direction gains a copy; the client's own stream is drained to `io.Discard` so an ill-behaved client cannot pin the window.
- **shell without a pty** never started the data pipe at all, so heredocs hung until the client gave up. A regression from eb20b41f, which gated piping on the request type and left `shell` out.
- **agent global requests** had a single drain that returned on any transient failure. The agent keeps sending, x/crypto buffers a handful, and the mux then blocks — freezing every channel on that connection, port forwards included. The drain moves to the session, where its lifetime belongs, and no longer gives up.

**Unauthenticated work**

- **publickey auth** ran the whole chain from the callback that x/crypto invokes for an unsigned key *query*: an approval row, a 90s browser wait, a registered session, a dial to the agent, and a minted key — all before any signature existed. Not an auth bypass, but an unauthenticated peer could create server-side state and burn resources, and `PartialSuccessError` does not count against `MaxAuthTries`. Legacy mode was affected identically, since the library overwrites the config's publickey callback with the server's handler. Auth now splits by what the client has proven: `Offer` only reads, and everything with a cost moves behind `VerifiedPublicKeyCallback`.
- **approval waits** are capped per source address. A parked wait holds a goroutine and a row for the length of the approval window, which is the most expensive thing a key-holding client can ask for.

**Liveness**

- **handshake**: bounded for the first time, derived from the approval window rather than picked, since an enrollment and a re-auth are two separate waits in one handshake.
- **dead peers** are reclaimed by TCP keepalive, now configured explicitly at the listener rather than left to Go's defaults. An idle deadline was tried and removed: it cannot tell a dead peer from a quiet one, so it dropped idle port forwards, and sessions only survived while the agent's keepalive interval stayed below it — an interval set on the agent, which the gateway does not control.
- **connect timeout**: `CONNECT_TIMEOUT` was parsed, copied into `Options`, and never read. It bounds the handshake against the agent; a device that has gone away entirely still fails earlier, in the dialer.

**Silent failures**

- the client's channel was accepted before the agent's was opened, so every rejection after that reached a channel that had already been decided and the client was told nothing. OpenSSH printed no message and exited 255. Opening the agent channel first means the reason survives.
- a malformed `pty-req` was logged and then ignored: the seat was still marked as having a pty, which turned recording on and wrote attacker-chosen dimensions into the audit trail.
- **agent, SFTP** resolved the account with `os/user` while every other path uses `osauth`. The agent normally runs containerized with the host mounted, so the two read different files and every SFTP session failed with "unknown user" — and with it `scp`, which speaks SFTP by default.

## Testing

Worth probing:

- **behaviour changes a reviewer may question.** Session recordings receive stdout only (a no-op in practice: recording requires a pty, and a pty has already merged the two). A malformed `pty-req` is no longer forwarded to the agent and no longer starts the pipe. The keepalive reaches the client as a connection-level global request rather than a channel request, which is what makes it reach a client holding only port forwards.
- **old agents.** Verified against published images from v0.26.0 down to v0.17.0, across both transports: exec, heredoc, pty, `scp`, `ssh -L`, and idle connections all behave. Note the two agent-side fixes only help once the agent is updated — the released images still deadlock on stderr, and still fail SFTP from v0.21 onward.
- **not covered live.** Published images stop at v0.17, so the gates for agents below 0.6.0, 0.9.3, 0.13 and 0.15 rest on code reading and unit tests rather than a run.
