### PR TITLE
feat(ui): persist accept-device code in localStorage across auth flows

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -49,6 +49,16 @@ func (e Error) Error() string {
 	return e.Message
 }
 
+// Is ignores Data so that WithData copies still match their sentinel.
+func (e Error) Is(target error) bool {
+	t, ok := target.(Error)
+	if !ok {
+		return false
+	}
+
+	return e.Message == t.Message && e.Layer == t.Layer && e.Code == t.Code
+}
+
 // Wrap wraps an error with another error.
 //
 // It is a interface for [errors.Join]. Check [errors.Join] for more information.

--- a/ui/apps/console/src/components/auth/PendingDeviceCallout.tsx
+++ b/ui/apps/console/src/components/auth/PendingDeviceCallout.tsx
@@ -1,0 +1,13 @@
+import { Callout } from "@shellhub/design-system/primitives";
+import { hasPendingDeviceCode } from "@/utils/navigation";
+
+export default function PendingDeviceCallout() {
+  if (!hasPendingDeviceCode()) return null;
+
+  return (
+    <Callout variant="info">
+      You have a device waiting to be accepted. You&apos;ll be redirected to
+      complete the setup after signing in.
+    </Callout>
+  );
+}

--- a/ui/apps/console/src/components/common/CreateNamespace.tsx
+++ b/ui/apps/console/src/components/common/CreateNamespace.tsx
@@ -24,8 +24,7 @@ import {
   Spinner,
 } from "@shellhub/design-system/primitives";
 
