### PR TITLE
fix(ui): correct and harden config.json generation

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -30,3 +30,29 @@ jobs:
       - name: Run is-latest-tag tests
         if: steps.filter.outputs.scripts == 'true'
         run: bash tests/is-latest-tag_test.sh
+
+  gen-config:
+    name: gen-config
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        id: filter
+        with:
+          filters: |
+            scripts:
+              - 'ui/scripts/gen-config.sh'
+              - 'tests/ui/**'
+              - '.github/workflows/script-tests.yml'
+
+      - name: Install bats
+        if: steps.filter.outputs.scripts == 'true'
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+
+      - name: Run gen-config tests
+        if: steps.filter.outputs.scripts == 'true'
+        run: bats tests/ui/gen-config.bats

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -47,6 +47,7 @@ jobs:
             scripts:
               - 'ui/scripts/gen-config.sh'
               - 'tests/ui/**'
+              - 'ui/Dockerfile'
               - '.github/workflows/script-tests.yml'
 
       - name: Install bats
@@ -56,3 +57,18 @@ jobs:
       - name: Run gen-config tests
         if: steps.filter.outputs.scripts == 'true'
         run: bats tests/ui/gen-config.bats
+
+      # The runner has GNU sed/tr, but gen-config.sh escapes JSON with the
+      # busybox ones in the production image, where the N-slurp, the \n match
+      # and the octal tr ranges all behave differently. Read the image out of
+      # the Dockerfile so an alpine bump is covered by the same guard.
+      - name: Run gen-config tests on busybox
+        if: steps.filter.outputs.scripts == 'true'
+        run: |
+          image=$(sed -n 's/^FROM \(alpine:[^[:space:]]*\) AS production$/\1/p' ui/Dockerfile)
+          if [ -z "$image" ]; then
+            echo "could not read the production alpine image from ui/Dockerfile" >&2
+            exit 1
+          fi
+          docker run --rm -v "$PWD:/src" -w /src "$image" \
+            sh -c 'apk add --no-cache bats jq >/dev/null && bats tests/ui/gen-config.bats'

--- a/tests/ui/gen-config.bats
+++ b/tests/ui/gen-config.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# Tests for ui/scripts/gen-config.sh.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd -P)"
+GEN_CONFIG="$REPO_ROOT/ui/scripts/gen-config.sh"
+
+# Run gen-config.sh with a pristine environment holding only the given
+# VAR=value pairs, then print the config.json it produced. The empty
+# environment is the point: it reproduces the container, which receives
+# nothing the deployment did not explicitly pass in.
+# Usage: gen_config VAR1=value VAR2=value ...
+gen_config() {
+    local out="$BATS_TEST_TMPDIR/config.json"
+    env -i PATH="$PATH" "$@" sh "$GEN_CONFIG" "$out" || return
+    cat "$out"
+}
+
+@test "stripePublishableKey comes from SHELLHUB_STRIPE_PUBLISHABLE_KEY" {
+    out=$(gen_config SHELLHUB_STRIPE_PUBLISHABLE_KEY=pk_test_123)
+    [[ "$out" == *'"stripePublishableKey": "pk_test_123"'* ]]
+}
+
+@test "every value reads a SHELLHUB_-prefixed variable" {
+    # Deployments only ever pass SHELLHUB_*, so an unprefixed reference is
+    # never satisfied and silently renders empty. Guards shellhub#6865.
+    # EDITION and OUTPUT are exempt because the script assigns them itself;
+    # nothing else belongs in that list.
+    # shellcheck disable=SC2016 # matching a literal $, not expanding it
+    unprefixed=$(grep -oE '\$\{?[A-Z_][A-Z0-9_]*' "$GEN_CONFIG" |
+        sed -E 's/^\$\{?//' |
+        grep -vE '^(SHELLHUB_[A-Z0-9_]*|EDITION|OUTPUT)$' |
+        sort -u)
+
+    if [ -n "$unprefixed" ]; then
+        echo "unprefixed variables in gen-config.sh: $unprefixed" >&2
+        return 1
+    fi
+}
+
+@test "an unset value renders an empty string" {
+    out=$(gen_config)
+    [[ "$out" == *'"stripePublishableKey": ""'* ]]
+}
+
+@test "edition defaults to community" {
+    out=$(gen_config)
+    [[ "$out" == *'"edition": "community"'* ]]
+}
+
+@test "edition is lowercased and stripped of whitespace" {
+    out=$(gen_config 'SHELLHUB_EDITION= Cloud ')
+    [[ "$out" == *'"edition": "cloud"'* ]]
+}
+
+@test "an invalid edition aborts without writing the config" {
+    run env -i PATH="$PATH" SHELLHUB_EDITION=bogus \
+        sh "$GEN_CONFIG" "$BATS_TEST_TMPDIR/config.json"
+    [ "$status" -ne 0 ]
+    [ ! -f "$BATS_TEST_TMPDIR/config.json" ]
+}

