### PR TITLE
fix(ui): responsive install-key drawers on narrow viewports

### DIFF
--- a/ui/apps/console/src/components/common/Drawer.tsx
+++ b/ui/apps/console/src/components/common/Drawer.tsx
@@ -56,7 +56,7 @@ export default function Drawer({
         aria-hidden={!open}
         {...(!open ? { inert: true } : {})}
         className={cn(
-          "fixed inset-y-0 right-0 z-drawer w-full",
+          "fixed inset-y-0 right-0 z-drawer w-full @container/drawer",
           WIDTH_MAP[width],
           "bg-surface border-l border-border shadow-2xl flex flex-col transition-transform duration-300 ease-out",
           open ? "translate-x-0" : "translate-x-full",

--- a/ui/apps/console/src/pages/install-keys/UsageLimitField.tsx
+++ b/ui/apps/console/src/pages/install-keys/UsageLimitField.tsx
@@ -51,17 +51,17 @@ export default function UsageLimitField({
   return (
     <div>
       <span className={LABEL}>Usage limit</span>
-      <div className="flex items-stretch h-11 bg-card border border-border rounded-lg overflow-hidden">
+      <div className="flex @sm/drawer:flex-row flex-col bg-card border border-border rounded-lg overflow-hidden">
         <button
           type="button"
           onClick={() => onChange(1)}
-          className={`${capBase} ${mode === "single" ? capOn : capOff}`}
+          className={`${capBase} h-11 justify-center ${mode === "single" ? capOn : capOff}`}
         >
           <span className="text-xs leading-none">1&times;</span> Single-use
         </button>
 
         <div
-          className={`flex items-center flex-1 min-w-0 border-x border-border transition-colors ${
+          className={`flex items-center @sm/drawer:flex-1 min-w-0 h-11 @sm/drawer:border-x border-y @sm/drawer:border-y-0 border-border transition-colors ${
             mode === "limited" ? "bg-primary/[0.07]" : ""
           }`}
         >
@@ -89,7 +89,7 @@ export default function UsageLimitField({
         <button
           type="button"
           onClick={() => onChange(0)}
-          className={`${capBase} ${mode === "unlimited" ? capOn : capOff}`}
+          className={`${capBase} h-11 justify-center ${mode === "unlimited" ? capOn : capOff}`}
         >
           <span className="text-[15px] leading-none">&#8734;</span> Unlimited
         </button>

--- a/ui/apps/console/tailwind.config.js
+++ b/ui/apps/console/tailwind.config.js
@@ -1,4 +1,5 @@
 import preset from "@shellhub/design-system/tailwind.preset";
+import containerQueries from "@tailwindcss/container-queries";
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -8,5 +9,5 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
     "../../packages/design-system/**/*.{ts,tsx}",
   ],
-  plugins: [],
+  plugins: [containerQueries],
 };

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@stylistic/eslint-plugin": "^5.10.0",
+        "@tailwindcss/container-queries": "^0.1.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2959,6 +2960,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tanstack/query-core": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-unused-imports": "^4.4.1",
     "postcss": "^8.4.49",
+    "@tailwindcss/container-queries": "^0.1.1",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",


### PR DESCRIPTION
## What

Install-key drawer components broke on viewports narrower than the drawer's 448px max-width. This PR adds container-query infrastructure to the Drawer and fixes the usage-limit trimode bar.

## Why

The Drawer is full-width below its `max-w-md` breakpoint, but the trimode bar (Single-use / Custom / Unlimited) used a fixed horizontal layout that can't fit below ~400px. Viewport media queries can't help here because the constraint is the drawer's own width, not the screen.

## Changes

- **`@tailwindcss/container-queries`**: installed as a dev dependency and registered in the console's Tailwind config
- **`Drawer`**: marked the panel as a named container (`@container/drawer`) so any child can use `@sm/drawer`-style breakpoints; switched `bodyClassName` from `??` to `cn()` so base layout classes are always preserved
- **`UsageLimitField`**: the trimode bar stacks vertically by default and goes horizontal at `@sm/drawer` (24rem), with border direction flipped to match

## Testing

Open a Create or Edit Install Key drawer and resize the browser below ~400px wide — the trimode bar should stack cleanly into three rows instead of overflowing.