### PR TITLE
perf(server): stop the device heartbeat from blocking HOT updates

### DIFF
--- a/server/api/store/pg/migrations/020_drop_device_presence_indexes.tx.down.sql
+++ b/server/api/store/pg/migrations/020_drop_device_presence_indexes.tx.down.sql
@@ -1,0 +1,7 @@
+-- Restores the index set from 001, which reinstates the HOT blocker on the heartbeat and so
+-- also restores its write amplification.
+CREATE INDEX IF NOT EXISTS devices_last_seen ON devices USING btree (last_seen);
+
+--bun:split
+
+CREATE INDEX IF NOT EXISTS devices_disconnected_at ON devices USING btree (disconnected_at);

--- a/server/api/store/pg/migrations/020_drop_device_presence_indexes.tx.up.sql
+++ b/server/api/store/pg/migrations/020_drop_device_presence_indexes.tx.up.sql
@@ -1,0 +1,20 @@
+-- PostgreSQL disqualifies HOT whenever an indexed column changes, and every device presence
+-- heartbeat writes last_seen — so this index is what forced each beat to rewrite the heap
+-- tuple and touch every index on the table. The device list's ORDER BY last_seen DESC sorts
+-- over a sequential scan instead.
+--
+-- lock_timeout because migrations run inline in startup before the listener binds: an
+-- ACCESS EXCLUSIVE request queued behind a long snapshot would otherwise stall the boot
+-- indefinitely. SET LOCAL is enough here because bun runs a .tx. file in one transaction.
+SET LOCAL lock_timeout = '60s';
+
+--bun:split
+
+-- IF EXISTS: operators may already have dropped this by hand, and an error fails the boot.
+DROP INDEX IF EXISTS devices_last_seen;
+
+--bun:split
+
+-- Unused: nothing filters or orders on disconnected_at alone, only as half of the online
+-- predicate, which is too unselective to be worth an index scan.
+DROP INDEX IF EXISTS devices_disconnected_at;

--- a/server/api/store/pg/migrations/021_set_devices_fillfactor.tx.down.sql
+++ b/server/api/store/pg/migrations/021_set_devices_fillfactor.tx.down.sql
@@ -1,0 +1,3 @@
+-- Back to the default 100. Existing pages keep whatever slack they already have; only pages
+-- allocated after this are packed full.
+ALTER TABLE devices RESET (fillfactor);

--- a/server/api/store/pg/migrations/021_set_devices_fillfactor.tx.up.sql
+++ b/server/api/store/pg/migrations/021_set_devices_fillfactor.tx.up.sql
@@ -1,0 +1,20 @@
+-- HOT needs free space in the same page to write the new tuple version into. Dropping the
+-- index in 020 makes a heartbeat HOT-eligible, but eligibility is not enough: at heartbeat
+-- rates a densely packed heap runs out of in-page room, falls back to a non-HOT update, and
+-- grows until it has accumulated the slack it needed all along. Reserving the slack up front
+-- is both cheaper and smaller than letting the table find it by bloating.
+--
+-- Measured locally, updating every row of a 58,670-row table six times over, starting from a
+-- freshly compacted heap: at the default fillfactor the HOT ratio reached 40.4% and the heap
+-- grew 4.7x, against 85.1% and 3.0x at fillfactor 85. Higher HOT means less expansion, so the
+-- reserved 15% pays for itself — the fillfactor 85 heap ends up smaller in absolute terms.
+--
+-- Must run before 022: VACUUM FULL honours fillfactor when it rewrites the heap (the same
+-- 58,670 rows rebuild into 2,257 pages at 100 and 2,667 at 85), so setting this afterwards
+-- would leave the compacted pages full and only apply to pages allocated later.
+--
+-- The autovacuum_vacuum_scale_factor / autovacuum_analyze_scale_factor knobs proposed
+-- alongside this one are deliberately left alone: the same measurement showed no material
+-- effect from them once fillfactor is set. They belong with the rest of the server-level
+-- tuning rather than here.
+ALTER TABLE devices SET (fillfactor = 85);

