### PR TITLE
fix(server): skip OpenAPI validation on routes that hijack the connection

### DIFF
--- a/server/api/routes/middleware/openapi.go
+++ b/server/api/routes/middleware/openapi.go
@@ -37,8 +37,13 @@ func (rw *capture) WriteHeader(statusCode int) {
 	rw.ResponseWriter.WriteHeader(statusCode)
 }
 
-// Unwrap lets http.ResponseController reach the underlying writer, which is how
-// echo resolves Hijack and Flush. Without it the SSH WebSocket routes fail here.
+// Unwrap lets http.ResponseController reach the underlying writer, which is how echo resolves
+// Hijack and Flush.
+//
+// It is not enough for the WebSocket routes: both libraries in use assert http.Hijacker on the
+// writer directly and never consult Unwrap, and capture cannot satisfy it because embedding the
+// http.ResponseWriter interface promotes only its three methods. Those routes are excluded from
+// validation instead - see openAPIValidationSkipper in the server package.
 func (rw *capture) Unwrap() http.ResponseWriter {
 	return rw.ResponseWriter
 }

--- a/server/app/openapi_test.go
+++ b/server/app/openapi_test.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v5"
+	"github.com/shellhub-io/shellhub/server/api/routes/middleware"
+	sshhttp "github.com/shellhub-io/shellhub/server/ssh/http"
+	"github.com/shellhub-io/shellhub/server/ssh/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	xwebsocket "golang.org/x/net/websocket"
+)
+
+// controlUpgradePath is an upgrade route the skipper does not exempt, used to prove the
+// validator really is in the request path. See TestOpenAPIValidationAllowsWebSocketUpgrades.
+const controlUpgradePath = "/api/openapi-validation-control"
+
+// openAPITestSchema is the smallest document the validator accepts. Its contents are
+// irrelevant: the test only needs the validator to initialize, since that is what installs
+// the response wrapper.
+const openAPITestSchema = `{
+  "openapi": "3.0.0",
+  "info": {"title": "test", "version": "1.0.0"},
+  "paths": {}
+}`
+
+// TestOpenAPIValidationAllowsWebSocketUpgrades drives a real handshake against every route
+// that hijacks the connection, with the validator middleware installed exactly as production
+// installs it.
+//
+// The control route is what keeps this test honest. The middleware silently becomes a no-op
+// when the validator fails to initialize, which would let every assertion below pass without
+// testing anything. An unskipped upgrade route must therefore still fail.
+func TestOpenAPIValidationAllowsWebSocketUpgrades(t *testing.T) {
+	schema := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(openAPITestSchema)) //nolint:errcheck
+	}))
+	t.Cleanup(schema.Close)
+
+	schemaURL, err := url.Parse(schema.URL + "/openapi.json")
+	require.NoError(t, err)
+
+	upgrader := &websocket.Upgrader{} //nolint:exhaustruct
+
+	upgrade := func(c *echo.Context) error {
+		conn, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
+		if err != nil {
+			return err
+		}
+
+		return conn.Close()
+	}
+
+	e := echo.New()
+	e.Use(middleware.OpenAPIValidator(&middleware.OpenAPIValidatorConfig{ //nolint:exhaustruct
+		SchemaPath: schemaURL,
+		Skipper:    openAPIValidationSkipper,
+	}))
+
+	for _, path := range []string{
+		sshhttp.HandleConnectionV1Path,
+		sshhttp.HandleConnectionV2Path,
+		sshhttp.HandleRevdialPath,
+		controlUpgradePath,
+	} {
+		e.GET(path, upgrade)
+	}
+
+	// The web terminal bridge upgrades through x/net/websocket, which panics rather than
+	// erroring when the writer cannot hijack. Registering it as production does keeps that
+	// path covered too.
+	e.GET(web.WebsocketSSHBridgeRoute, echo.WrapHandler(xwebsocket.Handler(func(conn *xwebsocket.Conn) {
+		conn.Close() //nolint:errcheck
+	})))
+
+	srv := httptest.NewServer(e)
+	t.Cleanup(srv.Close)
+
+	// x/net/websocket's Handler rejects a handshake without an Origin, which a browser
+	// always sends. Unrelated to hijacking, but the bridge route never completes without it.
+	headers := http.Header{"Origin": []string{srv.URL}}
+
+	dial := func(t *testing.T, path string) (*http.Response, error) {
+		t.Helper()
+
+		conn, res, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http")+path, headers)
+		if conn != nil {
+			conn.Close() //nolint:errcheck
+		}
+
+		return res, err
+	}
+
+	for _, path := range []string{
+		sshhttp.HandleConnectionV1Path,
+		sshhttp.HandleConnectionV2Path,
+		sshhttp.HandleRevdialPath,
+		web.WebsocketSSHBridgeRoute,
+	} {
+		t.Run("upgrade succeeds on "+path, func(t *testing.T) {
+			res, err := dial(t, path)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusSwitchingProtocols, res.StatusCode)
+		})
+	}
+
+	t.Run("an unskipped route still cannot upgrade", func(t *testing.T) {
+		_, err := dial(t, controlUpgradePath)
+		require.Error(t, err, "the validator did not initialize, so this test proves nothing")
+	})
+}
+
+func TestOpenAPIValidationSkipper(t *testing.T) {
+	cases := []struct {
+		path string
+		skip bool
+	}{
+		{sshhttp.HandleConnectionV1Path, true},
+		{sshhttp.HandleConnectionV2Path, true},
+		{sshhttp.HandleRevdialPath, true},
+		{web.WebsocketSSHBridgeRoute, true},
+		{"/metrics", true},
+		{"/internal/auth", true},
+		// Sits under the bridge route but answers with a JSON body, so prefix matching
+		// would wrongly exempt it.
+		{web.WebSessionRoute, false},
+		{"/api/devices", false},
+		{"/api/namespaces", false},
+	}
+
+	e := echo.New()
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			ctx := e.NewContext(req, httptest.NewRecorder())
+
+			assert.Equal(t, tc.skip, openAPIValidationSkipper(ctx))
+		})
+	}
+}

