### PR TITLE
fix(ui): extract StepperField and fix numeric input validation in install-key drawers

### DIFF
--- a/ui/apps/console/src/components/common/fields/StepperField.tsx
+++ b/ui/apps/console/src/components/common/fields/StepperField.tsx
@@ -1,0 +1,107 @@
+import { ComponentProps, useState } from "react";
+import { cn } from "@shellhub/design-system/cn";
+import { IconButton } from "@shellhub/design-system/primitives";
+import NumericInput from "@/components/common/fields/NumericInput";
+
+type StepperFieldProps = Pick<
+  ComponentProps<typeof NumericInput>,
+  "id" | "label" | "readOnly" | "className"
+> & {
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max?: number;
+  size?: "sm" | "md";
+};
+
+const SIZE = {
+  sm: { bar: "h-9", btn: "w-9 text-base" },
+  md: { bar: "h-11", btn: "w-10 text-lg" },
+} as const;
+
+export default function StepperField({
+  value,
+  onChange,
+  min,
+  max,
+  size = "md",
+  className,
+  ...rest
+}: StepperFieldProps) {
+  const { readOnly } = rest;
+
+  const [displayValue, setDisplayValue] = useState(String(value));
+
+  const [prevValue, setPrevValue] = useState(value);
+  if (value !== prevValue) {
+    setPrevValue(value);
+    setDisplayValue(String(value));
+  }
+
+  const step = (delta: number) => {
+    const next = value + delta;
+    setDisplayValue(String(next));
+    onChange(next);
+  };
+
+  const handleInput = (raw: string) => {
+    setDisplayValue(raw);
+    const n = parseInt(raw, 10);
+    if (n >= min && (max === undefined || n <= max)) {
+      onChange(n);
+    }
+  };
+
+  const handleBlur = () => {
+    if (!displayValue) {
+      setDisplayValue(String(min));
+      onChange(min);
+      return;
+    }
+    setDisplayValue(String(value));
+  };
+
+  const atMin = value <= min;
+  const atMax = max !== undefined && value >= max;
+  const s = SIZE[size];
+
+  const btnClass = cn(s.btn, "h-full rounded-none p-0");
+
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center overflow-hidden",
+        s.bar,
+        "bg-card border border-border rounded-lg",
+        className,
+      )}
+    >
+      <IconButton
+        variant="ghost"
+        aria-label="Decrease"
+        disabled={atMin}
+        onClick={() => step(-1)}
+        className={btnClass}
+      >
+        −
+      </IconButton>
+      <NumericInput
+        {...rest}
+        hideLabel
+        value={readOnly ? String(value) : displayValue}
+        onChange={handleInput}
+        onBlur={readOnly ? undefined : handleBlur}
+        className="border-0 bg-transparent rounded-none px-0 py-0 text-center font-mono text-sm font-semibold text-text-primary focus:ring-0 focus:border-transparent"
+      />
+      <IconButton
+        variant="ghost"
+        aria-label="Increase"
+        disabled={atMax}
+        onClick={() => step(1)}
+        className={btnClass}
+      >
+        +
+      </IconButton>
+    </div>
+  );
+}

--- a/ui/apps/console/src/components/common/fields/__tests__/StepperField.test.tsx
+++ b/ui/apps/console/src/components/common/fields/__tests__/StepperField.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import StepperField from "@/components/common/fields/StepperField";
+
+type Overrides = Partial<React.ComponentProps<typeof StepperField>>;
+
+function renderField(overrides: Overrides = {}) {
+  const props = {
+    id: "test-stepper",
+    label: "Count",
+    value: 5,
+    onChange: vi.fn(),
+    min: 1,
+    ...overrides,
+  };
+  render(<StepperField {...props} />);
+  return props;
+}
+
+describe("StepperField", () => {
+  it("renders the current value", () => {
+    renderField({ value: 7 });
+    expect(screen.getByRole("textbox", { name: "Count" })).toHaveValue("7");
+  });
+
+  it("increments the value when + is clicked", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderField();
+
+    await user.click(screen.getByRole("button", { name: "Increase" }));
+
+    expect(onChange).toHaveBeenCalledWith(6);
+  });
+
+  it("decrements the value when − is clicked", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderField();
+
+    await user.click(screen.getByRole("button", { name: "Decrease" }));
+
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it("disables the decrease button at min", () => {
+    renderField({ value: 1, min: 1 });
+    expect(screen.getByRole("button", { name: "Decrease" })).toBeDisabled();
+  });
+
+  it("disables the increase button at max", () => {
+    renderField({ value: 10, max: 10 });
+    expect(screen.getByRole("button", { name: "Increase" })).toBeDisabled();
+  });
+
+  it("does not disable the increase button when no max is set", () => {
+    renderField({ value: 999 });
+    expect(
+      screen.getByRole("button", { name: "Increase" }),
+    ).not.toBeDisabled();
+  });
+
+  it("calls onChange when a valid in-range number is typed", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderField({ min: 1, max: 100 });
+
+    const input = screen.getByRole("textbox", { name: "Count" });
+    await user.clear(input);
+    await user.type(input, "42");
+
+    expect(onChange).toHaveBeenCalledWith(42);
+  });
+
+  it("reverts out-of-range input on blur", async () => {
+    const user = userEvent.setup();
+    renderField({ min: 2 });
+
+    const input = screen.getByRole("textbox", { name: "Count" });
+    await user.clear(input);
+    await user.type(input, "1");
+    await user.tab();
+
+    expect(input).toHaveValue("5");
+  });
+
+  it("resets empty input to min on blur", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderField({ min: 3 });
+
+    const input = screen.getByRole("textbox", { name: "Count" });
+    await user.clear(input);
+    await user.tab();
+
+    expect(onChange).toHaveBeenLastCalledWith(3);
+  });
+
+  it("prevents typing in readOnly mode", () => {
+    renderField({ readOnly: true });
+    expect(screen.getByRole("textbox", { name: "Count" })).toHaveAttribute(
+      "readonly",
+    );
+  });
+
+  it("still allows stepping in readOnly mode", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderField({ readOnly: true });
+
+    await user.click(screen.getByRole("button", { name: "Increase" }));
+
+    expect(onChange).toHaveBeenCalledWith(6);
+  });
+});

