### PR TITLE
test(ui): extract shared test helpers to reduce boilerplate

### DIFF
--- a/ui/apps/console/src/components/billing/__tests__/BillingDialog.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/BillingDialog.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 
 const mockIsSdkError = vi.fn();
 vi.mock("@/api/errors", () => ({
@@ -75,15 +75,6 @@ vi.mock("@/components/common/BaseDialog", async () => ({
 
 import BillingDialog from "../BillingDialog";
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
   mockIsPending.value = false;
@@ -96,7 +87,7 @@ function renderDialog(onClose = vi.fn(), onSuccess = vi.fn()) {
     onSuccess,
     ...render(
       <BillingDialog open={true} onClose={onClose} onSuccess={onSuccess} />,
-      { wrapper: createWrapper() },
+      { wrapper: createTestWrapper() },
     ),
   };
 }

--- a/ui/apps/console/src/components/billing/__tests__/BillingSection.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/BillingSection.test.tsx
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
 import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 
 const mockLocation = { hash: "", pathname: "/settings", search: "" };
 
@@ -100,23 +99,12 @@ vi.mock("@/components/billing/BillingSuccessful", () => ({
 
 import BillingSection from "../BillingSection";
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) => (
-    <MemoryRouter>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </MemoryRouter>
-  );
-}
-
 function renderSection() {
   return render(
     <React.Suspense fallback={null}>
       <BillingSection sectionId="billing" />
     </React.Suspense>,
-    { wrapper: createWrapper() },
+    { wrapper: createTestWrapper({ initialEntries: ["/"] }) },
   );
 }
 

--- a/ui/apps/console/src/components/billing/__tests__/DeviceChooserDialog.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/DeviceChooserDialog.test.tsx
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
-import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 
 vi.mock("@/components/common/BaseDialog", async () => ({
   default: (await import("@/tests/mocks")).MockBaseDialog,
@@ -73,18 +71,6 @@ const ALL_DEVICES = [
 
 // ── Setup helpers ─────────────────────────────────────────────────────────────
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      React.createElement(MemoryRouter, null, children),
-    );
-}
-
 function setupHooks({
   suggested = SUGGESTED_DEVICES,
   suggestedLoading = false,
@@ -131,7 +117,7 @@ function renderDialog(props: { open?: boolean; onClose?: () => void } = {}) {
     onClose,
     ...render(
       <DeviceChooserDialog open={props.open ?? true} onClose={onClose} />,
-      { wrapper: createWrapper() },
+      { wrapper: createTestWrapper({ initialEntries: ["/"] }) },
     ),
   };
 }
@@ -316,7 +302,7 @@ describe("DeviceChooserDialog", () => {
       setupHooks({ suggested: SUGGESTED_DEVICES });
       const { rerender } = render(
         <DeviceChooserDialog open onClose={vi.fn()} />,
-        { wrapper: createWrapper() },
+        { wrapper: createTestWrapper({ initialEntries: ["/"] }) },
       );
       // User sees Suggested tab selected initially.
       expect(screen.getByRole("tab", { name: "Suggested" })).toHaveAttribute(
@@ -345,7 +331,7 @@ describe("DeviceChooserDialog", () => {
       const user = userEvent.setup();
       const { rerender } = render(
         <DeviceChooserDialog open onClose={vi.fn()} />,
-        { wrapper: createWrapper() },
+        { wrapper: createTestWrapper({ initialEntries: ["/"] }) },
       );
       // Forced to All because suggested is empty.
       expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute(
@@ -573,7 +559,7 @@ describe("DeviceChooserDialog", () => {
 
     it("Home key moves to the first enabled tab", () => {
       render(<DeviceChooserDialog open onClose={vi.fn()} />, {
-        wrapper: createWrapper(),
+        wrapper: createTestWrapper({ initialEntries: ["/"] }),
       });
       const allTab = screen.getByRole("tab", { name: "All" });
       fireEvent.click(allTab);

--- a/ui/apps/console/src/components/billing/__tests__/DeviceChooserTrigger.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/DeviceChooserTrigger.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 
 vi.mock("@/hooks/useHasPermission", () => ({
   useHasPermission: vi.fn(),
@@ -49,16 +49,6 @@ const mockGetConfig = vi.mocked(getConfig);
 const mockUseHasPermission = vi.mocked(useHasPermission);
 const mockUseStats = vi.mocked(useStats);
 const mockUseNamespace = vi.mocked(useNamespace);
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
 
 function makeStats(registeredDevices: number) {
   return {
@@ -115,7 +105,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   setupHooks();
 });
-// ── Tests ─────────────────────────────────────────────────────────────────────
+
+function renderTrigger() {
+  return render(<DeviceChooserTrigger />, { wrapper: createTestWrapper() });
+}
 
 describe("DeviceChooserTrigger", () => {
   describe("when edition isn't cloud", () => {
@@ -123,7 +116,7 @@ describe("DeviceChooserTrigger", () => {
       "renders nothing without mounting the inner component for edition=%s",
       (edition) => {
         setupHooks({ edition });
-        render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+        renderTrigger();
         expect(
           screen.queryByTestId("device-chooser-dialog"),
         ).not.toBeInTheDocument();
@@ -135,7 +128,7 @@ describe("DeviceChooserTrigger", () => {
   describe("when edition=cloud but user lacks device:choose permission", () => {
     it("renders nothing", async () => {
       setupHooks({ canChoose: false });
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       await waitFor(() =>
         expect(
           screen.queryByTestId("device-chooser-dialog"),
@@ -147,7 +140,7 @@ describe("DeviceChooserTrigger", () => {
   describe("when edition=cloud, owner, billing is active", () => {
     it("renders nothing", async () => {
       setupHooks({ billingActive: true });
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       await waitFor(() =>
         expect(
           screen.queryByTestId("device-chooser-dialog"),
@@ -159,7 +152,7 @@ describe("DeviceChooserTrigger", () => {
   describe("when edition=cloud, owner, billing inactive, registered_devices=3 (boundary)", () => {
     it("renders nothing — limit is strictly greater than 3", async () => {
       setupHooks({ registeredDevices: 3 });
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       await waitFor(() =>
         expect(
           screen.queryByTestId("device-chooser-dialog"),
@@ -170,14 +163,12 @@ describe("DeviceChooserTrigger", () => {
 
   describe("when all conditions are met (cloud, owner, billing inactive, >3 devices)", () => {
     it("auto-opens the dialog on mount", async () => {
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       await waitFor(() =>
         expect(screen.getByTestId("device-chooser-dialog")).toBeInTheDocument(),
       );
     });
   });
-
-  // ── C1 regression: don't render while loading or namespace undefined ─────────
 
   describe("when namespace is still loading", () => {
     it("renders nothing even if stats indicate over-limit", () => {
@@ -186,7 +177,7 @@ describe("DeviceChooserTrigger", () => {
         registeredDevices: 4,
         billingActive: false,
       });
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       expect(
         screen.queryByTestId("device-chooser-dialog"),
       ).not.toBeInTheDocument();
@@ -196,7 +187,7 @@ describe("DeviceChooserTrigger", () => {
   describe("when stats are still loading", () => {
     it("renders nothing", () => {
       setupHooks({ statsLoading: true, billingActive: false });
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       expect(
         screen.queryByTestId("device-chooser-dialog"),
       ).not.toBeInTheDocument();
@@ -206,7 +197,7 @@ describe("DeviceChooserTrigger", () => {
   describe("when namespace returned is undefined", () => {
     it("renders nothing — billing is unknown until namespace resolves", () => {
       setupHooks({ namespace: null, registeredDevices: 4 });
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       expect(
         screen.queryByTestId("device-chooser-dialog"),
       ).not.toBeInTheDocument();
@@ -222,19 +213,17 @@ describe("DeviceChooserTrigger", () => {
         error: new Error("network failure"),
         refetch: vi.fn(),
       });
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       expect(
         screen.queryByTestId("device-chooser-dialog"),
       ).not.toBeInTheDocument();
     });
   });
 
-  // ── Dismissal behaviour ──────────────────────────────────────────────────────
-
   describe("dismissal", () => {
     it("hides the dialog after dismissal", async () => {
       const user = userEvent.setup();
-      render(<DeviceChooserTrigger />, { wrapper: createWrapper() });
+      renderTrigger();
       await waitFor(() =>
         expect(screen.getByTestId("device-chooser-dialog")).toBeInTheDocument(),
       );
@@ -248,9 +237,7 @@ describe("DeviceChooserTrigger", () => {
 
     it("does not re-open the dialog after dismissal within the same mount", async () => {
       const user = userEvent.setup();
-      const { rerender } = render(<DeviceChooserTrigger />, {
-        wrapper: createWrapper(),
-      });
+      const { rerender } = renderTrigger();
       await waitFor(() =>
         expect(screen.getByTestId("device-chooser-dialog")).toBeInTheDocument(),
       );
@@ -261,7 +248,6 @@ describe("DeviceChooserTrigger", () => {
         ).not.toBeInTheDocument(),
       );
 
-      // Trigger a re-render with the same conditions — dialog must NOT reopen
       rerender(<DeviceChooserTrigger />);
       expect(
         screen.queryByTestId("device-chooser-dialog"),
@@ -270,7 +256,7 @@ describe("DeviceChooserTrigger", () => {
 
     it("reopens the dialog on a fresh remount after conditions are still true", async () => {
       const user = userEvent.setup();
-      const wrapper = createWrapper();
+      const wrapper = createTestWrapper();
 
       render(<DeviceChooserTrigger />, { wrapper });
       await waitFor(() =>
@@ -283,7 +269,6 @@ describe("DeviceChooserTrigger", () => {
         ).not.toBeInTheDocument(),
       );
 
-      // Unmount and remount — fresh component state, so dialog reopens
       cleanup();
 
       render(<DeviceChooserTrigger />, { wrapper });

--- a/ui/apps/console/src/components/common/__tests__/DeviceLimitBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/DeviceLimitBanner.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import type { GetLicenseResponse } from "@/client/types.gen";
 import { defaultConfig } from "@/env";
 import { useAuthStore } from "@/stores/authStore";
@@ -324,17 +324,7 @@ describe("DeviceLimitBanner", () => {
       // useAdminStats is still mocked from beforeEach; stats are irrelevant here
       // because the license guard (license != null) will suppress the banner first.
 
-      render(
-        <QueryClientProvider
-          client={
-            new QueryClient({
-              defaultOptions: { queries: { retry: false, retryDelay: 0 } },
-            })
-          }
-        >
-          <DeviceLimitBanner />
-        </QueryClientProvider>,
-      );
+      render(<DeviceLimitBanner />, { wrapper: createTestWrapper() });
 
       await waitFor(() => {
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();

--- a/ui/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import type { GetLicenseResponse } from "@/client/types.gen";
 import { defaultConfig } from "@/env";
 import { useAuthStore } from "@/stores/authStore";
@@ -350,17 +350,7 @@ describe("LicenseBanner", () => {
       // getLicense must never fire on cloud deployments.
       mockGetLicense.mockRejectedValue({ status: 400 });
 
-      render(
-        <QueryClientProvider
-          client={
-            new QueryClient({
-              defaultOptions: { queries: { retry: false, retryDelay: 0 } },
-            })
-          }
-        >
-          <LicenseBanner />
-        </QueryClientProvider>,
-      );
+      render(<LicenseBanner />, { wrapper: createTestWrapper() });
 
       await waitFor(() => {
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();

--- a/ui/apps/console/src/components/common/__tests__/LicenseGuard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/LicenseGuard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import { defaultConfig } from "@/env";
 import { useAuthStore } from "@/stores/authStore";
 import type { GetLicenseResponse } from "@/client/types.gen";
@@ -84,14 +84,6 @@ function makeHookReturn(
     installedLicense: null,
     ...overrides,
   } as unknown as HookReturn;
-}
-
-function createQueryWrapper() {
-  const qc = new QueryClient({
-    defaultOptions: { queries: { retry: false, retryDelay: 0 } },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
 }
 
 function renderGuard(
@@ -192,7 +184,7 @@ describe("LicenseGuard", () => {
       // getLicense must never fire on cloud deployments.
       mockGetLicense.mockRejectedValue({ status: 400 });
 
-      renderGuard(createQueryWrapper());
+      renderGuard(createTestWrapper());
 
       await waitFor(() => {
         expect(screen.getByText("protected content")).toBeInTheDocument();

--- a/ui/apps/console/src/components/common/__tests__/RenameSection.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/RenameSection.test.tsx
@@ -3,13 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import RenameSection, { type RenameSectionProps } from "../RenameSection";
-
-function makeSdkError(status: number) {
-  return Object.assign(new Error("Request failed"), {
-    status,
-    headers: new Headers(),
-  });
-}
+import { makeSdkError } from "@/tests/sdk";
 
 const mockRename = vi
   .fn<RenameSectionProps["rename"]>()
@@ -40,9 +34,7 @@ async function typeAndSave(
   const input = screen.getByRole("textbox");
   await user.clear(input);
   await user.type(input, name);
-  await user.click(
-    screen.getByRole("button", { name: /save device name/i }),
-  );
+  await user.click(screen.getByRole("button", { name: /save device name/i }));
 }
 
 beforeEach(() => {
@@ -191,9 +183,7 @@ describe("RenameSection", () => {
     it("uses entityLabel in error messages", async () => {
       mockRename.mockRejectedValue(makeSdkError(409));
       const user = userEvent.setup();
-      render(
-        <RenameSection {...defaultProps} entityLabel="container" />,
-      );
+      render(<RenameSection {...defaultProps} entityLabel="container" />);
       await user.click(
         screen.getByRole("button", { name: /rename container/i }),
       );

--- a/ui/apps/console/src/components/common/__tests__/TagsSection.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/TagsSection.test.tsx
@@ -18,10 +18,7 @@ import { isSdkError } from "@/api/errors";
 import { useTags } from "@/hooks/useTags";
 import { useHasPermission } from "@/hooks/useHasPermission";
 import TagsSection from "../TagsSection";
-
-function makeSdkError(status: number) {
-  return { status };
-}
+import { makeSdkError } from "@/tests/sdk";
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/ui/apps/console/src/components/layout/__tests__/AdminLayout.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/AdminLayout.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+import { createTestWrapper } from "@/tests/wrapper";
 import AdminLayout from "../AdminLayout";
 
 vi.mock("@/hooks/useSidebarLayout", () => ({
@@ -40,16 +39,9 @@ vi.mock("../SidebarShell", () => ({
   ),
 }));
 function renderLayout() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+  return render(<AdminLayout />, {
+    wrapper: createTestWrapper({ initialEntries: ["/"] }),
   });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <AdminLayout />
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
 }
 
 describe("AdminLayout", () => {

--- a/ui/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/AppLayout.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import AppLayout from "../AppLayout";
 import { ClipboardProvider } from "@/components/common/ClipboardProvider";
 import { getConfig, defaultConfig } from "@/env";
@@ -76,17 +75,11 @@ beforeEach(() => {
 });
 
 function renderLayout() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
   return render(
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <ClipboardProvider>
-          <AppLayout />
-        </ClipboardProvider>
-      </MemoryRouter>
-    </QueryClientProvider>,
+    <ClipboardProvider>
+      <AppLayout />
+    </ClipboardProvider>,
+    { wrapper: createTestWrapper({ initialEntries: ["/"] }) },
   );
 }
 

--- a/ui/apps/console/src/components/layout/__tests__/NamespaceSelector.test.tsx
+++ b/ui/apps/console/src/components/layout/__tests__/NamespaceSelector.test.tsx
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import { useAuthStore } from "@/stores/authStore";
 import { defaultConfig, getConfig } from "@/env";
 import NamespaceSelector from "../NamespaceSelector";
@@ -47,24 +45,9 @@ vi.mock("@/components/common/CreateNamespaceDialog", () => ({
   default: () => null,
 }));
 
-/* ------------------------------------------------------------------ */
-/* Helpers                                                             */
-/* ------------------------------------------------------------------ */
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) => (
-    <MemoryRouter>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </MemoryRouter>
-  );
-}
-
 function renderSelector(isAdminContext = false) {
   return render(<NamespaceSelector isAdminContext={isAdminContext} />, {
-    wrapper: createWrapper(),
+    wrapper: createTestWrapper({ initialEntries: ["/"] }),
   });
 }
 

--- a/ui/apps/console/src/components/mfa/__tests__/MfaDisableDialog.test.tsx
+++ b/ui/apps/console/src/components/mfa/__tests__/MfaDisableDialog.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MfaDisableDialog from "../MfaDisableDialog";
+import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
 
 vi.mock("@/client", () => ({
   disableMfa: vi.fn(),
@@ -13,20 +14,6 @@ import { useAuthStore } from "@/stores/authStore";
 
 const mockedDisableMfa = vi.mocked(disableMfa);
 const mockedRequestResetMfa = vi.mocked(requestResetMfa);
-
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 describe("MfaDisableDialog", () => {
   const onClose = vi.fn();

--- a/ui/apps/console/src/components/mfa/__tests__/MfaEnableDrawer.test.tsx
+++ b/ui/apps/console/src/components/mfa/__tests__/MfaEnableDrawer.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MfaEnableDrawer from "../MfaEnableDrawer";
+import { mockSdkResponse } from "@/tests/sdk";
 
 vi.mock("qrcode");
 
@@ -17,16 +18,6 @@ import type { MfaGenerate } from "@/client";
 const mockedGenerateMfa = vi.mocked(generateMfa);
 const mockedEnableMfa = vi.mocked(enableMfa);
 const mockedUpdateUser = vi.mocked(updateUser);
-
-type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 const mockMfaData: MfaGenerate = {
   link: "otpauth://totp/ShellHub:user@example.com?secret=ABCD1234&issuer=ShellHub",
@@ -59,7 +50,9 @@ describe("MfaEnableDrawer", () => {
       // Heading contains "Recovery Email"
       expect(screen.getByText(/Set Recovery Email/i)).toBeInTheDocument();
       // Input placeholder is "recovery@example.com"
-      expect(screen.getByPlaceholderText(/recovery@example\.com/i)).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(/recovery@example\.com/i),
+      ).toBeInTheDocument();
     });
 
     it("shows confirmation when recovery email already exists", () => {
@@ -74,7 +67,9 @@ describe("MfaEnableDrawer", () => {
 
       expect(screen.getByText(/recovery@example.com/)).toBeInTheDocument();
       // Use role-based selector to avoid matching the description text "Continue enabling MFA..."
-      expect(screen.getByRole("button", { name: /continue/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /continue/i }),
+      ).toBeInTheDocument();
     });
 
     it("saves new recovery email and proceeds to step 2", async () => {
@@ -234,7 +229,9 @@ describe("MfaEnableDrawer", () => {
     it("displays secret for manual entry", async () => {
       // Secret is in a readOnly input; use getByDisplayValue instead of getByText
       await waitFor(() => {
-        expect(screen.getByDisplayValue(mockMfaData.secret)).toBeInTheDocument();
+        expect(
+          screen.getByDisplayValue(mockMfaData.secret),
+        ).toBeInTheDocument();
       });
     });
 
@@ -247,8 +244,8 @@ describe("MfaEnableDrawer", () => {
 
       // Find OTP inputs and enter code
       const inputs = screen.getAllByRole("textbox");
-      const otpInputs = inputs.filter((input) =>
-        input.getAttribute("maxLength") === "1",
+      const otpInputs = inputs.filter(
+        (input) => input.getAttribute("maxLength") === "1",
       );
 
       // Type 6-digit code
@@ -284,8 +281,8 @@ describe("MfaEnableDrawer", () => {
 
       // Enter OTP
       const inputs = screen.getAllByRole("textbox");
-      const otpInputs = inputs.filter((input) =>
-        input.getAttribute("maxLength") === "1",
+      const otpInputs = inputs.filter(
+        (input) => input.getAttribute("maxLength") === "1",
       );
 
       await user.type(otpInputs[0], "9");
@@ -299,7 +296,9 @@ describe("MfaEnableDrawer", () => {
       await user.click(verifyButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/invalid verification code/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/invalid verification code/i),
+        ).toBeInTheDocument();
       });
     });
   });
@@ -332,8 +331,8 @@ describe("MfaEnableDrawer", () => {
 
       // Enter OTP
       const inputs = screen.getAllByRole("textbox");
-      const otpInputs = inputs.filter((input) =>
-        input.getAttribute("maxLength") === "1",
+      const otpInputs = inputs.filter(
+        (input) => input.getAttribute("maxLength") === "1",
       );
 
       await user.type(otpInputs[0], "1");
@@ -348,7 +347,9 @@ describe("MfaEnableDrawer", () => {
 
       await waitFor(() => {
         // Component shows "MFA Enabled Successfully!"
-        expect(screen.getByText(/MFA Enabled Successfully/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/MFA Enabled Successfully/i),
+        ).toBeInTheDocument();
       });
 
       const doneButton = screen.getByText(/done/i);

--- a/ui/apps/console/src/components/sessions/__tests__/RecentSessionsTable.test.tsx
+++ b/ui/apps/console/src/components/sessions/__tests__/RecentSessionsTable.test.tsx
@@ -1,9 +1,7 @@
-import { type ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import RecentSessionsTable from "../RecentSessionsTable";
 import type { Device, Session } from "@/client";
 
@@ -39,7 +37,12 @@ function makeSession(overrides: Partial<Session> = {}): Session {
   return {
     uid: "session-1",
     device_uid: "device-1",
-    device: { uid: "device-1", name: "my-device", online: true, info: { id: "ubuntu" } } as Device,
+    device: {
+      uid: "device-1",
+      name: "my-device",
+      online: true,
+      info: { id: "ubuntu" },
+    } as Device,
     tenant_id: "tenant-1",
     username: "root",
     ip_address: "192.168.1.1",
@@ -61,25 +64,17 @@ function mockSdkResponse(sessions: Session[] = [], totalCount?: number) {
   return {
     data: sessions,
     response: {
-      headers: new Headers({ "X-Total-Count": String(totalCount ?? sessions.length) }),
+      headers: new Headers({
+        "X-Total-Count": String(totalCount ?? sessions.length),
+      }),
     },
   } as never;
 }
 
 function renderTable(isAdmin = false) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+  return render(<RecentSessionsTable isAdmin={isAdmin} />, {
+    wrapper: createTestWrapper({ initialEntries: ["/"] }),
   });
-
-  function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>{children}</MemoryRouter>
-      </QueryClientProvider>
-    );
-  }
-
-  return render(<RecentSessionsTable isAdmin={isAdmin} />, { wrapper: Wrapper });
 }
 
 describe("RecentSessionsTable", () => {
@@ -93,7 +88,10 @@ describe("RecentSessionsTable", () => {
     it("renders 'View all' link to /sessions", async () => {
       renderTable();
       await waitFor(() => {
-        expect(screen.getByRole("link", { name: /view all/i })).toHaveAttribute("href", "/sessions");
+        expect(screen.getByRole("link", { name: /view all/i })).toHaveAttribute(
+          "href",
+          "/sessions",
+        );
       });
     });
 
@@ -129,7 +127,10 @@ describe("RecentSessionsTable", () => {
     it("renders 'View all' link to /admin/sessions", async () => {
       renderTable(true);
       await waitFor(() => {
-        expect(screen.getByRole("link", { name: /view all/i })).toHaveAttribute("href", "/admin/sessions");
+        expect(screen.getByRole("link", { name: /view all/i })).toHaveAttribute(
+          "href",
+          "/admin/sessions",
+        );
       });
     });
 
@@ -215,7 +216,9 @@ describe("RecentSessionsTable", () => {
 
     it("renders session type badge", async () => {
       vi.mocked(getSessions).mockResolvedValue(
-        mockSdkResponse([makeSession({ events: { types: ["shell"], seats: [] } })]),
+        mockSdkResponse([
+          makeSession({ events: { types: ["shell"], seats: [] } }),
+        ]),
       );
       renderTable();
       await waitFor(() => {

--- a/ui/apps/console/src/hooks/__tests__/useAdminFirewallRules.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminFirewallRules.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
 import {
   useAdminFirewallRules,
   useAdminFirewallRule,
 } from "../useAdminFirewallRules";
 import { useAuthStore } from "@/stores/authStore";
+import { renderHookWithClient } from "@/tests/wrapper";
 
 // Mock the SDK functions used by the generated options/queryFn helpers.
 vi.mock("@/client", () => ({
@@ -35,16 +34,6 @@ vi.mock("@/api/pagination", () => ({
 
 const mockGetFirewallRulesAdminFn = vi.fn();
 const mockGetFirewallRuleAdminFn = vi.fn();
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, retryDelay: 0 },
-    },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -82,9 +71,7 @@ describe("useAdminFirewallRules", () => {
         totalCount: 2,
       });
 
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminFirewallRules());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.rules).toHaveLength(2);
@@ -98,9 +85,7 @@ describe("useAdminFirewallRules", () => {
         totalCount: 42,
       });
 
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminFirewallRules());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.totalCount).toBe(42);
@@ -110,9 +95,7 @@ describe("useAdminFirewallRules", () => {
       // Never resolves — stays in loading state
       mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminFirewallRules());
 
       expect(result.current.rules).toEqual([]);
     });
@@ -120,9 +103,7 @@ describe("useAdminFirewallRules", () => {
     it("defaults totalCount to 0 while loading", () => {
       mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminFirewallRules());
 
       expect(result.current.totalCount).toBe(0);
     });
@@ -130,9 +111,7 @@ describe("useAdminFirewallRules", () => {
     it("returns isLoading true initially", () => {
       mockGetFirewallRulesAdminFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminFirewallRules());
 
       expect(result.current.isLoading).toBe(true);
     });
@@ -141,9 +120,7 @@ describe("useAdminFirewallRules", () => {
       const networkError = new Error("network failure");
       mockGetFirewallRulesAdminFn.mockRejectedValue(networkError);
 
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminFirewallRules());
 
       await waitFor(() => expect(result.current.error).toBeTruthy());
       expect(result.current.error).toBe(networkError);
@@ -154,9 +131,7 @@ describe("useAdminFirewallRules", () => {
     it("does not execute the query", async () => {
       useAuthStore.setState({ isAdmin: false } as never);
 
-      const { result } = renderHook(() => useAdminFirewallRules(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminFirewallRules());
 
       // Query is disabled — stays in non-loading state with empty data
       expect(result.current.isLoading).toBe(false);
@@ -172,7 +147,7 @@ describe("useAdminFirewallRules", () => {
         totalCount: 0,
       });
 
-      renderHook(() => useAdminFirewallRules(), { wrapper: createWrapper() });
+      renderHookWithClient(() => useAdminFirewallRules());
 
       await waitFor(() =>
         expect(mockGetFirewallRulesAdminFn).toHaveBeenCalled(),
@@ -190,9 +165,9 @@ describe("useAdminFirewallRules", () => {
         totalCount: 0,
       });
 
-      renderHook(() => useAdminFirewallRules({ page: 3, perPage: 25 }), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() =>
+        useAdminFirewallRules({ page: 3, perPage: 25 }),
+      );
 
       await waitFor(() =>
         expect(mockGetFirewallRulesAdminFn).toHaveBeenCalled(),
@@ -221,9 +196,9 @@ describe("useAdminFirewallRule", () => {
       };
       mockGetFirewallRuleAdminFn.mockResolvedValue(rawRule);
 
-      const { result } = renderHook(() => useAdminFirewallRule("rule-1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useAdminFirewallRule("rule-1"),
+      );
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.data?.id).toBe("rule-1");
@@ -242,9 +217,9 @@ describe("useAdminFirewallRule", () => {
       };
       mockGetFirewallRuleAdminFn.mockResolvedValue(rawRule);
 
-      const { result } = renderHook(() => useAdminFirewallRule("rule-1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useAdminFirewallRule("rule-1"),
+      );
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.data?.filter).toEqual({
@@ -256,9 +231,9 @@ describe("useAdminFirewallRule", () => {
     it("is loading initially when id is provided", () => {
       mockGetFirewallRuleAdminFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminFirewallRule("rule-1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useAdminFirewallRule("rule-1"),
+      );
 
       expect(result.current.isLoading).toBe(true);
     });
@@ -267,9 +242,9 @@ describe("useAdminFirewallRule", () => {
       const err = new Error("not found");
       mockGetFirewallRuleAdminFn.mockRejectedValue(err);
 
-      const { result } = renderHook(() => useAdminFirewallRule("rule-1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useAdminFirewallRule("rule-1"),
+      );
 
       await waitFor(() => expect(result.current.isError).toBe(true));
     });
@@ -277,9 +252,7 @@ describe("useAdminFirewallRule", () => {
 
   describe("when id is empty", () => {
     it("does not execute the query", () => {
-      const { result } = renderHook(() => useAdminFirewallRule(""), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminFirewallRule(""));
 
       expect(result.current.isLoading).toBe(false);
       expect(mockGetFirewallRuleAdminFn).not.toHaveBeenCalled();
@@ -290,9 +263,9 @@ describe("useAdminFirewallRule", () => {
     it("does not execute the query even when id is provided", () => {
       useAuthStore.setState({ isAdmin: false } as never);
 
-      const { result } = renderHook(() => useAdminFirewallRule("rule-1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useAdminFirewallRule("rule-1"),
+      );
 
       expect(result.current.isLoading).toBe(false);
       expect(mockGetFirewallRuleAdminFn).not.toHaveBeenCalled();

--- a/ui/apps/console/src/hooks/__tests__/useAdminLicense.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminLicense.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 import { defaultConfig } from "@/env";
 import { useAuthStore } from "@/stores/authStore";
 
@@ -29,17 +28,6 @@ const mockGetConfig = vi.mocked(getConfig);
 const mockGetLicense = vi.mocked(getLicense);
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, retryDelay: 0 },
-    },
-  });
-
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
 
 function makeLicense(overrides: Record<string, unknown> = {}) {
   return {
@@ -71,9 +59,7 @@ describe("useAdminLicense", () => {
       const license = makeLicense();
       mockGetLicense.mockResolvedValue({ data: license } as never);
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -86,9 +72,7 @@ describe("useAdminLicense", () => {
         data: makeLicense({ expired: false }),
       } as never);
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.isExpired).toBe(false);
@@ -99,9 +83,7 @@ describe("useAdminLicense", () => {
     it("normalizes 400 to installedLicense null", async () => {
       mockGetLicense.mockRejectedValue({ status: 400 });
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.installedLicense).toBeNull();
@@ -110,9 +92,7 @@ describe("useAdminLicense", () => {
     it("sets isExpired to true when no license is installed", async () => {
       mockGetLicense.mockRejectedValue({ status: 400 });
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.isExpired).toBe(true);
@@ -125,9 +105,7 @@ describe("useAdminLicense", () => {
         data: makeLicense({ expired: true }),
       } as never);
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.isExpired).toBe(true);
@@ -138,9 +116,7 @@ describe("useAdminLicense", () => {
         data: makeLicense({ expired: false, grace_period: true }),
       } as never);
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.isExpired).toBe(false);
@@ -151,9 +127,7 @@ describe("useAdminLicense", () => {
     it("does NOT call getLicense on cloud deployments", async () => {
       mockGetConfig.mockReturnValue({ ...defaultConfig, edition: "cloud" });
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       // Give React Query a chance to fire (it should not)
       await new Promise((r) => setTimeout(r, 20));
@@ -165,9 +139,7 @@ describe("useAdminLicense", () => {
     it("returns isExpired false on cloud deployments", async () => {
       mockGetConfig.mockReturnValue({ ...defaultConfig, edition: "cloud" });
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await new Promise((r) => setTimeout(r, 20));
       expect(result.current.isExpired).toBe(false);
@@ -178,9 +150,7 @@ describe("useAdminLicense", () => {
     it("does NOT call getLicense when user is not admin", async () => {
       useAuthStore.setState({ isAdmin: false } as never);
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await new Promise((r) => setTimeout(r, 20));
 
@@ -191,9 +161,7 @@ describe("useAdminLicense", () => {
     it("returns isExpired false when user is not admin", async () => {
       useAuthStore.setState({ isAdmin: false } as never);
 
-      const { result } = renderHook(() => useAdminLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminLicense());
 
       await new Promise((r) => setTimeout(r, 20));
       expect(result.current.isExpired).toBe(false);

--- a/ui/apps/console/src/hooks/__tests__/useAdminSessions.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminSessions.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createElement, type ReactNode } from "react";
+import { waitFor } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 
 vi.mock("@/stores/authStore", () => ({
   useAuthStore: vi.fn(),
@@ -23,14 +22,6 @@ import { useAuthStore } from "@/stores/authStore";
 import { paginatedQueryFn } from "@/api/pagination";
 import { useAdminSessions } from "../useAdminSessions";
 
-function makeWrapper() {
-  const qc = new QueryClient({
-    defaultOptions: { queries: { retryDelay: 0 } },
-  });
-  return ({ children }: { children: ReactNode }) =>
-    createElement(QueryClientProvider, { client: qc }, children);
-}
-
 const mockSession = {
   uid: "session-1",
   device_uid: "device-1",
@@ -43,10 +34,7 @@ const mockSession = {
 };
 
 function renderAdminSessions() {
-  return renderHook(
-    () => useAdminSessions({ page: 1, perPage: 10 }),
-    { wrapper: makeWrapper() },
-  );
+  return renderHookWithClient(() => useAdminSessions({ page: 1, perPage: 10 }));
 }
 
 describe("useAdminSessions", () => {
@@ -58,7 +46,9 @@ describe("useAdminSessions", () => {
     it("returns empty sessions and zero totalCount without fetching", () => {
       vi.mocked(useAuthStore).mockReturnValue(false);
       // paginatedQueryFn should not be called (query is disabled)
-      vi.mocked(paginatedQueryFn).mockReturnValue(() => Promise.resolve({ data: [], totalCount: 0 }));
+      vi.mocked(paginatedQueryFn).mockReturnValue(() =>
+        Promise.resolve({ data: [], totalCount: 0 }),
+      );
 
       const { result } = renderAdminSessions();
 
@@ -103,7 +93,10 @@ describe("useAdminSessions", () => {
 
     it("is loading while the query is in-flight", () => {
       vi.mocked(paginatedQueryFn).mockReturnValue(
-        () => new Promise(() => { /* never resolves */ }),
+        () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
       );
 
       const { result } = renderAdminSessions();

--- a/ui/apps/console/src/hooks/__tests__/useAdminUserMutations.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminUserMutations.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor, act } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 import {
   useCreateUser,
   useUpdateUser,
@@ -28,14 +27,6 @@ vi.mock("../useInvalidateQueries", () => ({
   useInvalidateByIds: vi.fn(() => mockInvalidate),
 }));
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { mutations: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -44,9 +35,7 @@ describe("useCreateUser", () => {
   describe("mutation call", () => {
     it("calls createUserAdmin with the provided body", async () => {
       mockCreateFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useCreateUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useCreateUser());
 
       const body = {
         body: {
@@ -65,9 +54,7 @@ describe("useCreateUser", () => {
   describe("on success", () => {
     it("calls invalidate after successful mutation", async () => {
       mockCreateFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useCreateUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useCreateUser());
 
       await act(() => result.current.mutateAsync({}));
 
@@ -79,9 +66,7 @@ describe("useCreateUser", () => {
     it("exposes error when mutation fails", async () => {
       const error = new Error("create failed");
       mockCreateFn.mockRejectedValue(error);
-      const { result } = renderHook(() => useCreateUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useCreateUser());
 
       act(() => result.current.mutate({}));
 
@@ -91,9 +76,7 @@ describe("useCreateUser", () => {
 
     it("does not call invalidate when mutation fails", async () => {
       mockCreateFn.mockRejectedValue(new Error("create failed"));
-      const { result } = renderHook(() => useCreateUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useCreateUser());
 
       act(() => result.current.mutate({}));
 
@@ -107,9 +90,7 @@ describe("useUpdateUser", () => {
   describe("mutation call", () => {
     it("calls adminUpdateUser with path and body", async () => {
       mockUpdateFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useUpdateUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useUpdateUser());
 
       const vars = { path: { id: "u1" }, body: { name: "Bob" } };
       await act(() => result.current.mutateAsync(vars as never));
@@ -121,9 +102,7 @@ describe("useUpdateUser", () => {
   describe("on success", () => {
     it("calls invalidate after successful update", async () => {
       mockUpdateFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useUpdateUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useUpdateUser());
 
       await act(() => result.current.mutateAsync({} as never));
 
@@ -135,9 +114,7 @@ describe("useUpdateUser", () => {
     it("exposes error when update fails", async () => {
       const error = new Error("update failed");
       mockUpdateFn.mockRejectedValue(error);
-      const { result } = renderHook(() => useUpdateUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useUpdateUser());
 
       act(() => result.current.mutate({} as never));
 
@@ -147,9 +124,7 @@ describe("useUpdateUser", () => {
 
     it("does not call invalidate when update fails", async () => {
       mockUpdateFn.mockRejectedValue(new Error("update failed"));
-      const { result } = renderHook(() => useUpdateUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useUpdateUser());
 
       act(() => result.current.mutate({} as never));
 
@@ -163,9 +138,7 @@ describe("useDeleteUser", () => {
   describe("mutation call", () => {
     it("calls adminDeleteUser with the path", async () => {
       mockDeleteFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useDeleteUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useDeleteUser());
 
       const vars = { path: { id: "u1" } };
       await act(() => result.current.mutateAsync(vars as never));
@@ -177,9 +150,7 @@ describe("useDeleteUser", () => {
   describe("on success", () => {
     it("calls invalidate after successful delete", async () => {
       mockDeleteFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useDeleteUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useDeleteUser());
 
       await act(() => result.current.mutateAsync({} as never));
 
@@ -191,9 +162,7 @@ describe("useDeleteUser", () => {
     it("exposes error when delete fails", async () => {
       const error = new Error("delete failed");
       mockDeleteFn.mockRejectedValue(error);
-      const { result } = renderHook(() => useDeleteUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useDeleteUser());
 
       act(() => result.current.mutate({} as never));
 
@@ -203,9 +172,7 @@ describe("useDeleteUser", () => {
 
     it("does not call invalidate when delete fails", async () => {
       mockDeleteFn.mockRejectedValue(new Error("delete failed"));
-      const { result } = renderHook(() => useDeleteUser(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useDeleteUser());
 
       act(() => result.current.mutate({} as never));
 
@@ -219,9 +186,7 @@ describe("useResetUserPassword", () => {
   describe("mutation call", () => {
     it("calls adminResetUserPassword with the path", async () => {
       mockResetPasswordFn.mockResolvedValue({ password: "generated-pw" });
-      const { result } = renderHook(() => useResetUserPassword(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useResetUserPassword());
 
       const vars = { path: { id: "u1" } };
       await act(() => result.current.mutateAsync(vars as never));
@@ -231,9 +196,7 @@ describe("useResetUserPassword", () => {
 
     it("returns the generated password from the mutation", async () => {
       mockResetPasswordFn.mockResolvedValue({ password: "s3cr3t-pass" });
-      const { result } = renderHook(() => useResetUserPassword(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useResetUserPassword());
 
       const data = await act(() => result.current.mutateAsync({} as never));
 
@@ -244,9 +207,7 @@ describe("useResetUserPassword", () => {
   describe("on success", () => {
     it("calls invalidate after successful password reset", async () => {
       mockResetPasswordFn.mockResolvedValue({ password: "pw" });
-      const { result } = renderHook(() => useResetUserPassword(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useResetUserPassword());
 
       await act(() => result.current.mutateAsync({} as never));
 
@@ -258,9 +219,7 @@ describe("useResetUserPassword", () => {
     it("exposes error when reset fails", async () => {
       const error = new Error("reset failed");
       mockResetPasswordFn.mockRejectedValue(error);
-      const { result } = renderHook(() => useResetUserPassword(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useResetUserPassword());
 
       act(() => result.current.mutate({} as never));
 
@@ -270,9 +229,7 @@ describe("useResetUserPassword", () => {
 
     it("does not call invalidate when reset fails", async () => {
       mockResetPasswordFn.mockRejectedValue(new Error("reset failed"));
-      const { result } = renderHook(() => useResetUserPassword(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useResetUserPassword());
 
       act(() => result.current.mutate({} as never));
 

--- a/ui/apps/console/src/hooks/__tests__/useAdminUsers.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminUsers.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 import { decodeB64url } from "@/tests/decodeB64url";
 import { useAdminUsers, useAdminUser } from "../useAdminUsers";
 import { useAuthStore } from "@/stores/authStore";
@@ -31,16 +30,6 @@ vi.mock("@/api/pagination", () => ({
 const mockGetUsersFn = vi.fn();
 const mockGetUserFn = vi.fn();
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, retryDelay: 0 },
-    },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
   // Default: authenticated admin
@@ -56,9 +45,7 @@ describe("useAdminUsers", () => {
       ];
       mockGetUsersFn.mockResolvedValue({ data: users, totalCount: 2 });
 
-      const { result } = renderHook(() => useAdminUsers(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUsers());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.users).toEqual(users);
@@ -67,9 +54,7 @@ describe("useAdminUsers", () => {
     it("returns totalCount from the paginated query result", async () => {
       mockGetUsersFn.mockResolvedValue({ data: [], totalCount: 99 });
 
-      const { result } = renderHook(() => useAdminUsers(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUsers());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.totalCount).toBe(99);
@@ -79,9 +64,7 @@ describe("useAdminUsers", () => {
       // Never resolves — stays in loading state
       mockGetUsersFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminUsers(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUsers());
 
       expect(result.current.users).toEqual([]);
     });
@@ -89,9 +72,7 @@ describe("useAdminUsers", () => {
     it("defaults totalCount to 0 while loading", () => {
       mockGetUsersFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminUsers(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUsers());
 
       expect(result.current.totalCount).toBe(0);
     });
@@ -99,9 +80,7 @@ describe("useAdminUsers", () => {
     it("returns isLoading true initially", () => {
       mockGetUsersFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminUsers(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUsers());
 
       expect(result.current.isLoading).toBe(true);
     });
@@ -110,9 +89,7 @@ describe("useAdminUsers", () => {
       const networkError = new Error("network failure");
       mockGetUsersFn.mockRejectedValue(networkError);
 
-      const { result } = renderHook(() => useAdminUsers(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUsers());
 
       await waitFor(() => expect(result.current.error).toBeTruthy());
       expect(result.current.error).toBe(networkError);
@@ -121,9 +98,7 @@ describe("useAdminUsers", () => {
     it("exposes refetch function", () => {
       mockGetUsersFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminUsers(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUsers());
 
       expect(typeof result.current.refetch).toBe("function");
     });
@@ -133,9 +108,7 @@ describe("useAdminUsers", () => {
     it("does not execute the query", async () => {
       useAuthStore.setState({ isAdmin: false } as never);
 
-      const { result } = renderHook(() => useAdminUsers(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUsers());
 
       // Query is disabled — stays in non-loading state with empty data
       expect(result.current.isLoading).toBe(false);
@@ -148,9 +121,9 @@ describe("useAdminUsers", () => {
     it("passes search parameter to the query options", async () => {
       mockGetUsersFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      const { result } = renderHook(() => useAdminUsers({ search: "alice" }), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useAdminUsers({ search: "alice" }),
+      );
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       // Query ran — the mock was called
@@ -160,9 +133,7 @@ describe("useAdminUsers", () => {
     it("does not pass filter when search is empty", async () => {
       mockGetUsersFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(() => useAdminUsers({ search: "" }), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => useAdminUsers({ search: "" }));
 
       await waitFor(() => expect(mockGetUsersFn).toHaveBeenCalled());
       // paginatedQueryFn receives options without a filter key when search is empty
@@ -178,9 +149,7 @@ describe("useAdminUsers", () => {
       // " >" (space + greater-than) encodes to base64url with a "-" character,
       // which atob() cannot decode — only Buffer.from(b64url.replace(/-/g,'+')
       // .replace(/_/g,'/'), 'base64') handles it correctly.
-      renderHook(() => useAdminUsers({ search: " >" }), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => useAdminUsers({ search: " >" }));
 
       await waitFor(() => expect(mockGetUsersFn).toHaveBeenCalled());
       const [opts] = mockGetUsersFn.mock.calls[0] as [
@@ -199,7 +168,7 @@ describe("useAdminUsers", () => {
     it("uses page 1 and perPage 10 as defaults", async () => {
       mockGetUsersFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(() => useAdminUsers(), { wrapper: createWrapper() });
+      renderHookWithClient(() => useAdminUsers());
 
       await waitFor(() => expect(mockGetUsersFn).toHaveBeenCalled());
       const [opts] = mockGetUsersFn.mock.calls[0] as [
@@ -212,9 +181,7 @@ describe("useAdminUsers", () => {
     it("forwards custom page and perPage", async () => {
       mockGetUsersFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(() => useAdminUsers({ page: 3, perPage: 25 }), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => useAdminUsers({ page: 3, perPage: 25 }));
 
       await waitFor(() => expect(mockGetUsersFn).toHaveBeenCalled());
       const [opts] = mockGetUsersFn.mock.calls[0] as [
@@ -232,9 +199,7 @@ describe("useAdminUser", () => {
       const user = { id: "u1", username: "alice" };
       mockGetUserFn.mockResolvedValue(user);
 
-      const { result } = renderHook(() => useAdminUser("u1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUser("u1"));
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.data).toEqual(user);
@@ -243,9 +208,7 @@ describe("useAdminUser", () => {
     it("is loading initially when id is provided", () => {
       mockGetUserFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useAdminUser("u1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUser("u1"));
 
       expect(result.current.isLoading).toBe(true);
     });
@@ -254,9 +217,7 @@ describe("useAdminUser", () => {
       const err = new Error("not found");
       mockGetUserFn.mockRejectedValue(err);
 
-      const { result } = renderHook(() => useAdminUser("u1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUser("u1"));
 
       await waitFor(() => expect(result.current.isError).toBe(true));
     });
@@ -264,9 +225,7 @@ describe("useAdminUser", () => {
 
   describe("when id is empty", () => {
     it("does not execute the query", () => {
-      const { result } = renderHook(() => useAdminUser(""), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUser(""));
 
       expect(result.current.isLoading).toBe(false);
       expect(mockGetUserFn).not.toHaveBeenCalled();
@@ -277,9 +236,7 @@ describe("useAdminUser", () => {
     it("does not execute the query even when id is provided", () => {
       useAuthStore.setState({ isAdmin: false } as never);
 
-      const { result } = renderHook(() => useAdminUser("u1"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAdminUser("u1"));
 
       expect(result.current.isLoading).toBe(false);
       expect(mockGetUserFn).not.toHaveBeenCalled();

--- a/ui/apps/console/src/hooks/__tests__/useBilling.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useBilling.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper, renderHookWithClient } from "@/tests/wrapper";
 
 const mockCreateCustomer = vi.fn();
 const mockCreateSubscription = vi.fn();
@@ -45,17 +44,6 @@ async function importHooks() {
   return await import("../useBilling");
 }
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      mutations: { retry: false },
-      queries: { retry: false },
-    },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -65,9 +53,7 @@ describe("useBilling mutations", () => {
     mockCreateCustomer.mockResolvedValue(undefined);
     const { useCreateCustomer } = await importHooks();
 
-    const { result } = renderHook(() => useCreateCustomer(), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useCreateCustomer());
 
     await act(() => result.current.mutateAsync({}));
 
@@ -79,9 +65,7 @@ describe("useBilling mutations", () => {
     mockCreateSubscription.mockResolvedValue(undefined);
     const { useCreateSubscription } = await importHooks();
 
-    const { result } = renderHook(() => useCreateSubscription(), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useCreateSubscription());
 
     await act(() => result.current.mutateAsync({}));
 
@@ -96,9 +80,7 @@ describe("useBilling mutations", () => {
     mockCreateSubscription.mockRejectedValue(err);
     const { useCreateSubscription } = await importHooks();
 
-    const { result } = renderHook(() => useCreateSubscription(), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useCreateSubscription());
 
     await expect(result.current.mutateAsync({})).rejects.toBe(err);
     expect(mockInvalidate).not.toHaveBeenCalled();
@@ -114,7 +96,7 @@ describe("useBilling mutations", () => {
       useSetDefaultPaymentMethod,
     } = await importHooks();
 
-    const wrapper = createWrapper();
+    const wrapper = createTestWrapper();
     const attachHook = renderHook(() => useAttachPaymentMethod(), { wrapper });
     await act(() =>
       attachHook.result.current.mutateAsync({ body: { id: "pm_1" } }),
@@ -141,9 +123,7 @@ describe("useCreateSubscription (query key coverage)", () => {
     mockCreateSubscription.mockResolvedValue(undefined);
     const { useCreateSubscription } = await importHooks();
 
-    const { result } = renderHook(() => useCreateSubscription(), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useCreateSubscription());
 
     await act(() => result.current.mutateAsync({}));
 
@@ -156,7 +136,7 @@ describe("useCustomer", () => {
   it("does not call the queryFn when enabled=false", async () => {
     const { useCustomer } = await importHooks();
 
-    renderHook(() => useCustomer(false), { wrapper: createWrapper() });
+    renderHookWithClient(() => useCustomer(false));
 
     expect(mockGetCustomerFn).not.toHaveBeenCalled();
   });
@@ -164,9 +144,7 @@ describe("useCustomer", () => {
   it("returns undefined customer when the query has no data", async () => {
     const { useCustomer } = await importHooks();
 
-    const { result } = renderHook(() => useCustomer(false), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useCustomer(false));
 
     expect(result.current.customer).toBeUndefined();
   });
@@ -176,7 +154,7 @@ describe("useSubscription", () => {
   it("does not call the queryFn when enabled=false", async () => {
     const { useSubscription } = await importHooks();
 
-    renderHook(() => useSubscription(false), { wrapper: createWrapper() });
+    renderHookWithClient(() => useSubscription(false));
 
     expect(mockGetSubscriptionFn).not.toHaveBeenCalled();
   });
@@ -184,9 +162,7 @@ describe("useSubscription", () => {
   it("exposes a refetch function even when disabled", async () => {
     const { useSubscription } = await importHooks();
 
-    const { result } = renderHook(() => useSubscription(false), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useSubscription(false));
 
     expect(typeof result.current.refetch).toBe("function");
   });
@@ -194,9 +170,7 @@ describe("useSubscription", () => {
   it("returns undefined subscription when query has no data", async () => {
     const { useSubscription } = await importHooks();
 
-    const { result } = renderHook(() => useSubscription(false), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useSubscription(false));
 
     expect(result.current.subscription).toBeUndefined();
   });
@@ -210,9 +184,7 @@ describe("useOpenBillingPortal", () => {
     });
     const { useOpenBillingPortal } = await importHooks();
 
-    const { result } = renderHook(() => useOpenBillingPortal(), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useOpenBillingPortal());
 
     await act(() => result.current.mutateAsync());
 
@@ -229,9 +201,7 @@ describe("useOpenBillingPortal", () => {
     mockCreateBillingPortalSession.mockResolvedValue({ data: {} });
     const { useOpenBillingPortal } = await importHooks();
 
-    const { result } = renderHook(() => useOpenBillingPortal(), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useOpenBillingPortal());
 
     await expect(result.current.mutateAsync()).rejects.toThrow(/portal URL/i);
   });

--- a/ui/apps/console/src/hooks/__tests__/useDeviceChooser.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useDeviceChooser.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor, act } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 
 // ── SDK mocks ────────────────────────────────────────────────────────────────
 
@@ -30,17 +29,6 @@ import { useInvalidateByIds } from "../useInvalidateQueries";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, retryDelay: 0 },
-      mutations: { retry: false },
-    },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -56,9 +44,7 @@ describe("useSuggestedDevices", () => {
       ];
       mockMostUsedQueryFn.mockResolvedValue(devices);
 
-      const { result } = renderHook(() => useSuggestedDevices(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useSuggestedDevices());
 
       await waitFor(() =>
         expect(result.current.devices).toEqual([
@@ -72,9 +58,7 @@ describe("useSuggestedDevices", () => {
       // Don't resolve yet — keep the query pending
       mockMostUsedQueryFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useSuggestedDevices(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useSuggestedDevices());
 
       expect(result.current.devices).toEqual([]);
     });
@@ -82,9 +66,7 @@ describe("useSuggestedDevices", () => {
     it("exposes isLoading=true while the query is in flight", () => {
       mockMostUsedQueryFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => useSuggestedDevices(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useSuggestedDevices());
 
       expect(result.current.isLoading).toBe(true);
     });
@@ -92,17 +74,13 @@ describe("useSuggestedDevices", () => {
 
   describe("when enabled=false", () => {
     it("does not call the queryFn", () => {
-      renderHook(() => useSuggestedDevices(false), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => useSuggestedDevices(false));
 
       expect(mockMostUsedQueryFn).not.toHaveBeenCalled();
     });
 
     it("returns an empty devices array", () => {
-      const { result } = renderHook(() => useSuggestedDevices(false), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useSuggestedDevices(false));
 
       expect(result.current.devices).toEqual([]);
     });
@@ -113,9 +91,7 @@ describe("useSuggestedDevices", () => {
       const err = new Error("network failure");
       mockMostUsedQueryFn.mockRejectedValue(err);
 
-      const { result } = renderHook(() => useSuggestedDevices(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useSuggestedDevices());
 
       await waitFor(() => expect(result.current.error).toBe(err));
     });
@@ -129,9 +105,7 @@ describe("useChoiceDevices", () => {
     it("calls the mutationFn with the choices body", async () => {
       mockChoiceMutationFn.mockResolvedValue(undefined);
 
-      const { result } = renderHook(() => useChoiceDevices(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useChoiceDevices());
 
       const vars = { body: { choices: ["uid1", "uid2"] } };
       await act(() => result.current.mutateAsync(vars as never));
@@ -147,9 +121,7 @@ describe("useChoiceDevices", () => {
     it("calls invalidate once after the mutation succeeds", async () => {
       mockChoiceMutationFn.mockResolvedValue(undefined);
 
-      const { result } = renderHook(() => useChoiceDevices(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useChoiceDevices());
 
       await act(() =>
         result.current.mutateAsync({ body: { choices: ["uid1"] } }),
@@ -159,7 +131,7 @@ describe("useChoiceDevices", () => {
     });
 
     it("registers invalidate using useInvalidateByIds with the correct query ids", () => {
-      renderHook(() => useChoiceDevices(), { wrapper: createWrapper() });
+      renderHookWithClient(() => useChoiceDevices());
 
       expect(useInvalidateByIds).toHaveBeenCalledWith(
         "getDevices",
@@ -174,9 +146,7 @@ describe("useChoiceDevices", () => {
       const err = new Error("server error");
       mockChoiceMutationFn.mockRejectedValue(err);
 
-      const { result } = renderHook(() => useChoiceDevices(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useChoiceDevices());
 
       act(() => result.current.mutate({ body: { choices: ["uid1"] } }));
 
@@ -187,9 +157,7 @@ describe("useChoiceDevices", () => {
     it("does not call invalidate when the mutation fails", async () => {
       mockChoiceMutationFn.mockRejectedValue(new Error("server error"));
 
-      const { result } = renderHook(() => useChoiceDevices(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useChoiceDevices());
 
       act(() => result.current.mutate({ body: { choices: ["uid1"] } }));
 

--- a/ui/apps/console/src/hooks/__tests__/useInvitationMutations.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useInvitationMutations.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor, act } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 import {
   useAcceptInvite,
   useGenerateInvitationLink,
@@ -27,14 +26,6 @@ vi.mock("../useInvalidateQueries", () => ({
   useInvalidateByIds: vi.fn(() => mockInvalidate),
 }));
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { mutations: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -43,9 +34,7 @@ describe("useAcceptInvite", () => {
   describe("mutation call", () => {
     it("calls acceptInvite with the provided path", async () => {
       mockAcceptFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useAcceptInvite(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAcceptInvite());
 
       const vars = { path: { tenant: "t1" } };
       await act(() => result.current.mutateAsync(vars as never));
@@ -57,9 +46,7 @@ describe("useAcceptInvite", () => {
   describe("on success", () => {
     it("calls invalidate after successful mutation", async () => {
       mockAcceptFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useAcceptInvite(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAcceptInvite());
 
       await act(() => result.current.mutateAsync({} as never));
 
@@ -71,9 +58,7 @@ describe("useAcceptInvite", () => {
     it("exposes error when mutation fails", async () => {
       const error = new Error("accept failed");
       mockAcceptFn.mockRejectedValue(error);
-      const { result } = renderHook(() => useAcceptInvite(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAcceptInvite());
 
       act(() => result.current.mutate({} as never));
 
@@ -83,9 +68,7 @@ describe("useAcceptInvite", () => {
 
     it("does not call invalidate when mutation fails", async () => {
       mockAcceptFn.mockRejectedValue(new Error("accept failed"));
-      const { result } = renderHook(() => useAcceptInvite(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useAcceptInvite());
 
       act(() => result.current.mutate({} as never));
 
@@ -101,9 +84,9 @@ describe("useGenerateInvitationLink", () => {
       mockGenerateLinkFn.mockResolvedValue({
         link: "https://example.com/invite/abc",
       });
-      const { result } = renderHook(() => useGenerateInvitationLink(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useGenerateInvitationLink(),
+      );
 
       const vars = {
         path: { tenant: "t1" },
@@ -117,9 +100,9 @@ describe("useGenerateInvitationLink", () => {
     it("returns the generated link from the mutation", async () => {
       const link = "https://example.com/invite/xyz";
       mockGenerateLinkFn.mockResolvedValue({ link });
-      const { result } = renderHook(() => useGenerateInvitationLink(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useGenerateInvitationLink(),
+      );
 
       const data = await act(() => result.current.mutateAsync({} as never));
 
@@ -132,9 +115,9 @@ describe("useGenerateInvitationLink", () => {
       mockGenerateLinkFn.mockResolvedValue({
         link: "https://example.com/invite/abc",
       });
-      const { result } = renderHook(() => useGenerateInvitationLink(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useGenerateInvitationLink(),
+      );
 
       await act(() => result.current.mutateAsync({} as never));
 
@@ -146,9 +129,9 @@ describe("useGenerateInvitationLink", () => {
     it("exposes error when mutation fails", async () => {
       const error = new Error("generate link failed");
       mockGenerateLinkFn.mockRejectedValue(error);
-      const { result } = renderHook(() => useGenerateInvitationLink(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useGenerateInvitationLink(),
+      );
 
       act(() => result.current.mutate({} as never));
 
@@ -158,9 +141,9 @@ describe("useGenerateInvitationLink", () => {
 
     it("does not call invalidate when mutation fails", async () => {
       mockGenerateLinkFn.mockRejectedValue(new Error("generate link failed"));
-      const { result } = renderHook(() => useGenerateInvitationLink(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useGenerateInvitationLink(),
+      );
 
       act(() => result.current.mutate({} as never));
 
@@ -174,9 +157,9 @@ describe("useCancelMembershipInvitation", () => {
   describe("mutation call", () => {
     it("calls cancelMembershipInvitation with path", async () => {
       mockCancelFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useCancelMembershipInvitation(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useCancelMembershipInvitation(),
+      );
 
       const vars = { path: { tenant: "t1", "user-id": "u1" } };
       await act(() => result.current.mutateAsync(vars as never));
@@ -188,9 +171,9 @@ describe("useCancelMembershipInvitation", () => {
   describe("on success", () => {
     it("calls invalidate after successful mutation", async () => {
       mockCancelFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useCancelMembershipInvitation(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useCancelMembershipInvitation(),
+      );
 
       await act(() => result.current.mutateAsync({} as never));
 
@@ -202,9 +185,9 @@ describe("useCancelMembershipInvitation", () => {
     it("exposes error when mutation fails", async () => {
       const error = new Error("cancel failed");
       mockCancelFn.mockRejectedValue(error);
-      const { result } = renderHook(() => useCancelMembershipInvitation(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useCancelMembershipInvitation(),
+      );
 
       act(() => result.current.mutate({} as never));
 
@@ -214,9 +197,9 @@ describe("useCancelMembershipInvitation", () => {
 
     it("does not call invalidate when mutation fails", async () => {
       mockCancelFn.mockRejectedValue(new Error("cancel failed"));
-      const { result } = renderHook(() => useCancelMembershipInvitation(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useCancelMembershipInvitation(),
+      );
 
       act(() => result.current.mutate({} as never));
 

--- a/ui/apps/console/src/hooks/__tests__/useInvitations.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useInvitations.test.ts
@@ -1,21 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 import {
   useNamespaceInvitations,
   useResolveInvitation,
 } from "../useInvitations";
-import type { MembershipInvitation } from "../../client";
+import type { MembershipInvitation } from "@/client";
 
-vi.mock("../../client", () => ({
+vi.mock("@/client", () => ({
   getMembershipInvitationList: vi.fn(),
   getNamespaceMembershipInvitationList: vi.fn(),
 }));
 
 const mockResolveFn = vi.fn();
 
-vi.mock("../../client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getMembershipInvitationListQueryKey: vi.fn((opts: unknown) => [
     { _id: "getMembershipInvitationList" },
     opts,
@@ -30,7 +29,7 @@ vi.mock("../../client/@tanstack/react-query.gen", () => ({
   })),
 }));
 
-vi.mock("../../api/pagination", () => ({
+vi.mock("@/api/pagination", () => ({
   paginatedQueryFn: vi.fn(
     (_sdkFn: unknown, opts: { query: Record<string, unknown> }) => {
       return () => mockFetchFn(opts) as unknown;
@@ -39,16 +38,6 @@ vi.mock("../../api/pagination", () => ({
 }));
 
 const mockFetchFn = vi.fn();
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, retryDelay: 0 },
-    },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
 
 function makeInvitation(
   overrides: Partial<MembershipInvitation> = {},
@@ -77,9 +66,8 @@ describe("useNamespaceInvitations", () => {
       const inv = makeInvitation({ status: "pending" });
       mockFetchFn.mockResolvedValue({ data: [inv], totalCount: 1 });
 
-      const { result } = renderHook(
+      const { result } = renderHookWithClient(
         () => useNamespaceInvitations({ tenantId: "t1" }),
-        { wrapper: createWrapper() },
       );
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -89,9 +77,8 @@ describe("useNamespaceInvitations", () => {
     it("returns totalCount from the paginated result", async () => {
       mockFetchFn.mockResolvedValue({ data: [], totalCount: 7 });
 
-      const { result } = renderHook(
+      const { result } = renderHookWithClient(
         () => useNamespaceInvitations({ tenantId: "t1" }),
-        { wrapper: createWrapper() },
       );
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -101,9 +88,8 @@ describe("useNamespaceInvitations", () => {
     it("defaults invitations to empty array while loading", () => {
       mockFetchFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(
+      const { result } = renderHookWithClient(
         () => useNamespaceInvitations({ tenantId: "t1" }),
-        { wrapper: createWrapper() },
       );
 
       expect(result.current.invitations).toEqual([]);
@@ -113,9 +99,8 @@ describe("useNamespaceInvitations", () => {
       const err = new Error("fetch failed");
       mockFetchFn.mockRejectedValue(err);
 
-      const { result } = renderHook(
+      const { result } = renderHookWithClient(
         () => useNamespaceInvitations({ tenantId: "t1" }),
-        { wrapper: createWrapper() },
       );
 
       await waitFor(() => expect(result.current.error).toBeTruthy());
@@ -127,11 +112,8 @@ describe("useNamespaceInvitations", () => {
     it("does not fetch when enabled is false", () => {
       mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(
+      renderHookWithClient(
         () => useNamespaceInvitations({ tenantId: "t1", enabled: false }),
-        {
-          wrapper: createWrapper(),
-        },
       );
 
       expect(mockFetchFn).not.toHaveBeenCalled();
@@ -140,9 +122,7 @@ describe("useNamespaceInvitations", () => {
     it("does not fetch when tenantId is empty", () => {
       mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(() => useNamespaceInvitations({ tenantId: "" }), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => useNamespaceInvitations({ tenantId: "" }));
 
       expect(mockFetchFn).not.toHaveBeenCalled();
     });
@@ -152,9 +132,7 @@ describe("useNamespaceInvitations", () => {
     it("uses page 1 and perPage 10 as defaults", async () => {
       mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(() => useNamespaceInvitations({ tenantId: "t1" }), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => useNamespaceInvitations({ tenantId: "t1" }));
 
       await waitFor(() => expect(mockFetchFn).toHaveBeenCalled());
       const [opts] = mockFetchFn.mock.calls[0] as [
@@ -175,9 +153,7 @@ describe("useResolveInvitation", () => {
       status: "confirmed",
     });
 
-    const { result } = renderHook(() => useResolveInvitation("CODE"), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useResolveInvitation("CODE"));
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.resolved).toEqual({
@@ -200,9 +176,9 @@ describe("useResolveInvitation", () => {
       };
       mockResolveFn.mockResolvedValue(data);
 
-      const { result } = renderHook(() => useResolveInvitation("CODE"), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useResolveInvitation("CODE"),
+      );
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.resolved).toBeNull();
@@ -217,18 +193,14 @@ describe("useResolveInvitation", () => {
       status: "invited",
     });
 
-    const { result } = renderHook(() => useResolveInvitation("CODE"), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useResolveInvitation("CODE"));
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.resolved?.email).toBe("");
   });
 
   it("does not fetch when invite is empty", () => {
-    const { result } = renderHook(() => useResolveInvitation(""), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHookWithClient(() => useResolveInvitation(""));
 
     expect(result.current.resolved).toBeNull();
     expect(result.current.isLoading).toBe(false);

--- a/ui/apps/console/src/hooks/__tests__/useLatestAnnouncement.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useLatestAnnouncement.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 import { useLatestAnnouncement } from "../useLatestAnnouncement";
 import type { Announcement } from "@/client";
 
@@ -48,16 +47,6 @@ function makeDetailOptions(uuid: string, fn: () => unknown) {
   };
 }
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, retryDelay: 0 },
-    },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
 // ── Setup ─────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -84,17 +73,13 @@ describe("useLatestAnnouncement", () => {
     });
 
     it("returns null announcement immediately", () => {
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       expect(result.current.announcement).toBeNull();
     });
 
     it("returns isLoading false", () => {
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       expect(result.current.isLoading).toBe(false);
     });
@@ -105,7 +90,7 @@ describe("useLatestAnnouncement", () => {
         makeListOptions(listFn) as never,
       );
 
-      renderHook(() => useLatestAnnouncement(), { wrapper: createWrapper() });
+      renderHookWithClient(() => useLatestAnnouncement());
 
       expect(listFn).not.toHaveBeenCalled();
     });
@@ -117,17 +102,13 @@ describe("useLatestAnnouncement", () => {
         makeListOptions(() => new Promise(() => {})) as never,
       );
 
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       expect(result.current.isLoading).toBe(true);
     });
 
     it("returns null announcement while queries are loading", () => {
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       expect(result.current.announcement).toBeNull();
     });
@@ -139,9 +120,7 @@ describe("useLatestAnnouncement", () => {
         makeListOptions(() => Promise.resolve([])) as never,
       );
 
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.announcement).toBeNull();
@@ -156,9 +135,7 @@ describe("useLatestAnnouncement", () => {
         makeDetailOptions("", detailFn) as never,
       );
 
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -177,9 +154,7 @@ describe("useLatestAnnouncement", () => {
         makeDetailOptions("ann-abc", () => Promise.resolve(ann)) as never,
       );
 
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       await waitFor(() => expect(result.current.announcement).not.toBeNull());
       expect(result.current.announcement).toEqual(ann);
@@ -197,9 +172,7 @@ describe("useLatestAnnouncement", () => {
         makeDetailOptions("ann-uuid-1", () => Promise.resolve(ann)) as never,
       );
 
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.announcement).toEqual(ann);
@@ -218,9 +191,7 @@ describe("useLatestAnnouncement", () => {
         makeDetailOptions("ann-uuid-1", () => new Promise(() => {})) as never,
       );
 
-      const { result } = renderHook(() => useLatestAnnouncement(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useLatestAnnouncement());
 
       // Let the list query settle so latestUuid is set and the detail query is enabled
       await waitFor(() =>

--- a/ui/apps/console/src/hooks/__tests__/usePublicKeys.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/usePublicKeys.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 import { usePublicKeys } from "../usePublicKeys";
 import type { PublicKeyResponse } from "@/client";
 
@@ -10,7 +9,10 @@ vi.mock("@/client", () => ({
 }));
 
 vi.mock("@/client/@tanstack/react-query.gen", () => ({
-  getPublicKeysQueryKey: vi.fn((opts: unknown) => [{ _id: "getPublicKeys" }, opts]),
+  getPublicKeysQueryKey: vi.fn((opts: unknown) => [
+    { _id: "getPublicKeys" },
+    opts,
+  ]),
 }));
 
 vi.mock("@/api/pagination", () => ({
@@ -23,17 +25,9 @@ vi.mock("@/api/pagination", () => ({
 
 const mockGetPublicKeysFn = vi.fn();
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, retryDelay: 0 },
-    },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
-function makeKey(overrides: Partial<PublicKeyResponse> = {}): PublicKeyResponse {
+function makeKey(
+  overrides: Partial<PublicKeyResponse> = {},
+): PublicKeyResponse {
   return {
     name: "test-key",
     fingerprint: "aa:bb:cc",
@@ -68,9 +62,7 @@ describe("usePublicKeys", () => {
       ];
       mockGetPublicKeysFn.mockResolvedValue({ data: keys, totalCount: 2 });
 
-      const { result } = renderHook(() => usePublicKeys(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => usePublicKeys());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.publicKeys).toHaveLength(2);
@@ -81,40 +73,32 @@ describe("usePublicKeys", () => {
     it("returns totalCount from the paginated result", async () => {
       mockGetPublicKeysFn.mockResolvedValue({ data: [], totalCount: 42 });
 
-      const { result } = renderHook(() => usePublicKeys(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => usePublicKeys());
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.totalCount).toBe(42);
     });
 
     it("defaults publicKeys to empty array while loading", () => {
-      mockGetPublicKeysFn.mockReturnValue(new Promise(() => { }));
+      mockGetPublicKeysFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => usePublicKeys(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => usePublicKeys());
 
       expect(result.current.publicKeys).toEqual([]);
     });
 
     it("defaults totalCount to 0 while loading", () => {
-      mockGetPublicKeysFn.mockReturnValue(new Promise(() => { }));
+      mockGetPublicKeysFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => usePublicKeys(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => usePublicKeys());
 
       expect(result.current.totalCount).toBe(0);
     });
 
     it("returns isLoading true initially", () => {
-      mockGetPublicKeysFn.mockReturnValue(new Promise(() => { }));
+      mockGetPublicKeysFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHook(() => usePublicKeys(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => usePublicKeys());
 
       expect(result.current.isLoading).toBe(true);
     });
@@ -123,9 +107,7 @@ describe("usePublicKeys", () => {
       const networkError = new Error("network failure");
       mockGetPublicKeysFn.mockRejectedValue(networkError);
 
-      const { result } = renderHook(() => usePublicKeys(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => usePublicKeys());
 
       await waitFor(() => expect(result.current.error).toBeTruthy());
       expect(result.current.error).toBe(networkError);
@@ -136,7 +118,7 @@ describe("usePublicKeys", () => {
     it("uses page 1 and perPage 10 as defaults", async () => {
       mockGetPublicKeysFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(() => usePublicKeys(), { wrapper: createWrapper() });
+      renderHookWithClient(() => usePublicKeys());
 
       await waitFor(() => expect(mockGetPublicKeysFn).toHaveBeenCalled());
       const [opts] = mockGetPublicKeysFn.mock.calls[0] as [
@@ -149,9 +131,7 @@ describe("usePublicKeys", () => {
     it("forwards custom page and perPage", async () => {
       mockGetPublicKeysFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHook(() => usePublicKeys({ page: 3, perPage: 25 }), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => usePublicKeys({ page: 3, perPage: 25 }));
 
       await waitFor(() => expect(mockGetPublicKeysFn).toHaveBeenCalled());
       const [opts] = mockGetPublicKeysFn.mock.calls[0] as [

--- a/ui/apps/console/src/hooks/__tests__/useSupportIdentifier.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useSupportIdentifier.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 
 const mockGetNamespaceSupportFn = vi.fn();
 
@@ -11,16 +10,6 @@ vi.mock("@/client/@tanstack/react-query.gen", () => ({
     queryFn: mockGetNamespaceSupportFn,
   })),
 }));
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, retryDelay: 0 },
-    },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -35,9 +24,8 @@ describe("useSupportIdentifier", () => {
     it("never fires the query and returns null identifier", async () => {
       const { useSupportIdentifier } = await importHook();
 
-      const { result } = renderHook(
-        () => useSupportIdentifier("tenant-123", false),
-        { wrapper: createWrapper() },
+      const { result } = renderHookWithClient(() =>
+        useSupportIdentifier("tenant-123", false),
       );
 
       expect(mockGetNamespaceSupportFn).not.toHaveBeenCalled();
@@ -51,9 +39,7 @@ describe("useSupportIdentifier", () => {
     it("does not fire the query when tenantId is empty string", async () => {
       const { useSupportIdentifier } = await importHook();
 
-      renderHook(() => useSupportIdentifier("", true), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => useSupportIdentifier("", true));
 
       expect(mockGetNamespaceSupportFn).not.toHaveBeenCalled();
     });
@@ -61,9 +47,7 @@ describe("useSupportIdentifier", () => {
     it("does not fire the query when tenantId is null", async () => {
       const { useSupportIdentifier } = await importHook();
 
-      renderHook(() => useSupportIdentifier(null, true), {
-        wrapper: createWrapper(),
-      });
+      renderHookWithClient(() => useSupportIdentifier(null, true));
 
       expect(mockGetNamespaceSupportFn).not.toHaveBeenCalled();
     });
@@ -71,9 +55,9 @@ describe("useSupportIdentifier", () => {
     it("returns null identifier when disabled by empty tenantId", async () => {
       const { useSupportIdentifier } = await importHook();
 
-      const { result } = renderHook(() => useSupportIdentifier("", true), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() =>
+        useSupportIdentifier("", true),
+      );
 
       expect(result.current.identifier).toBeNull();
       expect(result.current.isLoading).toBe(false);
@@ -85,9 +69,8 @@ describe("useSupportIdentifier", () => {
       mockGetNamespaceSupportFn.mockResolvedValue({ identifier: "abc123" });
       const { useSupportIdentifier } = await importHook();
 
-      const { result } = renderHook(
+      const { result } = renderHookWithClient(
         () => useSupportIdentifier("tenant-123", true),
-        { wrapper: createWrapper() },
       );
 
       await waitFor(() => expect(result.current.identifier).toBe("abc123"));
@@ -101,9 +84,8 @@ describe("useSupportIdentifier", () => {
       mockGetNamespaceSupportFn.mockRejectedValue(new Error("network error"));
       const { useSupportIdentifier } = await importHook();
 
-      const { result } = renderHook(
+      const { result } = renderHookWithClient(
         () => useSupportIdentifier("tenant-123", true),
-        { wrapper: createWrapper() },
       );
 
       await waitFor(() => expect(result.current.isError).toBe(true));

--- a/ui/apps/console/src/hooks/__tests__/useUploadLicense.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useUploadLicense.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { waitFor, act } from "@testing-library/react";
+import { renderHookWithClient } from "@/tests/wrapper";
 import { useUploadLicense } from "../useUploadLicense";
 
 const mockMutationFn = vi.fn();
@@ -15,14 +14,6 @@ vi.mock("../useInvalidateQueries", () => ({
   useInvalidateByIds: vi.fn(() => mockInvalidate),
 }));
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { mutations: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -31,9 +22,7 @@ describe("useUploadLicense", () => {
   describe("mutation call", () => {
     it("calls sendLicense with the provided body", async () => {
       mockMutationFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useUploadLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useUploadLicense());
 
       const body = { body: "license-data" };
       await act(() => result.current.mutateAsync(body as never));
@@ -45,9 +34,7 @@ describe("useUploadLicense", () => {
   describe("on success", () => {
     it("invalidates getLicense queries after a successful mutation", async () => {
       mockMutationFn.mockResolvedValue(undefined);
-      const { result } = renderHook(() => useUploadLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useUploadLicense());
 
       await act(() => result.current.mutateAsync({}));
 
@@ -59,9 +46,7 @@ describe("useUploadLicense", () => {
     it("rejects and exposes the error when sendLicense fails", async () => {
       const error = new Error("upload failed");
       mockMutationFn.mockRejectedValue(error);
-      const { result } = renderHook(() => useUploadLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useUploadLicense());
 
       act(() => result.current.mutate({}));
 
@@ -71,9 +56,7 @@ describe("useUploadLicense", () => {
 
     it("does not call invalidate when sendLicense fails", async () => {
       mockMutationFn.mockRejectedValue(new Error("upload failed"));
-      const { result } = renderHook(() => useUploadLicense(), {
-        wrapper: createWrapper(),
-      });
+      const { result } = renderHookWithClient(() => useUploadLicense());
 
       act(() => result.current.mutate({}));
 

--- a/ui/apps/console/src/pages/__tests__/AcceptDevice.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/AcceptDevice.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import { useAuthStore } from "@/stores/authStore";
 import {
   PENDING_DEVICE_CODE_KEY,
@@ -49,15 +48,6 @@ function mockDevice(overrides = {}) {
   };
 }
 
-function createQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  });
-}
-
 beforeEach(() => {
   vi.resetAllMocks();
   localStorage.removeItem(PENDING_DEVICE_CODE_KEY);
@@ -65,13 +55,9 @@ beforeEach(() => {
 });
 
 function renderPage(path: string) {
-  return render(
-    <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter initialEntries={[path]}>
-        <AcceptDevice />
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
+  return render(<AcceptDevice />, {
+    wrapper: createTestWrapper({ initialEntries: [path] }),
+  });
 }
 
 function renderFlow({
@@ -79,11 +65,8 @@ function renderFlow({
   inDialog,
 }: { initialCode?: string; inDialog?: boolean } = {}) {
   return render(
-    <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter>
-        <AcceptDeviceFlow initialCode={initialCode} inDialog={inDialog} />
-      </MemoryRouter>
-    </QueryClientProvider>,
+    <AcceptDeviceFlow initialCode={initialCode} inDialog={inDialog} />,
+    { wrapper: createTestWrapper({ initialEntries: ["/"] }) },
   );
 }
 

--- a/ui/apps/console/src/pages/__tests__/ConfirmAccount.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/ConfirmAccount.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { useSignUpStore } from "@/stores/signUpStore";
 import ConfirmAccount from "../ConfirmAccount";
+import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
 
 /* ------------------------------------------------------------------ */
 /* Mocks                                                               */
@@ -23,22 +24,13 @@ vi.mock("@/client", () => ({
 import { resendEmail as apiResendEmail } from "@/client";
 const mockedResendEmail = vi.mocked(apiResendEmail);
 
-type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
-
 /* ------------------------------------------------------------------ */
 /* Helpers                                                             */
 /* ------------------------------------------------------------------ */
 
 function renderConfirmAccount(username?: string) {
-  const search = username !== undefined ? `?username=${encodeURIComponent(username)}` : "";
+  const search =
+    username !== undefined ? `?username=${encodeURIComponent(username)}` : "";
   return render(
     <MemoryRouter initialEntries={[`/confirm-account${search}`]}>
       <ConfirmAccount />
@@ -62,8 +54,12 @@ describe("ConfirmAccount", () => {
   describe("rendering", () => {
     it("renders the heading and resend button", () => {
       renderConfirmAccount("admin");
-      expect(screen.getByText(/account activation required/i)).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /resend email/i })).toBeInTheDocument();
+      expect(
+        screen.getByText(/account activation required/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /resend email/i }),
+      ).toBeInTheDocument();
     });
 
     it("renders a back-to-login link", () => {
@@ -73,12 +69,16 @@ describe("ConfirmAccount", () => {
 
     it("redirects to /login when no username is provided", () => {
       renderConfirmAccount();
-      expect(screen.queryByText(/account activation required/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/account activation required/i),
+      ).not.toBeInTheDocument();
     });
 
     it("enables the button when a username is provided", () => {
       renderConfirmAccount("admin");
-      expect(screen.getByRole("button", { name: /resend email/i })).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /resend email/i }),
+      ).not.toBeDisabled();
     });
   });
 
@@ -87,11 +87,18 @@ describe("ConfirmAccount", () => {
       mockedResendEmail.mockResolvedValue(mockSdkResponse(undefined));
 
       renderConfirmAccount("admin");
-      await userEvent.click(screen.getByRole("button", { name: /resend email/i }));
+      await userEvent.click(
+        screen.getByRole("button", { name: /resend email/i }),
+      );
 
-      expect(mockedResendEmail).toHaveBeenCalledWith({ body: { username: "admin" }, throwOnError: true });
+      expect(mockedResendEmail).toHaveBeenCalledWith({
+        body: { username: "admin" },
+        throwOnError: true,
+      });
       await waitFor(() =>
-        expect(screen.getByText(/confirmation email sent successfully/i)).toBeInTheDocument(),
+        expect(
+          screen.getByText(/confirmation email sent successfully/i),
+        ).toBeInTheDocument(),
       );
     });
 
@@ -99,7 +106,9 @@ describe("ConfirmAccount", () => {
       mockedResendEmail.mockRejectedValue(new Error("500"));
 
       renderConfirmAccount("admin");
-      await userEvent.click(screen.getByRole("button", { name: /resend email/i }));
+      await userEvent.click(
+        screen.getByRole("button", { name: /resend email/i }),
+      );
 
       await waitFor(() =>
         expect(screen.getByText(/failed to resend email/i)).toBeInTheDocument(),

--- a/ui/apps/console/src/pages/__tests__/ForgotPassword.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/ForgotPassword.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import ForgotPassword from "../ForgotPassword";
+import { mockSdkResponse } from "@/tests/sdk";
 
 vi.mock("@/client", () => ({
   recoverPassword: vi.fn(),
@@ -11,16 +12,6 @@ vi.mock("@/client", () => ({
 import { recoverPassword as recoverPasswordSdk } from "@/client";
 
 const mockedRecoverPassword = vi.mocked(recoverPasswordSdk);
-
-type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 function renderForgotPassword() {
   return render(
@@ -37,13 +28,17 @@ describe("ForgotPassword", () => {
   describe("initial state", () => {
     it("does not show an account error before the field is touched", () => {
       renderForgotPassword();
-      expect(screen.queryByText(/enter a valid username or email/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/enter a valid username or email/i),
+      ).not.toBeInTheDocument();
       expect(screen.queryByText(/is required/i)).not.toBeInTheDocument();
     });
 
     it("disables the submit button when the form is empty", () => {
       renderForgotPassword();
-      expect(screen.getByRole("button", { name: /reset password/i })).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /reset password/i }),
+      ).toBeDisabled();
     });
   });
 
@@ -56,7 +51,9 @@ describe("ForgotPassword", () => {
       await user.type(input, "!!");
       await user.tab();
 
-      expect(await screen.findByText(/enter a valid username or email/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText(/enter a valid username or email/i),
+      ).toBeInTheDocument();
     });
 
     it("keeps the submit button disabled when the account is invalid", async () => {
@@ -67,7 +64,9 @@ describe("ForgotPassword", () => {
       await user.tab();
 
       await screen.findByText(/enter a valid username or email/i);
-      expect(screen.getByRole("button", { name: /reset password/i })).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /reset password/i }),
+      ).toBeDisabled();
     });
   });
 
@@ -78,7 +77,9 @@ describe("ForgotPassword", () => {
 
       await user.type(screen.getByLabelText(/username or email/i), "alice");
 
-      expect(screen.getByRole("button", { name: /reset password/i })).toBeEnabled();
+      expect(
+        screen.getByRole("button", { name: /reset password/i }),
+      ).toBeEnabled();
     });
 
     it("calls recoverPassword with the trimmed username on valid submit", async () => {
@@ -89,7 +90,9 @@ describe("ForgotPassword", () => {
       await user.type(screen.getByLabelText(/username or email/i), "  alice  ");
       await user.click(screen.getByRole("button", { name: /reset password/i }));
 
-      await waitFor(() => expect(mockedRecoverPassword).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(mockedRecoverPassword).toHaveBeenCalledTimes(1),
+      );
       expect(mockedRecoverPassword).toHaveBeenCalledWith(
         expect.objectContaining({
           body: expect.objectContaining({ username: "alice" }),

--- a/ui/apps/console/src/pages/__tests__/Login.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Login.test.tsx
@@ -8,7 +8,8 @@ import {
   hasPendingDeviceCode,
   setPendingDeviceCode,
 } from "@/utils/navigation";
-import type { UserAuth, Info } from "@/client";
+import type { Info, UserAuth } from "@/client";
+import { mockUserAuth } from "@/tests/userAuth";
 import Login from "../Login";
 import { mockSdkResponse, makeSdkError, type SdkResponse } from "@/tests/sdk";
 
@@ -50,24 +51,6 @@ function mockInfo(overrides: Partial<Info> = {}): Info {
     endpoints: null,
     setup: true,
     authentication: { local: true, saml: false },
-    ...overrides,
-  };
-}
-
-function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
-  return {
-    token: "jwt-token",
-    id: "uid",
-    origin: "local",
-    user: "admin",
-    name: "Admin",
-    email: "admin@test.com",
-    recovery_email: "recovery@test.com",
-    tenant: "tenant-1",
-    role: "owner",
-    mfa: false,
-    admin: false,
-    max_namespaces: -1,
     ...overrides,
   };
 }

--- a/ui/apps/console/src/pages/__tests__/Login.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Login.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/utils/navigation";
 import type { UserAuth, Info } from "@/client";
 import Login from "../Login";
+import { mockSdkResponse, makeSdkError, type SdkResponse } from "@/tests/sdk";
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 
@@ -43,12 +44,6 @@ const mockedGetInfo = vi.mocked(getInfoSdk);
 const mockedGetSamlAuthUrl = vi.mocked(getSamlAuthUrlSdk);
 const mockedGetConfig = vi.mocked(getConfig);
 
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
 function mockInfo(overrides: Partial<Info> = {}): Info {
   return {
     version: "0.0.0",
@@ -75,25 +70,6 @@ function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
     max_namespaces: -1,
     ...overrides,
   };
-}
-
-function mockSdkResponse<T>(
-  data: T,
-  headers: HeadersInit = {},
-): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(null, { headers }),
-  };
-}
-
-function makeSdkError(status: number, headers?: Record<string, string>) {
-  const headerObj = new Headers(headers);
-  return Object.assign(new Error("Request failed"), {
-    status,
-    headers: headerObj,
-  });
 }
 
 function renderLogin() {

--- a/ui/apps/console/src/pages/__tests__/MfaRecover.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/MfaRecover.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { useAuthStore } from "@/stores/authStore";
 import MfaRecover from "../MfaRecover";
+import { mockSdkResponse } from "@/tests/sdk";
 
 vi.mock("@/client", () => ({
   recoveryDisableMfa: vi.fn(),
@@ -11,20 +12,6 @@ vi.mock("@/client", () => ({
 
 import { recoveryDisableMfa } from "@/client";
 const mockedRecoveryDisableMfa = vi.mocked(recoveryDisableMfa);
-
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 function renderRecover() {
   return render(

--- a/ui/apps/console/src/pages/__tests__/SSHApproval.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/SSHApproval.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Routes, Route } from "react-router-dom";
+import { createTestWrapper } from "@/tests/wrapper";
 import SSHApproval from "../SSHApproval";
 import { getSshApproval, webTerminalReauth } from "@/client";
 
@@ -63,24 +63,18 @@ const approval = (overrides: Record<string, unknown> = {}) => ({
 });
 
 function renderAt(path: string) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
   return render(
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[path]}>
-        <Routes>
-          <Route
-            path="/ssh-identities/new/:code"
-            element={<SSHApproval flow="new" />}
-          />
-          <Route
-            path="/ssh-identities/confirm/:code"
-            element={<SSHApproval flow="confirm" />}
-          />
-        </Routes>
-      </MemoryRouter>
-    </QueryClientProvider>,
+    <Routes>
+      <Route
+        path="/ssh-identities/new/:code"
+        element={<SSHApproval flow="new" />}
+      />
+      <Route
+        path="/ssh-identities/confirm/:code"
+        element={<SSHApproval flow="confirm" />}
+      />
+    </Routes>,
+    { wrapper: createTestWrapper({ initialEntries: [path] }) },
   );
 }
 
@@ -203,20 +197,28 @@ describe("SSHApproval", () => {
   // invites typing past the check, so it only appears once the check is done.
   it("keeps the factor out of sight until the login has been reviewed", async () => {
     const user = userEvent.setup();
-    vi.mocked(getSshApproval).mockResolvedValue(approval({ kind: "reauth" }) as never);
+    vi.mocked(getSshApproval).mockResolvedValue(
+      approval({ kind: "reauth" }) as never,
+    );
 
     renderAt("/ssh-identities/confirm/WXYZ2K7Q");
     await screen.findByText(/re-authenticate to continue/i);
 
-    expect(screen.queryByLabelText(/account password/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/account password/i),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /continue/i }));
-    expect(await screen.findByLabelText(/account password/i)).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText(/account password/i),
+    ).toBeInTheDocument();
   });
 
   it("goes back to the details without deciding anything", async () => {
     const user = userEvent.setup();
-    vi.mocked(getSshApproval).mockResolvedValue(approval({ kind: "reauth" }) as never);
+    vi.mocked(getSshApproval).mockResolvedValue(
+      approval({ kind: "reauth" }) as never,
+    );
 
     renderAt("/ssh-identities/confirm/WXYZ2K7Q");
     await screen.findByText(/re-authenticate to continue/i);
@@ -227,7 +229,9 @@ describe("SSHApproval", () => {
     expect(
       await screen.findByText(/re-authenticate to continue/i),
     ).toBeInTheDocument();
-    expect(screen.queryByLabelText(/account password/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/account password/i),
+    ).not.toBeInTheDocument();
     expect(webTerminalReauth).not.toHaveBeenCalled();
   });
 
@@ -235,8 +239,12 @@ describe("SSHApproval", () => {
   // the code and the key it was asked for.
   it("proves the password and reports the login released", async () => {
     const user = userEvent.setup();
-    vi.mocked(getSshApproval).mockResolvedValue(approval({ kind: "reauth" }) as never);
-    vi.mocked(webTerminalReauth).mockResolvedValue({ data: undefined } as never);
+    vi.mocked(getSshApproval).mockResolvedValue(
+      approval({ kind: "reauth" }) as never,
+    );
+    vi.mocked(webTerminalReauth).mockResolvedValue({
+      data: undefined,
+    } as never);
 
     renderAt("/ssh-identities/confirm/WXYZ2K7Q");
     await screen.findByText(/re-authenticate to continue/i);

--- a/ui/apps/console/src/pages/__tests__/Setup.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Setup.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import Setup from "../Setup";
+import { mockSdkResponse, makeSdkError } from "@/tests/sdk";
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 
@@ -27,24 +28,6 @@ import { getConfig, defaultConfig } from "@/env";
 
 const mockedSetup = vi.mocked(setupSdk);
 const mockedGetConfig = vi.mocked(getConfig);
-
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
-
-function makeSdkError(status: number) {
-  return Object.assign(new Error("Request failed"), { status });
-}
 
 function renderSetup() {
   return render(

--- a/ui/apps/console/src/pages/__tests__/SignUp.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/SignUp.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { useSignUpStore } from "@/stores/signUpStore";
 import SignUp from "../SignUp";
+import { mockSdkResponse } from "@/tests/sdk";
 
 /* ------------------------------------------------------------------ */
 /* Mocks                                                               */
@@ -25,20 +26,6 @@ vi.mock("@/client", () => ({
 import { registerUser as registerUserSdk } from "@/client";
 
 const mockedRegisterUser = vi.mocked(registerUserSdk);
-
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 /* ------------------------------------------------------------------ */
 /* Helpers                                                             */

--- a/ui/apps/console/src/pages/__tests__/UpdatePassword.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/UpdatePassword.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import UpdatePassword from "../UpdatePassword";
+import { mockSdkResponse } from "@/tests/sdk";
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 
@@ -17,14 +18,6 @@ vi.mock("@/client", () => ({
 
 import { updateRecoverPassword } from "@/client";
 const mockedUpdate = vi.mocked(updateRecoverPassword);
-
-function mockSdkResponse<T>(data: T) {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 function renderWithParams(search = "?id=uid123&token=tok456") {
   return render(
@@ -74,9 +67,7 @@ describe("UpdatePassword", () => {
     it("shows no password error on initial render", () => {
       renderWithParams();
 
-      expect(
-        screen.queryByText(/password must be/i),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/password must be/i)).not.toBeInTheDocument();
     });
 
     it("shows no mismatch error on initial render", () => {
@@ -96,9 +87,7 @@ describe("UpdatePassword", () => {
       await user.type(screen.getByLabelText(/^new password$/i), "abc");
       await user.tab();
 
-      expect(
-        await screen.findByText(/password must be/i),
-      ).toBeInTheDocument();
+      expect(await screen.findByText(/password must be/i)).toBeInTheDocument();
     });
 
     it("shows a mismatch error after confirmPassword is blurred with a non-matching value", async () => {
@@ -106,7 +95,10 @@ describe("UpdatePassword", () => {
       renderWithParams();
 
       await user.type(screen.getByLabelText(/^new password$/i), "Secret123");
-      await user.type(screen.getByLabelText(/^confirm password$/i), "Different1");
+      await user.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "Different1",
+      );
       await user.tab();
 
       expect(
@@ -129,7 +121,10 @@ describe("UpdatePassword", () => {
       renderWithParams();
 
       await user.type(screen.getByLabelText(/^new password$/i), "Secret123");
-      await user.type(screen.getByLabelText(/^confirm password$/i), "Secret123");
+      await user.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "Secret123",
+      );
 
       expect(
         screen.getByRole("button", { name: /update password/i }),
@@ -155,8 +150,13 @@ describe("UpdatePassword", () => {
       renderWithParams();
 
       await user.type(screen.getByLabelText(/^new password$/i), "Secret123");
-      await user.type(screen.getByLabelText(/^confirm password$/i), "Secret123");
-      await user.click(screen.getByRole("button", { name: /update password/i }));
+      await user.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "Secret123",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /update password/i }),
+      );
 
       await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
       expect(mockedUpdate).toHaveBeenCalledWith(
@@ -175,8 +175,13 @@ describe("UpdatePassword", () => {
       renderWithParams();
 
       await user.type(screen.getByLabelText(/^new password$/i), "Secret123");
-      await user.type(screen.getByLabelText(/^confirm password$/i), "Secret123");
-      await user.click(screen.getByRole("button", { name: /update password/i }));
+      await user.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "Secret123",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /update password/i }),
+      );
 
       await waitFor(() =>
         expect(mockNavigate).toHaveBeenCalledWith(
@@ -196,8 +201,13 @@ describe("UpdatePassword", () => {
       renderWithParams();
 
       await user.type(screen.getByLabelText(/^new password$/i), "Secret123");
-      await user.type(screen.getByLabelText(/^confirm password$/i), "Secret123");
-      await user.click(screen.getByRole("button", { name: /update password/i }));
+      await user.type(
+        screen.getByLabelText(/^confirm password$/i),
+        "Secret123",
+      );
+      await user.click(
+        screen.getByRole("button", { name: /update password/i }),
+      );
 
       expect(await screen.findByRole("alert")).toBeInTheDocument();
     });

--- a/ui/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
+++ b/ui/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 
 /* ------------------------------------------------------------------ */
 /* Mocks                                                               */
@@ -22,21 +22,7 @@ import { useAdminSessions } from "@/hooks/useAdminSessions";
 import type { Device, Session } from "@/client";
 import AdminSessions from "../Sessions";
 import { sdkError } from "@/tests/sdkError";
-
-/* ------------------------------------------------------------------ */
-/* Helpers                                                             */
-/* ------------------------------------------------------------------ */
-
-/** Exposes the current search string from inside the MemoryRouter. */
-function LocationProbe({
-  onLocation,
-}: {
-  onLocation: (search: string) => void;
-}) {
-  const loc = useLocation();
-  onLocation(loc.search);
-  return null;
-}
+import { LocationProbe } from "@/tests/LocationProbe";
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {

--- a/ui/apps/console/src/pages/admin/settings/__tests__/Authentication.test.tsx
+++ b/ui/apps/console/src/pages/admin/settings/__tests__/Authentication.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import AdminAuthentication from "../Authentication";
+import { mockSdkResponse } from "@/tests/sdk";
 
 vi.mock("@/client", () => ({
   getAuthenticationSettings: vi.fn(),
@@ -19,24 +20,7 @@ const mockedGetSettings = vi.mocked(getAuthenticationSettings);
 const mockedConfigureLocal = vi.mocked(configureLocalAuthentication);
 const mockedConfigureSaml = vi.mocked(configureSamlAuthentication);
 
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
-
-function mockSettings({
-  localEnabled = true,
-  samlEnabled = false,
-} = {}) {
+function mockSettings({ localEnabled = true, samlEnabled = false } = {}) {
   return {
     local: { enabled: localEnabled },
     saml: { enabled: samlEnabled },
@@ -64,9 +48,7 @@ beforeEach(() => {
 describe("AdminAuthentication", () => {
   describe("DS Toggle usage", () => {
     it("renders the local-auth and SAML rows as role='switch' toggles", async () => {
-      mockedGetSettings.mockResolvedValue(
-        mockSdkResponse(mockSettings()),
-      );
+      mockedGetSettings.mockResolvedValue(mockSdkResponse(mockSettings()));
 
       renderPage();
       await settlePendingLoad();
@@ -81,9 +63,7 @@ describe("AdminAuthentication", () => {
 
     it("clicking the local-auth toggle fires configureLocalAuthentication with the flipped value", async () => {
       const user = userEvent.setup();
-      mockedGetSettings.mockResolvedValue(
-        mockSdkResponse(mockSettings()),
-      );
+      mockedGetSettings.mockResolvedValue(mockSdkResponse(mockSettings()));
 
       renderPage();
       await settlePendingLoad();
@@ -119,9 +99,7 @@ describe("AdminAuthentication", () => {
 
     it("disables the local-auth toggle while togglingLocal is true", async () => {
       const user = userEvent.setup();
-      mockedGetSettings.mockResolvedValue(
-        mockSdkResponse(mockSettings()),
-      );
+      mockedGetSettings.mockResolvedValue(mockSdkResponse(mockSettings()));
       let resolveConfigure: (() => void) | undefined;
       mockedConfigureLocal.mockReturnValue(
         new Promise((resolve) => {

--- a/ui/apps/console/src/pages/admin/settings/__tests__/SamlConfigDrawer.test.tsx
+++ b/ui/apps/console/src/pages/admin/settings/__tests__/SamlConfigDrawer.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import SamlConfigDrawer from "../SamlConfigDrawer";
+import { mockSdkResponse } from "@/tests/sdk";
 
 vi.mock("@/client", () => ({
   configureSamlAuthentication: vi.fn(),
@@ -16,20 +17,6 @@ const VALID_METADATA_URL = "https://idp.example.com/metadata.xml";
 const VALID_ENTITY_ID = "https://idp.example.com/entity";
 const VALID_CERT =
   "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n-----END CERTIFICATE-----";
-
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 const defaultProps = {
   open: true,

--- a/ui/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
+++ b/ui/apps/console/src/pages/secure-vault/__tests__/SecureVault.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import { useVaultStore } from "@/stores/vaultStore";
 import SecureVault from "../index";
 import ConnectDrawer from "@/components/ConnectDrawer";
@@ -769,12 +769,6 @@ describe("SecureVault", () => {
       // ConnectDrawer calls useQueryClient (identity-mode reconciliation); these
       // isolated tests aren't in identity mode, so no query actually runs — the
       // provider only satisfies the hook. A `wrapper` persists across rerender().
-      const queryClient = new QueryClient();
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <QueryClientProvider client={queryClient}>
-          {children}
-        </QueryClientProvider>
-      );
       return render(
         <ConnectDrawer
           open
@@ -783,7 +777,7 @@ describe("SecureVault", () => {
           deviceName="my-device"
           sshid="my-device.ns@localhost"
         />,
-        { wrapper },
+        { wrapper: createTestWrapper() },
       );
     }
 

--- a/ui/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
+++ b/ui/apps/console/src/pages/sessions/__tests__/Sessions.test.tsx
@@ -1,23 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, useLocation } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 import Sessions from "../index";
-
-/** Exposes the current search string from inside the MemoryRouter. */
-function LocationProbe({
-  onLocation,
-}: {
-  onLocation: (search: string) => void;
-}) {
-  const loc = useLocation();
-  onLocation(loc.search);
-  return null;
-}
-
-/* ------------------------------------------------------------------ */
-/* Mocks                                                               */
-/* ------------------------------------------------------------------ */
+import { LocationProbe } from "@/tests/LocationProbe";
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 

--- a/ui/apps/console/src/pages/ssh-identities/__tests__/IdentityDrawer.test.tsx
+++ b/ui/apps/console/src/pages/ssh-identities/__tests__/IdentityDrawer.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import IdentityDrawer from "../IdentityDrawer";
 import { useHasPermission } from "@/hooks/useHasPermission";
 
@@ -59,16 +58,9 @@ const mockUseHasPermission = vi.mocked(useHasPermission);
 /* ------------------------------------------------------------------ */
 
 function renderDrawer() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+  return render(<IdentityDrawer open editIdentity={null} onClose={vi.fn()} />, {
+    wrapper: createTestWrapper({ initialEntries: ["/"] }),
   });
-  return render(
-    <MemoryRouter>
-      <QueryClientProvider client={queryClient}>
-        <IdentityDrawer open editIdentity={null} onClose={vi.fn()} />
-      </QueryClientProvider>
-    </MemoryRouter>,
-  );
 }
 
 const KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILqk test@host";

--- a/ui/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createTestWrapper } from "@/tests/wrapper";
+import { makeSdkError } from "@/tests/sdk";
 import AddMemberDrawer from "../AddMemberDrawer";
 import { defaultConfig, getConfig } from "@/env";
-import type { SdkHttpError } from "@/api/errors";
 
 /* ------------------------------------------------------------------ */
 /* Mocks                                                               */
@@ -54,13 +54,6 @@ async function submit(
 ) {
   await user.type(screen.getByPlaceholderText(/user@example.com/i), email);
   await user.click(screen.getByRole("button", { name: /add member/i }));
-}
-
-function makeSdkError(status: number): SdkHttpError {
-  return Object.assign(new Error("request failed"), {
-    status,
-    headers: new Headers(),
-  });
 }
 
 /* ------------------------------------------------------------------ */

--- a/ui/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/AddMemberDrawer.test.tsx
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "@/tests/wrapper";
 import AddMemberDrawer from "../AddMemberDrawer";
 import { defaultConfig, getConfig } from "@/env";
 import type { SdkHttpError } from "@/api/errors";
@@ -43,21 +41,10 @@ const mockGetConfig = vi.mocked(getConfig);
 /* Helpers                                                             */
 /* ------------------------------------------------------------------ */
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return ({ children }: { children: React.ReactNode }) => (
-    <MemoryRouter>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </MemoryRouter>
-  );
-}
-
 function renderDrawer(open = true, onClose = vi.fn(), tenantId = "t1") {
   return render(
     <AddMemberDrawer open={open} onClose={onClose} tenantId={tenantId} />,
-    { wrapper: createWrapper() },
+    { wrapper: createTestWrapper({ initialEntries: ["/"] }) },
   );
 }
 

--- a/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, useLocation } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useLocation } from "react-router-dom";
+import { createTestWrapper } from "@/tests/wrapper";
 import type { ApiKey } from "@/client";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -96,22 +96,18 @@ function LocationProbe({
 }
 
 function renderTab(initialEntries: string[] = ["/"]) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
   let lastSearch = "";
 
   const result = render(
-    <MemoryRouter initialEntries={initialEntries}>
-      <QueryClientProvider client={queryClient}>
-        <ApiKeysTab />
-        <LocationProbe
-          onLocation={(s) => {
-            lastSearch = s;
-          }}
-        />
-      </QueryClientProvider>
-    </MemoryRouter>,
+    <>
+      <ApiKeysTab />
+      <LocationProbe
+        onLocation={(s) => {
+          lastSearch = s;
+        }}
+      />
+    </>,
+    { wrapper: createTestWrapper({ initialEntries }) },
   );
 
   return { ...result, getSearch: () => lastSearch };

--- a/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
+++ b/ui/apps/console/src/pages/team/__tests__/ApiKeysTab.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useLocation } from "react-router-dom";
 import { createTestWrapper } from "@/tests/wrapper";
+import { LocationProbe } from "@/tests/LocationProbe";
 import type { ApiKey } from "@/client";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -81,19 +81,6 @@ beforeEach(() => {
     mutateAsync: mockMutateAsync,
   } as never);
 });
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-/** Exposes the current search string from inside the MemoryRouter. */
-function LocationProbe({
-  onLocation,
-}: {
-  onLocation: (search: string) => void;
-}) {
-  const loc = useLocation();
-  onLocation(loc.search);
-  return null;
-}
 
 function renderTab(initialEntries: string[] = ["/"]) {
   let lastSearch = "";

--- a/ui/apps/console/src/stores/__tests__/authStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/authStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useAuthStore } from "../authStore";
 import type { UserAuth } from "@/client";
+import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
 
 vi.mock("@/client", () => ({
   login: vi.fn(),
@@ -18,12 +19,6 @@ const mockedGetUserInfo = vi.mocked(getUserInfo);
 const mockedAuthMfa = vi.mocked(authMfa);
 const mockedMfaRecover = vi.mocked(mfaRecover);
 
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
 function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
   return {
     token: "jwt-token",
@@ -39,17 +34,6 @@ function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
     admin: false,
     max_namespaces: -1,
     ...overrides,
-  };
-}
-
-function mockSdkResponse<T>(
-  data: T,
-  headers: HeadersInit = {},
-): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(null, { headers }),
   };
 }
 

--- a/ui/apps/console/src/stores/__tests__/authStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/authStore.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useAuthStore } from "../authStore";
 import type { UserAuth } from "@/client";
 import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
+import { mockUserAuth } from "@/tests/userAuth";
 
 vi.mock("@/client", () => ({
   login: vi.fn(),
@@ -18,24 +19,6 @@ const mockedLogin = vi.mocked(loginSdk);
 const mockedGetUserInfo = vi.mocked(getUserInfo);
 const mockedAuthMfa = vi.mocked(authMfa);
 const mockedMfaRecover = vi.mocked(mfaRecover);
-
-function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
-  return {
-    token: "jwt-token",
-    id: "user-123",
-    origin: "local",
-    user: "admin",
-    name: "Admin User",
-    email: "admin@test.com",
-    recovery_email: "recovery@test.com",
-    tenant: "tenant-456",
-    role: "owner",
-    mfa: false,
-    admin: false,
-    max_namespaces: -1,
-    ...overrides,
-  };
-}
 
 beforeEach(() => {
   useAuthStore.setState({

--- a/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useMfaResetStore } from "../mfaResetStore";
 import { useAuthStore } from "../authStore";
 import type { UserAuth } from "@/client";
+import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
 
 vi.mock("@/client", () => ({
   requestResetMfa: vi.fn(),
@@ -19,20 +20,6 @@ import { requestResetMfa, resetMfa } from "@/client";
 
 const mockedRequestResetMfa = vi.mocked(requestResetMfa);
 const mockedResetMfa = vi.mocked(resetMfa);
-
-type SdkResponse<T = unknown> = {
-  data: T;
-  request: Request;
-  response: Response;
-};
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
   return {

--- a/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useMfaResetStore } from "../mfaResetStore";
 import { useAuthStore } from "../authStore";
-import type { UserAuth } from "@/client";
 import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
+import { mockUserAuth } from "@/tests/userAuth";
 
 vi.mock("@/client", () => ({
   requestResetMfa: vi.fn(),
@@ -20,24 +20,6 @@ import { requestResetMfa, resetMfa } from "@/client";
 
 const mockedRequestResetMfa = vi.mocked(requestResetMfa);
 const mockedResetMfa = vi.mocked(resetMfa);
-
-function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
-  return {
-    token: "jwt-token",
-    id: "user-123",
-    origin: "local",
-    user: "admin",
-    name: "Admin User",
-    email: "admin@test.com",
-    recovery_email: "recovery@test.com",
-    tenant: "tenant-456",
-    role: "owner",
-    mfa: false,
-    admin: false,
-    max_namespaces: -1,
-    ...overrides,
-  };
-}
 
 beforeEach(() => {
   useMfaResetStore.setState({

--- a/ui/apps/console/src/stores/__tests__/signUpStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/signUpStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useSignUpStore } from "../signUpStore";
+import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
 
 vi.mock("@/client", () => ({
   registerUser: vi.fn(),
@@ -16,16 +17,6 @@ import {
 const mockedRegisterUser = vi.mocked(apiRegisterUser);
 const mockedResendEmail = vi.mocked(apiResendEmail);
 const mockedGetValidateAccount = vi.mocked(apiGetValidateAccount);
-
-type SdkResponse<T = unknown> = { data: T; request: Request; response: Response };
-
-function mockSdkResponse<T>(data: T): SdkResponse<T> {
-  return {
-    data,
-    request: new Request("http://localhost"),
-    response: new Response(),
-  };
-}
 
 beforeEach(() => {
   useSignUpStore.setState({
@@ -49,14 +40,22 @@ function createSdkError(status: number, body?: unknown) {
 
 describe("signUpStore", () => {
   describe("signUp", () => {
-    vi.spyOn(console, "warn").mockImplementation(() => { }); // Suppress expected warn logs during tests
+    vi.spyOn(console, "warn").mockImplementation(() => {}); // Suppress expected warn logs during tests
 
     it("sets loading during request", async () => {
       let resolve: (v: SdkResponse<{ token: string; tenant: string }>) => void;
-      mockedRegisterUser.mockReturnValue(new Promise<SdkResponse<{ token: string; tenant: string }>>((r) => { resolve = r; }));
+      mockedRegisterUser.mockReturnValue(
+        new Promise<SdkResponse<{ token: string; tenant: string }>>((r) => {
+          resolve = r;
+        }),
+      );
 
       const promise = useSignUpStore.getState().signUp({
-        name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
+        name: "Test",
+        email: "t@t.com",
+        username: "test",
+        password: "pass1",
+        email_marketing: false,
       });
 
       expect(useSignUpStore.getState().signUpLoading).toBe(true);
@@ -68,10 +67,16 @@ describe("signUpStore", () => {
     });
 
     it("stores token and tenant on success and returns token", async () => {
-      mockedRegisterUser.mockResolvedValue(mockSdkResponse({ token: "jwt-token", tenant: "tenant-abc" }));
+      mockedRegisterUser.mockResolvedValue(
+        mockSdkResponse({ token: "jwt-token", tenant: "tenant-abc" }),
+      );
 
       const result = await useSignUpStore.getState().signUp({
-        name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
+        name: "Test",
+        email: "t@t.com",
+        username: "test",
+        password: "pass1",
+        email_marketing: false,
       });
 
       expect(result).toBe("jwt-token");
@@ -83,7 +88,11 @@ describe("signUpStore", () => {
       mockedRegisterUser.mockResolvedValue(mockSdkResponse({}));
 
       const result = await useSignUpStore.getState().signUp({
-        name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
+        name: "Test",
+        email: "t@t.com",
+        username: "test",
+        password: "pass1",
+        email_marketing: false,
       });
 
       expect(result).toBeNull();
@@ -93,64 +102,104 @@ describe("signUpStore", () => {
 
     it("sets signUpServerFields on a 400 carrying per-field detail and returns null", async () => {
       mockedRegisterUser.mockRejectedValue(
-        createSdkError(400, { message: "user invalid", fields: { username: "required", email: "invalid" } }),
+        createSdkError(400, {
+          message: "user invalid",
+          fields: { username: "required", email: "invalid" },
+        }),
       );
 
       const result = await useSignUpStore.getState().signUp({
-        name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
+        name: "Test",
+        email: "t@t.com",
+        username: "test",
+        password: "pass1",
+        email_marketing: false,
       });
 
       expect(result).toBeNull();
       expect(useSignUpStore.getState().signUpLoading).toBe(false);
-      expect(useSignUpStore.getState().signUpServerFields).toEqual(["username", "email"]);
+      expect(useSignUpStore.getState().signUpServerFields).toEqual([
+        "username",
+        "email",
+      ]);
       expect(useSignUpStore.getState().signUpError).toBeNull();
     });
 
     it("sets signUpServerFields on a 409 carrying per-field detail and returns null", async () => {
       mockedRegisterUser.mockRejectedValue(
-        createSdkError(409, { message: "user duplicated", fields: { username: "duplicated" } }),
+        createSdkError(409, {
+          message: "user duplicated",
+          fields: { username: "duplicated" },
+        }),
       );
 
       const result = await useSignUpStore.getState().signUp({
-        name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
+        name: "Test",
+        email: "t@t.com",
+        username: "test",
+        password: "pass1",
+        email_marketing: false,
       });
 
       expect(result).toBeNull();
-      expect(useSignUpStore.getState().signUpServerFields).toEqual(["username"]);
+      expect(useSignUpStore.getState().signUpServerFields).toEqual([
+        "username",
+      ]);
       expect(useSignUpStore.getState().signUpError).toBeNull();
     });
 
     it("falls through to the status message when the 400 body carries no fields", async () => {
-      mockedRegisterUser.mockRejectedValue(createSdkError(400, { message: "validation error" }));
+      mockedRegisterUser.mockRejectedValue(
+        createSdkError(400, { message: "validation error" }),
+      );
 
       const result = await useSignUpStore.getState().signUp({
-        name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
+        name: "Test",
+        email: "t@t.com",
+        username: "test",
+        password: "pass1",
+        email_marketing: false,
       });
 
       expect(result).toBeNull();
       expect(useSignUpStore.getState().signUpServerFields).toEqual([]);
-      expect(useSignUpStore.getState().signUpError).toBe("Some values are invalid. Review the form and try again.");
+      expect(useSignUpStore.getState().signUpError).toBe(
+        "Some values are invalid. Review the form and try again.",
+      );
     });
 
     it("sets signUpError on non-field errors and returns null", async () => {
       mockedRegisterUser.mockRejectedValue(new Error("network error"));
 
       const result = await useSignUpStore.getState().signUp({
-        name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
+        name: "Test",
+        email: "t@t.com",
+        username: "test",
+        password: "pass1",
+        email_marketing: false,
       });
 
       expect(result).toBeNull();
       expect(useSignUpStore.getState().signUpLoading).toBe(false);
-      expect(useSignUpStore.getState().signUpError).toBe("Something went wrong. Please try again.");
+      expect(useSignUpStore.getState().signUpError).toBe(
+        "Something went wrong. Please try again.",
+      );
       expect(useSignUpStore.getState().signUpServerFields).toEqual([]);
     });
 
     it("clears stale token and tenant at the start of a new attempt", async () => {
-      useSignUpStore.setState({ signUpToken: "old-token", signUpTenant: "old-tenant" });
+      useSignUpStore.setState({
+        signUpToken: "old-token",
+        signUpTenant: "old-tenant",
+      });
       mockedRegisterUser.mockRejectedValue(new Error("network error"));
 
       await useSignUpStore.getState().signUp({
-        name: "Test", email: "t@t.com", username: "test", password: "pass1", email_marketing: false,
+        name: "Test",
+        email: "t@t.com",
+        username: "test",
+        password: "pass1",
+        email_marketing: false,
       });
 
       expect(useSignUpStore.getState().signUpToken).toBeNull();
@@ -200,12 +249,18 @@ describe("signUpStore", () => {
 
       expect(result).toBe(false);
       expect(useSignUpStore.getState().resendLoading).toBe(false);
-      expect(useSignUpStore.getState().resendError).toBe("Failed to resend email. Please try again.");
+      expect(useSignUpStore.getState().resendError).toBe(
+        "Failed to resend email. Please try again.",
+      );
     });
 
     it("sets loading during request", async () => {
       let resolve: (v: SdkResponse) => void;
-      mockedResendEmail.mockReturnValue(new Promise<SdkResponse>((r) => { resolve = r; }));
+      mockedResendEmail.mockReturnValue(
+        new Promise<SdkResponse>((r) => {
+          resolve = r;
+        }),
+      );
 
       const promise = useSignUpStore.getState().resendEmail("testuser");
       expect(useSignUpStore.getState().resendLoading).toBe(true);
@@ -229,7 +284,9 @@ describe("signUpStore", () => {
     it("transitions to failed-token on 400 (expired token)", async () => {
       mockedGetValidateAccount.mockRejectedValue(createSdkError(400));
 
-      await useSignUpStore.getState().validateAccount("t@t.com", "expired-token");
+      await useSignUpStore
+        .getState()
+        .validateAccount("t@t.com", "expired-token");
 
       expect(useSignUpStore.getState().validationStatus).toBe("failed-token");
     });
@@ -245,7 +302,9 @@ describe("signUpStore", () => {
     it("transitions to failed on 404 (user not found)", async () => {
       mockedGetValidateAccount.mockRejectedValue(createSdkError(404));
 
-      await useSignUpStore.getState().validateAccount("t@t.com", "unknown-user");
+      await useSignUpStore
+        .getState()
+        .validateAccount("t@t.com", "unknown-user");
 
       expect(useSignUpStore.getState().validationStatus).toBe("failed");
     });
@@ -264,7 +323,9 @@ describe("signUpStore", () => {
       const controller = new AbortController();
       controller.abort();
 
-      await useSignUpStore.getState().validateAccount("t@t.com", "tok", controller.signal);
+      await useSignUpStore
+        .getState()
+        .validateAccount("t@t.com", "tok", controller.signal);
 
       // Status must stay at "processing" — no terminal state set after an abort.
       expect(useSignUpStore.getState().validationStatus).toBe("processing");
@@ -272,9 +333,15 @@ describe("signUpStore", () => {
 
     it("sets processing during request", async () => {
       let resolve: (v: SdkResponse) => void;
-      mockedGetValidateAccount.mockReturnValue(new Promise<SdkResponse>((r) => { resolve = r; }));
+      mockedGetValidateAccount.mockReturnValue(
+        new Promise<SdkResponse>((r) => {
+          resolve = r;
+        }),
+      );
 
-      const promise = useSignUpStore.getState().validateAccount("t@t.com", "tok");
+      const promise = useSignUpStore
+        .getState()
+        .validateAccount("t@t.com", "tok");
       expect(useSignUpStore.getState().validationStatus).toBe("processing");
 
       resolve!(mockSdkResponse(undefined));

--- a/ui/apps/console/src/tests/LocationProbe.tsx
+++ b/ui/apps/console/src/tests/LocationProbe.tsx
@@ -1,0 +1,11 @@
+import { useLocation } from "react-router-dom";
+
+export function LocationProbe({
+  onLocation,
+}: {
+  onLocation: (search: string) => void;
+}) {
+  const loc = useLocation();
+  onLocation(loc.search);
+  return null;
+}

--- a/ui/apps/console/src/tests/__tests__/sdk.test.ts
+++ b/ui/apps/console/src/tests/__tests__/sdk.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { mockSdkResponse, makeSdkError } from "../sdk";
+
+describe("mockSdkResponse", () => {
+  it("wraps data with request and response", () => {
+    const res = mockSdkResponse({ id: 1 });
+    expect(res.data).toEqual({ id: 1 });
+    expect(res.request).toBeInstanceOf(Request);
+    expect(res.response).toBeInstanceOf(Response);
+  });
+
+  it("forwards headers to the response", () => {
+    const res = mockSdkResponse("ok", { "X-Total-Count": "42" });
+    expect(res.response.headers.get("X-Total-Count")).toBe("42");
+  });
+});
+
+describe("makeSdkError", () => {
+  it("returns an Error with status and headers", () => {
+    const err = makeSdkError(409);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(409);
+    expect(err.headers).toBeInstanceOf(Headers);
+  });
+
+  it("forwards headers", () => {
+    const err = makeSdkError(429, { "Retry-After": "60" });
+    expect(err.headers.get("Retry-After")).toBe("60");
+  });
+});

--- a/ui/apps/console/src/tests/__tests__/wrapper.test.tsx
+++ b/ui/apps/console/src/tests/__tests__/wrapper.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, render } from "@testing-library/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useLocation } from "react-router-dom";
+import { createTestWrapper, renderHookWithClient } from "../wrapper";
+
+describe("createTestWrapper", () => {
+  it("provides a QueryClient to children", () => {
+    const Wrapper = createTestWrapper();
+    const { result } = renderHook(() => useQueryClient(), { wrapper: Wrapper });
+    expect(result.current).toBeDefined();
+  });
+
+  it("provides a MemoryRouter when initialEntries is set", () => {
+    let pathname = "";
+    function Probe() {
+      pathname = useLocation().pathname;
+      return null;
+    }
+
+    const Wrapper = createTestWrapper({ initialEntries: ["/devices"] });
+    render(<Probe />, { wrapper: Wrapper });
+    expect(pathname).toBe("/devices");
+  });
+});
+
+describe("renderHookWithClient", () => {
+  it("provides a QueryClient without needing an explicit wrapper", () => {
+    const { result } = renderHookWithClient(() => useQueryClient());
+    expect(result.current).toBeDefined();
+  });
+});

--- a/ui/apps/console/src/tests/renderHookWithRouter.tsx
+++ b/ui/apps/console/src/tests/renderHookWithRouter.tsx
@@ -1,7 +1,5 @@
-import { type ReactNode } from "react";
 import { renderHook, type RenderHookOptions } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createTestWrapper } from "./wrapper";
 
 interface RenderHookWithRouterOptions
   extends Omit<RenderHookOptions<unknown>, "wrapper"> {
@@ -12,17 +10,8 @@ export function renderHookWithRouter<Result>(
   hook: () => Result,
   { initialEntries, ...rest }: RenderHookWithRouterOptions = {},
 ) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+  return renderHook(hook, {
+    wrapper: createTestWrapper({ initialEntries: initialEntries ?? ["/"] }),
+    ...rest,
   });
-
-  function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
-      </QueryClientProvider>
-    );
-  }
-
-  return renderHook(hook, { wrapper: Wrapper, ...rest });
 }

--- a/ui/apps/console/src/tests/sdk.ts
+++ b/ui/apps/console/src/tests/sdk.ts
@@ -1,0 +1,28 @@
+import type { SdkHttpError } from "@/api/errors";
+
+export type SdkResponse<T = unknown> = {
+  data: T;
+  request: Request;
+  response: Response;
+};
+
+export function mockSdkResponse<T>(
+  data: T,
+  headers?: HeadersInit,
+): SdkResponse<T> {
+  return {
+    data,
+    request: new Request("http://localhost"),
+    response: new Response(null, headers ? { headers } : undefined),
+  };
+}
+
+export function makeSdkError(
+  status: number,
+  headers?: HeadersInit,
+): SdkHttpError {
+  return Object.assign(new Error("Request failed"), {
+    status,
+    headers: new Headers(headers),
+  });
+}

--- a/ui/apps/console/src/tests/userAuth.ts
+++ b/ui/apps/console/src/tests/userAuth.ts
@@ -1,0 +1,19 @@
+import type { UserAuth } from "@/client";
+
+export function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
+  return {
+    token: "jwt-token",
+    id: "user-123",
+    origin: "local",
+    user: "admin",
+    name: "Admin User",
+    email: "admin@test.com",
+    recovery_email: "recovery@test.com",
+    tenant: "tenant-456",
+    role: "owner",
+    mfa: false,
+    admin: false,
+    max_namespaces: -1,
+    ...overrides,
+  };
+}

--- a/ui/apps/console/src/tests/wrapper.tsx
+++ b/ui/apps/console/src/tests/wrapper.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { renderHook, type RenderHookOptions } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, retryDelay: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+export function createTestWrapper(opts?: {
+  queryClient?: QueryClient;
+  initialEntries?: string[];
+}) {
+  const qc = opts?.queryClient ?? createTestQueryClient();
+
+  return function TestWrapper({ children }: { children: ReactNode }) {
+    const content = (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+    if (opts?.initialEntries) {
+      return (
+        <MemoryRouter initialEntries={opts.initialEntries}>
+          {content}
+        </MemoryRouter>
+      );
+    }
+    return content;
+  };
+}
+
+export function renderHookWithClient<Result>(
+  hook: () => Result,
+  opts?: Omit<RenderHookOptions<unknown>, "wrapper">,
+) {
+  return renderHook(hook, { wrapper: createTestWrapper(), ...opts });
+}


### PR DESCRIPTION
## What

Shared test utilities in `src/tests/` replace duplicated boilerplate scattered across ~50 console test files, cutting ~500 net lines.

## Why

The console test suite had identical helper definitions copied across dozens of files — `createWrapper`/`createQueryWrapper` (30 copies with config drift), `mockSdkResponse` (15 copies), `makeSdkError` (5 copies), `LocationProbe` (3 copies), and `mockUserAuth` (3 copies). Each copy was slightly different (4 distinct `QueryClient` configs, varying error shapes), making it hard to know which was correct and easy to introduce subtle test bugs.

Partial work toward shellhub-io/team#216

## Changes

- **`src/tests/wrapper.tsx`**: `createTestWrapper()` — composable wrapper factory accepting optional `queryClient` and `initialEntries` (for `MemoryRouter`). `renderHookWithClient()` — convenience for hook tests. Superset `QueryClient` config (`retry: false`, `gcTime: 0`) eliminates config drift across the 4 variants that existed before.
- **`src/tests/sdk.ts`**: `mockSdkResponse<T>()` with optional `headers` parameter (superset of the simple and with-headers variants), `makeSdkError()` that properly creates an `Error` with `status` and `headers` (some local copies only had `{ status }` without `Error` or `Headers`), and the `SdkResponse` type alias.
- **`src/tests/LocationProbe.tsx`**: callback-style `LocationProbe` component for URL assertion in routing tests (3 duplicates replaced; the single-use DOM variant in `CommandPalette.test.tsx` was intentionally left local).
- **`src/tests/userAuth.ts`**: `mockUserAuth()` factory for `UserAuth` fixtures (3 duplicates replaced).
- **`src/tests/renderHookWithRouter.tsx`**: refactored to delegate to `createTestWrapper` instead of duplicating the `QueryClient` + `MemoryRouter` setup.

## Testing

`npm run --workspace apps/console test` — all 211 test files pass. The shared helpers themselves have unit tests in `src/tests/__tests__/`.