### PR TITLE
feat(ui): add ctrl +/-/0 shortcuts for terminal font size

### DIFF
--- a/ui/apps/console/src/components/terminal/TerminalInstance.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalInstance.tsx
@@ -9,6 +9,7 @@ import { generateSignature } from "@/utils/sshKeys";
 import type { TerminalSession } from "@/stores/terminalStore";
 import { useTerminalStore } from "@/stores/terminalStore";
 import { useTerminalThemeStore } from "@/stores/terminalThemeStore";
+import { nextFontSize } from "./fontSizeShortcut";
 import type { TerminalError } from "./terminalErrors";
 import TerminalErrorBanner from "./TerminalErrorBanner";
 import {
@@ -114,6 +115,25 @@ export default function TerminalInstance({
         allowProposedApi: true,
       });
       termRef.current = term;
+
+      // Read the size off the store rather than the render-time binding: this
+      // handler is registered once and would otherwise always step from the
+      // size the terminal was created with.
+      term.attachCustomKeyEventHandler((event) => {
+        if (event.type !== "keydown") return true;
+
+        const { fontSize, setFontSize } = useTerminalThemeStore.getState();
+        const next = nextFontSize(fontSize, event);
+        if (next === null) return true;
+
+        setFontSize(next);
+
+        // Returning false only stops xterm forwarding the key to the shell;
+        // suppressing the browser's own zoom needs this.
+        event.preventDefault();
+
+        return false;
+      });
 
       const fitAddon = new FitAddon();
       fitRef.current = fitAddon;

--- a/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
+++ b/ui/apps/console/src/components/terminal/TerminalSettingsDrawer.tsx
@@ -5,6 +5,8 @@ import { IconButton } from "@shellhub/design-system/primitives";
 import {
   useTerminalThemeStore,
   TERMINAL_FONTS,
+  MIN_FONT_SIZE,
+  MAX_FONT_SIZE,
   type TerminalTheme,
 } from "@/stores/terminalThemeStore";
 import Drawer from "../common/Drawer";
@@ -88,10 +90,18 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
               type="button"
               key={font}
               onClick={() => setFontFamily(font)}
-              className={cn("flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 transition-all duration-150", font === fontFamily ? "bg-primary/10 border border-primary/20" : "hover:bg-hover-subtle border border-transparent")}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 transition-all duration-150",
+                font === fontFamily
+                  ? "bg-primary/10 border border-primary/20"
+                  : "hover:bg-hover-subtle border border-transparent",
+              )}
             >
               <span
-                className={cn("text-[13px]", font === fontFamily ? "text-primary" : "text-text-secondary")}
+                className={cn(
+                  "text-[13px]",
+                  font === fontFamily ? "text-primary" : "text-text-secondary",
+                )}
                 style={{ fontFamily: `"${font}", monospace` }}
               >
                 {font}
@@ -115,7 +125,7 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
         <div className="flex items-center gap-3">
           <IconButton
             aria-label="Decrease font size"
-            disabled={fontSize <= 8}
+            disabled={fontSize <= MIN_FONT_SIZE}
             onClick={() => setFontSize(fontSize - 1)}
             className="border border-border bg-hover-subtle"
           >
@@ -124,8 +134,8 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
           <div className="flex-1">
             <input
               type="range"
-              min={8}
-              max={24}
+              min={MIN_FONT_SIZE}
+              max={MAX_FONT_SIZE}
               value={fontSize}
               onChange={(e) => setFontSize(parseInt(e.target.value))}
               className="w-full accent-primary h-1"
