### PR TITLE
feat(server): answer every API error with a JSON body

### DIFF
--- a/openapi/spec/components/responses/400.yaml
+++ b/openapi/spec/components/responses/400.yaml
@@ -1,1 +1,9 @@
 description: Bad request
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/apiError.yaml
+    example:
+      message: invalid entity
+      fields:
+        username: must be at least 3 characters

--- a/openapi/spec/components/responses/401.yaml
+++ b/openapi/spec/components/responses/401.yaml
@@ -2,10 +2,6 @@ description: Unauthorized
 content:
   application/json:
     schema:
-      type: object
-      properties:
-        message:
-          description: Error message
-          type: string
+      $ref: ../schemas/apiError.yaml
     example:
       message: missing or malformed jwt or API token

--- a/openapi/spec/components/responses/402.yaml
+++ b/openapi/spec/components/responses/402.yaml
@@ -1,1 +1,7 @@
 description: Payment required
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/apiError.yaml
+    example:
+      message: payment required

--- a/openapi/spec/components/responses/403.yaml
+++ b/openapi/spec/components/responses/403.yaml
@@ -1,1 +1,7 @@
 description: Forbidden
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/apiError.yaml
+    example:
+      message: forbidden

--- a/openapi/spec/components/responses/404.yaml
+++ b/openapi/spec/components/responses/404.yaml
@@ -1,1 +1,7 @@
 description: Not found
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/apiError.yaml
+    example:
+      message: not found

--- a/openapi/spec/components/responses/406.yaml
+++ b/openapi/spec/components/responses/406.yaml
@@ -1,1 +1,7 @@
 description: Not Acceptable
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/apiError.yaml
+    example:
+      message: not acceptable

--- a/openapi/spec/components/responses/409.yaml
+++ b/openapi/spec/components/responses/409.yaml
@@ -1,1 +1,9 @@
 description: Conflict
+content:
+  application/json:
+    schema:
+      $ref: ../schemas/apiError.yaml
+    example:
+      message: tag duplicated
+      fields:
+        name: duplicated

--- a/openapi/spec/components/responses/500.yaml
+++ b/openapi/spec/components/responses/500.yaml
@@ -2,10 +2,6 @@ description: Internal error
 content:
   application/json:
     schema:
-      type: object
-      properties:
-        message:
-          description: Error message.
-          type: string
+      $ref: ../schemas/apiError.yaml
     example:
-      message: Internal Server Error
+      message: internal server error

--- a/openapi/spec/components/schemas/apiError.yaml
+++ b/openapi/spec/components/schemas/apiError.yaml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - message
+properties:
+  message:
+    description: A human-readable description of what failed.
+    type: string
+  fields:
+    description: |
+      The request field(s) the error concerns, mapped to the reason each was rejected. Present only
+      when the error carries per-field detail.
+    type: object
+    additionalProperties:
+      type: string

--- a/openapi/spec/paths/api@register.yaml
+++ b/openapi/spec/paths/api@register.yaml
@@ -61,10 +61,10 @@ post:
     '200':
       description: User registered successfully
     '400':
-      $ref: ../components/responses/invalidFields.yaml
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '409':
-      $ref: ../components/responses/conflictFields.yaml
+      $ref: ../components/responses/409.yaml
     '500':
       $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/api@users.yaml
+++ b/openapi/spec/paths/api@users.yaml
@@ -35,12 +35,12 @@ patch:
     '200':
       $ref: ../components/responses/200.yaml
     '400':
-      $ref: ../components/responses/invalidFields.yaml
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '404':
       $ref: ../components/responses/404.yaml
     '409':
-      $ref: ../components/responses/conflictFields.yaml
+      $ref: ../components/responses/409.yaml
     '500':
       $ref: ../components/responses/500.yaml

--- a/openapi/spec/paths/api@users@{id}@data.yaml
+++ b/openapi/spec/paths/api@users@{id}@data.yaml
@@ -41,12 +41,12 @@ patch:
     '200':
       $ref: ../components/responses/200.yaml
     '400':
-      $ref: ../components/responses/invalidFields.yaml
+      $ref: ../components/responses/400.yaml
     '401':
       $ref: ../components/responses/401.yaml
     '404':
       $ref: ../components/responses/404.yaml
     '409':
-      $ref: ../components/responses/conflictFields.yaml
+      $ref: ../components/responses/409.yaml
     '500':
       $ref: ../components/responses/500.yaml

--- a/pkg/api/responses/error.go
+++ b/pkg/api/responses/error.go
@@ -1,0 +1,13 @@
+package responses
+
+// Error is the body of every API error response.
+//
+// It is a projection, not a marshalling of the internal error type: that type carries a layer name
+// and an internal code which must never reach a client.
+type Error struct {
+	// Message is a human-readable description of what failed. It is always present.
+	Message string `json:"message"`
+	// Fields maps a request field name to the reason it was rejected. It is present only when the
+	// error carries per-field detail.
+	Fields map[string]string `json:"fields,omitempty"`
+}

--- a/server/api/pkg/echo/handlers/errors.go
+++ b/server/api/pkg/echo/handlers/errors.go
@@ -6,12 +6,17 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/labstack/echo/v5"
+	"github.com/shellhub-io/shellhub/pkg/api/responses"
 	"github.com/shellhub-io/shellhub/pkg/errors"
 	"github.com/shellhub-io/shellhub/server/api/pkg/echo/handlers/pkg/converter"
 	routes "github.com/shellhub-io/shellhub/server/api/routes/errors"
 	"github.com/shellhub-io/shellhub/server/api/services"
 	"github.com/shellhub-io/shellhub/server/api/store"
 )