--- a/tests/ui/gen-config.bats
+++ b/tests/ui/gen-config.bats
@@ -15,6 +15,12 @@ gen_config() {
     cat "$out"
 }
 
+# Skip when jq is absent. Assertions about the *shape* of the output need a
+# real parser; jq ships on the CI runner, so this only spares local devs.
+require_jq() {
+    command -v jq >/dev/null || skip "jq not installed"
+}
+
 @test "stripePublishableKey comes from SHELLHUB_STRIPE_PUBLISHABLE_KEY" {
     out=$(gen_config SHELLHUB_STRIPE_PUBLISHABLE_KEY=pk_test_123)
     [[ "$out" == *'"stripePublishableKey": "pk_test_123"'* ]]
@@ -54,6 +60,55 @@ gen_config() {
 
 @test "an invalid edition aborts without writing the config" {
     run env -i PATH="$PATH" SHELLHUB_EDITION=bogus \
+        sh "$GEN_CONFIG" "$BATS_TEST_TMPDIR/config.json"
+    [ "$status" -ne 0 ]
+    [ ! -f "$BATS_TEST_TMPDIR/config.json" ]
+}
+
+# Values arrive verbatim from the deployment's env, so the script has to treat
+# them as data rather than as JSON source text.
+
+@test "a quote in a value survives as data" {
+    require_jq
+    url='https://x.test/?q="hi"&r=1'
+    out=$(gen_config SHELLHUB_ONBOARDING_URL="$url")
+    [ "$(printf '%s' "$out" | jq -er .onboardingUrl)" = "$url" ]
+}
+
+@test "a backslash in a value survives as data" {
+    require_jq
+    token='tok\en\\x'
+    out=$(gen_config SHELLHUB_CHATWOOT_WEBSITE_TOKEN="$token")
+    [ "$(printf '%s' "$out" | jq -er .chatwootWebsiteToken)" = "$token" ]
+}
+
+@test "a tab or newline in a value survives as data" {
+    require_jq
+    url="$(printf 'a\tb\nc')"
+    out=$(gen_config SHELLHUB_ONBOARDING_URL="$url")
+    [ "$(printf '%s' "$out" | jq -er .onboardingUrl)" = "$url" ]
+}
+
+@test "a control character in a value does not corrupt the JSON" {
+    require_jq
+    out=$(gen_config SHELLHUB_ONBOARDING_URL="$(printf 'a\002b')")
+    [ "$(printf '%s' "$out" | jq -er .onboardingUrl)" = "ab" ]
+}
+
+@test "boolean flags render as JSON booleans" {
+    require_jq
+    out=$(gen_config SHELLHUB_ANNOUNCEMENTS=true)
+    [ "$(printf '%s' "$out" | jq -er '.announcements | type')" = "boolean" ]
+    [ "$(printf '%s' "$out" | jq -er '.webEndpoints | type')" = "boolean" ]
+    [ "$(printf '%s' "$out" | jq -er .announcements)" = "true" ]
+}
+
+@test "a non-boolean flag aborts instead of injecting raw JSON" {
+    # Unquoted fields are the opening: a crafted value can append a second
+    # "edition" key that wins at parse time, silently overriding the guard
+    # above and promoting a community deployment to cloud.
+    run env -i PATH="$PATH" SHELLHUB_EDITION=community \
+        SHELLHUB_ANNOUNCEMENTS='false, "edition": "cloud"' \
         sh "$GEN_CONFIG" "$BATS_TEST_TMPDIR/config.json"
     [ "$status" -ne 0 ]
     [ ! -f "$BATS_TEST_TMPDIR/config.json" ]

--- a/ui/scripts/gen-config.sh
+++ b/ui/scripts/gen-config.sh
@@ -24,7 +24,7 @@ cat > "$OUTPUT" <<EOF
   "onboardingUrl": "${SHELLHUB_ONBOARDING_URL:-}",
   "announcements": ${SHELLHUB_ANNOUNCEMENTS:-false},
   "webEndpoints": ${SHELLHUB_WEB_ENDPOINTS:-false},
-  "stripePublishableKey": "${STRIPE_PUBLISHABLE_KEY:-}",
+  "stripePublishableKey": "${SHELLHUB_STRIPE_PUBLISHABLE_KEY:-}",
   "chatwootWebsiteToken": "${SHELLHUB_CHATWOOT_WEBSITE_TOKEN:-}",
   "chatwootBaseUrl": "${SHELLHUB_CHATWOOT_BASEURL:-}"
 }

--- a/ui/scripts/gen-config.sh
+++ b/ui/scripts/gen-config.sh
@@ -17,15 +17,51 @@ case "$EDITION" in
         ;;
 esac
 
+# Booleans are rendered unquoted, so a value that is not true/false lands in
+# config.json as raw JSON — enough to append a second "edition" key that wins
+# at parse time and overrides the check above.
+require_bool() {
+    case "$2" in
+        true|false) ;;
+        *)
+            echo "🚫 ERROR: invalid $1 '$2': must be true or false." >&2
+            exit 1
+            ;;
+    esac
+}
+
+require_bool SHELLHUB_ANNOUNCEMENTS "${SHELLHUB_ANNOUNCEMENTS:-false}"
+require_bool SHELLHUB_WEB_ENDPOINTS "${SHELLHUB_WEB_ENDPOINTS:-false}"
+
+# Escape a value for use inside a JSON string literal. Values arrive verbatim
+# from the deployment's environment, and a lone quote or backslash would make
+# config.json unparseable, taking the whole console down. JSON also forbids
+# raw control characters: tab/newline/return become escapes, and the rest are
+# dropped since they have no meaning in a URL, token or version string.
+#
+# The $!{N;ba} guard matters: the more common :a;N;$!ba slurp makes sed print
+# and exit on single-line input, skipping every substitution below it.
+json_string() {
+    printf '%s' "$1" |
+        tr -d '\000-\010\013\014\016-\037' |
+        sed \
+            -e ':a' -e '$!{N;ba' -e '}' \
+            -e 's/\\/\\\\/g' \
+            -e 's/"/\\"/g' \
+            -e "s/$(printf '\t')/\\\\t/g" \
+            -e "s/$(printf '\r')/\\\\r/g" \
+            -e 's/\n/\\n/g'
+}
+
 cat > "$OUTPUT" <<EOF
 {
-  "version": "${SHELLHUB_VERSION:-}",
+  "version": "$(json_string "${SHELLHUB_VERSION:-}")",
   "edition": "${EDITION}",
-  "onboardingUrl": "${SHELLHUB_ONBOARDING_URL:-}",
+  "onboardingUrl": "$(json_string "${SHELLHUB_ONBOARDING_URL:-}")",
   "announcements": ${SHELLHUB_ANNOUNCEMENTS:-false},
   "webEndpoints": ${SHELLHUB_WEB_ENDPOINTS:-false},
-  "stripePublishableKey": "${SHELLHUB_STRIPE_PUBLISHABLE_KEY:-}",
-  "chatwootWebsiteToken": "${SHELLHUB_CHATWOOT_WEBSITE_TOKEN:-}",
-  "chatwootBaseUrl": "${SHELLHUB_CHATWOOT_BASEURL:-}"
+  "stripePublishableKey": "$(json_string "${SHELLHUB_STRIPE_PUBLISHABLE_KEY:-}")",
+  "chatwootWebsiteToken": "$(json_string "${SHELLHUB_CHATWOOT_WEBSITE_TOKEN:-}")",
+  "chatwootBaseUrl": "$(json_string "${SHELLHUB_CHATWOOT_BASEURL:-}")"
 }
 EOF


