### PR TITLE
fix(server): bound the reverse tunnel handshake with a deadline

### DIFF
--- a/server/ssh/pkg/dialer/dialer.go
+++ b/server/ssh/pkg/dialer/dialer.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/shellhub-io/shellhub/pkg/models"
 	log "github.com/sirupsen/logrus"
@@ -76,6 +78,12 @@ func NewDialer(devices DeviceStatuser, heartbeater Heartbeater) *Dialer {
 
 var ErrInvalidArgument = errors.New("invalid argument")
 
+// HandshakeTimeout bounds the target's handshake once the stream is open. The
+// exchange is short and has a known shape, unlike the streaming phase that
+// follows it, which is legitimately long-lived and runs without a deadline. It
+// is an upper bound only: an earlier deadline on the caller's context wins.
+const HandshakeTimeout = 30 * time.Second
+
 // DialTo establishes a raw reverse connection to the device and performs
 // the version-specific bootstrap for the provided target. It returns a
 // connection ready for application protocol usage.
@@ -93,5 +101,59 @@ func (t *Dialer) DialTo(ctx context.Context, tenant string, uid string, target T
 		return conn, nil
 	}
 
-	return target.prepare(conn, version)
+	return handshake(ctx, conn, version, target)
+}
+
+// handshake runs the target's bootstrap under a deadline and hands back a
+// connection with that deadline cleared, ready for streaming. An agent that
+// accepts the stream but never answers fails here instead of parking the
+// caller's goroutine until whatever sits in front times out.
+func handshake(ctx context.Context, conn net.Conn, version TransportVersion, target Target) (net.Conn, error) { // nolint:ireturn
+	deadline := time.Now().Add(HandshakeTimeout)
+	if caller, ok := ctx.Deadline(); ok && caller.Before(deadline) {
+		deadline = caller
+	}
+
+	if err := conn.SetDeadline(deadline); err != nil {
+		conn.Close()
+
+		return nil, err
+	}
+
+	// A deadline does not observe cancellation, so a caller that gives up
+	// mid-handshake would hold the stream until the deadline fires. Closing the
+	// connection is what unblocks the read. AfterFunc's stop answers only once,
+	// hence the OnceValue: the deferred call must not consume the verdict the
+	// return paths below read.
+	watchdogStopped := sync.OnceValue(context.AfterFunc(ctx, func() {
+		conn.Close()
+	}))
+	defer watchdogStopped()
+
+	prepared, err := target.prepare(ctx, conn, version)
+	if err != nil {
+		conn.Close()
+
+		// The watchdog's Close surfaces as an I/O error, which reads like a
+		// broken agent. Report what actually happened.
+		if !watchdogStopped() {
+			return nil, ctx.Err()
+		}
+
+		return nil, err
+	}
+
+	if !watchdogStopped() {
+		prepared.Close()
+
+		return nil, ctx.Err()
+	}
+
+	if err := prepared.SetDeadline(time.Time{}); err != nil {
+		prepared.Close()
+
+		return nil, err
+	}
+
+	return prepared, nil
 }