+
+// genericMessage is the message every 5xx answers with. An internal error's own text describes the
+// server's internals, so only the reporter sees it.
+const genericMessage = "internal server error"
 
 func report(reporter *sentry.Client, err error, request *http.Request) {
 	go func() {
@@ -28,6 +33,63 @@ func report(reporter *sentry.Client, err error, request *http.Request) {
 	}()
 }
 
+// respond writes the error body. A 5xx never echoes the error's own message, and a status that
+// forbids a body keeps its bare status.
+func respond(ctx *echo.Context, status int, message string, fields map[string]string) {
+	if status >= http.StatusInternalServerError {
+		message, fields = genericMessage, nil
+	}
+
+	if status == http.StatusNoContent {
+		ctx.NoContent(status) //nolint:errcheck
+
+		return
+	}
+
+	ctx.JSON(status, responses.Error{Message: message, Fields: fields}) //nolint:errcheck
+}
+
+// echoMessage returns the client-safe message an error carrying an HTTP status describes itself
+// with. It never falls back to Error(): those texts embed the internal cause, e.g.
+// "code=400, message=failed to bind field value to int, err=strconv.ParseInt: …".
+func echoMessage(err error, code int) string {
+	// A *echo.BindingError unwraps to its cause rather than to the *echo.HTTPError it embeds, so
+	// errors.As misses it on the check below. Match it first.
+	var binding *echo.BindingError
+	if errors.As(err, &binding) && binding.HTTPError != nil && binding.Message != "" {
+		return binding.Message
+	}
+
+	var httpErr *echo.HTTPError
+	if errors.As(err, &httpErr) && httpErr.Message != "" {
+		return httpErr.Message
+	}
+
+	return statusText(code)
+}
+
+// statusText names a status for a client, falling back to the generic message for a code net/http
+// does not name.
+func statusText(code int) string {
+	if text := http.StatusText(code); text != "" {
+		return text
+	}
+
+	return genericMessage
+}
+
+// fieldsOf returns the per-field detail an error carries, or nil when it carries none.
+func fieldsOf(e errors.Error) map[string]string {
+	switch data := e.Data.(type) {
+	case routes.ErrDataInvalidEntity:
+		return data.Fields
+	case services.ErrDataInvalidFields:
+		return data.Fields
+	default:
+		return nil
+	}
+}
+
 // NewErrors returns a custom echo's error handler.
 func NewErrors(reporter *sentry.Client) echo.HTTPErrorHandler {
 	return func(ctx *echo.Context, err error) {
@@ -40,7 +102,7 @@ func NewErrors(reporter *sentry.Client) echo.HTTPErrorHandler {
 		// must also be reported to Sentry, so it needs its own early branch.
 		if errors.Is(err, store.ErrInternal) {
 			report(reporter, err, ctx.Request())
-			ctx.NoContent(http.StatusInternalServerError) //nolint:errcheck
+			respond(ctx, http.StatusInternalServerError, "", nil)
 
 			return
 		}
@@ -49,7 +111,7 @@ func NewErrors(reporter *sentry.Client) echo.HTTPErrorHandler {
 		// Ask Echo for the status rather than matching on *echo.HTTPError: its own sentinels
 		// (echo.ErrNotFound and friends) are a different unexported type that a type match misses.
 		if code := echo.StatusCode(err); code != 0 {
-			ctx.NoContent(code) //nolint:errcheck
+			respond(ctx, code, echoMessage(err, code), nil)
 
 			return
 		}
@@ -59,7 +121,7 @@ func NewErrors(reporter *sentry.Client) echo.HTTPErrorHandler {
 		// Mongo, not even from HTTP, indicating that is something unknown by the API
 		var e errors.Error
 		if ok := errors.As(err, &e); !ok {
-			ctx.NoContent(http.StatusInternalServerError) //nolint:errcheck
+			respond(ctx, http.StatusInternalServerError, "", nil)
 
 			return
 		}
@@ -74,7 +136,12 @@ func NewErrors(reporter *sentry.Client) echo.HTTPErrorHandler {
 			// What happens when an error is returned directly from the store's layer, which means it doesn't have a
 			// service error affecting it, which requires fixing.
 			status = http.StatusInternalServerError
+		default:
+			// Layers this switch does not name, such as the scope package's, would otherwise
+			// produce status zero.
+			status = http.StatusInternalServerError
 		}
-		ctx.NoContent(status) //nolint:errcheck
+
+		respond(ctx, status, e.Message, fieldsOf(e))
 	}
 }

--- a/server/api/pkg/echo/handlers/errors_test.go
+++ b/server/api/pkg/echo/handlers/errors_test.go
@@ -2,15 +2,21 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/labstack/echo/v5"
+	"github.com/shellhub-io/shellhub/pkg/api/responses"
+	"github.com/shellhub-io/shellhub/pkg/api/scope"
 	"github.com/shellhub-io/shellhub/pkg/errors"
+	routes "github.com/shellhub-io/shellhub/server/api/routes/errors"
+	"github.com/shellhub-io/shellhub/server/api/services"
 	"github.com/shellhub-io/shellhub/server/api/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,6 +57,18 @@ func (s *spyTransport) reported() int {
 	defer s.mu.Unlock()
 
 	return len(s.events)
+}
+
+// firstMessage returns the message of the first captured event, or "" when none arrived.
+func (s *spyTransport) firstMessage() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.events) == 0 {
+		return ""
+	}
+
+	return s.events[0].Message
 }
 
 // waitForEvent blocks until at least one event has been delivered or the
@@ -94,28 +112,160 @@ func TestNewErrors(t *testing.T) {
 		description  string
 		err          error
 		wantStatus   int
+		wantBody     responses.Error
+		wantNoBody   bool
 		wantReported bool
 	}{
 		{
-			// (1) store.ErrInternal must yield 500 AND invoke report().
-			description:  "store.ErrInternal yields 500 and is reported to sentry",
+			// (1) store.ErrInternal must yield 500 AND invoke report(). The response carries the
+			//     generic message; only the reporter sees the real one.
+			description:  "store.ErrInternal yields a generic 500 body and is reported to sentry",
 			err:          errors.Wrap(store.ErrInternal, errors.New("some internal detail", store.ErrLayer, store.ErrCodeInternal)),
 			wantStatus:   http.StatusInternalServerError,
+			wantBody:     responses.Error{Message: "internal server error"},
 			wantReported: true,
 		},
 		{
-			// (2) A plain store-layer error that is NOT ErrInternal yields 500 but
-			//     MUST NOT invoke report().
-			description:  "store.ErrNoDocuments yields 500 without reporting to sentry",
+			// (2) A plain store-layer error that is NOT ErrInternal yields 500 but MUST NOT invoke
+			//     report(), and must not echo its own message either.
+			description:  "store.ErrNoDocuments yields a generic 500 body without reporting to sentry",
 			err:          store.ErrNoDocuments,
 			wantStatus:   http.StatusInternalServerError,
+			wantBody:     responses.Error{Message: "internal server error"},
 			wantReported: false,
 		},
 		{
-			// (3) context.Canceled must NOT be reported.
-			description:  "context.Canceled yields 500 without reporting to sentry",
+			// (3) context.Canceled cannot be classified: generic body, no report.
+			description:  "context.Canceled yields a generic 500 body without reporting to sentry",
 			err:          context.Canceled,
 			wantStatus:   http.StatusInternalServerError,
+			wantBody:     responses.Error{Message: "internal server error"},
+			wantReported: false,
+		},
+		{
+			// (4) An error carrying an HTTP status answers with that status and its own message.
+			description:  "an echo error yields its status and message",
+			err:          echo.ErrNotFound,
+			wantStatus:   http.StatusNotFound,
+			wantBody:     responses.Error{Message: "Not Found"},
+			wantReported: false,
+		},
+		{
+			description:  "an echo HTTPError yields its status and message",
+			err:          echo.NewHTTPError(http.StatusRequestTimeout, "request timeout"),
+			wantStatus:   http.StatusRequestTimeout,
+			wantBody:     responses.Error{Message: "request timeout"},
+			wantReported: false,
+		},
+		{
+			// A binding error reports 400 and reads its own Error() as
+			// "code=400, message=…, err=strconv.ParseInt: …" — the client must not see the cause.
+			description:  "a binding error yields 400 without echoing the underlying cause",
+			err:          echo.NewBindingError("page", []string{"abc"}, "failed to bind field value to int", strconv.ErrSyntax),
+			wantStatus:   http.StatusBadRequest,
+			wantBody:     responses.Error{Message: "failed to bind field value to int"},
+			wantReported: false,
+		},
+		{
+			description:  "a service not-found error yields 404 and its message",
+			err:          services.ErrUserNotFound,
+			wantStatus:   http.StatusNotFound,
+			wantBody:     responses.Error{Message: "user not found"},
+			wantReported: false,
+		},
+		{
+			description:  "a service invalid error yields 400 and its message",
+			err:          services.ErrUserInvalid,
+			wantStatus:   http.StatusBadRequest,
+			wantBody:     responses.Error{Message: "user invalid"},
+			wantReported: false,
+		},
+		{
+			description:  "a service duplicated error yields 409 and its message",
+			err:          services.ErrUserDuplicated,
+			wantStatus:   http.StatusConflict,
+			wantBody:     responses.Error{Message: "user duplicated"},
+			wantReported: false,
+		},
+		{
+			description:  "a service forbidden error yields 403 and its message",
+			err:          services.ErrUserNotConfirmed,
+			wantStatus:   http.StatusForbidden,
+			wantBody:     responses.Error{Message: "user not confirmed"},
+			wantReported: false,
+		},
+		{
+			description:  "a service locked error yields 423 and its message",
+			err:          services.ErrUserAwaitingApproval,
+			wantStatus:   http.StatusLocked,
+			wantBody:     responses.Error{Message: "user awaiting approval"},
+			wantReported: false,
+		},
+		{
+			description:  "a service payment error yields 402 and its message",
+			err:          services.ErrPaymentRequired,
+			wantStatus:   http.StatusPaymentRequired,
+			wantBody:     responses.Error{Message: "payment required"},
+			wantReported: false,
+		},
+		{
+			description:  "a service limit error yields 403 and its message",
+			err:          services.ErrMaxTagReached,
+			wantStatus:   http.StatusForbidden,
+			wantBody:     responses.Error{Message: "tag limit reached"},
+			wantReported: false,
+		},
+		{
+			// A service code with no HTTP mapping falls back to 500, so it must not echo either.
+			description:  "a service store error yields a generic 500 body",
+			err:          services.ErrUserUpdate,
+			wantStatus:   http.StatusInternalServerError,
+			wantBody:     responses.Error{Message: "internal server error"},
+			wantReported: false,
+		},
+		{
+			description:  "a service error carrying field detail yields 400 with the fields",
+			err:          services.NewErrInstallKeyInvalidField(map[string]string{"usage_limit": "must be greater than zero"}),
+			wantStatus:   http.StatusBadRequest,
+			wantBody:     responses.Error{Message: "install key field is invalid", Fields: map[string]string{"usage_limit": "must be greater than zero"}},
+			wantReported: false,
+		},
+		{
+			description:  "a route invalid-entity error yields 400 with the fields",
+			err:          routes.NewErrInvalidEntity(map[string]string{"username": "required"}),
+			wantStatus:   http.StatusBadRequest,
+			wantBody:     responses.Error{Message: "invalid entity", Fields: map[string]string{"username": "required"}},
+			wantReported: false,
+		},
+		{
+			description:  "a route unauthorized error yields 401 and its message",
+			err:          routes.NewErrUnauthorized(nil),
+			wantStatus:   http.StatusUnauthorized,
+			wantBody:     responses.Error{Message: "unauthorized"},
+			wantReported: false,
+		},
+		{
+			description:  "a route unprocessable-entity error yields 422 and its message",
+			err:          routes.NewErrUnprocessableEntity(nil),
+			wantStatus:   http.StatusUnprocessableEntity,
+			wantBody:     responses.Error{Message: "unprocessable entity"},
+			wantReported: false,
+		},
+		{
+			// 204 forbids a body, so this code keeps its bare status.
+			description:  "a service no-content-change error yields a bare 204",
+			err:          services.ErrNoContentChange,
+			wantStatus:   http.StatusNoContent,
+			wantNoBody:   true,
+			wantReported: false,
+		},
+		{
+			// The scope package declares a layer the switch does not name, so the default arm is
+			// reachable and must answer 500 rather than status zero.
+			description:  "an error from an unrecognised layer yields a generic 500 body",
+			err:          scope.ErrEmptyTenantID,
+			wantStatus:   http.StatusInternalServerError,
+			wantBody:     responses.Error{Message: "internal server error"},
 			wantReported: false,
 		},
 	}
@@ -130,11 +280,20 @@ func TestNewErrors(t *testing.T) {
 
 			assert.Equal(t, tc.wantStatus, rec.Code, "unexpected HTTP status code")
 
+			if tc.wantNoBody {
+				assert.Empty(t, rec.Body.Bytes(), "expected no response body")
+			} else {
+				body := responses.Error{} //nolint:exhaustruct
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body), "response body is not a JSON error")
+				assert.Equal(t, tc.wantBody, body, "unexpected response body")
+			}
+
 			if tc.wantReported {
 				// report() fires a goroutine; wait for the event to arrive.
 				got := spy.waitForEvent(500 * time.Millisecond)
 				require.True(t, got, "expected exactly one sentry event, got none within 500ms")
 				assert.Equal(t, 1, spy.reported(), "expected exactly one sentry event")
+				assert.Contains(t, spy.firstMessage(), "some internal detail", "the reporter must receive the real message")
 			} else {
 				// Give any (erroneous) async report a chance to arrive, then assert silence.
 				time.Sleep(50 * time.Millisecond)

--- a/server/api/routes/device_test.go
+++ b/server/api/routes/device_test.go
@@ -119,8 +119,10 @@ func TestGetDevice(t *testing.T) {
 			assert.Equal(t, tc.expected.expectedStatus, rec.Result().StatusCode)
 
 			var session *models.Device
-			if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
-				assert.ErrorIs(t, io.EOF, err)
+			if rec.Result().StatusCode < http.StatusBadRequest {
+				if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
+					assert.ErrorIs(t, io.EOF, err)
+				}
 			}
 
 			assert.Equal(t, tc.expected.expectedSession, session)

--- a/server/api/routes/install-key.go
+++ b/server/api/routes/install-key.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
 	"github.com/shellhub-io/shellhub/pkg/api/responses"
-	"github.com/shellhub-io/shellhub/pkg/errors"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
-	"github.com/shellhub-io/shellhub/server/api/services"
 )
 
 const (
@@ -36,15 +34,6 @@ func (h *Handler) CreateInstallKey(c *gateway.Context) error {
 
 	res, err := h.service.CreateInstallKey(c.Ctx(), req)
 	if err != nil {
-		// Surface an invalid mode field (webhook/allowlist config) with its per-field body instead of a
-		// bare 400, mirroring the update handler.
-		var e errors.Error
-		if errors.As(err, &e) {
-			if data, ok := e.Data.(services.ErrDataInvalidFields); ok {
-				return c.JSON(http.StatusBadRequest, data)
-			}
-		}
-
 		return err
 	}
 
@@ -94,15 +83,6 @@ func (h *Handler) UpdateInstallKey(c *gateway.Context) error {
 	}
 
 	if err := h.service.UpdateInstallKey(c.Ctx(), req); err != nil {
-		// The global error handler answers with a bare status. For an invalid field we escape it and
-		// return the offending field(s) and why, so a caller learns what to fix instead of a raw 400.
-		var e errors.Error
-		if errors.As(err, &e) {
-			if data, ok := e.Data.(services.ErrDataInvalidFields); ok {
-				return c.JSON(http.StatusBadRequest, data)
-			}
-		}
-
 		return err
 	}
 

--- a/server/api/routes/install-key_test.go
+++ b/server/api/routes/install-key_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/shellhub-io/shellhub/pkg/api/responses"
 	"github.com/shellhub-io/shellhub/server/api/services"
 	servicemock "github.com/shellhub-io/shellhub/server/api/services/mocks"
 	"github.com/stretchr/testify/mock"
@@ -15,7 +16,7 @@ import (
 
 func TestUpdateInstallKey(t *testing.T) {
 	type Expected struct {
-		fields map[string]string
+		body   *responses.Error
 		status int
 	}
 
@@ -44,15 +45,10 @@ func TestUpdateInstallKey(t *testing.T) {
 					})).
 					Once()
 			},
-			expected: Expected{
-				status: http.StatusBadRequest,
-				fields: map[string]string{
-					"usage_limit": "cannot be lower than the number of times the key was already used",
-				},
-			},
+			expected: Expected{status: http.StatusBadRequest},
 		},
 		{
-			description: "answers a bare status for a non-field error",
+			description: "answers a message-only body for a non-field error",
 			headers: map[string]string{
 				"Content-Type": "application/json",
 				"X-ID":         "000000000000000000000000",
@@ -65,7 +61,10 @@ func TestUpdateInstallKey(t *testing.T) {
 					Return(services.NewErrInstallKeyForbidden()).
 					Once()
 			},
-			expected: Expected{status: http.StatusForbidden},
+			expected: Expected{
+				status: http.StatusForbidden,
+				body:   &responses.Error{Message: "the legacy install key cannot be modified"},
+			},
 		},
 		{
 			description: "succeeds",
@@ -103,12 +102,10 @@ func TestUpdateInstallKey(t *testing.T) {
 
 			require.Equal(t, tc.expected.status, rec.Result().StatusCode)
 
-			if tc.expected.fields != nil {
-				var body struct {
-					Fields map[string]string `json:"fields"`
-				}
+			if tc.expected.body != nil {
+				body := responses.Error{} //nolint:exhaustruct
 				require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
-				require.Equal(t, tc.expected.fields, body.Fields)
+				require.Equal(t, *tc.expected.body, body)
 			}
 		})
 	}

--- a/server/api/routes/invitation.go
+++ b/server/api/routes/invitation.go
@@ -5,9 +5,7 @@ import (
 	"strconv"
 
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
-	"github.com/shellhub-io/shellhub/pkg/errors"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
-	"github.com/shellhub-io/shellhub/server/api/services"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -34,22 +32,9 @@ func (h *Handler) RegisterUser(c *gateway.Context) error {
 		return err
 	}
 
-	authInfo, conflictFields, err := h.service.RegisterUser(c.Ctx(), req, c.Request().Header.Get("X-Forwarded-Host"), c.Request().Header.Get("X-Forwarded-Proto"))
+	authInfo, err := h.service.RegisterUser(c.Ctx(), req, c.Request().Header.Get("X-Forwarded-Host"), c.Request().Header.Get("X-Forwarded-Proto"))
 	if err != nil {
-		// The UI uses the conflicting fields to tell invalid from duplicated.
-		var e errors.Error
-		if ok := errors.As(err, &e); !ok {
-			return err
-		}
-
-		switch e.Code {
-		case services.ErrCodeInvalid:
-			return c.JSON(http.StatusBadRequest, conflictFields)
-		case services.ErrCodeDuplicated:
-			return c.JSON(http.StatusConflict, conflictFields)
-		default:
-			return err
-		}
+		return err
 	}
 
 	if authInfo != nil {

--- a/server/api/routes/nsadm_test.go
+++ b/server/api/routes/nsadm_test.go
@@ -162,8 +162,10 @@ func TestGetNamespace(t *testing.T) {
 			assert.Equal(t, tc.expected.expectedStatus, rec.Result().StatusCode)
 
 			var session *models.Namespace
-			if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
-				assert.ErrorIs(t, io.EOF, err)
+			if rec.Result().StatusCode < http.StatusBadRequest {
+				if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
+					assert.ErrorIs(t, io.EOF, err)
+				}
 			}
 			assert.Equal(t, tc.expected.expectedSession, session)
 		})

--- a/server/api/routes/session_test.go
+++ b/server/api/routes/session_test.go
@@ -186,8 +186,10 @@ func TestGetSessionList(t *testing.T) {
 			assert.Equal(t, tc.expected.expectedStatus, rec.Result().StatusCode)
 
 			var session []models.Session
-			if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
-				assert.ErrorIs(t, io.EOF, err)
+			if rec.Result().StatusCode < http.StatusBadRequest {
+				if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
+					assert.ErrorIs(t, io.EOF, err)
+				}
 			}
 			assert.Equal(t, tc.expected.expectedSession, session)
 
@@ -295,8 +297,10 @@ func TestGetSession(t *testing.T) {
 			assert.Equal(t, tc.expected.expectedStatus, rec.Result().StatusCode)
 
 			var session *models.Session
-			if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
-				assert.ErrorIs(t, io.EOF, err)
+			if rec.Result().StatusCode < http.StatusBadRequest {
+				if err := json.NewDecoder(rec.Result().Body).Decode(&session); err != nil {
+					assert.ErrorIs(t, io.EOF, err)
+				}
 			}
 
 			assert.Equal(t, tc.expected.expectedSession, session)

--- a/server/api/routes/tags.go
+++ b/server/api/routes/tags.go
@@ -39,17 +39,14 @@ func (h *Handler) CreateTag(c *gateway.Context) error {
 		return err
 	}
 
-	insertedID, conflicts, err := h.service.CreateTag(c.Ctx(), req)
-	switch {
-	case len(conflicts) > 0:
-		return c.JSON(http.StatusConflict, map[string][]string{"conflicts": conflicts})
-	case err != nil:
+	insertedID, err := h.service.CreateTag(c.Ctx(), req)
+	if err != nil {
 		return err
-	default:
-		c.Response().Header().Add("X-Inserted-ID", insertedID)
-
-		return c.NoContent(http.StatusOK)
 	}
+
+	c.Response().Header().Add("X-Inserted-ID", insertedID)
+
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) GetTags(c *gateway.Context) error {
@@ -101,15 +98,11 @@ func (h *Handler) UpdateTag(c *gateway.Context) error {
 		return err
 	}
 
-	conflicts, err := h.service.UpdateTag(c.Ctx(), req)
-	switch {
-	case len(conflicts) > 0:
-		return c.JSON(http.StatusConflict, map[string][]string{"conflicts": conflicts})
-	case err != nil:
+	if err := h.service.UpdateTag(c.Ctx(), req); err != nil {
 		return err
-	default:
-		return c.NoContent(http.StatusOK)
 	}
+
+	return c.NoContent(http.StatusOK)
 }
 
 func (h *Handler) DeleteTag(c *gateway.Context) error {

--- a/server/api/routes/tags_test.go
+++ b/server/api/routes/tags_test.go
@@ -240,7 +240,6 @@ func TestCreateTag(t *testing.T) {
 	type Expected struct {
 		status     int
 		insertedID string
-		conflicts  []string
 	}
 
 	// Only observer lacks tag permissions; operator, administrator, and owner all hold them — do not test those as forbidden.
@@ -314,7 +313,7 @@ func TestCreateTag(t *testing.T) {
 						TenantID: "00000000-0000-4000-0000-000000000000",
 						Name:     "production",
 					}).
-					Return("", []string{}, svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
+					Return("", svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
 					Once()
 			},
 			expected: Expected{status: http.StatusNotFound},
@@ -337,7 +336,7 @@ func TestCreateTag(t *testing.T) {
 						TenantID: "00000000-0000-4000-0000-000000000000",
 						Name:     "production",
 					}).
-					Return("000000000000000000000001", []string{}, nil).
+					Return("000000000000000000000001", nil).
 					Once()
 			},
 			expected: Expected{
@@ -346,7 +345,7 @@ func TestCreateTag(t *testing.T) {
 			},
 		},
 		{
-			description: "returns 409 with conflicts JSON body",
+			description: "returns 409 when the name is already taken",
 			url:         "/api/tags",
 			headers: map[string]string{
 				"Content-Type": "application/json",
@@ -363,13 +362,10 @@ func TestCreateTag(t *testing.T) {
 						TenantID: "00000000-0000-4000-0000-000000000000",
 						Name:     "production",
 					}).
-					Return("", []string{"name"}, nil).
+					Return("", svc.NewErrTagDuplicated([]string{"name"}, nil)).
 					Once()
 			},
-			expected: Expected{
-				status:    http.StatusConflict,
-				conflicts: []string{"name"},
-			},
+			expected: Expected{status: http.StatusConflict},
 		},
 		{
 			description: "succeeds via legacy URL (tenant from path param)",
@@ -388,7 +384,7 @@ func TestCreateTag(t *testing.T) {
 						TenantID: "00000000-0000-4000-0000-000000000000",
 						Name:     "production",
 					}).
-					Return("000000000000000000000002", []string{}, nil).
+					Return("000000000000000000000002", nil).
 					Once()
 			},
 			expected: Expected{
@@ -423,12 +419,6 @@ func TestCreateTag(t *testing.T) {
 				assert.Equal(t, tc.expected.insertedID, res.Header.Get("X-Inserted-ID"))
 			}
 
-			if tc.expected.conflicts != nil {
-				var body map[string][]string
-				require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
-				assert.Equal(t, tc.expected.conflicts, body["conflicts"])
-			}
-
 			svcMock.AssertExpectations(t)
 		})
 	}
