### PR TITLE
test(pkg): fix data race in the asynq client test

### DIFF
--- a/pkg/worker/asynq/client_test.go
+++ b/pkg/worker/asynq/client_test.go
@@ -39,9 +39,13 @@ func TestClient(t *testing.T) {
 		},
 	)
 
-	assertTaskPayload := ""
+	// Buffered so the handler never blocks on a test that has already given up,
+	// and a channel rather than a variable because the handler runs on one of
+	// asynq's own goroutines: the send is what orders the write against the read
+	// below.
+	handled := make(chan string, 1)
 	asynqMux.HandleFunc("queue:kind", func(_ context.Context, t *asynqlib.Task) error {
-		assertTaskPayload = string(t.Payload())
+		handled <- string(t.Payload())
 
 		return nil
 	})
@@ -54,6 +58,11 @@ func TestClient(t *testing.T) {
 	defer client.Close()
 
 	require.NoError(t, client.Submit(ctx, "queue:kind", []byte("task was called")))
-	time.Sleep(10 * time.Second)
-	require.Equal(t, "task was called", assertTaskPayload)
+
+	select {
+	case payload := <-handled:
+		require.Equal(t, "task was called", payload)
+	case <-time.After(30 * time.Second):
+		t.Fatal("the task was never handled")
+	}
 }


### PR DESCRIPTION
## What

Removes a data race between the asynq task handler and the test that asserts on its payload.

## Why

The handler assigned to a variable the test then read, on different goroutines — asynq calls the handler on one of its own — with only a ten second sleep between them, which orders nothing.

It surfaces as soon as the race detector is enabled, which #6834 does for the Go suites. Splitting it out so that PR is not carrying an unrelated fix, and so this lands on master independently.

```
WARNING: DATA RACE
Read at 0x00c000502280 by goroutine 13:
      pkg/worker/asynq/client_test.go:58
Previous write at 0x00c000502280 by goroutine 158:
      pkg/worker/asynq/client_test.go:44
```

## Changes

- **pkg/worker/asynq**: the payload travels over a buffered channel, so the send is what orders the write against the read. The test now proceeds the moment the task is handled instead of always sleeping ten seconds, and fails with a message naming the problem if it never is.

## Testing

`go test -race ./worker/asynq/...` from `pkg`. Reproduced red before the change at exactly the two lines above, green after.
