### PR TITLE
fix(server): close the connection a device reconnect displaced

### DIFF
--- a/server/ssh/pkg/dialer/manager.go
+++ b/server/ssh/pkg/dialer/manager.go
@@ -3,6 +3,7 @@ package dialer
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"time"
@@ -32,15 +33,7 @@ func NewManager() *Manager {
 func (m *Manager) Set(key string, conn *wsconnadapter.Adapter, connPath string) {
 	dialer := revdial.NewDialer(conn.Logger, conn, connPath)
 
-	m.Connections.Store(key, dialer)
-
-	if size := m.Connections.Size(key); size > 1 {
-		log.WithFields(log.Fields{
-			"key":  key,
-			"size": size,
-		}).Warning("Multiple connections stored for the same identifier.")
-	}
-
+	m.evict(key, m.Connections.Store(key, dialer))
 	m.DialerKeepAliveCallback(key)
 
 	// Start the ping loop and get the channel for pong responses
@@ -54,10 +47,49 @@ func (m *Manager) Set(key string, conn *wsconnadapter.Adapter, connPath string) 
 
 				continue
 			case <-dialer.Done():
-				m.Connections.Delete(key, dialer)
-				m.DialerDoneCallback(key)
+				if m.Connections.Delete(key, dialer) == 0 {
+					m.DialerDoneCallback(key)
+				}
 
 				return
+			}
+		}
+	}()
+}
+
+// evict closes the connections a new registration for key displaced.
+//
+// A device that reconnects before the server has noticed its previous socket
+// is gone registers a second connection for the same identifier. Only the last
+// one is ever dialed, so the earlier ones are dead weight: they hold their
+// sockets and buffers until their own ping loop times out, which is up to
+// [BindPingInterval] away and never arrives at all for a peer that vanished
+// without resetting the connection.
+//
+// Closing runs in its own goroutine because it is teardown of an already
+// abandoned connection, and [revdial.Dialer.Close] blocks until its owner
+// observes the close. Neither belongs on the path registering the live
+// connection.
+func (m *Manager) evict(key string, displaced []interface{}) {
+	if len(displaced) == 0 {
+		return
+	}
+
+	log.WithFields(log.Fields{
+		"key":  key,
+		"size": len(displaced) + 1,
+	}).Warning("Multiple connections stored for the same identifier.")
+
+	go func() {
+		for _, conn := range displaced {
+			closer, ok := conn.(io.Closer)
+			if !ok {
+				continue
+			}
+
+			if err := closer.Close(); err != nil {
+				log.WithError(err).WithField("key", key).
+					Warning("failed to close a displaced connection")
 			}
 		}
 	}()
@@ -94,15 +126,7 @@ func (m *Manager) Bind(tenant string, uid string, conn *wsconnadapter.Adapter) e
 		return err
 	}
 
-	m.Connections.Store(key, session)
-
-	if size := m.Connections.Size(key); size > 1 {
-		log.WithFields(log.Fields{
-			"key":  key,
-			"size": size,
-		}).Warning("Multiple connections stored for the same identifier.")
-	}
-
+	m.evict(key, m.Connections.Store(key, session))
 	m.DialerKeepAliveCallback(key)
 
 	go func() {
@@ -115,8 +139,9 @@ func (m *Manager) Bind(tenant string, uid string, conn *wsconnadapter.Adapter) e
 						"key": key,
 					}).WithError(err).Error("failed to ping yamux session")
 
-					m.Connections.Delete(key, session)
-					m.DialerDoneCallback(key)
+					if m.Connections.Delete(key, session) == 0 {
+						m.DialerDoneCallback(key)
+					}
 
 					return
 				}
@@ -125,8 +150,9 @@ func (m *Manager) Bind(tenant string, uid string, conn *wsconnadapter.Adapter) e
 
 				continue
 			case <-session.CloseChan():
