### PR TITLE
fix(server): dropped bytes and sessions that never finish

### DIFF
--- a/server/ssh/pkg/dialer/bufferedconn.go
+++ b/server/ssh/pkg/dialer/bufferedconn.go
@@ -1,0 +1,25 @@
+package dialer
+
+import (
+	"io"
+	"net"
+)
+
+// bufferedConn reads through a reader holding what a handshake read ahead of
+// the payload. Handing back the bare connection instead loses those bytes,
+// since the decoder that buffered them is discarded.
+type bufferedConn struct {
+	net.Conn
+	reader io.Reader
+}
+
+func (c *bufferedConn) Read(b []byte) (int, error) {
+	return c.reader.Read(b)
+}
+
+// withBuffered returns conn reading through reader, which must yield the
+// buffered remainder and then the connection. A [bufio.Reader] can be passed
+// on its own, as it already chains to the connection.
+func withBuffered(conn net.Conn, reader io.Reader) net.Conn { //nolint:ireturn
+	return &bufferedConn{Conn: conn, reader: reader}
+}

--- a/server/ssh/pkg/dialer/dialer.go
+++ b/server/ssh/pkg/dialer/dialer.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -109,7 +110,7 @@ func (t *Dialer) DialTo(ctx context.Context, tenant string, uid string, target T
 // accepts the stream but never answers fails here instead of parking the
 // caller's goroutine until whatever sits in front times out.
 func handshake(ctx context.Context, conn net.Conn, version TransportVersion, target Target) (net.Conn, error) { // nolint:ireturn
-	deadline := time.Now().Add(HandshakeTimeout)
+	deadline := clock.Now().Add(HandshakeTimeout)
 	if caller, ok := ctx.Deadline(); ok && caller.Before(deadline) {
 		deadline = caller
 	}

--- a/server/ssh/pkg/dialer/manager.go
+++ b/server/ssh/pkg/dialer/manager.go
@@ -148,6 +148,42 @@ const (
 	TransportVersion2 TransportVersion = 2
 )
 
+// openStream opens a yamux stream without outliving the caller.
+//
+// Opening does not await an acknowledgement, but it does block where yamux
+// takes no context: the in-flight SYN semaphore, which has no deadline once
+// AcceptBacklog opens are unacknowledged, and sending the SYN, bounded by
+// ConnectionWriteTimeout. Both are reached when the peer stops reading.
+//
+// The open is left running so a stream that lands late is closed rather than
+// leaked on the device.
+func openStream(ctx context.Context, session *yamux.Session) (net.Conn, error) { //nolint:ireturn
+	type opened struct {
+		conn net.Conn
+		err  error
+	}
+
+	done := make(chan opened, 1)
+
+	go func() {
+		conn, err := session.Open()
+		done <- opened{conn: conn, err: err}
+	}()
+
+	select {
+	case result := <-done:
+		return result.conn, result.err
+	case <-ctx.Done():
+		go func() {
+			if result := <-done; result.err == nil {
+				result.conn.Close() //nolint:errcheck
+			}
+		}()
+
+		return nil, ctx.Err()
+	}
+}
+
 // Dial tries to find a connection by its key and dials it.
 //
 // It returns the connection, its version ([TransportVersion1] or [TransportVersion2]) and an error,
@@ -189,7 +225,7 @@ func (m *Manager) Dial(ctx context.Context, key string) (net.Conn, TransportVers
 			"version": "v2",
 		}).Debug("using v2 connection for reverse tunnel dialing")
 
-		conn, err := session.Open()
+		conn, err := openStream(ctx, session)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"key":     key,

--- a/server/ssh/pkg/dialer/openstream_test.go
+++ b/server/ssh/pkg/dialer/openstream_test.go
@@ -1,0 +1,66 @@
+package dialer
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unresponsiveSession is a yamux client whose peer never reads. Opening blocks
+// on sending the SYN, and with a backlog of one also on the in-flight
+// semaphore, which yamux waits on with no deadline.
+func unresponsiveSession(t *testing.T) *yamux.Session {
+	t.Helper()
+
+	client, peer := net.Pipe()
+
+	config := yamux.DefaultConfig()
+	config.LogOutput = io.Discard
+	config.AcceptBacklog = 1
+	config.StreamOpenTimeout = time.Minute
+	config.ConnectionWriteTimeout = time.Minute
+
+	session, err := yamux.Client(client, config)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		session.Close() //nolint:errcheck
+		peer.Close()    //nolint:errcheck
+	})
+
+	return session
+}
+
+func TestOpenStreamReturnsOnCancellation(t *testing.T) {
+	session := unresponsiveSession(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	conn, err := openStream(ctx, session)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, conn)
+	assert.Less(t, time.Since(start), 5*time.Second,
+		"a cancelled caller must not wait out yamux's stream open timeout")
+}
+
+func TestOpenStreamReturnsOnDeadline(t *testing.T) {
+	session := unresponsiveSession(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := openStream(ctx, session)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}

--- a/server/ssh/pkg/dialer/target.go
+++ b/server/ssh/pkg/dialer/target.go
@@ -91,13 +91,18 @@ func (t HTTPProxyTarget) prepare(ctx context.Context, conn net.Conn, version Tra
 		if err := handshakeReq.Write(conn); err != nil {
 			return nil, err
 		}
-		resp, err := http.ReadResponse(bufio.NewReader(conn), handshakeReq)
+
+		buffered := bufio.NewReader(conn)
+
+		resp, err := http.ReadResponse(buffered, handshakeReq)
 		if err != nil {
 			return nil, err
 		}
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("http proxy handshake failed: %s", resp.Status)
 		}
+
+		return withBuffered(conn, buffered), nil
 	case TransportVersion2:
 		if err := multistream.SelectProtoOrFail(ProtoHTTPProxy, conn); err != nil {
 			return nil, err
@@ -113,15 +118,17 @@ func (t HTTPProxyTarget) prepare(ctx context.Context, conn net.Conn, version Tra
 
 		// NOTE: limit the size of the response to avoid DoS via large payloads.
 		const Limit = 512
-		if err := json.NewDecoder(io.LimitReader(conn, Limit)).Decode(&result); err != nil {
+
+		decoder := json.NewDecoder(io.LimitReader(conn, Limit))
+		if err := decoder.Decode(&result); err != nil {
 			return nil, err
 		}
 		if result["status"] != "ok" {
 			return nil, fmt.Errorf("http proxy negotiation failed: %s", result["message"])
 		}
+
+		return withBuffered(conn, io.MultiReader(decoder.Buffered(), conn)), nil
 	default:
 		return nil, fmt.Errorf("unsupported transport version: %d", version)
 	}
-
-	return conn, nil
 }

--- a/server/ssh/pkg/dialer/target_test.go
+++ b/server/ssh/pkg/dialer/target_test.go
@@ -1,0 +1,90 @@
+package dialer
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/multiformats/go-multistream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// greeting stands for the opening line of a server-first protocol, as SMTP and
+// MySQL send on connect.
+const greeting = "220 smtp.example.com ESMTP ready\r\n"
+
+func pipeWithDeadline(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+
+	client, agent := net.Pipe()
+
+	t.Cleanup(func() {
+		client.Close()
+		agent.Close()
+	})
+
+	// Without a deadline a dropped greeting parks the read forever instead of
+	// failing the test.
+	require.NoError(t, client.SetDeadline(time.Now().Add(5*time.Second)))
+	require.NoError(t, agent.SetDeadline(time.Now().Add(5*time.Second)))
+
+	return client, agent
+}
+
+func TestHTTPProxyTargetKeepsGreetingSentWithTheReply(t *testing.T) {
+	client, agent := pipeWithDeadline(t)
+
+	go func() {
+		mux := multistream.NewMultistreamMuxer[string]()
+		mux.AddHandler(ProtoHTTPProxy, nil)
+
+		if _, _, err := mux.Negotiate(agent); err != nil {
+			return
+		}
+
+		headers := map[string]string{}
+		if err := json.NewDecoder(agent).Decode(&headers); err != nil {
+			return
+		}
+
+		// One write, because the agent answers and starts piping immediately:
+		// reply and payload can reach the caller in a single read.
+		agent.Write([]byte(`{"status":"ok"}` + greeting)) //nolint:errcheck
+	}()
+
+	conn, err := HTTPProxyTarget{Host: "127.0.0.1", Port: 5432}.
+		prepare(context.Background(), client, TransportVersion2)
+	require.NoError(t, err)
+
+	buf := make([]byte, len(greeting))
+	_, err = io.ReadFull(conn, buf)
+	require.NoError(t, err)
+	assert.Equal(t, greeting, string(buf))
+}
+
+func TestHTTPProxyTargetV1KeepsGreetingSentWithTheReply(t *testing.T) {
+	client, agent := pipeWithDeadline(t)
+
+	go func() {
+		if _, err := http.ReadRequest(bufio.NewReader(agent)); err != nil {
+			return
+		}
+
+		agent.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n" + greeting)) //nolint:errcheck
+	}()
+
+	conn, err := HTTPProxyTarget{Host: "127.0.0.1", Port: 5432}.
+		prepare(context.Background(), client, TransportVersion1)
+	require.NoError(t, err)
+
+	buf := make([]byte, len(greeting))
+	_, err = io.ReadFull(conn, buf)
+	require.NoError(t, err)
+	assert.Equal(t, greeting, string(buf))
+}

--- a/server/ssh/server/channels/session.go
+++ b/server/ssh/server/channels/session.go
@@ -93,7 +93,7 @@ func startsDataPipe(requestType string) bool {
 //
 // https://www.rfc-editor.org/rfc/rfc4254#section-6
 func DefaultSessionHandler() gliderssh.ChannelHandler {
-	return func(_ *gliderssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
+	return func(_ *gliderssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
 		sess, state := session.ObtainSession(ctx)
 		if sess == nil || state < session.StateFinished {
 			// Unreachable today: a channel only opens once authentication has
@@ -107,14 +107,6 @@ func DefaultSessionHandler() gliderssh.ChannelHandler {
 
 			return
 		}
-
-		go func() {
-			// NOTE: As [gossh.ServerConn] is shared by all channels calls, close it after a channel close block any
-			// other channel invocation. To avoid it, we wait for the connection to be closed to finish the session.
-			conn.Wait() //nolint:errcheck
-
-			sess.Finish() //nolint:errcheck
-		}()
 
 		logger := log.WithFields(
 			log.Fields{

--- a/server/ssh/server/channels/tcpip.go
+++ b/server/ssh/server/channels/tcpip.go
@@ -14,7 +14,7 @@ import (
 
 // DefaultDirectTCPIPHandler is the channel's handler for direct-tcpip channels like "local port forwarding" and "dynamic
 // application-level port forwarding".
-func DefaultDirectTCPIPHandler(server *gliderssh.Server, conn *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
+func DefaultDirectTCPIPHandler(server *gliderssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx gliderssh.Context) {
 	sess, state := session.ObtainSession(ctx)
 	if sess == nil || state < session.StateFinished {
 		// See the same guard in the session channel handler: unreachable today,
@@ -26,14 +26,6 @@ func DefaultDirectTCPIPHandler(server *gliderssh.Server, conn *gossh.ServerConn,
 
 		return
 	}
-
-	go func() {
-		// NOTICE: As [gossh.ServerConn] is shared by all channels calls, close it after a channel close block any
-		// other channel involkation. To avoid it, we wait for the connection be closed to finish the sesison.
-		conn.Wait() //nolint:errcheck
-
-		sess.Finish() //nolint:errcheck
-	}()
 
 	log.WithFields(log.Fields{
 		"username": sess.Target.Username,

--- a/server/ssh/server/server.go
+++ b/server/ssh/server/server.go
@@ -22,6 +22,25 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
+// finishingConn finishes the session bound to a connection when it closes.
+//
+// A channel handler cannot carry this: a client that opens no channel leaves
+// the session with nothing to finish it. The library closes this connection on
+// every exit path, so it is the one signal every session gets.
+type finishingConn struct {
+	net.Conn
+
+	ctx gliderssh.Context
+}
+
+func (c *finishingConn) Close() error {
+	if sess, _ := session.ObtainSession(c.ctx); sess != nil {
+		sess.Finish() //nolint:errcheck
+	}
+
+	return c.Conn.Close()
+}
+
 type Options struct {
 	ConnectTimeout time.Duration
 	// HostKeyFile is the path to the SSH host key. It is deliberately not read
@@ -248,9 +267,13 @@ func NewServer(dialer *dialer.Dialer, service services.Service, handoff *webhand
 		// that is never cleared, so it would kill established shells at the limit.
 		HandshakeTimeout: handshakeBudget,
 		ConnCallback: func(ctx gliderssh.Context, conn net.Conn) net.Conn {
-			ctx.SetValue("conn", conn)
+			wrapped := &finishingConn{Conn: conn, ctx: ctx}
 
-			return conn
+			// Stored wrapped as well: the auth handlers close this on a failed
+			// guard, and that has to finish the session too.
+			ctx.SetValue("conn", net.Conn(wrapped))
+
+			return wrapped
 		},
 		ServerConfigCallback: newServerConfigCallback,
 		BannerHandler:        newBannerHandler(dialer, service, handoff),


### PR DESCRIPTION
## What

Two defects in the reverse tunnel path, plus one preparatory change. Only the
first two are bugs; the third is labelled `refactor` because it fixes an
inconsistency rather than something that misbehaves today.

## Changes

- **fix, proxy handshake**: the target parsed its negotiation reply through a
  decoder and returned the bare connection. The decoder fills its own buffer
  from the socket, so anything the far end sent alongside the reply was
  discarded with it. Nothing hits this today because every consumer is
  client-first: HTTP sends the request, TLS to the backend starts with the
  ClientHello. A protocol that greets on connect, such as MySQL, SMTP or IMAP,
  loses that greeting whenever the reply and the payload arrive in the same
  read. Covered by a test that fails without the change.

- **fix, session lifecycle**: a session was only ever finished from a channel
  handler, so a client that opened no channel never finished its session. An
  idle `ssh -N -L` stayed in `active_sessions` after the client was gone, with
  nothing to clear it. Each handler also spawned one goroutine per channel to
  wait on the same shared connection. The connection is wrapped instead and
  finishes the session on close.

- **refactor, stream open**: `Dial` accepts a context and only honoured it on
  V1. Opening a yamux stream does not await an acknowledgement, so this is not
  a stall anyone reports; it matters for callers that dial per connection,
  where the two places yamux blocks without a context start to add up. Kept
  separate and labelled accordingly so it is not read as a bug fix.

## Verification

The lifecycle fix is the one observable on a running stack, and it was checked
both ways: on master an idle `ssh -N -L` leaves its session active after the
client exits, and on this branch it does not.

The other two are covered by unit tests that fail when their change is
reverted. Neither was reproduced end to end. For the handshake one that is not
for lack of trying: the loss needs the reply and the payload to arrive in the
same read, and in this environment they never did across 54 attempts, through
several attempts at queueing the path. The frequency in production is therefore
unmeasured, and the commit message says so.

## Notes for review

The proxy handshake change touches the code path the cloud web endpoint uses,
so it is worth exercising a web endpoint before merging.