### PR TITLE
chore(deps): update the SSH fork

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -28,6 +28,8 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/x/conpty v0.2.0 // indirect
+	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -56,6 +58,7 @@ require (
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pires/go-proxyproto v0.12.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sethvargo/go-envconfig v0.9.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
@@ -78,4 +81,4 @@ require (
 
 replace github.com/shellhub-io/shellhub => ../
 
-replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh v0.0.0-20260415152045-3e1bf24c2919
+replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh v0.0.0-20260802001203-122036eb1cc1

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -12,6 +12,10 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/charmbracelet/x/conpty v0.2.0 h1:eKtA2hm34qNfgJCDp/M6Dc0gLy7e07YEK4qAdNGOvVY=
+github.com/charmbracelet/x/conpty v0.2.0/go.mod h1:fexgUnVrZgw8scD49f6VSi0Ggj9GWYIrpedRthAwW/8=
+github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=
+github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -62,8 +66,8 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
-github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -102,6 +106,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/openwall/yescrypt-go v1.0.0 h1:jsGk48zkFvtUjGVOhYPGh+CS595JmTRcKnpggK2AON4=
 github.com/openwall/yescrypt-go v1.0.0/go.mod h1:e6CWtFizUEOUttaOjeVMiv1lJaJie3mfOtLJ9CCD6sA=
+github.com/pires/go-proxyproto v0.12.0 h1:TTCxD66dU898tahivkqc3hoceZp7P44FnorWyo9d5vM=
+github.com/pires/go-proxyproto v0.12.0/go.mod h1:qUvfqUMEoX7T8g0q7TQLDnhMjdTrxnG0hvpMn+7ePNI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.11 h1:0N92SLTB8JqASJB14ZLHHzFnBV8mG9zw4K7jghEFWuE=
@@ -113,8 +119,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sethvargo/go-envconfig v0.9.0 h1:Q6FQ6hVEeTECULvkJZakq3dZMeBQ3JUpcKMfPQbKMDE=
 github.com/sethvargo/go-envconfig v0.9.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
-github.com/shellhub-io/ssh v0.0.0-20260415152045-3e1bf24c2919 h1:T+9ELVaqekRQQtBeNcq5xSuBWtY1RmnpC0HSmLJbuFM=
-github.com/shellhub-io/ssh v0.0.0-20260415152045-3e1bf24c2919/go.mod h1:xVg6wNn8b+Cn8bVPGMEj/aoDSi3Q7R4gxbD6sFewkHs=
+github.com/shellhub-io/ssh v0.0.0-20260802001203-122036eb1cc1 h1:I0TvJejNL9PayQhfvkaRpXrAvYnGyMEm2lg1fASaork=
+github.com/shellhub-io/ssh v0.0.0-20260802001203-122036eb1cc1/go.mod h1:x9I554T2Lmh78Qai8VN4wnVyxXjkLAEYpJMBVchsG6A=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/agent/server/modes/host/sessioner_test.go
+++ b/agent/server/modes/host/sessioner_test.go
@@ -99,6 +99,8 @@ func (f *fakeSession) Pty() (gliderssh.Pty, <-chan gliderssh.Window, bool) {
 	return f.pty, f.winCh, f.isPty
 }
 
+func (f *fakeSession) EmulatedPty() bool { return false }
+
 func (f *fakeSession) Signals(c chan<- gliderssh.Signal) {}
 
 func (f *fakeSession) Break(c chan<- bool) {}

--- a/agent/server/modes/host/utils_test.go
+++ b/agent/server/modes/host/utils_test.go
@@ -64,6 +64,8 @@ func (s *stubSession) Pty() (gliderssh.Pty, <-chan gliderssh.Window, bool) {
 	return gliderssh.Pty{}, nil, false
 }
 
+func (s *stubSession) EmulatedPty() bool { return false }
+
 func (s *stubSession) Signals(_ chan<- gliderssh.Signal) {}
 
 func (s *stubSession) Break(_ chan<- bool) {}

--- a/server/go.mod
+++ b/server/go.mod
@@ -43,11 +43,14 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/x/conpty v0.2.0 // indirect
+	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -136,4 +139,4 @@ require (
 
 replace github.com/shellhub-io/shellhub => ../
 
-replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh v0.0.0-20260415152045-3e1bf24c2919
+replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh v0.0.0-20260802001203-122036eb1cc1

--- a/server/go.sum
+++ b/server/go.sum
@@ -26,6 +26,10 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/charmbracelet/x/conpty v0.2.0 h1:eKtA2hm34qNfgJCDp/M6Dc0gLy7e07YEK4qAdNGOvVY=
+github.com/charmbracelet/x/conpty v0.2.0/go.mod h1:fexgUnVrZgw8scD49f6VSi0Ggj9GWYIrpedRthAwW/8=
+github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=
+github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08 h1:ox2F0PSMlrAAiAdknSRMDrAr8mfxPCfSZolH+/qQnyQ=
 github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -261,8 +265,8 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEV
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sethvargo/go-envconfig v0.9.0 h1:Q6FQ6hVEeTECULvkJZakq3dZMeBQ3JUpcKMfPQbKMDE=
 github.com/sethvargo/go-envconfig v0.9.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
-github.com/shellhub-io/ssh v0.0.0-20260415152045-3e1bf24c2919 h1:T+9ELVaqekRQQtBeNcq5xSuBWtY1RmnpC0HSmLJbuFM=
-github.com/shellhub-io/ssh v0.0.0-20260415152045-3e1bf24c2919/go.mod h1:xVg6wNn8b+Cn8bVPGMEj/aoDSi3Q7R4gxbD6sFewkHs=
+github.com/shellhub-io/ssh v0.0.0-20260802001203-122036eb1cc1 h1:I0TvJejNL9PayQhfvkaRpXrAvYnGyMEm2lg1fASaork=
+github.com/shellhub-io/ssh v0.0.0-20260802001203-122036eb1cc1/go.mod h1:x9I554T2Lmh78Qai8VN4wnVyxXjkLAEYpJMBVchsG6A=
 github.com/shirou/gopsutil/v4 v4.26.5 h1:RPcBXkpz7kOj9PqGFQOlBPZHsyaPvPVQc098y9RmCNM=
 github.com/shirou/gopsutil/v4 v4.26.5/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/rand"
@@ -1144,28 +1145,31 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 				defer sess.Close()
 
 				err = sess.RequestPty("xterm", 24, 80, ssh.TerminalModes{
-					ssh.ECHO: 1,
+					ssh.ECHO: 0,
 				})
 				require.NoError(t, err)
 
-				stdin, _ := sess.StdinPipe()
+				// Nothing drains the size until the session handler starts, and that
+				// only happens on the exec below: a resize that blocks here never
+				// lets it through.
+				require.NoError(t, sess.WindowChange(48, 160))
+
+				// No reply confirms a resize reached the pty, so wait on the device's
+				// own report — it can only follow the ioctl. Under exec because an
+				// interactive shell defers the trap until its line editor returns.
+				const reportResizes = `sh -c 'trap "echo SIZE \$(stty size)" WINCH; echo READY; sleep 3600 & while :; do wait; done'`
+
 				stdout, _ := sess.StdoutPipe()
 
-				err = sess.Shell()
-				require.NoError(t, err)
-
-				var output struct {
-					sync.Mutex
-					buf bytes.Buffer
-				}
+				lines := make(chan string, 256)
 				go func() {
-					tmp := make([]byte, 1024)
+					defer close(lines)
+
+					reader := bufio.NewReader(stdout)
 					for {
-						n, err := stdout.Read(tmp)
-						if n > 0 {
-							output.Lock()
-							output.buf.Write(tmp[:n])
-							output.Unlock()
+						line, err := reader.ReadString('\n')
+						if line != "" {
+							lines <- strings.TrimSpace(line)
 						}
 						if err != nil {
 							return
@@ -1173,49 +1177,48 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 					}
 				}()
 
-				waitForOutput := func(substr string, timeout time.Duration) error {
-					deadline := time.After(timeout)
-					ticker := time.NewTicker(200 * time.Millisecond)
-					defer ticker.Stop()
+				// The deadline stops a wedged session hanging the suite, and is never
+				// the criterion — raising it has hidden this bug before.
+				waitFor := func(want string) error {
+					deadline := time.After(30 * time.Second)
 
 					for {
 						select {
-						case <-ticker.C:
-							output.Lock()
-							got := output.buf.String()
-							output.Unlock()
+						case line, ok := <-lines:
+							if !ok {
+								return fmt.Errorf("session ended while waiting for %q", want)
+							}
 
-							if strings.Contains(got, substr) {
+							if strings.Contains(line, want) {
 								return nil
 							}
 						case <-deadline:
-							output.Lock()
-							got := output.buf.String()
-							output.Unlock()
-
-							return fmt.Errorf("timed out waiting for %q in output (last %d bytes: %q)",
-								substr, min(len(got), 500), got[max(0, len(got)-500):])
+							return fmt.Errorf("timed out waiting for %q", want)
 						}
 					}
 				}
 
-				_, err = fmt.Fprintln(stdin, "bind 'set enable-bracketed-paste off'")
-				require.NoError(t, err)
+				// Start waits on the exec reply forever, and a wedged loop never sends one.
+				started := make(chan error, 1)
+				go func() {
+					started <- sess.Start(reportResizes)
+				}()
 
-				_, err = fmt.Fprintln(stdin, "echo READY")
-				require.NoError(t, err)
-				require.NoError(t, waitForOutput("READY", 30*time.Second))
+				select {
+				case err := <-started:
+					require.NoError(t, err)
+				case <-time.After(15 * time.Second):
+					require.FailNow(t, "exec went unanswered: the session's request loop is wedged")
+				}
 
-				err = sess.WindowChange(48, 160)
-				require.NoError(t, err)
+				require.NoError(t, waitFor("READY"))
 
-				output.Lock()
-				output.buf.Reset()
-				output.Unlock()
+				for _, size := range [][2]int{{40, 120}, {24, 80}, {50, 200}, {30, 100}} {
+					rows, cols := size[0], size[1]
 
-				_, err = fmt.Fprintln(stdin, "stty size")
-				require.NoError(t, err)
-				require.NoError(t, waitForOutput("48 160", 30*time.Second))
+					require.NoError(t, sess.WindowChange(rows, cols))
+					require.NoError(t, waitFor(fmt.Sprintf("SIZE %d %d", rows, cols)))
+				}
 			},
 		},
 		{


### PR DESCRIPTION
Points `server/` and `agent/` at the rebuilt SSH fork, whose master now
carries our patches on a current base instead of on a gliderlabs tree that
has not moved since 2023. Everything the old fork carried by hand is
already in the new base, verified in the code rather than from a
changelog: cross-account auth, the `Permissions` leak between callbacks,
nil `Extensions`, the `LocalAddr` panic, panic containment, nil `Handler`,
reverse-forward keyed by the bound port, `SetOption` after start, and the
`parseString` overflow.

Behaviour is meant to be identical. The default still rewrites writes the
way the old fork did unconditionally, so this can be validated on its own
before anything touches the agent's pty handling.

## The hang it fixes

`winch` is buffered to one and `pty-req` fills it with the initial size.
Nothing drains it until the session handler starts, and that only happens
once a `shell` or `exec` request is processed. A `window-change` arriving
in between blocked, and the request behind it in the queue was the very
one that would have started the consumer.

The result was a session that hung with no error anywhere: the gateway
forwarded `pty-req`, `window-change` and `exec`, the agent processed the
first two and never the third, and the client's `Start` waited on a reply
that was never coming. A terminal that resizes as soon as it has a pty,
before the shell is up, is enough to reach it.

The same shape wedges connector-mode sessions permanently, since nothing
there drains the window channel at all.

## The test

`terminal window size change` resized only after the shell was already
running, which is the order that cannot wedge, then polled `stty` until
the size matched. Both fixes it collected treat the symptom: one raised
the timeouts from 2s and 5s to 10s and 30s, the other cut it from eight
resize cycles to one. Neither exercises the path any more.

It now resizes once before asking for anything to run, and waits for the
device to report each size rather than polling for it. A `window-change`
carries no reply, so a report from the device is the only thing that
cannot precede the ioctl, which keeps the tunnel out of the measurement.
Against the old fork the session wedges and the test says so by name.

`Session` gained `EmulatedPty`, so the two hand-written doubles implement
it. `server/` needs no changes.

Depends on shellhub-io/cloud#2447, which has to land together: the
`replace` lines must move in step or the workspace build fails on
conflicting replacements.