### PR TITLE
feat(gateway): serve the development mail inbox at `mail.<domain>`

### DIFF
--- a/gateway/Caddyfile.tmpl
+++ b/gateway/Caddyfile.tmpl
@@ -255,5 +255,14 @@ http://idp.{{ $cfg.Domain }} {
 		import forwarded
 	}
 }
+
+# Mailpit catches every email the stack sends and shows it rendered. Its
+# container ships with the cloud repository's compose files, so a community
+# stack has no upstream here and this would only ever 502.
+http://mail.{{ $cfg.Domain }} {
+	reverse_proxy mailpit:8025 {
+		import forwarded
+	}
+}
 {{- end }}
 {{- end }}

--- a/gateway/caddy_test.go
+++ b/gateway/caddy_test.go
@@ -94,6 +94,30 @@ func TestCaddyfileServesTheEditionsRoutes(t *testing.T) {
 	assert.Contains(t, string(endpoints), "/admin/api")
 }
 
+// TestCaddyfileServesTheDevelopmentMailInbox pins the Mailpit vhost to the one
+// stack that has a Mailpit to reach: the mail code lives in the cloud repository,
+// so a community stack has nothing behind the hostname even in development.
+func TestCaddyfileServesTheDevelopmentMailInbox(t *testing.T) {
+	configs := configurations()
+
+	development, err := Caddyfile(configs["development"])
+	require.NoError(t, err)
+
+	assert.Contains(t, string(development), "http://mail.shellhub.example")
+
+	devCommunity, err := Caddyfile(configs["dev community"])
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(devCommunity), "mail.shellhub.example",
+		"the mail inbox is enterprise-only")
+
+	enterprise, err := Caddyfile(configs["enterprise"])
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(enterprise), "mail.shellhub.example",
+		"the mail inbox is development-only")
+}
+
 // TestEveryUpstreamReceivesTheClientAddress restores what the deleted nginx
 // headers test guarded. X-Real-IP is what the login lockout and the GeoIP rules
 // are keyed on, and it now reaches an upstream only because each route asks for


### PR DESCRIPTION
## What

Routes `mail.<domain>` to Mailpit's web UI in the development stack, so the inbox is opened by name like `docs.<domain>` and `website.<domain>` rather than by remembering a container port.

Part of https://github.com/shellhub-io/team/issues/223

Companion PR (cloud repo, the SMTP provider and the Mailpit container): shellhub-io/cloud/pull/2505 That one is where the work actually is: this PR only routes to it. On its own, this block has no upstream and the hostname would 502. Merge order doesn't matter.

## Why

The cloud repo's development stack now runs Mailpit, which catches every email the stack sends and shows it rendered. Nothing routed to it. The alternative was publishing its UI port to the host, which every other development-only service in this stack avoids.

## Changes

One vhost in `gateway/Caddyfile.tmpl`, proxying `mail.<domain>` to `mailpit:8025` and importing the shared `forwarded` snippet like every other route in the file.

It sits inside two conditionals: `.Development`, alongside the `website.` and `docs.` blocks, and `EnableEnterprise`, alongside `idp.`. The second guard is there because both the mail code and the Mailpit container ship with the cloud repository, so a community stack has no upstream here and the name would only ever error. That is the same reason the SAML test IdP is gated the way it is.

## Testing

`TestCaddyfileServesTheDevelopmentMailInbox` pins both halves of the gating: the hostname is present in the development enterprise config, absent from a community development stack, and absent from a non-development enterprise stack. An edition-gated block is invisible until someone runs that edition, which is what makes this worth a test rather than a read.

The existing `TestCaddyfileAdapts` already covers the block for free: it hands every configuration shape to the real Caddy adapter, so a typo or an unresolvable directive fails there rather than at boot. `TestEveryUpstreamReceivesTheClientAddress` likewise checks the new `reverse_proxy` carries the client address.

To exercise it, run a development stack with `SHELLHUB_EDITION=cloud` (or `enterprise`, though nothing will send mail on that edition) and open `http://mail.localhost`. Mailpit's UI answers through the gateway:

    curl -s -o /dev/null -w '%{http_code}\n' http://mail.localhost/

Note that `curl -I` returns 405 here: Mailpit's UI does not accept `HEAD`. That is the proxy working, not failing. Verified against a running stack: 200 on the UI and on its `/api/v1/messages` endpoint.