### PR TITLE
fix(billing): make a namespace's subscription an optional object

### DIFF
--- a/openapi/spec/components/schemas/namespaceBilling.yaml
+++ b/openapi/spec/components/schemas/namespaceBilling.yaml
@@ -1,48 +1,51 @@
 description: |
-  Billing information stored on a namespace. Reflects the current subscription
-  state for the namespace's owner.
+  Billing information stored on a namespace.
+
+  A namespace that has a customer on the payment gateway but never completed checkout carries
+  no `subscription`. It is not a failed subscription: the namespace keeps the free tier, the
+  same as a namespace with no billing at all.
 type: object
 properties:
-  active:
-    description: |
-      Whether the subscription is active. This is the source of truth for
-      whether the namespace is allowed to accept devices and create
-      connections; it tracks the subscription `status` and is `true` when
-      `status` is one of `active`, `trialing`, `past_due` or
-      `to_cancel_at_end_of_period`.
-    type: boolean
-    example: true
-  status:
-    $ref: billingStatus.yaml
   customer_id:
     description: ID of the customer the subscription belongs to on the payment gateway.
     type: string
     example: cus_H9J5n2eZvKYlo2C7X1QX2Qg
-  subscription_id:
-    description: ID of the subscription on the payment gateway.
-    type: string
-    example: sub_1H9J5n2eZvKYlo2C7X1QX2Qg
-  current_period_end:
+  subscription:
     description: |
-      End of the current billing period as a unix timestamp in seconds.
-    type: integer
-    format: int64
-    example: 1735689600
+      The namespace's subscription on the payment gateway. Absent when the namespace has no
+      subscription, either because checkout was never completed or because the subscription
+      was deleted.
+    type: object
+    properties:
+      id:
+        description: ID of the subscription on the payment gateway.
+        type: string
+        example: sub_1H9J5n2eZvKYlo2C7X1QX2Qg
+      status:
+        $ref: billingStatus.yaml
+      current_period_end:
+        description: |
+          End of the current billing period as a unix timestamp in seconds.
+        type: integer
+        format: int64
+        example: 1735689600
+    required:
+      - id
+      - status
+      - current_period_end
   created_at:
-    description: When the billing record was created (RFC 3339).
+    description: |
+      When the billing record was created (RFC 3339). Absent on records written before the
+      store began to maintain it.
     type: string
     format: date-time
     example: 2024-01-01T00:00:00Z
   updated_at:
-    description: When the billing record was last updated (RFC 3339).
+    description: |
+      When the billing record was last updated (RFC 3339). Absent on records written before
+      the store began to maintain it.
     type: string
     format: date-time
     example: 2024-06-01T00:00:00Z
 required:
-  - active
-  - status
   - customer_id
-  - subscription_id
-  - current_period_end
-  - created_at
-  - updated_at

--- a/pkg/models/billing.go
+++ b/pkg/models/billing.go
@@ -155,4 +155,18 @@ type BillingEvaluation struct {
 	CanAccept bool `json:"can_accept"`
 	// CanConnect indicates if the namespace can create a new connection SSH.
 	CanConnect bool `json:"can_connect"`
+	// Blocked names what denies the operation, and is empty when nothing does. The two reasons
+	// need different answers from the user, so a caller must report them as different errors.
+	Blocked BillingBlockReason `json:"blocked,omitempty"`
 }
+
+// BillingBlockReason names why a billing evaluation denies acceptance or connection.
+type BillingBlockReason string
+
+const (
+	// BillingBlockedQuota means the namespace uses every device its plan allows.
+	BillingBlockedQuota BillingBlockReason = "quota"
+	// BillingBlockedSubscription means the namespace's subscription denies the operation,
+	// whatever the device count is.
+	BillingBlockedSubscription BillingBlockReason = "subscription"
+)

--- a/pkg/models/billing.go
+++ b/pkg/models/billing.go
@@ -1,23 +1,24 @@
 package models
 
-import "time"
-
-// BillingStatus represents the status of a subscription.
+// BillingStatus represents the status of a subscription on the payment gateway.
 //
 // https://stripe.com/docs/api/subscriptions/object#subscription_object-status
 // https://stripe.com/docs/billing/subscriptions/overview#subscription-lifecycle
 type BillingStatus string
 
