### PR TITLE
fix(server): report a yamux stream that could not be opened

### DIFF
--- a/server/ssh/pkg/dialer/manager.go
+++ b/server/ssh/pkg/dialer/manager.go
@@ -195,6 +195,8 @@ func (m *Manager) Dial(ctx context.Context, key string) (net.Conn, TransportVers
 				"key":     key,
 				"version": "v2",
 			}).WithError(err).Error("failed to open yamux stream for reverse connection")
+
+			return nil, TransportVersionUnknown, err
 		}
 
 		return conn, TransportVersion2, nil

--- a/server/ssh/pkg/dialer/manager_test.go
+++ b/server/ssh/pkg/dialer/manager_test.go
@@ -1,0 +1,33 @@
+package dialer
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerDialFailsWhenTheStreamCannotBeOpened(t *testing.T) {
+	server, agent := net.Pipe()
+
+	t.Cleanup(func() {
+		server.Close()
+		agent.Close()
+	})
+
+	session, err := yamux.Client(server, nil)
+	require.NoError(t, err)
+	require.NoError(t, session.Close())
+
+	m := NewManager()
+	m.Connections.Store("tenant:uid", session)
+
+	conn, version, err := m.Dial(context.Background(), "tenant:uid")
+
+	assert.Error(t, err, "a stream that could not be opened must be reported to the caller")
+	assert.Nil(t, conn)
+	assert.Equal(t, TransportVersionUnknown, version)
+}


### PR DESCRIPTION
## What

`Manager.Dial` now returns the error when opening a yamux stream fails, instead of logging it and returning a nil connection with a nil error.

## Why

The V2 branch logged the failed `session.Open()` and then fell through to the shared success return:

```go
conn, err := session.Open()
if err != nil {
    log.WithFields(...).WithError(err).Error("failed to open yamux stream for reverse connection")
}

return conn, TransportVersion2, nil
```

`conn` is a nil `*yamux.Stream` boxed in a `net.Conn`, so the interface is non-nil and the caller's `err != nil` check passes. The first method call against it panics. A session that is shutting down — the ordinary case when a device drops while a request is in flight — becomes a crashed request rather than a failed one.

Found while investigating #6777; unrelated to that fix and based on master, so the two can merge in either order.

## Testing

The new test stores a closed yamux session in the manager and asserts `Dial` reports the failure. Without the fix it returns `(nil, TransportVersion2, nil)` and the assertions on the error and the version both fail.