@@ -436,8 +426,7 @@ func TestCreateTag(t *testing.T) {
 
 func TestUpdateTag(t *testing.T) {
 	type Expected struct {
-		status    int
-		conflicts []string
+		status int
 	}
 
 	// Only observer lacks tag permissions; operator, administrator, and owner all hold them — do not test those as forbidden.
@@ -512,7 +501,7 @@ func TestUpdateTag(t *testing.T) {
 						Name:     "production",
 						NewName:  "staging",
 					}).
-					Return([]string{}, svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
+					Return(svc.NewErrNamespaceNotFound("00000000-0000-4000-0000-000000000000", nil)).
 					Once()
 			},
 			expected: Expected{status: http.StatusNotFound},
@@ -536,7 +525,7 @@ func TestUpdateTag(t *testing.T) {
 						Name:     "production",
 						NewName:  "staging",
 					}).
-					Return([]string{}, nil).
+					Return(nil).
 					Once()
 			},
 			expected: Expected{status: http.StatusOK},
@@ -559,13 +548,13 @@ func TestUpdateTag(t *testing.T) {
 						Name:     "production",
 						NewName:  "staging",
 					}).
-					Return([]string{}, nil).
+					Return(nil).
 					Once()
 			},
 			expected: Expected{status: http.StatusOK},
 		},
 		{
-			description: "returns 409 with conflicts JSON body",
+			description: "returns 409 when the name is already taken",
 			url:         "/api/tags/production",
 			headers: map[string]string{
 				"Content-Type": "application/json",
@@ -583,13 +572,10 @@ func TestUpdateTag(t *testing.T) {
 						Name:     "production",
 						NewName:  "staging",
 					}).
-					Return([]string{"name"}, nil).
+					Return(svc.NewErrTagDuplicated([]string{"name"}, nil)).
 					Once()
 			},
-			expected: Expected{
-				status:    http.StatusConflict,
-				conflicts: []string{"name"},
-			},
+			expected: Expected{status: http.StatusConflict},
 		},
 	}
 
@@ -613,12 +599,6 @@ func TestUpdateTag(t *testing.T) {
 
 			res := rec.Result()
 			assert.Equal(t, tc.expected.status, res.StatusCode)
-
-			if tc.expected.conflicts != nil {
-				var body map[string][]string
-				require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
-				assert.Equal(t, tc.expected.conflicts, body["conflicts"])
-			}
 
 			svcMock.AssertExpectations(t)
 		})

--- a/server/api/routes/user.go
+++ b/server/api/routes/user.go
@@ -4,9 +4,7 @@ import (
 	"net/http"
 
 	"github.com/shellhub-io/shellhub/pkg/api/requests"
-	"github.com/shellhub-io/shellhub/pkg/errors"
 	"github.com/shellhub-io/shellhub/server/api/pkg/gateway"
-	"github.com/shellhub-io/shellhub/server/api/services"
 )
 
 const (
@@ -31,27 +29,8 @@ func (h *Handler) UpdateUser(c *gateway.Context) error {
 		return err
 	}
 
-	if fields, err := h.service.UpdateUser(c.Ctx(), req); err != nil {
-		// FIXME: API compatibility.
-		//
-		// The UI uses the fields with error messages to identify if it is invalid or duplicated.
-		var e errors.Error
-		if ok := errors.As(err, &e); !ok {
-			return err
-		}
-
-		switch e.Code {
-		case services.ErrCodeInvalid:
-			if len(fields) > 1 {
-				return c.JSON(http.StatusBadRequest, fields)
-			}
-
-			return c.NoContent(http.StatusBadRequest)
-		case services.ErrCodeDuplicated:
-			return c.JSON(http.StatusConflict, fields)
-		default:
-			return err
-		}
+	if err := h.service.UpdateUser(c.Ctx(), req); err != nil {
+		return err
 	}
 
 	return c.NoContent(http.StatusOK)

--- a/server/api/routes/user_test.go
+++ b/server/api/routes/user_test.go
@@ -86,7 +86,7 @@ func TestUpdateUser(t *testing.T) {
 							RecoveryEmail: "john.doe@test.com",
 						},
 					).
-					Return(nil, svc.ErrUserNotFound).
+					Return(svc.ErrUserNotFound).
 					Once()
 			},
 			expected: Expected{http.StatusNotFound},
@@ -116,7 +116,7 @@ func TestUpdateUser(t *testing.T) {
 							RecoveryEmail: "john.doe@test.com",
 						},
 					).
-					Return(nil, nil).
+					Return(nil).
 					Once()
 			},
 			expected: Expected{http.StatusOK},

--- a/server/api/services/errors.go
+++ b/server/api/services/errors.go
@@ -50,12 +50,6 @@ type ErrDataNotFound struct {
 	ID string
 }
 
