### PR TITLE
fix(agent): carry the install key through the standalone install

### DIFF
--- a/agent/installer.go
+++ b/agent/installer.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/shellhub-io/shellhub/pkg/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +40,7 @@ type installerConfig struct {
 	ServerAddress     string
 	TenantID          string
 	PrivateKey        string
+	InstallKey        string
 	PreferredHostname string
 	PreferredIdentity string
 	KeepaliveInterval uint
@@ -46,8 +48,9 @@ type installerConfig struct {
 
 func registerInstallerCommands(rootCmd *cobra.Command) {
 	installCmd := &cobra.Command{ // nolint: exhaustruct
-		Use:   "install",
-		Short: "Install ShellHub agent as a systemd service",
+		Use:          "install",
+		Short:        "Install ShellHub agent as a systemd service",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			flags := cmd.Flags()
 
@@ -56,6 +59,13 @@ func registerInstallerCommands(rootCmd *cobra.Command) {
 			privateKey, _ := flags.GetString("private-key")
 			preferredHostname, _ := flags.GetString("preferred-hostname")
 			preferredIdentity, _ := flags.GetString("preferred-identity")
+
+			installKey, _ := flags.GetString("install-key")
+			if installKey != "" {
+				if _, err := uuid.Parse(installKey); err != nil {
+					return fmt.Errorf("invalid install key: %q is not a valid UUID", installKey)
+				}
+			}
 
 			var keepaliveInterval uint
 			if flags.Changed("keepalive-interval") {
@@ -66,6 +76,7 @@ func registerInstallerCommands(rootCmd *cobra.Command) {
 				ServerAddress:     serverAddress,
 				TenantID:          tenantID,
 				PrivateKey:        privateKey,
+				InstallKey:        installKey,
 				PreferredHostname: preferredHostname,
 				PreferredIdentity: preferredIdentity,
 				KeepaliveInterval: keepaliveInterval,
@@ -84,6 +95,7 @@ func registerInstallerCommands(rootCmd *cobra.Command) {
 	installCmd.Flags().String("server-address", "", "ShellHub server address")
 	installCmd.Flags().String("tenant-id", "", "Namespace tenant ID")
 	installCmd.Flags().String("private-key", "/etc/shellhub.key", "Path to the agent private key file")
+	installCmd.Flags().String("install-key", "", "Install key used to enroll the device")
 	installCmd.Flags().String("preferred-hostname", "", "Preferred device hostname")
 	installCmd.Flags().String("preferred-identity", "", "Preferred device identity")
 	installCmd.Flags().Uint("keepalive-interval", 30, "Keepalive interval in seconds")
@@ -156,6 +168,10 @@ func writeAgentEnvFile(cfg installerConfig) error {
 	fmt.Fprintf(&buf, "SHELLHUB_SERVER_ADDRESS=%s\n", cfg.ServerAddress)
 	fmt.Fprintf(&buf, "SHELLHUB_TENANT_ID=%s\n", cfg.TenantID)
 	fmt.Fprintf(&buf, "SHELLHUB_PRIVATE_KEY=%s\n", cfg.PrivateKey)
+
+	if cfg.InstallKey != "" {
+		fmt.Fprintf(&buf, "SHELLHUB_INSTALL_KEY=%s\n", cfg.InstallKey)
+	}
 
 	if cfg.PreferredHostname != "" {
 		fmt.Fprintf(&buf, "SHELLHUB_PREFERRED_HOSTNAME=%s\n", cfg.PreferredHostname)

--- a/agent/main.go
+++ b/agent/main.go
@@ -437,7 +437,11 @@ It is initialized by the agent when a new SFTP session is created.`,
 		runtime.Version(),
 	))
 
-	rootCmd.Execute() // nolint: errcheck
+	// A failed command must exit non-zero: install.sh guards every agent call with
+	// `|| { ...; exit 1; }`, and a discarded error made a failed install report success.
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
 // waitForPairing enrolls a tenant-less agent from the main process: it creates

--- a/install.sh
+++ b/install.sh
@@ -289,6 +289,15 @@ docker_install() {
 snap_install() {
   require_tenant
 
+  # The snap package exposes no install-key setting, so a key given here would be
+  # dropped and the device would enroll without one, landing in manual approval.
+  # Refuse instead of reporting an enrollment that will not happen.
+  if [ -n "$INSTALL_KEY" ]; then
+    echo "❌ ERROR: INSTALL_KEY is not supported by the snap install method."
+    echo "Use the docker, podman or standalone method to enroll with an install key."
+    exit 1
+  fi
+
   if ! type snap >/dev/null 2>&1; then
     echo "❌ Snap is not installed or not supported on this system."
     exit 1
@@ -359,6 +368,7 @@ standalone_install() {
   echo "🚀 Installing ShellHub system service..."
 
   INSTALL_ARGS="--server-address=$SERVER_ADDRESS --tenant-id=$TENANT_ID"
+  [ -n "${INSTALL_KEY}" ] && INSTALL_ARGS="$INSTALL_ARGS --install-key=$INSTALL_KEY"
   [ -n "${PREFERRED_HOSTNAME}" ] && INSTALL_ARGS="$INSTALL_ARGS --preferred-hostname=$PREFERRED_HOSTNAME"
   [ -n "${PREFERRED_IDENTITY}" ] && INSTALL_ARGS="$INSTALL_ARGS --preferred-identity=$PREFERRED_IDENTITY"
   [ -n "${KEEPALIVE_INTERVAL}" ] && INSTALL_ARGS="$INSTALL_ARGS --keepalive-interval=$KEEPALIVE_INTERVAL"


### PR DESCRIPTION
## What

The standalone install method now passes `INSTALL_KEY` through to the agent, so a device installed that way enrolls under the key's policy instead of enrolling keyless. WSL is fixed along with it, since it delegates to the same path. Snap still cannot carry a key, so it now refuses the combination up front rather than reporting an enrollment that will not happen.

## Why

Installing with `INSTALL_KEY` and `INSTALL_METHOD=standalone` discarded the key. The standalone path built its installer arguments from the server address, tenant ID and three optional values and never included it, so only Docker and Podman ever passed one along. The agent had nowhere to receive it either: the `install` subcommand declared no flag for it, and the env file systemd reads was written without it.

The device then enrolled with no key, resolving the namespace's legacy key, which is always manual mode. A fleet imaged from one card landed pending and untagged, while the installer printed that it would be accepted automatically. That path is the one the documentation gives for Raspberry Pi, Yocto and Buildroot images, where nobody is present to type a pairing code and an install key is the only workable credential.

The false success had a second cause worth naming: the agent discarded the error from its root command, so every failed run exited zero and the installer's `|| { ...; exit 1; }` guard never fired. A missing `--server-address` reported success the same way.

## Changes

- `install.sh`: the standalone path appends `--install-key` when `INSTALL_KEY` is set, using the same guarded-append idiom as the neighbouring optional flags.
- `install.sh`: the snap path refuses an install key up front, since the snap package exposes no setting to carry one.
- `agent/installer.go`: `--install-key` flag on the `install` command, carried on the installer config and emitted as `SHELLHUB_INSTALL_KEY` in the agent env file. The key is validated as a UUID before anything is written.
- `agent/installer.go`: `SilenceUsage` on the `install` command, so a runtime validation failure prints the error without dumping the flag list.
- `agent/main.go`: a failed root command now exits non-zero instead of discarding the error.

No server-side, schema or API changes. The agent already supported install keys; this only connects the installer to that existing field.

## Testing

Verified manually against a development stack. `agent/installer.go` sits behind the `installer` build tag, which CI neither builds nor lints, so this path has no automated coverage.

Build an agent binary with the installer tag, from the repo root:

```sh
docker run --rm -v "$PWD":/src -w /src/agent golang:1.25 sh -c 'go build -buildvcs=false -tags installer -ldflags "-X main.AgentVersion=latest" -o /src/agent-installer .'
```

Create an install key in the console with automatic mode and at least one tag, then run the standalone install against your stack:

```sh
sudo env SERVER_ADDRESS=<server> TENANT_ID=<tenant> INSTALL_KEY=<uuid> INSTALL_METHOD=standalone AGENT_BINARY="$PWD/agent-installer" AGENT_VERSION=v0.26.0 sh install.sh
```

Expected:

1. `/etc/shellhub-agent.env` contains `SHELLHUB_INSTALL_KEY`.
2. `systemctl is-active shellhub-agent` reports `active`.
3. The device is attributed to the supplied key rather than the namespace's legacy key, and its status follows the key's mode.
4. The key's usage count increments.

Read the device's `install_key_id` rather than its status or tags: the device UID is derived from the MAC, so repeated runs on one host reuse the same device record and carry over state from earlier attempts.

Failure paths:

```sh
# refuses before writing anything, exits non-zero
sudo env ... INSTALL_KEY=not-a-uuid INSTALL_METHOD=standalone sh install.sh

# refuses the unsupported combination
sudo env ... INSTALL_KEY=<uuid> INSTALL_METHOD=snap sh install.sh
```

Cleanup:

```sh
sudo shellhub-agent uninstall && sudo rm -f /usr/local/bin/shellhub-agent /etc/shellhub.key && rm -f agent-installer
```

Agent unit tests pass and `golangci-lint` is clean with `--build-tags docker`, the set CI runs. Two pre-existing issues remain under `--build-tags installer` (a gofumpt alignment and a gosec `G306`); both are on master and untouched here.

Fixes: shellhub-io/team#224