### PR TITLE
build(ui): retry the static-web-server download

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -69,6 +69,8 @@ FROM alpine:3.24.1 AS production
 ARG SWS_VERSION=2.44.0
 ARG TARGETARCH
 
+# The release CDN refuses or drops the connection often enough to fail a noticeable
+# share of builds, and busybox wget retries nothing on its own, so retry here.
 RUN set -eux; \
     case "$TARGETARCH" in \
       amd64) target=x86_64-unknown-linux-musl; \
@@ -77,8 +79,14 @@ RUN set -eux; \
              sha=e9d6bd0b05dea441028eb4e690249ab585d711b311646bf9f420fcea01449670 ;; \
       *) echo "unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
     esac; \
-    wget -qO /tmp/sws.tar.gz \
-      "https://github.com/static-web-server/static-web-server/releases/download/v${SWS_VERSION}/static-web-server-v${SWS_VERSION}-${target}.tar.gz"; \
+    url="https://github.com/static-web-server/static-web-server/releases/download/v${SWS_VERSION}/static-web-server-v${SWS_VERSION}-${target}.tar.gz"; \
+    downloaded=; \
+    for attempt in 1 2 3 4 5; do \
+      if wget -T 20 -qO /tmp/sws.tar.gz "$url"; then downloaded=1; break; fi; \
+      echo "static-web-server download failed (attempt ${attempt}/5)" >&2; \
+      sleep $(( attempt * 3 )); \
+    done; \
+    [ -n "$downloaded" ]; \
     echo "${sha}  /tmp/sws.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/sws.tar.gz -C /tmp; \
     mv "/tmp/static-web-server-v${SWS_VERSION}-${target}/static-web-server" /usr/local/bin/; \


### PR DESCRIPTION
## Problem

The console image fetches `static-web-server` from the GitHub release CDN during the `production` stage. That CDN refuses or drops connections often enough to break builds regularly — three UI image builds failed there today alone:

```
wget: error getting response: Invalid argument
wget: error getting response: Resource temporarily unavailable
```

Both failed within 200ms of starting, so this is a refused connection rather than a slow one. Each failure took the entire Security workflow down, because `security-gate` fails when `trivy-image` does, and the SARIF report is never produced (`Path does not exist: trivy-ui.sarif`).

busybox `wget` has no retry of its own, so one refused connection is fatal to the build.

## Change

Retry the download up to five times with a linear backoff (3s, 6s, 9s, 12s) and a 20s timeout per attempt. When every attempt is exhausted, fail explicitly via a `[ -n "$downloaded" ]` guard, so the build reports a download failure instead of surfacing it as a confusing checksum mismatch on a missing tarball.

The pinned `sha256` verification is unchanged and still runs on whichever attempt succeeds.

## Testing

- Success path in `alpine:3.24.1`: downloads, checksum passes, `static-web-server --version` reports 2.44.0.
- Exhaustion path against an unroutable URL: all attempts run (`set -e` does not abort the loop early), the guard trips, and the step exits 1 without reaching the checksum.
- Full `docker build -f ui/Dockerfile .` as CI runs it: image builds, and `/usr/local/bin/static-web-server --version` in the resulting image reports 2.44.0.