### PR TITLE
fix(gateway): mark the seat as having a pty only once the device says so

### DIFF
--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -338,6 +338,7 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 					ok, err := agent.Channel.SendRequest(req.Type, req.WantReply, req.Payload)
 					if err != nil {
 						logger.WithError(err).Error("failed to send the request from client to agent")
+						ptyRequested = nil
 
 						continue
 					}
@@ -349,7 +350,10 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 					}
 
 					if ptyRequested != nil {
-						if ok {
+						// SendRequest reports false when the client asked for no
+						// reply, so only a client that wanted one tells us
+						// anything about the device's answer.
+						if ok || !req.WantReply {
 							sess.Seats.SetPty(seat, true)
 							sess.Event(PtyRequestType, *ptyRequested, seat) //nolint:errcheck
 						} else {

--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -231,6 +231,10 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 		go func() {
 			defer wg.Done()
 
+			// Carries a parsed pty-req from its case down to the tail, which is
+			// where the agent's answer arrives.
+			var ptyRequested *models.SSHPty
+
 			for {
 				select {
 				case <-ctx.Done():
@@ -267,9 +271,12 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 							continue
 						}
 
-						sess.Seats.SetPty(seat, true)
-
-						sess.Event(req.Type, pty, seat) //nolint:errcheck
+						// The seat is only marked once the agent says it allocated
+						// one, below. A device can refuse a pty-req — no /dev/ptmx
+						// in a restricted container — and a seat that claims a pty
+						// it does not have sends the announcement into a stdout
+						// that is a pipe, and records a session with no terminal.
+						ptyRequested = &pty
 					case WindowChangeRequestType:
 						var dimensions models.SSHWindowChange
 
@@ -339,6 +346,17 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 						if err := req.Reply(ok, nil); err != nil {
 							logger.WithError(err).Error(err)
 						}
+					}
+
+					if ptyRequested != nil {
+						if ok {
+							sess.Seats.SetPty(seat, true)
+							sess.Event(PtyRequestType, *ptyRequested, seat) //nolint:errcheck
+						} else {
+							logger.Warn("the device refused the pty; the session continues without one")
+						}
+
+						ptyRequested = nil
 					}
 
 					if startsDataPipe(req.Type) {


### PR DESCRIPTION
The seat is marked as having a pty on the way in, before the request has even
reached the device, and nothing rolls it back when the device refuses. A device
can refuse: no `/dev/ptmx` in a restricted container is enough, and OpenSSH does
the same thing in that situation — reply `SSH_MSG_CHANNEL_FAILURE` and let the
session carry on without a terminal.

A seat that claims a pty it does not have defeats two guards written for exactly
this case.

The namespace announcement is written straight into the client channel, guarded
by `seat.HasPty` precisely so it stays out of a non-tty stdout. With the seat
stale, a client piping the output gets `Connected to ... via ShellHub` in the
middle of whatever it was reading.

On Cloud and Enterprise the session is flagged as recorded, and `pty-output`
events are stored for a session that has no terminal. The guard at
`session.go` that reports `session won't be recorded because there is no pty`
never fires, so the recording is fed raw pipe bytes where it expects terminal
output.

The parsed request is now carried down to where the agent's answer arrives, and
the seat is marked there. The refusal is also logged, which it was not on this
side before.

## Reachability

Not reachable today: the agent runs on the library's emulated pty, which never
fails, so `pty-req` is always accepted. It becomes reachable as soon as the
agent allocates a real pty, which is why this lands first and on its own.

## Verification

Exercised end to end by forcing the device to refuse a pty, which produced the
two log lines that confirm the guards now hold, and the announcement stayed out
of the stream.

Ten released agent versions, v0.17.2 through v0.26.0, were driven through shell,
exec with and without a pty, heredoc, sftp and scp against this change. No
device refused a pty and nothing regressed.