### PR TITLE
ci: group the go modules that ship together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -127,10 +127,33 @@ updates:
   allow:
     - dependency-type: direct
   groups:
+    # group-by below gives each dependency its own pull request, which is right for
+    # dependencies that move on their own. It is wrong for a project shipping several
+    # modules: those release together and pin each other, so one pull request per
+    # module means each carries the same edits and only the first can land. The groups
+    # here name those projects, and the catch-all excludes them by hand because a
+    # dependency matching more than one group is not placed in the first match.
     caddy:
       patterns:
         - "github.com/caddyserver/*"
         - "github.com/caddy-dns/*"
+    # The module packages pin the core version they were built against.
+    testcontainers:
+      patterns:
+        - "github.com/testcontainers/testcontainers-go"
+        - "github.com/testcontainers/testcontainers-go/*"
+    # pgdialect is versioned in lockstep with bun and will not build against a
+    # different one.
+    bun:
+      patterns:
+        - "github.com/uptrace/bun"
+        - "github.com/uptrace/bun/*"
+    # Unlike the groups above these are not coupled, they just tend to move together,
+    # so applies-to keeps a crypto or net security fix arriving on its own.
+    golang-x:
+      applies-to: version-updates
+      patterns:
+        - "golang.org/x/*"
     go-modules:
       applies-to: version-updates
       group-by: dependency-name
@@ -139,6 +162,11 @@ updates:
       exclude-patterns:
         - "github.com/caddyserver/*"
         - "github.com/caddy-dns/*"
+        - "github.com/testcontainers/testcontainers-go"
+        - "github.com/testcontainers/testcontainers-go/*"
+        - "github.com/uptrace/bun"
+        - "github.com/uptrace/bun/*"
+        - "golang.org/x/*"
   ignore:
     - dependency-name: "github.com/shellhub-io/shellhub"
     # echo-contrib's v0.50 line is its Echo 5 support, published by mistake on the


### PR DESCRIPTION
`group-by: dependency-name` gives each dependency its own pull request across the
six Go modules, which is right for a dependency that moves on its own — and it is
why this config is not simply the one `cloud` uses.

It is wrong for a project shipping several modules. Those release together and pin
each other, so one pull request per module carries the same edits in each and only
the first can land. `caddy` was already carved out for exactly this reason; this
names the other three.

| group | modules | grouped for |
|---|---|---|
| `caddy` *(existing)* | `caddyserver/*`, `caddy-dns/*` | all updates |
| `testcontainers` | `testcontainers-go` + `compose`, `postgres`, `redis` | all updates |
| `bun` | `uptrace/bun`, `uptrace/bun/dialect/pgdialect` | all updates |
| `golang-x` | `golang.org/x/crypto`, `exp`, `net`, `sys`, `time` | version updates only |

The catch-all excludes each by hand, because a dependency matching more than one
group is not placed in the first match — the same caveat already noted on the npm
entry.

`golang-x` keeps `applies-to: version-updates` where the others drop it: those
modules are not coupled, they only tend to move together, so an `x/crypto` or
`x/net` security fix should still arrive on its own rather than waiting behind an
`x/exp` bump.

## Verification

Resolved the patterns against the **56** direct requirements across `/`, `/agent`,
`/gateway`, `/openapi`, `/server` and `/tests`:

- the four groups match exactly the modules in the table (5 + 4 + 2 + 5),
- no dependency matches more than one group, and
- the remaining 38 fall to the catch-all and keep arriving one pull request each.

No change to `github-actions`, `docker` or `npm`.