### PR TITLE
fix(ssh): stop warning about sessions that were never going to be recorded

### DIFF
--- a/server/ssh/server/channels/pipe_test.go
+++ b/server/ssh/server/channels/pipe_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/envs/envstest"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/ssh/session"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
@@ -169,6 +171,23 @@ func newPipeSession(t *testing.T) *session.Session {
 	return sess
 }
 
+// captureLogs collects what pipe logs on the standard logger, at debug level so
+// entries below the default threshold are recorded too.
+func captureLogs(t *testing.T) *test.Hook {
+	t.Helper()
+
+	hook := test.NewGlobal()
+	level := log.GetLevel()
+	log.SetLevel(log.DebugLevel)
+
+	t.Cleanup(func() {
+		log.SetLevel(level)
+		hook.Reset()
+	})
+
+	return hook
+}
+
 func runPipe(t *testing.T, sess *session.Session, client, agent gossh.Channel) chan struct{} {
 	t.Helper()
 
@@ -191,6 +210,64 @@ func waitFor(t *testing.T, finished chan struct{}) {
 	case <-finished:
 	case <-time.After(10 * time.Second):
 		t.Fatal("pipe did not return")
+	}
+}
+
+// TestPipeReportsExpectedRecordingSkips is the regression: a session that was
+// never going to be recorded — recording off for the namespace, or no pty to
+// record — was logged as a recording failure, so on a fleet of non-interactive
+// sessions every single one warned that a compliance feature had failed.
+func TestPipeReportsExpectedRecordingSkips(t *testing.T) {
+	tests := []struct {
+		description string
+		record      bool
+		pty         bool
+	}{
+		{
+			description: "recording disabled for the namespace",
+			record:      false,
+			pty:         true,
+		},
+		{
+			description: "seat has no pty to record",
+			record:      true,
+			pty:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			hook := captureLogs(t)
+
+			sess := newPipeSession(t)
+			// The recorder is only wired in on the editions that record.
+			envstest.SetEdition(t, envs.Enterprise)
+
+			sess.Namespace = &models.Namespace{ //nolint:exhaustruct
+				Settings: &models.NamespaceSettings{SessionRecord: tt.record}, //nolint:exhaustruct
+			}
+			sess.Seats.SetPty(0, tt.pty)
+
+			client, agent := newFakeChannel(), newFakeChannel()
+
+			client.quiet()
+			agent.quiet()
+
+			waitFor(t, runPipe(t, sess, client, agent))
+
+			var skipped *log.Entry
+
+			for _, entry := range hook.AllEntries() {
+				assert.NotEqual(t, log.WarnLevel, entry.Level, "expected recording skip reported as a failure: %s", entry.Message)
+
+				if entry.Message == "session will not be recorded" {
+					skipped = entry
+				}
+			}
+
+			require.NotNil(t, skipped, "expected the recording skip to be reported")
+			assert.Equal(t, log.DebugLevel, skipped.Level)
+		})
 	}
 }
 

--- a/server/ssh/server/channels/utils.go
+++ b/server/ssh/server/channels/utils.go
@@ -1,6 +1,7 @@
 package channels
 
 import (
+	"errors"
 	"io"
 	"sync"
 
@@ -99,9 +100,14 @@ func pipe(sess *session.Session, client gossh.Channel, agent gossh.Channel, seat
 			}
 
 			if err := sess.Recorded(seat); err != nil {
-				log.WithError(err).
-					WithFields(log.Fields{"session": sess.UID, "sshid": sess.SSHID}).
-					Warning("failed to set the session as recorded")
+				entry := log.WithError(err).
+					WithFields(log.Fields{"session": sess.UID, "sshid": sess.SSHID})
+
+				if errors.Is(err, session.ErrRecordingSkipped) {
+					entry.Debug("session will not be recorded")
+				} else {
+					entry.Warning("failed to set the session as recorded")
+				}
 
 				// NOTE: When we fail to update the session status to record, we don't send session's chunks to storage.
 				recorder = nil

--- a/server/ssh/session/session.go
+++ b/server/ssh/session/session.go
@@ -507,15 +507,29 @@ func (s *Session) authenticate(ctx context.Context) error {
 	})
 }
 
