### PR TITLE
refactor(ui): standardize generated client imports to use barrel

### DIFF
--- a/ui/apps/console/openapi-ts.config.ts
+++ b/ui/apps/console/openapi-ts.config.ts
@@ -6,7 +6,9 @@ if (!input) {
   // generating from its URL produces a client missing the other editions'
   // schemas. Use `npm run generate -w @shellhub/console`, which bundles the
   // combined spec before invoking openapi-ts.
-  throw new Error("OPENAPI_SPEC_PATH is not set; run `npm run generate -w @shellhub/console`.");
+  throw new Error(
+    "OPENAPI_SPEC_PATH is not set; run `npm run generate -w @shellhub/console`.",
+  );
 }
 
 export default defineConfig({
@@ -23,6 +25,7 @@ export default defineConfig({
       name: "@tanstack/react-query",
       queryOptions: true,
       mutationOptions: true,
+      includeInEntry: true,
     },
   ],
 });

--- a/ui/apps/console/src/components/ConnectDrawer.tsx
+++ b/ui/apps/console/src/components/ConnectDrawer.tsx
@@ -25,7 +25,7 @@ import {
 import { BROWSER_KEY_QUERY_KEY } from "@/hooks/useBrowserKey";
 import { isRecordingSupported } from "../utils/recordings";
 import { isAlreadyEnrolled } from "../utils/sshIdentity";
-import { listSshIdentitiesOptions } from "../client/@tanstack/react-query.gen";
+import { listSshIdentitiesOptions } from "../client";
 import BrowserEnrollDialog from "./terminal/BrowserEnrollDialog";
 import CopyButton from "./common/CopyButton";
 import Drawer from "./common/Drawer";

--- a/ui/apps/console/src/components/billing/BillingSection.tsx
+++ b/ui/apps/console/src/components/billing/BillingSection.tsx
@@ -14,7 +14,7 @@ import { useNamespace } from "@/hooks/useNamespaces";
 import { useOpenBillingPortal, useSubscription } from "@/hooks/useBilling";
 import { useInvalidateByIds } from "@/hooks/useInvalidateQueries";
 import { formatExpiry } from "@/utils/date";
-import type { BillingStatus } from "@/client/types.gen";
+import type { BillingStatus } from "@/client";
 import { cn } from "@shellhub/design-system/cn";
 import { Button } from "@shellhub/design-system/primitives";
 
@@ -157,7 +157,10 @@ function SectionRow({
 function StatusBadge({ status }: { status: BillingStatus }) {
   return (
     <span
-      className={cn("inline-flex items-center px-2.5 py-1 text-2xs font-mono font-semibold rounded border", STATUS_CHIP[status])}
+      className={cn(
+        "inline-flex items-center px-2.5 py-1 text-2xs font-mono font-semibold rounded border",
+        STATUS_CHIP[status],
+      )}
     >
       {STATUS_LABEL[status]}
     </span>
@@ -277,7 +280,10 @@ export default function BillingSection({ sectionId }: BillingSectionProps) {
           <div
             role="status"
             aria-live="polite"
-            className={cn("flex items-start gap-3 px-5 py-3 border-b", BANNER_CLASSES[banner.tone])}
+            className={cn(
+              "flex items-start gap-3 px-5 py-3 border-b",
+              BANNER_CLASSES[banner.tone],
+            )}
           >
             <banner.Icon
               aria-hidden="true"

--- a/ui/apps/console/src/components/common/__tests__/DeviceLimitBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/DeviceLimitBanner.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { createTestWrapper } from "@/tests/wrapper";
-import type { GetLicenseResponse } from "@/client/types.gen";
+import type { GetLicenseResponse } from "@/client";
 import { defaultConfig } from "@/env";
 import { useAuthStore } from "@/stores/authStore";
 
@@ -16,9 +16,6 @@ vi.mock("@/hooks/useAdminStats", () => ({
 }));
 vi.mock("@/client", () => ({
   getLicense: vi.fn(),
-}));
-
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getLicenseQueryKey: vi.fn(() => ["getLicense"]),
 }));
 

--- a/ui/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/LicenseBanner.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { createTestWrapper } from "@/tests/wrapper";
-import type { GetLicenseResponse } from "@/client/types.gen";
+import type { GetLicenseResponse } from "@/client";
 import { defaultConfig } from "@/env";
 import { useAuthStore } from "@/stores/authStore";
 
@@ -12,9 +12,6 @@ vi.mock("@/hooks/useAdminLicense", () => ({
 }));
 vi.mock("@/client", () => ({
   getLicense: vi.fn(),
-}));
-
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getLicenseQueryKey: vi.fn(() => ["getLicense"]),
 }));
 

--- a/ui/apps/console/src/components/common/__tests__/LicenseGuard.test.tsx
+++ b/ui/apps/console/src/components/common/__tests__/LicenseGuard.test.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { createTestWrapper } from "@/tests/wrapper";
 import { defaultConfig } from "@/env";
 import { useAuthStore } from "@/stores/authStore";
-import type { GetLicenseResponse } from "@/client/types.gen";
+import type { GetLicenseResponse } from "@/client";
 
 // ── Dependency mocks ──────────────────────────────────────────────────────────
 
