### PR TITLE
fix(agent): copy libeconf.so into production image

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -87,6 +87,7 @@ COPY --from=runtime-utils /bin/setpriv /bin/
 
 # Copy shared libraries from runtime-utils
 COPY --from=runtime-utils /usr/lib/libcap-ng.so.* /usr/lib/
+COPY --from=runtime-utils /usr/lib/libeconf.so.* /usr/lib/
 
 # Copy musl loader from runtime-utils
 COPY --from=runtime-utils /lib/ld-musl-*.so.1 /lib/


### PR DESCRIPTION
## What

Adds the missing `libeconf.so` shared library to the scratch-based production agent image so that `setpriv` can load at runtime.

## Why

The Alpine 3.22 → 3.24 bump (part of the Go 1.25.12 CVE fix in `9dbf37bc9`) upgraded `setpriv` from util-linux 2.41 to 2.42, which added a new runtime dependency on `libeconf.so.0`. The scratch production stage only copied `libcap-ng.so` and the musl loader — the libraries `setpriv` needed on Alpine 3.22 — so every SSH connection through a production-built agent fails with:

```
Error loading shared library libeconf.so.0: No such file or directory (needed by /bin/setpriv)
```

This broke in rc.3 (the first release that included the Alpine 3.24 bump); rc.2 and earlier are unaffected.

## Testing

Build the production agent image and verify `setpriv` resolves all its libraries:

```bash
docker build -f agent/Dockerfile -t agent-test .
docker run --rm agent-test /bin/setpriv --version
```

Before this fix, the second command prints the `libeconf.so.0` error. After, it prints `setpriv from util-linux 2.42.1`.