### PR TITLE
fix(ui): refresh identity list after approval confirmation

### DIFF
--- a/ui/apps/console/src/hooks/useSSHApproval.ts
+++ b/ui/apps/console/src/hooks/useSSHApproval.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  getSshApproval,
-  confirmSshApproval,
-  rejectSshApproval,
-} from "@/client";
+import { getSshApproval } from "@/client";
 import { isSdkError } from "@/api/errors";
+import {
+  useConfirmSSHApproval,
+  useRejectSSHApproval,
+} from "./useSSHIdentityMutations";
 
 /**
  * Drives the SSH login approval modal: fetch the request the gateway is holding
@@ -53,6 +53,8 @@ export function useSSHApproval(code: string) {
   const [deciding, setDeciding] = useState(false);
   const [actionError, setActionError] = useState("");
   const expiresAtRef = useRef(0);
+  const confirmMutation = useConfirmSSHApproval();
+  const rejectMutation = useRejectSSHApproval();
 
   // Fetch the request once on mount (or when the code changes).
   useEffect(() => {
@@ -132,21 +134,19 @@ export function useSSHApproval(code: string) {
     return () => window.clearInterval(id);
   }, [phase]);
 
-  /** Reports whether the decision landed, so a caller can react to it. */
   const decide = useCallback(
     async (decision: "confirm" | "reject") => {
       if (!code || deciding) return false;
       setDeciding(true);
       setActionError("");
       try {
-        const call =
-          decision === "confirm" ? confirmSshApproval : rejectSshApproval;
-        await call({ path: { code }, throwOnError: true });
+        const mutation =
+          decision === "confirm" ? confirmMutation : rejectMutation;
+        await mutation.mutateAsync({ path: { code } });
         setPhase(decision === "confirm" ? "confirmed" : "rejected");
 
         return true;
       } catch (err) {
-        // The window closed under us while deciding.
         if (isSdkError(err) && err.status === 404) {
           setPhase("expired");
           return false;
@@ -158,7 +158,7 @@ export function useSSHApproval(code: string) {
         setDeciding(false);
       }
     },
-    [code, deciding],
+    [code, deciding, confirmMutation, rejectMutation],
   );
 
   const confirm = useCallback(() => decide("confirm"), [decide]);

--- a/ui/apps/console/src/hooks/useSSHIdentityMutations.ts
+++ b/ui/apps/console/src/hooks/useSSHIdentityMutations.ts
@@ -1,10 +1,26 @@
 import { useMutation } from "@tanstack/react-query";
 import {
+  confirmSshApprovalMutation,
+  rejectSshApprovalMutation,
   createSshIdentityMutation,
   renameSshIdentityMutation,
   deleteSshIdentityMutation,
 } from "../client/@tanstack/react-query.gen";
 import { useInvalidateByIds } from "./useInvalidateQueries";
+
+export function useConfirmSSHApproval() {
+  const invalidate = useInvalidateByIds("listSshIdentities");
+  return useMutation({
+    ...confirmSshApprovalMutation(),
+    onSuccess: invalidate,
+  });
+}
+
+export function useRejectSSHApproval() {
+  return useMutation({
+    ...rejectSshApprovalMutation(),
+  });
+}
 
 export function useCreateSSHIdentity() {
   const invalidate = useInvalidateByIds("listSshIdentities");

--- a/ui/apps/console/src/pages/__tests__/SSHApproval.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/SSHApproval.test.tsx
@@ -2,19 +2,21 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import SSHApproval from "../SSHApproval";
-import {
-  getSshApproval,
-  confirmSshApproval,
-  rejectSshApproval,
-  webTerminalReauth,
-} from "@/client";
+import { getSshApproval, webTerminalReauth } from "@/client";
 
 vi.mock("@/client", () => ({
   getSshApproval: vi.fn(),
-  confirmSshApproval: vi.fn(),
-  rejectSshApproval: vi.fn(),
   webTerminalReauth: vi.fn(),
+}));
+
+const mockConfirmMutateAsync = vi.fn();
+const mockRejectMutateAsync = vi.fn();
+
+vi.mock("@/hooks/useSSHIdentityMutations", () => ({
+  useConfirmSSHApproval: () => ({ mutateAsync: mockConfirmMutateAsync }),
+  useRejectSSHApproval: () => ({ mutateAsync: mockRejectMutateAsync }),
 }));
 
 vi.mock("@/hooks/useNamespaces", () => ({
@@ -60,30 +62,34 @@ const approval = (overrides: Record<string, unknown> = {}) => ({
   },
 });
 
-/** Renders both routes so a canonicalizing redirect lands somewhere observable. */
 function renderAt(path: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route
-          path="/ssh-identities/new/:code"
-          element={<SSHApproval flow="new" />}
-        />
-        <Route
-          path="/ssh-identities/confirm/:code"
-          element={<SSHApproval flow="confirm" />}
-        />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/ssh-identities/new/:code"
+            element={<SSHApproval flow="new" />}
+          />
+          <Route
+            path="/ssh-identities/confirm/:code"
+            element={<SSHApproval flow="confirm" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
 describe("SSHApproval", () => {
   beforeEach(() => {
     vi.mocked(getSshApproval).mockReset();
-    vi.mocked(confirmSshApproval).mockReset();
-    vi.mocked(rejectSshApproval).mockReset();
     vi.mocked(webTerminalReauth).mockReset();
+    mockConfirmMutateAsync.mockReset();
+    mockRejectMutateAsync.mockReset();
   });
 
   it("asks to add the key, and names the account and namespace it lands in", async () => {
@@ -155,7 +161,7 @@ describe("SSHApproval", () => {
 
   it("confirms the request and reports the outcome", async () => {
     vi.mocked(getSshApproval).mockResolvedValue(approval() as never);
-    vi.mocked(confirmSshApproval).mockResolvedValue({} as never);
+    mockConfirmMutateAsync.mockResolvedValue({});
 
     renderAt("/ssh-identities/new/WXYZ2K7Q");
 
@@ -164,7 +170,7 @@ describe("SSHApproval", () => {
     );
 
     await waitFor(() =>
-      expect(confirmSshApproval).toHaveBeenCalledWith(
+      expect(mockConfirmMutateAsync).toHaveBeenCalledWith(
         expect.objectContaining({ path: { code: "WXYZ2K7Q" } }),
       ),
     );
@@ -173,7 +179,7 @@ describe("SSHApproval", () => {
 
   it("rejects the request and reports the outcome", async () => {
     vi.mocked(getSshApproval).mockResolvedValue(approval() as never);
-    vi.mocked(rejectSshApproval).mockResolvedValue({} as never);
+    mockRejectMutateAsync.mockResolvedValue({});
 
     renderAt("/ssh-identities/new/WXYZ2K7Q");
 
@@ -181,7 +187,7 @@ describe("SSHApproval", () => {
       await screen.findByRole("button", { name: /reject/i }),
     );
 
-    await waitFor(() => expect(rejectSshApproval).toHaveBeenCalled());
+    await waitFor(() => expect(mockRejectMutateAsync).toHaveBeenCalled());
     expect(await screen.findByText("Rejected")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## What
The SSH Identities list now updates immediately after confirming a new identity through the approval flow, without requiring a page reload.

## Why
The approval flow called `confirmSshApproval` and `rejectSshApproval` as raw SDK functions, bypassing TanStack Query's mutation layer entirely. Every other identity mutation (create via drawer, rename, delete) already invalidated the `listSshIdentities` cache through hooks in `useSSHIdentityMutations` — the approval path was the only one that didn't.

## Changes
- **`useSSHIdentityMutations`**: added `useConfirmSSHApproval` (invalidates `listSshIdentities` on success) and `useRejectSSHApproval` mutation hooks, matching the pattern of the existing create/rename/delete hooks
- **`useSSHApproval`**: replaced direct SDK calls with the new mutation hooks so cache invalidation is handled in the data layer, not in the component

## Testing
1. Start an SSH login with a key ShellHub doesn't know (triggers the approval flow)
2. Open the approval link, confirm the key
3. Close the dialog — the identity list should show the new entry without a reload