@@ -14,9 +14,6 @@ vi.mock("@/hooks/useAdminLicense", () => ({
 }));
 vi.mock("@/client", () => ({
   getLicense: vi.fn(),
-}));
-
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getLicenseQueryKey: vi.fn(() => ["getLicense"]),
 }));
 

--- a/ui/apps/console/src/hooks/__tests__/useAdminFirewallRules.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminFirewallRules.test.ts
@@ -11,9 +11,6 @@ import { renderHookWithClient } from "@/tests/wrapper";
 vi.mock("@/client", () => ({
   getFirewallRulesAdmin: vi.fn(),
   getFirewallRuleAdmin: vi.fn(),
-}));
-
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getFirewallRulesAdminQueryKey: vi.fn((opts: unknown) => [
     { _id: "getFirewallRulesAdmin" },
     opts,

--- a/ui/apps/console/src/hooks/__tests__/useAdminLicense.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminLicense.test.ts
@@ -7,9 +7,6 @@ import { useAuthStore } from "@/stores/authStore";
 // ── Dependency mocks ──────────────────────────────────────────────────────────
 vi.mock("@/client", () => ({
   getLicense: vi.fn(),
-}));
-
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getLicenseQueryKey: vi.fn(() => ["getLicense"]),
 }));
 

--- a/ui/apps/console/src/hooks/__tests__/useAdminSessions.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminSessions.test.ts
@@ -10,12 +10,9 @@ vi.mock("@/api/pagination", () => ({
   paginatedQueryFn: vi.fn(),
 }));
 
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
-  getSessionsAdminQueryKey: vi.fn(() => ["sessions-admin"]),
-}));
-
 vi.mock("@/client", () => ({
   getSessionsAdmin: vi.fn(),
+  getSessionsAdminQueryKey: vi.fn(() => ["sessions-admin"]),
 }));
 
 import { useAuthStore } from "@/stores/authStore";

--- a/ui/apps/console/src/hooks/__tests__/useAdminUserMutations.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminUserMutations.test.ts
@@ -14,7 +14,7 @@ const mockDeleteFn = vi.fn();
 const mockResetPasswordFn = vi.fn();
 const mockInvalidate = vi.fn();
 
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client", () => ({
   createUserAdminMutation: vi.fn(() => ({ mutationFn: mockCreateFn })),
   adminUpdateUserMutation: vi.fn(() => ({ mutationFn: mockUpdateFn })),
   adminDeleteUserMutation: vi.fn(() => ({ mutationFn: mockDeleteFn })),

