### PR TITLE
perf(server): stop re-resolving the namespace on every authenticated request

### DIFF
--- a/pkg/cache/keys.go
+++ b/pkg/cache/keys.go
@@ -1,0 +1,9 @@
+package cache
+
+// SystemKey caches the instance's singleton system row.
+//
+// It is deliberately shared across editions and layers: the Community API service reads it,
+// the Cloud/Enterprise service reads it, and the cloud store deletes it when an administrator
+// reconfigures authentication. Those live in three packages and two repositories, so the name
+// has to be defined once — a second literal spelling of it silently stops invalidating.
+const SystemKey = "system"

--- a/pkg/models/namespace.go
+++ b/pkg/models/namespace.go
@@ -22,19 +22,41 @@ type Namespace struct {
 	Type       Type      `json:"type"`
 }
 
-// HasMaxDevices checks if the namespace has a maximum number of devices.
+// NamespaceDeviceLimit is a namespace's device ceiling and the accepted-device count it is
+// measured against, carrying the rule so it stays defined once.
+type NamespaceDeviceLimit struct {
+	MaxDevices           int
+	DevicesAcceptedCount int64
+}
+
+// HasMax reports whether the namespace has a finite device ceiling.
 //
 // Generally, a namespace has a MaxDevices value greater than 0 when the ShellHub is either in community version or
 // the namespace does not have a billing plan enabled, because, in this case, we set this value to -1.
-func (n *Namespace) HasMaxDevices() bool {
-	return n.MaxDevices > 0
+func (l NamespaceDeviceLimit) HasMax() bool {
+	return l.MaxDevices > 0
 }
 
-// HasMaxDevicesReached checks if the namespace has reached the maximum number of devices.
+// IsReached reports whether the accepted-device count has caught up with the ceiling.
 // Only counts accepted devices. Removed devices no longer count towards the limit,
 // allowing immediate slot reuse after deletion.
+func (l NamespaceDeviceLimit) IsReached() bool {
+	return l.DevicesAcceptedCount >= int64(l.MaxDevices)
+}
+
+func (n *Namespace) DeviceLimit() NamespaceDeviceLimit {
+	return NamespaceDeviceLimit{
+		MaxDevices:           n.MaxDevices,
+		DevicesAcceptedCount: n.DevicesAcceptedCount,
+	}
+}
+
+func (n *Namespace) HasMaxDevices() bool {
+	return n.DeviceLimit().HasMax()
+}
+
 func (n *Namespace) HasMaxDevicesReached() bool {
-	return n.DevicesAcceptedCount >= int64(n.MaxDevices)
+	return n.DeviceLimit().IsReached()
 }
 
 // FindMember checks if a member with the specified ID exists in the namespace.

--- a/server/api/pkg/authctx/authctx.go
+++ b/server/api/pkg/authctx/authctx.go
@@ -1,0 +1,43 @@
+// Package authctx carries what the authentication step already resolved into the request
+// context, so the rest of the request can reuse it instead of reading the store again.
+package authctx
+
+import (
+	"context"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+)
+
+type ctxKey string
+
+const deviceLimitKey ctxKey = "namespace-device-limit"
+
+// namespaceDeviceLimit pairs the limit with the namespace it was read for, so a request
+// targeting a different namespace cannot be answered from it.
+type namespaceDeviceLimit struct {
+	tenantID string
+	limit    models.NamespaceDeviceLimit
+}
+
+// WithNamespaceDeviceLimit returns ctx carrying tenantID's device limit as authentication read it.
+func WithNamespaceDeviceLimit(ctx context.Context, tenantID string, limit models.NamespaceDeviceLimit) context.Context {
+	return context.WithValue(ctx, deviceLimitKey, namespaceDeviceLimit{tenantID: tenantID, limit: limit})
+}
+
+// NamespaceDeviceLimit returns tenantID's device limit as it stood when the request
+// authenticated. It is a snapshot, not a live read: a device accepted after authentication is
+// not reflected, which matches the handler it replaces — that one re-read the namespace within
+// the same request.
+//
+// It reports false when the request carries no limit, which is the ordinary case for a token
+// with no tenant, for API keys, for the admin surface, and for contexts built outside an HTTP
+// request; and when the limit belongs to another namespace. Callers must fall back to the store
+// rather than treat either as an error.
+func NamespaceDeviceLimit(ctx context.Context, tenantID string) (models.NamespaceDeviceLimit, bool) {
+	held, ok := ctx.Value(deviceLimitKey).(namespaceDeviceLimit)
+	if !ok || held.tenantID != tenantID {
+		return models.NamespaceDeviceLimit{}, false
+	}
+
+	return held.limit, true
+}

--- a/server/api/routes/middleware/authn.go
+++ b/server/api/routes/middleware/authn.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/jwttoken"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/api/pkg/authctx"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
 	log "github.com/sirupsen/logrus"
 )
