### PR TITLE
fix(server): answer 401 when a token's user or namespace is gone

### DIFF
--- a/server/api/routes/middleware/authn.go
+++ b/server/api/routes/middleware/authn.go
@@ -154,7 +154,12 @@ func (a *Authenticator) Resolve(c echo.Context) (*gateway.Identity, error) {
 			// surface the store's own status -- 404 for an unknown key, 400 for
 			// an expired one -- when the caller's problem is the credential.
 			// The edge proxy turned every non-2xx from the authentication
-			// subrequest into a 401, including when its store was down.
+			// subrequest into a 401, including when its store was down. Log the
+			// error for the same reason the bearer path does: an outage is
+			// otherwise indistinguishable from an unusable key. The key itself
+			// is a credential and never goes to the log.
+			log.WithError(err).Warn("failed to resolve the API key")
+
 			return nil, nil //nolint:nilerr
 		}
 

--- a/server/api/routes/middleware/authn.go
+++ b/server/api/routes/middleware/authn.go
@@ -187,10 +187,16 @@ func (a *Authenticator) Resolve(c echo.Context) (*gateway.Identity, error) {
 	case *authorizer.UserClaims:
 		// Role and admin are dynamic attributes that can change while a JWT is
 		// still valid, so we re-fetch them from the store on every request.
+		//
+		// Both lookups follow the same rule as the API key above: any failure
+		// yields no identity rather than an error, so a token whose namespace,
+		// membership or user is gone gets a 401 telling the caller to
+		// re-authenticate instead of the store's own status as a 500. As with
+		// the API key, that deliberately covers a store outage too.
 		if claims.TenantID != "" {
 			role, err := a.service.GetUserRole(c.Request().Context(), claims.TenantID, claims.ID)
 			if err != nil {
-				return nil, err
+				return nil, nil //nolint:nilerr
 			}
 
 			claims.Role = authorizer.RoleFromString(role)
@@ -198,7 +204,7 @@ func (a *Authenticator) Resolve(c echo.Context) (*gateway.Identity, error) {
 
 		admin, err := a.service.GetUserAdmin(c.Request().Context(), claims.ID)
 		if err != nil {
-			return nil, err
+			return nil, nil //nolint:nilerr
 		}
 
 		return &gateway.Identity{

--- a/server/api/routes/middleware/authn.go
+++ b/server/api/routes/middleware/authn.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/api/jwttoken"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
+	log "github.com/sirupsen/logrus"
 )
 
 // AuthnService is the slice of the service layer the authenticator needs to turn
@@ -192,10 +193,16 @@ func (a *Authenticator) Resolve(c echo.Context) (*gateway.Identity, error) {
 		// yields no identity rather than an error, so a token whose namespace,
 		// membership or user is gone gets a 401 telling the caller to
 		// re-authenticate instead of the store's own status as a 500. As with
-		// the API key, that deliberately covers a store outage too.
+		// the API key, that deliberately covers a store outage too, so both log
+		// the error they swallow: otherwise an outage is indistinguishable from
+		// a stale token and shows up only as a rise in 401s.
 		if claims.TenantID != "" {
 			role, err := a.service.GetUserRole(c.Request().Context(), claims.TenantID, claims.ID)
 			if err != nil {
+				log.WithError(err).
+					WithFields(log.Fields{"user_id": claims.ID, "tenant_id": claims.TenantID}).
+					Warn("failed to resolve the token's role")
+
 				return nil, nil //nolint:nilerr
 			}
 
@@ -204,6 +211,10 @@ func (a *Authenticator) Resolve(c echo.Context) (*gateway.Identity, error) {
 
 		admin, err := a.service.GetUserAdmin(c.Request().Context(), claims.ID)
 		if err != nil {
+			log.WithError(err).
+				WithField("user_id", claims.ID).
+				Warn("failed to resolve the token's admin status")
+
 			return nil, nil //nolint:nilerr
 		}
 

--- a/server/api/routes/middleware/authn_test.go
+++ b/server/api/routes/middleware/authn_test.go
@@ -1,0 +1,161 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
+	"github.com/shellhub-io/shellhub/pkg/api/jwttoken"
+	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
+	"github.com/shellhub-io/shellhub/server/api/services/mocks"
+	"github.com/shellhub-io/shellhub/server/api/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testTenant = "00000000-0000-4000-0000-000000000000"
+	testUserID = "6f4c1b2a1e2f3a4b5c6d7e8f"
+)
+
+// userBearer signs a user JWT and returns it alongside the key the
+// authenticator must verify it with.
+func userBearer(t *testing.T) (string, *rsa.PrivateKey) {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	bearer, err := jwttoken.EncodeUserClaims(
+		authorizer.UserClaims{ID: testUserID, TenantID: testTenant, Username: "john"},
+		privateKey,
+	)
+	require.NoError(t, err)
+
+	return bearer, privateKey
+}
+
+func authenticatedRequest(e *echo.Echo, bearer string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, "/api/namespaces", nil)
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/api/namespaces")
+
+	return c, rec
+}
+
+func TestAuthenticatorResolveUserClaims(t *testing.T) {
+	bearer, privateKey := userBearer(t)
+
+	cases := []struct {
+		description   string
+		requiredMocks func(service *mocks.MockService)
+		expected      *gateway.Identity
+	}{
+		{
+			description: "succeeds when both role and admin resolve",
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("owner", nil).Once()
+				service.On("GetUserAdmin", mock.Anything, testUserID).Return(true, nil).Once()
+			},
+			expected: &gateway.Identity{
+				ID:       testUserID,
+				Username: "john",
+				TenantID: testTenant,
+				Role:     authorizer.RoleOwner,
+				Admin:    true,
+			},
+		},
+		{
+			description: "yields no identity when the namespace no longer exists",
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("", store.ErrNoDocuments).Once()
+			},
+			expected: nil,
+		},
+		{
+			description: "yields no identity when the user no longer exists",
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("owner", nil).Once()
+				service.On("GetUserAdmin", mock.Anything, testUserID).Return(false, store.ErrNoDocuments).Once()
+			},
+			expected: nil,
+		},
+		{
+			description: "yields no identity when the store is unreachable",
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("", errors.New("connection refused")).Once()
+			},
+			expected: nil,
+		},
+		{
+			description: "yields no identity when the request is cancelled",
+			requiredMocks: func(service *mocks.MockService) {
+				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("owner", nil).Once()
+				service.On("GetUserAdmin", mock.Anything, testUserID).Return(false, context.DeadlineExceeded).Once()
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			service := new(mocks.MockService)
+			service.On("PublicKey").Return(&privateKey.PublicKey).Once()
+			tc.requiredMocks(service)
+
+			c, _ := authenticatedRequest(echo.New(), bearer)
+
+			identity, err := NewAuthenticator(service).Resolve(c)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, identity)
+
+			service.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAuthenticatorMiddlewareStaleToken(t *testing.T) {
+	bearer, privateKey := userBearer(t)
+
+	service := new(mocks.MockService)
+	service.On("PublicKey").Return(&privateKey.PublicKey).Once()
+	service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("", store.ErrNoDocuments).Once()
+
+	c, rec := authenticatedRequest(echo.New(), bearer)
+
+	next := func(echo.Context) error { return c.NoContent(http.StatusOK) }
+	require.NoError(t, NewAuthenticator(service).Middleware(next)(c))
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Result().StatusCode)
+	service.AssertExpectations(t)
+}
+
+func TestAuthenticatorMiddlewareStaleTokenOnAnonymousRoute(t *testing.T) {
+	bearer, privateKey := userBearer(t)
+
+	service := new(mocks.MockService)
+	service.On("PublicKey").Return(&privateKey.PublicKey).Once()
+	service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("", store.ErrNoDocuments).Once()
+
+	c, rec := authenticatedRequest(echo.New(), bearer)
+	c.Request().Header.Set("X-ID", "forged")
+
+	authenticator := NewAuthenticator(service)
+	authenticator.AllowAnonymous(http.MethodGet, "/api/namespaces")
+
+	next := func(echo.Context) error { return c.NoContent(http.StatusOK) }
+	require.NoError(t, authenticator.Middleware(next)(c))
+
+	assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	assert.Empty(t, c.Request().Header.Get("X-ID"))
+	service.AssertExpectations(t)
+}


### PR DESCRIPTION
## What

The in-process authenticator now yields no identity when it cannot resolve the
role or admin flag behind a JWT, so a stale token gets a 401 instead of a 500.

## Why

`Resolve` propagated the raw store error from `GetUserRole` and `GetUserAdmin`.
Those errors carry `Layer: "store"`, which the echo error handler maps to 500,
so every authenticated request with a token referencing deleted entities
answered 500 and the client was never told to re-authenticate. A database reset
without clearing the browser session reproduces it on every `GET /api/namespaces`.

Before auth moved into the API process, the nginx edge proxy turned any non-2xx
from the `/internal/auth` subrequest into a 401 and never leaked the store's own
status codes. `7fb6ef42` restored that behaviour for API keys; this restores it
for bearer tokens.

Closes #6844

## Changes

- **middleware/authn.go**: both lookups in the `*authorizer.UserClaims` branch
  return `nil, nil` on error. The middleware's fail-closed path then answers 401.
  A single comment above the branch carries the rationale for both sites rather
  than repeating the one on the API-key branch.
- **middleware/authn_test.go**: new. Covers the happy path, a missing namespace,
  a missing user, and — pinning the deliberate breadth of the rule — a store
  transport error and a cancelled request. Two middleware-level tests assert the
  401 on a protected route and that an anonymous route still reaches the handler
  with forged identity headers scrubbed.

## Testing

The blanket swallow is the point of contention worth a reviewer's attention: a
store outage now logs users out with a 401 rather than surfacing a 5xx you can
alert on. That matches the edge proxy's old behaviour and the API-key branch
directly above (whose comment already calls out "including when its store was
down"), but it is broader than "the entity does not exist". The two
non-not-found test cases exist so any future narrowing is visible in CI.