### PR TITLE
fix: unbreak the invitation flow and email-shaped-username login

### DIFF
--- a/server/api/services/auth.go
+++ b/server/api/services/auth.go
@@ -485,12 +485,7 @@ func (s *service) AuthLocalUser(ctx context.Context, req *requests.AuthLocalUser
 		return nil, 0, "", NewErrAuthMethodNotAllowed(models.UserAuthMethodLocal.String())
 	}
 
-	resolver := store.UserUsernameResolver
-	if req.Identifier.IsEmail() {
-		resolver = store.UserEmailResolver
-	}
-
-	user, err := s.store.UserResolve(ctx, resolver, strings.ToLower(string(req.Identifier)))
+	user, err := store.UserResolveByAuthIdentifier(ctx, s.store, req.Identifier)
 	if err != nil {
 		return nil, 0, "", NewErrAuthUnathorized(nil)
 	}

--- a/server/api/services/auth_test.go
+++ b/server/api/services/auth_test.go
@@ -1256,6 +1256,10 @@ func TestService_AuthLocalUser(t *testing.T) {
 					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
 					Return(nil, store.ErrNoDocuments).
 					Once()
+				mock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "john.doe@test.com").
+					Return(nil, store.ErrNoDocuments).
+					Once()
 			},
 			expected: Expected{
 				res:      nil,
@@ -1798,6 +1802,109 @@ func TestService_AuthLocalUser(t *testing.T) {
 					AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
 					Name:        "john doe",
 					User:        "john_doe",
+					Email:       "john.doe@test.com",
+					Tenant:      "",
+					Token:       "must ignore",
+				},
+				lockout:  0,
+				mfaToken: "",
+				err:      nil,
+			},
+		},
+		{
+			description: "succeeds to authenticate an email-shaped username that is not the account email",
+			sourceIP:    "127.0.0.1",
+			req: &requests.AuthLocalUser{
+				Identifier: "john.doe@personal.test",
+				Password:   "secret",
+			},
+			requiredMocks: func() {
+				user := &models.User{
+					ID:        "65fdd16b5f62f93184ec8a39",
+					Origin:    models.UserOriginLocal,
+					Status:    models.UserStatusConfirmed,
+					LastLogin: now,
+					MFA: models.UserMFA{
+						Enabled: false,
+					},
+					UserData: models.UserData{
+						Username: "john.doe@personal.test",
+						Email:    "john.doe@test.com",
+						Name:     "john doe",
+					},
+					Password: models.UserPassword{
+						Hash: "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi",
+					},
+					Preferences: models.UserPreferences{
+						PreferredNamespace: "",
+						AuthMethods:        []models.UserAuthMethod{models.UserAuthMethodLocal},
+					},
+				}
+				updatedUser := *user
+
+				mock.
+					On("SystemGet", ctx).
+					Return(
+						&models.System{
+							Authentication: &models.SystemAuthentication{
+								Local: &models.SystemAuthenticationLocal{
+									Enabled: true,
+								},
+							},
+						},
+						nil,
+					).
+					Once()
+				mock.
+					On("UserResolve", ctx, store.UserEmailResolver, "john.doe@personal.test").
+					Return(nil, store.ErrNoDocuments).
+					Once()
+				mock.
+					On("UserResolve", ctx, store.UserUsernameResolver, "john.doe@personal.test").
+					Return(user, nil).
+					Once()
+				cacheMock.
+					On("HasAccountLockout", ctx, "127.0.0.1", "65fdd16b5f62f93184ec8a39").
+					Return(int64(0), 0, nil).
+					Once()
+				hashMock.
+					On("CompareWith", "secret", "$2a$10$V/6N1wsjheBVvWosPfv02uf4WAOb9lmp8YWQCIa2UYuFV4OJby7Yi").
+					Return(true).
+					Once()
+				cacheMock.
+					On("ResetLoginAttempts", ctx, "127.0.0.1", "65fdd16b5f62f93184ec8a39").
+					Return(nil).
+					Once()
+				mock.
+					On("NamespaceGetPreferred", ctx, "65fdd16b5f62f93184ec8a39").
+					Return(nil, errors.New("error", "layer", 0)).
+					Once()
+
+				clockMock := clockmock.NewMockClock(t)
+				clock.DefaultBackend = clockMock
+				clockMock.On("Now").Return(now)
+
+				cacheMock.
+					On("Set", ctx, "token_65fdd16b5f62f93184ec8a39", testifymock.Anything, time.Hour*72).
+					Return(nil).
+					Once()
+
+				mock.
+					On("UserUpdate", ctx, &updatedUser).
+					Return(nil).
+					Once()
+				mock.
+					On("UserUpdatePreferredNamespace", ctx, "65fdd16b5f62f93184ec8a39", "").
+					Return(nil).
+					Once()
+			},
+			expected: Expected{
+				res: &models.UserAuthResponse{
+					ID:          "65fdd16b5f62f93184ec8a39",
+					Origin:      models.UserOriginLocal.String(),
+					AuthMethods: []models.UserAuthMethod{models.UserAuthMethodLocal},
+					Name:        "john doe",
+					User:        "john.doe@personal.test",
 					Email:       "john.doe@test.com",
 					Tenant:      "",
 					Token:       "must ignore",

--- a/server/api/store/user.go
+++ b/server/api/store/user.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"strings"
 
 	"github.com/shellhub-io/shellhub/pkg/models"
 )
@@ -40,4 +41,30 @@ type UserStore interface {
 	UserGetInfo(ctx context.Context, id string) (userInfo *models.UserInfo, err error)
 
 	UserDelete(ctx context.Context, user *models.User) error
+}
+
+// UserResolveByAuthIdentifier resolves the user behind a login identifier.
+//
+// An email-shaped identifier is looked up as an email first and as a username afterwards,
+// because usernames may legally contain "@" (see the username rule in pkg/validator).
+// Resolving such an identifier only by email locks those accounts out of their own username.
+//
+// It returns the error of the last attempted resolver when no user matches.
+func UserResolveByAuthIdentifier(ctx context.Context, s UserStore, identifier models.UserAuthIdentifier) (*models.User, error) {
+	resolvers := []UserResolver{UserUsernameResolver}
+	if identifier.IsEmail() {
+		resolvers = []UserResolver{UserEmailResolver, UserUsernameResolver}
+	}
+
+	value := strings.ToLower(string(identifier))
+
+	var err error
+	for _, resolver := range resolvers {
+		var user *models.User
+		if user, err = s.UserResolve(ctx, resolver, value); err == nil {
+			return user, nil
+		}
+	}
+
+	return nil, err
 }

--- a/server/api/store/user_test.go
+++ b/server/api/store/user_test.go
@@ -1,0 +1,98 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/shellhub-io/shellhub/server/api/store"
+	"github.com/shellhub-io/shellhub/server/api/store/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserResolveByAuthIdentifier(t *testing.T) {
+	ctx := context.Background()
+	user := &models.User{ID: "65fdd16b5f62f93184ec8a39"}
+
+	type Expected struct {
+		user *models.User
+		err  error
+	}
+
+	tests := []struct {
+		description   string
+		identifier    models.UserAuthIdentifier
+		requiredMocks func(m *mocks.MockStore)
+		expected      Expected
+	}{
+		{
+			description: "resolves a plain identifier as a username",
+			identifier:  "john_doe",
+			requiredMocks: func(m *mocks.MockStore) {
+				m.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
+					Return(user, nil).
+					Once()
+			},
+			expected: Expected{user, nil},
+		},
+		{
+			description: "lowercases the identifier before resolving",
+			identifier:  "John_Doe",
+			requiredMocks: func(m *mocks.MockStore) {
+				m.On("UserResolve", ctx, store.UserUsernameResolver, "john_doe").
+					Return(user, nil).
+					Once()
+			},
+			expected: Expected{user, nil},
+		},
+		{
+			description: "resolves an email-shaped identifier as an email first",
+			identifier:  "john.doe@test.com",
+			requiredMocks: func(m *mocks.MockStore) {
+				m.On("UserResolve", ctx, store.UserEmailResolver, "john.doe@test.com").
+					Return(user, nil).
+					Once()
+			},
+			expected: Expected{user, nil},
+		},
+		{
+			description: "falls back to the username when no account owns the email",
+			identifier:  "john.doe@personal.test",
+			requiredMocks: func(m *mocks.MockStore) {
+				m.On("UserResolve", ctx, store.UserEmailResolver, "john.doe@personal.test").
+					Return(nil, store.ErrNoDocuments).
+					Once()
+				m.On("UserResolve", ctx, store.UserUsernameResolver, "john.doe@personal.test").
+					Return(user, nil).
+					Once()
+			},
+			expected: Expected{user, nil},
+		},
+		{
+			description: "reports the last error when neither column matches",
+			identifier:  "nobody@test.com",
+			requiredMocks: func(m *mocks.MockStore) {
+				m.On("UserResolve", ctx, store.UserEmailResolver, "nobody@test.com").
+					Return(nil, store.ErrNoDocuments).
+					Once()
+				m.On("UserResolve", ctx, store.UserUsernameResolver, "nobody@test.com").
+					Return(nil, store.ErrNoDocuments).
+					Once()
+			},
+			expected: Expected{nil, store.ErrNoDocuments},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			m := mocks.NewMockStore(t)
+			tc.requiredMocks(m)
+
+			resolved, err := store.UserResolveByAuthIdentifier(ctx, m, tc.identifier)
+
+			assert.Equal(t, tc.expected, Expected{resolved, err})
+			require.True(t, m.AssertExpectations(t))
+		})
+	}
+}