--- a/server/api/store/pg/migrations/022_vacuum_full_devices.down.sql
+++ b/server/api/store/pg/migrations/022_vacuum_full_devices.down.sql
@@ -1,0 +1,4 @@
+-- This migration rewrites the devices heap and its indexes; it adds no schema and changes no
+-- data, so there is nothing to reverse — reintroducing bloat is not something a rollback
+-- should do. Leaving it as a no-op keeps the down runnable.
+SELECT 1;

--- a/server/api/store/pg/migrations/022_vacuum_full_devices.up.sql
+++ b/server/api/store/pg/migrations/022_vacuum_full_devices.up.sql
@@ -1,0 +1,34 @@
+-- Reclaims the bloat 020 stops accumulating: while HOT was impossible every heartbeat left a
+-- dead tuple behind, and the device list's default sort now scans that heap sequentially.
+-- Running after 020 also avoids rebuilding the two indexes that just went away, and running
+-- after 021 means the rewrite lays the pages out at that fillfactor.
+--
+-- VACUUM cannot run inside a transaction, which is why this file omits the .tx. suffix and
+-- keeps every statement in its own --bun:split chunk (see TestNonTransactionalMigrations).
+--
+-- The timeouts bound a boot, because migrations run inline before the listener binds. bun marks
+-- a migration applied before running it, so if one fires the boot fails but the restart skips
+-- this migration and comes up with the table merely still bloated — re-run the VACUUM by hand
+-- to finish the job. Peer replicas that boot while this holds the migration lock fail outright
+-- rather than wait: migrator.Lock inserts a row, it does not block.
+SET lock_timeout = '60s';
+
+--bun:split
+
+SET statement_timeout = '10min';
+
+--bun:split
+
+-- ANALYZE because VACUUM FULL does not refresh planner statistics, and 020 just changed which
+-- plans are available for this table.
+VACUUM (FULL, ANALYZE) devices;
+
+--bun:split
+
+-- SET rather than SET LOCAL above, since there is no transaction to scope it to. The connection
+-- returns to the pool unreset, so the timeouts leak into application queries unless undone.
+RESET lock_timeout;
+
+--bun:split
+
+RESET statement_timeout;


### PR DESCRIPTION
> **Merge order.** #6888 now lands ahead of this PR and takes migration `019`, so the three
> migrations here are `020`–`022`. #6888 also carries `migrations_test.go`, byte-identical to the
> copy in this branch, so it drops out of this diff on rebase and no conflict arises either way
> round.

Every device presence heartbeat writes `last_seen`, and PostgreSQL disqualifies HOT whenever an
indexed column changes. `devices_last_seen` was a btree on exactly that column, so **no heartbeat
could ever be a HOT update** — each one rewrote the heap tuple and inserted into every index on
the table.

Measured on a 58,670-device deployment: ~2,244 row updates/second, **107.7 GB of WAL per day**, a
heap bloated ~12× past the width of its rows, and autovacuum running continuously without keeping
up.

## What this does

| Migration | Change |
|---|---|
| `020` | drops `devices_last_seen` and `devices_disconnected_at` |
| `021` | `ALTER TABLE devices SET (fillfactor = 85)` |
| `022` | `VACUUM (FULL, ANALYZE) devices` |

Migrations only — this PR no longer touches `docker-compose.postgres.yml`. The
`wal_compression=lz4` change it used to carry is gone: #6886 adds a
`SHELLHUB_POSTGRES_EXTRA_ARGS` seam, so a deployment that wants it appends
`-c wal_compression=lz4` there rather than every deployment inheriting it. The measurements
below still include it, since that is how it was measured.

Order is load-bearing and follows from the numbering: the drops run before the rewrite so
`VACUUM FULL` never rebuilds indexes that are about to disappear, and `021` runs before `022`
because `VACUUM FULL` honours `fillfactor` as it rewrites (the same 58,670 rows rebuild into
2,257 pages at the default and 2,667 at 85).

## Verified in production