-// ErrDataDuplicated structure should be used to add errors.Data to an error when the resource is duplicated.
-type ErrDataDuplicated struct {
-	// Values is used to identify the duplicated resource.
-	Values []string
-}
-
 // ErrDataLimit structure should be used to add errors.Data to an error when the resource is reached the limit.
 type ErrDataLimit struct {
 	// Limit is the max number of resources.
@@ -185,9 +179,15 @@ func NewErrInvalid(err error, data map[string]interface{}, next error) error {
 	return errors.Wrap(errors.WithData(err, ErrDataInvalid{Data: data}), next)
 }
 
-// NewErrDuplicated returns an error with the ErrDataDuplicated and wrap an error.
-func NewErrDuplicated(err error, values []string, next error) error {
-	return errors.Wrap(errors.WithData(err, ErrDataDuplicated{Values: values}), next)
+// NewErrDuplicated returns an error naming the already-taken request field(s), e.g. ["email"], and
+// wrap an error.
+func NewErrDuplicated(err error, conflicts []string, next error) error {
+	fields := make(map[string]string, len(conflicts))
+	for _, field := range conflicts {
+		fields[field] = "duplicated"
+	}
+
+	return errors.Wrap(errors.WithData(err, ErrDataInvalidFields{Fields: fields}), next)
 }
 
 // NewErrLimit returns an error with the ErrDataLimit and wrap an error.
@@ -260,10 +260,16 @@ type ErrDataInvalidFields struct {
 	Fields map[string]string `json:"fields"`
 }
 
+// NewErrInvalidFields tags an error with the offending request field(s) and why each was rejected,
+// so the HTTP error handler can answer with a per-field body.
+func NewErrInvalidFields(err error, fields map[string]string) error {
+	return errors.WithData(err, ErrDataInvalidFields{Fields: fields})
+}
+
 // NewErrInstallKeyInvalidField returns a bad-request error tagging install key field(s) with a
 // human-readable reason, retrievable by the route from the error's Data.
 func NewErrInstallKeyInvalidField(fields map[string]string) error {
-	return errors.WithData(ErrInstallKeyInvalidField, ErrDataInvalidFields{Fields: fields})
+	return NewErrInvalidFields(ErrInstallKeyInvalidField, fields)
 }
 
 // NewErrTagInvalid returns an error when the tag is invalid.
@@ -286,9 +292,10 @@ func NewErrTagNotFound(tag string, next error) error {
 	return NewErrNotFound(ErrTagNameNotFound, tag, next)
 }
 
-// NewErrTagDuplicated returns an error when the tag is duplicated.
-func NewErrTagDuplicated(tag string, next error) error {
-	return NewErrDuplicated(ErrDuplicateTagName, []string{tag}, next)
+// NewErrTagDuplicated returns an error when the tag is duplicated. conflicts names the request
+// field(s) already taken, e.g. ["name"].
+func NewErrTagDuplicated(conflicts []string, next error) error {
+	return NewErrDuplicated(ErrDuplicateTagName, conflicts, next)
 }
 
 // NewErrUserNotFound returns an error when the user is not found.

--- a/server/api/services/mocks/mock_service.go
+++ b/server/api/services/mocks/mock_service.go
@@ -1845,7 +1845,7 @@ func (_c *MockService_CreateSession_Call) RunAndReturn(run func(ctx context.Cont
 }
 
 // CreateTag provides a mock function for the type MockService
-func (_mock *MockService) CreateTag(ctx context.Context, req *requests.CreateTag) (string, []string, error) {
+func (_mock *MockService) CreateTag(ctx context.Context, req *requests.CreateTag) (string, error) {
 	ret := _mock.Called(ctx, req)
 
 	if len(ret) == 0 {
@@ -1853,9 +1853,8 @@ func (_mock *MockService) CreateTag(ctx context.Context, req *requests.CreateTag
 	}
 
 	var r0 string
-	var r1 []string
-	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.CreateTag) (string, []string, error)); ok {
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.CreateTag) (string, error)); ok {
 		return returnFunc(ctx, req)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.CreateTag) string); ok {
@@ -1863,19 +1862,12 @@ func (_mock *MockService) CreateTag(ctx context.Context, req *requests.CreateTag
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *requests.CreateTag) []string); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *requests.CreateTag) error); ok {
 		r1 = returnFunc(ctx, req)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([]string)
-		}
+		r1 = ret.Error(1)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, *requests.CreateTag) error); ok {
-		r2 = returnFunc(ctx, req)
-	} else {
-		r2 = ret.Error(2)
-	}
-	return r0, r1, r2
+	return r0, r1
 }
 
 // MockService_CreateTag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateTag'
@@ -1908,12 +1900,12 @@ func (_c *MockService_CreateTag_Call) Run(run func(ctx context.Context, req *req
 	return _c
 }
 
-func (_c *MockService_CreateTag_Call) Return(insertedID string, conflicts []string, err error) *MockService_CreateTag_Call {
-	_c.Call.Return(insertedID, conflicts, err)
+func (_c *MockService_CreateTag_Call) Return(insertedID string, err error) *MockService_CreateTag_Call {
+	_c.Call.Return(insertedID, err)
 	return _c
 }
 
-func (_c *MockService_CreateTag_Call) RunAndReturn(run func(ctx context.Context, req *requests.CreateTag) (string, []string, error)) *MockService_CreateTag_Call {
+func (_c *MockService_CreateTag_Call) RunAndReturn(run func(ctx context.Context, req *requests.CreateTag) (string, error)) *MockService_CreateTag_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5489,7 +5481,7 @@ func (_c *MockService_PushTagTo_Call) RunAndReturn(run func(ctx context.Context,
 }
 
 // RegisterUser provides a mock function for the type MockService
-func (_mock *MockService) RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost string, forwardedProto string) (*models.UserAuthResponse, []string, error) {
+func (_mock *MockService) RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost string, forwardedProto string) (*models.UserAuthResponse, error) {
 	ret := _mock.Called(ctx, req, forwardedHost, forwardedProto)
 
 	if len(ret) == 0 {
@@ -5497,9 +5489,8 @@ func (_mock *MockService) RegisterUser(ctx context.Context, req requests.Registe
 	}
 
 	var r0 *models.UserAuthResponse
-	var r1 []string
-	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.RegisterUser, string, string) (*models.UserAuthResponse, []string, error)); ok {
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.RegisterUser, string, string) (*models.UserAuthResponse, error)); ok {
 		return returnFunc(ctx, req, forwardedHost, forwardedProto)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, requests.RegisterUser, string, string) *models.UserAuthResponse); ok {
@@ -5509,19 +5500,12 @@ func (_mock *MockService) RegisterUser(ctx context.Context, req requests.Registe
 			r0 = ret.Get(0).(*models.UserAuthResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, requests.RegisterUser, string, string) []string); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, requests.RegisterUser, string, string) error); ok {
 		r1 = returnFunc(ctx, req, forwardedHost, forwardedProto)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([]string)
-		}
+		r1 = ret.Error(1)
 	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context, requests.RegisterUser, string, string) error); ok {
-		r2 = returnFunc(ctx, req, forwardedHost, forwardedProto)
-	} else {
-		r2 = ret.Error(2)
-	}
-	return r0, r1, r2
+	return r0, r1
 }
 
 // MockService_RegisterUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RegisterUser'
@@ -5566,12 +5550,12 @@ func (_c *MockService_RegisterUser_Call) Run(run func(ctx context.Context, req r
 	return _c
 }
 
-func (_c *MockService_RegisterUser_Call) Return(userAuthResponse *models.UserAuthResponse, strings []string, err error) *MockService_RegisterUser_Call {
-	_c.Call.Return(userAuthResponse, strings, err)
+func (_c *MockService_RegisterUser_Call) Return(userAuthResponse *models.UserAuthResponse, err error) *MockService_RegisterUser_Call {
+	_c.Call.Return(userAuthResponse, err)
 	return _c
 }
 
-func (_c *MockService_RegisterUser_Call) RunAndReturn(run func(ctx context.Context, req requests.RegisterUser, forwardedHost string, forwardedProto string) (*models.UserAuthResponse, []string, error)) *MockService_RegisterUser_Call {
+func (_c *MockService_RegisterUser_Call) RunAndReturn(run func(ctx context.Context, req requests.RegisterUser, forwardedHost string, forwardedProto string) (*models.UserAuthResponse, error)) *MockService_RegisterUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -7203,31 +7187,20 @@ func (_c *MockService_UpdateSession_Call) RunAndReturn(run func(ctx context.Cont
 }
 
 // UpdateTag provides a mock function for the type MockService
-func (_mock *MockService) UpdateTag(ctx context.Context, req *requests.UpdateTag) ([]string, error) {
+func (_mock *MockService) UpdateTag(ctx context.Context, req *requests.UpdateTag) error {
 	ret := _mock.Called(ctx, req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateTag")
 	}
 
-	var r0 []string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.UpdateTag) ([]string, error)); ok {
-		return returnFunc(ctx, req)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.UpdateTag) []string); ok {
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.UpdateTag) error); ok {
 		r0 = returnFunc(ctx, req)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
+		r0 = ret.Error(0)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *requests.UpdateTag) error); ok {
-		r1 = returnFunc(ctx, req)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
+	return r0
 }
 
 // MockService_UpdateTag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateTag'
@@ -7260,42 +7233,31 @@ func (_c *MockService_UpdateTag_Call) Run(run func(ctx context.Context, req *req
 	return _c
 }
 
-func (_c *MockService_UpdateTag_Call) Return(conflicts []string, err error) *MockService_UpdateTag_Call {
-	_c.Call.Return(conflicts, err)
+func (_c *MockService_UpdateTag_Call) Return(err error) *MockService_UpdateTag_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockService_UpdateTag_Call) RunAndReturn(run func(ctx context.Context, req *requests.UpdateTag) ([]string, error)) *MockService_UpdateTag_Call {
+func (_c *MockService_UpdateTag_Call) RunAndReturn(run func(ctx context.Context, req *requests.UpdateTag) error) *MockService_UpdateTag_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateUser provides a mock function for the type MockService
-func (_mock *MockService) UpdateUser(ctx context.Context, req *requests.UpdateUser) ([]string, error) {
+func (_mock *MockService) UpdateUser(ctx context.Context, req *requests.UpdateUser) error {
 	ret := _mock.Called(ctx, req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateUser")
 	}
 
-	var r0 []string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.UpdateUser) ([]string, error)); ok {
-		return returnFunc(ctx, req)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.UpdateUser) []string); ok {
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *requests.UpdateUser) error); ok {
 		r0 = returnFunc(ctx, req)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
+		r0 = ret.Error(0)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *requests.UpdateUser) error); ok {
-		r1 = returnFunc(ctx, req)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
+	return r0
 }
 
 // MockService_UpdateUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUser'
