### PR TITLE
fix(ui): validate webhook fields in install-key drawers

### DIFF
--- a/ui/apps/console/src/pages/install-keys/CreateInstallKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/install-keys/CreateInstallKeyDrawer.tsx
@@ -60,6 +60,7 @@ function CreateInstallKeyDrawer({
     webhookUrl,
     webhookSecret,
     macList,
+    { webhookTimeout, webhookCallbackTtl },
   );
 
   useResetOnOpen(open, () => {

--- a/ui/apps/console/src/pages/install-keys/EditInstallKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/install-keys/EditInstallKeyDrawer.tsx
@@ -59,6 +59,8 @@ function EditInstallKeyDrawer({
     macList,
     {
       secretOptional: alreadyWebhook,
+      webhookTimeout,
+      webhookCallbackTtl,
     },
   );
 
@@ -235,6 +237,8 @@ function EditInstallKeyDrawer({
           onWebhookTimeoutChange={setWebhookTimeout}
           webhookCallbackTtl={webhookCallbackTtl}
           onWebhookCallbackTtlChange={setWebhookCallbackTtl}
+          isEditing={alreadyWebhook}
+          panelKey={installKey?.name}
         />
         {!isSystem && (
           <>

--- a/ui/apps/console/src/pages/install-keys/ModeField.tsx
+++ b/ui/apps/console/src/pages/install-keys/ModeField.tsx
@@ -1,8 +1,17 @@
-import { type KeyboardEvent, useRef } from "react";
+import { type KeyboardEvent, useRef, useState } from "react";
 import InputField from "@/components/common/fields/InputField";
+import PasswordField from "@/components/common/fields/PasswordField";
+import NumericInput from "@/components/common/fields/NumericInput";
 import KeyFileInput from "@/components/common/fields/KeyFileInput";
 import { LABEL } from "@/utils/styles";
 import { MODE_INFO } from "./constants";
+import {
+  TIMEOUT_MIN,
+  TIMEOUT_MAX,
+  WINDOW_MIN_H,
+  WINDOW_MAX_H,
+  isWebhookUrl,
+} from "./helpers";
 
 export type InstallKeyMode = "automatic" | "manual" | "webhook" | "allowlist";
 
@@ -12,10 +21,144 @@ const OPTIONS = (
   ["automatic", "manual", "webhook", "allowlist"] as InstallKeyMode[]
 ).map((value) => ({ value, ...MODE_INFO[value] }));
 
-/**
- * The enrollment policy for a key: a list of selectable cards (title + description) across the four
- * modes, revealing the mode-specific config (webhook endpoint + secret, or the MAC allowlist) beneath.
- */
+function WebhookPanel({
+  idPrefix,
+  webhookUrl,
+  onWebhookUrlChange,
+  webhookSecret,
+  onWebhookSecretChange,
+  webhookTimeout,
+  onWebhookTimeoutChange,
+  webhookCallbackTtl,
+  onWebhookCallbackTtlChange,
+  isEditing,
+}: {
+  idPrefix: string;
+  webhookUrl: string;
+  onWebhookUrlChange: (value: string) => void;
+  webhookSecret: string;
+  onWebhookSecretChange: (value: string) => void;
+  webhookTimeout: number;
+  onWebhookTimeoutChange: (value: number) => void;
+  webhookCallbackTtl: number;
+  onWebhookCallbackTtlChange: (value: number) => void;
+  isEditing?: boolean;
+}) {
+  const [urlError, setUrlError] = useState("");
+  const [timeoutStr, setTimeoutStr] = useState(String(webhookTimeout || 5));
+  const [windowStr, setWindowStr] = useState(
+    String(Math.round((webhookCallbackTtl || 3600) / 3600)),
+  );
+
+  const handleUrlChange = (value: string) => {
+    onWebhookUrlChange(value);
+    if (urlError && isWebhookUrl(value)) setUrlError("");
+  };
+
+  const handleUrlBlur = () => {
+    if (webhookUrl.trim() && !isWebhookUrl(webhookUrl)) {
+      setUrlError("Webhook URL must be a valid http or https URL.");
+    }
+  };
+
+  const clamp = (n: number, min: number, max: number) =>
+    Math.min(max, Math.max(min, n));
+
+  const rangeError = (raw: string, min: number, max: number) => {
+    const n = parseInt(raw, 10);
+    if (!raw || Number.isNaN(n) || n < min || n > max)
+      return `Must be ${min}–${max}.`;
+    return undefined;
+  };
+
+  const timeoutError = rangeError(timeoutStr, TIMEOUT_MIN, TIMEOUT_MAX);
+  const windowError = rangeError(windowStr, WINDOW_MIN_H, WINDOW_MAX_H);
+
+  const handleTimeoutChange = (raw: string) => {
+    setTimeoutStr(raw);
+    const n = parseInt(raw, 10);
+    onWebhookTimeoutChange(!raw || Number.isNaN(n) ? 0 : n);
+  };
+
+  const handleTimeoutBlur = () => {
+    const n = clamp(
+      parseInt(timeoutStr, 10) || TIMEOUT_MIN,
+      TIMEOUT_MIN,
+      TIMEOUT_MAX,
+    );
+    setTimeoutStr(String(n));
+    onWebhookTimeoutChange(n);
+  };
+
+  const handleWindowChange = (raw: string) => {
+    setWindowStr(raw);
+    const n = parseInt(raw, 10);
+    onWebhookCallbackTtlChange(!raw || Number.isNaN(n) ? 0 : n * 3600);
+  };
+
+  const handleWindowBlur = () => {
+    const n = clamp(
+      parseInt(windowStr, 10) || WINDOW_MIN_H,
+      WINDOW_MIN_H,
+      WINDOW_MAX_H,
+    );
+    setWindowStr(String(n));
+    onWebhookCallbackTtlChange(n * 3600);
+  };
+
+  const secretHint = isEditing
+    ? "Leave blank to keep the current secret. Signs the request as the X-ShellHub-Signature header (HMAC-SHA256)."
+    : "Signs the request as the X-ShellHub-Signature header (HMAC-SHA256), so your endpoint can verify it came from ShellHub.";
+
+  return (
+    <div className="space-y-3 border-t border-primary/20 bg-card/40 px-3.5 py-3">
+      <InputField
+        id={`${idPrefix}-webhook-url`}
+        label="Webhook URL"
+        value={webhookUrl}
+        onChange={handleUrlChange}
+        onBlur={handleUrlBlur}
+        placeholder="https://register.example.com/hook"
+        hint="Called with a signed payload at registration. http or https."
+        error={urlError || undefined}
+        autoComplete="webhook"
+      />
+      <PasswordField
+        id={`${idPrefix}-webhook-secret`}
+        label="Signing secret"
+        value={webhookSecret}
+        suppressPasswordManager
+        onChange={onWebhookSecretChange}
+        hint={secretHint}
+      />
+      <div className="flex flex-wrap gap-3">
+        <div className="flex-1 min-w-[10rem]">
+          <NumericInput
+            id={`${idPrefix}-webhook-timeout`}
+            label="Reply timeout (s)"
+            value={timeoutStr}
+            onChange={handleTimeoutChange}
+            onBlur={handleTimeoutBlur}
+            hint="How long ShellHub waits for your endpoint to answer, in seconds (1–15)."
+            error={timeoutError}
+          />
+        </div>
+        <div className="flex-1 min-w-[10rem]">
+          <NumericInput
+            id={`${idPrefix}-webhook-window`}
+            label="Callback window (h)"
+            value={windowStr}
+            onChange={handleWindowChange}
+            onBlur={handleWindowBlur}
+            hint="If your endpoint replies later instead of right away, how long it has to call back (up to 24h)."
+            error={windowError}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function ModeField({
   idPrefix,
   mode,
@@ -30,6 +173,8 @@ export default function ModeField({
   onWebhookTimeoutChange,
   webhookCallbackTtl,
   onWebhookCallbackTtlChange,
+  isEditing,
+  panelKey,
 }: {
   // Unique per drawer: Create and Edit are both mounted at once, so shared field ids would cross-wire
   // their labels (a click in one drawer targeting the other's inert input).
@@ -46,10 +191,9 @@ export default function ModeField({
   onWebhookTimeoutChange: (value: number) => void;
   webhookCallbackTtl: number;
   onWebhookCallbackTtlChange: (value: number) => void;
+  isEditing?: boolean;
+  panelKey?: string;
 }) {
-  const clamp = (n: number, min: number, max: number) =>
-    Math.min(max, Math.max(min, n));
-
   // Roving-tabindex radiogroup: Tab lands on the selected option, then arrows move the selection (and
   // focus) between the four, wrapping around — the keyboard behavior a radiogroup is expected to have.
   const radioRefs = useRef<Record<string, HTMLButtonElement | null>>({});
@@ -129,52 +273,19 @@ export default function ModeField({
               </button>
 
               {selected && option.value === "webhook" && (
-                <div className="space-y-3 border-t border-primary/20 bg-card/40 px-3.5 py-3">
-                  <InputField
-                    id={`${idPrefix}-webhook-url`}
-                    label="Webhook URL"
-                    value={webhookUrl}
-                    onChange={onWebhookUrlChange}
-                    placeholder="https://register.example.com/hook"
-                    hint="Called with a signed payload at registration. http or https."
-                  />
-                  <InputField
-                    id={`${idPrefix}-webhook-secret`}
-                    label="Signing secret"
-                    type="password"
-                    value={webhookSecret}
-                    onChange={onWebhookSecretChange}
-                    hint="Signs the request as the X-ShellHub-Signature header (HMAC-SHA256), so your endpoint can verify it came from ShellHub."
-                  />
-                  <div className="grid grid-cols-2 gap-3">
-                    <InputField
-                      id={`${idPrefix}-webhook-timeout`}
-                      label="Reply timeout (s)"
-                      type="number"
-                      value={String(webhookTimeout || 5)}
-                      onChange={(v) =>
-                        onWebhookTimeoutChange(
-                          clamp(parseInt(v, 10) || 5, 1, 15),
-                        )
-                      }
-                      hint="How long ShellHub waits for your endpoint to answer, in seconds (1–15)."
-                    />
-                    <InputField
-                      id={`${idPrefix}-webhook-window`}
-                      label="Callback window (h)"
-                      type="number"
-                      value={String(
-                        Math.round((webhookCallbackTtl || 3600) / 3600),
-                      )}
-                      onChange={(v) =>
-                        onWebhookCallbackTtlChange(
-                          clamp(parseInt(v, 10) || 1, 1, 24) * 3600,
-                        )
-                      }
-                      hint="If your endpoint replies later instead of right away, how long it has to call back (up to 24h)."
-                    />
-                  </div>
-                </div>
+                <WebhookPanel
+                  key={panelKey}
+                  idPrefix={idPrefix}
+                  webhookUrl={webhookUrl}
+                  onWebhookUrlChange={onWebhookUrlChange}
+                  webhookSecret={webhookSecret}
+                  onWebhookSecretChange={onWebhookSecretChange}
+                  webhookTimeout={webhookTimeout}
+                  onWebhookTimeoutChange={onWebhookTimeoutChange}
+                  webhookCallbackTtl={webhookCallbackTtl}
+                  onWebhookCallbackTtlChange={onWebhookCallbackTtlChange}
+                  isEditing={isEditing}
+                />
               )}
 
               {selected && option.value === "allowlist" && (

--- a/ui/apps/console/src/pages/install-keys/__tests__/helpers.test.ts
+++ b/ui/apps/console/src/pages/install-keys/__tests__/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   getUsageInfo,
   installKeyDisplayName,
   isPairingKey,
+  isWebhookUrl,
   parseAllowedMacs,
   resolveEnrollmentSource,
   validateModeConfig,
@@ -158,13 +159,38 @@ describe("getExpiryInfo", () => {
   });
 });
 
+describe("isWebhookUrl", () => {
+  it.each([
+    "https://hook.example.com",
+    "http://10.0.0.1:8080/hook",
+    "https://register.example.com/v1/enroll?key=abc",
+  ])("accepts %s", (url) => {
+    expect(isWebhookUrl(url)).toBe(true);
+  });
+
+  it.each([
+    ["https://", "protocol-only, no host"],
+    ["ftp://files.example.com", "wrong protocol"],
+    ["not-a-url", "plain string"],
+    ["", "empty string"],
+    ["   ", "whitespace only"],
+  ])("rejects %s (%s)", (url) => {
+    expect(isWebhookUrl(url)).toBe(false);
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(isWebhookUrl("  https://example.com  ")).toBe(true);
+  });
+});
+
 describe("validateModeConfig", () => {
   it("accepts a non-webhook, non-allowlist mode with no extra config", () => {
     expect(validateModeConfig("automatic", "", "", [])).toBe("");
   });
 
-  it("requires an http(s) url and a secret for webhook mode", () => {
+  it("requires a structurally valid http(s) url and a secret for webhook mode", () => {
     expect(validateModeConfig("webhook", "not-a-url", "s", [])).not.toBe("");
+    expect(validateModeConfig("webhook", "https://", "s", [])).not.toBe("");
     expect(
       validateModeConfig("webhook", "https://hook.example", "", []),
     ).not.toBe("");
@@ -180,6 +206,16 @@ describe("validateModeConfig", () => {
     );
   });
 
+  it("rejects an out-of-range timeout or callback window", () => {
+    const valid = (opts = {}) =>
+      validateModeConfig("webhook", "https://hook.example", "s", [], opts);
+    expect(valid({ webhookTimeout: 0 })).not.toBe("");
+    expect(valid({ webhookTimeout: 16 })).not.toBe("");
+    expect(valid({ webhookCallbackTtl: 0 })).not.toBe("");
+    expect(valid({ webhookCallbackTtl: 25 * 3600 })).not.toBe("");
+    expect(valid({ webhookTimeout: 5, webhookCallbackTtl: 3600 })).toBe("");
+  });
+
   it("lets a blank secret pass when it is optional (editing a webhook key)", () => {
     expect(
       validateModeConfig("webhook", "https://hook.example", "", []),
@@ -189,7 +225,6 @@ describe("validateModeConfig", () => {
         secretOptional: true,
       }),
     ).toBe("");
-    // The URL is still validated even when the secret is optional.
     expect(
       validateModeConfig("webhook", "bad", "", [], { secretOptional: true }),
     ).not.toBe("");

--- a/ui/apps/console/src/pages/install-keys/helpers.ts
+++ b/ui/apps/console/src/pages/install-keys/helpers.ts
@@ -62,6 +62,20 @@ export function validateName(value: string): string {
   return "";
 }
 
+export const TIMEOUT_MIN = 1;
+export const TIMEOUT_MAX = 15;
+export const WINDOW_MIN_H = 1;
+export const WINDOW_MAX_H = 24;
+
+export function isWebhookUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Client-side check of a mode's required config, mirroring the API: webhook needs an https URL and a
  * secret; allowlist needs at least one MAC. Returns an error message, or "" when valid. Pass
@@ -73,13 +87,28 @@ export function validateModeConfig(
   webhookUrl: string,
   webhookSecret: string,
   macs: string[],
-  options: { secretOptional?: boolean } = {},
+  options: {
+    secretOptional?: boolean;
+    webhookTimeout?: number;
+    webhookCallbackTtl?: number;
+  } = {},
 ): string {
   if (mode === "webhook") {
-    if (!/^https?:\/\//.test(webhookUrl.trim()))
+    if (!isWebhookUrl(webhookUrl))
       return "Webhook URL must be an http or https URL.";
     if (!webhookSecret && !options.secretOptional)
       return "A signing secret is required for webhook mode.";
+    const { webhookTimeout, webhookCallbackTtl } = options;
+    if (
+      webhookTimeout !== undefined &&
+      (webhookTimeout < TIMEOUT_MIN || webhookTimeout > TIMEOUT_MAX)
+    )
+      return `Reply timeout must be ${TIMEOUT_MIN}–${TIMEOUT_MAX} seconds.`;
+    if (webhookCallbackTtl !== undefined) {
+      const hours = Math.round(webhookCallbackTtl / 3600);
+      if (hours < WINDOW_MIN_H || hours > WINDOW_MAX_H)
+        return `Callback window must be ${WINDOW_MIN_H}–${WINDOW_MAX_H} hours.`;
+    }
   }
   if (mode === "allowlist" && macs.length === 0) {
     return "Add at least one MAC address for allowlist mode.";


### PR DESCRIPTION

## What

Replaced the four webhook-mode fields in the install-key drawers (Create and Edit) with purpose-built components that properly validate input and block submit on invalid values.

## Why

The webhook URL only checked for an `http://`/`https://` prefix via regex — structurally invalid URLs like `https://` (no host) passed client-side validation. The signing secret was a plain `InputField type="password"` with no visibility toggle. The reply timeout and callback window used `InputField type="number"`, which accepts non-numeric characters (`e`, `+`, `-`, `.`) past the browser's native spinner and rendered inconsistently across browsers. On mobile, the two-column `grid-cols-2` layout overflowed the drawer.

## Changes

- **URL validation** (`helpers.ts`, `ModeField.tsx`): replaced the prefix regex in `validateModeConfig` with `isWebhookUrl`, which uses `new URL()` + protocol check. The URL field now shows an inline error on blur when the value is non-empty and structurally invalid.
- **Signing secret** (`ModeField.tsx`): swapped `InputField type="password"` for `PasswordField` with `suppressPasswordManager`. In edit mode (`isEditing` prop), the hint tells the user to leave the field blank to keep the current secret.
- **Timeout / callback window** (`ModeField.tsx`): swapped `InputField type="number"` for `NumericInput` (digit-only regex filter via `type="text"` + `inputMode="numeric"`). Each field shows an inline range error and eagerly syncs the parsed value to the parent on every keystroke, so `validateModeConfig` always sees the current typed value and disables the submit button while out of range. On blur, the value clamps to the valid range.
- **Range constants** (`helpers.ts`): extracted `TIMEOUT_MIN/MAX` and `WINDOW_MIN_H/MAX_H` so inline errors and `validateModeConfig` share a single source of truth.
- **Mobile layout** (`ModeField.tsx`): replaced `grid grid-cols-2` with `flex flex-wrap gap-3` so the timeout and callback fields stack when the drawer is narrow.

## Testing

- `isWebhookUrl`: 8 cases (valid URLs, protocol-only, wrong protocol, empty, whitespace)
- `validateModeConfig`: updated to reject `https://` (no host); new cases for out-of-range timeout (0, 16) and callback (0, 25h)
- Full suite: 3023 tests green, build and lint clean