### PR TITLE
deps: bump Go from 1.25.12 to 1.25.13

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -2,7 +2,7 @@
 # Default build: production multiarch
 # Development: use --target development
 
-ARG GOLANG_VERSION=1.25.12
+ARG GOLANG_VERSION=1.25.13
 ARG ALPINE_VERSION=3.24
 
 # Base stage for both development and production

--- a/agent/Dockerfile.test
+++ b/agent/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine3.24
+FROM golang:1.25.13-alpine3.24
 
 ARG GOPROXY
 

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/agent
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # base stage
-FROM golang:1.25.12-alpine3.24 AS base
+FROM golang:1.25.13-alpine3.24 AS base
 
 ARG GOPROXY
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/gateway
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/caddy-dns/acmedns v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/adhocore/gronx v1.20.0

--- a/openapi/Dockerfile
+++ b/openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12-alpine3.24 AS base
+FROM golang:1.25.13-alpine3.24 AS base
 
 ARG GOPROXY
 ENV GOPROXY=${GOPROXY}

--- a/openapi/go.mod
+++ b/openapi/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/openapi
 
-go 1.25.12
+go 1.25.13
 
 require github.com/shellhub-io/shellhub v0.0.0
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,7 +19,7 @@ ARG MJML_VERSION=4.10.1
 FROM scratch AS cloud-src
 
 # ── base stage ────────────────────────────────────────────────────────────────
-FROM golang:1.25.12-alpine3.24 AS base
+FROM golang:1.25.13-alpine3.24 AS base
 
 ARG GOPROXY
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/server
 
-go 1.25.12
+go 1.25.13
 
 require (
 	code.dny.dev/ssrf v0.3.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/shellhub-io/shellhub/tests
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/bramvdbogaerde/go-scp v1.6.1


### PR DESCRIPTION
## What

Bumps the Go toolchain from 1.25.12 to 1.25.13 across all modules and Dockerfiles to address CVE-2026-39821.

## Changes

- **`go.mod`**: updated `go` directive in root, server, agent, gateway, openapi, api, and tests modules
- **Dockerfiles**: updated base image tags in server, gateway, openapi, and agent (including `Dockerfile.test`)