--- a/server/ssh/pkg/dialer/dialer_test.go
+++ b/server/ssh/pkg/dialer/dialer_test.go
@@ -1,0 +1,215 @@
+package dialer
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingConn records the deadlines set on a connection and whether it was
+// closed, so tests can assert on the handshake's bookkeeping rather than on
+// timing alone.
+type recordingConn struct {
+	net.Conn
+
+	mu        sync.Mutex
+	deadlines []time.Time
+	closed    bool
+}
+
+func (c *recordingConn) SetDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.deadlines = append(c.deadlines, t)
+	c.mu.Unlock()
+
+	return c.Conn.SetDeadline(t)
+}
+
+func (c *recordingConn) Close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+
+	return c.Conn.Close()
+}
+
+func (c *recordingConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.closed
+}
+
+func (c *recordingConn) deadlineAt(i int) (time.Time, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if i < 0 {
+		i += len(c.deadlines)
+	}
+
+	if i < 0 || i >= len(c.deadlines) {
+		return time.Time{}, false
+	}
+
+	return c.deadlines[i], true
+}
+
+// unresponsivePeer stands in for an agent that accepts the stream and reads the
+// handshake but never answers it.
+func unresponsivePeer(t *testing.T) *recordingConn {
+	t.Helper()
+
+	server, agent := net.Pipe()
+
+	go io.Copy(io.Discard, agent) // nolint:errcheck
+
+	t.Cleanup(func() {
+		agent.Close()
+	})
+
+	return &recordingConn{Conn: server}
+}
+
+func TestHandshakeFailsAndClosesTheStream(t *testing.T) {
+	cases := []struct {
+		description string
+		target      Target
+		version     TransportVersion
+		ctx         func(t *testing.T) context.Context
+	}{
+		{
+			description: "http proxy v2 negotiation the agent never answers",
+			target:      HTTPProxyTarget{RequestID: "request", Host: "localhost", Port: 8080},
+			version:     TransportVersion2,
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+				t.Cleanup(cancel)
+
+				return ctx
+			},
+		},
+		{
+			description: "ssh open v2 protocol selection the agent never answers",
+			target:      SSHOpenTarget{SessionID: "session"},
+			version:     TransportVersion2,
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+				t.Cleanup(cancel)
+
+				return ctx
+			},
+		},
+		{
+			description: "caller gives up while the handshake is in flight",
+			target:      HTTPProxyTarget{RequestID: "request", Host: "localhost", Port: 8080},
+			version:     TransportVersion2,
+			ctx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				time.AfterFunc(100*time.Millisecond, cancel)
+				t.Cleanup(cancel)
+
+				return ctx
+			},
+		},
+		{
+			description: "unsupported transport version",
+			target:      SSHOpenTarget{SessionID: "session"},
+			version:     TransportVersionUnknown,
+			ctx: func(_ *testing.T) context.Context {
+				return context.Background()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			conn := unresponsivePeer(t)
+
+			done := make(chan error, 1)
+			go func() {
+				_, err := handshake(tc.ctx(t), conn, tc.version, tc.target)
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				assert.Error(t, err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("handshake blocked instead of failing")
+			}
+
+			assert.True(t, conn.isClosed(), "a failed handshake must not leak the stream")
+		})
+	}
+}
+
+func TestHandshakeReportsCancellationAsSuch(t *testing.T) {
+	cases := []struct {
+		description string
+		version     TransportVersion
+	}{
+		{
+			description: "cancelled while the handshake is blocked",
+			version:     TransportVersion2,
+		},
+		{
+			description: "cancelled as the handshake completes",
+			version:     TransportVersion1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			conn := unresponsivePeer(t)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			if tc.version == TransportVersion2 {
+				time.AfterFunc(100*time.Millisecond, cancel)
+			} else {
+				cancel()
+			}
+
+			defer cancel()
+
+			_, err := handshake(ctx, conn, tc.version, SSHOpenTarget{SessionID: "session"})
+			assert.ErrorIs(t, err, context.Canceled, "the caller must be able to tell a hang-up from a broken agent")
+		})
+	}
+}
+
+func TestHandshakeClearsDeadlineOnSuccess(t *testing.T) {
+	conn := unresponsivePeer(t)
+
+	prepared, err := handshake(context.Background(), conn, TransportVersion1, SSHOpenTarget{SessionID: "session"})
+	require.NoError(t, err)
+	assert.Equal(t, net.Conn(conn), prepared)
+
+	deadline, ok := conn.deadlineAt(-1)
+	require.True(t, ok, "the handshake must bound itself with a deadline")
+	assert.True(t, deadline.IsZero(), "the deadline must be cleared before streaming")
+	assert.False(t, conn.isClosed())
+}
+
+func TestHandshakeHonorsTheEarlierDeadline(t *testing.T) {
+	conn := unresponsivePeer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	callerDeadline, _ := ctx.Deadline()
+
+	_, err := handshake(ctx, conn, TransportVersion2, SSHOpenTarget{SessionID: "session"})
+	assert.Error(t, err)
+
+	first, ok := conn.deadlineAt(0)
+	require.True(t, ok)
+
+	assert.Equal(t, callerDeadline, first, "the caller's deadline is earlier than HandshakeTimeout and must win")
+}

--- a/server/ssh/pkg/dialer/target.go
+++ b/server/ssh/pkg/dialer/target.go
@@ -2,6 +2,7 @@ package dialer
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,19 +15,19 @@ import (
 )
 
 type Target interface {
-	prepare(conn net.Conn, version TransportVersion) (net.Conn, error)
+	prepare(ctx context.Context, conn net.Conn, version TransportVersion) (net.Conn, error)
 }
 
 // SSHOpenTarget prepares a connection for initiating a new SSH session
 // with the agent.
 type SSHOpenTarget struct{ SessionID string }
 
