### PR TITLE
refactor(ui): install-keys shared components and self-owning dialog

### DIFF
--- a/ui/apps/console/src/pages/install-keys/ExpiryLabel.tsx
+++ b/ui/apps/console/src/pages/install-keys/ExpiryLabel.tsx
@@ -1,0 +1,34 @@
+import { ClockIcon } from "@heroicons/react/24/outline";
+import { ExclamationCircleIcon } from "@heroicons/react/24/solid";
+import { type InstallKey } from "@/client";
+import { getExpiryInfo, getKeyBlockers } from "./helpers";
+import { cn } from "@shellhub/design-system/cn";
+
+const ICON_CLASS = "w-3.5 h-3.5 shrink-0";
+
+export default function ExpiryLabel({
+  installKey,
+  className,
+}: {
+  installKey: InstallKey;
+  className?: string;
+}) {
+  const { expired, revoked, disabled } = getKeyBlockers(installKey);
+  const quiet = revoked || disabled;
+
+  return (
+    <span
+      className={cn("flex items-center gap-1 font-mono", className)}
+      title={expired ? "Expired" : undefined}
+    >
+      {expired ? (
+        <ExclamationCircleIcon
+          className={cn(ICON_CLASS, !quiet && "text-accent-red")}
+        />
+      ) : (
+        <ClockIcon className={ICON_CLASS} />
+      )}
+      {getExpiryInfo(installKey.expires_at).label}
+    </span>
+  );
+}

--- a/ui/apps/console/src/pages/install-keys/InstallKeyActions.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeyActions.tsx
@@ -1,71 +1,18 @@
 import { useState } from "react";
-import { useUpdateInstallKey } from "@/hooks/useInstallKeyMutations";
 import { type InstallKey } from "@/client";
 import InstallKeyActionsMenu from "./InstallKeyActionsMenu";
 import EditInstallKeyDrawer from "./EditInstallKeyDrawer";
 import RevokeInstallKeyDialog from "./RevokeInstallKeyDialog";
+import { useToggleInstallKey } from "./useToggleInstallKey";
 