@@ -133,7 +143,7 @@ export default function TerminalSettingsDrawer({ open, onClose }: Props) {
           </div>
           <IconButton
             aria-label="Increase font size"
-            disabled={fontSize >= 24}
+            disabled={fontSize >= MAX_FONT_SIZE}
             onClick={() => setFontSize(fontSize + 1)}
             className="border border-border bg-hover-subtle"
           >
@@ -216,7 +226,12 @@ function ThemeCard({
     <button
       type="button"
       onClick={onClick}
-      className={cn("relative rounded-lg border p-2 text-left transition-all duration-150", selected ? "border-primary/40 bg-primary/[0.06] ring-1 ring-primary/10" : "border-border hover:border-border-light bg-hover-subtle")}
+      className={cn(
+        "relative rounded-lg border p-2 text-left transition-all duration-150",
+        selected
+          ? "border-primary/40 bg-primary/[0.06] ring-1 ring-primary/10"
+          : "border-border hover:border-border-light bg-hover-subtle",
+      )}
     >
       {/* Color preview */}
       <div

--- a/ui/apps/console/src/components/terminal/__tests__/fontSizeShortcut.test.ts
+++ b/ui/apps/console/src/components/terminal/__tests__/fontSizeShortcut.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { nextFontSize } from "../fontSizeShortcut";
+import { DEFAULT_FONT_SIZE } from "@/stores/terminalThemeStore";
+
+const event = (init: Partial<KeyboardEventInit> & { key: string }) =>
+  new KeyboardEvent("keydown", { ctrlKey: false, metaKey: false, altKey: false, shiftKey: false, ...init });
+
+const CURRENT = 14;
+
+describe("nextFontSize", () => {
+  describe("with the ctrl modifier", () => {
+    it.each([
+      ["+", CURRENT + 1],
+      ["=", CURRENT + 1],
+      ["-", CURRENT - 1],
+      ["0", DEFAULT_FONT_SIZE],
+    ])("maps %s to %i", (key, expected) => {
+      expect(nextFontSize(CURRENT, event({ key, ctrlKey: true }))).toBe(expected);
+    });
+  });
+
+  describe("with the meta modifier", () => {
+    it.each([
+      ["+", CURRENT + 1],
+      ["=", CURRENT + 1],
+      ["-", CURRENT - 1],
+      ["0", DEFAULT_FONT_SIZE],
+    ])("maps %s to %i so macOS behaves the same", (key, expected) => {
+      expect(nextFontSize(CURRENT, event({ key, metaKey: true }))).toBe(expected);
+    });
+  });
+
+  it("steps from the size it is given, not from the default", () => {
+    expect(nextFontSize(20, event({ key: "+", ctrlKey: true }))).toBe(21);
+    expect(nextFontSize(20, event({ key: "-", ctrlKey: true }))).toBe(19);
+  });
+
+  it("resets to the default from any size", () => {
+    expect(nextFontSize(24, event({ key: "0", ctrlKey: true }))).toBe(DEFAULT_FONT_SIZE);
+  });
+
+  it("treats a shifted plus as an increase, so US layouts need no extra keypress", () => {
+    expect(nextFontSize(CURRENT, event({ key: "+", ctrlKey: true, shiftKey: true }))).toBe(CURRENT + 1);
+  });
+
+  // Numpad add/subtract need no entries of their own: browsers report them as
+  // "+" and "-" in `key` (the "Numpad*" name lives in `code`).
+  it.each([
+    ["NumpadAdd", "+", CURRENT + 1],
+    ["NumpadSubtract", "-", CURRENT - 1],
+  ])("handles %s via its key", (code, key, expected) => {
+    expect(nextFontSize(CURRENT, event({ key, code, ctrlKey: true }))).toBe(expected);
+  });
+
+  it("ignores ctrl+_, leaving 0x1F (readline/emacs undo) for the remote shell", () => {
+    expect(nextFontSize(CURRENT, event({ key: "_", ctrlKey: true }))).toBeNull();
+  });
+
+  it.each(["+", "-", "0", "="])("ignores %s without a modifier", (key) => {
+    expect(nextFontSize(CURRENT, event({ key }))).toBeNull();
+  });
+
+  it.each(["+", "-", "0"])("ignores %s when alt is held, leaving it for the remote shell", (key) => {
+    expect(nextFontSize(CURRENT, event({ key, ctrlKey: true, altKey: true }))).toBeNull();
+  });
+
+  it.each(["a", "c", "1", "9", "Enter", "ArrowUp", "constructor", "toString"])(
+    "ignores the unrelated key %s",
+    (key) => {
+      expect(nextFontSize(CURRENT, event({ key, ctrlKey: true }))).toBeNull();
+    },
+  );
+});

--- a/ui/apps/console/src/components/terminal/fontSizeShortcut.ts
+++ b/ui/apps/console/src/components/terminal/fontSizeShortcut.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_FONT_SIZE } from "@/stores/terminalThemeStore";
+
+type FontSizeIntent = "increase" | "decrease" | "reset";
+
+// "=" is accepted alongside "+" because the two share a key on a US layout and
+// browsers report either depending on whether Shift was held. "_" is
+// deliberately absent: "-" needs no Shift, so accepting it would only steal
+// ctrl+_ (0x1F, readline/emacs undo) from the remote shell. Numpad add and
+// subtract already arrive as "+" and "-".
+const INTENT_BY_KEY: Record<string, FontSizeIntent> = {
+  "+": "increase",
+  "=": "increase",
+  "-": "decrease",
+  0: "reset",
+};
+
+const STEP = 1;
+
+/** The size the given keystroke asks for, or null if it asks for nothing. */
+export const nextFontSize = (current: number, event: KeyboardEvent): number | null => {
+  if (event.altKey) return null;
+  if (!event.ctrlKey && !event.metaKey) return null;
+  if (!Object.hasOwn(INTENT_BY_KEY, event.key)) return null;
+
+  switch (INTENT_BY_KEY[event.key]) {
+    case "increase":
+      return current + STEP;
+    case "decrease":
+      return current - STEP;
+    case "reset":
+      return DEFAULT_FONT_SIZE;
+  }
+};

--- a/ui/apps/console/src/stores/__tests__/terminalThemeStore.test.ts
+++ b/ui/apps/console/src/stores/__tests__/terminalThemeStore.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const STORAGE_KEY = "terminalFontSize";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.resetModules();
+});
+
+describe("terminalThemeStore font size", () => {
+  // The store reads localStorage in its initializer, which runs at import time,
+  // so each case imports it fresh to control what was persisted.
+  describe("initialization", () => {
+    it("starts at the default size when nothing is persisted", async () => {
+      const { useTerminalThemeStore, DEFAULT_FONT_SIZE } = await import("@/stores/terminalThemeStore");
+
+      expect(useTerminalThemeStore.getState().fontSize).toBe(DEFAULT_FONT_SIZE);
+    });
+
+    it("restores a persisted size", async () => {
+      localStorage.setItem(STORAGE_KEY, "18");
+      const { useTerminalThemeStore } = await import("@/stores/terminalThemeStore");
+
+      expect(useTerminalThemeStore.getState().fontSize).toBe(18);
+    });
+
+    it("falls back to the default when the persisted value is not a number", async () => {
+      localStorage.setItem(STORAGE_KEY, "not-a-number");
+      const { useTerminalThemeStore, DEFAULT_FONT_SIZE } = await import("@/stores/terminalThemeStore");
+
+      expect(useTerminalThemeStore.getState().fontSize).toBe(DEFAULT_FONT_SIZE);
+    });
+
+    it("clamps a persisted size that is out of range", async () => {
+      localStorage.setItem(STORAGE_KEY, "999");
+      const { useTerminalThemeStore, MAX_FONT_SIZE } = await import("@/stores/terminalThemeStore");
+
+      expect(useTerminalThemeStore.getState().fontSize).toBe(MAX_FONT_SIZE);
+    });
+  });
+
+  describe("setFontSize", () => {
+    it("applies and persists a size inside the allowed range", async () => {
+      const { useTerminalThemeStore } = await import("@/stores/terminalThemeStore");
+
+      useTerminalThemeStore.getState().setFontSize(16);
+
+      expect(useTerminalThemeStore.getState().fontSize).toBe(16);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe("16");
+    });
+
+    it("clamps a size below the minimum", async () => {
+      const { useTerminalThemeStore, MIN_FONT_SIZE } = await import("@/stores/terminalThemeStore");
+
+      useTerminalThemeStore.getState().setFontSize(MIN_FONT_SIZE - 5);
+
+      expect(useTerminalThemeStore.getState().fontSize).toBe(MIN_FONT_SIZE);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(String(MIN_FONT_SIZE));
+    });
+
+    it("clamps a size above the maximum", async () => {
+      const { useTerminalThemeStore, MAX_FONT_SIZE } = await import("@/stores/terminalThemeStore");
+
+      useTerminalThemeStore.getState().setFontSize(MAX_FONT_SIZE + 5);
+
+      expect(useTerminalThemeStore.getState().fontSize).toBe(MAX_FONT_SIZE);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(String(MAX_FONT_SIZE));
+    });
+  });
+});