--- a/ui/apps/console/index.html
+++ b/ui/apps/console/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ShellHub</title>

--- a/ui/apps/console/migrate.html
+++ b/ui/apps/console/migrate.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ShellHub — Migration</title>

--- a/ui/apps/console/src/__tests__/entryDocuments.test.ts
+++ b/ui/apps/console/src/__tests__/entryDocuments.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import indexHtml from "../../index.html?raw";
+import migrateHtml from "../../migrate.html?raw";
+
+/**
+ * Chrome's auto-translation moves text nodes into <font> wrappers, which detaches the text
+ * nodes React tracks and makes the next insertBefore/removeChild throw NotFoundError.
+ * Opting the whole document out is the only defence that covers every route at once.
+ */
+const ENTRY_POINTS: [string, string][] = [
+  ["index.html", indexHtml],
+  ["migrate.html", migrateHtml],
+];
+
+describe.each(ENTRY_POINTS)("%s", (_name, html) => {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+
+  it("opts the document out of browser auto-translation", () => {
+    expect(doc.documentElement.getAttribute("translate")).toBe("no");
+  });
+
+  it("opts out of Google Translate's page-level toolbar", () => {
+    const meta = doc.querySelector('meta[name="google"]');
+
+    expect(meta?.getAttribute("content")).toBe("notranslate");
+  });
+});