--- a/ui/apps/console/src/pages/install-keys/EphemeralField.tsx
+++ b/ui/apps/console/src/pages/install-keys/EphemeralField.tsx
@@ -1,14 +1,6 @@
 import CheckboxField from "@/components/common/fields/CheckboxField";
+import StepperField from "@/components/common/fields/StepperField";
 
-const EPHEMERAL_MIN = 1;
-const EPHEMERAL_MAX = 10;
-
-/**
- * Ephemeral lifecycle for a key's devices: when on, an enrolled device is removed
- * after it stays offline past the timeout (1-10 min). A selectable card that
- * lights up when enabled and reveals the timeout stepper. The on/off stays a
- * plain checkbox so it inherits the design-system field when that lands.
- */
 export default function EphemeralField({
   id,
   enabled,
@@ -16,22 +8,12 @@ export default function EphemeralField({
   timeout,
   onTimeoutChange,
 }: {
-  // Unique per drawer: Create and Edit are both mounted at once, so a shared id would make one
-  // checkbox's label toggle the other's (inert) input.
   id: string;
   enabled: boolean;
   onEnabledChange: (value: boolean) => void;
   timeout: number;
   onTimeoutChange: (value: number) => void;
 }) {
-  const step = (delta: number) =>
-    onTimeoutChange(
-      Math.min(EPHEMERAL_MAX, Math.max(EPHEMERAL_MIN, timeout + delta)),
-    );
-
-  const stepBtn =
-    "w-9 h-full grid place-items-center text-base text-text-secondary hover:text-text-primary hover:bg-hover-medium transition-colors";
-
   return (
     <div
       className={`rounded-xl border p-4 transition-colors ${
@@ -50,27 +32,17 @@ export default function EphemeralField({
       {enabled && (
         <div className="flex items-center gap-3 mt-4 pt-4 border-t border-border/70">
           <span className="text-xs text-text-secondary">Remove after</span>
-          <div className="inline-flex items-center h-9 bg-card border border-border rounded-lg overflow-hidden">
-            <button
-              type="button"
-              aria-label="Decrease"
-              onClick={() => step(-1)}
-              className={stepBtn}
-            >
-              −
-            </button>
-            <span className="min-w-[2.25rem] text-center font-mono text-sm font-semibold text-text-primary">
-              {timeout}
-            </span>
-            <button
-              type="button"
-              aria-label="Increase"
-              onClick={() => step(1)}
-              className={stepBtn}
-            >
-              +
-            </button>
-          </div>
+          <StepperField
+            id={`${id}-timeout`}
+            label="Timeout in minutes"
+            value={timeout}
+            onChange={onTimeoutChange}
+            min={1}
+            max={10}
+            readOnly
+            size="sm"
+            className="[&_input]:w-9"
+          />
           <span className="text-2xs text-text-muted">min offline</span>
         </div>
       )}

--- a/ui/apps/console/src/pages/install-keys/UsageLimitField.tsx
+++ b/ui/apps/console/src/pages/install-keys/UsageLimitField.tsx
@@ -1,13 +1,6 @@
 import { useState } from "react";
+import StepperField from "@/components/common/fields/StepperField";
 import { LABEL } from "@/utils/styles";
-
-/**
- * The enrollment budget maps to a single `usage_limit` int: 1 is single-use, N
- * (>=2) enrolls N devices, 0 is unlimited (reusable forever). This control is
- * one bar: a "Single-use" cap on the left, a hand-editable number with a stepper
- * in the middle (>=2), and an "Unlimited" cap on the right. Editing the middle
- * (typing or stepping) implies the "limited" mode.
- */
 
 type Mode = "single" | "limited" | "unlimited";
 
@@ -23,12 +16,6 @@ function helperFor(value: number): string {
   return `Registers up to ${value} devices.`;
 }
 
-const clamp = (n: number) => Math.max(2, n);
-
-// Hide the native number spinners so the middle reads as plain text in the bar.
-const NO_SPINNER =
-  "[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none";
-
 export default function UsageLimitField({
   value,
   onChange,
@@ -37,42 +24,22 @@ export default function UsageLimitField({
   onChange: (value: number) => void;
 }) {
   const mode = modeFromValue(value);
-  // The middle keeps its own string so multi-digit typing isn't clamped mid-edit;
-  // it also remembers a count to restore when toggling back from single/unlimited.
-  const [countStr, setCountStr] = useState(String(value >= 2 ? value : 5));
+  const [lastCount, setLastCount] = useState(value >= 2 ? value : 5);
 
-  // Resync the middle when the value changes from outside (edit prefill / reset),
-  // using React's adjust-state-on-prop-change during render (no effect needed).
   const [prevValue, setPrevValue] = useState(value);
   if (value !== prevValue) {
     setPrevValue(value);
-    if (value >= 2) setCountStr(String(value));
+    if (value >= 2) setLastCount(value);
   }
 
   const goLimited = () => {
-    const n = clamp(parseInt(countStr, 10) || 2);
-    setCountStr(String(n));
+    const n = Math.max(2, lastCount);
     onChange(n);
   };
 
-  const step = (delta: number) => {
-    const n = clamp((parseInt(countStr, 10) || 2) + delta);
-    setCountStr(String(n));
+  const handleStepperChange = (n: number) => {
+    setLastCount(n);
     onChange(n);
-  };
-
-  const handleInput = (raw: string) => {
-    setCountStr(raw);
-    const n = parseInt(raw, 10);
-    if (!Number.isNaN(n) && n >= 2) onChange(n);
-  };
-
-  const handleBlur = () => {
-    const n = parseInt(countStr, 10);
-    if (Number.isNaN(n) || n < 2) {
-      setCountStr("2");
-      if (mode === "limited") onChange(2);
-    }
   };
 
   const capBase =
@@ -80,8 +47,6 @@ export default function UsageLimitField({
   const capOn = "bg-primary/[0.13] text-primary";
   const capOff =
     "text-text-secondary hover:text-text-primary hover:bg-hover-medium";
-  const stepBtn =
-    "w-10 h-full grid place-items-center text-lg text-text-secondary hover:text-text-primary hover:bg-hover-medium transition-colors";
 
   return (
     <div>
@@ -101,33 +66,14 @@ export default function UsageLimitField({
           }`}
         >
           {mode === "limited" ? (
-            <>
-              <button
-                type="button"
-                aria-label="Decrease"
-                onClick={() => step(-1)}
-                className={stepBtn}
-              >
-                −
-              </button>
-              <input
-                type="number"
-                min={2}
-                aria-label="Number of devices"
-                value={countStr}
-                onChange={(e) => handleInput(e.target.value)}
-                onBlur={handleBlur}
-                className={`flex-1 min-w-0 text-center bg-transparent font-mono text-sm font-semibold text-text-primary outline-none ${NO_SPINNER}`}
-              />
-              <button
-                type="button"
-                aria-label="Increase"
-                onClick={() => step(1)}
-                className={stepBtn}
-              >
-                +
-              </button>
-            </>
+            <StepperField
+              id="usage-limit-stepper"
+              label="Number of devices"
+              value={value}
+              onChange={handleStepperChange}
+              min={2}
+              className="border-0 bg-transparent rounded-none w-full h-full [&>div]:flex-1 [&>div]:min-w-0"
+            />
           ) : (
             <button
               type="button"


### PR DESCRIPTION
  ## What

   Extracts the duplicated stepper control (−/+ buttons around a numeric value) from `UsageLimitField` and `EphemeralField` into a shared `StepperField` component, fixing input validation in the process.

   ## Why

   The usage limit input used a native `<input type="number">`, which accepts characters the field should reject: `e`, `+`, `-`, `.`, and browser-dependent edge cases. Typing `2e3` or `--5` produced silent failures where `e.target.value` returned an empty string, bypassing all validation. Both steppers also duplicated step/clamp logic and button styling independently, so fixes to one wouldn't reach the other.

   ## Changes

   - **`StepperField`** (new, `components/common/fields/`): composes `NumericInput` (digit-only regex filter via `type="text"` + `inputMode="numeric"`) and the design-system `IconButton` (`ghost` variant). Props derived from `NumericInput` via `Pick` + rest spread. Supports `readOnly` (step-only, no typing) and two sizes (`sm`/`md`). Buttons disable at `min`/`max` boundaries.
   - **`UsageLimitField`**: replaced 30 lines of inline stepper with `<StepperField min={2}>`. Tri-mode bar (single/limited/unlimited) and mode-toggle state preserved. Passes `className` to strip container chrome and stretch the input for the embedded layout.
   - **`EphemeralField`**: replaced 20 lines of inline stepper with `<StepperField readOnly size="sm" min={1} max={10}>`. Checkbox toggle and card wrapper preserved. Passes `className` to constrain input width to the original `2.25rem`.

   ## Testing

   12 behaviour tests cover stepping, boundary disable, digit-only filtering, blur revert for out-of-range values, empty-to-min reset, `readOnly` mode, and editable typing. Full suite (3017 tests) green, build and lint clean.