--- a/ui/apps/console/src/stores/terminalThemeStore.ts
+++ b/ui/apps/console/src/stores/terminalThemeStore.ts
@@ -52,6 +52,13 @@ export const TERMINAL_FONTS = [
 
 export type TerminalFont = (typeof TERMINAL_FONTS)[number];
 
+export const MIN_FONT_SIZE = 8;
+export const MAX_FONT_SIZE = 24;
+export const DEFAULT_FONT_SIZE = 14;
+
+export const clampFontSize = (size: number) =>
+  Math.min(Math.max(size, MIN_FONT_SIZE), MAX_FONT_SIZE);
+
 const STORAGE_KEYS = {
   theme: "terminalTheme",
   fontFamily: "terminalFontFamily",
@@ -91,7 +98,8 @@ const FALLBACK_THEME: TerminalTheme = {
 // its auth pipeline entirely.
 async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
-  if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  if (!response.ok)
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
   return (await response.json()) as T;
 }
 
@@ -124,7 +132,10 @@ export const useTerminalThemeStore = create<TerminalThemeState>((set, get) => {
 
   const initialThemeName = savedTheme || "ShellHub Dark";
   const initialFont = (savedFont as TerminalFont) || "IBM Plex Mono";
-  const initialSize = savedSize ? parseInt(savedSize, 10) : 14;
+  const parsedSize = savedSize ? parseInt(savedSize, 10) : NaN;
+  const initialSize = Number.isNaN(parsedSize)
+    ? DEFAULT_FONT_SIZE
+    : clampFontSize(parsedSize);
 
   return {
     themes: [FALLBACK_THEME],
@@ -139,12 +150,16 @@ export const useTerminalThemeStore = create<TerminalThemeState>((set, get) => {
       if (get().loaded) return;
 
       try {
-        const metadata = await fetchJson<ThemeMetadata[]>("/xterm-themes/metadata.json");
+        const metadata = await fetchJson<ThemeMetadata[]>(
+          "/xterm-themes/metadata.json",
+        );
 
         const results = await Promise.all(
           metadata.map(async (meta) => {
             try {
-              const raw = await fetchJson<Record<string, string>>(`/xterm-themes/${meta.file}`);
+              const raw = await fetchJson<Record<string, string>>(
+                `/xterm-themes/${meta.file}`,
+              );
               return {
                 name: meta.name,
                 dark: meta.dark,
@@ -158,7 +173,10 @@ export const useTerminalThemeStore = create<TerminalThemeState>((set, get) => {
         );
 
         const themes = results.filter(Boolean) as TerminalTheme[];
-        const current = themes.find((t) => t.name === get().themeName) || themes[0] || FALLBACK_THEME;
+        const current =
+          themes.find((t) => t.name === get().themeName) ||
+          themes[0] ||
+          FALLBACK_THEME;
         set({ themes, theme: current, loaded: true });
       } catch {
         set({ loaded: true });
@@ -179,7 +197,7 @@ export const useTerminalThemeStore = create<TerminalThemeState>((set, get) => {
     },
 
     setFontSize: (size) => {
-      const clamped = Math.min(Math.max(size, 8), 24);
+      const clamped = clampFontSize(size);
       localStorage.setItem(STORAGE_KEYS.fontSize, clamped.toString());
       set({ fontSize: clamped });
     },


### PR DESCRIPTION
## What

While a terminal is focused, `Ctrl` `+` and `Ctrl` `-` step the terminal font size by one within the existing 8-24 range, and `Ctrl` `0` returns it to the default. `Cmd` substitutes for `Ctrl` on macOS. The keystroke is withheld from both the browser and the remote shell, so the page no longer zooms and no stray character lands on the command line.

Closes: shellhub-io/shellhub#6936

## Why

Changing the font size previously meant opening the settings drawer and clicking its `+`/`-` buttons, which is a mouse round-trip in the middle of a keyboard-driven task. Every native terminal binds these keys for this, so the muscle memory was already there but did nothing useful: the browser claimed the keystroke and zoomed the whole console UI instead of the terminal text.

The shortcut deliberately reuses the size that already exists rather than introducing a second one, so the drawer and the keyboard can never disagree and the choice keeps surviving reloads for free.

## Changes

- New `fontSizeShortcut.ts`: a pure `nextFontSize(current, event)` that maps a keystroke to the size it asks for, or `null`. Keeping the step arithmetic behind this seam is what makes the whole behaviour unit-testable without constructing xterm.
- `TerminalInstance.tsx`: registers the handler via xterm's `attachCustomKeyEventHandler`, which is the seam that can withhold a key from the remote shell. It guards on `keydown` (the handler also fires for `keyup`), calls `preventDefault()` to suppress browser zoom, and reads the current size from the store rather than a render-time binding, since the handler is registered once and would otherwise always step from the size the terminal was created with.
- `terminalThemeStore.ts`: bounds and default extracted into exported constants now that a third caller needs them. Restoring a persisted size now parses defensively.
- `TerminalSettingsDrawer.tsx`: consumes those constants instead of repeating `8` and `24`.

Two incidental fixes fell out of testing the store: a corrupt `localStorage` value was accepted as `NaN` and became the font size, and a persisted out-of-range value was applied unclamped.

`Ctrl` `_` is deliberately not bound. `-` needs no Shift, so accepting it would buy nothing and would steal `0x1F` (readline/emacs undo) from the remote shell.

## Testing

Unit tests cover the two seams the behaviour actually lives at - 36 tests across `nextFontSize` and the store. The mapping is table-driven over `+`, `=`, `-`, `0`, numpad, both modifiers, no modifier, `Alt` held, and unrelated keys.

These do not prove the feature works, only that the logic is right. Rendering xterm under jsdom was rejected (it needs a real canvas), so the wiring and the resize round-trip were exercised by hand in the running stack:

1. Open a web terminal and `ssh root@dev.agent@localhost`
2. `Ctrl` `-` / `Ctrl` `+` - terminal text resizes, console chrome (sidebar, tabs, taskbar) does not, confirming browser zoom is suppressed
3. No `-` or `+` character appears on the command line, confirming the key is withheld from the shell
4. Run `htop`, resize, and confirm it redraws correctly rather than corrupting - this is what proves the resize frame reached the PTY and the remote program got its SIGWINCH
5. `Ctrl` `0` snaps back to the default
6. Open the settings drawer and confirm it shows the keyboard-set size, then reload and confirm it persists

## Known limitation

Holding the key is not as fluid as a native terminal. Each step reflows the scrollback, resizes the remote PTY and writes a recorder event, and that cost is per-step. An accelerating step was tried and reverted - it traded the slowness for visible jumpiness, which felt worse. Making it genuinely smooth needs a profile to establish which reflow dominates, so it is left alone here rather than tuned blind.