@@ -7328,12 +7290,12 @@ func (_c *MockService_UpdateUser_Call) Run(run func(ctx context.Context, req *re
 	return _c
 }
 
-func (_c *MockService_UpdateUser_Call) Return(conflicts []string, err error) *MockService_UpdateUser_Call {
-	_c.Call.Return(conflicts, err)
+func (_c *MockService_UpdateUser_Call) Return(err error) *MockService_UpdateUser_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockService_UpdateUser_Call) RunAndReturn(run func(ctx context.Context, req *requests.UpdateUser) ([]string, error)) *MockService_UpdateUser_Call {
+func (_c *MockService_UpdateUser_Call) RunAndReturn(run func(ctx context.Context, req *requests.UpdateUser) error) *MockService_UpdateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/api/services/register.go
+++ b/server/api/services/register.go
@@ -18,7 +18,7 @@ import (
 // code via req.Sig, or a pending user_invitation matching the email), it completes the invited
 // account and — if the code resolves — joins the namespace in the same step. Open self-registration
 // is a capability (cloud only); community and enterprise are invite-only.
-func (s *service) RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, []string, error) {
+func (s *service) RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, error) {
 	// A valid invite code (Sig) is the only way to complete an invited account: it resolves the
 	// invitation server-side and the email comes from it, so the invitee can't retarget it.
 	if req.Sig != "" {
@@ -35,7 +35,7 @@ func (s *service) RegisterUser(ctx context.Context, req requests.RegisterUser, f
 	// An empty Email also refuses: validation only requires Email when Sig is absent, so a
 	// present-but-unresolved Sig reaches here with a blank email that must not create an account.
 	if !openSignupAllowed() || req.Email == "" {
-		return nil, nil, NewErrAuthForbidden()
+		return nil, NewErrAuthForbidden()
 	}
 
 	if invitation, err := s.store.UserInvitationGet(ctx, store.UserInvitationEmailResolver, strings.ToLower(req.Email)); err == nil && invitation.Status == models.UserInvitationStatusPending {
@@ -46,10 +46,10 @@ func (s *service) RegisterUser(ctx context.Context, req requests.RegisterUser, f
 }
 
 // createNewUser handles the creation of a new user who was not invited to register.
-func (s *service) createNewUser(ctx context.Context, req *requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, []string, error) {
+func (s *service) createNewUser(ctx context.Context, req *requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, error) {
 	password, err := models.HashUserPassword(req.Password)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	user := &models.User{
@@ -74,13 +74,13 @@ func (s *service) createNewUser(ctx context.Context, req *requests.RegisterUser,
 	if user.ID, err = s.store.UserCreate(ctx, user); err != nil {
 		if errors.Is(err, store.ErrDuplicate) {
 			if field, ok := store.DuplicatedField(err); ok {
-				return nil, []string{field}, NewErrUserDuplicated([]string{field}, err)
+				return nil, NewErrUserDuplicated([]string{field}, err)
 			}
 
-			return nil, []string{}, NewErrUserDuplicated([]string{}, err)
+			return nil, NewErrUserDuplicated([]string{}, err)
 		}
 
-		return nil, nil, NewErrUserCreate(err)
+		return nil, NewErrUserCreate(err)
 	}
 
 	validUntil := clock.Now().Add(24 * time.Hour)
@@ -90,18 +90,18 @@ func (s *service) createNewUser(ctx context.Context, req *requests.RegisterUser,
 		log.WithError(err).WithField("user_id", user.ID).Error("Failed to send verification email")
 	}
 
-	return nil, nil, nil
+	return nil, nil
 }
 
 // createInvitedUser handles the creation of a user who was previously invited through user_invitations.
-func (s *service) createInvitedUser(ctx context.Context, req *requests.RegisterUser, invitation *models.UserInvitation, forwardedHost, forwardedProto string) (*models.UserAuthResponse, []string, error) {
+func (s *service) createInvitedUser(ctx context.Context, req *requests.RegisterUser, invitation *models.UserInvitation, forwardedHost, forwardedProto string) (*models.UserAuthResponse, error) {
 	if invitation.Status != models.UserInvitationStatusPending {
-		return nil, nil, errors.New("invitation already accepted")
+		return nil, errors.New("invitation already accepted")
 	}
 
 	password, err := models.HashUserPassword(req.Password)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	user := &models.User{
@@ -175,19 +175,19 @@ func (s *service) createInvitedUser(ctx context.Context, req *requests.RegisterU
 	}); txErr != nil {
 		if errors.Is(txErr, store.ErrDuplicate) {
 			if field, ok := store.DuplicatedField(txErr); ok {
-				return nil, []string{field}, NewErrUserDuplicated([]string{field}, txErr)
+				return nil, NewErrUserDuplicated([]string{field}, txErr)
 			}
 
-			return nil, []string{}, NewErrUserDuplicated([]string{}, txErr)
+			return nil, NewErrUserDuplicated([]string{}, txErr)
 		}
 
-		return nil, nil, NewErrUserCreate(txErr)
+		return nil, NewErrUserCreate(txErr)
 	}
 
 	// An account awaiting approval is inert: minting a session token here would let the invitee
 	// slip past the login gate. Return no token so the UI lands on "waiting for approval".
 	if user.AwaitingApproval {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	switch user.Status {
@@ -198,18 +198,18 @@ func (s *service) createInvitedUser(ctx context.Context, req *requests.RegisterU
 				WithField("user_id", invitation.ID).
 				Error("CreateUserToken failed after transaction commit; user exists but registration returned error")
 
-			return nil, nil, NewErrUserGetToken(invitation.ID, err)
+			return nil, NewErrUserGetToken(invitation.ID, err)
 		}
 
-		return res, nil, nil
+		return res, nil
 	case models.UserStatusNotConfirmed:
 		validUntil := clock.Now().Add(24 * time.Hour)
 		if err := fireUserRegistered(ctx, user, forwardedHost, forwardedProto, validUntil); err != nil {
 			log.WithError(err).WithField("user_id", user.ID).Error("Failed to send verification email for invited user")
 		}
 
-		return nil, nil, nil
+		return nil, nil
 	default:
-		return nil, nil, errors.New("invalid user status")
+		return nil, errors.New("invalid user status")
 	}
 }

--- a/server/api/services/register_test.go
+++ b/server/api/services/register_test.go
@@ -29,9 +29,8 @@ func TestService_RegisterUser(t *testing.T) {
 	runTx := func(_ context.Context, cb store.TransactionCb) error { return cb(ctx) }
 
 	type Expected struct {
-		hasToken  bool
-		conflicts []string
-		err       error
+		hasToken bool
+		err      error
 	}
 
 	cases := []struct {
@@ -49,7 +48,7 @@ func TestService_RegisterUser(t *testing.T) {
 				Name: "Alice", Username: "alice", Email: "alice@test.com", Password: "secret123",
 			},
 			requiredMocks: func(_ *storemock.MockStore) {},
-			expected:      Expected{false, nil, NewErrAuthForbidden()},
+			expected:      Expected{false, NewErrAuthForbidden()},
 		},
 		{
 			// A non-resolving Sig with an empty email must not fall through to createNewUser:
@@ -64,7 +63,7 @@ func TestService_RegisterUser(t *testing.T) {
 				storeMock.On("MembershipInvitationResolveBySig", ctx, "STALECODE123").
 					Return(nil, store.ErrNoDocuments).Once()
 			},
-			expected: Expected{false, nil, NewErrAuthForbidden()},
+			expected: Expected{false, NewErrAuthForbidden()},
 		},
 		{
 			description: "completes an invited account by email match when open signup is on",
@@ -84,7 +83,7 @@ func TestService_RegisterUser(t *testing.T) {
 				storeMock.On("UserInvitationUpdate", ctx, mock.AnythingOfType("*models.UserInvitation")).
 					Return(nil).Once()
 			},
-			expected: Expected{false, nil, nil},
+			expected: Expected{false, nil},
 		},
 		{
 			description: "completes an invited account with a sig, joining the namespace and returning a token",
@@ -118,7 +117,7 @@ func TestService_RegisterUser(t *testing.T) {
 				storeMock.On("NamespaceGetPreferred", ctx, "invitee").
 					Return(nil, store.ErrNoDocuments).Once()
 			},
-			expected: Expected{true, nil, nil},
+			expected: Expected{true, nil},
 		},
 		{
 			description:          "sets awaiting-approval for a sig registration invited by a non-admin (enterprise)",
@@ -149,7 +148,7 @@ func TestService_RegisterUser(t *testing.T) {
 					Return(nil).Once()
 				storeMock.On("MembershipInvitationDelete", ctx, membership).Return(nil).Once()
 			},
-			expected: Expected{false, nil, nil},
+			expected: Expected{false, nil},
 		},
 		{
 			description: "returns the conflicting field when the invited user's username is duplicated",
@@ -174,7 +173,6 @@ func TestService_RegisterUser(t *testing.T) {
 			},
 			expected: Expected{
 				false,
-				[]string{"username"},
 				NewErrUserDuplicated([]string{"username"}, errors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "username"})),
 			},
 		},
@@ -195,8 +193,7 @@ func TestService_RegisterUser(t *testing.T) {
 
 			s := NewService(store.Store(storeMock), privateKey, publicKey, storecache.NewNullCache())
 
-			res, conflicts, err := s.RegisterUser(ctx, tc.req, "shellhub.test", "")
-			assert.Equal(t, tc.expected.conflicts, conflicts)
+			res, err := s.RegisterUser(ctx, tc.req, "shellhub.test", "")
 			assert.Equal(t, tc.expected.err, err)
 			if tc.expected.hasToken {
 				assert.NotNil(t, res)

--- a/server/api/services/tags.go
+++ b/server/api/services/tags.go
@@ -30,8 +30,9 @@ type TagsService interface {
 	// Tags can share the same attributes (e.g. name) if they belong to different tenants.
 	// For example, tenant1 and tenant2 can each have a tag named "production".
 	//
-	// It returns the insertedID, an array of conflicting field names, e.g. `["name"]` and an error if any.
-	CreateTag(ctx context.Context, req *requests.CreateTag) (insertedID string, conflicts []string, err error)
+	// It returns the insertedID and an error if any. A name already taken yields
+	// [ErrDuplicateTagName], carrying the conflicting field name(s).
+	CreateTag(ctx context.Context, req *requests.CreateTag) (insertedID string, err error)
 
 	// PushTagTo adds an existing tag in a namespace to a target document (e.g. Device, PublicKey, FirewallRule).
 	//
@@ -52,8 +53,9 @@ type TagsService interface {
 
 	// UpdateTag updates a tag with the specified name in the specified namespace.
 	//
-	// It returns an array of conflicting field names, e.g. `["name"]` and an error if any.
-	UpdateTag(ctx context.Context, req *requests.UpdateTag) (conflicts []string, err error)
+	// It returns an error if any. A name already taken yields [ErrDuplicateTagName], carrying the
+	// conflicting field name(s).
+	UpdateTag(ctx context.Context, req *requests.UpdateTag) (err error)
 
 	// DeleteTag deletes a tag with the specified name in the specified namespace.
 	//
@@ -61,26 +63,30 @@ type TagsService interface {
 	DeleteTag(ctx context.Context, req *requests.DeleteTag) (err error)
 }
 
-func (s *service) CreateTag(ctx context.Context, req *requests.CreateTag) (string, []string, error) {
+func (s *service) CreateTag(ctx context.Context, req *requests.CreateTag) (string, error) {
 	sc, err := BoundTo(req.TenantID)
 	if err != nil {
-		return "", []string{}, err
+		return "", err
 	}
 
 	if _, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID); err != nil {
-		return "", []string{}, NewErrNamespaceNotFound(req.TenantID, err)
+		return "", NewErrNamespaceNotFound(req.TenantID, err)
 	}
 
 	if conflicts, has, err := s.store.TagConflicts(ctx, sc, &models.TagConflicts{Name: req.Name}); has || err != nil {
-		return "", conflicts, err
+		if !has {
+			return "", err
+		}
+
+		return "", NewErrTagDuplicated(conflicts, err)
 	}
 
 	insertedID, err := s.store.TagCreate(ctx, &models.Tag{Name: req.Name, TenantID: req.TenantID})
 	if err != nil {
-		return "", []string{}, err
+		return "", err
 	}
 
-	return insertedID, []string{}, nil
+	return insertedID, nil
 }
 
 func (s *service) PushTagTo(ctx context.Context, target store.TagTarget, req *requests.PushTag) (err error) {
@@ -153,19 +159,19 @@ func (s *service) ListTags(ctx context.Context, req *requests.ListTags) ([]model
 	return tags, totalCount, nil
 }
 
-func (s *service) UpdateTag(ctx context.Context, req *requests.UpdateTag) ([]string, error) {
+func (s *service) UpdateTag(ctx context.Context, req *requests.UpdateTag) error {
 	sc, err := BoundTo(req.TenantID)
 	if err != nil {
-		return []string{}, err
+		return err
 	}
 
 	if _, err := s.store.NamespaceResolve(ctx, store.NamespaceTenantIDResolver, req.TenantID); err != nil {
-		return []string{}, NewErrNamespaceNotFound(req.TenantID, err)
+		return NewErrNamespaceNotFound(req.TenantID, err)
 	}
 
 	tag, err := s.store.TagResolve(ctx, sc, store.TagNameResolver, req.Name)
 	if err != nil {
-		return []string{}, NewErrTagNotFound(req.Name, err)
+		return NewErrTagNotFound(req.Name, err)
 	}
 
 	conflictsAttrs := &models.TagConflicts{}
@@ -174,18 +180,18 @@ func (s *service) UpdateTag(ctx context.Context, req *requests.UpdateTag) ([]str
 	}
 
 	if conflicts, has, err := s.store.TagConflicts(ctx, sc, conflictsAttrs); has || err != nil {
-		return conflicts, NewErrTagDuplicated(req.NewName, err)
+		if !has {
+			return err
+		}
+
+		return NewErrTagDuplicated(conflicts, err)
 	}
 
 	if req.NewName != "" && !strings.EqualFold(req.NewName, tag.Name) {
 		tag.Name = req.NewName
 	}
 
-	if err := s.store.TagUpdate(ctx, tag); err != nil {
-		return nil, err
-	}
-
-	return []string{}, nil
+	return s.store.TagUpdate(ctx, tag)
 }
 
 func (s *service) DeleteTag(ctx context.Context, req *requests.DeleteTag) error {

--- a/server/api/services/tags_test.go
+++ b/server/api/services/tags_test.go
@@ -22,7 +22,6 @@ func TestService_CreateTag(t *testing.T) {
 
 	type Expected struct {
 		insertedID string
-		conflicts  []string
 		err        error
 	}
 
@@ -46,7 +45,6 @@ func TestService_CreateTag(t *testing.T) {
 			},
 			expected: Expected{
 				insertedID: "",
-				conflicts:  []string{},
 				err:        NewErrNamespaceNotFound("tenant1", errors.New("error")),
 			},
 		},
@@ -68,8 +66,7 @@ func TestService_CreateTag(t *testing.T) {
 			},
 			expected: Expected{
 				insertedID: "",
-				conflicts:  []string{"name"},
-				err:        nil,
+				err:        NewErrTagDuplicated([]string{"name"}, nil),
 			},
 		},
 		{
@@ -94,7 +91,6 @@ func TestService_CreateTag(t *testing.T) {
 			},
 			expected: Expected{
 				insertedID: "",
-				conflicts:  []string{},
 				err:        errors.New("error"),
 			},
 		},
@@ -120,7 +116,6 @@ func TestService_CreateTag(t *testing.T) {
 			},
 			expected: Expected{
 				insertedID: "000000000000000000000000",
-				conflicts:  []string{},
 				err:        nil,
 			},
 		},
@@ -132,8 +127,8 @@ func TestService_CreateTag(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.requiredMocks()
 
-			insertedID, conflicts, err := service.CreateTag(ctx, tc.req)
-			require.Equal(t, tc.expected, Expected{insertedID, conflicts, err})
+			insertedID, err := service.CreateTag(ctx, tc.req)
+			require.Equal(t, tc.expected, Expected{insertedID, err})
 		})
 	}
 
@@ -503,8 +498,7 @@ func TestService_UpdateTag(t *testing.T) {
 	ctx := context.TODO()
 
 	type Expected struct {
-		conflicts []string
-		err       error
+		err error
 	}
 
 	cases := []struct {
@@ -527,8 +521,7 @@ func TestService_UpdateTag(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
-				err:       NewErrNamespaceNotFound("tenant1", errors.New("error")),
+				err: NewErrNamespaceNotFound("tenant1", errors.New("error")),
 			},
 		},
 		{
@@ -549,8 +542,7 @@ func TestService_UpdateTag(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
-				err:       NewErrTagNotFound("production", errors.New("error")),
+				err: NewErrTagNotFound("production", errors.New("error")),
 			},
 		},
 		{
@@ -575,8 +567,32 @@ func TestService_UpdateTag(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{"name"},
-				err:       NewErrTagDuplicated("staging", nil),
+				err: NewErrTagDuplicated([]string{"name"}, nil),
+			},
+		},
+		{
+			description: "reports a conflict lookup failure as itself, not as a conflict",
+			req: &requests.UpdateTag{
+				Name:     "production",
+				NewName:  "staging",
+				TenantID: "tenant1",
+			},
+			requiredMocks: func() {
+				storeMock.
+					On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, "tenant1").
+					Return(&models.Namespace{}, nil).
+					Once()
+				storeMock.
+					On("TagResolve", ctx, mock.Anything, store.TagNameResolver, "production").
+					Return(&models.Tag{ID: "tag_00000000-0000-4000-0000-000000000000", Name: "production"}, nil).
+					Once()
+				storeMock.
+					On("TagConflicts", ctx, scope.MustBounded("tenant1"), &models.TagConflicts{Name: "staging"}).
+					Return(nil, false, errors.New("error")).
+					Once()
+			},
+			expected: Expected{
+				err: errors.New("error"),
 			},
 		},
 		{
@@ -608,8 +624,7 @@ func TestService_UpdateTag(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: nil,
-				err:       errors.New("error"),
+				err: errors.New("error"),
 			},
 		},
 		{
@@ -644,8 +659,7 @@ func TestService_UpdateTag(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
-				err:       nil,
+				err: nil,
 			},
 		},
 	}
@@ -656,8 +670,8 @@ func TestService_UpdateTag(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.requiredMocks()
 
-			conflicts, err := service.UpdateTag(ctx, tc.req)
-			require.Equal(t, tc.expected, Expected{conflicts, err})
+			err := service.UpdateTag(ctx, tc.req)
+			require.Equal(t, tc.expected, Expected{err})
 		})
 	}
 

--- a/server/api/services/user.go
+++ b/server/api/services/user.go
@@ -14,50 +14,49 @@ type UserService interface {
 	// RegisterUser creates a user account. When the registration carries a valid invitation (an
 	// invite code or a pending user_invitation for the email), it completes the invited account
 	// and joins the namespace. Open self-registration is cloud-only; community and enterprise are
-	// invite-only. Returns the auth response (when the account goes live), conflicting fields, and
-	// an error if any.
-	RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, []string, error)
+	// invite-only. Returns the auth response (when the account goes live) and an error if any. A
+	// value already taken yields [ErrUserDuplicated], carrying the conflicting field name(s).
+	RegisterUser(ctx context.Context, req requests.RegisterUser, forwardedHost, forwardedProto string) (*models.UserAuthResponse, error)
 
-	// UpdateUser updates the user's data, such as email and username. Since some attributes must be unique per user,
-	// it returns a list of duplicated unique values and an error if any.
-	//
-	// FIX:
-	// When `req.RecoveryEmail` is equal to `user.Email` or `req.Email`, return a bad request status
-	// with an error object like `{"error": "recovery_email must be different from email"}` instead of setting
-	// conflicts to `["email", "recovery_email"]`.
-	UpdateUser(ctx context.Context, req *requests.UpdateUser) (conflicts []string, err error)
+	// UpdateUser updates the user's data, such as email and username. Since some attributes must be
+	// unique per user, a value already taken yields [ErrUserDuplicated], carrying the conflicting
+	// field name(s).
+	UpdateUser(ctx context.Context, req *requests.UpdateUser) (err error)
 
 	UpdatePasswordUser(ctx context.Context, id string, currentPassword, newPassword string) error
 }
 
-func (s *service) UpdateUser(ctx context.Context, req *requests.UpdateUser) ([]string, error) {
+func (s *service) UpdateUser(ctx context.Context, req *requests.UpdateUser) error {
 	user, err := s.store.UserResolve(ctx, store.UserIDResolver, req.UserID)
 	if err != nil {
-		return []string{}, NewErrUserNotFound(req.UserID, nil)
+		return NewErrUserNotFound(req.UserID, nil)
 	}
 
 	if req.RecoveryEmail != "" && (strings.EqualFold(req.RecoveryEmail, user.Email) || strings.EqualFold(req.RecoveryEmail, req.Email)) {
-		return []string{"email", "recovery_email"}, NewErrBadRequest(nil)
+		return NewErrInvalidFields(ErrBadRequest, map[string]string{
+			"email":          "must be different from the recovery email",
+			"recovery_email": "must be different from the email",
+		})
 	}
 
 	updatedUser, err := applyUserChanges(user, req)
 	if err != nil {
-		return []string{}, err
+		return err
 	}
 
 	if err := s.store.UserUpdate(ctx, updatedUser); err != nil {
 		if errors.Is(err, store.ErrDuplicate) {
 			if field, ok := store.DuplicatedField(err); ok {
-				return []string{field}, NewErrUserDuplicated([]string{field}, err)
+				return NewErrUserDuplicated([]string{field}, err)
 			}
 
-			return []string{}, NewErrUserUnhandledDuplicate()
+			return NewErrUserUnhandledDuplicate()
 		}
 
-		return []string{}, NewErrUserUpdate(user, err)
+		return NewErrUserUpdate(user, err)
 	}
 
-	return []string{}, nil
+	return nil
 }
 
 // UpdatePasswordUser updates a user's password.

--- a/server/api/services/user_test.go
+++ b/server/api/services/user_test.go
@@ -16,8 +16,7 @@ import (
 
 func TestUpdateUser(t *testing.T) {
 	type Expected struct {
-		conflicts []string
-		err       error
+		err error
 	}
 
 	storeMock := mocks.NewMockStore(t)
@@ -44,8 +43,7 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
-				err:       NewErrUserNotFound("000000000000000000000000", nil),
+				err: NewErrUserNotFound("000000000000000000000000", nil),
 			},
 		},
 		{
@@ -75,8 +73,10 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{"email", "recovery_email"},
-				err:       NewErrBadRequest(nil),
+				err: NewErrInvalidFields(ErrBadRequest, map[string]string{
+					"email":          "must be different from the recovery email",
+					"recovery_email": "must be different from the email",
+				}),
 			},
 		},
 		{
@@ -106,8 +106,10 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{"email", "recovery_email"},
-				err:       NewErrBadRequest(nil),
+				err: NewErrInvalidFields(ErrBadRequest, map[string]string{
+					"email":          "must be different from the recovery email",
+					"recovery_email": "must be different from the email",
+				}),
 			},
 		},
 		{
@@ -137,8 +139,10 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{"email", "recovery_email"},
-				err:       NewErrBadRequest(nil),
+				err: NewErrInvalidFields(ErrBadRequest, map[string]string{
+					"email":          "must be different from the recovery email",
+					"recovery_email": "must be different from the email",
+				}),
 			},
 		},
 		{
@@ -168,8 +172,10 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{"email", "recovery_email"},
-				err:       NewErrBadRequest(nil),
+				err: NewErrInvalidFields(ErrBadRequest, map[string]string{
+					"email":          "must be different from the recovery email",
+					"recovery_email": "must be different from the email",
+				}),
 			},
 		},
 		{
@@ -208,8 +214,7 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
-				err:       NewErrUserPasswordNotMatch(nil),
+				err: NewErrUserPasswordNotMatch(nil),
 			},
 		},
 		{
@@ -251,7 +256,6 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
 				err: NewErrUserUpdate(
 					&models.User{
 						ID: "000000000000000000000000",
@@ -305,8 +309,7 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{"email"},
-				err:       NewErrUserDuplicated([]string{"email"}, stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "email"})),
+				err: NewErrUserDuplicated([]string{"email"}, stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "email"})),
 			},
 		},
 		{
@@ -348,8 +351,7 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{"username"},
-				err:       NewErrUserDuplicated([]string{"username"}, stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "username"})),
+				err: NewErrUserDuplicated([]string{"username"}, stderrors.Join(store.ErrDuplicate, store.DuplicateFieldError{Field: "username"})),
 			},
 		},
 		{
@@ -391,8 +393,7 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
-				err:       NewErrUserUnhandledDuplicate(),
+				err: NewErrUserUnhandledDuplicate(),
 			},
 		},
 		{
@@ -441,8 +442,7 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
-				err:       nil,
+				err: nil,
 			},
 		},
 		{
@@ -484,8 +484,7 @@ func TestUpdateUser(t *testing.T) {
 					Once()
 			},
 			expected: Expected{
-				conflicts: []string{},
-				err:       nil,
+				err: nil,
 			},
 		},
 	}
