### PR TITLE
refactor(ui): consolidate login page card styles into LoginLayoutCard

### DIFF
--- a/ui/apps/console/src/components/auth/AccountCreated.tsx
+++ b/ui/apps/console/src/components/auth/AccountCreated.tsx
@@ -4,6 +4,7 @@ import { ArrowRightIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import { useAuthStore } from "@/stores/authStore";
 import { useSignUpStore } from "@/stores/signUpStore";
 import { Button } from "@shellhub/design-system/primitives";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function AccountCreated() {
   const navigate = useNavigate();
@@ -32,32 +33,30 @@ export default function AccountCreated() {
   };
 
   return (
-    <div className="w-full max-w-sm mx-auto animate-fade-in">
-      <div className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm text-center">
-        <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-green/10 border border-accent-green/20 mb-5">
-          <CheckCircleIcon
-            className="w-7 h-7 text-accent-green"
-            strokeWidth={1.5}
-          />
-        </div>
-
-        <h2 className="text-lg font-semibold text-text-primary mb-3">
-          Account Creation Successful
-        </h2>
-
-        <p className="text-sm text-text-secondary leading-relaxed mb-6">
-          Thank you for registering an account on ShellHub. You will be
-          redirected in 5 seconds. If you weren&apos;t redirected, please click
-          the button below.
-        </p>
-
-        <Button
-          iconRight={<ArrowRightIcon className="w-4 h-4" strokeWidth={2} />}
-          onClick={handleRedirect}
-        >
-          Redirect
-        </Button>
+    <LoginLayoutCard className="text-center">
+      <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-green/10 border border-accent-green/20 mb-5">
+        <CheckCircleIcon
+          className="w-7 h-7 text-accent-green"
+          strokeWidth={1.5}
+        />
       </div>
-    </div>
+
+      <h2 className="text-lg font-semibold text-text-primary mb-3">
+        Account Creation Successful
+      </h2>
+
+      <p className="text-sm text-text-secondary leading-relaxed mb-6">
+        Thank you for registering an account on ShellHub. You will be redirected
+        in 5 seconds. If you weren&apos;t redirected, please click the button
+        below.
+      </p>
+
+      <Button
+        iconRight={<ArrowRightIcon className="w-4 h-4" strokeWidth={2} />}
+        onClick={handleRedirect}
+      >
+        Redirect
+      </Button>
+    </LoginLayoutCard>
   );
 }

--- a/ui/apps/console/src/components/layout/LoginLayout.tsx
+++ b/ui/apps/console/src/components/layout/LoginLayout.tsx
@@ -5,7 +5,7 @@ export default function LoginLayout() {
   return (
     <div className="relative min-h-screen flex items-center justify-center bg-background overflow-hidden">
       <AmbientBackground />
-      <div className="relative z-raised w-full">
+      <div className="relative z-raised w-full px-8 py-12 flex flex-col items-center">
         <Outlet />
       </div>
     </div>

--- a/ui/apps/console/src/components/layout/LoginLayoutCard.tsx
+++ b/ui/apps/console/src/components/layout/LoginLayoutCard.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { cn } from "@shellhub/design-system/cn";
+
+export default function LoginLayoutCard({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "w-full max-w-md bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/ui/apps/console/src/pages/AcceptDevice.tsx
+++ b/ui/apps/console/src/pages/AcceptDevice.tsx
@@ -1,6 +1,7 @@
 import { useSearchParams } from "react-router-dom";
 import AcceptDeviceFlow from "@/components/devices/AcceptDeviceFlow";
 import { setPendingDeviceCode } from "@/utils/navigation";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 /**
  * Full-page accept surface, reached from the URL the agent prints
@@ -15,10 +16,8 @@ export default function AcceptDevice() {
   if (code) setPendingDeviceCode(code);
 
   return (
-    <div className="w-full max-w-md mx-auto animate-fade-in">
-      <div className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm">
-        <AcceptDeviceFlow code={code} />
-      </div>
-    </div>
+    <LoginLayoutCard>
+      <AcceptDeviceFlow code={code} />
+    </LoginLayoutCard>
   );
 }

--- a/ui/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui/apps/console/src/pages/AcceptInvite.tsx
@@ -23,6 +23,7 @@ import {
 import { Button, Spinner, Callout } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
 import { inviteResolver, type InviteFormValues } from "./setup/inviteResolver";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 type Branch =
   | "loading"
@@ -320,8 +321,8 @@ export default function AcceptInvite() {
   const message = messages[branch];
 
   return (
-    <div className="w-full max-w-md mx-auto animate-fade-in">
-      <div className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm">
+    <>
+      <LoginLayoutCard>
         {branch === "loading" && (
           <div
             className="flex flex-col items-center gap-3 py-6"
@@ -334,7 +335,7 @@ export default function AcceptInvite() {
         )}
 
         {message && <InvitationMessage {...message} />}
-      </div>
+      </LoginLayoutCard>
 
       <ConfirmDialog
         open={showConfirm}
@@ -349,7 +350,7 @@ export default function AcceptInvite() {
         variant="primary"
         errorMessage={error || null}
       />
-    </div>
+    </>
   );
 }
 
@@ -373,7 +374,10 @@ const toneStyles: Record<Tone, { ring: string; iconColor: string }> = {
     ring: "bg-accent-yellow/10 border-accent-yellow/20",
     iconColor: "text-accent-yellow",
   },
-  primary: { ring: "bg-primary/10 border-primary/20", iconColor: "text-primary" },
+  primary: {
+    ring: "bg-primary/10 border-primary/20",
+    iconColor: "text-primary",
+  },
   success: {
     ring: "bg-accent-green/10 border-accent-green/20",
     iconColor: "text-accent-green",

--- a/ui/apps/console/src/pages/ConfirmAccount.tsx
+++ b/ui/apps/console/src/pages/ConfirmAccount.tsx
@@ -4,6 +4,7 @@ import { EnvelopeIcon } from "@heroicons/react/24/outline";
 import { Button, Callout } from "@shellhub/design-system/primitives";
 import { useSignUpStore } from "../stores/signUpStore";
 import { useResendEmail } from "../hooks/useResendEmail";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function ConfirmAccount() {
   const [searchParams] = useSearchParams();
@@ -26,59 +27,57 @@ export default function ConfirmAccount() {
   if (!username) return <Navigate to="/login" replace />;
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
-      <div className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm text-center animate-slide-up">
-        <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 border border-primary/20 mb-5">
-          <EnvelopeIcon className="w-7 h-7 text-primary" strokeWidth={1.5} />
-        </div>
-
-        <h1 className="text-lg font-semibold text-text-primary mb-3">
-          Account Activation Required
-        </h1>
-
-        <p className="text-sm text-text-secondary leading-relaxed mb-6">
-          Thank you for registering an account on ShellHub. An email was sent
-          with a confirmation link. You need to click on the link to activate
-          your account. If you haven&apos;t received the email, click on the
-          Resend Email button.
-        </p>
-
-        {resendSuccess && (
-          <Callout variant="success" className="mb-4">
-            Confirmation email sent successfully.
-          </Callout>
-        )}
-
-        {resendError && (
-          <Callout variant="error" className="mb-4">
-            {resendError}
-          </Callout>
-        )}
-
-        <Button
-          fullWidth
-          loading={resendLoading}
-          disabled={resendLoading || resendCooldown > 0}
-          onClick={() => void handleResend()}
-          className="mb-5"
-        >
-          {resendLoading
-            ? "Sending..."
-            : resendCooldown > 0
-              ? `Resend Email (${resendCooldown}s)`
-              : "Resend Email"}
-        </Button>
-
-        <p className="text-xs text-text-muted">
-          Back to{" "}
-          <Link
-            to="/login"
-            className="text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            Login
-          </Link>
-        </p>
+    <LoginLayoutCard className="text-center">
+      <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-primary/10 border border-primary/20 mb-5">
+        <EnvelopeIcon className="w-7 h-7 text-primary" strokeWidth={1.5} />
       </div>
-    </div>
+
+      <h1 className="text-lg font-semibold text-text-primary mb-3">
+        Account Activation Required
+      </h1>
+
+      <p className="text-sm text-text-secondary leading-relaxed mb-6">
+        Thank you for registering an account on ShellHub. An email was sent with
+        a confirmation link. You need to click on the link to activate your
+        account. If you haven&apos;t received the email, click on the Resend
+        Email button.
+      </p>
+
+      {resendSuccess && (
+        <Callout variant="success" className="mb-4">
+          Confirmation email sent successfully.
+        </Callout>
+      )}
+
+      {resendError && (
+        <Callout variant="error" className="mb-4">
+          {resendError}
+        </Callout>
+      )}
+
+      <Button
+        fullWidth
+        loading={resendLoading}
+        disabled={resendLoading || resendCooldown > 0}
+        onClick={() => void handleResend()}
+        className="mb-5"
+      >
+        {resendLoading
+          ? "Sending..."
+          : resendCooldown > 0
+            ? `Resend Email (${resendCooldown}s)`
+            : "Resend Email"}
+      </Button>
+
+      <p className="text-xs text-text-muted">
+        Back to{" "}
+        <Link
+          to="/login"
+          className="text-primary hover:text-primary/80 font-medium transition-colors"
+        >
+          Login
+        </Link>
+      </p>
+    </LoginLayoutCard>
   );
 }

--- a/ui/apps/console/src/pages/ForgotPassword.tsx
+++ b/ui/apps/console/src/pages/ForgotPassword.tsx
@@ -13,16 +13,18 @@ import {
   forgotPasswordResolver,
   type ForgotPasswordFormValues,
 } from "./setup/forgotPasswordResolver";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function ForgotPassword() {
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
 
-  const { control, handleSubmit, formState } = useForm<ForgotPasswordFormValues>({
-    resolver: forgotPasswordResolver,
-    mode: "onTouched",
-    defaultValues: { account: "" },
-  });
+  const { control, handleSubmit, formState } =
+    useForm<ForgotPasswordFormValues>({
+      resolver: forgotPasswordResolver,
+      mode: "onTouched",
+      defaultValues: { account: "" },
+    });
 
   const onSubmit = async (values: ForgotPasswordFormValues) => {
     setLoading(true);
@@ -40,7 +42,7 @@ export default function ForgotPassword() {
   };
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero */}
       <div className="text-center mb-12 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -65,10 +67,7 @@ export default function ForgotPassword() {
       </div>
 
       {/* Card */}
-      <div
-        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-        style={{ animationDelay: "200ms" }}
-      >
+      <LoginLayoutCard>
         {sent ? (
           <div
             role="alert"
@@ -91,7 +90,10 @@ export default function ForgotPassword() {
             </div>
           </div>
         ) : (
-          <form onSubmit={(e) => void handleSubmit(onSubmit)(e)} className="space-y-5">
+          <form
+            onSubmit={(e) => void handleSubmit(onSubmit)(e)}
+            className="space-y-5"
+          >
             <FormInputField<ForgotPasswordFormValues>
               name="account"
               control={control}
@@ -116,10 +118,10 @@ export default function ForgotPassword() {
             </Button>
           </form>
         )}
-      </div>
+      </LoginLayoutCard>
 
       {/* Back to login */}
-      <div className="mt-8 animate-fade-in" style={{ animationDelay: "600ms" }}>
+      <div className="mt-8 animate-fade-in">
         <Link
           to="/login"
           className="text-xs text-text-muted hover:text-text-secondary transition-colors"
@@ -127,6 +129,6 @@ export default function ForgotPassword() {
           &larr; Back to login
         </Link>
       </div>
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/Login.tsx
+++ b/ui/apps/console/src/pages/Login.tsx
@@ -18,6 +18,7 @@ import { isCloud, isEnterpriseOrCloud } from "../env";
 import { getSafeRedirect, resolvePostLoginRedirect } from "@/utils/navigation";
 import PendingDeviceCallout from "@/components/auth/PendingDeviceCallout";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 import { getInfo, getSamlAuthUrl } from "../client";
 import {
   FormInputField,
@@ -224,7 +225,7 @@ export default function Login() {
   }
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero */}
       <div className="text-center mb-12 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -249,7 +250,7 @@ export default function Login() {
       </div>
 
       {/* Alerts — rendered outside the form so they are visible in SSO-only mode too */}
-      <div className="w-full max-w-sm flex flex-col gap-3 mb-4 empty:hidden">
+      <div className="w-full max-w-md flex flex-col gap-3 mb-4 empty:hidden">
         <PendingDeviceCallout />
         {lockoutExpired && (
           <Callout variant="success">
@@ -277,10 +278,7 @@ export default function Login() {
 
       {/* Form card — only shown once we know local auth is enabled */}
       {showLocalForm && (
-        <div
-          className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-          style={{ animationDelay: "200ms" }}
-        >
+        <LoginLayoutCard>
           <form onSubmit={handleFormSubmit} className="space-y-5">
             <FormInputField<LoginFormValues>
               id="username"
@@ -323,15 +321,12 @@ export default function Login() {
               {loading ? "Authenticating..." : "Sign In"}
             </Button>
           </form>
-        </div>
+        </LoginLayoutCard>
       )}
 
       {/* SSO login */}
       {isEnterpriseOrCloudEdition && authentication?.saml && (
-        <div
-          className="w-full max-w-sm animate-slide-up"
-          style={{ animationDelay: ssoOnly ? "200ms" : "300ms" }}
-        >
+        <div className="w-full max-w-md animate-slide-up">
           {!ssoOnly && (
             <div className="flex items-center gap-3 my-4">
               <div className="flex-1 h-px bg-border" />
@@ -358,6 +353,6 @@ export default function Login() {
 
       {/* Footer links */}
       <AuthFooterLinks />
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/MfaLogin.tsx
+++ b/ui/apps/console/src/pages/MfaLogin.tsx
@@ -7,6 +7,7 @@ import { resolvePostLoginRedirect } from "@/utils/navigation";
 import PendingDeviceCallout from "@/components/auth/PendingDeviceCallout";
 import { Button, Callout } from "@shellhub/design-system/primitives";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function MfaLogin() {
   const otp = useOtpInput(6);
@@ -41,7 +42,7 @@ export default function MfaLogin() {
   };
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero */}
       <div className="text-center mb-12 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -65,15 +66,12 @@ export default function MfaLogin() {
         </p>
       </div>
 
-      <div className="w-full max-w-sm flex flex-col gap-3 mb-4 empty:hidden">
+      <div className="w-full max-w-md flex flex-col gap-3 mb-4 empty:hidden">
         <PendingDeviceCallout />
       </div>
 
       {/* Form card */}
-      <div
-        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-        style={{ animationDelay: "200ms" }}
-      >
+      <LoginLayoutCard>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
           {error && <Callout variant="error">{error}</Callout>}
 
@@ -127,9 +125,9 @@ export default function MfaLogin() {
             </Link>
           </div>
         </form>
-      </div>
+      </LoginLayoutCard>
       {/* Footer links */}
       <AuthFooterLinks />
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/MfaRecover.tsx
+++ b/ui/apps/console/src/pages/MfaRecover.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from "../stores/authStore";
 import { recoveryDisableMfa } from "../client";
 import MfaRecoveryTimeoutModal from "../components/mfa/MfaRecoveryTimeoutModal";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 import { mfaRecoverResolver } from "./setup/mfaRecoverResolver";
 import type { MfaRecoverFormValues } from "./setup/mfaRecoverResolver";
 
@@ -75,7 +76,7 @@ export default function MfaRecover() {
   };
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero */}
       <div className="text-center mb-12 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -100,10 +101,7 @@ export default function MfaRecover() {
       </div>
 
       {/* Form card */}
-      <div
-        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-        style={{ animationDelay: "200ms" }}
-      >
+      <LoginLayoutCard>
         <form onSubmit={handleFormSubmit} className="space-y-5">
           {error && <Callout variant="error">{error}</Callout>}
 
@@ -151,13 +149,10 @@ export default function MfaRecover() {
             </Link>
           </div>
         </form>
-      </div>
+      </LoginLayoutCard>
 
       {/* Warning note */}
-      <div
-        className="w-full max-w-sm mt-6 p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg animate-fade-in"
-        style={{ animationDelay: "400ms" }}
-      >
+      <div className="w-full max-w-md mt-6 p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg animate-fade-in">
         <p className="text-2xs text-text-muted leading-relaxed">
           <span className="font-semibold text-accent-yellow">Note:</span> After
           using a recovery code, you'll have a 10-minute window to disable MFA
@@ -177,6 +172,6 @@ export default function MfaRecover() {
           onDisable={handleDisableMfa}
         />
       )}
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/MfaResetComplete.tsx
+++ b/ui/apps/console/src/pages/MfaResetComplete.tsx
@@ -9,6 +9,7 @@ import { resetMfa } from "../client";
 import { useAuthStore } from "../stores/authStore";
 import { useOtpInput } from "../hooks/useOtpInput";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function MfaResetComplete() {
   const [searchParams] = useSearchParams();
@@ -61,7 +62,7 @@ export default function MfaResetComplete() {
 
   if (!userId) {
     return (
-      <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+      <>
         <div className="text-center mb-12 animate-fade-in">
           <div className="animate-float mb-6 inline-block">
             <div className="w-20 h-20 rounded-2xl bg-accent-red/15 border border-accent-red/25 flex items-center justify-center shadow-lg shadow-accent-red/10">
@@ -85,12 +86,12 @@ export default function MfaResetComplete() {
           ← Request a new reset link
         </Link>
         <AuthFooterLinks />
-      </div>
+      </>
     );
   }
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero Section */}
       <div className="text-center mb-12 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -112,10 +113,7 @@ export default function MfaResetComplete() {
         </p>
       </div>
       {/* Form Card */}
-      <div
-        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-        style={{ animationDelay: "200ms" }}
-      >
+      <LoginLayoutCard>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
           {error && <Callout variant="error">{error}</Callout>}
 
@@ -134,7 +132,7 @@ export default function MfaResetComplete() {
                 <input
                   key={index}
                   ref={(el) => {
-                    (otpMain.inputRefs.current[index] = el);
+                    otpMain.inputRefs.current[index] = el;
                   }}
                   type="text"
                   maxLength={1}
@@ -166,7 +164,7 @@ export default function MfaResetComplete() {
                 <input
                   key={index}
                   ref={(el) => {
-                    (otpRecovery.inputRefs.current[index] = el);
+                    otpRecovery.inputRefs.current[index] = el;
                   }}
                   type="text"
                   maxLength={1}
@@ -197,12 +195,9 @@ export default function MfaResetComplete() {
             {loading ? "Verifying..." : "Reset MFA and Login"}
           </Button>
         </form>
-      </div>
+      </LoginLayoutCard>
       {/* Info Note */}
-      <div
-        className="w-full max-w-sm mt-6 p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg animate-fade-in"
-        style={{ animationDelay: "400ms" }}
-      >
+      <div className="w-full max-w-md mt-6 p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg animate-fade-in">
         <p className="text-2xs text-text-muted leading-relaxed">
           <span className="font-semibold text-accent-yellow">Security:</span>{" "}
           Both codes are required to prove ownership of your account's email
@@ -210,6 +205,6 @@ export default function MfaResetComplete() {
         </p>
       </div>
       <AuthFooterLinks />
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/MfaResetRequest.tsx
+++ b/ui/apps/console/src/pages/MfaResetRequest.tsx
@@ -6,6 +6,7 @@ import { Button, Callout } from "@shellhub/design-system/primitives";
 import { useAuthStore } from "../stores/authStore";
 import { useMfaResetStore } from "../stores/mfaResetStore";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function MfaResetRequest() {
   const { user, username, mfaToken } = useAuthStore();
@@ -43,7 +44,7 @@ export default function MfaResetRequest() {
   };
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero Section */}
       <div className="text-center mb-12 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -67,10 +68,7 @@ export default function MfaResetRequest() {
       </div>
 
       {/* Form */}
-      <div
-        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-        style={{ animationDelay: "200ms" }}
-      >
+      <LoginLayoutCard>
         <form
           onSubmit={(e) => void handleSubmit(onSubmit)(e)}
           className="space-y-5"
@@ -108,13 +106,10 @@ export default function MfaResetRequest() {
             </Link>
           </div>
         </form>
-      </div>
+      </LoginLayoutCard>
 
       {/* Info Note */}
-      <div
-        className="w-full max-w-sm mt-6 p-4 bg-primary/5 border border-primary/20 rounded-lg animate-fade-in"
-        style={{ animationDelay: "400ms" }}
-      >
+      <div className="w-full max-w-md mt-6 p-4 bg-primary/5 border border-primary/20 rounded-lg animate-fade-in">
         <p className="text-2xs text-text-muted leading-relaxed">
           <span className="font-semibold text-primary">Note:</span> You'll
           receive two separate emails with verification codes. Both codes are
@@ -123,6 +118,6 @@ export default function MfaResetRequest() {
       </div>
 
       <AuthFooterLinks />
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/MfaResetVerify.tsx
+++ b/ui/apps/console/src/pages/MfaResetVerify.tsx
@@ -5,6 +5,7 @@ import { Button, Callout } from "@shellhub/design-system/primitives";
 import { useMfaResetStore } from "../stores/mfaResetStore";
 import { useOtpInput } from "../hooks/useOtpInput";
 import AuthFooterLinks from "../components/common/AuthFooterLinks";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function MfaResetVerify() {
   const {
@@ -50,7 +51,7 @@ export default function MfaResetVerify() {
   };
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero Section */}
       <div className="text-center mb-12 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -73,10 +74,7 @@ export default function MfaResetVerify() {
         </p>
       </div>
       {/* Form Card */}
-      <div
-        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-        style={{ animationDelay: "200ms" }}
-      >
+      <LoginLayoutCard>
         <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
           {error && <Callout variant="error">{error}</Callout>}
 
@@ -167,12 +165,9 @@ export default function MfaResetVerify() {
             </Link>
           </div>
         </form>
-      </div>
+      </LoginLayoutCard>
       {/* Info Note */}
-      <div
-        className="w-full max-w-sm mt-6 p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg animate-fade-in"
-        style={{ animationDelay: "400ms" }}
-      >
+      <div className="w-full max-w-md mt-6 p-4 bg-accent-yellow/5 border border-accent-yellow/20 rounded-lg animate-fade-in">
         <p className="text-2xs text-text-muted leading-relaxed">
           <span className="font-semibold text-accent-yellow">Security:</span>{" "}
           Both codes are required to prove ownership of your account's email
@@ -180,6 +175,6 @@ export default function MfaResetVerify() {
         </p>
       </div>
       <AuthFooterLinks />
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/SignUp.tsx
+++ b/ui/apps/console/src/pages/SignUp.tsx
@@ -14,6 +14,7 @@ import {
   FormCheckboxField,
 } from "@/components/common/fields/rhf";
 import CheckboxField from "@/components/common/fields/CheckboxField";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 const SERVER_FIELD_MAP: Record<string, keyof SignUpFormValues> = {
   username: "username",
@@ -110,15 +111,11 @@ export default function SignUp() {
   };
 
   if (accountCreated) {
-    return (
-      <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
-        <AccountCreated />
-      </div>
-    );
+    return <AccountCreated />;
   }
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero */}
       <div className="text-center mb-10 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -141,14 +138,11 @@ export default function SignUp() {
         </p>
       </div>
 
-      <div className="w-full max-w-sm space-y-4">
+      <div className="w-full max-w-md space-y-4">
         <PendingDeviceCallout />
 
         {/* Form card */}
-        <div
-          className="bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-          style={{ animationDelay: "150ms" }}
-        >
+        <LoginLayoutCard>
           {signUpError && (
             <Callout variant="error" className="mb-5">
               {signUpError}
@@ -253,13 +247,10 @@ export default function SignUp() {
               {signUpLoading ? "Creating account..." : "Create Account"}
             </Button>
           </form>
-        </div>
+        </LoginLayoutCard>
 
         {/* Footer link */}
-        <div
-          className="flex items-center justify-center gap-1.5 text-xs text-text-muted animate-fade-in"
-          style={{ animationDelay: "400ms" }}
-        >
+        <div className="flex items-center justify-center gap-1.5 text-xs text-text-muted animate-fade-in">
           Already have an account?
           <Link
             to="/login"
@@ -269,6 +260,6 @@ export default function SignUp() {
           </Link>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/UpdatePassword.tsx
+++ b/ui/apps/console/src/pages/UpdatePassword.tsx
@@ -10,6 +10,7 @@ import { updateRecoverPassword } from "@/client";
 import { updatePasswordResolver } from "./setup/updatePasswordResolver";
 import type { UpdatePasswordFormValues } from "./setup/updatePasswordResolver";
 import { FormPasswordField } from "@/components/common/fields/rhf";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function UpdatePassword() {
   const [searchParams] = useSearchParams();
@@ -21,13 +22,12 @@ export default function UpdatePassword() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const { control, handleSubmit, formState } = useForm<UpdatePasswordFormValues>(
-    {
+  const { control, handleSubmit, formState } =
+    useForm<UpdatePasswordFormValues>({
       resolver: updatePasswordResolver,
       mode: "onTouched",
       defaultValues: { password: "", confirmPassword: "" },
-    },
-  );
+    });
 
   const onSubmit = async (values: UpdatePasswordFormValues) => {
     setError("");
@@ -56,31 +56,29 @@ export default function UpdatePassword() {
 
   if (!uid || !token) {
     return (
-      <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
-        <div className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 text-center animate-fade-in">
-          <ExclamationCircleIcon
-            className="w-10 h-10 text-accent-red mx-auto mb-4"
-            strokeWidth={1.5}
-          />
-          <p className="text-sm font-semibold text-text-primary mb-2">
-            Invalid reset link
-          </p>
-          <p className="text-xs text-text-muted mb-6">
-            This password reset link is invalid or has expired.
-          </p>
-          <Link
-            to="/forgot-password"
-            className="text-xs text-primary hover:text-primary-400 transition-colors"
-          >
-            Request a new reset link
-          </Link>
-        </div>
-      </div>
+      <LoginLayoutCard className="text-center">
+        <ExclamationCircleIcon
+          className="w-10 h-10 text-accent-red mx-auto mb-4"
+          strokeWidth={1.5}
+        />
+        <p className="text-sm font-semibold text-text-primary mb-2">
+          Invalid reset link
+        </p>
+        <p className="text-xs text-text-muted mb-6">
+          This password reset link is invalid or has expired.
+        </p>
+        <Link
+          to="/forgot-password"
+          className="text-xs text-primary hover:text-primary-400 transition-colors"
+        >
+          Request a new reset link
+        </Link>
+      </LoginLayoutCard>
     );
   }
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
+    <>
       {/* Hero */}
       <div className="text-center mb-12 animate-fade-in">
         <div className="animate-float mb-6 inline-block">
@@ -104,10 +102,7 @@ export default function UpdatePassword() {
       </div>
 
       {/* Card */}
-      <div
-        className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm animate-slide-up"
-        style={{ animationDelay: "200ms" }}
-      >
+      <LoginLayoutCard>
         <form onSubmit={handleFormSubmit} className="space-y-5">
           {error && (
             <div
@@ -153,10 +148,10 @@ export default function UpdatePassword() {
             {loading ? "Updating..." : "Update Password"}
           </Button>
         </form>
-      </div>
+      </LoginLayoutCard>
 
       {/* Back to login */}
-      <div className="mt-8 animate-fade-in" style={{ animationDelay: "600ms" }}>
+      <div className="mt-8 animate-fade-in">
         <Link
           to="/login"
           className="text-xs text-text-muted hover:text-text-secondary transition-colors"
@@ -164,6 +159,6 @@ export default function UpdatePassword() {
           &larr; Back to login
         </Link>
       </div>
-    </div>
+    </>
   );
 }

--- a/ui/apps/console/src/pages/ValidationAccount.tsx
+++ b/ui/apps/console/src/pages/ValidationAccount.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/outline";
 import { useSignUpStore } from "../stores/signUpStore";
 import { Spinner } from "@shellhub/design-system/primitives";
+import LoginLayoutCard from "@/components/layout/LoginLayoutCard";
 
 export default function ValidationAccount() {
   const navigate = useNavigate();
@@ -41,77 +42,74 @@ export default function ValidationAccount() {
   }, [validationStatus, navigate]);
 
   return (
-    <div className="w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center">
-      <div className="w-full max-w-sm bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm text-center animate-slide-up">
-        <h1 className="text-lg font-semibold text-text-primary mb-5">
-          Account Verification
-        </h1>
+    <LoginLayoutCard className="text-center">
+      <h1 className="text-lg font-semibold text-text-primary mb-5">
+        Account Verification
+      </h1>
 
-        <div
-          className="min-h-32 flex flex-col items-center justify-center"
-          role="status"
-          aria-live="polite"
-        >
-          {validationStatus === "processing" || validationStatus === "idle" ? (
-            <>
-              <Spinner size="2xl" className="mb-4" />
-              <p className="text-sm text-text-secondary">
-                Processing your account activation...
-              </p>
-            </>
-          ) : validationStatus === "success" ? (
-            <>
-              <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-green/10 border border-accent-green/20 mb-4">
-                <CheckCircleIcon
-                  className="w-7 h-7 text-accent-green"
-                  strokeWidth={1.5}
-                />
-              </div>
-              <p className="text-sm text-text-secondary leading-relaxed">
-                Congratulations! Your account has been activated successfully.
-                Redirecting to login...
-              </p>
-            </>
-          ) : validationStatus === "failed-token" ? (
-            <>
-              <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-red/10 border border-accent-red/20 mb-4">
-                <XCircleIcon
-                  className="w-7 h-7 text-accent-red"
-                  strokeWidth={1.5}
-                />
-              </div>
-              <p className="text-sm text-text-secondary leading-relaxed">
-                Your account activation token has expired. Go to the login page
-                and log in to receive another email with the activation link.
-              </p>
-            </>
-          ) : (
-            <>
-              <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-red/10 border border-accent-red/20 mb-4">
-                <XCircleIcon
-                  className="w-7 h-7 text-accent-red"
-                  strokeWidth={1.5}
-                />
-              </div>
-              <p className="text-sm text-text-secondary leading-relaxed">
-                There was a problem activating your account. Go to the login
-                page and log in to receive another email with the activation
-                link.
-              </p>
-            </>
-          )}
-        </div>
-
-        <p className="text-xs text-text-muted mt-6">
-          Back to{" "}
-          <Link
-            to="/login"
-            className="text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            Login
-          </Link>
-        </p>
+      <div
+        className="min-h-32 flex flex-col items-center justify-center"
+        role="status"
+        aria-live="polite"
+      >
+        {validationStatus === "processing" || validationStatus === "idle" ? (
+          <>
+            <Spinner size="2xl" className="mb-4" />
+            <p className="text-sm text-text-secondary">
+              Processing your account activation...
+            </p>
+          </>
+        ) : validationStatus === "success" ? (
+          <>
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-green/10 border border-accent-green/20 mb-4">
+              <CheckCircleIcon
+                className="w-7 h-7 text-accent-green"
+                strokeWidth={1.5}
+              />
+            </div>
+            <p className="text-sm text-text-secondary leading-relaxed">
+              Congratulations! Your account has been activated successfully.
+              Redirecting to login...
+            </p>
+          </>
+        ) : validationStatus === "failed-token" ? (
+          <>
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-red/10 border border-accent-red/20 mb-4">
+              <XCircleIcon
+                className="w-7 h-7 text-accent-red"
+                strokeWidth={1.5}
+              />
+            </div>
+            <p className="text-sm text-text-secondary leading-relaxed">
+              Your account activation token has expired. Go to the login page
+              and log in to receive another email with the activation link.
+            </p>
+          </>
+        ) : (
+          <>
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-accent-red/10 border border-accent-red/20 mb-4">
+              <XCircleIcon
+                className="w-7 h-7 text-accent-red"
+                strokeWidth={1.5}
+              />
+            </div>
+            <p className="text-sm text-text-secondary leading-relaxed">
+              There was a problem activating your account. Go to the login page
+              and log in to receive another email with the activation link.
+            </p>
+          </>
+        )}
       </div>
-    </div>
+
+      <p className="text-xs text-text-muted mt-6">
+        Back to{" "}
+        <Link
+          to="/login"
+          className="text-primary hover:text-primary/80 font-medium transition-colors"
+        >
+          Login
+        </Link>
+      </p>
+    </LoginLayoutCard>
   );
 }


### PR DESCRIPTION
## What

Extracted a shared `LoginLayoutCard` component and moved the outer centering shell into `LoginLayout`, eliminating duplicated card-wrapper markup across all 14 pages rendered under `LoginLayout`.

## Why

Every page duplicated two layers of boilerplate: an outer centering div (`w-full max-w-5xl mx-auto px-8 py-12 flex flex-col items-center`) and an inline card div (`bg-card/80 border border-border rounded-2xl p-8 backdrop-blur-sm`). The styles had drifted — `UpdatePassword`'s error branch was missing `backdrop-blur-sm`, cards used `max-w-sm` or `max-w-md` inconsistently, and animation delays varied without reason. Changing the card look required editing 14+ files.

## Changes

- **`LoginLayout`**: absorbed `px-8 py-12 flex flex-col items-center` into the inner wrapper that holds `<Outlet />` — this was redundantly declared by every child page
- **`LoginLayoutCard` (new)**: owns the card chrome (`bg-card/80`, `border`, `rounded-2xl`, `p-8`, `backdrop-blur-sm`, `animate-slide-up`, `max-w-md`); accepts only `className` and `children`
- **All pages**: replaced inline card divs with `<LoginLayoutCard>`, dropped the outer centering wrapper (now in the layout), and standardized on `max-w-md` (was a mix of `sm`/`md`)
- **Animation**: standardized every card to `animate-slide-up` with no delay — previously some pages used `animate-fade-in` and delays ranged from 150ms to 200ms
- **Bug fix**: `UpdatePassword`'s invalid-link branch now gets `backdrop-blur-sm` (was missing)
- **`Setup`**: untouched internally — it uses a different visual treatment (`bg-surface`, `rounded-lg`, split header/body) and is not a candidate for `LoginLayoutCard`

## Testing

- Visit `/login`, `/sign-up`, `/setup`, `/accept-device`, `/confirm-account`, `/update-password` — cards should look consistent and centered
- Check `/setup` specifically — it inherits `px-8 py-12` from the layout now (previously had none); verify it still looks correct on narrow viewports
- Toggle dark/light mode on `/login`
- Resize browser to mobile width — cards should remain within viewport