-/**
- * The install key overflow menu wired to its own drawers/dialogs, for anywhere a single key is shown
- * on its own (the activity page header). Bundles Edit, Disable/Enable, and the type-to-confirm Revoke
- * so a caller only drops in <InstallKeyActions installKey={key} />. The list page keeps its own
- * shared wiring since it drives one set of dialogs for every row.
- */
 export default function InstallKeyActions({
   installKey,
 }: {
   installKey: InstallKey;
 }) {
-  const updateKey = useUpdateInstallKey();
   const [editOpen, setEditOpen] = useState(false);
   const [revokeOpen, setRevokeOpen] = useState(false);
-  const [revokeConfirmText, setRevokeConfirmText] = useState("");
-  const [revokeError, setRevokeError] = useState<string | null>(null);
-  const [toggleError, setToggleError] = useState<string | null>(null);
-
-  // Pause/resume is reversible, so it fires the mutation directly (no confirm).
-  const toggleDisabled = async () => {
-    setToggleError(null);
-    try {
-      await updateKey.mutateAsync({
-        path: { key: installKey.name },
-        body: { disabled: !installKey.disabled },
-      });
-    } catch (err) {
-      setToggleError(
-        err instanceof Error
-          ? err.message
-          : `Failed to ${installKey.disabled ? "enable" : "disable"} Install Key.`,
-      );
-    }
-  };
-
-  const openRevoke = () => {
-    setRevokeConfirmText("");
-    setRevokeError(null);
-    setRevokeOpen(true);
-  };
-
-  const closeRevoke = () => {
-    setRevokeConfirmText("");
-    setRevokeError(null);
-    setRevokeOpen(false);
-  };
-
-  const confirmRevoke = async () => {
-    setRevokeError(null);
-    try {
-      await updateKey.mutateAsync({
-        path: { key: installKey.name },
-        body: { revoked: true },
-      });
-      closeRevoke();
-    } catch (err) {
-      setRevokeError(
-        err instanceof Error ? err.message : "Failed to revoke Install Key.",
-      );
-    }
-  };
+  const { toggle, error: toggleError } = useToggleInstallKey();
 
   return (
     <>
@@ -73,8 +20,8 @@ export default function InstallKeyActions({
         <InstallKeyActionsMenu
           installKey={installKey}
           onEdit={() => setEditOpen(true)}
-          onToggleDisabled={() => void toggleDisabled()}
-          onRevoke={openRevoke}
+          onToggleDisabled={() => void toggle(installKey)}
+          onRevoke={() => setRevokeOpen(true)}
         />
         {toggleError && (
           <p className="mt-1 text-xs text-accent-red">{toggleError}</p>
@@ -87,13 +34,8 @@ export default function InstallKeyActions({
       />
 
       <RevokeInstallKeyDialog
-        installKey={installKey}
-        open={revokeOpen}
-        confirmText={revokeConfirmText}
-        onConfirmTextChange={setRevokeConfirmText}
-        onClose={closeRevoke}
-        onConfirm={confirmRevoke}
-        error={revokeError}
+        installKey={revokeOpen ? installKey : null}
+        onRevoked={() => setRevokeOpen(false)}
       />
     </>
   );

--- a/ui/apps/console/src/pages/install-keys/InstallKeyHistoryPage.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeyHistoryPage.tsx
@@ -1,7 +1,6 @@
 import { type ReactNode, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
-import { ClockIcon, TicketIcon } from "@heroicons/react/24/outline";
-import { ExclamationCircleIcon as ExclamationCircleSolidIcon } from "@heroicons/react/24/solid";
+import { TicketIcon } from "@heroicons/react/24/outline";
 import { IconBadge } from "@shellhub/design-system/primitives";
 import { type InstallKey } from "@/client";
 import { useInstallKeys } from "@/hooks/useInstallKeys";
@@ -15,12 +14,8 @@ import StatusChip from "./StatusChip";
 import KeyValueChip from "./KeyValueChip";
 import UsageMeter from "./UsageMeter";
 import { modeInfo } from "./constants";
-import {
-  getExpiryInfo,
-  getKeyBlockers,
-  installKeyDisplayName,
-  isPairingKey,
-} from "./helpers";
+import { installKeyDisplayName, isPairingKey } from "./helpers";
+import ExpiryLabel from "./ExpiryLabel";
 
 /** One labelled fact in the key summary strip. */
 function Fact({ label, children }: { label: string; children: ReactNode }) {
@@ -114,25 +109,7 @@ export default function InstallKeyHistoryPage() {
                 </div>
               </Fact>
               <Fact label="Expires">
-                {(() => {
-                  const { expired, revoked, disabled } = getKeyBlockers(key);
-                  const quiet = revoked || disabled;
-                  return (
-                    <span
-                      className="flex items-center gap-1 font-mono"
-                      title={expired ? "Expired" : undefined}
-                    >
-                      {expired ? (
-                        <ExclamationCircleSolidIcon
-                          className={`w-3.5 h-3.5 shrink-0 ${quiet ? "" : "text-accent-red"}`}
-                        />
-                      ) : (
-                        <ClockIcon className="w-3.5 h-3.5 shrink-0" />
-                      )}
-                      {getExpiryInfo(key.expires_at).label}
-                    </span>
-                  );
-                })()}
+                <ExpiryLabel installKey={key} />
               </Fact>
               {key.tags && key.tags.length > 0 && (
                 <Fact label="Tags">

--- a/ui/apps/console/src/pages/install-keys/InstallKeysTable.tsx
+++ b/ui/apps/console/src/pages/install-keys/InstallKeysTable.tsx
@@ -1,14 +1,12 @@
 import { useNavigate } from "react-router-dom";
 import {
   BoltIcon,
-  ClockIcon,
   NoSymbolIcon,
   PauseCircleIcon,
   PlusIcon,
   QrCodeIcon,
   TicketIcon,
 } from "@heroicons/react/24/outline";
-import { ExclamationCircleIcon as ExclamationCircleSolidIcon } from "@heroicons/react/24/solid";
 import { Button } from "@shellhub/design-system/primitives";
 import { type InstallKey } from "@/client";
 import DataTable, { type Column } from "@/components/common/DataTable";
@@ -18,12 +16,12 @@ import StatusChip, { DeprecatedBadge } from "./StatusChip";
 import UsageMeter from "./UsageMeter";
 import { modeInfo } from "./constants";
 import {
-  getExpiryInfo,
   getKeyBlockers,
   installKeyDisplayName,
   isPairingKey,
   isSystemKey,
 } from "./helpers";
+import ExpiryLabel from "./ExpiryLabel";
 
 /**
  * The Mode cell: the key's mode identity (icon tile + label). Its secondary line is the mode summary
@@ -192,29 +190,12 @@ export default function InstallKeysTable({
       key: "expiry",
       header: "Expires",
       render: (key) => {
-        const expiry = getExpiryInfo(key.expires_at);
-        const { expired, revoked, disabled } = getKeyBlockers(key);
-        // The date stays muted (never an alarm-red string). An elapsed expiry swaps the clock for a
-        // solid exclamation glyph — shown even on a revoked/disabled key, so the "expired" fact never
-        // hides behind another state. Only the red pip is conditional: a revoked/disabled key mutes
-        // it (that expiry no longer matters), a live one keeps it as the at-a-glance signal.
-        const quiet = revoked || disabled;
-        const dateTitle = expired ? "Expired" : undefined;
         return (
           <div className="flex flex-col gap-1">
-            <span
-              title={dateTitle}
-              className="flex items-center gap-1 text-2xs font-mono text-text-muted whitespace-nowrap"
-            >
-              {expired ? (
-                <ExclamationCircleSolidIcon
-                  className={`w-3.5 h-3.5 shrink-0 ${quiet ? "" : "text-accent-red"}`}
-                />
-              ) : (
-                <ClockIcon className="w-3.5 h-3.5 shrink-0" />
-              )}
-              {expiry.label}
-            </span>
+            <ExpiryLabel
+              installKey={key}
+              className="text-2xs text-text-muted whitespace-nowrap"
+            />
             {key.ephemeral && (
               <span
                 className="flex items-center gap-1 text-2xs text-text-muted whitespace-nowrap"

--- a/ui/apps/console/src/pages/install-keys/RevealInstallKeyDialog.tsx
+++ b/ui/apps/console/src/pages/install-keys/RevealInstallKeyDialog.tsx
@@ -1,11 +1,15 @@
 import { useId, useState } from "react";
 import {
-  ExclamationCircleIcon,
   ExclamationTriangleIcon,
   EyeIcon,
   LockClosedIcon,
 } from "@heroicons/react/24/outline";
-import { Button, Card, Spinner } from "@shellhub/design-system/primitives";
+import {
+  Button,
+  Callout,
+  Card,
+  Spinner,
+} from "@shellhub/design-system/primitives";
 import { useRevealInstallKey } from "@/hooks/useRevealInstallKey";
 import { type InstallKey } from "@/client";
 import { installKeyDisplayName } from "./helpers";
@@ -122,18 +126,9 @@ export default function RevealInstallKeyDialog({
                 <Spinner />
               </div>
             ) : error ? (
-              <div
-                role="alert"
-                className="flex items-start gap-2 bg-accent-red/[0.06] border border-accent-red/20 rounded-lg px-3 py-2.5 text-xs text-accent-red"
-              >
-                <ExclamationCircleIcon
-                  className="w-4 h-4 shrink-0 mt-px"
-                  strokeWidth={2}
-                />
-                <span>
-                  Could not load the key. Check your connection and try again.
-                </span>
-              </div>
+              <Callout variant="error">
+                Could not load the key. Check your connection and try again.
+              </Callout>
             ) : (
               <>
                 <Card

--- a/ui/apps/console/src/pages/install-keys/RevokeInstallKeyDialog.tsx
+++ b/ui/apps/console/src/pages/install-keys/RevokeInstallKeyDialog.tsx
@@ -1,36 +1,48 @@
+import { useState } from "react";
+import { useUpdateInstallKey } from "@/hooks/useInstallKeyMutations";
+import { useResetOnOpen } from "@/hooks/useResetOnOpen";
+import { type InstallKey } from "@/client";
 import ConfirmDialog from "@/components/common/ConfirmDialog";
 import InputField from "@/components/common/fields/InputField";
-import { type InstallKey } from "@/client";
 
-/**
- * The type-to-confirm revoke dialog for an install key, shared by the list page (one dialog for the
- * targeted row) and the activity-page actions menu (bound to its single key). The caller owns the
- * open/confirm-text/error state since the two drive it differently.
- */
 export default function RevokeInstallKeyDialog({
   installKey,
-  open,
-  confirmText,
-  onConfirmTextChange,
-  onClose,
-  onConfirm,
-  error,
+  onRevoked,
 }: {
   installKey: InstallKey | null;
-  open: boolean;
-  confirmText: string;
-  onConfirmTextChange: (value: string) => void;
-  onClose: () => void;
-  onConfirm: () => Promise<void> | void;
-  error: string | null;
+  onRevoked: () => void;
 }) {
+  const updateKey = useUpdateInstallKey();
+  const [confirmText, setConfirmText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const open = !!installKey;
   const name = installKey?.name ?? "";
+
+  useResetOnOpen(open, () => {
+    setConfirmText("");
+    setError(null);
+  });
+
+  const handleConfirm = async () => {
+    if (!installKey) return;
+    setError(null);
+    try {
+      await updateKey.mutateAsync({
+        path: { key: installKey.name },
+        body: { revoked: true },
+      });
+      onRevoked();
+    } catch {
+      setError("Failed to revoke Install Key.");
+    }
+  };
 
   return (
     <ConfirmDialog
       open={open}
-      onClose={onClose}
-      onConfirm={onConfirm}
+      onClose={onRevoked}
+      onConfirm={handleConfirm}
       title="Revoke Install Key"
       description={
         <>
@@ -50,7 +62,7 @@ export default function RevokeInstallKeyDialog({
         label="Type the key's name to confirm"
         hideLabel
         value={confirmText}
-        onChange={onConfirmTextChange}
+        onChange={setConfirmText}
         autoComplete="off"
       />
     </ConfirmDialog>

--- a/ui/apps/console/src/pages/install-keys/index.tsx
+++ b/ui/apps/console/src/pages/install-keys/index.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { TicketIcon } from "@heroicons/react/24/outline";
 import { Button, Spinner } from "@shellhub/design-system/primitives";
 import { useInstallKeys } from "@/hooks/useInstallKeys";
-import { useUpdateInstallKey } from "@/hooks/useInstallKeyMutations";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { type InstallKey } from "@/client";
 import PageHeader from "@/components/common/PageHeader";
@@ -12,6 +11,7 @@ import CreateInstallKeyDrawer from "./CreateInstallKeyDrawer";
 import EditInstallKeyDrawer from "./EditInstallKeyDrawer";
 import RevokeInstallKeyDialog from "./RevokeInstallKeyDialog";
 import { isSystemKey } from "./helpers";
+import { useToggleInstallKey } from "./useToggleInstallKey";
 
 const PER_PAGE = 10;
 
@@ -29,70 +29,13 @@ export default function InstallKeys() {
   const page = params.page;
   const { installKeys, totalCount, isLoading } = useInstallKeys({ page });
 
-  // The store pins the namespace's auto-managed built-in keys (legacy, pairing) first and paginates
-  // them together with the user's keys, so totalCount already counts them. Drive both the page count
-  // and the item count off that one base, or the "N keys" label and the page controls disagree.
   const totalPages = Math.ceil(totalCount / PER_PAGE);
 
-  const updateKey = useUpdateInstallKey();
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<InstallKey | null>(null);
   const [revokeTarget, setRevokeTarget] = useState<InstallKey | null>(null);
-  const [revokeConfirmText, setRevokeConfirmText] = useState("");
-  const [revokeError, setRevokeError] = useState<string | null>(null);
-  const [toggleError, setToggleError] = useState<string | null>(null);
+  const { toggle, error: toggleError } = useToggleInstallKey();
 
-  // Pause/resume is reversible, so it fires the mutation directly (no confirm).
-  const toggleDisabled = async (key: InstallKey) => {
-    setToggleError(null);
-    try {
-      await updateKey.mutateAsync({
-        path: { key: key.name },
-        body: { disabled: !key.disabled },
-      });
-    } catch (err) {
-      setToggleError(
-        err instanceof Error
-          ? err.message
-          : `Failed to ${key.disabled ? "enable" : "disable"} Install Key.`,
-      );
-    }
-  };
-
-  // Revoke is irreversible (no un-revoke) and cuts off the key for new enrollments, so it's gated
-  // behind typing the key's name — mirroring the vault-reset confirmation.
-  const openRevoke = (key: InstallKey) => {
-    setRevokeConfirmText("");
-    setRevokeError(null);
-    setRevokeTarget(key);
-  };
-
-  const closeRevoke = () => {
-    setRevokeConfirmText("");
-    setRevokeError(null);
-    setRevokeTarget(null);
-  };
-
-  const confirmRevoke = async () => {
-    if (!revokeTarget) return;
-    setRevokeError(null);
-    try {
-      await updateKey.mutateAsync({
-        path: { key: revokeTarget.name },
-        body: { revoked: true },
-      });
-      closeRevoke();
-    } catch (err) {
-      setRevokeError(
-        err instanceof Error ? err.message : "Failed to revoke Install Key.",
-      );
-    }
-  };
-
-  // The built-in keys (legacy + pairing) always fill the table, so a namespace with no user-created
-  // keys is not an empty page — it's an empty "Custom keys" section. Detect that (any non-built-in key
-  // on this page, or more than one page, means custom keys exist) so the table can show the onboarding
-  // placeholder in that section instead. Replaces the old full-page hero, which never showed.
   const noCustomKeys =
     !installKeys.some((key) => !isSystemKey(key)) && totalPages <= 1;
 
@@ -133,8 +76,8 @@ export default function InstallKeys() {
             onPageChange={setPage}
             onCreate={() => setCreateOpen(true)}
             onEdit={setEditTarget}
-            onToggleDisabled={(k) => void toggleDisabled(k)}
-            onRevoke={openRevoke}
+            onToggleDisabled={(k) => void toggle(k)}
+            onRevoke={setRevokeTarget}
           />
         </div>
       )}
@@ -149,12 +92,7 @@ export default function InstallKeys() {
       />
       <RevokeInstallKeyDialog
         installKey={revokeTarget}
-        open={!!revokeTarget}
-        confirmText={revokeConfirmText}
-        onConfirmTextChange={setRevokeConfirmText}
-        onClose={closeRevoke}
-        onConfirm={confirmRevoke}
-        error={revokeError}
+        onRevoked={() => setRevokeTarget(null)}
       />
     </div>
   );

--- a/ui/apps/console/src/pages/install-keys/useToggleInstallKey.ts
+++ b/ui/apps/console/src/pages/install-keys/useToggleInstallKey.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { useUpdateInstallKey } from "@/hooks/useInstallKeyMutations";
+import { type InstallKey } from "@/client";
+
+export function useToggleInstallKey() {
+  const updateKey = useUpdateInstallKey();
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = async (key: InstallKey) => {
+    setError(null);
+    try {
+      await updateKey.mutateAsync({
+        path: { key: key.name },
+        body: { disabled: !key.disabled },
+      });
+    } catch {
+      setError(
+        `Failed to ${key.disabled ? "enable" : "disable"} Install Key.`,
+      );
+    }
+  };
+
+  return { toggle, error, isToggling: updateKey.isPending };
+}


### PR DESCRIPTION
## What

Completes the install-keys cleanup (team#195 items 1–4): replaces hand-rolled markup with DS primitives, deduplicates shared rendering, and moves dialog/toggle state into reusable units.

## Why

Both callers of `RevokeInstallKeyDialog` duplicated ~25 lines of confirm-text, error, and mutation wiring. The toggle-disabled handler was copy-pasted with a dead `err instanceof Error` branch (hey-api SDK errors are never `Error` instances). The expiry icon+date block was duplicated between the table and history page. The reveal dialog's error state hand-rolled what `Callout` already provides.

Closes shellhub-io/team#195

## Changes

- **`RevealInstallKeyDialog`**: replaced hand-rolled error banner with `<Callout variant="error">`, gaining `role="alert"` and `aria-live="assertive"` from the DS primitive
- **`ExpiryLabel`**: extracted the shared expired/clock icon + date label into a component, replacing identical blocks in `InstallKeysTable` and `InstallKeyHistoryPage`
- **`RevokeInstallKeyDialog`**: internalized confirm-text, error, and mutation state — callers now pass `installKey | null` + `onRevoked` instead of threading five props
- **`useToggleInstallKey`**: extracted the shared disable/enable toggle from `index.tsx` and `InstallKeyActions.tsx`, dropping the dead `err instanceof Error` branch