### PR TITLE
fix(ui): add ARIA attributes to access policy action toggle

### DIFF
--- a/ui/apps/console/src/pages/access-policies/AccessPolicyDrawer.tsx
+++ b/ui/apps/console/src/pages/access-policies/AccessPolicyDrawer.tsx
@@ -630,11 +630,16 @@ function AccessPolicyDrawer({
           <Label hint="Allow grants the access below; deny blocks it and wins over any allow.">
             Action
           </Label>
-          <div className="inline-flex bg-card border border-border rounded-lg p-0.5 gap-0.5">
+          <div
+            role="group"
+            aria-label="Policy action"
+            className="inline-flex bg-card border border-border rounded-lg p-0.5 gap-0.5"
+          >
             {(["allow", "deny"] as const).map((e) => (
               <button
                 key={e}
                 type="button"
+                aria-pressed={action === e}
                 onClick={() => setAction(e)}
                 className={cn(
                   "flex items-center justify-center gap-2 px-4 py-1.5 rounded-md text-sm font-medium transition-colors",


### PR DESCRIPTION
## What

The allow/deny toggle in the access policy drawer is now accessible to screen readers.

## Why

The toggle used two plain `<button>` elements with no grouping or pressed-state semantics. A screen reader saw two unrelated buttons with no way to tell which was active — selection was conveyed only through color (green/red), violating WCAG 1.4.1.

## Changes

- **`AccessPolicyDrawer`**: added `role="group"` and `aria-label="Policy action"` on the wrapper so assistive tech identifies the buttons as a related set, and `aria-pressed` on each button so the active option is programmatically exposed.