--- a/ui/apps/console/src/pages/AcceptInvite.tsx
+++ b/ui/apps/console/src/pages/AcceptInvite.tsx
@@ -190,11 +190,13 @@ export default function AcceptInvite() {
       title: "Different Account Signed In",
       description: (
         <>
-          You're signed in as{" "}
+          <span>You're signed in as </span>
           <span className="font-medium text-text-primary font-mono">
             {authEmail ?? "another account"}
           </span>
-          . Sign out and use the account this invitation was sent to.
+          <span>
+            . Sign out and use the account this invitation was sent to.
+          </span>
         </>
       ),
       action: { label: "Sign Out", onClick: handleSignOut },
@@ -206,11 +208,11 @@ export default function AcceptInvite() {
       descriptionId: "invite-email-hint",
       description: (
         <>
-          Set up your account to join. You're joining as{" "}
+          <span>Set up your account to join. You're joining as </span>
           <span className="font-medium text-text-primary font-mono">
             {inviteEmail || "your email"}
           </span>
-          .
+          <span>.</span>
         </>
       ),
       children: (
@@ -275,17 +277,16 @@ export default function AcceptInvite() {
       title: "You're in",
       description: (
         <>
-          Your account is now a member of the namespace
+          <span>Your account is now a member of the namespace</span>
           {inviteEmail ? (
             <>
-              {" "}
-              as{" "}
+              <span> as </span>
               <span className="font-medium text-text-primary font-mono">
                 {inviteEmail}
               </span>
             </>
           ) : null}
-          .
+          <span>.</span>
         </>
       ),
       action: {

--- a/ui/apps/console/src/pages/Login.tsx
+++ b/ui/apps/console/src/pages/Login.tsx
@@ -267,10 +267,10 @@ export default function Login() {
         {error && !lockoutExpired && (
           <Callout variant="error">
             <span>
-              {error}
-              {countdownDisplay && (
+              <span>{error}</span>
+              {countdownDisplay ? (
                 <span className="font-semibold"> ({countdownDisplay})</span>
-              )}
+              ) : null}
             </span>
           </Callout>
         )}

--- a/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AcceptInvite.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import React from "react";
 import { useAuthStore } from "@/stores/authStore";
+import { simulateBrowserTranslation } from "@/tests/simulateBrowserTranslation";
 import AcceptInvite from "../AcceptInvite";
 
 vi.mock("@/components/common/ConfirmDialog", async () => ({
@@ -376,6 +377,50 @@ describe("AcceptInvite", () => {
           expect.stringMatching(/^\/login\?redirect=/),
         ),
       );
+    });
+  });
+
+  describe("under a browser-translated DOM", () => {
+    it("still reaches the joined confirmation after signing up", async () => {
+      setResolved("invited");
+      mockSignUp.mockResolvedValue("tok");
+      const user = userEvent.setup();
+      const { container } = renderPage(VALID_PARAMS);
+      await screen.findByRole("heading", { name: /you've been invited/i });
+
+      simulateBrowserTranslation(container);
+      await user.type(screen.getByLabelText(/^name$/i), "Alice");
+      await user.type(screen.getByLabelText(/^username$/i), "alice");
+      await user.type(screen.getByLabelText(/^password$/i), "Secret123");
+      await user.type(screen.getByLabelText(/confirm password/i), "Secret123");
+      await user.click(screen.getByRole("button", { name: /join namespace/i }));
+
+      expect(
+        await screen.findByRole("heading", { name: /you're in/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("still reaches the joined confirmation after accepting", async () => {
+      useAuthStore.setState({
+        token: "jwt-token",
+        userId: "u1",
+        email: "alice@example.com",
+        loading: false,
+      });
+      const user = userEvent.setup();
+      const { container } = renderPage(VALID_PARAMS);
+      await screen.findByRole("heading", { name: /namespace invitation/i });
+
+      simulateBrowserTranslation(container);
+      await user.click(screen.getByRole("button", { name: /^accept$/i }));
+      const dialog = screen.getByRole("dialog");
+      await user.click(
+        within(dialog).getByRole("button", { name: /^accept$/i }),
+      );
+
+      expect(
+        await screen.findByRole("heading", { name: /you're in/i }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/ui/apps/console/src/pages/__tests__/Login.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Login.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/utils/navigation";
 import type { Info, UserAuth } from "@/client";
 import { mockUserAuth } from "@/tests/userAuth";
+import { simulateBrowserTranslation } from "@/tests/simulateBrowserTranslation";
 import Login from "../Login";
 import { mockSdkResponse, makeSdkError, type SdkResponse } from "@/tests/sdk";
 
@@ -390,6 +391,25 @@ describe("Login", () => {
       expect(
         screen.queryByText(/too many failed login attempts/i),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("under a browser-translated DOM", () => {
+    it("keeps updating the lockout countdown", async () => {
+      const epoch = Math.floor(Date.now() / 1000) + 30;
+      mockedLogin.mockRejectedValue(
+        makeSdkError(429, { "x-account-lockout": String(epoch) }),
+      );
+
+      const { container } = renderLogin();
+      await fillAndSubmit();
+      await screen.findByText(/too many failed login attempts/i);
+      simulateBrowserTranslation(container);
+
+      await waitFor(
+        () => expect(screen.getByText(/seconds/i)).toBeInTheDocument(),
+        { timeout: 2000 },
+      );
     });
   });
 

--- a/ui/apps/console/src/tests/simulateBrowserTranslation.ts
+++ b/ui/apps/console/src/tests/simulateBrowserTranslation.ts
@@ -1,0 +1,21 @@
+/**
+ * Rewrites a rendered tree the way Chrome's auto-translation does: every non-blank text node
+ * is moved inside a fresh <font> wrapper. The text node itself survives, so React still
+ * updates it, but it is no longer a child of the element React recorded as its parent — the
+ * next insertBefore or removeChild against that parent then throws NotFoundError.
+ *
+ * Use it to prove a subtree keeps re-rendering when a translated DOM is underneath it.
+ */
+export function simulateBrowserTranslation(root: HTMLElement): void {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const texts: Text[] = [];
+
+  while (walker.nextNode()) texts.push(walker.currentNode as Text);
+
+  for (const text of texts) {
+    if (!text.textContent?.trim()) continue;
+    const font = document.createElement("font");
+    text.parentNode?.insertBefore(font, text);
+    font.appendChild(text);
+  }
+}

--- a/ui/apps/website/index.html
+++ b/ui/apps/website/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ShellHub - SSH Gateway for Remote Device Access</title>

--- a/ui/apps/website/src/__tests__/entryDocument.test.ts
+++ b/ui/apps/website/src/__tests__/entryDocument.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import indexHtml from "../../index.html?raw";
+
+// See the console app's entryDocuments test: auto-translation detaches the text nodes React
+// tracks, so every React document opts out at the root.
+describe("index.html", () => {
+  const doc = new DOMParser().parseFromString(indexHtml, "text/html");
+
+  it("opts the document out of browser auto-translation", () => {
+    expect(doc.documentElement.getAttribute("translate")).toBe("no");
+  });
+
+  it("opts out of Google Translate's page-level toolbar", () => {
+    const meta = doc.querySelector('meta[name="google"]');
+
+    expect(meta?.getAttribute("content")).toBe("notranslate");
+  });
+});

--- a/ui/apps/website/src/vite-env.d.ts
+++ b/ui/apps/website/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## What

Fixes the three defects behind a customer being unable to accept a workspace invitation, and unblocks the 149 production accounts whose username is an email address.

## Why

The customer's browser showed the top-level `ErrorBoundary` on `/accept-invite`:

> Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.

The backend was healthy — the user was confirmed, the invitation pending and unexpired, the cache entry present. The failure was in the browser, and separately in login identifier resolution.

## Changes

- **ui, translation opt-out**: `translate="no"` plus `<meta name="google" content="notranslate">` on the console, its migrate entry, and the website. Chrome's auto-translation moves each text node into a `<font>` wrapper; the node survives, so React keeps writing to it, but it is no longer a child of the parent React recorded. The next `insertBefore` or `removeChild` throws `NotFoundError`. Nothing in `ui/` used the HTML `translate` attribute, so the opt-out breaks no intentional per-element usage.

- **ui, bare text nodes**: wrapped the bare text in the `AcceptInvite` and `Login` alert subtrees in `<span>`. React materialises a text node as a fiber only when text and elements are siblings; such a node is fatal under a translated DOM whenever React must insert a sibling before it or remove it. An element anchor survives translation.

- **server, identifier resolution**: `AuthLocalUser` now tries the email column first and falls back to the username column. The username rule in `pkg/validator` has always permitted `@` (`^([a-z0-9-_.@]){3,32}$`), so an email-shaped identifier is not necessarily an email. Resolving only by email returned a permanent 401. The rule is extracted to `store.UserResolveByAuthIdentifier` because cloud repeats it in three recovery flows.

- **website**: added the missing `src/vite-env.d.ts` so `tsc -b` resolves the `?raw` import the new test needs.

## Testing

`simulateBrowserTranslation()` (`src/tests/simulateBrowserTranslation.ts`) reproduces Chrome's rewrite in jsdom. The `AcceptInvite` test fails on the unpatched page with `NotFoundError: The node to be removed is not a child of this node.`

Worth knowing while reviewing:

- **`Login.tsx` never crashed.** Its conditional is the last child, so React appends, which is safe. It is hardened, not fixed — no test can go red for it.
- **52 sites elsewhere still carry the shape** (22 insert-before, 30 remove-child), across billing, dialogs, install-keys, sessions and the website. `translate="no"` already protects all of them in Chrome. They remain exposed to anything else that rewrites the DOM. Not fixed here to keep the blast radius small.
- **Auto-translation was not verified in a real Chrome** — this environment has no browser with a non-English UI language. Only the DOM rewrite and the resulting React error class were reproduced. Please confirm in a real Chrome before release.

The store integration tests (`api/store/pg`, `TestEnrollmentE2E_*`) need testcontainers and were not run.