Each half was applied and measured independently, then reverted:

| | baseline | + `wal_compression=lz4` (not in this PR) | + indexes dropped |
|---|---|---|---|
| HOT ratio | 0.0000% | 0.0000% | **97.2521%** |
| WAL | 107.7 GB/day | 97.0 GB/day | **31.7 GB/day** |
| `wal_records`/s | 12,203 | 12,204 | **3,044** |
| postgres CPU (core-s/s) | 0.326 | 0.264 | **0.205** |

The win shows up in `wal_records`, not `wal_fpi`: a non-HOT update emitted a heap record plus
index-tuple inserts into two btrees, where a HOT update emits one. `wal_compression` is separate
and additive at ~10% — full-page images are only ~36% of WAL volume here — and it *lowered*
postgres CPU by 19%, because compressing a page costs less than writing the extra bytes. That
column is context for the deployment that appends the flag, not something this PR delivers: the
HOT win in the third column is independent of it.


## Post-merge: the full sequence, applied and left in place

The table above measured each half separately and reverted both. All three migrations have since
been applied together on the same deployment — now 59,906 devices, ~2,000 updates/s, 8 vCPU /
15 GB — and left running. Applied as raw SQL rather than through bun's runner, since that
deployment's schema predates these migrations; the statements are byte-identical to the files.

| | before | after `020`–`022` |
|---|---|---|
| HOT ratio | 0.0449% | **96.7 – 98.7%** |
| `wal_records`/s | 12,203 | **2,900 – 3,150** |
| WAL | 107.7 GB/day | **19 – 22 GB/day** |
| heap | 296 MB | **60 MB** |
| indexes | 60 MB | 24 MB after `020`, **9.6 MB** after `022` |
| `n_dead_tup` | 81,413 | 8k – 15k |
| lock waiters | 0 | 0 |

Three things this changes in the text above.

**The WAL estimate here was conservative.** This PR predicts 31.7 GB/day; the full sequence lands
at 19–22. That figure came from the third column, where the indexes were dropped but the heap was
still bloated. Compacting cuts WAL a second time and for a different reason: `wal_fpi` is a
function of how many *distinct* pages are touched between checkpoints, and a heap 5.7x smaller has
proportionally fewer to image. The `wal_records` mechanism described above is correct and remains
the dominant term — this is the FPI term the third column could not show.

**`021` now has production evidence, on the state that actually needs it.** The 97.25% in the
third column was reached at the default fillfactor, which is why the text says fillfactor is not
required for HOT to *work*. The claim it is required to *keep* HOT working once `022` compacts the
slack away rested on the local six-pass measurement alone. On the compacted heap HOT held at
96.7–98.7% across the following half hour, and the heap grew from 52 MB to 60 MB and then stopped.
That is the condition the local table modelled, now observed under real heartbeat traffic.

**`022` is cheaper than the release-note caveat implies.** The rewrite took **1.69 s** of ACCESS
EXCLUSIVE at this scale, with no queued waiters, on the largest deployment there is. The
`statement_timeout = '10min'` in the file has roughly 350x headroom rather than the narrow margin
the framing suggests. The free-space requirement stands — the copy is real — but "acceptable
inside the upgrade's own restart window" understates it: it is not distinguishable from an
ordinary restart.

The read-path prediction held exactly. Measured on the compacted heap, medians of 3, `work_mem`
at the stock 4 MB:

| Query | bloated heap, no index | **compacted, no index** |
|---|---|---|
| device list, first page | 120.7 ms | **23.7 ms** |
| admin unscoped list | 128.5 ms | **21.1 ms** |
| device list, offset 5000 | 99.2 ms | 47.3 ms (`external merge Disk: ~13 MB`/worker) |

`~24 ms once compacted` in **The trade** is confirmed at 23.7 ms. The deep-pagination row is the
one remaining rough edge, and it is a `work_mem` problem rather than an index one: at 4 MB the
top-N sort spills, and raising `work_mem` to 16 MB at the deployment layer keeps it in memory and
brings it to 31.8 ms. Nothing in this PR needs to change for it.