--- a/server/app/server.go
+++ b/server/app/server.go
@@ -432,6 +432,40 @@ func (s *Server) firewallEvaluatorOption(ctx context.Context, st store.Store, c 
 	return nil, nil
 }
 
+// openAPIValidationSkipper reports whether a request's response must not be captured for
+// OpenAPI validation.
+//
+// Metrics and internal endpoints are exempt only for now: the schema does not describe them
+// today, and nothing stops them being brought in later.
+//
+// The upgrade routes are exempt permanently. They hijack the connection, so past the handshake
+// there is no HTTP response left to validate, and the validator's response wrapper hides
+// http.Hijacker from the WebSocket libraries. Both assert that interface directly, so wrapping
+// fails every agent tunnel and every web terminal - and with no tunnel there is no heartbeat,
+// so the whole fleet then ages out to offline.
+//
+// They match exactly rather than by prefix: WebSessionRoute sits under WebsocketSSHBridgeRoute
+// and does answer with a JSON body worth validating.
+func openAPIValidationSkipper(ctx *echo.Context) bool {
+	path := ctx.Request().URL.Path
+
+	switch path {
+	case sshhttp.HandleConnectionV1Path,
+		sshhttp.HandleConnectionV2Path,
+		sshhttp.HandleRevdialPath,
+		web.WebsocketSSHBridgeRoute:
+		return true
+	}
+
+	for _, prefix := range []string{"/metrics", "/internal"} {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // routerOptions returns configuration options for the HTTP router.
 func (s *Server) routerOptions() ([]routes.Option, error) {
 	opts := []routes.Option{}
@@ -466,18 +500,7 @@ func (s *Server) routerOptions() ([]routes.Option, error) {
 		log.Info("Enabling OpenAPI validation in development mode")
 
 		opts = append(opts, routes.WithOpenAPIValidator(&middleware.OpenAPIValidatorConfig{
-			// NOTE: By default, metrics and internal endpoints are skipped from validation for now.
-			Skipper: func(ctx *echo.Context) bool {
-				routes := []string{"/metrics", "/internal"}
-
-				for _, path := range routes {
-					if strings.HasPrefix(ctx.Request().URL.Path, path) {
-						return true
-					}
-				}
-
-				return false
-			},
+			Skipper: openAPIValidationSkipper,
 		}))
 	}
 


### PR DESCRIPTION
## What

Exempts the four WebSocket upgrade routes from OpenAPI response validation, which is enabled in development only.

## Why

The validator wraps the response writer in a `capture` type so it can read a body that has already been written. That wrapper embeds the `http.ResponseWriter` interface, so it inherits exactly three methods and does not satisfy `http.Hijacker`. Its `Unwrap` method does not help: only `http.ResponseController` consults it, and both WebSocket libraries assert the interface on the writer directly.

Every upgrade therefore failed. `gorilla` returned an error the handler answered with a second write, producing the `500` and `response already written to client` pairs; `x/net/websocket` panicked instead. No agent could open its tunnel, no device was reachable over SSH, and since the heartbeat rides on that tunnel the whole fleet aged out to offline a couple of minutes after boot.

Exempting is the right shape rather than teaching the wrapper to hijack. Past the handshake there is no HTTP response left to validate, and none of these routes appear in the schema anyway.

## Changes

**`server/app/server.go`** - the inline skipper closure becomes a named `openAPIValidationSkipper` (testable, same reason `licenseEvaluatorOption` was extracted) and now also exempts `/agent/connection`, `/ssh/connection`, `/ssh/revdial` and `/ws/ssh`. They are referenced by their route constants so a rename cannot silently drop the exemption, and matched exactly rather than by prefix so `WebSessionRoute`, which sits under the bridge route and answers with JSON, keeps being validated.

**`server/api/routes/middleware/openapi.go`** - comment only. The old one claimed `Unwrap` fixed the WebSocket routes, which is a large part of why this was invisible on a read-through.

**`server/app/openapi_test.go`** - new. Drives a real handshake against all four routes with the middleware installed as production installs it. The middleware silently no-ops when the validator fails to start, so the test also asserts that an unexempt upgrade route still fails; without that control it would pass while proving nothing.

## Testing

On a development stack (`SHELLHUB_ENV=development`, which is what enables the validator):

1. Bring the stack up and connect an agent.
2. Server logs should show `v2 connection established` and no `500` on `/agent/connection`.
3. `ssh <user>@<namespace>.<device>@localhost` opens a session.
4. Open the device's terminal in the console. Before this change that path panicked the serving goroutine.
5. Leave it for three minutes or so. The device stays online rather than dropping off with the rest of the fleet.

To see the old behaviour, check out `master` and repeat step 2.

Fixes #6907