-// IsActive returns true if the subscription is active.
-// It is active if its status is `active`, `past_due`, `trailing` or `to_cancel_at_end_of_period`.
+// IsActive returns true if the subscription grants full service.
+//
+// `past_due` counts as active because Stripe is still retrying the payment, and
+// `to_cancel_at_end_of_period` still has a paid period left to run.
 func (s BillingStatus) IsActive() bool {
 	return s == BillingStatusActive || s == BillingStatusPastDue || s == BillingStatusTrialing || s == BillingStatusToCancelAtEndOfPeriod
 }
 
 // Represents the possible statuses of a subscription.
+//
+// There is no "no subscription" status: a namespace that never completed checkout carries a
+// Billing with a nil Subscription instead.
 const (
-	// BillingStatusInactive represents inactive status.
-	BillingStatusInactive BillingStatus = "inactive"
 	// BillingStatusActive represents active status without any issues.
 	BillingStatusActive BillingStatus = "active"
 	// BillingStatusTrialing represents active status without any issues, but the subscription is in trial period.
@@ -47,88 +48,103 @@ const (
 	BillingStatusToCancelAtEndOfPeriod BillingStatus = "to_cancel_at_end_of_period"
 )
 
-// Billing contains information about the ShellHub's subscription.
-type Billing struct {
-	// Active indicates if the subscription is active.
-	// IT IS THE SOURCE OF TRUTH THAT DEFINES WHETHER A SUBSCRIPTION IS ACTIVE OR NOT and change due to the status of
-	// the subscription.
-	//
-	// A subscription is active if its status is `active`, `trailing`, `past_due` or `to_cancel_at_end_of_period`.
-	// `past_due` is a temporary status that occurs when a payment to renew the subscription fails, but the subscription
-	// has not been canceled yet.
-	// `to_cancel_at_end_of_period` is a custom status used by this package to indicate that the subscription is set to
-	// cancel at the end of the period.
-	// A subscription is not active if its status is `incomplete`, `incomplete_expired`, `canceled`, `unpaid` or `paused`.
-	// TODO: evaluate if `paused` should be considered active.
-	Active bool `json:"active"`
+// BillingSubscription is the namespace's subscription on the payment gateway.
+type BillingSubscription struct {
+	// ID is the ID of the subscription on the payment gateway.
+	ID string `json:"id"`
 	// Status is the current status of the subscription.
 	Status BillingStatus `json:"status"`
-	// Customer is the ID of the customer the subscription belongs to.
-	// Customer string `json:"customer"`
-	CustomerID string `json:"customer_id"`
-	// SubscriptionID is the ID of the subscription.
-	SubscriptionID string `json:"subscription_id"`
 	// CurrentPeriodEnd is the end of the current period.
 	CurrentPeriodEnd int64 `json:"current_period_end"`
-	// CreatedAt is the time at which this billing was created.
-	// It must follow the RFC 3339 format.
-	CreatedAt string `json:"created_at"`
-	// UpdatedAt is the time at which this billing was last updated.
-	// It must follow the RFC 3339 format.
-	UpdatedAt string `json:"updated_at"`
 }
 
-func NewBilling(status BillingStatus, customer, subscription string, currentPeridoEnd int64) *Billing {
-	return &Billing{
-		Active:           status.IsActive(),
-		Status:           status,
-		CustomerID:       customer,
-		SubscriptionID:   subscription,
-		CurrentPeriodEnd: currentPeridoEnd,
-		CreatedAt:        time.Now().Format(time.RFC3339),
-		UpdatedAt:        time.Now().Format(time.RFC3339),
+// Billing contains information about the ShellHub's subscription.
+type Billing struct {
+	// CustomerID is the ID of the customer on the payment gateway.
+	CustomerID string `json:"customer_id"`
+	// Subscription is the namespace's subscription, or nil when the namespace has a customer but
+	// never completed checkout. A nil Subscription is not a failed subscription: the namespace
+	// keeps the free tier, exactly as a namespace with no Billing at all does.
+	Subscription *BillingSubscription `json:"subscription,omitempty"`
+	// CreatedAt is the time at which this billing was created.
+	// It follows the RFC 3339 format, and it is empty on records written before the store began
+	// to maintain it.
+	CreatedAt string `json:"created_at,omitempty"`
+	// UpdatedAt is the time at which this billing was last updated.
+	// It follows the RFC 3339 format, and it is empty on records written before the store began
+	// to maintain it.
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// NewBilling returns a billing record for a namespace that has a customer on the payment gateway
+// but no subscription yet. The store stamps CreatedAt and UpdatedAt when it writes the record.
+func NewBilling(customerID string) *Billing {
+	return &Billing{ //nolint:exhaustruct
+		CustomerID: customerID,
 	}
+}
+
+// Clone returns a deep copy, so that a caller can build the next billing state without touching
+// the one the namespace still holds.
+func (b *Billing) Clone() *Billing {
+	if b == nil {
+		return nil
+	}
+
+	clone := *b
+
+	if b.Subscription != nil {
+		subscription := *b.Subscription
+		clone.Subscription = &subscription
+	}
+
+	return &clone
 }
 
 func (b *Billing) IsNil() bool {
 	return b == nil
 }
 
-// IsActive indicates if the subscription is active.
+// IsActive indicates whether the namespace has a subscription that grants full service.
 func (b *Billing) IsActive() bool {
-	return b != nil && b.Active
+	return b.HasSubscription() && b.Subscription.Status.IsActive()
 }
 
-func (b *Billing) HasCutomer() bool {
+func (b *Billing) HasCustomer() bool {
 	return b != nil && b.CustomerID != ""
 }
 
 func (b *Billing) HasSubscription() bool {
-	return b != nil && b.SubscriptionID != ""
-}
-
-func (b *Billing) HasCurrentPeriodEnd() bool {
-	return b != nil && b.CurrentPeriodEnd != 0
-}
-
-// UpdateBillingStatus updates the status of the billing.
-func (b *Billing) UpdateBillingStatus(status BillingStatus) {
-	b.Active = status.IsActive()
-	b.Status = status
+	return b != nil && b.Subscription != nil
 }
 
 func (b *Billing) SetCustomer(id string) {
 	b.CustomerID = id
 }
 
-func (b *Billing) SetSubscription(id string, status BillingStatus) {
-	b.Active = status.IsActive()
-	b.Status = status
-	b.SubscriptionID = id
+// SetSubscription attaches a subscription to the billing, replacing any subscription already
+// there.
+func (b *Billing) SetSubscription(id string, status BillingStatus, currentPeriodEnd int64) {
+	b.Subscription = &BillingSubscription{
+		ID:               id,
+		Status:           status,
+		CurrentPeriodEnd: currentPeriodEnd,
+	}
 }
 
-func (b *Billing) SetCurrentPeriodEnd(end int64) {
-	b.CurrentPeriodEnd = end
+// SetSubscriptionStatus updates the status of the subscription, and does nothing when the billing
+// has no subscription.
+func (b *Billing) SetSubscriptionStatus(status BillingStatus) {
+	if !b.HasSubscription() {
+		return
+	}
+
+	b.Subscription.Status = status
+}
+
+// ClearSubscription detaches the subscription, returning the namespace to the free tier.
+func (b *Billing) ClearSubscription() {
+	b.Subscription = nil
 }
 
 // BillingEvaluation contains information about the billing evaluation of acceptance and connection.

--- a/server/api/services/billing.go
+++ b/server/api/services/billing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/shellhub-io/shellhub/pkg/cache"
 	"github.com/shellhub-io/shellhub/pkg/models"
 	"github.com/shellhub-io/shellhub/server/api/store"
+	log "github.com/sirupsen/logrus"
 )
 
 // ========================================
@@ -123,25 +124,30 @@ func (s *service) EvaluateBilling(ctx context.Context, tenant string) error {
 	}
 
 	if !evaluation.CanConnect {
+		log.WithFields(log.Fields{
+			"tenant":  tenant,
+			"blocked": evaluation.Blocked,
+		}).Error("billing blocked the connection")
+
 		return ErrBillingBlocked
 	}
 
 	return nil
 }
 
-// evaluateBilling checks if a namespace can accept more devices.
-// Returns false if billing provider is not available (Community Edition).
-func (s *service) evaluateBilling(ctx context.Context, tenant string) (bool, error) {
+// evaluateBilling reports what the namespace's billing state allows.
+// It fails when the billing provider is not available (Community Edition).
+func (s *service) evaluateBilling(ctx context.Context, tenant string) (*models.BillingEvaluation, error) {
 	if s.billing == nil {
-		return false, ErrBillingNotAvailable
+		return nil, ErrBillingNotAvailable
 	}
 
 	evaluation, err := s.billing.Evaluate(ctx, tenant)
 	if err != nil {
-		return false, NewErrBillingEvaluate(err)
+		return nil, NewErrBillingEvaluate(err)
 	}
 
-	return evaluation.CanAccept, nil
+	return evaluation, nil
 }
 
 func (s *service) ReportBilling(ctx context.Context, tenant string, action BillingAction) error {
@@ -173,11 +179,20 @@ func (s *service) validateBillingForDeviceAcceptance(ctx context.Context, namesp
 		}
 	} else {
 		// Inactive subscription - evaluate if namespace can still accept
-		canAccept, err := s.evaluateBilling(ctx, namespace.TenantID)
+		evaluation, err := s.evaluateBilling(ctx, namespace.TenantID)
 		if err != nil {
 			return NewErrBillingEvaluate(err)
 		}
-		if !canAccept {
+
+		if !evaluation.CanAccept {
+			// The two denials need different answers from the user: one has to remove a device
+			// or upgrade, the other has to finish or repair the subscription. Reporting both as
+			// a device limit sends a namespace that is under its allowance to delete devices
+			// that were never the problem.
+			if evaluation.Blocked == models.BillingBlockedSubscription {
+				return ErrDeviceBillingBlocked
+			}
+
 			return ErrDeviceLimit
 		}
 	}

--- a/server/api/services/billing_test.go
+++ b/server/api/services/billing_test.go
@@ -1,0 +1,92 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shellhub-io/shellhub/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBillingProvider stands in for BillingProvider. It lives here rather than in the generated
+// mocks package because this package's own tests use it: services/mocks imports services, so an
+// internal test importing it would form a cycle.
+type mockBillingProvider struct {
+	mock.Mock
+}
+
+func (m *mockBillingProvider) Evaluate(ctx context.Context, tenant string) (*models.BillingEvaluation, error) {
+	args := m.Called(ctx, tenant)
+
+	evaluation, _ := args.Get(0).(*models.BillingEvaluation)
+
+	return evaluation, args.Error(1)
+}
+
+func (m *mockBillingProvider) Report(ctx context.Context, tenant string, action BillingAction) error {
+	args := m.Called(ctx, tenant, action)
+
+	return args.Error(0)
+}
+
+func TestValidateBillingForDeviceAcceptance(t *testing.T) {
+	ctx := context.Background()
+
+	namespace := &models.Namespace{ //nolint:exhaustruct
+		TenantID: "00000000-0000-4000-0000-000000000000",
+		Billing:  models.NewBilling("cus_H9J5n2eZvKYlo2C7X1QX2Qg"),
+	}
+
+	cases := []struct {
+		description string
+		evaluation  *models.BillingEvaluation
+		expected    error
+	}{
+		{
+			description: "succeeds when the namespace can accept the device",
+			evaluation:  &models.BillingEvaluation{CanAccept: true, CanConnect: true, Blocked: ""},
+			expected:    nil,
+		},
+		{
+			description: "reports a device limit when the namespace used its whole allowance",
+			evaluation: &models.BillingEvaluation{
+				CanAccept:  false,
+				CanConnect: true,
+				Blocked:    models.BillingBlockedQuota,
+			},
+			expected: ErrDeviceLimit,
+		},
+		{
+			description: "reports a billing block when the subscription denies the device",
+			evaluation: &models.BillingEvaluation{
+				CanAccept:  false,
+				CanConnect: false,
+				Blocked:    models.BillingBlockedSubscription,
+			},
+			expected: ErrDeviceBillingBlocked,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			billing := new(mockBillingProvider)
+			billing.On("Evaluate", ctx, namespace.TenantID).Return(tc.evaluation, nil).Once()
+
+			s := &service{billing: billing} //nolint:exhaustruct
+
+			require.ErrorIs(t, s.validateBillingForDeviceAcceptance(ctx, namespace), tc.expected)
+			billing.AssertExpectations(t)
+		})
+	}
+}
+
+// TestErrDeviceBillingBlocked asserts that ErrDeviceBillingBlocked is a distinct sentinel from
+// ErrDeviceLimit. They share a layer and a code, so only the message separates them, and a caller
+// that tells a namespace to free a device slot must not match a billing block.
+func TestErrDeviceBillingBlocked(t *testing.T) {
+	assert.False(t, errors.Is(ErrDeviceBillingBlocked, ErrDeviceLimit))
+	assert.False(t, errors.Is(ErrDeviceLimit, ErrDeviceBillingBlocked))
+}

--- a/server/api/services/errors.go
+++ b/server/api/services/errors.go
@@ -114,6 +114,7 @@ var (
 	ErrDeviceInvalid                   = errors.New("device invalid", ErrLayer, ErrCodeInvalid)
 	ErrDeviceDuplicated                = errors.New("device duplicated", ErrLayer, ErrCodeDuplicated)
 	ErrDeviceLimit                     = errors.New("device limit reached", ErrLayer, ErrCodePayment)
+	ErrDeviceBillingBlocked            = errors.New("the namespace's subscription blocks new devices", ErrLayer, ErrCodePayment)
 	ErrDeviceLicenseLimit              = errors.New("device license limit reached", ErrLayer, ErrCodePayment)
 	ErrDeviceStatusInvalid             = errors.New("device status invalid", ErrLayer, ErrCodeInvalid)
 	ErrDeviceStatusAccepted            = errors.New("device status accepted", ErrLayer, ErrCodeInvalid)

--- a/server/api/services/namespace.go
+++ b/server/api/services/namespace.go
@@ -224,7 +224,7 @@ func (s *service) DeleteNamespace(ctx context.Context, tenantID string) error {
 	}
 
 	ableToReportDeleteNamespace := func(ns *models.Namespace) bool {
-		return !ns.Billing.IsNil() && ns.Billing.HasCutomer() && ns.Billing.HasSubscription()
+		return !ns.Billing.IsNil() && ns.Billing.HasCustomer() && ns.Billing.HasSubscription()
 	}
 
 	if envs.IsCloud() && ableToReportDeleteNamespace(n) {

--- a/server/ssh/server/server.go
+++ b/server/ssh/server/server.go
@@ -161,7 +161,21 @@ func newBannerHandlerWithDeps(d *dialer.Dialer, service services.Service, handof
 		}
 
 		if err := deps.evaluate(sess, ctx); err != nil {
-			logger.WithError(err).Error("destination device has a firewall to blocked it or a billing issue")
+			// Firewall and billing denials look the same to the user but need different
+			// answers from us, so they must not share a log message.
+			evaluated := logger.WithError(err)
+			if sess.Device != nil {
+				evaluated = evaluated.WithField("tenant", sess.Device.TenantID)
+			}
+
+			switch {
+			case errors.Is(err, session.ErrBillingBlock):
+				evaluated.Error("destination device is blocked by the namespace's billing state")
+			case errors.Is(err, session.ErrFirewallBlock), errors.Is(err, session.ErrFirewallUnknown):
+				evaluated.Error("destination device is blocked by a firewall rule")
+			default:
+				evaluated.Error("destination device did not pass the connection evaluation")
+			}
 
 			return banner.Message(banner.KindAccessDenied)
 		}

--- a/server/ssh/session/session.go
+++ b/server/ssh/session/session.go
@@ -453,8 +453,9 @@ func (s *Session) checkFirewall(ctx context.Context) error {
 	}
 
 	log.WithError(err).WithFields(log.Fields{
-		"uid":   s.UID,
-		"sshid": s.SSHID,
+		"uid":    s.UID,
+		"sshid":  s.SSHID,
+		"tenant": s.Namespace.TenantID,
 	}).Info("an error or a firewall rule block this connection")
 
 	if errors.Is(err, services.ErrFirewallBlocked) {

--- a/ui/apps/console/src/components/billing/BillingSection.tsx
+++ b/ui/apps/console/src/components/billing/BillingSection.tsx
@@ -194,7 +194,7 @@ export default function BillingSection({ sectionId }: BillingSectionProps) {
   // Gating only on customer_id causes a retry cascade after customer bootstrap
   // — and every billing mutation's invalidate() then awaits those 400 retries,
   // making Save card / Set default hang for ~7s on each click.
-  const hasSubscription = !!billing?.customer_id && !!billing?.subscription_id;
+  const hasSubscription = !!billing?.customer_id && !!billing?.subscription?.id;
   const { subscription, isLoading } = useSubscription(hasSubscription);
   const openPortal = useOpenBillingPortal();
   const invalidate = useInvalidateByIds(

--- a/ui/apps/console/src/components/billing/DeviceChooserTrigger.tsx
+++ b/ui/apps/console/src/components/billing/DeviceChooserTrigger.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useState } from "react";
 import { isCloud } from "@/env";
 import { useStats } from "@/hooks/useStats";
+import { hasActiveSubscription } from "@/utils/billing";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useHasPermission } from "@/hooks/useHasPermission";
 import { useAuthStore } from "@/stores/authStore";
@@ -31,7 +32,7 @@ function DeviceChooserTriggerInner() {
     return null;
 
   const overLimit = (stats?.registered_devices ?? 0) > FREE_TIER_DEVICE_LIMIT;
-  const noActiveSubscription = !namespace.billing?.active;
+  const noActiveSubscription = !hasActiveSubscription(namespace.billing);
   const shouldShow = canChoose && noActiveSubscription && overLimit;
 
   if (!shouldShow || dismissed) return null;

--- a/ui/apps/console/src/components/billing/__tests__/BillingSection.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/BillingSection.test.tsx
@@ -59,13 +59,12 @@ function renderSection() {
   );
 }
 
-function billingRecord(active: boolean) {
+function billingRecord(subscribed: boolean) {
   return {
-    active,
-    status: "active" as const,
     customer_id: "cus_123",
-    subscription_id: "sub_123",
-    current_period_end: 0,
+    subscription: subscribed
+      ? { id: "sub_123", status: "active" as const, current_period_end: 0 }
+      : undefined,
     created_at: "2024-01-01T00:00:00Z",
     updated_at: "2024-01-01T00:00:00Z",
   };

--- a/ui/apps/console/src/components/billing/__tests__/DeviceChooserTrigger.test.tsx
+++ b/ui/apps/console/src/components/billing/__tests__/DeviceChooserTrigger.test.tsx
@@ -73,11 +73,12 @@ function setupMocks({
         mockNamespace({
           billing: billingActive
             ? {
-                active: true,
-                status: "active" as const,
                 customer_id: "cus_123",
-                subscription_id: "sub_123",
-                current_period_end: 0,
+                subscription: {
+                  id: "sub_123",
+                  status: "active" as const,
+                  current_period_end: 0,
+                },
                 created_at: "2024-01-01T00:00:00Z",
                 updated_at: "2024-01-01T00:00:00Z",
               }

--- a/ui/apps/console/src/hooks/__tests__/useChatwoot.test.ts
+++ b/ui/apps/console/src/hooks/__tests__/useChatwoot.test.ts
@@ -50,7 +50,13 @@ describe("useChatwoot", () => {
       tenant: "tenant-abc",
     });
     sdk.getNamespace.mockResolvedValue(
-      mockSdkResponse({ name: "my-ns", billing: { active: true } }),
+      mockSdkResponse({
+        name: "my-ns",
+        billing: {
+          customer_id: "cus_123",
+          subscription: { id: "sub_123", status: "active", current_period_end: 0 },
+        },
+      }),
     );
     sdk.getNamespaceSupport.mockResolvedValue(
       mockSdkResponse({ identifier: "abc123" }),
@@ -122,9 +128,9 @@ describe("useChatwoot", () => {
   });
 
   describe("status: no-subscription", () => {
-    it("returns 'no-subscription' when billing.active !== true", async () => {
+    it("returns 'no-subscription' when the namespace has no subscription", async () => {
       sdk.getNamespace.mockResolvedValue(
-        mockSdkResponse({ name: "my-ns", billing: { active: false } }),
+        mockSdkResponse({ name: "my-ns", billing: { customer_id: "cus_123" } }),
       );
 
       const { result } = renderHook(() => useChatwoot(), {

--- a/ui/apps/console/src/hooks/useChatwoot.ts
+++ b/ui/apps/console/src/hooks/useChatwoot.ts
@@ -10,6 +10,7 @@ import { getConfig, isCloud } from "@/env";
 import { useAuthStore } from "@/stores/authStore";
 import { useNamespace } from "@/hooks/useNamespaces";
 import { useSupportIdentifier } from "@/hooks/useSupportIdentifier";
+import { hasActiveSubscription } from "@/utils/billing";
 import {
   falseSnapshot,
   getBootstrapFailedSnapshot,
@@ -48,7 +49,7 @@ export function useChatwoot(): ChatwootHandle {
 
   const { namespace } = useNamespace(tenant ?? "");
   const namespaceName = namespace?.name ?? "";
-  const hasActiveBilling = namespace?.billing?.active === true;
+  const hasActiveBilling = hasActiveSubscription(namespace?.billing);
 
   const isCloudEdition = isCloud();
   const hasCloudConfig =

--- a/ui/apps/console/src/utils/__tests__/deviceErrors.test.ts
+++ b/ui/apps/console/src/utils/__tests__/deviceErrors.test.ts
@@ -45,6 +45,23 @@ describe("getAcceptDeviceErrorMessage", () => {
       expect(cloudMsg).not.toBe(enterpriseMsg);
     });
 
+    it("separates a subscription block from a device-limit hit on cloud 402", () => {
+      mockGetConfig.mockReturnValue({
+        ...defaultConfig,
+        edition: "cloud",
+      });
+
+      const limitMsg = getAcceptDeviceErrorMessage({ status: 402 });
+      const subscriptionMsg = getAcceptDeviceErrorMessage({
+        status: 402,
+        message: "the namespace's subscription blocks new devices",
+      });
+
+      expect(subscriptionMsg).not.toBe(limitMsg);
+      expect(limitMsg).toMatch(/device limit/i);
+      expect(subscriptionMsg).not.toMatch(/device limit/i);
+    });
+
     it("returns generic fallback for community on 402 (not billing copy)", () => {
       mockGetConfig.mockReturnValue({
         ...defaultConfig,

--- a/ui/apps/console/src/utils/billing.ts
+++ b/ui/apps/console/src/utils/billing.ts
@@ -1,0 +1,19 @@
+import type { BillingStatus, NamespaceBilling } from "@/client";
+
+const ACTIVE_STATUSES = new Set<BillingStatus>([
+  "active",
+  "trialing",
+  "past_due",
+  "to_cancel_at_end_of_period",
+]);
+
+/**
+ * Whether the namespace has a subscription that still grants service. A namespace with a
+ * customer but no subscription never completed checkout, and stays on the free tier.
+ */
+export function hasActiveSubscription(
+  billing: NamespaceBilling | undefined | null,
+): boolean {
+  const status = billing?.subscription?.status;
+  return status !== undefined && ACTIVE_STATUSES.has(status);
+}

--- a/ui/apps/console/src/utils/deviceErrors.ts
+++ b/ui/apps/console/src/utils/deviceErrors.ts
@@ -8,16 +8,27 @@ const LICENSE_402 =
   "Your instance has reached its device limit. Please update your license to accept more devices or contact the instance administrator.";
 const BILLING_402 =
   "Your subscription plan has reached its device limit. Please update your billing plan to accept more devices.";
+const SUBSCRIPTION_402 =
+  "Your subscription needs attention before this namespace can accept devices. Open Billing to finish or repair it — your device count is not the problem.";
 const NAMESPACE_403 =
   "You do not have permission to accept devices in this namespace.";
 const RENAME_409 =
   "A device with this name already exists in the namespace. Please rename the device and try again.";
 
 /**
+ * The message the API sends when the namespace's subscription — not its device count — denies
+ * the device. The API has no machine-readable error code yet, so the sentinel message is the
+ * only signal that separates the two 402s; a change to it falls back to the device-limit copy.
+ */
+const SUBSCRIPTION_BLOCKED_MESSAGE =
+  "the namespace's subscription blocks new devices";
+
+/**
  * Translate an error thrown by the accept-device SDK call into a user-facing
  * message.  The 402 branch is split three ways:
  *   - enterprise && !cloud  → license copy (on-premises)
- *   - cloud                 → billing/subscription copy
+ *   - cloud                 → billing copy, itself split by whether the namespace is at its
+ *                             device limit or held by its subscription
  *   - community             → generic fallback
  */
 export function getAcceptDeviceErrorMessage(err: unknown): string {
@@ -25,7 +36,11 @@ export function getAcceptDeviceErrorMessage(err: unknown): string {
 
   switch (err.status) {
     case 402: {
-      if (isCloud()) return BILLING_402;
+      if (isCloud()) {
+        return err.message === SUBSCRIPTION_BLOCKED_MESSAGE
+          ? SUBSCRIPTION_402
+          : BILLING_402;
+      }
       if (isEnterprise()) return LICENSE_402;
       return FALLBACK;
     }


### PR DESCRIPTION
Pairs with shellhub-io/cloud#2510 (same branch name). Neither side builds without the other.

## Why

On Cloud, a namespace that added a payment method but never completed checkout could accept no device and open no SSH session, and the API called it `device limit reached`. Its free allowance was not reduced — it was zero. See shellhub-io/team#214 for the production analysis: 124 namespaces, 118 accepted devices unreachable.

The cause is in this repo's model. `Billing.Status` had to carry two unrelated facts: whether a subscription exists at all, and how it is doing. Customer creation wrote `inactive` there, and every reader had to guess which fact the value meant.

## What changes

**The subscription becomes an optional object** (`pkg/models/billing.go`).

```go
type Billing struct {
    CustomerID   string
    Subscription *BillingSubscription  // nil = checkout never completed
    CreatedAt, UpdatedAt string
}
```

- `BillingStatusInactive` is gone. No subscription means no status, so the ambiguous state cannot be written.
- The stored `Active` boolean is gone. It duplicated `Status.IsActive()` at five write sites and could drift from the status it mirrored; `IsActive()` derives it now.
- `Clone()` deep-copies. The webhook handlers used `billing := *namespace.Billing`, which with a pointer field would share the subscription with the namespace and mutate it.
- `HasCutomer` is spelled `HasCustomer`.

**Device acceptance stops lying** (`server/api/services/`). `BillingEvaluation` now names the rule that denied the device, and the two denials get different errors:

| Denial | Error | Console copy |
|---|---|---|
| Namespace used its whole allowance | `ErrDeviceLimit` | free a slot or upgrade |
| Subscription denies the device | `ErrDeviceBillingBlocked` | finish or repair the subscription; the device count is not the problem |

Both stay HTTP 402. The customer in the report deleted all three of their devices because the old message told them to.

**Observability** (`server/ssh/`). The banner handler logged a firewall block and a billing block under one message, which made the incident readable only by grouping on the error text. Each case now has its own message, and both carry the tenant. `EvaluateBilling` logs the block reason.

**API contract.** `namespaceBilling` follows the model: `subscription` nested and optional, `active` removed, timestamps optional. `billingStatus` keeps `inactive`, because that enum is shared with the payment-gateway `subscription` schema, where the console uses it as its own "no subscription" placeholder.

## Test plan

- `go test ./...` — `server/` and root: pass. New: `TestValidateBillingForDeviceAcceptance`, `TestErrDeviceBillingBlocked`.
- `golangci-lint run ./...` — 0 issues in both modules.
- `go mod tidy` — no drift.
- Console `npm run build`, `lint`, `test` — pass, 3149 tests.

## Deploy note

Cloud carries migration 003, which reshapes the stored records. It runs at store construction, under a lock, before the server serves. During a rolling deploy an old replica that reads a migrated row sees an empty status and applies the free-tier math, so the window locks nobody out.