### PR DESCRIPTION
## What

Two independent fixes to `ui/scripts/gen-config.sh`, which renders the `/config.json` the console fetches at boot. Stripe checkout works again, and the generated document is now always valid JSON.

**Requires https://github.com/shellhub-io/cloud/pull/2481.** That PR passes the renamed variable through to the `ui` service. Merging this one alone leaves cloud deployments and local dev serving an empty key, because the compose overlay still exports the old name.

## Why

`gen-config.sh` read the Stripe publishable key from `STRIPE_PUBLISHABLE_KEY` — the only unprefixed variable in the file. The `shellhub-ui` secret only sets `SHELLHUB_STRIPE_PUBLISHABLE_KEY`, so the container never received the name the script looked for, the `:-` fallback rendered `stripePublishableKey: ""`, and `BillingPayment.tsx` passed `stripe={null}` into `<Elements>`. Stripe Elements never mounted and customers could not enter card details.

Closes #6865

## Changes

- **stripe key** (157269330): renamed the read to `SHELLHUB_STRIPE_PUBLISHABLE_KEY`, matching every other value in the file.

- **prefix guard** (157269330): `tests/ui/gen-config.bats` asserts that *every* value in the script reads a `SHELLHUB_`-prefixed variable. This is the point of the test file — it fails the whole bug class rather than this one key. `EDITION` and `OUTPUT` are exempt because the script assigns them itself.