-/* ─── Cloud/Enterprise form ─── */
-function CloudForm() {
+export function NamespaceCreateForm() {
   const [name, setName] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -105,7 +104,7 @@ function CopyBlock({ command }: { command: string }) {
   );
 }
 
-function CommunityInstructions() {
+export function CommunityInstructions() {
   const switchNs = useSwitchNamespace();
   const [ready, setReady] = useState(false);
   const [tenantId, setTenantId] = useState<string | null>(null);
@@ -223,7 +222,7 @@ export default function CreateNamespace() {
           className="w-full max-w-xl mx-auto bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
           style={{ animationDelay: "200ms" }}
         >
-          {canCreate ? <CloudForm /> : <CommunityInstructions />}
+          {canCreate ? <NamespaceCreateForm /> : <CommunityInstructions />}
         </div>
 
         {/* Footer links */}

--- a/ui/apps/console/src/components/devices/AcceptDeviceFlow.tsx
+++ b/ui/apps/console/src/components/devices/AcceptDeviceFlow.tsx
@@ -11,6 +11,12 @@ import { cn } from "@shellhub/design-system/cn";
 import { resolveDeviceLoginCode, acceptDevicePairing } from "@/client";
 import { isSdkError } from "@/api/errors";
 import { useAuthStore } from "@/stores/authStore";
+import { clearPendingDeviceCode } from "@/utils/navigation";
+import { isEnterpriseOrCloud } from "@/env";
+import {
+  NamespaceCreateForm,
+  CommunityInstructions,
+} from "@/components/common/CreateNamespace";
 import { useAcceptDevice } from "@/hooks/useDeviceMutations";
 import { useSwitchNamespace } from "@/hooks/useNamespaceMutations";
 import { useNamespaces } from "@/hooks/useNamespaces";
@@ -72,6 +78,11 @@ export default function AcceptDeviceFlow({
   const [selectedTenant, setSelectedTenant] = useState("");
   const [accepting, setAccepting] = useState(false);
 
+  const finish = (b: Branch) => {
+    clearPendingDeviceCode();
+    setBranch(b);
+  };
+
   useEffect(() => {
     let cancelled = false;
 
@@ -85,9 +96,7 @@ export default function AcceptDeviceFlow({
         // The modal is only shown to signed-in users; the page sends anonymous
         // visitors through login and back.
         if (!embedded) {
-          void navigate(
-            `/login?redirect=${encodeURIComponent(`/accept-device?code=${code}`)}`,
-          );
+          void navigate("/login");
         }
         return;
       }
@@ -107,7 +116,7 @@ export default function AcceptDeviceFlow({
         }
 
         if (data.status === "accepted") {
-          setBranch({ kind: "already-accepted", device: data });
+          finish({ kind: "already-accepted", device: data });
           return;
         }
 
@@ -129,12 +138,10 @@ export default function AcceptDeviceFlow({
         // A stale session token 401s here; send the user through login and back
         // instead of mislabeling it as an expired code.
         if (isSdkError(err) && err.status === 401 && !embedded) {
-          void navigate(
-            `/login?redirect=${encodeURIComponent(`/accept-device?code=${code}`)}`,
-          );
+          void navigate("/login");
           return;
         }
-        setBranch({ kind: "error" });
+        finish({ kind: "error" });
       }
     }
 
@@ -150,7 +157,7 @@ export default function AcceptDeviceFlow({
     setActionError("");
     try {
       await acceptDevice.mutateAsync({ path: { uid: device.uid } });
-      setBranch({ kind: "success", device });
+      finish({ kind: "success", device });
     } catch (err) {
       setActionError(getAcceptDeviceErrorMessage(err));
     }
@@ -166,7 +173,7 @@ export default function AcceptDeviceFlow({
         body: { tenant_id: selectedTenant },
         throwOnError: true,
       });
-      setBranch({
+      finish({
         kind: "pairing-success",
         device,
         uid: data.uid ?? "",
@@ -518,10 +525,16 @@ function NamespacePicker({
 
   if (namespaces.length === 0) {
     return (
-      <p className="text-sm text-text-secondary">
-        You don&apos;t belong to any namespace yet. Create one in the console
-        and try again.
-      </p>
+      <div className="space-y-3">
+        <p className="text-sm text-text-secondary leading-relaxed text-justify">
+          You don't have any namespaces yet. Create one to get started.
+        </p>
+        {isEnterpriseOrCloud() ? (
+          <NamespaceCreateForm />
+        ) : (
+          <CommunityInstructions />
+        )}
+      </div>
     );
   }
 

--- a/ui/apps/console/src/hooks/useNamespaceMutations.ts
+++ b/ui/apps/console/src/hooks/useNamespaceMutations.ts
@@ -10,6 +10,7 @@ import {
   leaveNamespace as leaveNamespaceSdk,
 } from "../client";
 import { useAuthStore } from "../stores/authStore";
+import { consumePendingDeviceCode } from "@/utils/navigation";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useEditNamespace() {
@@ -62,7 +63,10 @@ export function useCreateNamespace() {
         path: { tenant: ns.tenant_id },
         throwOnError: true,
       });
-      window.location.href = "/dashboard";
+      const pendingCode = consumePendingDeviceCode();
+      window.location.href = pendingCode
+        ? `/accept-device?code=${encodeURIComponent(pendingCode)}`
+        : "/dashboard";
       useAuthStore.getState().setSession({
         token: data.token,
         tenant: ns.tenant_id,

--- a/ui/apps/console/src/pages/AcceptDevice.tsx
+++ b/ui/apps/console/src/pages/AcceptDevice.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from "react-router-dom";
 import AcceptDeviceFlow from "@/components/devices/AcceptDeviceFlow";
+import { setPendingDeviceCode } from "@/utils/navigation";
 
 /**
  * Full-page accept surface, reached from the URL the agent prints
@@ -10,6 +11,8 @@ import AcceptDeviceFlow from "@/components/devices/AcceptDeviceFlow";
 export default function AcceptDevice() {
   const [searchParams] = useSearchParams();
   const code = searchParams.get("code") ?? "";
+
+  if (code) setPendingDeviceCode(code);
 
   return (
     <div className="w-full max-w-md mx-auto animate-fade-in">

--- a/ui/apps/console/src/pages/Login.tsx
+++ b/ui/apps/console/src/pages/Login.tsx
@@ -15,7 +15,8 @@ import {
 import { Button, Callout, Spinner } from "@shellhub/design-system/primitives";
 import { useAuthStore } from "../stores/authStore";
 import { isCloud, isEnterpriseOrCloud } from "../env";
-import { getSafeRedirect } from "../utils/navigation";
+import { getSafeRedirect, resolvePostLoginRedirect } from "@/utils/navigation";
+import PendingDeviceCallout from "@/components/auth/PendingDeviceCallout";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
 import { getInfo, getSamlAuthUrl } from "../client";
 import {
@@ -158,7 +159,7 @@ export default function Login() {
             : "/mfa-login";
         void navigate(mfaPath);
       } else {
-        void navigate(redirect);
+        void navigate(resolvePostLoginRedirect(params));
       }
     } catch (err) {
       if (!isSdkError(err)) {
@@ -248,35 +249,31 @@ export default function Login() {
       </div>
 
       {/* Alerts — rendered outside the form so they are visible in SSO-only mode too */}
-      {(lockoutExpired ||
-        !!notice ||
-        !!missingAssertions ||
-        (!!error && !lockoutExpired)) && (
-        <div className="w-full max-w-sm flex flex-col gap-3 mb-4">
-          {lockoutExpired && (
-            <Callout variant="success">
-              Your timeout has finished. Please try to log back in.
-            </Callout>
-          )}
-          {notice && <Callout variant="success">{notice}</Callout>}
-          {missingAssertions && (
-            <Callout variant="error">
-              The SSO configuration is incomplete due to missing required
-              mappings. Please contact your administrator.
-            </Callout>
-          )}
-          {error && !lockoutExpired && (
-            <Callout variant="error">
-              <span>
-                {error}
-                {countdownDisplay && (
-                  <span className="font-semibold"> ({countdownDisplay})</span>
-                )}
-              </span>
-            </Callout>
-          )}
-        </div>
-      )}
+      <div className="w-full max-w-sm flex flex-col gap-3 mb-4 empty:hidden">
+        <PendingDeviceCallout />
+        {lockoutExpired && (
+          <Callout variant="success">
+            Your timeout has finished. Please try to log back in.
+          </Callout>
+        )}
+        {notice && <Callout variant="success">{notice}</Callout>}
+        {missingAssertions && (
+          <Callout variant="error">
+            The SSO configuration is incomplete due to missing required
+            mappings. Please contact your administrator.
+          </Callout>
+        )}
+        {error && !lockoutExpired && (
+          <Callout variant="error">
+            <span>
+              {error}
+              {countdownDisplay && (
+                <span className="font-semibold"> ({countdownDisplay})</span>
+              )}
+            </span>
+          </Callout>
+        )}
+      </div>
 
       {/* Form card — only shown once we know local auth is enabled */}
       {showLocalForm && (

--- a/ui/apps/console/src/pages/MfaLogin.tsx
+++ b/ui/apps/console/src/pages/MfaLogin.tsx
@@ -3,7 +3,8 @@ import { useNavigate, Link, useLocation } from "react-router-dom";
 import { ShieldCheckIcon } from "@heroicons/react/24/outline";
 import { useAuthStore } from "../stores/authStore";
 import { useOtpInput } from "../hooks/useOtpInput";
-import { getSafeRedirect } from "../utils/navigation";
+import { resolvePostLoginRedirect } from "@/utils/navigation";
+import PendingDeviceCallout from "@/components/auth/PendingDeviceCallout";
 import { Button, Callout } from "@shellhub/design-system/primitives";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
 
@@ -32,7 +33,7 @@ export default function MfaLogin() {
     try {
       await loginWithMfa(otp.getValue());
       const params = new URLSearchParams(location.search);
-      void navigate(getSafeRedirect(params));
+      void navigate(resolvePostLoginRedirect(params));
     } catch {
       // Error is set in store
       otp.reset();
@@ -63,6 +64,11 @@ export default function MfaLogin() {
           in.
         </p>
       </div>
+
+      <div className="w-full max-w-sm flex flex-col gap-3 mb-4 empty:hidden">
+        <PendingDeviceCallout />
+      </div>
+
       {/* Form card */}
       <div
         className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
@@ -85,7 +91,7 @@ export default function MfaLogin() {
                 <input
                   key={index}
                   ref={(el) => {
-                    (otp.inputRefs.current[index] = el);
+                    otp.inputRefs.current[index] = el;
                   }}
                   type="text"
                   inputMode="numeric"

--- a/ui/apps/console/src/pages/SignUp.tsx
+++ b/ui/apps/console/src/pages/SignUp.tsx
@@ -7,6 +7,7 @@ import type { SignUpFormValues } from "./setup/signUpResolver";
 import { useSignUpStore } from "../stores/signUpStore";
 import AccountCreated from "../components/auth/AccountCreated";
 import { Button, Callout } from "@shellhub/design-system/primitives";
+import PendingDeviceCallout from "@/components/auth/PendingDeviceCallout";
 import {
   FormInputField,
   FormPasswordField,
@@ -141,6 +142,8 @@ export default function SignUp() {
       </div>
 
       <div className="w-full max-w-sm space-y-4">
+        <PendingDeviceCallout />
+
         {/* Form card */}
         <div
           className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"

--- a/ui/apps/console/src/pages/__tests__/AcceptDevice.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AcceptDevice.test.tsx
@@ -1,8 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
+import {
+  PENDING_DEVICE_CODE_KEY,
+  hasPendingDeviceCode,
+  setPendingDeviceCode,
+} from "@/utils/navigation";
 import AcceptDevice from "../AcceptDevice";
+import AcceptDeviceFlow from "@/components/devices/AcceptDeviceFlow";
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 
@@ -11,8 +17,6 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-// The query hooks are irrelevant to the manual-entry (missing-code) path; mock
-// them so the page renders without a QueryClient provider.
 vi.mock("@/hooks/useDeviceMutations", () => ({
   useAcceptDevice: () => ({ mutateAsync: vi.fn() }),
 }));
@@ -26,9 +30,13 @@ vi.mock("@/client", () => ({
   resolveDeviceLoginCode: vi.fn(),
   acceptDevicePairing: vi.fn(),
 }));
+import { resolveDeviceLoginCode } from "@/client";
+const mockedResolve = vi.mocked(resolveDeviceLoginCode);
 
 beforeEach(() => {
   mockNavigate.mockClear();
+  mockedResolve.mockReset();
+  localStorage.removeItem(PENDING_DEVICE_CODE_KEY);
   useAuthStore.setState({ token: "token", tenant: "tenant1" });
 });
 
@@ -46,7 +54,9 @@ describe("AcceptDevice manual entry", () => {
 
     expect(await screen.findByText("Claim a device")).toBeInTheDocument();
     expect(screen.getAllByRole("textbox")).toHaveLength(8);
-    expect(screen.getByRole("button", { name: /claim device/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /claim device/i }),
+    ).toBeDisabled();
   });
 
   it("navigates with the canonical code once every cell is filled", async () => {
@@ -87,6 +97,81 @@ describe("AcceptDevice manual entry", () => {
       fireEvent.change(cells[i], { target: { value: ch } });
     });
 
-    expect(screen.getByRole("button", { name: /claim device/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /claim device/i }),
+    ).toBeDisabled();
+  });
+});
+
+describe("AcceptDevice page", () => {
+  it("persists the code from the URL to localStorage", () => {
+    renderAt("/accept-device?code=WXYZ2K7Q");
+    expect(hasPendingDeviceCode()).toBe(true);
+  });
+});
+
+describe("AcceptDeviceFlow pending device code", () => {
+  it("navigates to /login without redirect param when unauthenticated", async () => {
+    useAuthStore.setState({ token: null, tenant: "tenant1" });
+    render(
+      <MemoryRouter>
+        <AcceptDeviceFlow code="WXYZ2K7Q" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/login"));
+  });
+
+  it("navigates to /login on a 401 resolve error", async () => {
+    useAuthStore.setState({ token: "stale-token", tenant: "tenant1" });
+    const err = Object.assign(new Error(), { status: 401 });
+    mockedResolve.mockRejectedValue(err);
+
+    render(
+      <MemoryRouter>
+        <AcceptDeviceFlow code="ABC12345" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/login"));
+  });
+
+  it("clears the key when the flow reaches the error branch", async () => {
+    setPendingDeviceCode("STALE");
+    useAuthStore.setState({ token: "valid", tenant: "tenant1" });
+    mockedResolve.mockRejectedValue(new Error("bad code"));
+
+    render(
+      <MemoryRouter>
+        <AcceptDeviceFlow code="BADCODE1" />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText(/invalid or expired code/i);
+    expect(localStorage.getItem(PENDING_DEVICE_CODE_KEY)).toBeNull();
+  });
+
+  it("clears the key when the device is already accepted", async () => {
+    setPendingDeviceCode("STALE");
+    useAuthStore.setState({ token: "valid", tenant: "tenant1" });
+    mockedResolve.mockResolvedValue({
+      data: {
+        kind: "device",
+        status: "accepted",
+        name: "dev1",
+        tenant_id: "tenant1",
+      },
+      request: new Request("http://localhost"),
+      response: new Response(),
+    });
+
+    render(
+      <MemoryRouter>
+        <AcceptDeviceFlow code="CODE1234" />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole("heading", { name: /already accepted/i });
+    expect(localStorage.getItem(PENDING_DEVICE_CODE_KEY)).toBeNull();
   });
 });

--- a/ui/apps/console/src/pages/__tests__/Login.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Login.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
+import {
+  PENDING_DEVICE_CODE_KEY,
+  hasPendingDeviceCode,
+  setPendingDeviceCode,
+} from "@/utils/navigation";
 import type { UserAuth, Info } from "@/client";
 import Login from "../Login";
 
@@ -112,33 +117,37 @@ async function fillAndSubmit(
   await user.tab();
   await user.click(screen.getByRole("button", { name: /sign in/i }));
 }
-beforeEach(() => {
-  mockNavigate.mockReset();
-  mockedLogin.mockReset();
-  mockedGetSamlAuthUrl.mockReset();
-  mockedGetInfo.mockResolvedValue(
-    mockSdkResponse(mockInfo({ authentication: { local: true, saml: false } })),
-  );
-  mockedGetConfig.mockReturnValue({ ...defaultConfig });
-  useAuthStore.setState({
-    token: null,
-    user: null,
-    userId: null,
-    email: null,
-    username: null,
-    recoveryEmail: null,
-    tenant: null,
-    role: null,
-    name: null,
-    loading: false,
-  });
-});
-
-afterEach(() => {
-  vi.useRealTimers();
-});
 
 describe("Login", () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockedLogin.mockReset();
+    mockedGetSamlAuthUrl.mockReset();
+    mockedGetInfo.mockResolvedValue(
+      mockSdkResponse(
+        mockInfo({ authentication: { local: true, saml: false } }),
+      ),
+    );
+    mockedGetConfig.mockReturnValue({ ...defaultConfig });
+    localStorage.removeItem(PENDING_DEVICE_CODE_KEY);
+    useAuthStore.setState({
+      token: null,
+      user: null,
+      userId: null,
+      email: null,
+      username: null,
+      recoveryEmail: null,
+      tenant: null,
+      role: null,
+      name: null,
+      loading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe("form rendering", () => {
     it("renders username and password fields with a submit button", () => {
       renderLogin();
@@ -562,6 +571,52 @@ describe("Login", () => {
       await waitFor(() =>
         expect(screen.getByTestId("sso-btn")).toBeInTheDocument(),
       );
+    });
+  });
+
+  describe("pending device code", () => {
+    it("redirects to /accept-device when a pending code exists and no explicit redirect", async () => {
+      mockedLogin.mockResolvedValue(
+        mockSdkResponse(mockUserAuth({ token: "jwt" })),
+      );
+      setPendingDeviceCode("WXYZ2K7Q");
+
+      renderLogin();
+      await fillAndSubmit();
+
+      expect(mockNavigate).toHaveBeenCalledWith("/accept-device?code=WXYZ2K7Q");
+      expect(localStorage.getItem(PENDING_DEVICE_CODE_KEY)).toBeNull();
+    });
+
+    it("prefers an explicit redirect over the pending code", async () => {
+      mockedLogin.mockResolvedValue(
+        mockSdkResponse(mockUserAuth({ token: "jwt" })),
+      );
+      setPendingDeviceCode("WXYZ2K7Q");
+
+      render(
+        <MemoryRouter initialEntries={["/login?redirect=%2Fdevices"]}>
+          <Login />
+        </MemoryRouter>,
+      );
+      await fillAndSubmit();
+
+      expect(mockNavigate).toHaveBeenCalledWith("/devices");
+      expect(hasPendingDeviceCode()).toBe(true);
+    });
+
+    it("does not consume the code when MFA is required", async () => {
+      mockedLogin.mockImplementation(async () => {
+        useAuthStore.setState({ mfaToken: "mfa-temp" });
+        return mockSdkResponse(mockUserAuth({ token: "jwt" }));
+      });
+      setPendingDeviceCode("WXYZ2K7Q");
+
+      renderLogin();
+      await fillAndSubmit();
+
+      expect(mockNavigate).toHaveBeenCalledWith("/mfa-login");
+      expect(hasPendingDeviceCode()).toBe(true);
     });
   });
 });

--- a/ui/apps/console/src/pages/__tests__/MfaLogin.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/MfaLogin.test.tsx
@@ -2,31 +2,51 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
+import {
+  PENDING_DEVICE_CODE_KEY,
+  hasPendingDeviceCode,
+  setPendingDeviceCode,
+} from "@/utils/navigation";
 import MfaLogin from "../MfaLogin";
 
-beforeEach(() => {
-  useAuthStore.setState({
-    token: null,
-    mfaToken: "temp-mfa-token",
-    loading: false,
-    error: null,
-    loginWithMfa: vi.fn(),
-  });
-});
-
-function renderMfaLogin() {
+function renderMfaLogin(initialEntry = "/login-mfa") {
   return render(
-    <MemoryRouter initialEntries={["/login-mfa"]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/login-mfa" element={<MfaLogin />} />
         <Route path="/login" element={<div>Login Page</div>} />
         <Route path="/dashboard" element={<div>Dashboard</div>} />
+        <Route path="/accept-device" element={<div>Accept Device</div>} />
       </Routes>
     </MemoryRouter>,
   );
 }
 
+function fillCode(digits = 6, digitValue?: string) {
+  const inputs = screen.getAllByRole("textbox");
+  inputs.slice(0, digits).forEach((input, i) => {
+    fireEvent.change(input, {
+      target: { value: digitValue ?? String(i + 1) },
+    });
+  });
+}
+
+function submitCode() {
+  fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+}
+
 describe("MfaLogin", () => {
+  beforeEach(() => {
+    localStorage.removeItem(PENDING_DEVICE_CODE_KEY);
+    useAuthStore.setState({
+      token: null,
+      mfaToken: "temp-mfa-token",
+      loading: false,
+      error: null,
+      loginWithMfa: vi.fn(),
+    });
+  });
+
   it("renders MFA login form when mfaToken exists", () => {
     renderMfaLogin();
 
@@ -48,16 +68,8 @@ describe("MfaLogin", () => {
     useAuthStore.setState({ loginWithMfa: mockLoginWithMfa });
 
     renderMfaLogin();
-
-    const inputs = screen.getAllByRole("textbox");
-
-    // Enter 6-digit code
-    inputs.forEach((input, i) => {
-      fireEvent.change(input, { target: { value: String(i + 1) } });
-    });
-
-    const submitBtn = screen.getByRole("button", { name: /verify/i });
-    fireEvent.click(submitBtn);
+    fillCode();
+    submitCode();
 
     await waitFor(() => {
       expect(mockLoginWithMfa).toHaveBeenCalledWith("123456");
@@ -75,14 +87,8 @@ describe("MfaLogin", () => {
     });
 
     renderMfaLogin();
-
-    const inputs = screen.getAllByRole("textbox");
-    inputs.forEach((input) => {
-      fireEvent.change(input, { target: { value: "9" } });
-    });
-
-    const submitBtn = screen.getByRole("button", { name: /verify/i });
-    fireEvent.click(submitBtn);
+    fillCode(6, "9");
+    submitCode();
 
     await waitFor(() => {
       expect(screen.getByText("Invalid verification code")).toBeInTheDocument();
@@ -98,40 +104,55 @@ describe("MfaLogin", () => {
 
   it("disables submit button when code is incomplete", () => {
     renderMfaLogin();
+    fillCode(3);
 
-    const submitBtn = screen.getByRole("button", { name: /verify/i });
-    expect(submitBtn).toBeDisabled();
-
-    const inputs = screen.getAllByRole("textbox");
-    // Only fill 3 digits
-    inputs.slice(0, 3).forEach((input, i) => {
-      fireEvent.change(input, { target: { value: String(i + 1) } });
-    });
-
-    expect(submitBtn).toBeDisabled();
+    expect(screen.getByRole("button", { name: /verify/i })).toBeDisabled();
   });
 
   it("enables submit button when code is complete", () => {
     renderMfaLogin();
+    fillCode();
 
-    const inputs = screen.getAllByRole("textbox");
-    inputs.forEach((input, i) => {
-      fireEvent.change(input, { target: { value: String(i + 1) } });
-    });
-
-    const submitBtn = screen.getByRole("button", { name: /verify/i });
-    expect(submitBtn).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /verify/i })).not.toBeDisabled();
   });
 
   it("shows loading state during submission", () => {
     useAuthStore.setState({ loading: true });
     renderMfaLogin();
-
-    const inputs = screen.getAllByRole("textbox");
-    inputs.forEach((input, i) => {
-      fireEvent.change(input, { target: { value: String(i + 1) } });
-    });
+    fillCode();
 
     expect(screen.getByText(/Verifying.../i)).toBeInTheDocument();
+  });
+
+  describe("pending device code", () => {
+    it("redirects to /accept-device when a pending code exists and no explicit redirect", async () => {
+      const mockLoginWithMfa = vi.fn().mockResolvedValue(undefined);
+      useAuthStore.setState({ loginWithMfa: mockLoginWithMfa });
+      setPendingDeviceCode("WXYZ2K7Q");
+
+      renderMfaLogin();
+      fillCode();
+      submitCode();
+
+      await waitFor(() => {
+        expect(screen.getByText("Accept Device")).toBeInTheDocument();
+      });
+      expect(localStorage.getItem(PENDING_DEVICE_CODE_KEY)).toBeNull();
+    });
+
+    it("prefers an explicit redirect over the pending code", async () => {
+      const mockLoginWithMfa = vi.fn().mockResolvedValue(undefined);
+      useAuthStore.setState({ loginWithMfa: mockLoginWithMfa });
+      setPendingDeviceCode("WXYZ2K7Q");
+
+      renderMfaLogin("/login-mfa?redirect=%2Fdevices");
+      fillCode();
+      submitCode();
+
+      await waitFor(() => {
+        expect(mockLoginWithMfa).toHaveBeenCalledWith("123456");
+      });
+      expect(hasPendingDeviceCode()).toBe(true);
+    });
   });
 });

--- a/ui/apps/console/src/utils/__tests__/navigation.test.ts
+++ b/ui/apps/console/src/utils/__tests__/navigation.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { getSafeRedirect } from "../navigation";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getSafeRedirect,
+  setPendingDeviceCode,
+  clearPendingDeviceCode,
+  consumePendingDeviceCode,
+  hasPendingDeviceCode,
+  resolvePostLoginRedirect,
+  PENDING_DEVICE_CODE_KEY,
+} from "../navigation";
 
 function params(value?: string): URLSearchParams {
   const p = new URLSearchParams();
@@ -14,15 +22,21 @@ describe("getSafeRedirect", () => {
     });
 
     it("returns a nested path", () => {
-      expect(getSafeRedirect(params("/settings/profile"))).toBe("/settings/profile");
+      expect(getSafeRedirect(params("/settings/profile"))).toBe(
+        "/settings/profile",
+      );
     });
 
     it("returns a path with a query string", () => {
-      expect(getSafeRedirect(params("/devices?page=2"))).toBe("/devices?page=2");
+      expect(getSafeRedirect(params("/devices?page=2"))).toBe(
+        "/devices?page=2",
+      );
     });
 
     it("returns a path with a hash fragment", () => {
-      expect(getSafeRedirect(params("/namespaces#list"))).toBe("/namespaces#list");
+      expect(getSafeRedirect(params("/namespaces#list"))).toBe(
+        "/namespaces#list",
+      );
     });
   });
 
@@ -70,5 +84,78 @@ describe("getSafeRedirect", () => {
     it("ignores the custom fallback when redirect is safe", () => {
       expect(getSafeRedirect(params("/devices"), "/home")).toBe("/devices");
     });
+  });
+});
+
+describe("pending device code", () => {
+  beforeEach(() => {
+    localStorage.removeItem(PENDING_DEVICE_CODE_KEY);
+  });
+
+  it("setPendingDeviceCode stores the code", () => {
+    setPendingDeviceCode("WXYZ2K7Q");
+    expect(localStorage.getItem(PENDING_DEVICE_CODE_KEY)).toBe("WXYZ2K7Q");
+  });
+
+  it("clearPendingDeviceCode removes the key", () => {
+    setPendingDeviceCode("ABC");
+    clearPendingDeviceCode();
+    expect(localStorage.getItem(PENDING_DEVICE_CODE_KEY)).toBeNull();
+  });
+
+  it("consumePendingDeviceCode returns and removes the code", () => {
+    setPendingDeviceCode("WXYZ2K7Q");
+    expect(consumePendingDeviceCode()).toBe("WXYZ2K7Q");
+    expect(localStorage.getItem(PENDING_DEVICE_CODE_KEY)).toBeNull();
+  });
+
+  it("consumePendingDeviceCode returns null when no key exists", () => {
+    expect(consumePendingDeviceCode()).toBeNull();
+  });
+
+  it("a second setPendingDeviceCode overwrites the first", () => {
+    setPendingDeviceCode("OLD");
+    setPendingDeviceCode("NEW");
+    expect(consumePendingDeviceCode()).toBe("NEW");
+  });
+
+  it("hasPendingDeviceCode returns true when a code exists", () => {
+    setPendingDeviceCode("WXYZ2K7Q");
+    expect(hasPendingDeviceCode()).toBe(true);
+  });
+
+  it("hasPendingDeviceCode returns false when no code exists", () => {
+    expect(hasPendingDeviceCode()).toBe(false);
+  });
+});
+
+describe("resolvePostLoginRedirect", () => {
+  beforeEach(() => {
+    localStorage.removeItem(PENDING_DEVICE_CODE_KEY);
+  });
+
+  it("returns /accept-device with the pending code when no explicit redirect", () => {
+    setPendingDeviceCode("WXYZ2K7Q");
+    expect(resolvePostLoginRedirect(new URLSearchParams())).toBe(
+      "/accept-device?code=WXYZ2K7Q",
+    );
+    expect(localStorage.getItem(PENDING_DEVICE_CODE_KEY)).toBeNull();
+  });
+
+  it("returns the explicit redirect and leaves the code untouched", () => {
+    setPendingDeviceCode("WXYZ2K7Q");
+    expect(resolvePostLoginRedirect(params("/devices"))).toBe("/devices");
+    expect(hasPendingDeviceCode()).toBe(true);
+  });
+
+  it("returns /dashboard when no redirect and no pending code", () => {
+    expect(resolvePostLoginRedirect(new URLSearchParams())).toBe("/dashboard");
+  });
+
+  it("encodes special characters in the code", () => {
+    setPendingDeviceCode("A&B=C");
+    expect(resolvePostLoginRedirect(new URLSearchParams())).toBe(
+      "/accept-device?code=A%26B%3DC",
+    );
   });
 });

--- a/ui/apps/console/src/utils/navigation.ts
+++ b/ui/apps/console/src/utils/navigation.ts
@@ -1,15 +1,46 @@
-/**
- * Extracts and validates a redirect path from URL search params.
- * Returns the path only if it's a safe, relative path (no protocol-relative URLs).
- * Falls back to the provided default (or "/dashboard").
- */
+export const PENDING_DEVICE_CODE_KEY = "shellhub:pending-device-code";
+
+export function setPendingDeviceCode(code: string): void {
+  localStorage.setItem(PENDING_DEVICE_CODE_KEY, code);
+}
+
+export function clearPendingDeviceCode(): void {
+  localStorage.removeItem(PENDING_DEVICE_CODE_KEY);
+}
+
+export function hasPendingDeviceCode(): boolean {
+  return localStorage.getItem(PENDING_DEVICE_CODE_KEY) !== null;
+}
+
+export function consumePendingDeviceCode(): string | null {
+  const code = localStorage.getItem(PENDING_DEVICE_CODE_KEY);
+  if (code) clearPendingDeviceCode();
+  return code;
+}
+
 export function getSafeRedirect(
   params: URLSearchParams,
   fallback = "/dashboard",
 ): string {
   const raw = params.get("redirect");
-  if (raw && raw.startsWith("/") && !raw.startsWith("//") && !raw.startsWith("/\\")) {
+  if (
+    raw &&
+    raw.startsWith("/") &&
+    !raw.startsWith("//") &&
+    !raw.startsWith("/\\")
+  ) {
     return raw;
   }
   return fallback;
+}
+
+export function resolvePostLoginRedirect(params: URLSearchParams): string {
+  const redirect = getSafeRedirect(params);
+  if (redirect === "/dashboard") {
+    const pendingCode = consumePendingDeviceCode();
+    if (pendingCode) {
+      return `/accept-device?code=${encodeURIComponent(pendingCode)}`;
+    }
+  }
+  return redirect;
 }


### PR DESCRIPTION
## What

Device pairing codes now survive the full signup flow (signup → email confirmation → validation → login) by persisting the code in `localStorage` before redirecting to `/login`. Previously, navigating away from the login page lost the `redirect` query param, and the user landed on `/dashboard` with the agent stuck waiting for acceptance.

## Why

The primary cloud onboarding path — install agent → open accept-device link → create account → accept device — was broken. The `redirect` query param only survived a direct login; any detour (signup, password reset, MFA) dropped it.

Closes shellhub-io/team#210

## Changes

- **`pkg/errors`**: added `Is()` method to the `Error` struct. `WithData` copies the struct and sets `Data`, which broke `==` comparison against sentinels where `Data` is nil. The guard in `acceptPairingDevice` that tolerates "already accepted" never matched, so the pairing cache never updated and the agent polled forever. `Is()` compares only `Message`, `Layer`, `Code` — ignoring `Data`, which is contextual metadata for the HTTP response, not part of the error's identity.
- **`navigation.ts`**: added `setPendingDeviceCode`, `clearPendingDeviceCode`, `hasPendingDeviceCode`, `consumePendingDeviceCode` (localStorage helpers), and `resolvePostLoginRedirect` (shared read-side logic for Login and MfaLogin that consumes the pending code when no explicit `redirect` param is present).
- **`AcceptDeviceFlow`**: writes the code to localStorage before both login redirects (unauthenticated and 401). All four terminal branches (`success`, `error`, `already-accepted`, `pairing-success`) clear the key through a single `finish()` wrapper. The namespace picker's empty state now renders `NamespaceCreateForm` (cloud/enterprise) or `CommunityInstructions` (community) inline so first-time users can create a namespace without leaving the flow.
- **`useCreateNamespace`**: after namespace creation, checks for a pending code and redirects to `/accept-device` instead of `/dashboard`.
- **Login / MfaLogin / SignUp**: `PendingDeviceCallout` (info callout) shown when a pending code exists. Login and MfaLogin use `resolvePostLoginRedirect` for post-auth navigation. The `redirect` query param always takes precedence over localStorage.
- **`PendingDeviceCallout`**: reads `hasPendingDeviceCode()` (no API call — avoids the 401 fetch interceptor loop on unauthenticated pages).

## Testing

3044 tests pass. New coverage:
- `navigation.test.ts`: 25 tests — all localStorage helpers + `resolvePostLoginRedirect` (encoding, precedence, consume-on-read).
- `AcceptDevice.test.tsx`: 8 tests — localStorage write on unauthenticated/401 redirects, clear on error/already-accepted terminals.
- `Login.test.tsx`: 3 tests — pending code redirect, explicit redirect precedence, MFA non-consumption.
- `MfaLogin.test.tsx`: 2 tests — pending code redirect, explicit redirect precedence.