--- a/ui/apps/console/src/hooks/__tests__/useAdminUsers.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useAdminUsers.test.ts
@@ -9,9 +9,6 @@ import { useAuthStore } from "@/stores/authStore";
 vi.mock("@/client", () => ({
   getUsers: vi.fn(),
   getUser: vi.fn(),
-}));
-
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getUsersQueryKey: vi.fn((opts: unknown) => [{ _id: "getUsers" }, opts]),
   getUserOptions: vi.fn((opts: unknown) => ({
     queryKey: [{ _id: "getUser" }, opts],

--- a/ui/apps/console/src/hooks/__tests__/useBilling.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useBilling.test.ts
@@ -12,7 +12,7 @@ const mockGetSubscriptionFn = vi.fn();
 const mockInvalidate = vi.fn();
 const mockCreateBillingPortalSession = vi.fn();
 
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client", () => ({
   getCustomerOptions: vi.fn(() => ({
     queryKey: [{ _id: "getCustomer" }],
     queryFn: mockGetCustomerFn,
@@ -30,14 +30,11 @@ vi.mock("@/client/@tanstack/react-query.gen", () => ({
   setDefaultPaymentMethodMutation: vi.fn(() => ({
     mutationFn: mockSetDefault,
   })),
+  createBillingPortalSession: (): unknown => mockCreateBillingPortalSession(),
 }));
 
 vi.mock("../useInvalidateQueries", () => ({
   useInvalidateByIds: vi.fn(() => mockInvalidate),
-}));
-
-vi.mock("@/client", () => ({
-  createBillingPortalSession: (): unknown => mockCreateBillingPortalSession(),
 }));
 
 async function importHooks() {

--- a/ui/apps/console/src/hooks/__tests__/useDeviceChooser.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useDeviceChooser.test.ts
@@ -8,7 +8,7 @@ const mockMostUsedQueryFn = vi.fn();
 const mockChoiceMutationFn = vi.fn();
 const mockInvalidate = vi.fn();
 
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client", () => ({
   getDevicesMostUsedOptions: vi.fn(() => ({
     queryKey: [{ _id: "getDevicesMostUsed" }],
     queryFn: mockMostUsedQueryFn,

--- a/ui/apps/console/src/hooks/__tests__/useInvitationMutations.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useInvitationMutations.test.ts
@@ -12,7 +12,7 @@ const mockGenerateLinkFn = vi.fn();
 const mockCancelFn = vi.fn();
 const mockInvalidate = vi.fn();
 
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client", () => ({
   acceptInviteMutation: vi.fn(() => ({ mutationFn: mockAcceptFn })),
   generateInvitationLinkMutation: vi.fn(() => ({
     mutationFn: mockGenerateLinkFn,

--- a/ui/apps/console/src/hooks/__tests__/useInvitations.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useInvitations.test.ts
@@ -7,14 +7,11 @@ import {
 } from "../useInvitations";
 import type { MembershipInvitation } from "@/client";
 
+const mockResolveFn = vi.fn();
+
 vi.mock("@/client", () => ({
   getMembershipInvitationList: vi.fn(),
   getNamespaceMembershipInvitationList: vi.fn(),
-}));
-
-const mockResolveFn = vi.fn();
-
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getMembershipInvitationListQueryKey: vi.fn((opts: unknown) => [
     { _id: "getMembershipInvitationList" },
     opts,
@@ -66,8 +63,8 @@ describe("useNamespaceInvitations", () => {
       const inv = makeInvitation({ status: "pending" });
       mockFetchFn.mockResolvedValue({ data: [inv], totalCount: 1 });
 
-      const { result } = renderHookWithClient(
-        () => useNamespaceInvitations({ tenantId: "t1" }),
+      const { result } = renderHookWithClient(() =>
+        useNamespaceInvitations({ tenantId: "t1" }),
       );
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -77,8 +74,8 @@ describe("useNamespaceInvitations", () => {
     it("returns totalCount from the paginated result", async () => {
       mockFetchFn.mockResolvedValue({ data: [], totalCount: 7 });
 
-      const { result } = renderHookWithClient(
-        () => useNamespaceInvitations({ tenantId: "t1" }),
+      const { result } = renderHookWithClient(() =>
+        useNamespaceInvitations({ tenantId: "t1" }),
       );
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -88,8 +85,8 @@ describe("useNamespaceInvitations", () => {
     it("defaults invitations to empty array while loading", () => {
       mockFetchFn.mockReturnValue(new Promise(() => {}));
 
-      const { result } = renderHookWithClient(
-        () => useNamespaceInvitations({ tenantId: "t1" }),
+      const { result } = renderHookWithClient(() =>
+        useNamespaceInvitations({ tenantId: "t1" }),
       );
 
       expect(result.current.invitations).toEqual([]);
@@ -99,8 +96,8 @@ describe("useNamespaceInvitations", () => {
       const err = new Error("fetch failed");
       mockFetchFn.mockRejectedValue(err);
 
-      const { result } = renderHookWithClient(
-        () => useNamespaceInvitations({ tenantId: "t1" }),
+      const { result } = renderHookWithClient(() =>
+        useNamespaceInvitations({ tenantId: "t1" }),
       );
 
       await waitFor(() => expect(result.current.error).toBeTruthy());
@@ -112,8 +109,8 @@ describe("useNamespaceInvitations", () => {
     it("does not fetch when enabled is false", () => {
       mockFetchFn.mockResolvedValue({ data: [], totalCount: 0 });
 
-      renderHookWithClient(
-        () => useNamespaceInvitations({ tenantId: "t1", enabled: false }),
+      renderHookWithClient(() =>
+        useNamespaceInvitations({ tenantId: "t1", enabled: false }),
       );
 
       expect(mockFetchFn).not.toHaveBeenCalled();

--- a/ui/apps/console/src/hooks/__tests__/useLatestAnnouncement.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useLatestAnnouncement.test.ts
@@ -5,16 +5,13 @@ import { useLatestAnnouncement } from "../useLatestAnnouncement";
 import type { Announcement } from "@/client";
 
 // Mock the generated query-option factories so we control what queryFn runs
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client", () => ({
   listAnnouncementsOptions: vi.fn(),
   getAnnouncementOptions: vi.fn(),
 }));
 
 import { getConfig, defaultConfig } from "@/env";
-import {
-  listAnnouncementsOptions,
-  getAnnouncementOptions,
-} from "@/client/@tanstack/react-query.gen";
+import { listAnnouncementsOptions, getAnnouncementOptions } from "@/client";
 
 const mockGetConfig = vi.mocked(getConfig);
 const mockListAnnouncementsOptions = vi.mocked(listAnnouncementsOptions);

--- a/ui/apps/console/src/hooks/__tests__/usePublicKeys.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/usePublicKeys.test.ts
@@ -6,9 +6,6 @@ import type { PublicKeyResponse } from "@/client";
 
 vi.mock("@/client", () => ({
   getPublicKeys: vi.fn(),
-}));
-
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
   getPublicKeysQueryKey: vi.fn((opts: unknown) => [
     { _id: "getPublicKeys" },
     opts,

--- a/ui/apps/console/src/hooks/__tests__/useSupportIdentifier.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useSupportIdentifier.test.ts
@@ -4,7 +4,7 @@ import { renderHookWithClient } from "@/tests/wrapper";
 
 const mockGetNamespaceSupportFn = vi.fn();
 
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client", () => ({
   getNamespaceSupportOptions: vi.fn(() => ({
     queryKey: [{ _id: "getNamespaceSupport" }],
     queryFn: mockGetNamespaceSupportFn,
@@ -69,8 +69,8 @@ describe("useSupportIdentifier", () => {
       mockGetNamespaceSupportFn.mockResolvedValue({ identifier: "abc123" });
       const { useSupportIdentifier } = await importHook();
 
-      const { result } = renderHookWithClient(
-        () => useSupportIdentifier("tenant-123", true),
+      const { result } = renderHookWithClient(() =>
+        useSupportIdentifier("tenant-123", true),
       );
 
       await waitFor(() => expect(result.current.identifier).toBe("abc123"));
@@ -84,8 +84,8 @@ describe("useSupportIdentifier", () => {
       mockGetNamespaceSupportFn.mockRejectedValue(new Error("network error"));
       const { useSupportIdentifier } = await importHook();
 
-      const { result } = renderHookWithClient(
-        () => useSupportIdentifier("tenant-123", true),
+      const { result } = renderHookWithClient(() =>
+        useSupportIdentifier("tenant-123", true),
       );
 
       await waitFor(() => expect(result.current.isError).toBe(true));

--- a/ui/apps/console/src/hooks/__tests__/useUploadLicense.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useUploadLicense.test.ts
@@ -6,7 +6,7 @@ import { useUploadLicense } from "../useUploadLicense";
 const mockMutationFn = vi.fn();
 const mockInvalidate = vi.fn();
 
-vi.mock("@/client/@tanstack/react-query.gen", () => ({
+vi.mock("@/client", () => ({
   sendLicenseMutation: vi.fn(() => ({ mutationFn: mockMutationFn })),
 }));
 

--- a/ui/apps/console/src/hooks/useAccessPolicies.ts
+++ b/ui/apps/console/src/hooks/useAccessPolicies.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { listAccessPoliciesOptions } from "../client/@tanstack/react-query.gen";
-import type { AccessPolicy } from "../client";
+import { listAccessPoliciesOptions, type AccessPolicy } from "../client";
 
 export function useAccessPolicies() {
   const result = useQuery(listAccessPoliciesOptions());

--- a/ui/apps/console/src/hooks/useAccessPolicyMutations.ts
+++ b/ui/apps/console/src/hooks/useAccessPolicyMutations.ts
@@ -3,7 +3,7 @@ import {
   createAccessPolicyMutation,
   updateAccessPolicyMutation,
   deleteAccessPolicyMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreateAccessPolicy() {

--- a/ui/apps/console/src/hooks/useAdminAccountRequestMutations.ts
+++ b/ui/apps/console/src/hooks/useAdminAccountRequestMutations.ts
@@ -1,8 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import {
-  approveUserMutation,
-  adminDeleteUserMutation,
-} from "../client/@tanstack/react-query.gen";
+import { approveUserMutation, adminDeleteUserMutation } from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 // Approving clears the awaiting_approval flag; the account stays not-confirmed until the

--- a/ui/apps/console/src/hooks/useAdminAccountRequests.ts
+++ b/ui/apps/console/src/hooks/useAdminAccountRequests.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   getUsers as getUsersSdk,
+  getUsersQueryKey,
   type GetUsersData,
   type UserAdminResponse,
 } from "../client";
-import { getUsersQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";

--- a/ui/apps/console/src/hooks/useAdminAnnouncementMutations.ts
+++ b/ui/apps/console/src/hooks/useAdminAnnouncementMutations.ts
@@ -3,7 +3,7 @@ import {
   createAnnouncementMutation,
   updateAnnouncementMutation,
   deleteAnnouncementMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useAdminCreateAnnouncement() {

--- a/ui/apps/console/src/hooks/useAdminAnnouncements.ts
+++ b/ui/apps/console/src/hooks/useAdminAnnouncements.ts
@@ -1,13 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   listAnnouncementsAdmin as listAnnouncementsAdminSdk,
+  listAnnouncementsAdminQueryKey,
+  getAnnouncementAdminOptions,
   type ListAnnouncementsAdminData,
   type AnnouncementShort,
 } from "../client";
-import {
-  listAnnouncementsAdminQueryKey,
-  getAnnouncementAdminOptions,
-} from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";

--- a/ui/apps/console/src/hooks/useAdminDevices.ts
+++ b/ui/apps/console/src/hooks/useAdminDevices.ts
@@ -2,14 +2,12 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   getDevicesAdmin,
+  getDevicesAdminQueryKey,
+  getDeviceAdminOptions,
   type GetDevicesAdminData,
   type Device,
   type DeviceStatus,
 } from "../client";
-import {
-  getDevicesAdminQueryKey,
-  getDeviceAdminOptions,
-} from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";

--- a/ui/apps/console/src/hooks/useAdminFirewallRules.ts
+++ b/ui/apps/console/src/hooks/useAdminFirewallRules.ts
@@ -2,13 +2,11 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   getFirewallRulesAdmin,
+  getFirewallRulesAdminQueryKey,
+  getFirewallRuleAdminOptions,
   type GetFirewallRulesAdminData,
   type FirewallRulesResponse,
 } from "../client";
-import {
-  getFirewallRulesAdminQueryKey,
-  getFirewallRuleAdminOptions,
-} from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";

--- a/ui/apps/console/src/hooks/useAdminLicense.ts
+++ b/ui/apps/console/src/hooks/useAdminLicense.ts
@@ -1,10 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import { getLicenseQueryKey } from "../client/@tanstack/react-query.gen";
-import { getLicense } from "../client";
+import {
+  getLicense,
+  getLicenseQueryKey,
+  type GetLicenseResponse,
+} from "../client";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
 import { isCloud } from "../env";
-import type { GetLicenseResponse } from "../client/types.gen";
 
 export { getLicenseQueryKey };
 

--- a/ui/apps/console/src/hooks/useAdminNamespaceMutations.ts
+++ b/ui/apps/console/src/hooks/useAdminNamespaceMutations.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import {
   editNamespaceAdminMutation,
   deleteNamespaceAdminMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useAdminEditNamespace() {

--- a/ui/apps/console/src/hooks/useAdminNamespaces.ts
+++ b/ui/apps/console/src/hooks/useAdminNamespaces.ts
@@ -1,13 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   getNamespacesAdmin as getNamespacesAdminSdk,
+  getNamespacesAdminQueryKey,
+  getNamespaceAdminOptions,
   type GetNamespacesAdminData,
   type Namespace,
 } from "../client";
-import {
-  getNamespacesAdminQueryKey,
-  getNamespaceAdminOptions,
-} from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";

--- a/ui/apps/console/src/hooks/useAdminSessionDetail.ts
+++ b/ui/apps/console/src/hooks/useAdminSessionDetail.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getSessionAdminOptions } from "../client/@tanstack/react-query.gen";
+import { getSessionAdminOptions } from "../client";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
 

--- a/ui/apps/console/src/hooks/useAdminSessions.ts
+++ b/ui/apps/console/src/hooks/useAdminSessions.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   getSessionsAdmin,
+  getSessionsAdminQueryKey,
   type GetSessionsAdminData,
   type Session,
 } from "@/client";
-import { getSessionsAdminQueryKey } from "@/client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "@/api/pagination";
 import { useAuthStore } from "@/stores/authStore";
 import { isSdkError } from "@/api/errors";

--- a/ui/apps/console/src/hooks/useAdminStats.ts
+++ b/ui/apps/console/src/hooks/useAdminStats.ts
@@ -1,8 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import {
-  getStatsOptions,
-  getStatsQueryKey,
-} from "../client/@tanstack/react-query.gen";
+import { getStatsOptions, getStatsQueryKey } from "../client";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";
 

--- a/ui/apps/console/src/hooks/useAdminUserMutations.ts
+++ b/ui/apps/console/src/hooks/useAdminUserMutations.ts
@@ -4,7 +4,7 @@ import {
   adminUpdateUserMutation,
   adminDeleteUserMutation,
   adminResetUserPasswordMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreateUser() {

--- a/ui/apps/console/src/hooks/useAdminUsers.ts
+++ b/ui/apps/console/src/hooks/useAdminUsers.ts
@@ -1,13 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   getUsers as getUsersSdk,
+  getUsersQueryKey,
+  getUserOptions,
   type GetUsersData,
   type UserAdminResponse,
 } from "../client";
-import {
-  getUsersQueryKey,
-  getUserOptions,
-} from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { useAuthStore } from "../stores/authStore";
 import { isSdkError } from "../api/errors";

--- a/ui/apps/console/src/hooks/useApiKeyMutations.ts
+++ b/ui/apps/console/src/hooks/useApiKeyMutations.ts
@@ -3,7 +3,7 @@ import {
   apiKeyCreateMutation,
   apiKeyUpdateMutation,
   apiKeyDeleteMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreateApiKey() {

--- a/ui/apps/console/src/hooks/useApiKeys.ts
+++ b/ui/apps/console/src/hooks/useApiKeys.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   apiKeyList,
+  apiKeyListQueryKey,
   type ApiKeyListData,
   type ApiKey,
 } from "../client";
-import { apiKeyListQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 
 interface UseApiKeysParams {

--- a/ui/apps/console/src/hooks/useBilling.ts
+++ b/ui/apps/console/src/hooks/useBilling.ts
@@ -7,8 +7,8 @@ import {
   attachPaymentMethodMutation,
   detachPaymentMethodMutation,
   setDefaultPaymentMethodMutation,
-} from "../client/@tanstack/react-query.gen";
-import { createBillingPortalSession } from "@/client";
+  createBillingPortalSession,
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 function useInvalidateBilling() {

--- a/ui/apps/console/src/hooks/useContainer.ts
+++ b/ui/apps/console/src/hooks/useContainer.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getContainerOptions } from "../client/@tanstack/react-query.gen";
+import { getContainerOptions } from "../client";
 
 export function useContainer(uid: string) {
   const result = useQuery({

--- a/ui/apps/console/src/hooks/useContainerMutations.ts
+++ b/ui/apps/console/src/hooks/useContainerMutations.ts
@@ -4,8 +4,10 @@ import {
   deleteContainerMutation,
   updateContainerMutation,
   updateContainerStatusMutation,
-} from "../client/@tanstack/react-query.gen";
-import { createTag, pushTagToContainer, pullTagFromContainer } from "../client";
+  createTag,
+  pushTagToContainer,
+  pullTagFromContainer,
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useUpdateContainerStatus() {

--- a/ui/apps/console/src/hooks/useContainers.ts
+++ b/ui/apps/console/src/hooks/useContainers.ts
@@ -2,10 +2,11 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   getContainers as getContainersSdk,
+  getContainersQueryKey,
   type GetContainersData,
+  type Device,
+  type DeviceStatus,
 } from "../client";
-import type { Device, DeviceStatus } from "../client";
-import { getContainersQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { toBase64Json } from "@/utils/encoding";
 import { normalizeDeviceTags } from "@/utils/deviceTags";

--- a/ui/apps/console/src/hooks/useDevice.ts
+++ b/ui/apps/console/src/hooks/useDevice.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getDeviceOptions } from "../client/@tanstack/react-query.gen";
+import { getDeviceOptions } from "../client";
 
 export function useDevice(uid: string) {
   const result = useQuery({

--- a/ui/apps/console/src/hooks/useDeviceChooser.ts
+++ b/ui/apps/console/src/hooks/useDeviceChooser.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   choiceDevicesMutation,
   getDevicesMostUsedOptions,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 import { normalizeDeviceTags, type TaggedDevice } from "@/utils/deviceTags";
 

--- a/ui/apps/console/src/hooks/useDeviceCode.ts
+++ b/ui/apps/console/src/hooks/useDeviceCode.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import {
   resolveDeviceLoginCodeOptions,
   acceptDevicePairingMutation,
-} from "@/client/@tanstack/react-query.gen";
+} from "@/client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useResolveDeviceCode(code: string) {

--- a/ui/apps/console/src/hooks/useDeviceMutations.ts
+++ b/ui/apps/console/src/hooks/useDeviceMutations.ts
@@ -8,8 +8,9 @@ import {
   pullTagFromDeviceMutation,
   setDeviceCustomFieldMutation,
   deleteDeviceCustomFieldMutation,
-} from "../client/@tanstack/react-query.gen";
-import { createTag, pushTagToDevice } from "../client";
+  createTag,
+  pushTagToDevice,
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useAcceptDevice() {

--- a/ui/apps/console/src/hooks/useDevices.ts
+++ b/ui/apps/console/src/hooks/useDevices.ts
@@ -2,12 +2,12 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   getDevices as getDevicesSdk,
+  getDevicesQueryKey,
   type GetDevicesData,
   type DeviceStatus,
+  type Device as GeneratedDevice,
 } from "../client";
-import { getDevicesQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
-import type { Device as GeneratedDevice } from "../client";
 import { toBase64Json } from "@/utils/encoding";
 import { normalizeDeviceTags } from "@/utils/deviceTags";
 

--- a/ui/apps/console/src/hooks/useFirewallRuleMutations.ts
+++ b/ui/apps/console/src/hooks/useFirewallRuleMutations.ts
@@ -3,7 +3,7 @@ import {
   createFirewallRuleMutation,
   updateFirewallRuleMutation,
   deleteFirewallRuleMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreateFirewallRule() {

--- a/ui/apps/console/src/hooks/useFirewallRules.ts
+++ b/ui/apps/console/src/hooks/useFirewallRules.ts
@@ -2,10 +2,10 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   getFirewallRules as getFirewallRulesSdk,
+  getFirewallRulesQueryKey,
   type GetFirewallRulesData,
   type FirewallRulesResponse,
 } from "../client";
-import { getFirewallRulesQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 
 interface UseFirewallRulesParams {

--- a/ui/apps/console/src/hooks/useInstallKeyEvents.ts
+++ b/ui/apps/console/src/hooks/useInstallKeyEvents.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   installKeyHistory,
+  installKeyHistoryQueryKey,
   type InstallKeyHistoryData,
   type InstallKeyEvent,
 } from "../client";
-import { installKeyHistoryQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 
 interface UseInstallKeyEventsParams {

--- a/ui/apps/console/src/hooks/useInstallKeyMutations.ts
+++ b/ui/apps/console/src/hooks/useInstallKeyMutations.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import {
   installKeyCreateMutation,
   installKeyUpdateMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreateInstallKey() {

--- a/ui/apps/console/src/hooks/useInstallKeys.ts
+++ b/ui/apps/console/src/hooks/useInstallKeys.ts
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { installKeyList, type InstallKeyListData, type InstallKey } from "../client";
-import { installKeyListQueryKey } from "../client/@tanstack/react-query.gen";
+import {
+  installKeyList,
+  installKeyListQueryKey,
+  type InstallKeyListData,
+  type InstallKey,
+} from "../client";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 
 interface UseInstallKeysParams {

--- a/ui/apps/console/src/hooks/useInvitationMutations.ts
+++ b/ui/apps/console/src/hooks/useInvitationMutations.ts
@@ -3,7 +3,7 @@ import {
   acceptInviteMutation,
   generateInvitationLinkMutation,
   cancelMembershipInvitationMutation,
-} from "@/client/@tanstack/react-query.gen";
+} from "@/client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useAcceptInvite() {

--- a/ui/apps/console/src/hooks/useInvitations.ts
+++ b/ui/apps/console/src/hooks/useInvitations.ts
@@ -1,13 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   getNamespaceMembershipInvitationList,
+  getNamespaceMembershipInvitationListQueryKey,
+  resolveInvitationOptions,
   type GetNamespaceMembershipInvitationListData,
   type MembershipInvitation,
 } from "@/client";
-import {
-  getNamespaceMembershipInvitationListQueryKey,
-  resolveInvitationOptions,
-} from "@/client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "@/api/pagination";
 import {
   invitationStatusFilter,

--- a/ui/apps/console/src/hooks/useLatestAnnouncement.ts
+++ b/ui/apps/console/src/hooks/useLatestAnnouncement.ts
@@ -3,7 +3,7 @@ import { getConfig } from "@/env";
 import {
   listAnnouncementsOptions,
   getAnnouncementOptions,
-} from "@/client/@tanstack/react-query.gen";
+} from "@/client";
 
 export function useLatestAnnouncement() {
   const enabled = getConfig().announcements;

--- a/ui/apps/console/src/hooks/useMemberMutations.ts
+++ b/ui/apps/console/src/hooks/useMemberMutations.ts
@@ -4,7 +4,7 @@ import {
   approveUserMutation,
   removeNamespaceMemberMutation,
   updateNamespaceMemberMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useAddMember() {

--- a/ui/apps/console/src/hooks/useNamespaceMutations.ts
+++ b/ui/apps/console/src/hooks/useNamespaceMutations.ts
@@ -2,8 +2,6 @@ import { useMutation } from "@tanstack/react-query";
 import {
   editNamespaceMutation,
   setSshAccessModeMutation,
-} from "../client/@tanstack/react-query.gen";
-import {
   getNamespaceToken,
   createNamespace as createNamespaceSdk,
   deleteNamespace as deleteNamespaceSdk,

--- a/ui/apps/console/src/hooks/useNamespaces.ts
+++ b/ui/apps/console/src/hooks/useNamespaces.ts
@@ -1,15 +1,13 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
+  type Namespace as GeneratedNamespace,
+  type NamespaceMemberRole,
+  type MemberView,
   getNamespacesOptions,
   getNamespaceOptions,
   getNamespaceTokenOptions,
   listNamespaceMembersOptions,
-} from "../client/@tanstack/react-query.gen";
-import type {
-  Namespace as GeneratedNamespace,
-  NamespaceMemberRole,
-  MemberView,
 } from "../client";
 import { useAuthStore } from "../stores/authStore";
 

--- a/ui/apps/console/src/hooks/usePublicKeyMutations.ts
+++ b/ui/apps/console/src/hooks/usePublicKeyMutations.ts
@@ -3,7 +3,7 @@ import {
   createPublicKeyMutation,
   updatePublicKeyMutation,
   deletePublicKeyMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreatePublicKey() {

--- a/ui/apps/console/src/hooks/usePublicKeys.ts
+++ b/ui/apps/console/src/hooks/usePublicKeys.ts
@@ -2,10 +2,10 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   getPublicKeys as getPublicKeysSdk,
+  getPublicKeysQueryKey,
   type GetPublicKeysData,
   type PublicKeyResponse,
 } from "../client";
-import { getPublicKeysQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { toBase64Json } from "@/utils/encoding";
 

--- a/ui/apps/console/src/hooks/useRevealInstallKey.ts
+++ b/ui/apps/console/src/hooks/useRevealInstallKey.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { installKeyRevealOptions } from "../client/@tanstack/react-query.gen";
+import { installKeyRevealOptions } from "../client";
 
 /**
  * Reveal a install key's plaintext on demand. The secret is never preloaded for

--- a/ui/apps/console/src/hooks/useSSHIdentities.ts
+++ b/ui/apps/console/src/hooks/useSSHIdentities.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { listSshIdentitiesOptions } from "../client/@tanstack/react-query.gen";
-import type { SshIdentity } from "../client";
+import { listSshIdentitiesOptions, type SshIdentity } from "../client";
 
 export function useSSHIdentities(all = false) {
   const options = all ? { query: { all: true } } : {};

--- a/ui/apps/console/src/hooks/useSSHIdentityMutations.ts
+++ b/ui/apps/console/src/hooks/useSSHIdentityMutations.ts
@@ -5,7 +5,7 @@ import {
   createSshIdentityMutation,
   renameSshIdentityMutation,
   deleteSshIdentityMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useConfirmSSHApproval() {

--- a/ui/apps/console/src/hooks/useServiceAccountMutations.ts
+++ b/ui/apps/console/src/hooks/useServiceAccountMutations.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import {
   createServiceAccountMutation,
   deleteServiceAccountMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreateServiceAccount() {

--- a/ui/apps/console/src/hooks/useServiceAccounts.ts
+++ b/ui/apps/console/src/hooks/useServiceAccounts.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { listServiceAccountsOptions } from "../client/@tanstack/react-query.gen";
-import type { ServiceAccount } from "../client";
+import { listServiceAccountsOptions, type ServiceAccount } from "../client";
 
 export function useServiceAccounts() {
   const result = useQuery(listServiceAccountsOptions());

--- a/ui/apps/console/src/hooks/useSession.ts
+++ b/ui/apps/console/src/hooks/useSession.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getSessionOptions } from "../client/@tanstack/react-query.gen";
+import { getSessionOptions } from "../client";
 
 export function useSession(uid: string) {
   const result = useQuery({

--- a/ui/apps/console/src/hooks/useSessionMutations.ts
+++ b/ui/apps/console/src/hooks/useSessionMutations.ts
@@ -1,6 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { clsoeSessionMutation } from "../client/@tanstack/react-query.gen";
-import { deleteSessionRecord } from "@/client";
+import { clsoeSessionMutation, deleteSessionRecord } from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCloseSession() {

--- a/ui/apps/console/src/hooks/useSessions.ts
+++ b/ui/apps/console/src/hooks/useSessions.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   getSessions as getSessionsSdk,
+  getSessionsQueryKey,
   type GetSessionsData,
   type Session,
 } from "../client";
-import { getSessionsQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 
 interface UseSessionsParams {

--- a/ui/apps/console/src/hooks/useStats.ts
+++ b/ui/apps/console/src/hooks/useStats.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getStatusDevicesOptions } from "../client/@tanstack/react-query.gen";
+import { getStatusDevicesOptions } from "../client";
 
 export function useStats() {
   const result = useQuery(getStatusDevicesOptions());

--- a/ui/apps/console/src/hooks/useSupportIdentifier.ts
+++ b/ui/apps/console/src/hooks/useSupportIdentifier.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getNamespaceSupportOptions } from "@/client/@tanstack/react-query.gen";
+import { getNamespaceSupportOptions } from "@/client";
 
 export function useSupportIdentifier(
   tenantId: string | null | undefined,

--- a/ui/apps/console/src/hooks/useTagMutations.ts
+++ b/ui/apps/console/src/hooks/useTagMutations.ts
@@ -3,7 +3,7 @@ import {
   createTagMutation,
   deleteTagMutation,
   updateTagMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreateTag() {

--- a/ui/apps/console/src/hooks/useTags.ts
+++ b/ui/apps/console/src/hooks/useTags.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   getTags as getTagsSdk,
+  getTagsQueryKey,
   type GetTagsData,
   type Tag,
 } from "../client";
-import { getTagsQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 
 interface UseTagsParams {

--- a/ui/apps/console/src/hooks/useUploadLicense.ts
+++ b/ui/apps/console/src/hooks/useUploadLicense.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { sendLicenseMutation } from "../client/@tanstack/react-query.gen";
+import { sendLicenseMutation } from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useUploadLicense() {

--- a/ui/apps/console/src/hooks/useWebEndpointMutations.ts
+++ b/ui/apps/console/src/hooks/useWebEndpointMutations.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import {
   createWebEndpointMutation,
   deleteWebEndpointMutation,
-} from "../client/@tanstack/react-query.gen";
+} from "../client";
 import { useInvalidateByIds } from "./useInvalidateQueries";
 
 export function useCreateWebEndpoint() {

--- a/ui/apps/console/src/hooks/useWebEndpoints.ts
+++ b/ui/apps/console/src/hooks/useWebEndpoints.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   listWebEndpoints as listWebEndpointsSdk,
+  listWebEndpointsQueryKey,
   type ListWebEndpointsData,
   type Webendpoint,
 } from "../client";
-import { listWebEndpointsQueryKey } from "../client/@tanstack/react-query.gen";
 import { paginatedQueryFn, type PaginatedResult } from "../api/pagination";
 import { toBase64Json } from "@/utils/encoding";
 

--- a/ui/apps/console/src/pages/__tests__/WebEndpoints.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/WebEndpoints.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import type { Webendpoint } from "@/client/types.gen";
+import type { Webendpoint } from "@/client";
 import WebEndpoints from "../WebEndpoints";
 
 vi.mock("@/hooks/useWebEndpoints");

--- a/ui/apps/console/src/pages/admin/License.tsx
+++ b/ui/apps/console/src/pages/admin/License.tsx
@@ -25,7 +25,7 @@ import {
   validateLicenseFile,
   getLicenseAlertConfig,
 } from "@/utils/license";
-import type { GetLicenseResponse } from "@/client/types.gen";
+import type { GetLicenseResponse } from "@/client";
 import PageLoader from "@/components/common/PageLoader";
 import { Button, Card, IconButton } from "@shellhub/design-system/primitives";
 

--- a/ui/apps/console/src/utils/license.ts
+++ b/ui/apps/console/src/utils/license.ts
@@ -1,5 +1,5 @@
 import { formatExpiry } from "./date";
-import type { GetLicenseResponse } from "../client/types.gen";
+import type { GetLicenseResponse } from "../client";
 
 export function formatLicenseTimestamp(value: number): string {
   if (value === -1) return "Now";


### PR DESCRIPTION
## What
All hooks and production code now import generated client symbols (`*Options`, `*QueryKey`, `*Mutation`, types) from the `@/client` barrel instead of internal submodules (`@/client/@tanstack/react-query.gen`, `@/client/types.gen`, `@/client/sdk.gen`).

## Why
Prerequisite for shellhub-io/team#216 (Task 5). Once every hook imports from the barrel, page and component tests only need a single `vi.mock("@/client")` to intercept all SDK calls — eliminating the need to mock individual submodules or hooks.

## Changes
- **`openapi-ts.config.ts`**: added `includeInEntry: true` to all `@hey-api/openapi-ts` plugin entries so the barrel re-exports every generated symbol
- **54 hook files**: merged value and type imports from `../client/@tanstack/react-query.gen`, `../client/types.gen`, and `../client/sdk.gen` into a single `../client` import
- **4 production files** (`ConnectDrawer`, `BillingSection`, `License`, `license.ts`): same submodule-to-barrel migration
- **13 hook tests**: changed mock targets from `@/client/@tanstack/react-query.gen` to `@/client`
- **3 component tests** (`DeviceLimitBanner`, `LicenseBanner`, `LicenseGuard`): merged separate `@/client/@tanstack/react-query.gen` mocks into the existing `@/client` mock block — these tests had split mocks because the hooks previously imported from different submodules
- **1 page test** (`WebEndpoints`): `@/client/sdk.gen` → `@/client`

## Testing
`npm run test` passes. The hook and component tests that changed mock targets were the ones that broke when imports moved to the barrel — each was verified individually.