@@ -18,7 +19,7 @@ import (
 // a credential into an identity.
 type AuthnService interface {
 	AuthAPIKey(ctx context.Context, key string) (*models.APIKey, error)
-	GetUserRole(ctx context.Context, tenantID, userID string) (string, error)
+	ResolveNamespaceRole(ctx context.Context, tenantID, userID string) (*models.Namespace, string, error)
 	GetUserAdmin(ctx context.Context, userID string) (bool, error)
 	PublicKey() *rsa.PublicKey
 }
@@ -202,7 +203,7 @@ func (a *Authenticator) Resolve(c *echo.Context) (*gateway.Identity, error) {
 		// the error they swallow: otherwise an outage is indistinguishable from
 		// a stale token and shows up only as a rise in 401s.
 		if claims.TenantID != "" {
-			role, err := a.service.GetUserRole(c.Request().Context(), claims.TenantID, claims.ID)
+			ns, role, err := a.service.ResolveNamespaceRole(c.Request().Context(), claims.TenantID, claims.ID)
 			if err != nil {
 				log.WithError(err).
 					WithFields(log.Fields{"user_id": claims.ID, "tenant_id": claims.TenantID}).
@@ -212,6 +213,12 @@ func (a *Authenticator) Resolve(c *echo.Context) (*gateway.Identity, error) {
 			}
 
 			claims.Role = authorizer.RoleFromString(role)
+
+			// Resolving the role already read the namespace, and the device-limit check in
+			// the handler would otherwise read it a second time.
+			c.SetRequest(c.Request().WithContext(
+				authctx.WithNamespaceDeviceLimit(c.Request().Context(), ns.TenantID, ns.DeviceLimit()),
+			))
 		}
 
 		admin, err := a.service.GetUserAdmin(c.Request().Context(), claims.ID)

--- a/server/api/routes/middleware/authn_test.go
+++ b/server/api/routes/middleware/authn_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/jwttoken"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/api/pkg/authctx"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
 	"github.com/shellhub-io/shellhub/server/api/services/mocks"
 	"github.com/shellhub-io/shellhub/server/api/store"
@@ -63,7 +65,8 @@ func TestAuthenticatorResolveUserClaims(t *testing.T) {
 		{
 			description: "succeeds when both role and admin resolve",
 			requiredMocks: func(service *mocks.MockService) {
-				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("owner", nil).Once()
+				service.On("ResolveNamespaceRole", mock.Anything, testTenant, testUserID).
+					Return(&models.Namespace{TenantID: testTenant}, "owner", nil).Once()
 				service.On("GetUserAdmin", mock.Anything, testUserID).Return(true, nil).Once()
 			},
 			expected: &gateway.Identity{
@@ -77,14 +80,15 @@ func TestAuthenticatorResolveUserClaims(t *testing.T) {
 		{
 			description: "yields no identity when the namespace no longer exists",
 			requiredMocks: func(service *mocks.MockService) {
-				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("", store.ErrNoDocuments).Once()
+				service.On("ResolveNamespaceRole", mock.Anything, testTenant, testUserID).Return(nil, "", store.ErrNoDocuments).Once()
 			},
 			expected: nil,
 		},
 		{
 			description: "yields no identity when the user no longer exists",
 			requiredMocks: func(service *mocks.MockService) {
-				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("owner", nil).Once()
+				service.On("ResolveNamespaceRole", mock.Anything, testTenant, testUserID).
+					Return(&models.Namespace{TenantID: testTenant}, "owner", nil).Once()
 				service.On("GetUserAdmin", mock.Anything, testUserID).Return(false, store.ErrNoDocuments).Once()
 			},
 			expected: nil,
@@ -92,14 +96,15 @@ func TestAuthenticatorResolveUserClaims(t *testing.T) {
 		{
 			description: "yields no identity when the store is unreachable",
 			requiredMocks: func(service *mocks.MockService) {
-				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("", errors.New("connection refused")).Once()
+				service.On("ResolveNamespaceRole", mock.Anything, testTenant, testUserID).Return(nil, "", errors.New("connection refused")).Once()
 			},
 			expected: nil,
 		},
 		{
 			description: "yields no identity when the request is cancelled",
 			requiredMocks: func(service *mocks.MockService) {
-				service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("owner", nil).Once()
+				service.On("ResolveNamespaceRole", mock.Anything, testTenant, testUserID).
+					Return(&models.Namespace{TenantID: testTenant}, "owner", nil).Once()
 				service.On("GetUserAdmin", mock.Anything, testUserID).Return(false, context.DeadlineExceeded).Once()
 			},
 			expected: nil,
@@ -123,12 +128,40 @@ func TestAuthenticatorResolveUserClaims(t *testing.T) {
 	}
 }
 
+// The namespace resolved to establish the caller's role is handed to the rest of the request,
+// so handlers can use it instead of resolving it a second time.
+func TestAuthenticatorResolveForwardsNamespace(t *testing.T) {
+	bearer, privateKey := userBearer(t)
+
+	ns := &models.Namespace{TenantID: testTenant, MaxDevices: 3, DevicesAcceptedCount: 1}
+
+	service := new(mocks.MockService)
+	service.On("PublicKey").Return(&privateKey.PublicKey).Once()
+	service.On("ResolveNamespaceRole", mock.Anything, testTenant, testUserID).Return(ns, "owner", nil).Once()
+	service.On("GetUserAdmin", mock.Anything, testUserID).Return(false, nil).Once()
+
+	c, _ := authenticatedRequest(echo.New(), bearer)
+
+	_, err := NewAuthenticator(service).Resolve(c)
+	require.NoError(t, err)
+
+	forwarded, ok := authctx.NamespaceDeviceLimit(c.Request().Context(), testTenant)
+	require.True(t, ok)
+	assert.Equal(t, ns.DeviceLimit(), forwarded)
+
+	// A request targeting a different namespace must not be answered from it.
+	_, ok = authctx.NamespaceDeviceLimit(c.Request().Context(), "00000000-0000-4000-0000-000000000009")
+	assert.False(t, ok)
+
+	service.AssertExpectations(t)
+}
+
 func TestAuthenticatorMiddlewareStaleToken(t *testing.T) {
 	bearer, privateKey := userBearer(t)
 
 	service := new(mocks.MockService)
 	service.On("PublicKey").Return(&privateKey.PublicKey).Once()
-	service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("", store.ErrNoDocuments).Once()
+	service.On("ResolveNamespaceRole", mock.Anything, testTenant, testUserID).Return(nil, "", store.ErrNoDocuments).Once()
 
 	c, rec := authenticatedRequest(echo.New(), bearer)
 
@@ -144,7 +177,7 @@ func TestAuthenticatorMiddlewareStaleTokenOnAnonymousRoute(t *testing.T) {
 
 	service := new(mocks.MockService)
 	service.On("PublicKey").Return(&privateKey.PublicKey).Once()
-	service.On("GetUserRole", mock.Anything, testTenant, testUserID).Return("", store.ErrNoDocuments).Once()
+	service.On("ResolveNamespaceRole", mock.Anything, testTenant, testUserID).Return(nil, "", store.ErrNoDocuments).Once()
 
 	c, rec := authenticatedRequest(echo.New(), bearer)
 	c.Request().Header.Set("X-ID", "forged")

--- a/server/api/services/auth.go
+++ b/server/api/services/auth.go
@@ -57,8 +57,12 @@ type AuthService interface {
 	//
 	// It returns the created token and an error if any.
 	CreateUserToken(ctx context.Context, req *requests.CreateUserToken) (res *models.UserAuthResponse, err error)
-	// GetUserRole get the user's role. It returns the user's role and an error, if any.
-	GetUserRole(ctx context.Context, tenantID, userID string) (role string, err error)
+	// ResolveNamespaceRole returns the namespace tenantID names, as [store.NamespaceStore.NamespaceResolve]
+	// returns it — memberships included — together with userID's role in it.
+	//
+	// It returns ErrNamespaceMemberNotFound when the user is not a member. The namespace is a
+	// snapshot taken at the moment of the call, not a handle onto live state.
+	ResolveNamespaceRole(ctx context.Context, tenantID, userID string) (ns *models.Namespace, role string, err error)
 	// GetUserAdmin checks whether the user currently has admin privileges.
 	// Unlike the JWT claim, this queries the store so changes take effect immediately.
 	GetUserAdmin(ctx context.Context, userID string) (admin bool, err error)
@@ -743,7 +747,7 @@ func (s *service) AuthAPIKey(ctx context.Context, key string) (*models.APIKey, e
 	// outlive its creator's access: reject it if they left the namespace, and
 	// cap it at their current role so a demotion is honoured while the
 	// least-privilege role chosen at creation is preserved.
-	role, err := s.GetUserRole(ctx, apiKey.TenantID, apiKey.CreatedBy)
+	_, role, err := s.ResolveNamespaceRole(ctx, apiKey.TenantID, apiKey.CreatedBy)
 	if err != nil {
 		return nil, NewErrAPIKeyInvalid(apiKey.Name)
 	}
@@ -782,18 +786,18 @@ func (s *service) AuthPublicKey(ctx context.Context, req requests.PublicKeyAuth)
 	}, nil
 }
 
-func (s *service) GetUserRole(ctx context.Context, tenantID, userID string) (string, error) {
+func (s *service) ResolveNamespaceRole(ctx context.Context, tenantID, userID string) (*models.Namespace, string, error) {
 	ns, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, tenantID)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 
 	member, ok := ns.FindMember(userID)
 	if !ok {
-		return "", NewErrNamespaceMemberNotFound(userID, nil)
+		return nil, "", NewErrNamespaceMemberNotFound(userID, nil)
 	}
 
-	return member.Role.String(), nil
+	return ns, member.Role.String(), nil
 }
 
 func (s *service) GetUserAdmin(ctx context.Context, userID string) (bool, error) {

--- a/server/api/services/device.go
+++ b/server/api/services/device.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/api/pkg/authctx"
 	"github.com/shellhub-io/shellhub/server/api/store"
 	log "github.com/sirupsen/logrus"
 )
@@ -102,6 +103,16 @@ type DeviceService interface {
 	DeleteDeviceCustomField(ctx context.Context, req *requests.DeviceDeleteCustomField) error
 }
 
+// deviceLimit prefers the limit authentication already read for this request, falling back to
+// the store when it carries none.
+func (s *service) deviceLimit(ctx context.Context, tenantID string) (models.NamespaceDeviceLimit, error) {
+	if limit, ok := authctx.NamespaceDeviceLimit(ctx, tenantID); ok {
+		return limit, nil
+	}
+
+	return s.store.NamespaceGetDeviceLimit(ctx, tenantID)
+}
+
 func (s *service) ListDevices(ctx context.Context, sc scope.Scope, req *requests.DeviceList) ([]models.Device, int, error) {
 	opts := []store.QueryOption{}
 
@@ -124,12 +135,12 @@ func (s *service) ListDevices(ctx context.Context, sc scope.Scope, req *requests
 	acceptable := store.DeviceAcceptableIfNotAccepted
 
 	if sc.IsBounded() {
-		ns, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID)
+		limit, err := s.deviceLimit(ctx, req.TenantID)
 		if err != nil {
 			return nil, 0, NewErrNamespaceNotFound(req.TenantID, err)
 		}
 
-		if ns.HasMaxDevices() && ns.HasMaxDevicesReached() {
+		if limit.HasMax() && limit.IsReached() {
 			acceptable = store.DeviceAcceptableAsFalse
 		}
 	}

--- a/server/api/services/device_test.go
+++ b/server/api/services/device_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/envs/envstest"
 	"github.com/shellhub-io/shellhub/pkg/errors"
 	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/api/pkg/authctx"
 	"github.com/shellhub-io/shellhub/server/api/store"
 	storemock "github.com/shellhub-io/shellhub/server/api/store/mocks"
 	"github.com/stretchr/testify/assert"
@@ -68,8 +69,8 @@ func TestListDevices(t *testing.T) {
 					Return(nil).
 					Once()
 				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{TenantID: "00000000-0000-4000-0000-000000000000"}, nil).
+					On("NamespaceGetDeviceLimit", ctx, "00000000-0000-4000-0000-000000000000").
+					Return(models.NamespaceDeviceLimit{}, nil).
 					Once()
 				storeMock.
 					On("DeviceList", ctx, scope.MustBounded("00000000-0000-4000-0000-000000000000"), store.DeviceAcceptableIfNotAccepted, mock.MatchedBy(func(opts []store.QueryOption) bool { return len(opts) == 4 })).
@@ -110,8 +111,8 @@ func TestListDevices(t *testing.T) {
 					Return(nil).
 					Once()
 				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{TenantID: "00000000-0000-4000-0000-000000000000"}, nil).
+					On("NamespaceGetDeviceLimit", ctx, "00000000-0000-4000-0000-000000000000").
+					Return(models.NamespaceDeviceLimit{}, nil).
 					Once()
 				storeMock.
 					On("DeviceList", ctx, scope.MustBounded("00000000-0000-4000-0000-000000000000"), store.DeviceAcceptableIfNotAccepted, mock.MatchedBy(func(opts []store.QueryOption) bool { return len(opts) == 4 })).
@@ -178,6 +179,71 @@ func TestListDevices(t *testing.T) {
 	}
 
 	storeMock.AssertExpectations(t)
+}
+
+func TestListDevices_namespaceFromRequestContext(t *testing.T) {
+	const tenantID = "00000000-0000-4000-0000-000000000000"
+
+	req := &requests.DeviceList{
+		TenantID:     tenantID,
+		DeviceStatus: models.DeviceStatusAccepted,
+		Paginator:    query.Paginator{Page: 1, PerPage: 10},
+		Sorter:       query.Sorter{By: "created_at", Order: "asc"},
+		Filters:      query.Filters{},
+	}
+
+	expectQueryOptions := func(queryOptionsMock *storemock.MockQueryOptions) {
+		queryOptionsMock.On("WithDeviceStatus", models.DeviceStatusAccepted).Return(nil).Once()
+		queryOptionsMock.On("Match", &query.Filters{}).Return(nil).Once()
+		queryOptionsMock.On("Sort", &query.Sorter{By: "created_at", Order: query.OrderAsc, Tiebreak: "id"}).Return(nil).Once()
+		queryOptionsMock.On("Paginate", &query.Paginator{Page: 1, PerPage: 10}).Return(nil).Once()
+	}
+
+	// The authenticator resolved the namespace for this request, so the device-limit check
+	// must read it from the context instead of going back to the store. MockStore fails the
+	// test on any call that was not set up, which is what asserts the store is untouched.
+	t.Run("uses the authenticated namespace instead of reading the store", func(t *testing.T) {
+		storeMock := storemock.NewMockStore(t)
+		queryOptionsMock := storemock.NewMockQueryOptions(t)
+		storeMock.On("Options").Return(queryOptionsMock).Maybe()
+		expectQueryOptions(queryOptionsMock)
+
+		ctx := authctx.WithNamespaceDeviceLimit(context.TODO(), tenantID,
+			models.NamespaceDeviceLimit{MaxDevices: 3, DevicesAcceptedCount: 3})
+
+		storeMock.
+			On("DeviceList", ctx, scope.MustBounded(tenantID), store.DeviceAcceptableAsFalse, mock.MatchedBy(func(opts []store.QueryOption) bool { return len(opts) == 4 })).
+			Return([]models.Device{}, 0, nil).
+			Once()
+
+		service := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache())
+		_, _, err := service.ListDevices(ctx, scope.MustBounded(tenantID), req)
+		require.NoError(t, err)
+	})
+
+	// An authenticated namespace for a different tenant must not answer this request's limit.
+	t.Run("falls back to the store when the context namespace is another tenant", func(t *testing.T) {
+		storeMock := storemock.NewMockStore(t)
+		queryOptionsMock := storemock.NewMockQueryOptions(t)
+		storeMock.On("Options").Return(queryOptionsMock).Maybe()
+		expectQueryOptions(queryOptionsMock)
+
+		ctx := authctx.WithNamespaceDeviceLimit(context.TODO(), "00000000-0000-4000-0000-000000000001",
+			models.NamespaceDeviceLimit{MaxDevices: 3, DevicesAcceptedCount: 3})
+
+		storeMock.
+			On("NamespaceGetDeviceLimit", ctx, tenantID).
+			Return(models.NamespaceDeviceLimit{MaxDevices: 3, DevicesAcceptedCount: 1}, nil).
+			Once()
+		storeMock.
+			On("DeviceList", ctx, scope.MustBounded(tenantID), store.DeviceAcceptableIfNotAccepted, mock.MatchedBy(func(opts []store.QueryOption) bool { return len(opts) == 4 })).
+			Return([]models.Device{}, 0, nil).
+			Once()
+
+		service := NewService(storeMock, privateKey, publicKey, storecache.NewNullCache())
+		_, _, err := service.ListDevices(ctx, scope.MustBounded(tenantID), req)
+		require.NoError(t, err)
+	})
 }
 
 func TestListDevices_status_removed(t *testing.T) {
@@ -342,8 +408,8 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(nil, errors.New("error", "", 0)).
+					On("NamespaceGetDeviceLimit", ctx, "00000000-0000-4000-0000-000000000000").
+					Return(models.NamespaceDeviceLimit{}, errors.New("error", "", 0)).
 					Once()
 			},
 			expected: Expected{
@@ -381,8 +447,8 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{TenantID: "00000000-0000-4000-0000-000000000000", MaxDevices: 3, DevicesAcceptedCount: 3}, nil).
+					On("NamespaceGetDeviceLimit", ctx, "00000000-0000-4000-0000-000000000000").
+					Return(models.NamespaceDeviceLimit{MaxDevices: 3, DevicesAcceptedCount: 3}, nil).
 					Once()
 				storeMock.
 					On("DeviceList", ctx, mock.Anything, store.DeviceAcceptableAsFalse, mock.MatchedBy(func(opts []store.QueryOption) bool { return len(opts) == 4 })).
@@ -424,8 +490,8 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{TenantID: "00000000-0000-4000-0000-000000000000", MaxDevices: 3, DevicesAcceptedCount: 3}, nil).
+					On("NamespaceGetDeviceLimit", ctx, "00000000-0000-4000-0000-000000000000").
+					Return(models.NamespaceDeviceLimit{MaxDevices: 3, DevicesAcceptedCount: 3}, nil).
 					Once()
 				storeMock.
 					On("DeviceList", ctx, mock.Anything, store.DeviceAcceptableAsFalse, mock.MatchedBy(func(opts []store.QueryOption) bool { return len(opts) == 4 })).
@@ -467,8 +533,8 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{TenantID: "00000000-0000-4000-0000-000000000000", MaxDevices: 3, DevicesAcceptedCount: 2}, nil).
+					On("NamespaceGetDeviceLimit", ctx, "00000000-0000-4000-0000-000000000000").
+					Return(models.NamespaceDeviceLimit{MaxDevices: 3, DevicesAcceptedCount: 2}, nil).
 					Once()
 				storeMock.
 					On("DeviceList", ctx, mock.Anything, store.DeviceAcceptableIfNotAccepted, mock.MatchedBy(func(opts []store.QueryOption) bool { return len(opts) == 4 })).
@@ -510,8 +576,8 @@ func TestListDevices_tenant_not_empty(t *testing.T) {
 					Return(nil).
 					Once()
 				storeMock.
-					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "00000000-0000-4000-0000-000000000000").
-					Return(&models.Namespace{TenantID: "00000000-0000-4000-0000-000000000000", MaxDevices: 3, DevicesAcceptedCount: 2}, nil).
+					On("NamespaceGetDeviceLimit", ctx, "00000000-0000-4000-0000-000000000000").
+					Return(models.NamespaceDeviceLimit{MaxDevices: 3, DevicesAcceptedCount: 2}, nil).
 					Once()
 				storeMock.
 					On("DeviceList", ctx, mock.Anything, store.DeviceAcceptableIfNotAccepted, mock.MatchedBy(func(opts []store.QueryOption) bool { return len(opts) == 4 })).

--- a/server/api/services/mocks/mock_service.go
+++ b/server/api/services/mocks/mock_service.go
@@ -3964,78 +3964,6 @@ func (_c *MockService_GetUserAdmin_Call) RunAndReturn(run func(ctx context.Conte
 	return _c
 }
 
-// GetUserRole provides a mock function for the type MockService
-func (_mock *MockService) GetUserRole(ctx context.Context, tenantID string, userID string) (string, error) {
-	ret := _mock.Called(ctx, tenantID, userID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetUserRole")
-	}
-
-	var r0 string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
-		return returnFunc(ctx, tenantID, userID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = returnFunc(ctx, tenantID, userID)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = returnFunc(ctx, tenantID, userID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockService_GetUserRole_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserRole'
-type MockService_GetUserRole_Call struct {
-	*mock.Call
-}
-
-// GetUserRole is a helper method to define mock.On call
-//   - ctx context.Context
-//   - tenantID string
-//   - userID string
-func (_e *MockService_Expecter) GetUserRole(ctx any, tenantID any, userID any) *MockService_GetUserRole_Call {
-	return &MockService_GetUserRole_Call{Call: _e.mock.On("GetUserRole", ctx, tenantID, userID)}
-}
-
-func (_c *MockService_GetUserRole_Call) Run(run func(ctx context.Context, tenantID string, userID string)) *MockService_GetUserRole_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockService_GetUserRole_Call) Return(role string, err error) *MockService_GetUserRole_Call {
-	_c.Call.Return(role, err)
-	return _c
-}
-
-func (_c *MockService_GetUserRole_Call) RunAndReturn(run func(ctx context.Context, tenantID string, userID string) (string, error)) *MockService_GetUserRole_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // KeepAliveSession provides a mock function for the type MockService
 func (_mock *MockService) KeepAliveSession(ctx context.Context, uid models.UID) error {
 	ret := _mock.Called(ctx, uid)
@@ -6242,6 +6170,86 @@ func (_c *MockService_ResolveInvitation_Call) Return(resolveInvitation *response
 }
 
 func (_c *MockService_ResolveInvitation_Call) RunAndReturn(run func(ctx context.Context, req *requests.ResolveInvitation) (*responses0.ResolveInvitation, error)) *MockService_ResolveInvitation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResolveNamespaceRole provides a mock function for the type MockService
+func (_mock *MockService) ResolveNamespaceRole(ctx context.Context, tenantID string, userID string) (*models.Namespace, string, error) {
+	ret := _mock.Called(ctx, tenantID, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveNamespaceRole")
+	}
+
+	var r0 *models.Namespace
+	var r1 string
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*models.Namespace, string, error)); ok {
+		return returnFunc(ctx, tenantID, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *models.Namespace); ok {
+		r0 = returnFunc(ctx, tenantID, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.Namespace)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) string); ok {
+		r1 = returnFunc(ctx, tenantID, userID)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string) error); ok {
+		r2 = returnFunc(ctx, tenantID, userID)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockService_ResolveNamespaceRole_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveNamespaceRole'
+type MockService_ResolveNamespaceRole_Call struct {
+	*mock.Call
+}
+
+// ResolveNamespaceRole is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tenantID string
+//   - userID string
+func (_e *MockService_Expecter) ResolveNamespaceRole(ctx any, tenantID any, userID any) *MockService_ResolveNamespaceRole_Call {
+	return &MockService_ResolveNamespaceRole_Call{Call: _e.mock.On("ResolveNamespaceRole", ctx, tenantID, userID)}
+}
+
+func (_c *MockService_ResolveNamespaceRole_Call) Run(run func(ctx context.Context, tenantID string, userID string)) *MockService_ResolveNamespaceRole_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockService_ResolveNamespaceRole_Call) Return(ns *models.Namespace, role string, err error) *MockService_ResolveNamespaceRole_Call {
+	_c.Call.Return(ns, role, err)
+	return _c
+}
+
+func (_c *MockService_ResolveNamespaceRole_Call) RunAndReturn(run func(ctx context.Context, tenantID string, userID string) (*models.Namespace, string, error)) *MockService_ResolveNamespaceRole_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/api/services/setup.go
+++ b/server/api/services/setup.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/cache"
 	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/envs"
 	"github.com/shellhub-io/shellhub/pkg/models"
@@ -127,6 +128,10 @@ func (s *service) Setup(ctx context.Context, req requests.Setup) (*models.UserAu
 	system.InstanceTenantID = namespace.TenantID
 	if err := s.store.SystemSet(ctx, system); err != nil {
 		return nil, err
+	}
+
+	if err := s.cache.Delete(ctx, cache.SystemKey); err != nil {
+		log.WithError(err).Warn("failed to evict the cached system row after setup")
 	}
 
 	// Issue an authenticated session for the admin we just created so the client can enter the

--- a/server/api/services/system.go
+++ b/server/api/services/system.go
@@ -6,10 +6,14 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/cache"
 	"github.com/shellhub-io/shellhub/pkg/envs"
+	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/api/pkg/responses"
+	log "github.com/sirupsen/logrus"
 )
 
 type SystemService interface {
@@ -22,8 +26,46 @@ type SystemService interface {
 	SystemDownloadInstallScript(ctx context.Context, req *requests.SystemInstallScript) (string, error)
 }
 
-func (s *service) GetSystemInfo(ctx context.Context, req *requests.GetSystemInfo) (*responses.SystemInfo, error) {
+// systemCacheTTL backstops invalidation, bounding how long a write this cache never hears
+// about can be served stale.
+const systemCacheTTL = time.Minute
+
+// systemGet reads the instance's singleton system row through the cache. The UI polls it on
+// every page load, but it only changes at setup and when an administrator reconfigures
+// authentication.
+//
+// Nothing is cached until setup completes: the transition is what the UI polls for, and the
+// admin CLI performs it on the first user it creates without any cache to invalidate. After
+// that the only mutable field this endpoint exposes is the local-authentication flag.
+//
+// Cloud and Enterprise serve /info from their own service, which caches the same key on its
+// own side because it has the SAML config to fetch alongside this row.
+func (s *service) systemGet(ctx context.Context) (*models.System, error) {
+	// Guard the authentication chain rather than just the hit: callers dereference it, and a
+	// cache miss leaves the value zeroed.
+	cached := new(models.System)
+	if err := s.cache.Get(ctx, cache.SystemKey, cached); err == nil &&
+		cached.Setup && cached.Authentication != nil && cached.Authentication.Local != nil {
+
+		return cached, nil
+	}
+
 	system, err := s.store.SystemGet(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if system.Setup {
+		if err := s.cache.Set(ctx, cache.SystemKey, system, systemCacheTTL); err != nil {
+			log.WithError(err).Warn("failed to cache the system row")
+		}
+	}
+
+	return system, nil
+}
+
+func (s *service) GetSystemInfo(ctx context.Context, req *requests.GetSystemInfo) (*responses.SystemInfo, error) {
+	system, err := s.systemGet(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/api/services/system_test.go
+++ b/server/api/services/system_test.go
@@ -1,10 +1,18 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
+	"github.com/shellhub-io/shellhub/pkg/cache"
+	cachemock "github.com/shellhub-io/shellhub/pkg/cache/mocks"
+	"github.com/shellhub-io/shellhub/pkg/errors"
+	"github.com/shellhub-io/shellhub/pkg/models"
+	storemock "github.com/shellhub-io/shellhub/server/api/store/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildInstallOverrides(t *testing.T) {
@@ -103,4 +111,98 @@ func TestBuildInstallOverrides(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSystemGet(t *testing.T) {
+	setupSystem := &models.System{
+		Setup: true,
+		Authentication: &models.SystemAuthentication{
+			Local: &models.SystemAuthenticationLocal{Enabled: true},
+		},
+	}
+
+	t.Run("serves a cached row without touching the store", func(t *testing.T) {
+		storeMock := storemock.NewMockStore(t)
+		cacheMock := cachemock.NewMockCache(t)
+
+		cacheMock.
+			On("Get", mock.Anything, cache.SystemKey, mock.AnythingOfType("*models.System")).
+			Run(func(args mock.Arguments) { *args.Get(2).(*models.System) = *setupSystem }).
+			Return(nil).
+			Once()
+
+		system, err := NewService(storeMock, privateKey, publicKey, cacheMock).systemGet(context.TODO())
+		require.NoError(t, err)
+		assert.Equal(t, setupSystem, system)
+	})
+
+	// A miss leaves the destination zeroed and reports no error, so the hit is only usable once
+	// the guard has confirmed the row is actually populated.
+	t.Run("reads through on a miss and caches the result", func(t *testing.T) {
+		storeMock := storemock.NewMockStore(t)
+		cacheMock := cachemock.NewMockCache(t)
+
+		cacheMock.On("Get", mock.Anything, cache.SystemKey, mock.AnythingOfType("*models.System")).Return(nil).Once()
+		storeMock.On("SystemGet", mock.Anything).Return(setupSystem, nil).Once()
+		cacheMock.On("Set", mock.Anything, cache.SystemKey, setupSystem, systemCacheTTL).Return(nil).Once()
+
+		system, err := NewService(storeMock, privateKey, publicKey, cacheMock).systemGet(context.TODO())
+		require.NoError(t, err)
+		assert.Equal(t, setupSystem, system)
+	})
+
+	// The setup flow polls this endpoint to learn setup completed, and the admin CLI flips the
+	// flag from a package with no access to this cache. Caching only after the transition is what
+	// keeps that from being served stale.
+	t.Run("does not cache before setup completes", func(t *testing.T) {
+		pending := &models.System{Setup: false, Authentication: setupSystem.Authentication}
+
+		storeMock := storemock.NewMockStore(t)
+		cacheMock := cachemock.NewMockCache(t)
+
+		cacheMock.On("Get", mock.Anything, cache.SystemKey, mock.AnythingOfType("*models.System")).Return(nil).Once()
+		storeMock.On("SystemGet", mock.Anything).Return(pending, nil).Once()
+
+		system, err := NewService(storeMock, privateKey, publicKey, cacheMock).systemGet(context.TODO())
+		require.NoError(t, err)
+		assert.False(t, system.Setup)
+	})
+
+	// GetSystemInfo dereferences Authentication.Local, so a hit missing it must not be served.
+	t.Run("ignores a cached row with no authentication", func(t *testing.T) {
+		storeMock := storemock.NewMockStore(t)
+		cacheMock := cachemock.NewMockCache(t)
+
+		cacheMock.
+			On("Get", mock.Anything, cache.SystemKey, mock.AnythingOfType("*models.System")).
+			Run(func(args mock.Arguments) { *args.Get(2).(*models.System) = models.System{Setup: true} }).
+			Return(nil).
+			Once()
+		storeMock.On("SystemGet", mock.Anything).Return(setupSystem, nil).Once()
+		cacheMock.On("Set", mock.Anything, cache.SystemKey, setupSystem, systemCacheTTL).Return(nil).Once()
+
+		system, err := NewService(storeMock, privateKey, publicKey, cacheMock).systemGet(context.TODO())
+		require.NoError(t, err)
+		require.NotNil(t, system.Authentication)
+		assert.True(t, system.Authentication.Local.Enabled)
+	})
+
+	t.Run("serves the row when the cache is unreachable", func(t *testing.T) {
+		storeMock := storemock.NewMockStore(t)
+		cacheMock := cachemock.NewMockCache(t)
+
+		cacheMock.
+			On("Get", mock.Anything, cache.SystemKey, mock.AnythingOfType("*models.System")).
+			Return(errors.New("connection refused", "", 0)).
+			Once()
+		storeMock.On("SystemGet", mock.Anything).Return(setupSystem, nil).Once()
+		cacheMock.
+			On("Set", mock.Anything, cache.SystemKey, setupSystem, systemCacheTTL).
+			Return(errors.New("connection refused", "", 0)).
+			Once()
+
+		system, err := NewService(storeMock, privateKey, publicKey, cacheMock).systemGet(context.TODO())
+		require.NoError(t, err)
+		assert.Equal(t, setupSystem, system)
+	})
 }

--- a/server/api/store/mocks/mock_store.go
+++ b/server/api/store/mocks/mock_store.go
@@ -3789,6 +3789,72 @@ func (_c *MockStore_NamespaceDeleteMembership_Call) RunAndReturn(run func(ctx co
 	return _c
 }
 
+// NamespaceGetDeviceLimit provides a mock function for the type MockStore
+func (_mock *MockStore) NamespaceGetDeviceLimit(ctx context.Context, tenantID string) (models.NamespaceDeviceLimit, error) {
+	ret := _mock.Called(ctx, tenantID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for NamespaceGetDeviceLimit")
+	}
+
+	var r0 models.NamespaceDeviceLimit
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (models.NamespaceDeviceLimit, error)); ok {
+		return returnFunc(ctx, tenantID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) models.NamespaceDeviceLimit); ok {
+		r0 = returnFunc(ctx, tenantID)
+	} else {
+		r0 = ret.Get(0).(models.NamespaceDeviceLimit)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, tenantID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_NamespaceGetDeviceLimit_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'NamespaceGetDeviceLimit'
+type MockStore_NamespaceGetDeviceLimit_Call struct {
+	*mock.Call
+}
+
+// NamespaceGetDeviceLimit is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tenantID string
+func (_e *MockStore_Expecter) NamespaceGetDeviceLimit(ctx any, tenantID any) *MockStore_NamespaceGetDeviceLimit_Call {
+	return &MockStore_NamespaceGetDeviceLimit_Call{Call: _e.mock.On("NamespaceGetDeviceLimit", ctx, tenantID)}
+}
+
+func (_c *MockStore_NamespaceGetDeviceLimit_Call) Run(run func(ctx context.Context, tenantID string)) *MockStore_NamespaceGetDeviceLimit_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_NamespaceGetDeviceLimit_Call) Return(namespaceDeviceLimit models.NamespaceDeviceLimit, err error) *MockStore_NamespaceGetDeviceLimit_Call {
+	_c.Call.Return(namespaceDeviceLimit, err)
+	return _c
+}
+
+func (_c *MockStore_NamespaceGetDeviceLimit_Call) RunAndReturn(run func(ctx context.Context, tenantID string) (models.NamespaceDeviceLimit, error)) *MockStore_NamespaceGetDeviceLimit_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NamespaceGetMembers provides a mock function for the type MockStore
 func (_mock *MockStore) NamespaceGetMembers(ctx context.Context, sc scope.Scope, opts ...store.QueryOption) ([]models.MemberView, int, error) {
 	var tmpRet mock.Arguments

--- a/server/api/store/namespace.go
+++ b/server/api/store/namespace.go
@@ -29,6 +29,13 @@ type NamespaceStore interface {
 	// It returns the resolved namespace if found and an error, if any.
 	NamespaceResolve(ctx context.Context, resolver NamespaceResolver, value string) (*models.Namespace, error)
 
+	// NamespaceGetDeviceLimit returns the namespace's device ceiling and its accepted-device
+	// count. It exists so the device-limit check does not have to go through NamespaceResolve,
+	// which carries every membership and its user for callers that never read them.
+	//
+	// It returns ErrNoDocuments when no namespace matches the tenant ID.
+	NamespaceGetDeviceLimit(ctx context.Context, tenantID string) (models.NamespaceDeviceLimit, error)
+
 	// NamespaceGetMembers returns the namespace's members as enriched MemberView rows (name,
 	// username, email, role and a flattened status), joining the users table so the caller gets
 	// full identity rather than the thin Member embedded in a namespace. A list of options can be

--- a/server/api/store/pg/namespace.go
+++ b/server/api/store/pg/namespace.go
@@ -205,6 +205,28 @@ func (pg *Pg) NamespaceResolve(ctx context.Context, resolver store.NamespaceReso
 	return entity.NamespaceToModel(ns), nil
 }
 
+func (pg *Pg) NamespaceGetDeviceLimit(ctx context.Context, tenantID string) (models.NamespaceDeviceLimit, error) {
+	db := pg.GetConnection(ctx)
+
+	limit := models.NamespaceDeviceLimit{}
+
+	// Same guard as NamespaceResolve: namespaces.id is uuid-typed, so a malformed value
+	// would reach Postgres and fail with SQLSTATE 22P02 instead of a clean not-found.
+	if _, err := uuid.Parse(tenantID); err != nil {
+		return limit, store.ErrNoDocuments
+	}
+
+	if err := db.NewSelect().
+		Model((*entity.Namespace)(nil)).
+		Column("max_devices", "devices_accepted_count").
+		Where("id = ?", tenantID).
+		Scan(ctx, &limit.MaxDevices, &limit.DevicesAcceptedCount); err != nil {
+		return models.NamespaceDeviceLimit{}, fromSQLError(err)
+	}
+
+	return limit, nil
+}
+
 func (pg *Pg) NamespaceGetMembers(ctx context.Context, sc scope.Scope, opts ...store.QueryOption) ([]models.MemberView, int, error) {
 	db := pg.GetConnection(ctx)
 

--- a/server/api/store/pg/stats.go
+++ b/server/api/store/pg/stats.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/shellhub-io/shellhub/pkg/api/scope"
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/api/store"
 	"github.com/shellhub-io/shellhub/server/api/store/pg/entity"
@@ -18,34 +19,31 @@ func (pg *Pg) GetStats(ctx context.Context, sc scope.Scope) (*models.Stats, erro
 		return nil, store.ErrInvalidScope
 	}
 
-	onlineDevicesQuery := buildOnlineDevicesQuery(db, sc)
-	onlineDevices, err := onlineDevicesQuery.Count(ctx)
+	onlineDevices, err := countInScope(ctx, buildOnlineDevicesQuery(db), sc)
 	if err != nil {
-		return nil, fromSQLError(err)
+		return nil, err
 	}
 
-	registeredDevicesQuery := buildRegisteredDevicesQuery(db, sc)
-	registeredDevices, err := registeredDevicesQuery.Count(ctx)
+	registeredDevices, err := countInScope(ctx, buildRegisteredDevicesQuery(db), sc)
 	if err != nil {
-		return nil, fromSQLError(err)
+		return nil, err
 	}
 
-	pendingDevicesQuery := buildPendingDevicesQuery(db, sc)
-	pendingDevices, err := pendingDevicesQuery.Count(ctx)
+	pendingDevices, err := countInScope(ctx, buildPendingDevicesQuery(db), sc)
 	if err != nil {
-		return nil, fromSQLError(err)
+		return nil, err
 	}
 
-	rejectedDevicesQuery := buildRejectedDevicesQuery(db, sc)
-	rejectedDevices, err := rejectedDevicesQuery.Count(ctx)
+	rejectedDevices, err := countInScope(ctx, buildRejectedDevicesQuery(db), sc)
 	if err != nil {
-		return nil, fromSQLError(err)
+		return nil, err
 	}
 
-	activeSessionsQuery := buildActiveSessionsQuery(db, sc)
-	activeSessions, err := activeSessionsQuery.Count(ctx)
+	// The active-session count reaches the namespace through devices, so the scope predicate
+	// has to name that table rather than the query's own model.
+	activeSessions, err := countInScope(context.WithValue(ctx, CtxTableAlias, "devices"), buildActiveSessionsQuery(db), sc)
 	if err != nil {
-		return nil, fromSQLError(err)
+		return nil, err
 	}
 
 	stats := &models.Stats{
@@ -59,65 +57,49 @@ func (pg *Pg) GetStats(ctx context.Context, sc scope.Scope) (*models.Stats, erro
 	return stats, nil
 }
 
-func buildOnlineDevicesQuery(db bun.IDB, sc scope.Scope) *bun.SelectQuery {
-	query := db.NewSelect().
+func countInScope(ctx context.Context, query *bun.SelectQuery, sc scope.Scope) (int, error) {
+	query, err := applyScopedOptions(ctx, query, sc)
+	if err != nil {
+		return 0, err
+	}
+
+	count, err := query.Count(ctx)
+	if err != nil {
+		return 0, fromSQLError(err)
+	}
+
+	return count, nil
+}
+
+func buildOnlineDevicesQuery(db bun.IDB) *bun.SelectQuery {
+	return db.NewSelect().
 		Model((*entity.Device)(nil)).
 		Where("disconnected_at IS NULL").
-		Where("last_seen > ?", time.Now().Add(-2*time.Minute)).
+		Where("last_seen > ?", clock.Now().Add(-2*time.Minute)).
 		Where("status = ?", "accepted")
-
-	if sc.IsBounded() {
-		query = query.Where("namespace_id = (SELECT id FROM namespaces WHERE id = ?)", sc.TenantID())
-	}
-
-	return query
 }
 
-func buildRegisteredDevicesQuery(db bun.IDB, sc scope.Scope) *bun.SelectQuery {
-	query := db.NewSelect().
+func buildRegisteredDevicesQuery(db bun.IDB) *bun.SelectQuery {
+	return db.NewSelect().
 		Model((*entity.Device)(nil)).
 		Where("status = ?", "accepted")
-
-	if sc.IsBounded() {
-		query = query.Where("namespace_id = (SELECT id FROM namespaces WHERE id = ?)", sc.TenantID())
-	}
-
-	return query
 }
 
-func buildPendingDevicesQuery(db bun.IDB, sc scope.Scope) *bun.SelectQuery {
-	query := db.NewSelect().
+func buildPendingDevicesQuery(db bun.IDB) *bun.SelectQuery {
+	return db.NewSelect().
 		Model((*entity.Device)(nil)).
 		Where("status = ?", "pending")
-
-	if sc.IsBounded() {
-		query = query.Where("namespace_id = (SELECT id FROM namespaces WHERE id = ?)", sc.TenantID())
-	}
-
-	return query
 }
 
-func buildRejectedDevicesQuery(db bun.IDB, sc scope.Scope) *bun.SelectQuery {
-	query := db.NewSelect().
+func buildRejectedDevicesQuery(db bun.IDB) *bun.SelectQuery {
+	return db.NewSelect().
 		Model((*entity.Device)(nil)).
 		Where("status = ?", "rejected")
-
-	if sc.IsBounded() {
-		query = query.Where("namespace_id = (SELECT id FROM namespaces WHERE id = ?)", sc.TenantID())
-	}
-
-	return query
 }
 
-func buildActiveSessionsQuery(db bun.IDB, sc scope.Scope) *bun.SelectQuery {
-	query := db.NewSelect().
+func buildActiveSessionsQuery(db bun.IDB) *bun.SelectQuery {
+	return db.NewSelect().
 		Model((*entity.ActiveSession)(nil)).
 		Join("JOIN sessions ON active_session.session_id = sessions.id").
 		Join("JOIN devices ON sessions.device_id = devices.id")
-
-	if sc.IsBounded() {
-		query = query.Where("devices.namespace_id = (SELECT id FROM namespaces WHERE id = ?)", sc.TenantID())
-	}
-
-	return query
 }

--- a/server/api/store/pg/store_test.go
+++ b/server/api/store/pg/store_test.go
@@ -31,6 +31,7 @@ func TestPgStore(t *testing.T) {
 	runSubSuite(t, "NamespaceStore", func(suite *storetest.Suite, t *testing.T) {
 		suite.TestNamespaceList(t)
 		suite.TestNamespaceResolve(t)
+		suite.TestNamespaceGetDeviceLimit(t)
 		suite.TestNamespaceGetPreferred(t)
 		suite.TestNamespaceCreate(t)
 		suite.TestNamespaceCreateDuplicate(t)
@@ -109,6 +110,7 @@ func TestPgStore(t *testing.T) {
 
 	runSubSuite(t, "StatsStore", func(suite *storetest.Suite, t *testing.T) {
 		suite.TestGetStats(t)
+		suite.TestGetStatsOnlineBoundary(t)
 	})
 
 	runSubSuite(t, "PrivateKeyStore", func(suite *storetest.Suite, t *testing.T) {

--- a/server/api/store/storetest/helpers.go
+++ b/server/api/store/storetest/helpers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/shellhub-io/shellhub/pkg/api/authorizer"
 	"github.com/shellhub-io/shellhub/pkg/api/scope"
+	"github.com/shellhub-io/shellhub/pkg/clock"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/pkg/uuid"
 	"github.com/shellhub-io/shellhub/server/api/store"
@@ -182,6 +183,13 @@ func WithDeviceRemovedAt(removedAt *time.Time) DeviceOption {
 	}
 }
 
+// WithDeviceLastSeen sets the last_seen timestamp
+func WithDeviceLastSeen(lastSeen time.Time) DeviceOption {
+	return func(d *models.Device) {
+		d.LastSeen = lastSeen
+	}
+}
+
 // WithDeviceStatusUpdatedAt sets the status_updated_at timestamp
 func WithDeviceStatusUpdatedAt(statusUpdatedAt time.Time) DeviceOption {
 	return func(d *models.Device) {
@@ -209,6 +217,24 @@ func nextDeviceMAC() string {
 	n := deviceSeq.Add(1)
 
 	return fmt.Sprintf("00:00:%02x:%02x:%02x:%02x", (n>>24)&0xFF, (n>>16)&0xFF, (n>>8)&0xFF, n&0xFF)
+}
+
+// fixedClock pins clock.Now so a test can place a row at an arbitrary point in time.
+type fixedClock struct{ now time.Time }
+
+func (c *fixedClock) Now() time.Time { return c.now }
+
+// pinClock redirects the package clock for the duration of the test and returns the handle the
+// test moves to advance time.
+func pinClock(t *testing.T, at time.Time) *fixedClock {
+	t.Helper()
+
+	clk := &fixedClock{now: at}
+	prev := clock.DefaultBackend
+	t.Cleanup(func() { clock.DefaultBackend = prev })
+	clock.DefaultBackend = clk
+
+	return clk
 }
 
 // CreateDevice creates a device with default or customized values

--- a/server/api/store/storetest/namespace_tests.go
+++ b/server/api/store/storetest/namespace_tests.go
@@ -189,6 +189,46 @@ func (s *Suite) TestNamespaceResolve(t *testing.T) {
 	})
 }
 
+// TestNamespaceGetDeviceLimit tests the narrow device-ceiling read
+func (s *Suite) TestNamespaceGetDeviceLimit(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	t.Run("returns the ceiling and the accepted count", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		tenantID := s.CreateNamespace(t)
+		require.NoError(t, st.NamespaceIncrementDeviceCount(ctx, scope.MustBounded(tenantID), models.DeviceStatusAccepted, 2))
+
+		ns, err := st.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, tenantID)
+		require.NoError(t, err)
+
+		limit, err := st.NamespaceGetDeviceLimit(ctx, tenantID)
+		require.NoError(t, err)
+
+		// The narrow read must agree with the full resolve it replaces.
+		assert.Equal(t, ns.MaxDevices, limit.MaxDevices)
+		assert.Equal(t, ns.DevicesAcceptedCount, limit.DevicesAcceptedCount)
+		assert.Equal(t, int64(2), limit.DevicesAcceptedCount)
+	})
+
+	t.Run("returns ErrNoDocuments for non-existent tenant ID", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		limit, err := st.NamespaceGetDeviceLimit(ctx, "00000000-0000-0000-0000-000000000000")
+		assert.ErrorIs(t, err, store.ErrNoDocuments)
+		assert.Zero(t, limit)
+	})
+
+	t.Run("returns ErrNoDocuments for malformed tenant ID", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+
+		limit, err := st.NamespaceGetDeviceLimit(ctx, "83176492-e6cl-43d7-922e-ee01c3693e26")
+		assert.ErrorIs(t, err, store.ErrNoDocuments)
+		assert.Zero(t, limit)
+	})
+}
+
 // TestNamespaceGetPreferred tests getting user's preferred namespace
 func (s *Suite) TestNamespaceGetPreferred(t *testing.T) {
 	ctx := context.Background()

--- a/server/api/store/storetest/stats_tests.go
+++ b/server/api/store/storetest/stats_tests.go
@@ -3,6 +3,7 @@ package storetest
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/shellhub-io/shellhub/pkg/api/scope"
 
@@ -90,5 +91,50 @@ func (s *Suite) TestGetStats(t *testing.T) {
 		assert.Equal(t, 0, stats.ActiveSessions)
 		assert.Equal(t, 0, stats.PendingDevices)
 		assert.Equal(t, 0, stats.RejectedDevices)
+	})
+}
+
+// TestGetStatsOnlineBoundary pins the clock to assert the two-minute window that decides
+// whether a device counts as online. The other stats tests create devices at the current
+// time, so they pass whether the query reads the package clock or the wall clock; this one
+// does not.
+func (s *Suite) TestGetStatsOnlineBoundary(t *testing.T) {
+	ctx := context.Background()
+	st := s.provider.Store()
+
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+
+	t.Run("counts only devices seen within the window", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+		pinClock(t, now)
+
+		tenantID := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("accepted"), WithDeviceLastSeen(now.Add(-1*time.Minute)))
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("accepted"), WithDeviceLastSeen(now.Add(-3*time.Minute)))
+
+		stats, err := st.GetStats(ctx, scope.MustBounded(tenantID))
+		require.NoError(t, err)
+		require.NotNil(t, stats)
+
+		assert.Equal(t, 1, stats.OnlineDevices)
+		assert.Equal(t, 2, stats.RegisteredDevices, "both devices are registered regardless of presence")
+	})
+
+	t.Run("moving the clock past the window takes a device offline", func(t *testing.T) {
+		require.NoError(t, s.provider.CleanDatabase(t))
+		clk := pinClock(t, now)
+
+		tenantID := s.CreateNamespace(t)
+		s.CreateDevice(t, WithTenantID(tenantID), WithDeviceStatus("accepted"), WithDeviceLastSeen(now.Add(-1*time.Minute)))
+
+		stats, err := st.GetStats(ctx, scope.MustBounded(tenantID))
+		require.NoError(t, err)
+		assert.Equal(t, 1, stats.OnlineDevices)
+
+		clk.now = now.Add(2 * time.Minute)
+
+		stats, err = st.GetStats(ctx, scope.MustBounded(tenantID))
+		require.NoError(t, err)
+		assert.Equal(t, 0, stats.OnlineDevices, "the window follows the clock, not wall time")
 	})
 }

--- a/server/api/store/storetest/suite.go
+++ b/server/api/store/storetest/suite.go
@@ -19,6 +19,7 @@ func (s *Suite) Run(t *testing.T) {
 	t.Run("NamespaceStore", func(t *testing.T) {
 		s.TestNamespaceList(t)
 		s.TestNamespaceResolve(t)
+		s.TestNamespaceGetDeviceLimit(t)
 		s.TestNamespaceGetPreferred(t)
 		s.TestNamespaceCreate(t)
 		s.TestNamespaceCreateDuplicate(t)
@@ -99,6 +100,7 @@ func (s *Suite) Run(t *testing.T) {
 
 	t.Run("StatsStore", func(t *testing.T) {
 		s.TestGetStats(t)
+		s.TestGetStatsOnlineBoundary(t)
 	})
 
 	t.Run("PrivateKeyStore", func(t *testing.T) {


### PR DESCRIPTION
## What

Cuts identity resolution on an authenticated device-list request from five statements to
three, removes five `namespaces` scans per `/stats` call, and puts the `systems` singleton
behind the cache.

This branch applies directly on top of `master` — it is no longer stacked on #6888. It is a
single commit; the clock-pinning store tests are part of it, since they assert this change's
own switch from `time.Now()` to `clock.Now()`.

## Why

Part of shellhub-io/team#200. On the 58,670-device production instance the review measured,
a **2-row** `namespaces` table took **1,371,078,783** sequential scans in 66 days, with
`users` and `memberships` at ~472 million each. The plans are correct — PostgreSQL should
seq-scan a 2-row table — so the cost is call volume, not query shape, and no index would
help.

Traced to source, one authenticated `GET /api/devices` spends five statements establishing
who is calling against two that answer the request:

1. `Authenticator.Resolve` → `GetUserRole` → `NamespaceResolve`, which carries
   `Relation("Memberships.User")` — bun issues the has-many as a **second** statement.
2. `GetUserAdmin` → `UserResolve`, a third, on `users`.
3. `ListDevices` then resolves **the same namespace again**, memberships included, purely to
   read two integers off it (`HasMaxDevices` / `HasMaxDevicesReached`).

That mechanism is why `users` and `memberships` sit at near-identical counts, and why
`namespaces` runs ahead of both — it is fetched twice per request.

## Changes

- **`NamespaceGetDeviceLimit`**: reads the two columns the device-limit check needs. Kept
  **additive** on purpose — `NamespaceResolve` keeps its relation, so the ~40 sites in the
  `cloud` repo that read memberships off a resolved namespace are untouched. Dropping the
  relation from `NamespaceResolve` itself would have broken cloud at runtime, not at compile
  time.
- **`models.NamespaceDeviceLimit`**: the ceiling rule moves here;
  `Namespace.HasMaxDevices`/`HasMaxDevicesReached` delegate, so it stays defined once.
- **`authctx`**: the authenticator forwards the limit it already read, paired with the tenant
  it belongs to so a request targeting another namespace cannot be answered from it. The
  guard lives inside the accessor rather than at the call site, so a future caller cannot
  skip it. Falls back to the store when the request carries no limit — API keys, internal
  callers, the admin surface.
- **`GetUserRole` deleted**: it had become a one-line wrapper over `ResolveNamespaceRole`
  with a single caller.
- **`GetStats`**: its five counts bounded the namespace with
  `namespace_id = (SELECT id FROM namespaces WHERE id = ?)`, one `namespaces` scan per stat,
  where every other scoped query in the store uses the shared scope option. They now do too.
- **`systems` cache**: one row, **10,401,522** sequential scans and **zero** index scans in
  the same window. The key gets a single definition in `pkg/cache` — it is spelled in three
  packages across two repositories, and a second literal would silently stop invalidating. It
  was already spelled twice, with nothing populating it.

## Reviewer notes

**Re-fetching per request stays deliberate.** `authn.go` re-reads role and admin on every
request because shellhub-io/team#193 found a demoted admin keeping API access for up to 72
hours. This PR does not cache them; it removes the *duplicate* resolve in the handler. Any
future identity cache needs explicit invalidation on membership/role/user writes.

**One error code changes.** `scope.NewBounded` rejects only *empty* tenant IDs, so a bounded
scope can carry a malformed UUID. It used to reach PostgreSQL as SQLSTATE 22P02; the shared
scope option's guard now returns `ErrNoDocuments`, matching `NamespaceResolve` and the rest of
the store.

**`pinClock` now lives in `storetest/helpers.go`.** #6888 introduced the helper next to the
session-retention tests it was written for. This PR needs it and no longer sits on that
branch, so the helper moves to the shared helpers file. If #6888 rebases onto a `master` that
carries this PR, it must drop its own copy.

**The `systems` cache does not help Enterprise or Cloud on its own** — they serve `/info`
from their own service. shellhub-io/cloud#2491 covers that side, and must land
with this PR anyway: `NamespaceGetDeviceLimit` on the store interface requires cloud's
generated mock to be regenerated, or cloud's test build fails in eight packages.

**Not in this PR**, and deliberately so: caching identity resolution (needs its own design
against the #193 constraint), the unattributed `sessions` scans (blocked on
`pg_stat_statements` in #6886), the `devices` online count (moved to
shellhub-io/team#209), and the enterprise license evaluator's unbounded `GetStats` — split
out to shellhub-io/team#212 after it turned out to account for ~43% of the `devices`
sequential scans on that host.

## Testing

`server`: full suite and `golangci-lint` clean; root `pkg/models` and `pkg/cache` clean.

Worth probing:

- `TestGetStats` already covers cross-tenant isolation on the rewritten counts, including the
  active-session count that reaches the namespace through `devices` — that one needed a table
  alias, and a wrong alias would silently widen the bound rather than error.
- `TestSystemGet` covers the subtle path: `Cache.Get` reports **no error** on a miss and
  leaves the destination zeroed, so the `Setup && Authentication.Local != nil` guard is the
  only thing standing between a miss and a zero-value response.
- `TestGetStatsOnlineBoundary` fails if `buildOnlineDevicesQuery` goes back to `time.Now()`;
  verified by reverting it.