-				m.Connections.Delete(key, session)
-				m.DialerDoneCallback(key)
+				if m.Connections.Delete(key, session) == 0 {
+					m.DialerDoneCallback(key)
+				}
 
 				return
 			}

--- a/server/ssh/pkg/dialer/manager_test.go
+++ b/server/ssh/pkg/dialer/manager_test.go
@@ -3,12 +3,42 @@ package dialer
 import (
 	"context"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/hashicorp/yamux"
+	"github.com/shellhub-io/shellhub/pkg/wsconnadapter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newAgentConn returns the server side of a live WebSocket, as the connection
+// handler hands it to Bind. The peer is left connected and silent, so the
+// session stays up until the test closes it.
+func newAgentConn(t *testing.T) *wsconnadapter.Adapter {
+	t.Helper()
+
+	ready := make(chan *wsconnadapter.Adapter, 1)
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+
+		ready <- wsconnadapter.New(conn)
+	}))
+	t.Cleanup(srv.Close)
+
+	peer, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { peer.Close() })
+
+	return <-ready
+}
 
 func TestManagerDialFailsWhenTheStreamCannotBeOpened(t *testing.T) {
 	server, agent := net.Pipe()
@@ -30,4 +60,61 @@ func TestManagerDialFailsWhenTheStreamCannotBeOpened(t *testing.T) {
 	assert.Error(t, err, "a stream that could not be opened must be reported to the caller")
 	assert.Nil(t, conn)
 	assert.Equal(t, TransportVersionUnknown, version)
+}
+
+func TestManagerBindClosesTheConnectionItDisplaced(t *testing.T) {
+	key := NewKey("tenant", "uid")
+
+	offline := make(chan string, 1)
+
+	m := NewManager()
+	m.DialerDoneCallback = func(key string) { offline <- key }
+
+	require.NoError(t, m.Bind("tenant", "uid", newAgentConn(t)))
+
+	stored, ok := m.Connections.Load(key)
+	require.True(t, ok)
+	displaced := stored.(*yamux.Session)
+
+	require.NoError(t, m.Bind("tenant", "uid", newAgentConn(t)))
+
+	assert.Eventually(t, displaced.IsClosed, time.Second, 10*time.Millisecond,
+		"a reconnect must close the connection it replaced instead of leaving it resident")
+
+	assert.Eventually(t, func() bool { return m.Connections.Size(key) == 1 },
+		time.Second, 10*time.Millisecond, "only the live connection may remain registered")
+
+	stored, ok = m.Connections.Load(key)
+	require.True(t, ok)
+	assert.NotSame(t, displaced, stored.(*yamux.Session), "the live connection is the one that is dialed")
+
+	select {
+	case key := <-offline:
+		t.Fatalf("device %q was marked offline while a live connection remained", key)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestManagerReportsTheDeviceOfflineWhenItsLastConnectionGoes(t *testing.T) {
+	key := NewKey("tenant", "uid")
+
+	offline := make(chan string, 1)
+
+	m := NewManager()
+	m.DialerDoneCallback = func(key string) { offline <- key }
+
+	require.NoError(t, m.Bind("tenant", "uid", newAgentConn(t)))
+
+	stored, ok := m.Connections.Load(key)
+	require.True(t, ok)
+	require.NoError(t, stored.(*yamux.Session).Close())
+
+	select {
+	case reported := <-offline:
+		assert.Equal(t, key, reported)
+	case <-time.After(time.Second):
+		t.Fatal("the device was never reported offline")
+	}
+
+	assert.Equal(t, 0, m.Connections.Size(key))
 }

--- a/server/ssh/pkg/dialer/syncslicemap.go
+++ b/server/ssh/pkg/dialer/syncslicemap.go
@@ -1,54 +1,77 @@
 package dialer
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
-// SyncSliceMap is a struct that uses sync.Map and stores values in a slice.
+// SyncSliceMap is a map that holds a slice of values per key, safe for
+// concurrent use.
+//
+// Its mutating operations report what they observed under the lock: Store
+// returns the values it displaced and Delete the count that survived. Callers
+// need both to decide whether a key has just gained a duplicate or lost its
+// last value, and reading them back afterwards would race with the next
+// caller.
 type SyncSliceMap struct {
-	syncMap sync.Map
+	mu     sync.RWMutex
+	values map[interface{}][]interface{}
 }
 
-// Load retrieves the last value associated with the key in the slice along with the size of the slice.
+// Load retrieves the most recently stored value for the key.
 func (ssm *SyncSliceMap) Load(key interface{}) (interface{}, bool) {
-	if values, ok := ssm.syncMap.Load(key); ok {
-		if valSlice := values.([]interface{}); len(valSlice) > 0 {
-			return valSlice[len(valSlice)-1], true
-		}
+	ssm.mu.RLock()
+	defer ssm.mu.RUnlock()
+
+	if values := ssm.values[key]; len(values) > 0 {
+		return values[len(values)-1], true
 	}
 
 	return nil, false
 }
 
-// Store appends the value to the slice associated with the key and updates the value in sync.Map.
-// It returns the size of the slice after the append operation.
-func (ssm *SyncSliceMap) Store(key, value interface{}) {
-	ssm.syncMap.LoadOrStore(key, []interface{}{})
-	ssm.syncMap.Store(key, append(ssm.getValues(key), value))
+// Store appends the value to the key's slice and returns the values that were
+// already stored under it.
+func (ssm *SyncSliceMap) Store(key, value interface{}) []interface{} {
+	ssm.mu.Lock()
+	defer ssm.mu.Unlock()
+
+	if ssm.values == nil {
+		ssm.values = make(map[interface{}][]interface{})
+	}
+
+	displaced := slices.Clone(ssm.values[key])
+	ssm.values[key] = append(ssm.values[key], value)
+
+	return displaced
 }
 
-// Delete removes the value from the slice associated with the key and updates the value in sync.Map.
-func (ssm *SyncSliceMap) Delete(key, value interface{}) {
-	if values, ok := ssm.syncMap.Load(key); ok {
-		var updatedValues []interface{}
-		for _, v := range values.([]interface{}) {
-			if v != value {
-				updatedValues = append(updatedValues, v)
-			}
-		}
+// Delete removes the value from the key's slice and returns how many values
+// remain under it. The key itself is dropped once its last value is gone, so
+// the map does not retain an entry for every device ever seen.
+func (ssm *SyncSliceMap) Delete(key, value interface{}) int {
+	ssm.mu.Lock()
+	defer ssm.mu.Unlock()
 
-		ssm.syncMap.Store(key, updatedValues)
+	remaining := slices.DeleteFunc(ssm.values[key], func(v interface{}) bool {
+		return v == value
+	})
+
+	if len(remaining) == 0 {
+		delete(ssm.values, key)
+
+		return 0
 	}
+
+	ssm.values[key] = remaining
+
+	return len(remaining)
 }
 
 // Size returns the current size of the slice associated with the key.
 func (ssm *SyncSliceMap) Size(key interface{}) int {
-	return len(ssm.getValues(key))
-}
+	ssm.mu.RLock()
+	defer ssm.mu.RUnlock()
 
-// getValues returns the slice of values associated with the key.
-func (ssm *SyncSliceMap) getValues(key interface{}) []interface{} {
-	if values, ok := ssm.syncMap.Load(key); ok {
-		return values.([]interface{})
-	}
-
-	return nil
+	return len(ssm.values[key])
 }

--- a/server/ssh/pkg/dialer/syncslicemap_test.go
+++ b/server/ssh/pkg/dialer/syncslicemap_test.go
@@ -1,6 +1,8 @@
 package dialer
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,12 +32,12 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
-			title: "fails when loading from a map with multiple values",
+			title: "loads the last value when the key holds multiple",
 			setup: func() *SyncSliceMap {
 				ssm := &SyncSliceMap{}
-				key := "keys"
-				values := []interface{}{"value1", "value2", "value3"}
-				ssm.syncMap.Store(key, values)
+				ssm.Store("keys", "value1")
+				ssm.Store("keys", "value2")
+				ssm.Store("keys", "value3")
 
 				return ssm
 			},
@@ -43,6 +45,21 @@ func TestLoad(t *testing.T) {
 			expected: Expected{
 				result: "value3",
 				status: true,
+			},
+		},
+		{
+			title: "fails when the key held a value that was deleted",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key", "value1")
+				ssm.Delete("key", "value1")
+
+				return ssm
+			},
+			key: "key",
+			expected: Expected{
+				result: nil,
+				status: false,
 			},
 		},
 	}
@@ -58,84 +75,146 @@ func TestLoad(t *testing.T) {
 }
 
 func TestStore(t *testing.T) {
-	type Expected struct {
-		values any
-		status bool
-	}
-
 	cases := []struct {
-		title    string
-		setup    func() *SyncSliceMap
-		key      string
-		value    interface{}
-		expected Expected
+		title             string
+		setup             func() *SyncSliceMap
+		key               string
+		value             interface{}
+		expectedDisplaced []interface{}
+		expectedSize      int
 	}{
 		{
-			title: "success when storing a value for a new key",
+			title: "reports nothing displaced when storing under a new key",
 			setup: func() *SyncSliceMap {
 				return &SyncSliceMap{}
 			},
-			key:   "key",
-			value: "value1",
-			expected: Expected{
-				values: []interface{}{"value1"},
-				status: true,
+			key:               "key",
+			value:             "value1",
+			expectedDisplaced: nil,
+			expectedSize:      1,
+		},
+		{
+			title: "reports the values already held by the key",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key", "value1")
+				ssm.Store("key", "value2")
+
+				return ssm
 			},
+			key:               "key",
+			value:             "value3",
+			expectedDisplaced: []interface{}{"value1", "value2"},
+			expectedSize:      3,
+		},
+		{
+			title: "reports nothing displaced for a key whose values were deleted",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key", "value1")
+				ssm.Delete("key", "value1")
+
+				return ssm
+			},
+			key:               "key",
+			value:             "value2",
+			expectedDisplaced: nil,
+			expectedSize:      1,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.title, func(t *testing.T) {
 			ssm := tc.setup()
-			ssm.Store(tc.key, tc.value)
 
-			result, ok := ssm.syncMap.Load(tc.key)
-			assert.Equal(t, tc.expected, Expected{result, ok})
+			assert.Equal(t, tc.expectedDisplaced, ssm.Store(tc.key, tc.value))
+			assert.Equal(t, tc.expectedSize, ssm.Size(tc.key))
+
+			value, ok := ssm.Load(tc.key)
+			assert.True(t, ok)
+			assert.Equal(t, tc.value, value)
 		})
 	}
 }
 
 func TestDelete(t *testing.T) {
-	type Expected struct {
-		values any
-		status bool
-	}
-
 	cases := []struct {
-		title         string
-		setup         func() *SyncSliceMap
-		key           string
-		valueToDelete interface{}
-		expected      Expected
+		title             string
+		setup             func() *SyncSliceMap
+		key               string
+		valueToDelete     interface{}
+		expectedRemaining int
 	}{
 		{
-			title: "success when try deleting a value from an existing key",
+			title: "deletes a value from a key that holds several",
 			setup: func() *SyncSliceMap {
 				ssm := &SyncSliceMap{}
-				key := "existingKey"
-				values := []interface{}{"value1.1", "value1.2", "value1.3"}
-				ssm.syncMap.Store(key, values)
+				ssm.Store("existingKey", "value1.1")
+				ssm.Store("existingKey", "value1.2")
+				ssm.Store("existingKey", "value1.3")
 
 				return ssm
 			},
-			key:           "existingKey",
-			valueToDelete: "value1.2",
-			expected: Expected{
-				values: []interface{}{"value1.1", "value1.3"},
-				status: true,
+			key:               "existingKey",
+			valueToDelete:     "value1.2",
+			expectedRemaining: 2,
+		},
+		{
+			title: "reports no remaining values when the last one is deleted",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key", "value1")
+
+				return ssm
 			},
+			key:               "key",
+			valueToDelete:     "value1",
+			expectedRemaining: 0,
+		},
+		{
+			title: "reports no remaining values for an unknown key",
+			setup: func() *SyncSliceMap {
+				return &SyncSliceMap{}
+			},
+			key:               "missing",
+			valueToDelete:     "value1",
+			expectedRemaining: 0,
+		},
+		{
+			title: "leaves the key untouched when the value is not held by it",
+			setup: func() *SyncSliceMap {
+				ssm := &SyncSliceMap{}
+				ssm.Store("key", "value1")
+
+				return ssm
+			},
+			key:               "key",
+			valueToDelete:     "other",
+			expectedRemaining: 1,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.title, func(t *testing.T) {
 			ssm := tc.setup()
-			ssm.Delete(tc.key, tc.valueToDelete)
 
-			result, ok := ssm.syncMap.Load(tc.key)
-			assert.Equal(t, tc.expected, Expected{result, ok})
+			assert.Equal(t, tc.expectedRemaining, ssm.Delete(tc.key, tc.valueToDelete))
+			assert.Equal(t, tc.expectedRemaining, ssm.Size(tc.key))
 		})
 	}
+}
+
+// TestDeleteDropsTheKey guards the map against growing one entry per device
+// ever connected: a key whose last value is gone must leave nothing behind.
+func TestDeleteDropsTheKey(t *testing.T) {
+	ssm := &SyncSliceMap{}
+	ssm.Store("key", "value1")
+	ssm.Delete("key", "value1")
+
+	ssm.mu.RLock()
+	defer ssm.mu.RUnlock()
+
+	assert.NotContains(t, ssm.values, "key")
 }
 
 func TestSize(t *testing.T) {
@@ -157,9 +236,9 @@ func TestSize(t *testing.T) {
 			title: "getting size of a slice with multiple values",
 			setup: func() *SyncSliceMap {
 				ssm := &SyncSliceMap{}
-				key := "keys"
-				values := []interface{}{"value1", "value2", "value3"}
-				ssm.syncMap.Store(key, values)
+				ssm.Store("keys", "value1")
+				ssm.Store("keys", "value2")
+				ssm.Store("keys", "value3")
 
 				return ssm
 			},
@@ -170,9 +249,7 @@ func TestSize(t *testing.T) {
 			title: "getting size of a slice after adding a new value",
 			setup: func() *SyncSliceMap {
 				ssm := &SyncSliceMap{}
-				key := "key"
-				valueToAdd := "newValue"
-				ssm.syncMap.Store(key, []interface{}{valueToAdd})
+				ssm.Store("key", "newValue")
 
 				return ssm
 			},
@@ -189,4 +266,68 @@ func TestSize(t *testing.T) {
 			assert.Equal(t, tc.expectedSize, size)
 		})
 	}
+}
+
+// TestConcurrentStoreKeepsEveryValue is the reason this type is not a bare
+// sync.Map: a read-modify-write of the key's slice loses one of two concurrent
+// stores, and a connection the manager never recorded is one it never tears
+// down. Run under -race.
+func TestConcurrentStoreKeepsEveryValue(t *testing.T) {
+	const goroutines = 50
+
+	ssm := &SyncSliceMap{}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			ssm.Store("key", fmt.Sprintf("value%d", i))
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, goroutines, ssm.Size("key"))
+}
+
+// TestConcurrentStoreAndDeleteReportOneWinner pins the contract the manager
+// relies on to decide a device went offline: across concurrent registrations
+// and teardowns of one key, exactly one Delete may observe an empty key.
+func TestConcurrentStoreAndDeleteReportOneWinner(t *testing.T) {
+	const goroutines = 50
+
+	ssm := &SyncSliceMap{}
+
+	values := make([]string, goroutines)
+	for i := range values {
+		values[i] = fmt.Sprintf("value%d", i)
+		ssm.Store("key", values[i])
+	}
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		emptied int
+	)
+
+	wg.Add(goroutines)
+
+	for _, value := range values {
+		go func() {
+			defer wg.Done()
+
+			if ssm.Delete("key", value) == 0 {
+				mu.Lock()
+				emptied++
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, 1, emptied, "exactly one teardown must see the key empty")
+	assert.Equal(t, 0, ssm.Size("key"))
 }


### PR DESCRIPTION
## What

Stale device connections are now torn down when the device reconnects, instead of being
detected, logged and left resident. The connection map they live in became consistent
under concurrent access, which it had to be before eviction could be built on it.

## Why

Investigating a managed deployment (58,670 devices, 51,187 online) turned up the `ssh`
service logging `"Multiple connections stored for the same identifier."` with `"size":2` at
175 occurrences/hour. The manager detected the duplicate and only warned about it.

A device that reconnects before the server has noticed its previous socket is gone
registers a second connection under the same identifier. Only the last one is ever dialed,
so the earlier one is dead weight: it holds its socket and buffers until its own ping loop
times out — up to 35s away, and never at all for a peer that vanished without resetting the
connection.

The wider "104k connections for 58k devices" claim in the issue turned out to be a
measurement artifact (a gateway netns counts both legs of every proxied connection), so
this is not the multi-gigabyte win that issue proposed. These are the two real defects that
survived the analysis. Refs: shellhub-io/team#202 — cross-repo, so it will not auto-close.

## Changes

- **`SyncSliceMap`**: `Store` and `Delete` were read-modify-write over a `sync.Map`. Two
  concurrent registrations for one key could drop one, leaving a live connection the
  manager never recorded and therefore never tears down. Guarded with a mutex, and both
  now report what they observed *under the lock* — `Store` returns the values it displaced,
  `Delete` the count that survived. Returning them is not a convenience: reading either
  back afterwards would race with the next caller, which is the bug being fixed.

- **`SyncSliceMap.Delete`**: drops the key once its last value is gone. Previously an
  entry stayed behind for every device the server had ever seen.

- **`Manager.evict`**: closes the connections a registration displaced, in both `Set` (v1
  revdial) and `Bind` (v2 yamux). It runs in its own goroutine — this is teardown of an
  already-abandoned connection, and `revdial.Dialer.Close` blocks until its owner observes
  the close. Neither belongs on the path registering the live connection.

- **Offline reporting**: `DialerDoneCallback` now fires only when `Delete` reports no
  connections remaining. Without this, evicting a stale connection would mark a device that
  had just reconnected as offline. It also fixes the pre-existing, rarer flap where a stale
  connection dying on its own timeout did the same.

## Testing

`go test -race ./ssh/...` and `golangci-lint run ./ssh/...` are clean.

Worth a reviewer's attention:

- The eviction test was checked against a deliberately broken `evict` (close removed) and
  fails on both assertions there, so it is not vacuous.
- `TestConcurrentStoreAndDeleteReportOneWinner` pins the contract the offline decision
  depends on: across 50 concurrent teardowns of one key, exactly one `Delete` may observe
  it empty. If that ever reports more than one, devices get spurious offline writes.
- The `size > 1` warning on the `Dial` path was deliberately kept. With eviction in place it
  should become rare enough to be a real signal rather than the background noise it is now
  — it is the cheapest way to tell whether this actually worked in production.