- **CI** (157269330): a `gen-config` job in `script-tests.yml`, mirroring the existing `is-latest-tag` job (pinned SHAs, paths-filter, draft guard).

### Unrelated pre-existing bug, second commit

`4f399a701` is **not part of #6865**. It was found while reviewing the first commit and is kept separate so it can be reviewed, or dropped, on its own.

Values were interpolated straight into the JSON, so a quote, backslash or control character produced a `config.json` the console could not parse at all. The unquoted boolean fields were the sharper edge:

```sh
SHELLHUB_EDITION=community SHELLHUB_ANNOUNCEMENTS='false, "edition": "cloud"'
# -> {"edition": "community", "announcements": false, "edition": "cloud", ...}
# -> JSON.parse() yields edition === "cloud"
```

A second `"edition"` key wins at parse time, silently promoting a community deployment to cloud despite the `SHELLHUB_EDITION` guard rejecting exactly that value. Not a vulnerability — it needs control of the container's environment, and anyone with that can set `SHELLHUB_EDITION` directly — but it defeats a check the script goes out of its way to perform.

String fields are now escaped; boolean fields are validated rather than escaped, since no escaping makes a non-boolean valid in an unquoted position.

**Behavioural change worth a look:** `SHELLHUB_ANNOUNCEMENTS` or `SHELLHUB_WEB_ENDPOINTS` set to anything but `true`/`false` now aborts startup instead of rendering garbage. Every declared value in the repo is already `true`/`false`, and this matches how the script already treats an invalid `SHELLHUB_EDITION`, but an operator with a hand-rolled `.env.override` could hit it.

## Testing

```sh
bats tests/ui/gen-config.bats
```

Two things are easy to get wrong here and worth a reviewer's attention:

- **`json_string` uses `$!{N;ba}`, not the more familiar `:a;N;$!ba`.** The familiar form makes both GNU and busybox `sed` print-and-exit on single-line input, skipping every substitution after it and emitting *unescaped* output — i.e. it silently fails on the common case. Verified in `alpine:3.24.1`, the production base image, under busybox `sh`/`sed`/`tr`.
- **Escape ordering.** Backslash doubling runs first, so the backslashes introduced by the later `"`, `\t`, `\r` and `\n` rules are not re-escaped.

Beyond the bats suite, the escaping was fuzzed over 200 random values drawn from quotes, backslashes, tabs, newlines and control characters, checking every output parses: zero invalid documents.
