### PR TITLE
fix(server): conflict on an ssh key the caller already enrolled

### DIFF
--- a/server/api/services/ssh-approval.go
+++ b/server/api/services/ssh-approval.go
@@ -253,11 +253,11 @@ func (s *service) applySSHApproval(ctx context.Context, userID string, approval 
 		return nil
 	}
 
-	// Enrollment is idempotent for the same account, so a re-confirm does not
-	// fail. An empty name lets the identity service generate a default from the
-	// key. The source is the one the server asserts for itself: it saw the key
-	// offered on a login it was holding open.
-	if _, err := s.enrollSSHIdentity(ctx, &models.SSHIdentity{
+	// A confirmation can be replayed, so this enrolls through the tolerant path.
+	// An empty name lets the identity service generate a default from the key.
+	// The source is the one the server asserts for itself: it saw the key offered
+	// on a login it was holding open.
+	if _, err := s.reenrollSSHIdentity(ctx, &models.SSHIdentity{
 		TenantID:    approval.TenantID,
 		PrincipalID: userID,
 		Fingerprint: approval.Fingerprint,

--- a/server/api/services/ssh-identity.go
+++ b/server/api/services/ssh-identity.go
@@ -108,18 +108,32 @@ func (s *service) ConsumeSSHIdentity(ctx context.Context, tenantID, fingerprint 
 	return s.store.SSHIdentityConsume(ctx, tenantID, fingerprint)
 }
 
-// enrollSSHIdentity creates the binding, returning the existing one unchanged
-// when the same account already holds it (idempotent) and a duplicated error
-// when the fingerprint is taken by another identity in the namespace. A zero
-// ExpiresAt and SingleUse give the durable, reusable key most callers want.
+// enrollSSHIdentity creates the binding, failing with a duplicated error when
+// the fingerprint is already taken in the namespace — by this principal or
+// another. A caller re-adding a key it already holds is a mistake worth
+// reporting, not a no-op to hide; the one path that must tolerate a replay uses
+// reenrollSSHIdentity. A zero ExpiresAt and SingleUse give the durable,
+// reusable key most callers want.
 func (s *service) enrollSSHIdentity(ctx context.Context, identity *models.SSHIdentity) (*models.SSHIdentity, error) {
-	sc, err := BoundTo(identity.TenantID)
+	existing, err := s.resolveEnrolledSSHIdentity(ctx, identity.TenantID, identity.Fingerprint)
 	if err != nil {
 		return nil, err
 	}
 
-	existing, err := s.store.SSHIdentityResolve(ctx, sc, store.SSHIdentityFingerprintResolver, identity.Fingerprint)
-	if err != nil && !errors.Is(err, store.ErrNoDocuments) {
+	if existing != nil {
+		return nil, NewErrSSHIdentityDuplicated(identity.Fingerprint, nil)
+	}
+
+	return s.persistSSHIdentity(ctx, identity)
+}
+
+// reenrollSSHIdentity is enrollSSHIdentity for the paths that can legitimately
+// run twice for the same key — a confirmation replayed by the person or the
+// gateway — returning the existing binding unchanged instead of a conflict. The
+// fingerprint held by a different principal still conflicts.
+func (s *service) reenrollSSHIdentity(ctx context.Context, identity *models.SSHIdentity) (*models.SSHIdentity, error) {
+	existing, err := s.resolveEnrolledSSHIdentity(ctx, identity.TenantID, identity.Fingerprint)
+	if err != nil {
 		return nil, err
 	}
 
@@ -131,6 +145,27 @@ func (s *service) enrollSSHIdentity(ctx context.Context, identity *models.SSHIde
 		return nil, NewErrSSHIdentityDuplicated(identity.Fingerprint, nil)
 	}
 
+	return s.persistSSHIdentity(ctx, identity)
+}
+
+// resolveEnrolledSSHIdentity reports a free fingerprint as a nil identity rather
+// than an error, so the enroll paths branch on the holder instead of on
+// ErrNoDocuments.
+func (s *service) resolveEnrolledSSHIdentity(ctx context.Context, tenantID, fingerprint string) (*models.SSHIdentity, error) {
+	sc, err := BoundTo(tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := s.store.SSHIdentityResolve(ctx, sc, store.SSHIdentityFingerprintResolver, fingerprint)
+	if err != nil && !errors.Is(err, store.ErrNoDocuments) {
+		return nil, err
+	}
+
+	return existing, nil
+}
+
+func (s *service) persistSSHIdentity(ctx context.Context, identity *models.SSHIdentity) (*models.SSHIdentity, error) {
 	if identity.Name == "" {
 		identity.Name = defaultSSHIdentityName(identity.Fingerprint, identity.Data)
 	}

--- a/server/api/services/ssh-identity_test.go
+++ b/server/api/services/ssh-identity_test.go
@@ -122,12 +122,12 @@ func TestEnrollSSHIdentity(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			description: "is idempotent when the same account already holds the key",
+			description: "rejects when the same account already holds the key",
 			requireMocks: func(storeMock *storemock.MockStore, queryOptionsMock *storemock.MockQueryOptions) {
 				storeMock.On("SSHIdentityResolve", ctx, mock.Anything, store.SSHIdentityFingerprintResolver, fingerprint).
 					Return(&models.SSHIdentity{ID: "id1", PrincipalID: userID, Fingerprint: fingerprint}, nil).Once()
 			},
-			expectedErr: nil,
+			expectedErr: NewErrSSHIdentityDuplicated(fingerprint, nil),
 		},
 		{
 			description: "rejects when the fingerprint is bound to another identity",
@@ -173,6 +173,79 @@ func TestEnrollSSHIdentity(t *testing.T) {
 	}
 }
 
+func TestReenrollSSHIdentity(t *testing.T) {
+	ctx := context.TODO()
+
+	const (
+		tenantID    = "00000000-0000-4000-0000-000000000000"
+		fingerprint = "SHA256:abc"
+		userID      = "user1"
+	)
+
+	cases := []struct {
+		description  string
+		requireMocks func(storeMock *storemock.MockStore, queryOptionsMock *storemock.MockQueryOptions)
+		expectedID   string
+		expectedErr  error
+	}{
+		{
+			description: "returns the existing binding when the same account already holds the key",
+			requireMocks: func(storeMock *storemock.MockStore, queryOptionsMock *storemock.MockQueryOptions) {
+				storeMock.On("SSHIdentityResolve", ctx, mock.Anything, store.SSHIdentityFingerprintResolver, fingerprint).
+					Return(&models.SSHIdentity{ID: "existing", PrincipalID: userID, Fingerprint: fingerprint}, nil).Once()
+			},
+			expectedID:  "existing",
+			expectedErr: nil,
+		},
+		{
+			description: "creates the binding when the fingerprint is free",
+			requireMocks: func(storeMock *storemock.MockStore, queryOptionsMock *storemock.MockQueryOptions) {
+				storeMock.On("SSHIdentityResolve", ctx, mock.Anything, store.SSHIdentityFingerprintResolver, fingerprint).
+					Return(nil, store.ErrNoDocuments).Once()
+				storeMock.On("SSHIdentityCreate", ctx, mock.Anything).Return("created", nil).Once()
+			},
+			expectedID:  "created",
+			expectedErr: nil,
+		},
+		{
+			description: "rejects when the fingerprint is bound to another identity",
+			requireMocks: func(storeMock *storemock.MockStore, queryOptionsMock *storemock.MockQueryOptions) {
+				storeMock.On("SSHIdentityResolve", ctx, mock.Anything, store.SSHIdentityFingerprintResolver, fingerprint).
+					Return(&models.SSHIdentity{ID: "id2", PrincipalID: "other", Fingerprint: fingerprint}, nil).Once()
+			},
+			expectedErr: NewErrSSHIdentityDuplicated(fingerprint, nil),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			storeMock := new(storemock.MockStore)
+			queryOptionsMock := new(storemock.MockQueryOptions)
+			storeMock.On("Options").Return(queryOptionsMock).Maybe()
+
+			tc.requireMocks(storeMock, queryOptionsMock)
+
+			service := NewService(storeMock, privateKey, publicKey, nil)
+
+			identity, err := service.reenrollSSHIdentity(ctx, &models.SSHIdentity{
+				TenantID:    tenantID,
+				PrincipalID: userID,
+				Fingerprint: fingerprint,
+				Data:        []byte("ssh-ed25519 AAAA"),
+				Source:      models.SSHIdentitySourceApproval,
+			})
+			require.Equal(t, tc.expectedErr, err)
+
+			if tc.expectedErr == nil {
+				require.NotNil(t, identity)
+				require.Equal(t, tc.expectedID, identity.ID)
+			}
+
+			storeMock.AssertExpectations(t)
+		})
+	}
+}
+
 func TestCreateSSHIdentity(t *testing.T) {
 	ctx := context.TODO()
 
@@ -208,6 +281,21 @@ func TestCreateSSHIdentity(t *testing.T) {
 		identity, err := service.CreateSSHIdentity(ctx, &requests.SSHIdentityCreate{TenantID: tenantID, UserID: userID, Name: "laptop", Data: authorized})
 		require.NoError(t, err)
 		require.Equal(t, fingerprint, identity.Fingerprint)
+
+		storeMock.AssertExpectations(t)
+	})
+
+	t.Run("reports a duplicate when the caller already enrolled the key", func(t *testing.T) {
+		storeMock := new(storemock.MockStore)
+		queryOptionsMock := new(storemock.MockQueryOptions)
+		storeMock.On("Options").Return(queryOptionsMock).Maybe()
+		storeMock.On("SSHIdentityResolve", ctx, mock.Anything, store.SSHIdentityFingerprintResolver, fingerprint).
+			Return(&models.SSHIdentity{ID: "id1", PrincipalID: userID, Fingerprint: fingerprint}, nil).Once()
+
+		service := NewService(storeMock, privateKey, publicKey, nil)
+
+		_, err := service.CreateSSHIdentity(ctx, &requests.SSHIdentityCreate{TenantID: tenantID, UserID: userID, Name: "laptop", Data: authorized})
+		require.Equal(t, NewErrSSHIdentityDuplicated(fingerprint, nil), err)
 
 		storeMock.AssertExpectations(t)
 	})

--- a/ui/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui/apps/console/src/components/ConnectDrawer.tsx
@@ -24,6 +24,7 @@ import {
 } from "../utils/browserKey";
 import { BROWSER_KEY_QUERY_KEY } from "@/hooks/useBrowserKey";
 import { isRecordingSupported } from "../utils/recordings";
+import { isAlreadyEnrolled } from "../utils/sshIdentity";
 import { listSshIdentitiesOptions } from "../client/@tanstack/react-query.gen";
 import BrowserEnrollDialog from "./terminal/BrowserEnrollDialog";
 import CopyButton from "./common/CopyButton";
@@ -238,9 +239,16 @@ export default function ConnectDrawer({
     params: ConnectParams,
     name: string,
   ) => {
-    await createIdentity.mutateAsync({
-      body: { name, data: key.publicKeyLine, source: "browser" },
-    });
+    try {
+      await createIdentity.mutateAsync({
+        body: { name, data: key.publicKeyLine, source: "browser" },
+      });
+    } catch (err: unknown) {
+      // The registered check above reads the server, so another tab enrolling
+      // this same key in between lands here. The key works either way, so the
+      // connection this consent was for should still happen.
+      if (!isAlreadyEnrolled(err)) throw err;
+    }
     await persistBrowserKey(scope, key);
     // This browser now holds a key it did not a moment ago, and the identities
     // list reads that to mark its own row.

--- a/ui/apps/console/src/pages/ssh-identities/IdentityDrawer.tsx
+++ b/ui/apps/console/src/pages/ssh-identities/IdentityDrawer.tsx
@@ -5,7 +5,6 @@ import {
   CpuChipIcon,
 } from "@heroicons/react/24/outline";
 import { Button } from "@shellhub/design-system/primitives";
-import { isSdkError } from "@/api/errors";
 import { useResetOnOpen } from "@/hooks/useResetOnOpen";
 import {
   useCreateSSHIdentity,
@@ -25,6 +24,7 @@ import {
   keyExpiryPayload,
   serviceAccountLifecyclePayload,
   sshIdentitySource,
+  isAlreadyEnrolled,
 } from "@/utils/sshIdentity";
 import KeyExpiryField from "@/components/common/KeyExpiryField";
 import { useBrowserKeyFingerprint } from "@/hooks/useBrowserKey";
@@ -119,7 +119,7 @@ function IdentityDrawer({
       }
       onClose();
     } catch (err: unknown) {
-      if (!isEdit && isSdkError(err) && err.status === 409) {
+      if (!isEdit && isAlreadyEnrolled(err)) {
         setKeyError("This key is already an identity in this namespace.");
       } else {
         setError(

--- a/ui/apps/console/src/utils/__tests__/sshIdentity.test.ts
+++ b/ui/apps/console/src/utils/__tests__/sshIdentity.test.ts
@@ -5,6 +5,7 @@ import {
   serviceAccountLifecyclePayload,
   sshIdentitySource,
   shortFingerprint,
+  isAlreadyEnrolled,
 } from "@/utils/sshIdentity";
 
 const NOW = Date.UTC(2026, 0, 10);
@@ -182,5 +183,29 @@ describe("sshIdentityEndOfLife", () => {
       value: "on first use",
       tone: "armed",
     });
+  });
+});
+
+describe("isAlreadyEnrolled", () => {
+  it("recognizes the conflict the enroll endpoint answers with", () => {
+    expect(isAlreadyEnrolled({ status: 409, headers: new Headers() })).toBe(
+      true,
+    );
+  });
+
+  it.each([400, 401, 403, 404, 500])(
+    "does not treat %i as an existing enrollment",
+    (status) => {
+      expect(isAlreadyEnrolled({ status, headers: new Headers() })).toBe(false);
+    },
+  );
+
+  it.each([
+    ["a plain error", new Error("network down")],
+    ["null", null],
+    ["undefined", undefined],
+    ["a bare object", {}],
+  ])("does not treat %s as an existing enrollment", (_label, err) => {
+    expect(isAlreadyEnrolled(err)).toBe(false);
   });
 });

--- a/ui/apps/console/src/utils/sshIdentity.ts
+++ b/ui/apps/console/src/utils/sshIdentity.ts
@@ -1,6 +1,16 @@
 import { differenceInDays } from "date-fns";
 import { formatDateShort } from "@/utils/date";
+import { isSdkError } from "@/api/errors";
 import type { SshIdentity } from "@/client";
+
+/**
+ * Whether an enroll failure means the key is already an identity. The endpoint
+ * answers 409 for a fingerprint already taken in the namespace, which for a key
+ * the caller holds privately can only be an enrollment of their own.
+ */
+export function isAlreadyEnrolled(err: unknown): boolean {
+  return isSdkError(err) && err.status === 409;
+}
 
 /**
  * Turn the expiry form value into the create-request field. "-1" (never) omits


### PR DESCRIPTION
## What

Enrolling an SSH public key that the caller already holds now answers `409 Conflict` instead of `200` with the pre-existing record.

## Why

`enrollSSHIdentity` treated same-fingerprint-same-principal as an idempotent success, returning the existing `*models.SSHIdentity` with a nil error. The handler then responded `200` with the old record — indistinguishable from a real creation, so the frontend had nothing to key off and the person saw no feedback at all. This aligns the endpoint with `CreatePublicKey`, which already returns `ErrPublicKeyDuplicated` for a taken fingerprint.

Closes #6846

## Changes

**Server**

- **`enrollSSHIdentity`**: strict. Any fingerprint already taken in the namespace — by this principal or another — returns `NewErrSSHIdentityDuplicated`, which the existing `ErrCodeDuplicated` -> `http.StatusConflict` mapping in `converter.FromErrServiceToHTTPStatus` turns into a 409.
- **`reenrollSSHIdentity`**: new, and the reason the strict change is safe. An SSH approval can legitimately be confirmed twice for the same key, so `applySSHApproval` enrolls through this variant, which still returns the existing binding for the same principal. A fingerprint held by a *different* principal conflicts on both paths.
- **`resolveEnrolledSSHIdentity` / `persistSSHIdentity`**: the shared halves both paths need. Each enroll path performs exactly one store lookup — the split adds no query.

**UI**

The identity drawer already branched on 409 to show "This key is already an identity in this namespace.", so the reported symptom needed no frontend change. But `ConnectDrawer`'s browser-key consent flow did: it asks the server whether the key is registered *before* enrolling, and a second tab enrolling the same key in between previously fell into the idempotent 200. Under the strict server it would have hit 409 and refused the connection the person had just consented to.

- **`isAlreadyEnrolled`**: one named predicate for the status, replacing the drawer's inline `isSdkError(err) && err.status === 409`.
- **`enrollAndConnect`**: swallows that specific conflict and connects. The key is one only this browser holds privately, so a 409 on it can only be an enrollment of the caller's own.

No API-surface change was needed — `openapi/spec/paths/api@ssh-identities.yaml` already documented `409`.

## Testing

Reviewers should focus on the enroll/reenroll split rather than the error mapping.

- The behaviour that separates the two variants is the reenroll same-principal case returning the *existing* row — `TestReenrollSSHIdentity` asserts the returned `ID`, not just a nil error, so it cannot pass on `nil, nil`.
- Service-account creation is unaffected by design, not by accident: it enrolls against a user ID minted inside the same transaction, so the same-principal branch was already unreachable there.
- The `ConnectDrawer` change itself is untested. That component has no test harness and standing one up needs WebCrypto Ed25519 plus IndexedDB fakes; the extracted predicate is covered instead. Worth exercising by hand: open the connect drawer in two tabs on a browser with no enrolled key and confirm consent in both — the second should connect rather than show "Could not register this browser."

Server suite (27 packages) and `golangci-lint run ./...` clean; console build, lint, and 3000 tests clean.