-func (t SSHOpenTarget) prepare(conn net.Conn, version TransportVersion) (net.Conn, error) { // nolint:ireturn
+func (t SSHOpenTarget) prepare(ctx context.Context, conn net.Conn, version TransportVersion) (net.Conn, error) { // nolint:ireturn
 	switch version {
 	case TransportVersion1:
 		log.Debug("preparing SSH open target for transport version 1")
 
-		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/ssh/%s", t.SessionID), nil)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("/ssh/%s", t.SessionID), nil)
 		if err := req.Write(conn); err != nil {
 			log.Errorf("failed to write HTTP request: %v", err)
 
@@ -51,10 +52,10 @@ func (t SSHOpenTarget) prepare(conn net.Conn, version TransportVersion) (net.Con
 // SSHCloseTarget prepares a connection to request closing an existing SSH session.
 type SSHCloseTarget struct{ SessionID string }
 
-func (t SSHCloseTarget) prepare(conn net.Conn, version TransportVersion) (net.Conn, error) { // nolint:ireturn
+func (t SSHCloseTarget) prepare(ctx context.Context, conn net.Conn, version TransportVersion) (net.Conn, error) { // nolint:ireturn
 	switch version {
 	case TransportVersion1:
-		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/ssh/close/%s", t.SessionID), nil)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("/ssh/close/%s", t.SessionID), nil)
 		if err := req.Write(conn); err != nil {
 			return nil, err
 		}
@@ -82,11 +83,11 @@ type HTTPProxyTarget struct {
 	Port      int
 }
 
-func (t HTTPProxyTarget) prepare(conn net.Conn, version TransportVersion) (net.Conn, error) { // nolint:ireturn
+func (t HTTPProxyTarget) prepare(ctx context.Context, conn net.Conn, version TransportVersion) (net.Conn, error) { // nolint:ireturn
 	switch version {
 	case TransportVersion1:
 		// Write initial handshake request and expect 200 OK.
-		handshakeReq, _ := http.NewRequest(http.MethodConnect, fmt.Sprintf("/http/proxy/%s:%d", t.Host, t.Port), nil)
+		handshakeReq, _ := http.NewRequestWithContext(ctx, http.MethodConnect, fmt.Sprintf("/http/proxy/%s:%d", t.Host, t.Port), nil)
 		if err := handshakeReq.Write(conn); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What

Bounds the per-target handshake that follows a successful reverse dial, so a device that accepts the stream but never answers fails the request instead of parking the calling goroutine.

## Why

`Dialer.DialTo` handed its context to `Manager.Dial`, which used it to open the stream — after which the context stopped being consulted. `Target.prepare` then talked to the agent over the raw `net.Conn` with no deadline and nothing observing cancellation.

The request did not fail; it hung. Whatever sat in front decided when it ended (nginx closing at `proxy_read_timeout` with a 504), and nothing was logged until then, because the access log line is written when the handler returns. A client that gave up did not release the server side either. Until the edge timed out, the hijacked client connection and the tunnel stream both stayed open.

A reachable agent holding a healthy tunnel is enough to reach this — the device answers the reverse dial, so the stream opens and only the handshake stalls. The motivating case was a device-side listener wedged on a single keep-alive connection; the more interesting one is a wedged or partially-upgraded agent, where the tunnel looks healthy from the server's side while every dial through it parks a goroutine.

Closes #6777

## Changes

- **`dialer`**: extracted the post-dial bootstrap into a `handshake` seam that bounds the exchange with `min(now + HandshakeTimeout, ctx.Deadline())` and clears the deadline before handing the connection back. The handshake is a short exchange with a known shape; the streaming phase that follows it is legitimately long-lived and must stay unbounded, which is why the deadline belongs here and not on the stream.
- **`dialer`**: a watchdog goroutine closes the connection on `ctx.Done()`, torn down when the handshake returns. A deadline does not observe cancellation, so without this a caller that hangs up would still hold the stream until the deadline fired.
- **`dialer`**: cancellation is reported as `ctx.Err()` rather than the `use of closed network connection` the watchdog's `Close` produces, so callers can distinguish a hang-up from a broken agent.
- **`dialer`**: every handshake failure path now closes the connection. `DialTo` previously returned a `prepare` error without closing, which would have turned the hang into a leaked stream per attempt once the deadline started firing.
- **`dialer`**: `Target.prepare` takes a `context.Context`; the V1 request builders use `http.NewRequestWithContext`.

`DialTo`'s signature is unchanged, so all three call sites (`ssh/session`, `ssh/http`, and cloud's web-endpoint proxy) pick this up without modification. Verified that `cloud` still builds against the change.

## Testing

The new tests exercise each blocking site the issue names against an unresponsive peer over `net.Pipe`: `http.ReadResponse` (V1), the negotiation `json.Decode` (V2), and the read inside `multistream.SelectProtoOrFail` (V2). Worth probing on review: that the deadline is genuinely cleared before streaming — a leftover deadline would silently kill long-lived SSH sessions and proxied responses, which is the failure mode this change could plausibly introduce.

Deadlines are real on both transports: V1 connections are `*wsconnadapter.Adapter` (delegating to the websocket read/write deadlines) and V2 are `*yamux.Stream`.

Two adjacent defects were found while working on this and deliberately left out of scope: `Manager.Dial` logs but swallows a failed `session.Open()`, returning a nil connection with a nil error; and `HTTPProxyTarget`'s V1 branch discards the `bufio.Reader` it used for `http.ReadResponse`, losing any bytes read past the response.
