### PR TITLE
docs(models): drop the stale default from the legacy access mode comment

### DIFF
--- a/pkg/models/namespace.go
+++ b/pkg/models/namespace.go
@@ -73,7 +73,7 @@ func (n *Namespace) FindMember(id string) (*Member, bool) {
 // SSHAccessMode selects how a namespace authorizes SSH access.
 const (
 	// SSHAccessModeLegacy is the key/firewall model: access is a public key with
-	// an ACL plus, on Cloud/Enterprise, firewall rules. This is the default.
+	// an ACL plus, on Cloud/Enterprise, firewall rules.
 	SSHAccessModeLegacy = "legacy"
 	// SSHAccessModeIdentity is the identity model: access is a ShellHub identity
 	// (established by the out-of-band browser approval) plus Access Policies


### PR DESCRIPTION
## What

Removes "This is the default." from the `SSHAccessModeLegacy` comment in
`pkg/models/namespace.go`.

## Why

Legacy is not the default, and the `SSHAccessMode` field comment twenty lines
below already says so. The schema settles it: migration 016 defaults the column
to `identity`, the store assigns `identity` when the field is empty, and the API
service always leaves it empty. Legacy is only what pre-identity namespaces
carry.

Access mode decides whether a namespace authorizes by Access Policies or by the
legacy key ACL and firewall rules, so a wrong default in the comment teaches the
wrong security model.

## Changes

- `pkg/models/namespace.go`: one line, comment only. No behavior change.

Fixes: shellhub-io/team#227