### PR TITLE
fix(agent): report a shell's exit code and reap every session

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -81,4 +81,4 @@ require (
 
 replace github.com/shellhub-io/shellhub => ../
 
-replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh v0.0.0-20260802041333-0de04e2021d3
+replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh v0.0.0-20260802071412-17dd3955caac

--- a/agent/go.sum
+++ b/agent/go.sum
@@ -66,8 +66,8 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
-github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
+github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
+github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -119,8 +119,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sethvargo/go-envconfig v0.9.0 h1:Q6FQ6hVEeTECULvkJZakq3dZMeBQ3JUpcKMfPQbKMDE=
 github.com/sethvargo/go-envconfig v0.9.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
-github.com/shellhub-io/ssh v0.0.0-20260802041333-0de04e2021d3 h1:nM3S27LbcZsX2s0AXUSEB1BVqT1m8KXozlstYTIyM2E=
-github.com/shellhub-io/ssh v0.0.0-20260802041333-0de04e2021d3/go.mod h1:x9I554T2Lmh78Qai8VN4wnVyxXjkLAEYpJMBVchsG6A=
+github.com/shellhub-io/ssh v0.0.0-20260802071412-17dd3955caac h1:FoFcRe6uMUZ4ctoJ0VVViLMiZ0+kc4BtMLzCwWw6Qxk=
+github.com/shellhub-io/ssh v0.0.0-20260802071412-17dd3955caac/go.mod h1:x9I554T2Lmh78Qai8VN4wnVyxXjkLAEYpJMBVchsG6A=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/agent/pkg/agentd/modes.go
+++ b/agent/pkg/agentd/modes.go
@@ -2,7 +2,6 @@ package agentd
 
 import (
 	"context"
-	"os/exec"
 
 	dockerclient "github.com/docker/docker/client"
 	"github.com/shellhub-io/shellhub/agent/pkg/sysinfo"
@@ -42,7 +41,7 @@ func (m *HostMode) Serve(agent *Agent) {
 		agent.cli,
 		&host.Mode{
 			Authenticator: *host.NewAuthenticator(agent.cli, agent.authData, agent.config.SingleUserPassword, &agent.authData.Name),
-			Sessioner:     *host.NewSessioner(&agent.authData.Name, make(map[string]*exec.Cmd), agent.config.SFTPServerCommand),
+			Sessioner:     *host.NewSessioner(&agent.authData.Name, agent.config.SFTPServerCommand),
 		},
 		&server.Config{
 			PrivateKey:        agent.config.PrivateKey,

--- a/agent/server/modes/host/sessioner.go
+++ b/agent/server/modes/host/sessioner.go
@@ -74,10 +74,29 @@ func PtyFailureHint(err error) string {
 	return ""
 }
 
+// reapOnDisconnect kills cmd once the SSH connection is gone. It must be called
+// after a successful start, so the process is there to kill.
+//
+// Nothing else ends the command when a client vanishes. On a pty session the
+// terminal stays open because the server holds it until the handler returns,
+// and the handler is inside Wait; on the piped ones the command keeps its ends
+// of the pipes.
+func reapOnDisconnect(session gliderssh.Session, cmd *exec.Cmd) error {
+	serverConn, ok := session.Context().Value(gliderssh.ContextKeyConn).(*gossh.ServerConn)
+	if !ok {
+		return errors.New("failed to get server connection from session context")
+	}
+
+	go func() {
+		serverConn.Wait()  //nolint:errcheck
+		cmd.Process.Kill() //nolint:errcheck
+	}()
+
+	return nil
+}
+
 // Sessioner implements the Sessioner interface when the server is running in host mode.
 type Sessioner struct {
-	mu   sync.Mutex
-	cmds map[string]*exec.Cmd
 	// deviceName is the device name.
 	//
 	// NOTICE: It's a pointer because when the server is created, we don't know the device name yet, that is set later.
@@ -89,10 +108,6 @@ type Sessioner struct {
 	sftpServerCommand func() *exec.Cmd
 }
 
-func (s *Sessioner) SetCmds(cmds map[string]*exec.Cmd) {
-	s.cmds = cmds
-}
-
 // NewSessioner creates a new instance of Sessioner for the host mode.
 // The device name is a pointer to a string because when the server is created, we don't know the device name yet, that
 // is set later.
@@ -100,10 +115,9 @@ func (s *Sessioner) SetCmds(cmds map[string]*exec.Cmd) {
 // sftpServerCommand builds the command used to start the SFTP server subprocess. When nil,
 // [command.SFTPServerCommand] is used (re-executing /proc/self/exe). It can be overridden so
 // the agent can run embedded in another binary, where /proc/self/exe is not the agent.
-func NewSessioner(deviceName *string, cmds map[string]*exec.Cmd, sftpServerCommand func() *exec.Cmd) *Sessioner {
+func NewSessioner(deviceName *string, sftpServerCommand func() *exec.Cmd) *Sessioner {
 	return &Sessioner{
 		deviceName:        deviceName,
-		cmds:              cmds,
 		sftpServerCommand: sftpServerCommand,
 	}
 }
@@ -155,9 +169,9 @@ func (s *Sessioner) Shell(session gliderssh.Session) error {
 		remoteAddr.String(),
 	)
 
-	s.mu.Lock()
-	s.cmds[session.Context().Value(gliderssh.ContextKeySessionID).(string)] = scmd
-	s.mu.Unlock()
+	if err := reapOnDisconnect(session, scmd); err != nil {
+		return err
+	}
 
 	if err := scmd.Wait(); err != nil {
 		log.Warn(err)
@@ -171,6 +185,15 @@ func (s *Sessioner) Shell(session gliderssh.Session) error {
 	}).Info("Session ended")
 
 	utmp.UtmpEndSession(ut)
+
+	code := 1
+	if scmd.ProcessState != nil {
+		code = scmd.ProcessState.ExitCode()
+	}
+
+	if err := session.Exit(code); err != nil {
+		log.Warn(err)
+	}
 
 	return nil
 }
@@ -222,11 +245,6 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 	stdin, _ := cmd.StdinPipe()
 	stderr, _ := cmd.StderrPipe()
 
-	serverConn, ok := session.Context().Value(gliderssh.ContextKeyConn).(*gossh.ServerConn)
-	if !ok {
-		return fmt.Errorf("failed to get server connection from session context")
-	}
-
 	log.WithFields(log.Fields{
 		"user":        session.User(),
 		"ispty":       isPty,
@@ -242,12 +260,9 @@ func (s *Sessioner) Heredoc(session gliderssh.Session) error {
 		return err
 	}
 
-	// kill the process if the SSH connection is interrupted — must be after a
-	// successful cmd.Start() so cmd.Process is guaranteed non-nil.
-	go func() {
-		serverConn.Wait()  // nolint:errcheck
-		cmd.Process.Kill() // nolint:errcheck
-	}()
+	if err := reapOnDisconnect(session, cmd); err != nil {
+		return err
+	}
 
 	go func() {
 		if _, err := io.Copy(stdin, session); err != nil {
@@ -363,20 +378,16 @@ func (s *Sessioner) Exec(session gliderssh.Session) error {
 		return err
 	}
 
+	// Before the wait below, not after: that wait ends when the command closes
+	// its output, which a command that ignores a vanished client never does, so
+	// a reaper installed afterwards would never be installed at all.
+	if err := reapOnDisconnect(session, cmd); err != nil {
+		return err
+	}
+
 	if !sIsPty {
 		wg.Wait()
 	}
-
-	serverConn, ok := session.Context().Value(gliderssh.ContextKeyConn).(*gossh.ServerConn)
-	if !ok {
-		return fmt.Errorf("failed to get server connection from session context")
-	}
-
-	// kill the process if the SSH connection is interrupted
-	go func() {
-		serverConn.Wait()  // nolint:errcheck
-		cmd.Process.Kill() // nolint:errcheck
-	}()
 
 	if err := cmd.Wait(); err != nil {
 		log.Warn(err)
@@ -472,6 +483,10 @@ func (s *Sessioner) SFTP(session gliderssh.Session) error {
 		}).Error("Failed to start command")
 
 		return errors.New("failed to start command")
+	}
+
+	if err := reapOnDisconnect(session, cmd); err != nil {
+		return err
 	}
 
 	go func() {

--- a/agent/server/modes/host/sessioner_native_test.go
+++ b/agent/server/modes/host/sessioner_native_test.go
@@ -5,7 +5,6 @@ package host
 import (
 	"errors"
 	"net"
-	"os/exec"
 	"sync/atomic"
 	"testing"
 
@@ -47,11 +46,11 @@ func (f *fakeGosshConn) Wait() error {
 	select {}
 }
 
-// TestShell_DeniedCredentialSwitch verifies that Shell() returns a non-nil error,
-// calls session.Exit(1) exactly once, and leaves s.cmds empty when
-// checkCredentialSwitchFn returns an error.  The gate must fire before any call
-// to session.Pty(), generateShellCmd, or startPtyFn, so the test does NOT need a
-// real ServerConn in the session context.
+// TestShell_DeniedCredentialSwitch verifies that Shell() returns a non-nil error
+// and calls session.Exit(1) exactly once when checkCredentialSwitchFn returns an
+// error. The gate must fire before any call to session.Pty() or
+// generateShellCmd, so the test does NOT need a real ServerConn in the session
+// context.
 func TestShell_DeniedCredentialSwitch(t *testing.T) {
 	origCheckCredentialSwitch := checkCredentialSwitchFn
 
@@ -65,8 +64,7 @@ func TestShell_DeniedCredentialSwitch(t *testing.T) {
 	}
 
 	deviceName := "test-device"
-	cmds := make(map[string]*exec.Cmd)
-	s := NewSessioner(&deviceName, cmds, nil)
+	s := NewSessioner(&deviceName, nil)
 
 	sess := newFakeSession("session-cred-switch", "root")
 
@@ -79,7 +77,6 @@ func TestShell_DeniedCredentialSwitch(t *testing.T) {
 	assert.NotNil(t, retErr, "Shell() must return a non-nil error when credential switch is denied")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCalled), "session.Exit must be called once")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&sess.exitCode), "session.Exit must be called with code 1")
-	assert.Empty(t, s.cmds, "s.cmds must be empty — the session must not have been registered")
 }
 
 // TestExec_DeniedCredentialSwitch verifies that Exec() returns a non-nil error,
@@ -99,8 +96,7 @@ func TestExec_DeniedCredentialSwitch(t *testing.T) {
 	}
 
 	deviceName := "test-device"
-	cmds := make(map[string]*exec.Cmd)
-	s := NewSessioner(&deviceName, cmds, nil)
+	s := NewSessioner(&deviceName, nil)
 
 	sess := newFakeSession("session-exec-cred-switch", "root")
 	sess.command = []string{"/bin/true"}
@@ -145,8 +141,7 @@ func TestHeredoc_StartFailure(t *testing.T) {
 	osauthMock.On("ListGroups", mock.AnythingOfType("string")).Return([]uint32{}, nil).Maybe()
 
 	deviceName := "test-device"
-	cmds := make(map[string]*exec.Cmd)
-	s := NewSessioner(&deviceName, cmds, nil)
+	s := NewSessioner(&deviceName, nil)
 
 	sess := newFakeSession("session-heredoc-start-fail", "root")
 
@@ -184,8 +179,7 @@ func TestHeredoc_DeniedCredentialSwitch(t *testing.T) {
 	}
 
 	deviceName := "test-device"
-	cmds := make(map[string]*exec.Cmd)
-	s := NewSessioner(&deviceName, cmds, nil)
+	s := NewSessioner(&deviceName, nil)
 
 	sess := newFakeSession("session-heredoc-cred-switch", "root")
 
@@ -227,8 +221,7 @@ func TestExec_NonPty_SucceedingCommand(t *testing.T) {
 	osauthMock.On("ListGroups", mock.AnythingOfType("string")).Return([]uint32{}, nil).Maybe()
 
 	deviceName := "test-device"
-	cmds := make(map[string]*exec.Cmd)
-	s := NewSessioner(&deviceName, cmds, nil)
+	s := NewSessioner(&deviceName, nil)
 
 	sess := newFakeSession("session-exec-npty", "root")
 	sess.isPty = false

--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"net"
-	"os/exec"
 	"sync"
 	"time"
 
@@ -20,27 +19,11 @@ const (
 	SFTPSubsystemName = "sftp"
 )
 
-type sshConn struct {
-	net.Conn
-	closeCallback func(string)
-	ctx           gliderssh.Context
-}
-
-func (c *sshConn) Close() error {
-	if id, ok := c.ctx.Value(gliderssh.ContextKeySessionID).(string); ok {
-		c.closeCallback(id)
-	}
-
-	return c.Conn.Close()
-}
-
 type Server struct {
 	sshd              *gliderssh.Server
 	api               client.Client
-	cmds              map[string]*exec.Cmd
 	deviceName        string
 	ContainerID       string
-	mu                sync.Mutex
 	keepAliveInterval uint32
 
 	// mode is the mode of the server, identifing where and how the SSH's server is running.
@@ -102,13 +85,8 @@ func NewServer(api client.Client, mode modes.Mode, cfg *Config) *Server {
 	server := &Server{
 		api:               api,
 		mode:              mode,
-		cmds:              make(map[string]*exec.Cmd),
 		keepAliveInterval: cfg.KeepAliveInterval,
 		Sessions:          sync.Map{},
-	}
-
-	if m, ok := mode.(*host.Mode); ok {
-		m.Sessioner.SetCmds(server.cmds)
 	}
 
 	server.sshd = &gliderssh.Server{
@@ -118,19 +96,6 @@ func NewServer(api client.Client, mode modes.Mode, cfg *Config) *Server {
 		SessionRequestCallback: server.sessionRequestCallback,
 		SubsystemHandlers: map[string]gliderssh.SubsystemHandler{
 			SFTPSubsystemName: server.sftpSubsystemHandler,
-		},
-		ConnCallback: func(ctx gliderssh.Context, conn net.Conn) net.Conn {
-			closeCallback := func(id string) {
-				server.mu.Lock()
-				defer server.mu.Unlock()
-
-				if v, ok := server.cmds[id]; ok {
-					v.Process.Kill() // nolint:errcheck
-					delete(server.cmds, id)
-				}
-			}
-
-			return &sshConn{conn, closeCallback, ctx}
 		},
 		LocalPortForwardingCallback: func(_ gliderssh.Context, _ string, _ uint32) bool {
 			return cfg.Features&LocalPortForwardFeature > 0

--- a/server/go.mod
+++ b/server/go.mod
@@ -139,4 +139,4 @@ require (
 
 replace github.com/shellhub-io/shellhub => ../
 
-replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh v0.0.0-20260802041333-0de04e2021d3
+replace github.com/gliderlabs/ssh => github.com/shellhub-io/ssh v0.0.0-20260802071412-17dd3955caac

--- a/server/go.sum
+++ b/server/go.sum
@@ -265,8 +265,8 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEV
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sethvargo/go-envconfig v0.9.0 h1:Q6FQ6hVEeTECULvkJZakq3dZMeBQ3JUpcKMfPQbKMDE=
 github.com/sethvargo/go-envconfig v0.9.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
-github.com/shellhub-io/ssh v0.0.0-20260802041333-0de04e2021d3 h1:nM3S27LbcZsX2s0AXUSEB1BVqT1m8KXozlstYTIyM2E=
-github.com/shellhub-io/ssh v0.0.0-20260802041333-0de04e2021d3/go.mod h1:x9I554T2Lmh78Qai8VN4wnVyxXjkLAEYpJMBVchsG6A=
+github.com/shellhub-io/ssh v0.0.0-20260802071412-17dd3955caac h1:FoFcRe6uMUZ4ctoJ0VVViLMiZ0+kc4BtMLzCwWw6Qxk=
+github.com/shellhub-io/ssh v0.0.0-20260802071412-17dd3955caac/go.mod h1:x9I554T2Lmh78Qai8VN4wnVyxXjkLAEYpJMBVchsG6A=
 github.com/shirou/gopsutil/v4 v4.26.5 h1:RPcBXkpz7kOj9PqGFQOlBPZHsyaPvPVQc098y9RmCNM=
 github.com/shirou/gopsutil/v4 v4.26.5/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
@@ -290,8 +290,8 @@ github.com/testcontainers/testcontainers-go v0.43.0 h1:oEQx5MW2DGd9z3AeEQfB2lPM0
 github.com/testcontainers/testcontainers-go v0.43.0/go.mod h1:+VxkT2NQnKOZPKi6praMuMKYHYyOGXr0XSBSlSMCzFo=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0 h1:ShNOFYAF4lKHvdIG258hi69bSxC88uXnxJkJvNs/IVs=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0/go.mod h1:vdq5/RqmGfWeefzyfcVI/pID1rzmc1TDvqXa15bPJks=
-github.com/testcontainers/testcontainers-go/modules/redis v0.42.0 h1:id/6LH8ZeDrtAUVSuNvZUAJ1kVpb82y1pr9yweAWsRg=
-github.com/testcontainers/testcontainers-go/modules/redis v0.42.0/go.mod h1:uF0jI8FITagQpBNOgweGBmPf6rP4K0SeL1XFPbsZSSY=
+github.com/testcontainers/testcontainers-go/modules/redis v0.43.0 h1:qzATMhrltLr07KcGl/d674ouqI0AFtf6wnQb3VnqP7M=
+github.com/testcontainers/testcontainers-go/modules/redis v0.43.0/go.mod h1:ygEcEUIZzmIlOKpjBfnPn/lUIRNorr1kPj3XfFPTQXM=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/tests/ssh_test.go
+++ b/tests/ssh_test.go
@@ -970,6 +970,93 @@ func testSSHWithVersion(t *testing.T, connectionVersion int) {
 			},
 		},
 		{
+			// A shell with a pty used to report success whatever it exited with,
+			// because the agent never sent a status of its own and the library
+			// filled in a zero. Exec and the heredoc shape both got this right,
+			// so the gap was invisible unless you asked for a terminal.
+			name: "connection SHELL with Pty reports the exit code",
+			run: func(t *testing.T, environment *Environment, device *models.Device) {
+				config := &ssh.ClientConfig{
+					User: fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name),
+					Auth: []ssh.AuthMethod{
+						ssh.Password(ShellHubAgentPassword),
+					},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+				}
+
+				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				require.NoError(t, err)
+				defer conn.Close()
+
+				sess, err := conn.NewSession()
+				require.NoError(t, err)
+				defer sess.Close()
+
+				stdin, err := sess.StdinPipe()
+				require.NoError(t, err)
+
+				require.NoError(t, sess.RequestPty("xterm", 24, 80, ssh.TerminalModes{}))
+				require.NoError(t, sess.Shell())
+
+				_, err = io.WriteString(stdin, "exit 42\n")
+				require.NoError(t, err)
+
+				done := make(chan error, 1)
+
+				go func() { done <- sess.Wait() }()
+
+				select {
+				case err := <-done:
+					var status *ssh.ExitError
+
+					require.ErrorAs(t, err, &status)
+					assert.Equal(t, 42, status.ExitStatus())
+				case <-time.After(60 * time.Second):
+					t.Fatal("a shell with a pty never reported an exit status")
+				}
+			},
+		},
+		{
+			name: "connection SHELL with Pty reports a successful exit",
+			run: func(t *testing.T, environment *Environment, device *models.Device) {
+				config := &ssh.ClientConfig{
+					User: fmt.Sprintf("%s@%s.%s", ShellHubAgentUsername, ShellHubNamespaceName, device.Name),
+					Auth: []ssh.AuthMethod{
+						ssh.Password(ShellHubAgentPassword),
+					},
+					HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+				}
+
+				conn, err := ssh.Dial("tcp", fmt.Sprintf("localhost:%s", environment.services.Env("SHELLHUB_SSH_PORT")), config)
+				require.NoError(t, err)
+				defer conn.Close()
+
+				sess, err := conn.NewSession()
+				require.NoError(t, err)
+				defer sess.Close()
+
+				stdin, err := sess.StdinPipe()
+				require.NoError(t, err)
+
+				require.NoError(t, sess.RequestPty("xterm", 24, 80, ssh.TerminalModes{}))
+				require.NoError(t, sess.Shell())
+
+				_, err = io.WriteString(stdin, "exit 0\n")
+				require.NoError(t, err)
+
+				done := make(chan error, 1)
+
+				go func() { done <- sess.Wait() }()
+
+				select {
+				case err := <-done:
+					require.NoError(t, err)
+				case <-time.After(60 * time.Second):
+					t.Fatal("a shell with a pty never reported an exit status")
+				}
+			},
+		},
+		{
 			// Regression: a shell with no pty is all a heredoc sends, and it was
 			// not one of the requests that started the data pipe, so the session
 			// had no data path and hung until the client gave up.


### PR DESCRIPTION
A shell with a pty always reported success to the client. The agent never sent a status of its own, so the library filled in a zero. Exec and the heredoc shape both got this right, which is why the gap only showed up when you asked for a terminal. Nothing in the e2e suite covered it: four cases request a pty and then a shell, and none of them looked at the exit status.

Reaping the process now sits next to the command that started it, in all four handlers. That lets the `cmds` map go, and three defects go with it.

The map was written under the Sessioner mutex and read under the Server one, so two unrelated locks guarded the same map. Its key was the connection's exchange hash rather than the channel's, so two sessions multiplexed on one connection collided and only the second was ever killed. And a shell was registered only after utmp had been written, leaving a window in which the callback found nothing and never ran again, because it runs once per connection.

Exec installed its reaper after waiting on the command's output. A command that ignores a vanished client never closes that output, so for exactly the case the reaper exists for, it was never installed. SFTP had no reaper at all.

The fork bump carries the matching library fix: a command that wrote a burst and exited at once lost the end of it, because nothing ordered the copy out of the pty against the close of the channel. Reproducing it needs stressing, 400 runs caught it four times before the change and none after, and one of those lost 31300 of 200000 bytes.

Depends on shellhub-io/ssh@17dd395.