### PR TITLE
fix(ui): default install key usage limit to unlimited

### DIFF
--- a/ui/apps/console/src/pages/install-keys/CreateInstallKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/install-keys/CreateInstallKeyDrawer.tsx
@@ -42,7 +42,7 @@ function CreateInstallKeyDrawer({
   const [allowedMacs, setAllowedMacs] = useState("");
   const [webhookTimeout, setWebhookTimeout] = useState(5);
   const [webhookCallbackTtl, setWebhookCallbackTtl] = useState(3600);
-  const [usageLimit, setUsageLimit] = useState(1);
+  const [usageLimit, setUsageLimit] = useState(0);
   const [ephemeral, setEphemeral] = useState(false);
   const [ephemeralTimeout, setEphemeralTimeout] = useState(10);
   const [tags, setTags] = useState<string[]>([]);
@@ -69,7 +69,7 @@ function CreateInstallKeyDrawer({
     setAllowedMacs("");
     setWebhookTimeout(5);
     setWebhookCallbackTtl(3600);
-    setUsageLimit(1);
+    setUsageLimit(0);
     setEphemeral(false);
     setEphemeralTimeout(10);
     setTags([]);

--- a/ui/apps/console/src/pages/install-keys/EditInstallKeyDrawer.tsx
+++ b/ui/apps/console/src/pages/install-keys/EditInstallKeyDrawer.tsx
@@ -37,7 +37,7 @@ function EditInstallKeyDrawer({
   const [allowedMacs, setAllowedMacs] = useState("");
   const [webhookTimeout, setWebhookTimeout] = useState(5);
   const [webhookCallbackTtl, setWebhookCallbackTtl] = useState(3600);
-  const [usageLimit, setUsageLimit] = useState(1);
+  const [usageLimit, setUsageLimit] = useState(0);
   const [ephemeral, setEphemeral] = useState(false);
   const [ephemeralTimeout, setEphemeralTimeout] = useState(10);
   const [expiresIn, setExpiresIn] = useState("-1");
@@ -81,7 +81,7 @@ function EditInstallKeyDrawer({
     setAllowedMacs((installKey?.allowed_macs ?? []).join("\n"));
     setWebhookTimeout(installKey?.webhook_timeout || 5);
     setWebhookCallbackTtl(installKey?.webhook_callback_ttl || 3600);
-    setUsageLimit(installKey?.usage_limit ?? 1);
+    setUsageLimit(installKey?.usage_limit ?? 0);
     setEphemeral(installKey?.ephemeral ?? false);
     setEphemeralTimeout(installKey?.ephemeral_timeout || 10);
     const { days, expired } = getRemainingDays(installKey?.expires_at);


### PR DESCRIPTION
## What

Changed the default usage limit for install keys from single-use (1) to unlimited (0) in both the create and edit drawers.

## Why

Single-use was rarely the intended default — most install keys are created for reusable device enrollment. Users had to manually switch to unlimited on every new key.

## Changes

- **CreateInstallKeyDrawer**: initial state and reset function default `usageLimit` to `0` (unlimited) instead of `1`
- **EditInstallKeyDrawer**: initial state and the field-sync fallback default to `0` instead of `1`; the `??` (nullish coalescing) operator preserves any existing key's real value