### PR TITLE
test(ui): consolidate SDK test helpers

### DIFF
--- a/ui/apps/console/src/pages/__tests__/Login.test.tsx
+++ b/ui/apps/console/src/pages/__tests__/Login.test.tsx
@@ -9,7 +9,7 @@ import {
   setPendingDeviceCode,
 } from "@/utils/navigation";
 import type { Info, UserAuth } from "@/client";
-import { mockUserAuth } from "@/tests/userAuth";
+import { mockUserAuth } from "@/tests/factories";
 import { simulateBrowserTranslation } from "@/tests/simulateBrowserTranslation";
 import Login from "../Login";
 import { mockSdkResponse, makeSdkError, type SdkResponse } from "@/tests/sdk";

--- a/ui/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
+++ b/ui/apps/console/src/pages/admin/__tests__/Sessions.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import { makeSdkError } from "@/tests/sdk";
 
 /* ------------------------------------------------------------------ */
 /* Mocks                                                               */
@@ -21,7 +22,6 @@ vi.mock("@/hooks/useAdminSessions", () => ({
 import { useAdminSessions } from "@/hooks/useAdminSessions";
 import type { Device, Session } from "@/client";
 import AdminSessions from "../Sessions";
-import { sdkError } from "@/tests/sdkError";
 import { LocationProbe } from "@/tests/LocationProbe";
 
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -104,13 +104,13 @@ describe("AdminSessions", () => {
 
   describe("error state", () => {
     it("renders the error banner with role='alert'", () => {
-      setupHook({ error: sdkError(500) });
+      setupHook({ error: makeSdkError(500) });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
 
     it("displays the console's own copy for the status in the banner", () => {
-      setupHook({ error: sdkError(403) });
+      setupHook({ error: makeSdkError(403) });
       renderPage();
       expect(screen.getByRole("alert")).toHaveTextContent(
         "You do not have permission to do this.",

--- a/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
+++ b/ui/apps/console/src/pages/admin/announcements/__tests__/AdminAnnouncements.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { AnnouncementShort } from "@/client";
+import { makeSdkError } from "@/tests/sdk";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -34,8 +35,18 @@ vi.mock("../DeleteAnnouncementDialog", () => ({
     if (!open || !announcement) return null;
     return (
       <div role="dialog" aria-label={`Delete ${announcement.title}`}>
-        <button type="button" onClick={onClose}>Cancel delete</button>
-        <button type="button" onClick={() => { onClose(); onDeleted?.(); }}>Confirm delete</button>
+        <button type="button" onClick={onClose}>
+          Cancel delete
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            onClose();
+            onDeleted?.();
+          }}
+        >
+          Confirm delete
+        </button>
       </div>
     );
   },
@@ -45,7 +56,6 @@ vi.mock("../DeleteAnnouncementDialog", () => ({
 
 import { useAdminAnnouncements } from "@/hooks/useAdminAnnouncements";
 import AdminAnnouncements from "../index";
-import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -357,7 +367,7 @@ describe("AdminAnnouncements", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminAnnouncements).mockReturnValue({
         ...defaultHookState,
-        error: sdkError(500),
+        error: makeSdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
@@ -366,10 +376,12 @@ describe("AdminAnnouncements", () => {
     it("renders the error message text", () => {
       vi.mocked(useAdminAnnouncements).mockReturnValue({
         ...defaultHookState,
-        error: sdkError(500),
+        error: makeSdkError(500),
       });
       renderPage();
-      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong on our side. Try again."),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
+++ b/ui/apps/console/src/pages/admin/devices/__tests__/AdminDevices.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { NormalizedDevice } from "@/hooks/useAdminDevices";
+import { makeSdkError } from "@/tests/sdk";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -21,7 +22,6 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 import { useAdminDevices } from "@/hooks/useAdminDevices";
 import AdminDevices from "../index";
-import { sdkError } from "@/tests/sdkError";
 
 const defaultHookState = {
   devices: [] as NormalizedDevice[],
@@ -163,11 +163,13 @@ describe("AdminDevices", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminDevices).mockReturnValue({
         ...defaultHookState,
-        error: sdkError(500),
+        error: makeSdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong on our side. Try again."),
+      ).toBeInTheDocument();
     });
   });
 
@@ -262,7 +264,9 @@ describe("AdminDevices", () => {
       renderPage(["/?page=3"]);
 
       // Click the "Sort by Hostname" sort button (maps to "name" field)
-      await user.click(screen.getByRole("button", { name: /sort by hostname/i }));
+      await user.click(
+        screen.getByRole("button", { name: /sort by hostname/i }),
+      );
 
       // name has initialOrder=asc, so switching to it uses asc
       expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
@@ -275,7 +279,9 @@ describe("AdminDevices", () => {
       // Start already sorted by name asc
       renderPage(["/?sortField=name&sortOrder=asc"]);
 
-      await user.click(screen.getByRole("button", { name: /sort by hostname/i }));
+      await user.click(
+        screen.getByRole("button", { name: /sort by hostname/i }),
+      );
 
       expect(vi.mocked(useAdminDevices)).toHaveBeenCalledWith(
         expect.objectContaining({ sortBy: "name", orderBy: "desc" }),

--- a/ui/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
+++ b/ui/apps/console/src/pages/admin/firewall-rules/__tests__/AdminFirewallRules.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import { makeSdkError } from "@/tests/sdk";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -19,7 +20,9 @@ vi.mock("@/components/common/DataTable", async (importOriginal) => {
     default: (props: Record<string, unknown>) => {
       capturedDataTableProps.push({ ...props });
       // Render the real DataTable so existing tests keep working.
-      return actual.default(props as unknown as Parameters<typeof actual.default>[0]);
+      return actual.default(
+        props as unknown as Parameters<typeof actual.default>[0],
+      );
     },
   };
 });
@@ -36,7 +39,6 @@ vi.mock("react-router-dom", async (importOriginal) => {
 import { useAdminFirewallRules } from "@/hooks/useAdminFirewallRules";
 import AdminFirewallRules from "../index";
 import { FirewallRulesResponse } from "@/client";
-import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -247,11 +249,13 @@ describe("AdminFirewallRules", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminFirewallRules).mockReturnValue({
         ...defaultHookState,
-        error: sdkError(500),
+        error: makeSdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong on our side. Try again."),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/admin/namespaces/__tests__/AdminNamespaces.test.tsx
+++ b/ui/apps/console/src/pages/admin/namespaces/__tests__/AdminNamespaces.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { Namespace } from "@/client";
+import { makeSdkError } from "@/tests/sdk";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -41,7 +42,6 @@ vi.mock("react-router-dom", async (importOriginal) => {
 
 import { useAdminNamespaces } from "@/hooks/useAdminNamespaces";
 import AdminNamespaces from "../index";
-import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -158,11 +158,13 @@ describe("AdminNamespaces", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminNamespaces).mockReturnValue({
         ...defaultHookState,
-        error: sdkError(500),
+        error: makeSdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong on our side. Try again."),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/admin/users/__tests__/AdminUsers.test.tsx
+++ b/ui/apps/console/src/pages/admin/users/__tests__/AdminUsers.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { UserAdminResponse } from "@/client";
+import { makeSdkError } from "@/tests/sdk";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -53,7 +54,6 @@ vi.mock("react-router-dom", async (importOriginal) => {
 import { useAdminUsers } from "@/hooks/useAdminUsers";
 import { useLoginAsUser } from "@/hooks/useLoginAsUser";
 import AdminUsers from "../index";
-import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -170,11 +170,13 @@ describe("AdminUsers", () => {
     it("renders an error alert when the hook returns an error", () => {
       vi.mocked(useAdminUsers).mockReturnValue({
         ...defaultHookState,
-        error: sdkError(500),
+        error: makeSdkError(500),
       });
       renderPage();
       expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong on our side. Try again."),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
+++ b/ui/apps/console/src/pages/containers/__tests__/Containers.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { NormalizedContainer } from "@/hooks/useContainers";
+import { makeSdkError } from "@/tests/sdk";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -131,7 +132,6 @@ vi.mock("react-router-dom", async (importOriginal) => {
 import React from "react";
 import { useContainers } from "@/hooks/useContainers";
 import Containers from "../index";
-import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -258,10 +258,12 @@ describe("Containers list", () => {
     it("renders an error message when hook returns an error", () => {
       vi.mocked(useContainers).mockReturnValue({
         ...defaultHookState,
-        error: sdkError(500),
+        error: makeSdkError(500),
       });
       renderPage();
-      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong on our side. Try again."),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/pages/devices/__tests__/Devices.test.tsx
+++ b/ui/apps/console/src/pages/devices/__tests__/Devices.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import type { NormalizedDevice } from "@/hooks/useDevices";
 import type { UseDeviceActionsResult } from "@/hooks/useDeviceActions";
+import { makeSdkError } from "@/tests/sdk";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -138,7 +139,6 @@ import React from "react";
 import { useDevices } from "@/hooks/useDevices";
 import { useDeviceActions } from "@/hooks/useDeviceActions";
 import Devices from "../index";
-import { sdkError } from "@/tests/sdkError";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -279,10 +279,12 @@ describe("Devices list", () => {
     it("renders an error message when hook returns an error", () => {
       vi.mocked(useDevices).mockReturnValue({
         ...defaultHookState,
-        error: sdkError(500),
+        error: makeSdkError(500),
       });
       renderPage();
-      expect(screen.getByText("Something went wrong on our side. Try again.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong on our side. Try again."),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/apps/console/src/stores/__tests__/authStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/authStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useAuthStore } from "../authStore";
 import type { UserAuth } from "@/client";
 import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
-import { mockUserAuth } from "@/tests/userAuth";
+import { mockUserAuth } from "@/tests/factories";
 
 vi.mock("@/client", () => ({
   login: vi.fn(),

--- a/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/mfaResetStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useMfaResetStore } from "../mfaResetStore";
 import { useAuthStore } from "../authStore";
 import { mockSdkResponse, type SdkResponse } from "@/tests/sdk";
-import { mockUserAuth } from "@/tests/userAuth";
+import { mockUserAuth } from "@/tests/factories";
 
 vi.mock("@/client", () => ({
   requestResetMfa: vi.fn(),

--- a/ui/apps/console/src/tests/__tests__/sdk.test.ts
+++ b/ui/apps/console/src/tests/__tests__/sdk.test.ts
@@ -5,6 +5,7 @@ describe("mockSdkResponse", () => {
   it("wraps data with request and response", () => {
     const res = mockSdkResponse({ id: 1 });
     expect(res.data).toEqual({ id: 1 });
+    expect(res.error).toBeUndefined();
     expect(res.request).toBeInstanceOf(Request);
     expect(res.response).toBeInstanceOf(Response);
   });

--- a/ui/apps/console/src/tests/factories.ts
+++ b/ui/apps/console/src/tests/factories.ts
@@ -1,6 +1,8 @@
 import type { UserAuth } from "@/client";
 
-export function mockUserAuth(overrides: Partial<UserAuth> = {}): UserAuth {
+export function mockUserAuth(
+  overrides: Partial<UserAuth> = {},
+): UserAuth {
   return {
     token: "jwt-token",
     id: "user-123",

--- a/ui/apps/console/src/tests/sdk.ts
+++ b/ui/apps/console/src/tests/sdk.ts
@@ -2,6 +2,7 @@ import type { SdkHttpError } from "@/api/errors";
 
 export type SdkResponse<T = unknown> = {
   data: T;
+  error: undefined;
   request: Request;
   response: Response;
 };
@@ -12,6 +13,7 @@ export function mockSdkResponse<T>(
 ): SdkResponse<T> {
   return {
     data,
+    error: undefined,
     request: new Request("http://localhost"),
     response: new Response(null, headers ? { headers } : undefined),
   };
@@ -20,7 +22,7 @@ export function mockSdkResponse<T>(
 export function makeSdkError(
   status: number,
   headers?: HeadersInit,
-): SdkHttpError {
+): Error & SdkHttpError {
   return Object.assign(new Error("Request failed"), {
     status,
     headers: new Headers(headers),

--- a/ui/apps/console/src/tests/sdkError.ts
+++ b/ui/apps/console/src/tests/sdkError.ts
@@ -1,8 +1,0 @@
-/**
- * Builds a value shaped like what the SDK throws: the parsed error body with the `status` the
- * fetch error interceptor attaches.
- */
-export function sdkError(status: number, body: Record<string, unknown> = {}) {
-  // An Error instance, so it also satisfies hooks whose error type is the built-in Error.
-  return Object.assign(new Error(`HTTP ${status}`), { ...body, status });
-}


### PR DESCRIPTION
## What
Consolidated duplicated SDK test factories into canonical locations and aligned `SdkResponse` with the actual hey-api client shape.

## Why
Prerequisite cleanup for shellhub-io/team#216 (Task 5 — migrating page/component tests to mock `@/client`). Reduces the number of ad-hoc error factories tests need to know about before the migration touches every test file.

## Changes
- **`factories.ts`**: renamed from `userAuth.ts` to host all API type factory functions (`mockUserAuth` today, `mockTag`/`mockNamespace` next); updated 3 consumers (`Login.test.tsx`, `authStore.test.ts`, `mfaResetStore.test.ts`)
- **`sdkError.ts` deleted**: duplicated `makeSdkError` from `sdk.ts` without the `SdkHttpError` type or header support; 8 page tests migrated to `makeSdkError`
- **`SdkResponse`**: added `error: undefined` to match the hey-api `RequestResult` discriminated union (`{ data, error, request, response }`)
- **`makeSdkError`**: return type widened to `Error & SdkHttpError` so it satisfies both `SdkHttpError` and React Query's `Error | null` error field on hook mocks (temporary — the `Error` side becomes irrelevant once page tests stop mocking hooks)