### PR TITLE
chore: bump shellhub version to v0.27.0-rc.5

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # This is in order to avoid conflict with upstream code when updating to a newer version
 
 # ShellHub version. 
-SHELLHUB_VERSION=v0.27.0-rc.4
+SHELLHUB_VERSION=v0.27.0-rc.5
 
 # The default log level for ShellHub.
 # VALUES: https://pkg.go.dev/github.com/sirupsen/logrus#Level


### PR DESCRIPTION
Bumps `SHELLHUB_VERSION` in `.env` to `v0.27.0-rc.5` ahead of tagging the release.