One interaction worth knowing about operationally: a long-lived snapshot pins the xmin horizon and
suppresses HOT while it is held, so a deployment taking a nightly logical backup will see a daily
window where the heartbeat falls back to non-HOT and WAL briefly exceeds the old baseline. That is
a property of the backup, not of these migrations, but it only becomes visible once HOT is working.
## The trade

`devices_last_seen` did serve the device list's default `ORDER BY last_seen DESC`, which now sorts
over a sequential scan: ~121 ms on the bloated heap, **~24 ms once compacted** — which is why
`022` is part of this PR rather than a follow-up. No index on `last_seen` can coexist with HOT
(composite and partial alike), so this is structural: either the write side pays or the read side
does, and one endpoint at ~24 ms is much cheaper than 76 GB/day of WAL.

`devices_disconnected_at` goes along for free. Nothing filters or orders on it alone, only inside
the unselective `online` predicate; 0 scans in 66 days of counters.

## Why `021` is needed

Production hit 97.25% HOT with `fillfactor` at the default, because a 12×-bloated heap already
holds all the free space HOT needs — so `fillfactor` is *not* required for HOT to work, contrary
to the original issue. It is required to **keep** HOT working once `022` compacts that space away.
Measured locally from a freshly compacted heap, six full passes over a 58,670-row table:

| | HOT ratio | heap growth |
|---|---|---|
| default fillfactor | 40.4% | 4.7× |
| `fillfactor = 85` | **85.1%** | **3.0×** |

Better HOT *and* a smaller table — reserving 15% up front costs less than letting the heap
rediscover the same slack by bloating. The autovacuum scale-factor knobs proposed alongside it
showed no material effect once `fillfactor` is set and are not included.

## `022` is the repo's first non-transactional migration

`VACUUM` cannot run inside a transaction block, so the file omits the `.tx.` suffix — and because
the pool runs in pgx `QueryExecModeSimpleProtocol`, where a multi-statement `Exec` is *itself* an
implicit transaction, every statement must sit alone between `--bun:split` markers. Neither
requirement is visible in the SQL, which is what `TestNonTransactionalMigrations` checks — the
guard exists for exactly this migration, and #6888 puts it in place ahead of it.

Two further edges are handled rather than ignored:

- **Timeouts bound the boot.** Migrations run inline in `Server.Setup` before the listener binds.
  `lock_timeout` makes `022` fail fast rather than queue behind a long snapshot (a nightly logical
  backup, say). bun marks a migration applied *before* running it, so a failure there costs one
  crash-restart and leaves the table merely still bloated — degraded, not broken. Recover with
  `psql -c 'VACUUM (FULL, ANALYZE) devices;'`.
- **The GUCs are reset explicitly.** A non-transactional migration runs on one pooled `bun.Conn`
  that returns to the pool without a session reset, so `SET lock_timeout` would otherwise leak
  into application queries.

`VACUUM FULL` needs free space for a full copy of the table (~320 MB at the reference scale) and
holds ACCESS EXCLUSIVE for its duration, which is acceptable inside the upgrade's own restart
window. Worth a line in the release notes.

## Testing

- `TestNonTransactionalMigrations` — scans every embedded migration for a statement PostgreSQL
  refuses inside a transaction and asserts it neither carries `.tx.` nor shares its
  `--bun:split` chunk. `TestNonTransactionalDetection` covers the guard itself, including prose
  that merely names a `VACUUM`.
- Full `pg` store suite green against a schema built from `001` through `022`.
- End-to-end through bun's runner on the dev stack: `021` applies, `reloptions` becomes
  `{fillfactor=85}`, `022` compacts, three indexes remain, clean boot.
- Re-verified after the renumber and the rebase onto `master`: `go build` clean,
  `./api/store/...` green, `golangci-lint run ./...` reports 0 issues. The same suite is green on
  the combined tree (#6888 merged, then this rebased on top), where migrations run `019`–`022`
  with no gap.

Fixes shellhub-io/team#197.




