### PR TITLE
fix(api): answer 404 for a public key outside the caller's namespace

### DIFF
--- a/server/api/services/sshkeys.go
+++ b/server/api/services/sshkeys.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"regexp"
 
 	"github.com/shellhub-io/shellhub/pkg/api/query"
@@ -81,7 +82,19 @@ func (s *service) GetPublicKey(ctx context.Context, fingerprint, tenant string) 
 		return nil, NewErrNamespaceNotFound(tenant, err)
 	}
 
-	return s.store.PublicKeyResolve(ctx, sc, store.PublicKeyFingerprintResolver, fingerprint)
+	publicKey, err := s.store.PublicKeyResolve(ctx, sc, store.PublicKeyFingerprintResolver, fingerprint)
+	if err != nil {
+		// The store matches by fingerprint *and* namespace, so a key owned by another namespace is
+		// indistinguishable from one that does not exist — and must stay so, to avoid disclosing
+		// keys across namespaces.
+		if errors.Is(err, store.ErrNoDocuments) {
+			return nil, NewErrPublicKeyNotFound(fingerprint, err)
+		}
+
+		return nil, err
+	}
+
+	return publicKey, nil
 }
 
 func (s *service) CreatePublicKey(ctx context.Context, req requests.PublicKeyCreate, tenant string) (*responses.PublicKeyCreate, error) {

--- a/server/api/services/sshkeys_test.go
+++ b/server/api/services/sshkeys_test.go
@@ -312,6 +312,19 @@ func TestGetPublicKeys(t *testing.T) {
 			expected: Expected{nil, errors.New("error", "", 0)},
 		},
 		{
+			description: "fails when the key belongs to another namespace",
+			ctx:         ctx,
+			fingerprint: "fingerprint",
+			tenantID:    "tenant1",
+			requiredMocks: func() {
+				namespace := models.Namespace{TenantID: "tenant1"}
+
+				storeMock.On("NamespaceResolve", ctx, store.NamespaceTenantIDResolver, namespace.TenantID).Return(&namespace, nil).Once()
+				storeMock.On("PublicKeyResolve", ctx, mock.Anything, store.PublicKeyFingerprintResolver, "fingerprint").Return(nil, store.ErrNoDocuments).Once()
+			},
+			expected: Expected{nil, NewErrPublicKeyNotFound("fingerprint", store.ErrNoDocuments)},
+		},
+		{
 			description: "Successful get the key",
 			ctx:         ctx,
 			fingerprint: "fingerprint",


### PR DESCRIPTION
## What

`GET /api/sshkeys/public-keys/{fingerprint}` answers 404 instead of 500 when the key belongs to
another namespace.

## Why

`GetPublicKey` resolves the key bounded to the caller's namespace, so a foreign fingerprint
matches no row and the store returns `ErrNoDocuments`. The method returned that error untouched,
and `server/api/pkg/echo/handlers/errors.go` maps a bare store-layer error to 500 — the handler
documents that case as one the service must fix.

`UpdatePublicKey` and `DeletePublicKey` already wrapped the identical read correctly, so this was
an inconsistency inside one file rather than a design gap.

Found while auditing an enterprise report of the same defect class on the firewall rule endpoint
(shellhub-io/team#220, private).

## Changes

- **sshkeys service**: `GetPublicKey` maps `ErrNoDocuments` to `ErrPublicKeyNotFound`. 404 rather
  than 403 is deliberate: it does not disclose that the key exists in another namespace.
- **tests**: a case in `TestGetPublicKeys` pins the mapping.

## Audit scope

I read every namespace-scoped service path in `server/api/services`. This was the only other
client-reachable instance. Already correct: devices, sessions, tags, access policies, SSH
identities, namespaces, members, API keys — each resolves the row and wraps the error before it
mutates. The remaining raw store returns are read-backs after a successful write, where 500 is
the right answer.

## Testing

Create a public key in namespace A, then `GET /api/sshkeys/public-keys/{fingerprint}` with
credentials for namespace B. Expect 404, not 500.
