### PR TITLE
fix(ui): restore terminal focus after re-auth dialog closes

### DIFF
--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -434,7 +434,10 @@ export default function TerminalInstance({
             setApprovalCode(null);
             setError(WS_REAUTH_CANCELLED);
           }}
-          onDecided={() => setApprovalCode(null)}
+          onDecided={() => {
+            setApprovalCode(null);
+            requestAnimationFrame(() => termRef.current?.focus());
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
## What

After completing re-authentication in the web terminal's inline approval dialog, focus now returns to the terminal so the user can type immediately.

## Why

When a re-auth policy triggers during an SSH session, the `SSHApproval` dialog mounts over the terminal. On successful authentication the dialog unmounts, but nothing handed focus back to xterm — the user had to click the terminal manually to resume typing.

## Testing

1. Connect to a device that has a re-authentication access policy
2. Complete the re-auth flow in the inline dialog
3. Verify the terminal is focused and accepts keyboard input without clicking