### PR TITLE
fix(server): thread X-Forwarded-Proto through RegisterUser and user hooks

### DIFF
--- a/server/api/routes/invitation.go
+++ b/server/api/routes/invitation.go
@@ -34,7 +34,7 @@ func (h *Handler) RegisterUser(c *gateway.Context) error {
 		return err
 	}
 
-	authInfo, conflictFields, err := h.service.RegisterUser(c.Ctx(), req, c.Request().Header.Get("X-Forwarded-Host"))
+	authInfo, conflictFields, err := h.service.RegisterUser(c.Ctx(), req, c.Request().Header.Get("X-Forwarded-Host"), c.Request().Header.Get("X-Forwarded-Proto"))
 	if err != nil {
 		// The UI uses the conflicting fields to tell invalid from duplicated.
 		var e errors.Error

--- a/server/api/services/mocks/mock_service.go
+++ b/server/api/services/mocks/mock_service.go
@@ -5561,8 +5561,8 @@ func (_c *MockService_PushTagTo_Call) RunAndReturn(run func(ctx context.Context,
 }
 
 // RegisterUser provides a mock function for the type MockService
-func (_mock *MockService) RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost string) (*models.UserAuthResponse, []string, error) {
-	ret := _mock.Called(ctx, req, forwardedHost)
+func (_mock *MockService) RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost string, forwardedProto string) (*models.UserAuthResponse, []string, error) {
+	ret := _mock.Called(ctx, req, forwardedHost, forwardedProto)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RegisterUser")
@@ -5571,25 +5571,25 @@ func (_mock *MockService) RegisterUser(ctx context.Context, req requests.Registe
 	var r0 *models.UserAuthResponse
 	var r1 []string
 	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.RegisterUser, string) (*models.UserAuthResponse, []string, error)); ok {
-		return returnFunc(ctx, req, forwardedHost)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.RegisterUser, string, string) (*models.UserAuthResponse, []string, error)); ok {
+		return returnFunc(ctx, req, forwardedHost, forwardedProto)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.RegisterUser, string) *models.UserAuthResponse); ok {
-		r0 = returnFunc(ctx, req, forwardedHost)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.RegisterUser, string, string) *models.UserAuthResponse); ok {
+		r0 = returnFunc(ctx, req, forwardedHost, forwardedProto)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.UserAuthResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, requests.RegisterUser, string) []string); ok {
-		r1 = returnFunc(ctx, req, forwardedHost)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, requests.RegisterUser, string, string) []string); ok {
+		r1 = returnFunc(ctx, req, forwardedHost, forwardedProto)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, requests.RegisterUser, string) error); ok {
-		r2 = returnFunc(ctx, req, forwardedHost)
+	if returnFunc, ok := ret.Get(2).(func(context.Context, requests.RegisterUser, string, string) error); ok {
+		r2 = returnFunc(ctx, req, forwardedHost, forwardedProto)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -5605,11 +5605,12 @@ type MockService_RegisterUser_Call struct {
 //   - ctx context.Context
 //   - req requests.RegisterUser
 //   - forwardedHost string
-func (_e *MockService_Expecter) RegisterUser(ctx any, req any, forwardedHost any) *MockService_RegisterUser_Call {
-	return &MockService_RegisterUser_Call{Call: _e.mock.On("RegisterUser", ctx, req, forwardedHost)}
+//   - forwardedProto string
+func (_e *MockService_Expecter) RegisterUser(ctx any, req any, forwardedHost any, forwardedProto any) *MockService_RegisterUser_Call {
+	return &MockService_RegisterUser_Call{Call: _e.mock.On("RegisterUser", ctx, req, forwardedHost, forwardedProto)}
 }
 
-func (_c *MockService_RegisterUser_Call) Run(run func(ctx context.Context, req requests.RegisterUser, forwardedHost string)) *MockService_RegisterUser_Call {
+func (_c *MockService_RegisterUser_Call) Run(run func(ctx context.Context, req requests.RegisterUser, forwardedHost string, forwardedProto string)) *MockService_RegisterUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -5623,10 +5624,15 @@ func (_c *MockService_RegisterUser_Call) Run(run func(ctx context.Context, req r
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -5637,7 +5643,7 @@ func (_c *MockService_RegisterUser_Call) Return(userAuthResponse *models.UserAut
 	return _c
 }
 
-func (_c *MockService_RegisterUser_Call) RunAndReturn(run func(ctx context.Context, req requests.RegisterUser, forwardedHost string) (*models.UserAuthResponse, []string, error)) *MockService_RegisterUser_Call {
+func (_c *MockService_RegisterUser_Call) RunAndReturn(run func(ctx context.Context, req requests.RegisterUser, forwardedHost string, forwardedProto string) (*models.UserAuthResponse, []string, error)) *MockService_RegisterUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/api/services/register.go
+++ b/server/api/services/register.go
@@ -18,14 +18,14 @@ import (
 // code via req.Sig, or a pending user_invitation matching the email), it completes the invited
 // account and — if the code resolves — joins the namespace in the same step. Open self-registration
 // is a capability (cloud only); community and enterprise are invite-only.
-func (s *service) RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost string) (*models.UserAuthResponse, []string, error) {
+func (s *service) RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, []string, error) {
 	// A valid invite code (Sig) is the only way to complete an invited account: it resolves the
 	// invitation server-side and the email comes from it, so the invitee can't retarget it.
 	if req.Sig != "" {
 		if membership, err := s.store.MembershipInvitationResolveBySig(ctx, req.Sig); err == nil {
 			invitation, err := s.store.UserInvitationGet(ctx, store.UserInvitationIDResolver, membership.UserID)
 			if err == nil && invitation.Status == models.UserInvitationStatusPending {
-				return s.createInvitedUser(ctx, &req, invitation, forwardedHost)
+				return s.createInvitedUser(ctx, &req, invitation, forwardedHost, forwardedProto)
 			}
 		}
 	}
@@ -39,14 +39,14 @@ func (s *service) RegisterUser(ctx context.Context, req requests.RegisterUser, f
 	}
 
 	if invitation, err := s.store.UserInvitationGet(ctx, store.UserInvitationEmailResolver, strings.ToLower(req.Email)); err == nil && invitation.Status == models.UserInvitationStatusPending {
-		return s.createInvitedUser(ctx, &req, invitation, forwardedHost)
+		return s.createInvitedUser(ctx, &req, invitation, forwardedHost, forwardedProto)
 	}
 
-	return s.createNewUser(ctx, &req, forwardedHost)
+	return s.createNewUser(ctx, &req, forwardedHost, forwardedProto)
 }
 
 // createNewUser handles the creation of a new user who was not invited to register.
-func (s *service) createNewUser(ctx context.Context, req *requests.RegisterUser, forwardedHost string) (*models.UserAuthResponse, []string, error) {
+func (s *service) createNewUser(ctx context.Context, req *requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, []string, error) {
 	password, err := models.HashUserPassword(req.Password)
 	if err != nil {
 		return nil, nil, err
@@ -86,7 +86,7 @@ func (s *service) createNewUser(ctx context.Context, req *requests.RegisterUser,
 	validUntil := clock.Now().Add(24 * time.Hour)
 
 	// Email delivery is an edition add-on (cloud) and non-fatal: the user can request a resend.
-	if err := fireUserRegistered(ctx, user, forwardedHost, validUntil); err != nil {
+	if err := fireUserRegistered(ctx, user, forwardedHost, forwardedProto, validUntil); err != nil {
 		log.WithError(err).WithField("user_id", user.ID).Error("Failed to send verification email")
 	}
 
@@ -94,7 +94,7 @@ func (s *service) createNewUser(ctx context.Context, req *requests.RegisterUser,
 }
 
 // createInvitedUser handles the creation of a user who was previously invited through user_invitations.
-func (s *service) createInvitedUser(ctx context.Context, req *requests.RegisterUser, invitation *models.UserInvitation, forwardedHost string) (*models.UserAuthResponse, []string, error) {
+func (s *service) createInvitedUser(ctx context.Context, req *requests.RegisterUser, invitation *models.UserInvitation, forwardedHost, forwardedProto string) (*models.UserAuthResponse, []string, error) {
 	if invitation.Status != models.UserInvitationStatusPending {
 		return nil, nil, errors.New("invitation already accepted")
 	}
@@ -204,7 +204,7 @@ func (s *service) createInvitedUser(ctx context.Context, req *requests.RegisterU
 		return res, nil, nil
 	case models.UserStatusNotConfirmed:
 		validUntil := clock.Now().Add(24 * time.Hour)
-		if err := fireUserRegistered(ctx, user, forwardedHost, validUntil); err != nil {
+		if err := fireUserRegistered(ctx, user, forwardedHost, forwardedProto, validUntil); err != nil {
 			log.WithError(err).WithField("user_id", user.ID).Error("Failed to send verification email for invited user")
 		}
 

--- a/server/api/services/register_test.go
+++ b/server/api/services/register_test.go
@@ -195,7 +195,7 @@ func TestService_RegisterUser(t *testing.T) {
 
 			s := NewService(store.Store(storeMock), privateKey, publicKey, storecache.NewNullCache())
 
-			res, conflicts, err := s.RegisterUser(ctx, tc.req, "shellhub.test")
+			res, conflicts, err := s.RegisterUser(ctx, tc.req, "shellhub.test", "")
 			assert.Equal(t, tc.expected.conflicts, conflicts)
 			assert.Equal(t, tc.expected.err, err)
 			if tc.expected.hasToken {

--- a/server/api/services/user.go
+++ b/server/api/services/user.go
@@ -16,7 +16,7 @@ type UserService interface {
 	// and joins the namespace. Open self-registration is cloud-only; community and enterprise are
 	// invite-only. Returns the auth response (when the account goes live), conflicting fields, and
 	// an error if any.
-	RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost string) (*models.UserAuthResponse, []string, error)
+	RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, []string, error)
 
 	// UpdateUser updates the user's data, such as email and username. Since some attributes must be unique per user,
 	// it returns a list of duplicated unique values and an error if any.

--- a/server/api/services/user_hooks.go
+++ b/server/api/services/user_hooks.go
@@ -11,7 +11,7 @@ import (
 // UserRegisteredHookFn is called after a not-confirmed user is created during registration. Cloud
 // uses it to send the email-verification link. It runs outside any transaction and its failure is
 // non-fatal (registration succeeds; the user can request a resend).
-type UserRegisteredHookFn func(ctx context.Context, user *models.User, forwardedHost string, validUntil time.Time) error
+type UserRegisteredHookFn func(ctx context.Context, user *models.User, forwardedHost, forwardedProto string, validUntil time.Time) error
 
 var userRegisteredHooks []UserRegisteredHookFn
 
@@ -26,9 +26,9 @@ func OnUserRegistered(fn UserRegisteredHookFn) {
 }
 
 // fireUserRegistered dispatches all registered post-registration hooks sequentially.
-func fireUserRegistered(ctx context.Context, user *models.User, forwardedHost string, validUntil time.Time) error {
+func fireUserRegistered(ctx context.Context, user *models.User, forwardedHost, forwardedProto string, validUntil time.Time) error {
 	for _, fn := range userRegisteredHooks {
-		if err := fn(ctx, user, forwardedHost, validUntil); err != nil {
+		if err := fn(ctx, user, forwardedHost, forwardedProto, validUntil); err != nil {
 			return fmt.Errorf("user registered hook failed: %w", err)
 		}
 	}


### PR DESCRIPTION
## What
`UserRegisteredHookFn`, `RegisterUser`, and their internal call chain now accept a `forwardedProto` parameter sourced from the request's `X-Forwarded-Proto` header. Cloud's `SendVerifyEmail` hook uses it to build email verification links with the correct scheme.

## Why
Email verification links sent after registration hardcode `https://`, which breaks in local development where the gateway runs plain HTTP. The `InviteMember` flow already solved this by threading `X-Forwarded-Proto` through to the template — this change extends the same pattern to the registration path.
Closes shellhub-io/team#211

## Changes
- **`UserRegisteredHookFn` / `fireUserRegistered`**: added `forwardedProto string` parameter between `forwardedHost` and `validUntil`
- **`UserService.RegisterUser`**: interface and implementation (`createNewUser`, `createInvitedUser`) thread `forwardedProto` to both `fireUserRegistered` call sites
- **`RegisterUser` route handler**: reads `X-Forwarded-Proto` alongside the existing `X-Forwarded-Host`

Companion PR in `cloud/` updates the hook implementation and email templates to consume the new parameter.