### PR TITLE
ci: notify cloud when master gains code it builds against

### DIFF
--- a/.github/workflows/notify-cloud-master.yml
+++ b/.github/workflows/notify-cloud-master.yml
@@ -1,0 +1,53 @@
+name: Notify Cloud (master)
+
+# Cloud builds against this repository through the replace directives in its go.mod, and its
+# own master QA resolves the shellhub source by branch name, falling back to master. A change
+# that spans both repositories therefore races: whichever side merges first, cloud master runs
+# QA against a sibling that does not carry the other half yet, and stays red until some later
+# push happens to re-run it. This dispatch re-validates cloud master whenever the Go trees it
+# consumes move, so the second merge of a pair repairs the first.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      # The two modules cloud replaces, and nothing else. The ui, docs, gateway and agent trees
+      # are not on its build path.
+      - 'pkg/**'
+      - 'server/**'
+      - 'go.mod'
+      - 'go.sum'
+
+concurrency:
+  group: notify-cloud-master
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch enterprise re-validation to cloud
+
+    runs-on: ubuntu-24.04
+
+    permissions: {}
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.CLOUD_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CLOUD_DISPATCH_APP_PRIVATE_KEY }}
+          owner: shellhub-io
+          repositories: cloud
+
+      - name: Dispatch to cloud
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'shellhub-io',
+              repo: 'cloud',
+              event_type: 'shellhub-master',
+              client_payload: { sha: context.sha },
+            });


### PR DESCRIPTION
## What

Dispatches a `shellhub-master` event to shellhub-io/cloud after a master push that touches the
Go trees cloud builds against, so cloud can re-validate its own master.

## Why

Cloud consumes this repository through the replace directives in its `go.mod`. Two workflows
already notify it: `notify-cloud.yml` on every pull request, and `notify-cloud-deps.yml` when
`go.mod` or `go.sum` move. Neither covers a master push that only changes Go source.

That gap turned a merge-order race into a lasting red. Cloud master QA resolves the shellhub ref
by branch name and falls back to `master`, so a change spanning both repositories lands as two
merges and the first one builds against a sibling missing the other half.

On 2026-08-18 the cloud half of session recording retention merged at 18:14:19 and this
repository's half at 18:14:40. Cloud's QA run started three seconds after the first merge and
eighteen seconds before the second, and failed on symbols that had not landed yet. Nothing told
cloud when they did, so its master stayed red for about fifteen hours, until an unrelated push
happened to re-run QA.

## Changes

- **`notify-cloud-master.yml`**: on a master push touching `pkg/**`, `server/**`, `go.mod` or
  `go.sum`, dispatch `shellhub-master` to cloud. Path-filtered to the two modules cloud replaces;
  the ui, docs, gateway and agent trees are not on its build path.
- Reuses the existing `CLOUD_DISPATCH_APP_ID` app token and the pinned action SHAs the two
  sibling workflows already use. `permissions: {}` — the job needs none of its own.

Beyond repairing the race, this also surfaces the other direction: a commit here that removes a
symbol cloud uses now reddens cloud master when it lands, instead of whenever cloud next pushes.

## Testing

Cannot be exercised before merge — the trigger only fires from the default branch. `actionlint`
reports no findings on the new file.

Pairs with shellhub-io/cloud#2503, which adds the matching `repository_dispatch` trigger.
Until that merges the dispatch is simply ignored, so the two can land in either order.