+// Errors reported by [Session.Recorded] when the session was never going to be recorded. They
+// are expected conditions, not failures, and callers should not report them as such. The
+// specific ones wrap [ErrRecordingSkipped] so a caller that only wants to know whether anything
+// went wrong needs a single comparison.
+var (
+	ErrRecordingSkipped  = errors.New("session recording skipped")
+	ErrRecordingDisabled = fmt.Errorf("%w: disabled for this namespace", ErrRecordingSkipped)
+	ErrRecordingNoPty    = fmt.Errorf("%w: session has no pty", ErrRecordingSkipped)
+)
+
+// Recorded marks the session as recorded on the API.
+//
+// It returns an error wrapping [ErrRecordingSkipped] when the session is not meant to be
+// recorded; any other error means marking it failed.
 func (s *Session) Recorded(seat int) error {
 	value := true
 
 	if !s.Namespace.Settings.SessionRecord {
-		return errors.New("record is disable for this namespace")
+		return ErrRecordingDisabled
 	}
 
 	if seat, ok := s.Seats.Get(seat); !ok || !seat.HasPty {
-		return errors.New("session won't be recorded because there is no pty")
+		return ErrRecordingNoPty
 	}
 
 	// Not the pipe's context: this records that the session is being recorded, and

--- a/server/ssh/session/session_test.go
+++ b/server/ssh/session/session_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shellhub-io/shellhub/server/ssh/pkg/target"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // stubContext is a minimal gliderssh.Context backed by a map for SetValue/Value
@@ -83,6 +84,83 @@ func newTestSession(service services.Service) *Session {
 		Client: &Client{
 			Channels: make(map[int]*ClientChannel),
 		},
+	}
+}
+
+func TestRecorded(t *testing.T) {
+	errStoreDown := errors.New("store is down")
+
+	tests := []struct {
+		description string
+		record      bool
+		pty         bool
+		setupMock   func(m *servicemocks.MockService)
+		expectedErr error
+		// expectSkipped is whether the error means the session was never going to be
+		// recorded, which is what the caller reports below a warning.
+		expectSkipped bool
+	}{
+		{
+			description:   "recording disabled for the namespace",
+			record:        false,
+			pty:           true,
+			setupMock:     func(_ *servicemocks.MockService) {},
+			expectedErr:   ErrRecordingDisabled,
+			expectSkipped: true,
+		},
+		{
+			description:   "seat has no pty to record",
+			record:        true,
+			pty:           false,
+			setupMock:     func(_ *servicemocks.MockService) {},
+			expectedErr:   ErrRecordingNoPty,
+			expectSkipped: true,
+		},
+		{
+			description: "marking the session as recorded fails",
+			record:      true,
+			pty:         true,
+			setupMock: func(m *servicemocks.MockService) {
+				m.EXPECT().
+					UpdateSession(mock.Anything, models.UID("test-uid"), mock.Anything).
+					Return(errStoreDown).
+					Once()
+			},
+			expectedErr:   errStoreDown,
+			expectSkipped: false,
+		},
+		{
+			description: "session is marked as recorded",
+			record:      true,
+			pty:         true,
+			setupMock: func(m *servicemocks.MockService) {
+				m.EXPECT().
+					UpdateSession(mock.Anything, models.UID("test-uid"), mock.Anything).
+					Return(nil).
+					Once()
+			},
+			expectedErr:   nil,
+			expectSkipped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			serviceMock := servicemocks.NewMockService(t)
+			tt.setupMock(serviceMock)
+
+			sess := newTestSession(serviceMock)
+			sess.Namespace.Settings = &models.NamespaceSettings{SessionRecord: tt.record}
+
+			seat, err := sess.Seats.NewSeat()
+			require.NoError(t, err)
+			sess.Seats.SetPty(seat, tt.pty)
+
+			err = sess.Recorded(seat)
+
+			assert.ErrorIs(t, err, tt.expectedErr)
+			assert.Equal(t, tt.expectSkipped, errors.Is(err, ErrRecordingSkipped))
+		})
 	}
 }
 


### PR DESCRIPTION
## What

`Session.Recorded` now reports the two conditions under which a session was never going to be
recorded as expected outcomes rather than failures, so `pipe` logs them at debug instead of
warning. Recording behaviour is unchanged.

## Why

`Recorded` returned an undifferentiated `error` for three unrelated outcomes: recording disabled
for the namespace, a seat with no pty, and a genuine `UpdateSession` failure. The only call site
logged every non-nil return at warning as `failed to set the session as recorded`, so both
expected cases were reported as a compliance feature failing.

On a fleet whose sessions are almost entirely non-interactive automation (`ssh host <command>`),
that is every session — an observed deployment logged the warning for 66 of 66 sessions in a
99-minute window, which triggered an incident investigation before the error string was read
closely enough to show the condition was normal.

Closes #6894

## Changes

- **`session`**: added `ErrRecordingDisabled` and `ErrRecordingNoPty`, both wrapping
  `ErrRecordingSkipped`. Wrapping keeps the specific reason in the log's `error` field while
  letting a caller ask a single question — a third skip condition won't require touching any
  caller. The sentinels live beside `Recorded` rather than in `errors.go`, whose contents are
  scoped to errors returned to the SSH client.
- **`channels`**: `pipe` branches on `errors.Is(err, session.ErrRecordingSkipped)`, logging
  `session recording skipped` at debug and reserving the warning for a real `UpdateSession`
  failure. `recorder = nil` still runs for all three outcomes.
- **tests**: `TestRecorded` covers the four outcomes and asserts sentinel identity with
  `errors.Is`, not message text, since identity is what the call site dispatches on.
  `TestPipeReportsExpectedRecordingSkips` covers the defect itself — an enterprise-edition pipe
  plus a logrus hook, asserting nothing is emitted at warn level and the skip lands at debug.

The signature was kept, rather than moving to `(bool, error)`, because the reason for the skip is
what makes the debug line worth reading.

## Testing

The warning branch has no call-site test: `Session.service` is unexported, so the `channels`
package cannot inject a failing service. Its error origin is covered by `TestRecorded`'s
"marking the session as recorded fails" case in the `session` package.

```
go test ./ssh/session/ ./ssh/server/channels/ -count=1
golangci-lint run ./ssh/...
```