@@ -497,8 +496,8 @@ func TestUpdateUser(t *testing.T) {
 			ctx := context.Background()
 			tc.requiredMocks(ctx)
 
-			conflicts, err := service.UpdateUser(ctx, tc.req)
-			assert.Equal(t, tc.expected, Expected{conflicts, err})
+			err := service.UpdateUser(ctx, tc.req)
+			assert.Equal(t, tc.expected, Expected{err})
 		})
 	}
 

--- a/ui/apps/console/src/api/__tests__/errors.test.ts
+++ b/ui/apps/console/src/api/__tests__/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSdkError } from "../errors";
+import { apiErrorFields, apiErrorMessage, isSdkError } from "../errors";
 
 describe("isSdkError", () => {
   describe("returns true for valid SDK errors", () => {
@@ -62,5 +62,62 @@ describe("isSdkError", () => {
     it("returns false for a plain array without status", () => {
       expect(isSdkError(["username"])).toBe(false);
     });
+  });
+});
+
+describe("apiErrorMessage", () => {
+  it.each([
+    [400, "Some values are invalid. Review the form and try again."],
+    [401, "Your session has expired. Sign in again."],
+    [402, "This action needs an active subscription."],
+    [403, "You do not have permission to do this."],
+    [404, "We could not find what you asked for."],
+    [409, "That value is already in use."],
+    [423, "This account is not active yet."],
+    [429, "Too many attempts. Wait a moment and try again."],
+    [500, "Something went wrong on our side. Try again."],
+    [503, "The service is unavailable right now. Try again shortly."],
+  ])("maps status %i to its own copy", (status, expected) => {
+    expect(apiErrorMessage({ status })).toBe(expected);
+  });
+
+  it("falls back to a generic message for an unmapped status", () => {
+    expect(apiErrorMessage({ status: 418 })).toBe("Something went wrong. Please try again.");
+  });
+
+  it("falls back to a generic message for a value that is not an API error", () => {
+    expect(apiErrorMessage(new Error("boom"))).toBe("Something went wrong. Please try again.");
+  });
+
+  it("never renders the server's own message", () => {
+    expect(apiErrorMessage({ status: 409, message: "user duplicated" })).toBe(
+      "That value is already in use.",
+    );
+  });
+});
+
+describe("apiErrorFields", () => {
+  it("returns the field map when the body carries one", () => {
+    expect(apiErrorFields({ status: 409, fields: { username: "duplicated" } })).toEqual({
+      username: "duplicated",
+    });
+  });
+
+  it("returns an empty map when the body carries no fields", () => {
+    expect(apiErrorFields({ status: 409, message: "user duplicated" })).toEqual({});
+  });
+
+  it("returns an empty map for a value that is not an API error", () => {
+    expect(apiErrorFields(new Error("boom"))).toEqual({});
+  });
+
+  it("drops members whose value is not a string", () => {
+    expect(
+      apiErrorFields({ status: 400, fields: { username: "required", age: 42, email: null } }),
+    ).toEqual({ username: "required" });
+  });
+
+  it("returns an empty map when fields is not an object", () => {
+    expect(apiErrorFields({ status: 400, fields: "username" })).toEqual({});
   });
 });

--- a/ui/apps/console/src/api/errors.ts
+++ b/ui/apps/console/src/api/errors.ts
@@ -2,10 +2,15 @@
  * Shape attached to errors by the fetch error interceptor in fetchInterceptors.ts.
  * The interceptor monkey-patches `.status` and `.headers` onto the parsed
  * response body before it is thrown by the SDK with `throwOnError: true`.
+ *
+ * `message` and `fields` come from the body the API sends. `message` is for API clients — the
+ * console renders its own copy, keyed by status; see `apiErrorMessage`.
  */
 export interface SdkHttpError {
   status: number;
   headers: Headers;
+  message?: unknown;
+  fields?: unknown;
 }
 
 /**
@@ -19,5 +24,50 @@ export function isSdkError(err: unknown): err is SdkHttpError {
     && err !== null
     && "status" in err
     && typeof err.status === "number"
+  );
+}
+
+const GENERIC_MESSAGE = "Something went wrong. Please try again.";
+
+const STATUS_MESSAGES: Record<number, string> = {
+  400: "Some values are invalid. Review the form and try again.",
+  401: "Your session has expired. Sign in again.",
+  402: "This action needs an active subscription.",
+  403: "You do not have permission to do this.",
+  404: "We could not find what you asked for.",
+  409: "That value is already in use.",
+  423: "This account is not active yet.",
+  429: "Too many attempts. Wait a moment and try again.",
+  500: "Something went wrong on our side. Try again.",
+  502: "The service is unavailable right now. Try again shortly.",
+  503: "The service is unavailable right now. Try again shortly.",
+  504: "The service is unavailable right now. Try again shortly.",
+};
+
+/**
+ * Turns a caught value into text to show the user, keyed by HTTP status.
+ *
+ * The console keeps its own copy: the server's `message` member is for API clients, and reads as
+ * internal phrasing here.
+ */
+export function apiErrorMessage(err: unknown): string {
+  if (!isSdkError(err)) return GENERIC_MESSAGE;
+
+  return STATUS_MESSAGES[err.status] ?? GENERIC_MESSAGE;
+}
+
+/**
+ * Reads the per-field detail an API error carries, mapping a request field name to the reason it
+ * was rejected. Returns an empty map when the error carries none.
+ */
+export function apiErrorFields(err: unknown): Record<string, string> {
+  if (!isSdkError(err)) return {};
+
+  const { fields } = err;
+  if (typeof fields !== "object" || fields === null || Array.isArray(fields)) return {};
+
+  return Object.fromEntries(
+    Object.entries(fields as Record<string, unknown>)
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
   );
 }

--- a/ui/apps/console/src/pages/__tests__/SignUp.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/SignUp.test.tsx
@@ -267,16 +267,17 @@ describe("SignUp", () => {
   /* ---------------------------------------------------------------- */
   describe("server field errors", () => {
     /**
-     * Simulate a 400 server response with field errors, matching the shape
-     * that isSdkError accepts: an error with numeric `status` that is also
-     * Array-like (the store checks `Array.isArray(error)`).
+     * Simulate a server error response carrying per-field detail: the parsed body with the
+     * numeric `status` the fetch error interceptor attaches.
      */
     function makeServerFieldError(fields: string[], status = 400) {
-      // The store does: isSdkError(error) && Array.isArray(error)
-      // isSdkError checks for numeric `status` on the object
-      // Array.isArray requires the value to actually be an array
-      const err = Object.assign([...fields], { status }) as unknown as Error;
-      return err;
+      const body = {
+        message: "user invalid",
+        fields: Object.fromEntries(fields.map((field) => [field, "invalid"])),
+        status,
+      };
+
+      return body as unknown as Error;
     }
 
     it("shows server-side username error on the username field and disables submit", async () => {

--- a/ui/apps/console/src/pages/admin/Sessions.tsx
+++ b/ui/apps/console/src/pages/admin/Sessions.tsx
@@ -14,6 +14,7 @@ import DataTable, { type Column } from "@/components/common/DataTable";
 import DeviceChip from "@/components/common/DeviceChip";
 import { formatDateFull } from "@/utils/date";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 
@@ -157,7 +158,7 @@ export default function AdminSessions() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
+++ b/ui/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/hooks/useAdminSessionsList", () => ({
 
 import { useAdminSessionsList } from "@/hooks/useAdminSessionsList";
 import AdminSessions from "../Sessions";
+import { sdkError } from "@/tests/sdkError";
 
 /* ------------------------------------------------------------------ */
 /* Helpers                                                             */
@@ -107,16 +108,16 @@ describe("AdminSessions", () => {
 
   describe("error state", () => {
     it("renders the error banner with role='alert'", () => {
-      setupHook({ error: new Error("Server error. Please try again later.") });
+      setupHook({ error: sdkError(500) });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
 
-    it("displays the error message in the banner", () => {
-      setupHook({ error: new Error("You don't have permission to view sessions.") });
+    it("displays the console's own copy for the status in the banner", () => {
+      setupHook({ error: sdkError(403) });
       renderPage();
       expect(screen.getByRole("alert")).toHaveTextContent(
-        "You don't have permission to view sessions.",
+        "You do not have permission to do this.",
       );
     });
 

--- a/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
@@ -45,6 +45,7 @@ vi.mock("../DeleteAnnouncementDialog", () => ({
 
 import { useAdminAnnouncements } from "@/hooks/useAdminAnnouncements";
 import AdminAnnouncements from "../index";
+import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -356,7 +357,7 @@ describe("AdminAnnouncements", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminAnnouncements).mockReturnValue({
         ...defaultHookState,
-        error: new Error("Request failed"),
+        error: sdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
@@ -365,10 +366,10 @@ describe("AdminAnnouncements", () => {
     it("renders the error message text", () => {
       vi.mocked(useAdminAnnouncements).mockReturnValue({
         ...defaultHookState,
-        error: new Error("Request failed"),
+        error: sdkError(500),
       });
       renderPage();
-      expect(screen.getByText("Request failed")).toBeInTheDocument();
+      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/admin/announcements/index.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/index.tsx
@@ -19,6 +19,7 @@ import {
   IconButton,
 } from "@shellhub/design-system/primitives";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 
@@ -126,7 +127,7 @@ export default function AdminAnnouncements() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/pages/admin/devices/__tests__/AdminDeviceDetails.test.tsx
+++ b/ui/apps/console/src/pages/admin/devices/__tests__/AdminDeviceDetails.test.tsx
@@ -97,8 +97,8 @@ describe("AdminDeviceDetails", () => {
       vi.mocked(useAdminDevice).mockReturnValue({
         data: undefined,
         isLoading: false,
-        error: new Error("404 Not Found"),
-      } as ReturnType<typeof useAdminDevice>);
+        error: { message: "device not found" },
+      } as unknown as ReturnType<typeof useAdminDevice>);
 
       renderPage();
       expect(screen.getByText("Device not found")).toBeInTheDocument();

--- a/ui/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
+++ b/ui/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
@@ -21,6 +21,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 import { useAdminDevices } from "@/hooks/useAdminDevices";
 import AdminDevices from "../index";
+import { sdkError } from "@/tests/sdkError";
 
 const defaultHookState = {
   devices: [] as NormalizedDevice[],
@@ -162,11 +163,11 @@ describe("AdminDevices", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminDevices).mockReturnValue({
         ...defaultHookState,
-        error: new Error("Request failed"),
+        error: sdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Request failed")).toBeInTheDocument();
+      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/admin/devices/index.tsx
+++ b/ui/apps/console/src/pages/admin/devices/index.tsx
@@ -17,6 +17,7 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import DeviceStatusChip from "./DeviceStatusChip";
 import { formatRelative } from "@/utils/date";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -233,7 +234,7 @@ export default function AdminDevices() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
@@ -36,6 +36,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
 import AdminFirewallRules from "../index";
 import { FirewallRulesResponse } from "@/client";
+import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -246,11 +247,11 @@ describe("AdminFirewallRules", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminFirewallRules).mockReturnValue({
         ...defaultHookState,
-        error: new Error("Request failed"),
+        error: sdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Request failed")).toBeInTheDocument();
+      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/admin/firewall-rules/index.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/index.tsx
@@ -14,6 +14,7 @@ import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
 import { usePaginatedListState } from "@/hooks/usePaginatedListState";
 import { type FirewallRulesResponse as FirewallRule } from "@/client";
 import { Badge, Callout } from "@shellhub/design-system/primitives";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 
@@ -147,7 +148,7 @@ export default function AdminFirewallRules() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/pages/admin/namespaces/__tests__/AdminNamespaces.test.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/__tests__/AdminNamespaces.test.tsx
@@ -41,6 +41,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 import { useAdminNamespaces } from "@/hooks/useAdminNamespaces";
 import AdminNamespaces from "../index";
+import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -157,11 +158,11 @@ describe("AdminNamespaces", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminNamespaces).mockReturnValue({
         ...defaultHookState,
-        error: new Error("Request failed"),
+        error: sdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Request failed")).toBeInTheDocument();
+      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/admin/namespaces/index.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/index.tsx
@@ -17,6 +17,7 @@ import DeleteNamespaceDialog from "./DeleteNamespaceDialog";
 import { formatDateShort } from "@/utils/date";
 import { formatMaxDevices } from "./utils";
 import { Callout, IconButton } from "@shellhub/design-system/primitives";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -148,7 +149,7 @@ export default function AdminNamespaces() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/pages/admin/users/__tests__/AdminUsers.test.tsx
+++ b/ui/apps/console/src/pages/admin/users/__tests__/AdminUsers.test.tsx
@@ -53,6 +53,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 import { useAdminUsers } from "@/hooks/useAdminUsers";
 import { useLoginAsUser } from "@/hooks/useLoginAsUser";
 import AdminUsers from "../index";
+import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -169,11 +170,11 @@ describe("AdminUsers", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminUsers).mockReturnValue({
         ...defaultHookState,
-        error: new Error("Request failed"),
+        error: sdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Request failed")).toBeInTheDocument();
+      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/admin/users/index.tsx
+++ b/ui/apps/console/src/pages/admin/users/index.tsx
@@ -28,6 +28,7 @@ import {
   Callout,
   IconButton,
 } from "@shellhub/design-system/primitives";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -210,7 +211,7 @@ export default function AdminUsers() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
+++ b/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
@@ -131,6 +131,7 @@ vi.mock("react-router-dom", async (importOriginal) => {
 import React from "react";
 import { useContainers } from "@/hooks/useContainers";
 import Containers from "../index";
+import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -257,10 +258,10 @@ describe("Containers list", () => {
     it("renders an error message when hook returns an error", () => {
       vi.mocked(useContainers).mockReturnValue({
         ...defaultHookState,
-        error: new Error("Request failed"),
+        error: sdkError(500),
       });
       renderPage();
-      expect(screen.getByText("Request failed")).toBeInTheDocument();
+      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/containers/index.tsx
+++ b/ui/apps/console/src/pages/containers/index.tsx
@@ -38,6 +38,7 @@ import {
 } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
 import RestrictedAction from "@/components/common/RestrictedAction";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -454,7 +455,7 @@ export default function Containers() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/pages/devices/__tests__/Devices.test.tsx
+++ b/ui/apps/console/src/pages/devices/__tests__/Devices.test.tsx
@@ -138,6 +138,7 @@ import React from "react";
 import { useDevices } from "@/hooks/useDevices";
 import { useDeviceActions } from "@/hooks/useDeviceActions";
 import Devices from "../index";
+import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -278,10 +279,10 @@ describe("Devices list", () => {
     it("renders an error message when hook returns an error", () => {
       vi.mocked(useDevices).mockReturnValue({
         ...defaultHookState,
-        error: new Error("Request failed"),
+        error: sdkError(500),
       });
       renderPage();
-      expect(screen.getByText("Request failed")).toBeInTheDocument();
+      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/devices/index.tsx
+++ b/ui/apps/console/src/pages/devices/index.tsx
@@ -40,6 +40,7 @@ import {
 } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
 import RestrictedAction from "@/components/common/RestrictedAction";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -467,7 +468,7 @@ export default function Devices() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/pages/sessions/index.tsx
+++ b/ui/apps/console/src/pages/sessions/index.tsx
@@ -29,6 +29,7 @@ import {
   Spinner,
 } from "@shellhub/design-system/primitives";
 import { cn } from "@shellhub/design-system/cn";
+import { apiErrorMessage } from "@/api/errors";
 
 const PER_PAGE = 10;
 
@@ -329,7 +330,7 @@ export default function Sessions() {
 
       {error && (
         <Callout variant="error" className="mb-4">
-          {error.message}
+          {apiErrorMessage(error)}
         </Callout>
       )}
 

--- a/ui/apps/console/src/stores/__tests__/signUpStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/signUpStore.test.ts
@@ -91,8 +91,10 @@ describe("signUpStore", () => {
       expect(useSignUpStore.getState().signUpTenant).toBeNull();
     });
 
-    it("sets signUpServerFields on 400/409 with field array and returns null", async () => {
-      mockedRegisterUser.mockRejectedValue(createSdkError(400, ["username", "email"]));
+    it("sets signUpServerFields on a 400 carrying per-field detail and returns null", async () => {
+      mockedRegisterUser.mockRejectedValue(
+        createSdkError(400, { message: "user invalid", fields: { username: "required", email: "invalid" } }),
+      );
 
       const result = await useSignUpStore.getState().signUp({
         name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
@@ -104,8 +106,10 @@ describe("signUpStore", () => {
       expect(useSignUpStore.getState().signUpError).toBeNull();
     });
 
-    it("sets signUpServerFields on 409 with field array and returns null", async () => {
-      mockedRegisterUser.mockRejectedValue(createSdkError(409, ["username"]));
+    it("sets signUpServerFields on a 409 carrying per-field detail and returns null", async () => {
+      mockedRegisterUser.mockRejectedValue(
+        createSdkError(409, { message: "user duplicated", fields: { username: "duplicated" } }),
+      );
 
       const result = await useSignUpStore.getState().signUp({
         name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
@@ -116,7 +120,7 @@ describe("signUpStore", () => {
       expect(useSignUpStore.getState().signUpError).toBeNull();
     });
 
-    it("falls through to generic error when 400 body is not an array", async () => {
+    it("falls through to the status message when the 400 body carries no fields", async () => {
       mockedRegisterUser.mockRejectedValue(createSdkError(400, { message: "validation error" }));
 
       const result = await useSignUpStore.getState().signUp({
@@ -125,7 +129,7 @@ describe("signUpStore", () => {
 
       expect(result).toBeNull();
       expect(useSignUpStore.getState().signUpServerFields).toEqual([]);
-      expect(useSignUpStore.getState().signUpError).toBe("An error occurred. Please try again.");
+      expect(useSignUpStore.getState().signUpError).toBe("Some values are invalid. Review the form and try again.");
     });
 
     it("sets signUpError on non-field errors and returns null", async () => {
@@ -137,7 +141,7 @@ describe("signUpStore", () => {
 
       expect(result).toBeNull();
       expect(useSignUpStore.getState().signUpLoading).toBe(false);
-      expect(useSignUpStore.getState().signUpError).toBe("An error occurred. Please try again.");
+      expect(useSignUpStore.getState().signUpError).toBe("Something went wrong. Please try again.");
       expect(useSignUpStore.getState().signUpServerFields).toEqual([]);
     });
 

--- a/ui/apps/console/src/stores/signUpStore.ts
+++ b/ui/apps/console/src/stores/signUpStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { isSdkError } from "../api/errors";
+import { apiErrorFields, apiErrorMessage, isSdkError } from "../api/errors";
 import {
   registerUser,
   resendEmail as resendEmailSdk,
@@ -66,15 +66,15 @@ export const useSignUpStore = create<SignUpState>()((set) => ({
       });
       return response.token ?? null;
     } catch (error: unknown) {
-      if (isSdkError(error) && (error.status === 400 || error.status === 409) && Array.isArray(error)) {
-        const fields = (error as unknown[]).filter((f): f is string => typeof f === "string");
+      const fields = Object.keys(apiErrorFields(error));
+      if (fields.length > 0) {
         set({ signUpLoading: false, signUpServerFields: fields });
         return null;
       }
       if (import.meta.env.DEV && isSdkError(error)) {
         console.warn("Unhandled sign-up error response:", { status: error.status });
       }
-      set({ signUpLoading: false, signUpError: "An error occurred. Please try again." });
+      set({ signUpLoading: false, signUpError: apiErrorMessage(error) });
       return null;
     }
   },

--- a/ui/apps/console/src/tests/sdkError.ts
+++ b/ui/apps/console/src/tests/sdkError.ts
@@ -1,0 +1,8 @@
+/**
+ * Builds a value shaped like what the SDK throws: the parsed error body with the `status` the
+ * fetch error interceptor attaches.
+ */
+export function sdkError(status: number, body: Record<string, unknown> = {}) {
+  // An Error instance, so it also satisfies hooks whose error type is the built-in Error.
+  return Object.assign(new Error(`HTTP ${status}`), { ...body, status });
+}


### PR DESCRIPTION
## What

Every API error response now carries a JSON body: `{"message": …}`, plus `{"fields": …}` when the
error names the request fields it concerns. The console stopped rendering server prose and shows
its own copy, keyed by status.

## Why

Every 4xx and 5xx returned an empty body. A client learned that something failed but never what.
Nine error banners in the console rendered the server's message and therefore rendered nothing.
Eight handlers worked around the gap by building their own bodies, producing three different shapes
for the same kind of failure. The OpenAPI specification declared a message body for 401 on 109
operations and for 500 on 137, and the server sent none of them.

Closes #6915

## Changes

- **server/api/pkg/echo/handlers**: the HTTP error handler renders the body on all four exit paths.
  A 5xx answers with a fixed generic message — the reporter still receives the real one, because
  those texts describe internals. An error carrying an HTTP status reads its `Message` member
  rather than `Error()`, which embeds the internal cause; `*echo.BindingError` is matched
  explicitly because it unwraps to its cause rather than to the `*echo.HTTPError` it embeds.
  The layer switch gains a `default` arm: the `scope` package declares a layer the switch does not
  name, which previously produced status zero.
- **server/api/routes**: the eight handlers that built their own bodies return the error instead.
  `RegisterUser`, `UpdateUser`, `CreateTag` and `UpdateTag` carry the conflicting field names on
  the error and dropped the extra return value. `NewErrDuplicated` builds the field map, so cloud's
  admin duplicates gain bodies with no cloud-side change.
- **server/api/services**: `UpdateTag` reported a `TagConflicts` store failure as a 409 conflict.
  It now returns the store error, matching `CreateTag`. This is the one status this PR changes.
- **openapi**: the shared 4xx and 5xx responses reference a new `apiError` schema. The three
  operations whose body shape changed point at the shared 400 and 409. The admin paths keep
  `invalidFields`/`conflictFields`, because cloud's admin handlers still emit those arrays.
- **ui/apps/console**: `apiErrorMessage` and `apiErrorFields` in `src/api/errors.ts`. The nine
  banners call the first. Sign-up and accept-invite read the field map through the second, so they
  keep per-field highlighting. Neither reads the server's `message`: that member is for API
  clients, and reads as internal phrasing in the console.

## Testing

The behaviour is pinned at two seams: the table in
`server/api/pkg/echo/handlers/errors_test.go` (19 cases, including the binding-error leak, an
unrecognised layer, and the two paths that must not echo their own message) and
`ui/apps/console/src/api/__tests__/errors.test.ts`.

Worth probing:

- `GET /api/devices?page=abc` — a binding error must answer `{"message":"failed to bind field
  value to int"}`, never the `strconv.ParseInt` cause.
- `server/api/routes/nsadm_test.go` guards that a 403 body leaks neither a namespace owner's nor a
  member's email. It is the reason the module renders the error's own message and never resource
  detail.
- The `message` member has no console consumer by design. It exists for API clients and for the
  specification's existing promise — it is not dead code.

Full suites pass: shellhub server (27 packages), cloud with `-tags enterprise` (22 packages), and
console (211 files). `golangci-lint`, the console lint and build, redocly lint and prettier are all
clean, and `go mod tidy` leaves both modules unchanged.
