### PR TITLE
fix(agent): fall back to `/etc/shellhub-agent.env` when env vars are missing

### DIFF
--- a/agent/pkg/agentd/agent.go
+++ b/agent/pkg/agentd/agent.go
@@ -176,6 +176,8 @@ func LoadConfigFromEnv() (*Config, map[string]interface{}, error) {
 	//  This behavior is driven by the [envconfig] package. Check it out for more information.
 	//
 	// [envconfig]: https://github.com/sethvargo/go-envconfig
+	applyEnvFileFallback(defaultEnvFilePath)
+
 	cfg, err := envs.ParseWithPrefix[Config]("SHELLHUB_")
 	if err != nil {
 		log.Error("failed to parse the configuration")

--- a/agent/pkg/agentd/envfile.go
+++ b/agent/pkg/agentd/envfile.go
@@ -1,0 +1,49 @@
+package agentd
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+const defaultEnvFilePath = "/etc/shellhub-agent.env"
+
+// loadEnvFile parses a KEY=VALUE env file into a map, skipping blank lines and
+// comments. Returns nil when the file does not exist or cannot be read.
+func loadEnvFile(path string) map[string]string {
+	f, err := os.Open(path) //nolint:gosec // path is defaultEnvFilePath in production, parameterised for tests.
+	if err != nil {
+		return nil
+	}
+	defer f.Close() //nolint:errcheck
+
+	vars := make(map[string]string)
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+
+		vars[key] = value
+	}
+
+	return vars
+}
+
+// applyEnvFileFallback loads the env file at path and sets any variable that is
+// not already present in the process environment. Existing env vars are never
+// overridden.
+func applyEnvFileFallback(path string) {
+	for key, value := range loadEnvFile(path) {
+		if _, set := os.LookupEnv(key); !set {
+			os.Setenv(key, value)
+		}
+	}
+}

--- a/agent/pkg/agentd/envfile_test.go
+++ b/agent/pkg/agentd/envfile_test.go
@@ -1,0 +1,51 @@
+package agentd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadEnvFile(t *testing.T) {
+	t.Run("returns nil when file does not exist", func(t *testing.T) {
+		got := loadEnvFile("/no/such/file.env")
+		assert.Empty(t, got)
+	})
+
+	t.Run("parses KEY=VALUE lines and skips blanks and comments", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.env")
+		content := "FOO=bar\n# comment\n\nBAZ=qux\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		got := loadEnvFile(path)
+		assert.Equal(t, map[string]string{"FOO": "bar", "BAZ": "qux"}, got)
+	})
+
+	t.Run("preserves values containing equals signs", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.env")
+		content := "URL=http://host:80/path?a=1&b=2\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		got := loadEnvFile(path)
+		assert.Equal(t, map[string]string{"URL": "http://host:80/path?a=1&b=2"}, got)
+	})
+}
+
+func TestApplyEnvFileFallback(t *testing.T) {
+	t.Run("sets missing vars from file without overriding existing ones", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "test.env")
+		content := "TEST_ENVFILE_EXISTING=from-file\nTEST_ENVFILE_MISSING=from-file\n"
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+		t.Setenv("TEST_ENVFILE_EXISTING", "from-env")
+
+		applyEnvFileFallback(path)
+
+		assert.Equal(t, "from-env", os.Getenv("TEST_ENVFILE_EXISTING"))
+		assert.Equal(t, "from-file", os.Getenv("TEST_ENVFILE_MISSING"))
+		t.Cleanup(func() { os.Unsetenv("TEST_ENVFILE_MISSING") })
+	})
+}


### PR DESCRIPTION
## What

`LoadConfigFromEnv` now loads `/etc/shellhub-agent.env` as a fallback before parsing environment variables, so `shellhub-agent login` works from an interactive shell after a standalone install.

## Why

The standalone installer writes `SHELLHUB_SERVER_ADDRESS`, `SHELLHUB_PRIVATE_KEY`, and `SHELLHUB_TENANT_ID` into `/etc/shellhub-agent.env`. systemd loads that file through its `EnvironmentFile` directive, but an interactive shell does not — making `shellhub-agent login` (the documented pairing command) fail on missing required variables. The only workaround was `sudo env $(cat /etc/shellhub-agent.env | xargs) shellhub-agent login`, which no user would discover unprompted.

Closes shellhub-io/team#225

## Changes

- **`agent/pkg/agentd/envfile.go`**: `loadEnvFile` parses a `KEY=VALUE` env file into a map (skips comments and blank lines); `applyEnvFileFallback` sets any variable not already present in the process environment — existing env vars always win, so the container path (where the wrapper already carries the environment) is unaffected.
- **`agent/pkg/agentd/agent.go`**: one-line call to `applyEnvFileFallback(defaultEnvFilePath)` before `envs.ParseWithPrefix`, so the file acts as a transparent fallback.
- **`agent/pkg/agentd/envfile_test.go`**: covers parsing (missing file, comments, values with `=` signs) and the fallback-without-override semantics.